### PR TITLE
Adjust style of evolution doc

### DIFF
--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -155,9 +155,9 @@ should typically bias towards maintaining the status quo and letting the
 proposal come back with more information rather than overriding it. It is
 expected to be relatively rare that the arbiters need to take on this role.
 
-Arbiters may make a decision when at least two agree. If no two can agree the
-decision returns to the core team. For example, if an arbiter is unavailable,
-there may be a tie.
+Arbiters may make a decision when at least two agree. If no two can agree, then
+the decision returns to the core team. For example, if an arbiter is
+unavailable, there may be a tie.
 
 There should always be three arbiters.
 


### PR DESCRIPTION
- Sentence case headers: https://developers.google.com/style/headings
- Remove parentheticals where possible: https://developers.google.com/style/parentheses
- Avoid latin abbreviations: https://developers.google.com/style/abbreviations#dont-use

Also some evolution-specific changes:

- Remove obsolete PDF references
- "decision is to accept the proposal" instead of "decision is to approve the change"
- Adjust review manager actions for accepted/declined/deferred decisions.
- Rephrase arbiter decisions, particularly to avoid 1-0 being considered a "majority".
  - I think this was always intended, and does not reflect a substantive change.