### PR TITLE
Remove sharing message, it's not particular to proposals

### DIFF
--- a/proposals/p0044.md
+++ b/proposals/p0044.md
@@ -6,8 +6,6 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-**_PLEASE_ DO NOT SHARE OUTSIDE CARBON FORUMS**
-
 [Pull request](https://github.com/carbon-language/carbon-lang/pull/44)
 
 ## Table of contents

--- a/proposals/p0074.md
+++ b/proposals/p0074.md
@@ -6,8 +6,6 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-**_PLEASE_ DO NOT SHARE OUTSIDE CARBON FORUMS**
-
 [Pull request](https://github.com/carbon-language/carbon-lang/pull/74)
 
 ## Table of contents

--- a/proposals/template.md
+++ b/proposals/template.md
@@ -6,8 +6,6 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-**_PLEASE_ DO NOT SHARE OUTSIDE CARBON FORUMS**
-
 [Pull request](https://github.com/carbon-language/carbon-lang/pull/####)
 
 ## Table of contents


### PR DESCRIPTION
This sentence feels like a hold-over from the Google Doc, which still feels useful in that context. Especially because it's so easy to copy/share Docs outside the shared drive. However, for things going to GitHub, it seems like we should either have it everywhere or nowhere, and it doesn't feel helpful enough to have in every file.

My feeling would be different about a notice on the website -- that could be done centrally for all pages, and may be more useful. However, I haven't bothered there because we restrict access to docs, and I think the login flow should make it clearer that a lack of re-sharing is the intent.