### PR TITLE
Make a couple type-aware changes

### DIFF
--- a/src/firebase/functions/index.js
+++ b/src/firebase/functions/index.js
@@ -182,6 +182,12 @@ const serveContent = async (req, res) => {
     }
     res.type(type);
 
+    // Generally allow caching, particularly for css, js, images, etc, but not
+    // HTML.
+    if (type != ".html") {
+      res.set('Cache-Control', 'public, max-age=31557600');
+    }
+
     // Check cache.
     var cacheHit = "hit";
     var contents = contentCache.get(file);


### PR DESCRIPTION
- Allow caching of css+js
- Serve files with no extension (e.g. LICENSE) as plain text, because that's the most likely appropriate choice.