### PR TITLE
Carbon: Lexical conventions

### DIFF
--- a/docs/proposals/p0016.md
+++ b/docs/proposals/p0016.md
@@ -101,6 +101,28 @@ potentially disallow everything other than space and newline (and, depending
 on what we decide for [directionality](#directionality), perhaps LTR marks),
 which would lead to a substantially simpler indentation rule.
 
+#### Directionality
+
+Explicit left-to-right marks are permitted in order to allow the user to ensure
+that the visual appearance of the code matches the actual parse order of the
+tokens.
+[[why?]](#directionality-rationale)
+
+The Carbon formatter tool will insert such marks as necessary in order
+to guarantee this property. For example, left-to-right marks may be inserted
+around identifiers containing right-to-left text to avoid adjacent operators
+being reversed, and left-to-right marks may be inserted around string literals
+in order to ensure that the delimiters are displayed at the beginning and end
+of the literal.
+[[why?]](#formatting-rationale)
+
+**Open question:** Should we require that in a well-formed Carbon program, the
+appearance of the source code (as determined by the Unicode Bidirectional
+Algorithm) matches the token order as interpreted by the Carbon implementation?
+This would introduce implementation and compilation-time cost, but would allow
+us to provide stronger guarantees that code does what a reader believes it to
+do.
+
 ### Comments
 
 A *comment* begins with the characters `//` and runs to the end of the line.
@@ -527,21 +549,6 @@ circumstances:
 A *token* is a documentation comment, a literal, a keyword, an identifier, a
 designator, an operator, or a bracket.
 
-### Directionality
-
-After tokens are formed, a final check is performed to ensure that the
-appearance of the code matches its meaning, as follows. The Unicode
-Bidirectional Algorithm, as described in Unicode 13.0.0
-[UAX#9](https://unicode.org/reports/tr9/), is applied to the source text. It is
-an error if any part of a token would be displayed after any part of a later
-token, or if any operator or bracket or the delimiters of a string literal or
-comment does not have a resolved directionality of L (left-to-right).
-
-Such issues can be resolved by the insertion of explicit left-to-right marks.
-The Carbon formatter tool will insert such marks as necessary to satisfy these
-constraints.
-[[why?]](#formatting-rationale)
-
 ## Rationale
 
 ### Encoding rationale
@@ -602,6 +609,43 @@ deliberate and accidental problems) by ensuring that Unicode left-to-right marks
 are used where necessary, that identifiers are properly normalized, and so on,
 and we can simplify our implementation somewhat by only permitting input in a
 single Unicode normalization form.
+
+### Directionality rationale
+
+Source code containing right-to-left string literals and right-to-left
+identifiers will often display in a way that differs from its interpretation as
+code. For example:
+
+```
+// The left operand of the + is "مرحبا", the right operand is "بالعالم".
+var String: x = "مرحبا" + "بالعالم";
+```
+
+Here, when displaying the code, the Unicode Bidirectional Algorithm identifies
+all the text from the first `"` to the last `"` as being a single right-to-left
+context, and so reverses that entire substring (including the `" + "` in the
+middle).
+
+Inserting a left-to-right mark after each string literal containing
+right-to-left text fixes the problem in this case:
+
+```
+// Same example as before, but now a left-to-right mark has been inserted after
+// each string literal.
+var String: x = "مرحبا"‎ + "بالعالم"‎;
+```
+
+Similar things can happen with right-to-left identifiers. For example, in
+
+```
+var مرحبا: بالعالم;
+```
+
+the declared identifier and type are likely to be displayed in the opposite
+order from how they would be interpreted by a Carbon implementation.
+
+If we allow explicit left-to-right marks in the source code and treat them as
+whitespace, such issues can be fixed by the Carbon formatting tool.
 
 ### Line continuation rationale
 


### PR DESCRIPTION
Possible set of lexical conventions for Carbon. Early draft circulated for initial feedback.

The primary principles leading to this approach are to make language evolution (adding keywords, operators, brackets, new kinds of comments) as easy as possible, and to make lexing and parsing as straightforward and efficient as we reasonably can.

RFC: https://forums.carbon-lang.dev/t/rfc-lexical-conventions/67

Fixes #16.