### PR TITLE
Fix direct navigation to a page with an anchor.

### DIFF
--- a/src/jekyll/theme/js/customscripts.js
+++ b/src/jekyll/theme/js/customscripts.js
@@ -14,12 +14,13 @@ $( document ).ready(function() {
     $('[data-toggle="tooltip"]').tooltip({
         placement : 'top'
     });
+});
 
-    /**
-     * AnchorJS
-     */
+document.addEventListener("DOMContentLoaded", function(event) {
+    // AnchorJS
+    // Note that this needs to be run early, not on document.ready(), or jumps
+    // to the invented IDs will not work on page load.
     anchors.add('h2,h3,h4,h5');
-
 });
 
 // needed for nav tabs on pages. See Formatting > Nav tabs for more details.


### PR DESCRIPTION
Previously we generated 'id' attributes for headings after the page load
completed, so page.html#foo would not jump to heading 'foo' (because id
'foo' did not yet exist).