### PR TITLE
Canonicalize license file header to reliably fit in 80-columns.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
@@ -219,8 +219,8 @@ Markdown files always have at the top:
 
 ```
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/commenting_guidelines.md
+++ b/docs/project/commenting_guidelines.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/consensus_decision_making.md
+++ b/docs/project/consensus_decision_making.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/project/roadmap_process.md
+++ b/docs/project/roadmap_process.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 

--- a/src/firebase/functions/index.js
+++ b/src/firebase/functions/index.js
@@ -1,6 +1,5 @@
-// Part of the Carbon Language, under the Apache License v2.0 with LLVM
-// Exceptions.
-// See /LICENSE for license information.
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 'use strict';

--- a/src/firebase/public/login.html
+++ b/src/firebase/public/login.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 <html>

--- a/src/firebase/public/logout.html
+++ b/src/firebase/public/logout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
-Part of the Carbon Language, under the Apache License v2.0 with LLVM Exceptions.
-See /LICENSE for license information.
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 <html>

--- a/src/jekyll/Gemfile
+++ b/src/jekyll/Gemfile
@@ -1,6 +1,5 @@
-# Part of the Carbon Language, under the Apache License v2.0 with LLVM
-# Exceptions.
-# See /LICENSE for license information.
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 source 'https://rubygems.org'

--- a/src/jekyll/Makefile
+++ b/src/jekyll/Makefile
@@ -1,6 +1,5 @@
-# Part of the Carbon Language, under the Apache License v2.0 with LLVM
-# Exceptions.
-# See /LICENSE for license information.
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 all: site

--- a/src/jekyll/_config.yml
+++ b/src/jekyll/_config.yml
@@ -1,6 +1,5 @@
-# Part of the Carbon Language, under the Apache License v2.0 with LLVM
-# Exceptions.
-# See /LICENSE for license information.
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 repository: carbon-language/carbon-lang

--- a/src/jekyll/theme/_includes/footer.html
+++ b/src/jekyll/theme/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer>
   <div class="row">
     <div class="col-lg-12 footer">
-      Part of the Carbon Language, under the
+      Part of the Carbon Language project, under the
       <a href="/LICENSE.txt">Apache License 2.0 with LLVM Exceptions.</a><br />
       {% if page.last_updated %}<span>Page last updated:</span>
       {{page.last_updated}}<br />{% endif %} Site last generated {{ site.time |


### PR DESCRIPTION
The original header was exactly 80-columns which made every file format
with a line-start comment syntax reflow the text. Instead, pick
a canonical re-flowing that keeps it to just three lines. This also lets
the text refer to the project which seems more clear.

No practical or semantic change here, just getting consistent wording
and line breaks for regularity.