### PR TITLE
Keyword extensibility

### DIFF
--- a/proposals/p0093.md
+++ b/proposals/p0093.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   - [Context sensitivity](#context-sensitivity)
   - [File-at-a-time transition](#file-at-a-time-transition)
   - [Reserved words](#reserved-words)
-    - [Open questions for reserved words](#open-questions-for-reserved-words)
+    - [Reserved words policy](#reserved-words-policy)
   - [Raw identifiers](#raw-identifiers)
   - [Name lookup impact](#name-lookup-impact)
   - [Grammar impact](#grammar-impact)
@@ -69,14 +69,10 @@ functionality. One important lexical element is a word, such as `Foo` or `fn` or
 `Int`.
 
 An appearance of a word in a source file is a word token. There are two
-different kinds of word tokens:
-
-- A _keyword token_, which matches a terminal symbol for that specific word in
-  grammar productions. For example, the grammar production for a function
-  declaration includes a reference to the word `fn`, which will only match a
-  keyword token for the word `fn`.
-
-- An _identifier token_, which matches the terminal symbol _identifier_.
+different kinds of word tokens: _keyword tokens_ and _identifier tokens_.
+Keyword tokens affect how the program is parsed, for example by introducing a
+specific grammar production, whereas all identifier tokens are treated
+equivalently by the grammar.
 
 Example:
 
@@ -85,15 +81,17 @@ Example:
 > ```
 >
 > Here, the `fn` token is a keyword token and the `Foo` token is an identifier
-> token.
+> token. This program would parse in the same way if `Foo` were replaced by any
+> other identifier token, but replacing `fn` with any other word token would
+> change at least the grammatical structure -- and very likely also the validity
+> -- of the program.
 
-A word is a _keyword_ if it appears as a terminal symbol in any grammar
-production -- that is, if it can meaningfully be used as a keyword token. The
-set of keywords is expected to change over time.
+A word is a _keyword_ if it can meaningfully be used as a keyword token. The set
+of keywords is expected to change over time.
 
 For each word token, we must decide whether to treat it as a keyword token or an
-identifier token. Traditionally, this choice depends only on the word: if the
-word is a keyword, the word token is a keyword token, and otherwise the word
+identifier token. Traditionally, this choice depends only on the spelling: if
+the word is a keyword, the word token is a keyword token, and otherwise the word
 token is an identifier token. This proposal suggests a different choice,
 depending on the context in which the word appears.
 
@@ -138,8 +136,8 @@ See also
   is a keyword, they are keyword tokens. Otherwise, the usage is invalid.
 
 - Within each source file, we require a consistent choice to be made: either
-  every word token for a given word is an identifier token or every word token
-  for that word is a keyword token.
+  every word token with a given spelling is an identifier token or every word
+  token with that spelling is a keyword token.
 
 - We have a set of _reserved words_, which are not allowed to be used as
   identifier tokens. These might be keywords, or they might be words with
@@ -157,14 +155,14 @@ incrementally, one file at a time. In each file, declarations and uses of the
 word that are not part of an externally-visible API can be renamed to a
 different word, and the remaining uses can be changed to use raw identifier
 syntax. Finally, once a suitable transition period has completed, the word can
-optionally be added to the set of reserved words.
+be added to the set of reserved words.
 
 ## Details
 
 ### Context sensitivity
 
-A declaration of a name causes name lookup for that word in the same lexical
-scope to find the entity declared. For example:
+A declaration of a name causes any name lookups for that word in the same
+lexical scope to find the entity declared. For example:
 
 ```
 // Declares 'x'.
@@ -175,10 +173,11 @@ return x;
 
 Each such declaration contains a word token that specifies the name bound by
 that declaration. In the example above, this is the first `x` token. Every other
-word token in a Carbon program is looked up by recursively searching outwards
-through lexical scopes until a lexical scope is encountered in which the word is
-declared. If the outermost lexical scope of the file is encountered, the prelude
--- which contains declarations of words such as `Int` -- is searched.
+word token in a Carbon program is looked up by recursively searching upwards and
+outwards through lexical scopes until a lexical scope is encountered in which
+the word is declared. If the outermost lexical scope of the file is encountered,
+the prelude -- which contains declarations of words such as `Int` -- is
+searched.
 
 If this lookup finds nothing, then the word token is instead interpreted as a
 keyword token. Note that if the word is not a keyword, this will result in an
@@ -263,6 +262,15 @@ access a member `x.yield` even in a source file where `yield` is used as a
 keyword token, and `X(.yield = 123)` is similarly unproblematic in such a source
 file.
 
+This restriction also does not apply to names in the prelude. There is no
+fundamental reason that we could not apply such a restriction to prelude names,
+or remove this restriction from keywords. The rationale for imposing this
+restriction on keywords but not on prelude names is that the distinction between
+a keyword and an identifier can change the grammatical structure of the program,
+which is a much more fundamental change to the meaning of the program than
+affecting which entity a name is bound to. We should revisit this decision when
+we decide how to handle name shadowing for prelude names.
+
 ### Reserved words
 
 We may want to disallow using some keywords as identifier tokens in cases where
@@ -280,20 +288,14 @@ there is no evolutionary benefit to permitting such use. For example:
   are keywords in C++, to discourage Carbon code from conflicting with expected
   language evolution paths or with our interoperability goal.
 
-We might introduce keywords that we never intend to reserve. For example, we
-might choose to never reserve the word `yield`, on the basis that it is a useful
-noun that is important in several industries and domains such as finance and
-manufacturing, but still use it as a keyword in the context of generators.
-
-This proposal suggests that we classify some possibly-empty set of words as
-_reserved_. A declaration that would bind a reserved word is invalid.
-Consequently, in a valid program, every word token naming a reserved word is a
-keyword token. However, this proposal does not suggest reserving any words.
+This proposal suggests that we classify some set of words as _reserved_. A
+declaration that would bind a reserved word is invalid. Consequently, in a valid
+program, every word token naming a reserved word is a keyword token.
 
 [Designators](#designators) and [raw identifiers](#raw-identifiers) are allowed
 to name reserved words.
 
-#### Open questions for reserved words
+#### Reserved words policy
 
 We should establish a reserved words policy. In particular, we should choose:
 
@@ -304,12 +306,12 @@ We should establish a reserved words policy. In particular, we should choose:
 - How long a notice period is provided after determining the intent to reserve a
   word, before reserving it?
 
-The intent is for these questions to be answered separately from this proposal;
-this proposal seeks to create a framework within which such a policy decision
-can be established.
-
-Until such a policy is established, proposals should not perform ad-hoc
-reservation of words, and instead, no words should be reserved.
+This proposal suggests an initial policy: we plan to eventually reserve every
+non-experimental keyword. The Carbon community should expect that every keyword
+that we add as part of a non-experimental language feature will become reserved,
+and respond accordingly. However, this proposal suggests no specific timeline
+for reserving a keyword after its addition; such a decision should be made on a
+case-by-case basis.
 
 ### Raw identifiers
 


### PR DESCRIPTION
This proposal presents a path for allowing new keywords to be added to the Carbon language in a backwards-compatible fashion. This path places restrictions on various parts of the Carbon design, including how we design grammar productions and the process by which name lookup is performed, but in exchange allows us to guarantee that new keywords can be added and adopted incrementally.

RFC: https://forums.carbon-lang.dev/t/rfc-keyword-extensibility/84