### PR TITLE
Carbon: Proposal tracking

### DIFF
--- a/proposals/p0044.md
+++ b/proposals/p0044.md
@@ -15,7 +15,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Problem](#problem)
 - [Background](#background)
 - [Proposal](#proposal)
@@ -567,9 +566,9 @@ Cons:
 - Email notifications include only the lines of code affected, not what is being
   replied to. This will generally make it infeasible to get context from emails.
 - Comment threads sometimes make it unclear what's being replied to. e.g.,
-  [https://github.com/carbon-language/carbon-proposals/pull/5#discussion_r423401993](https://github.com/carbon-language/carbon-proposals/pull/5#discussion_r423401993)
+  https://github.com/carbon-language/carbon-proposals/pull/5#discussion_r423401993
   and
-  [https://github.com/carbon-language/carbon-proposals/pull/5/files/a51ff951561accfb4aee403d7add6e8e69009ce1#r423401993](https://github.com/carbon-language/carbon-proposals/pull/5/files/a51ff951561accfb4aee403d7add6e8e69009ce1#r423401993)
+  ttps://github.com/carbon-language/carbon-proposals/pull/5/files/a51ff951561accfb4aee403d7add6e8e69009ce1#r423401993
   are equivalent, but the replied-to-comment is only visible in the file view.
   - This may be particularly visible as an issue if high-level discussions are
     often not line-specific.
@@ -808,7 +807,8 @@ Cons:
 https://gsuite.google.com/marketplace/app/code_blocks/100740430168
 
 This is another code formatting tool, but doesn't seem to work as well as
-Google's internal-only equivalent. Google's internal-only equivalent happens to do some syntax highlighting, whereas Code blocks does none.
+Google's internal-only equivalent. Google's internal-only equivalent happens to
+do some syntax highlighting, whereas Code blocks does none.
 
 Pros:
 


### PR DESCRIPTION
Note this proposal dates to 2020-04-08, even though the PR is new.

- [Draft proposal doc](https://docs.google.com/document/d/1LSR63t3MU4iGvwJKGQwYVH_BToziRAKTCOCdZYItOEw)
- [RFC](https://forums.carbon-lang.dev/t/rfc-carbon-proposal-tracking/26)
- [Decision request](https://forums.carbon-lang.dev/t/request-for-decision-carbon-proposal-tracking/51)
- [Decision announcement](https://forums.carbon-lang.dev/t/accepted-carbon-proposal-tracking/58)
- [Implementation PR](https://github.com/carbon-language/carbon-lang/pull/45)