### PR TITLE
Add github action to publish docs.

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -2,7 +2,7 @@ name: Publish Carbon Documentation
 on:
   push:
     branches:
-    - test-doc-setup
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
This change add a placeholder action which:

(A) Authenticates with gcloud using the appropriate GCP AS.
(B) Copies the docs/ folder as-is into
www.carbon-lang.dev/test-doc-root/

When this action is merged into master, it must be updated to
make it run on pushes to master as well.