### PR TITLE
Move page titles above the license for jekyll compat.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
+# Carbon: Code of conduct
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Code of conduct
 
 The Carbon community works to be welcoming and respectful, with a deep
 commitment to psychological safety, and we want to ensure that doesn’t change as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
+# Carbon: Contributing
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Contributing
 
 Thank you for your interest in contributing to Carbon! There are many ways to
 contribute, and we appreciate all of them. If you have questions, please feel
@@ -218,6 +218,8 @@ It puts the license at the top of every page if printed.
 Markdown files always have at the top:
 
 ```
+# DOC TITLE
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+# Carbon language
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon language
 
 The Carbon Language project is an **_experiment_** to explore a possible,
 distant future for the C++ programming language. It is designed around a

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
+# Carbon: Docs
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Docs
 
 This directory contains current, accepted documentation underpinning Carbon.
 These documents cover all aspects of Carbon ranging from the project down to

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,10 +1,10 @@
+# Carbon: Guides
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Guides
 
 This directory contains end user documentation on how to use Carbon. These
 should be focused on people trying to use and write code in Carbon.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,10 +1,10 @@
+# Carbon: Project
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Project
 
 This directory contains project-related documentation for Carbon. Information
 about how the project works, goals and community information belong here.

--- a/docs/project/commenting_guidelines.md
+++ b/docs/project/commenting_guidelines.md
@@ -1,10 +1,10 @@
+# Carbon: Commenting guidelines
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Commenting guidelines
 
 These commenting guidelines are complementary to the
 [evolution process](evolution.md). The community comments on proposals when the

--- a/docs/project/consensus_decision_making.md
+++ b/docs/project/consensus_decision_making.md
@@ -1,10 +1,10 @@
+# Carbon: Consensus decision-making
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Consensus decision-making
 
 Carbon's teams will use a
 [blocking consensus decision-making process](https://en.wikipedia.org/wiki/Consensus_decision-making#Blocking)

--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -1,10 +1,10 @@
+# Carbon: Governance and Evolution
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Governance and Evolution
 
 The Carbon project aims to provide consistent and clear governance and language
 evolution over time. We want to provide a reasonably broad representation for

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,10 +1,10 @@
+# Carbon: Goals
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Goals
 
 This is a placeholder. See the
 [pending proposal](https://docs.google.com/document/d/1MJvVIDXQrhIj6hZ7NwMDbDch9XLO2VaYrGq29E57meU/edit).

--- a/docs/project/groups.md
+++ b/docs/project/groups.md
@@ -1,5 +1,11 @@
 # Carbon: Groups
 
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
 These are groups used by the Carbon Language project, listed here for central
 tracking.
 

--- a/docs/project/roadmap_process.md
+++ b/docs/project/roadmap_process.md
@@ -1,10 +1,10 @@
+# Carbon: Roadmap process
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Roadmap process
 
 Carbon has an annual roadmap to align and focus the work of the teams and
 community. Teams will need to defer work on Carbon that may be good and make

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,10 +1,10 @@
+# Carbon: Spec
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Carbon: Spec
 
 Eventually, this will be the home of a formal specification for the Carbon
 Language. We are committed to having a specification that is sufficiently

--- a/src/jekyll/theme/search.json
+++ b/src/jekyll/theme/search.json
@@ -11,7 +11,7 @@ search: exclude
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
-"url": "{{ page.url | remove: "/"}}",
+"url": "{{ page.url }}",
 "summary": "{{page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -24,7 +24,7 @@ search: exclude
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url | remove: "/" }}",
+"url": "{{ post.url }}",
 "summary": "{{post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
Also fixes search links to the pages, which is where I noticed this.