### PR TITLE
Deduplicate Jekyll titles.

### DIFF
--- a/src/jekyll/theme/css/customstyles.css
+++ b/src/jekyll/theme/css/customstyles.css
@@ -1200,7 +1200,6 @@ h4.panel-title {
 }
 
 /** Hide the title because it's repeated above the TOC. */
-/** TODO: A right-hand-side TOC might be nice, eliminating the post title. */
 h1.post-title-main {
   display: block;
 }


### PR DESCRIPTION
In the future, it may be nice to move the TOC to the RHS, which would remove the need for the injected title. For now, this seems like the quick-and-simple fix.