### PR TITLE
Stop specifying the full python version for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:


### PR DESCRIPTION
python3.6 causes weird venv issues for at least josh11b -- not sure why. 

```
$ ls -l /usr/bin/python3.6
-rwxr-xr-x 2 root root 4538776 Jan  2  2019 /usr/bin/python3.6*
$ virtualenv -p python3.6 venv
RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.6'
```