### PR TITLE
Extend final comment period to 7 days

### DIFF
--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -380,12 +380,12 @@ The review manager is responsible for validating that the proposal is ready for
 the reviewing team to make a decision. They will ensure that at least a couple
 members of the reviewing team have reviewed the document before it leaves RFC.
 
-The review manager will announce a planned end to the community comment period on the "Evolution > RFCs" topic. The message will specify the end date, which
-will be at least one week (or four working days, if longer) after
-the announcement. If nothing significant arises, the
-reviewing team will be asked to start making a decision as scheduled. Otherwise,
-the review manager may extend the comment period by posting another message to
-the "Evolution > RFCs" topic.
+The review manager will announce a planned end to the community comment period
+on the "Evolution > RFCs" topic. The message will specify the end date, which
+will be at least one week (or four working days, if longer) after the
+announcement. If nothing significant arises, the reviewing team will be asked to
+start making a decision as scheduled. Otherwise, the review manager may extend
+the comment period by posting another message to the "Evolution > RFCs" topic.
 
 ##### Actions
 


### PR DESCRIPTION
This is the implementation of the [proposal 0004](https://github.com/carbon-language/carbon-proposals/issues/4), "Carbon: Change comment/decision timelines in proposal process", which was approved on Jun 2, 2020.