### PR TITLE
Numeric literal semantics

### DIFF
--- a/proposals/p0144.md
+++ b/proposals/p0144.md
@@ -22,6 +22,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Implicit conversions](#implicit-conversions)
     -   [Examples](#examples)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Use an ordinary integer or floating-point type for literals](#use-an-ordinary-integer-or-floating-point-type-for-literals)
+    -   [Use same type for all literals](#use-same-type-for-all-literals)
+    -   [Allow leading `-` in literal tokens](#allow-leading---in-literal-tokens)
 
 <!-- tocstop -->
 
@@ -111,7 +114,8 @@ The following types are defined in the Carbon prelude:
     class BigInt;
     ```
 
--   A rational type, parameterized by a type used for its numerator and denominator.
+-   A rational type, parameterized by a type used for its numerator and
+    denominator.
 
     ```
     class Rational(T:! Type);
@@ -231,7 +235,11 @@ var v: i8 = OneHigher(255);
 
 ## Alternatives considered
 
-We could decide on a type based on the form of the literal.
+### Use an ordinary integer or floating-point type for literals
+
+We could decide on a fixed-width type based on the form of the literal, for
+example using a type suffix with some rules to determine what type to pick for
+unsuffixed literals.
 
 Advantages:
 
@@ -248,8 +256,10 @@ Disadvantages:
 -   May select types that don't match the programmer's expectations.
 -   Whatever types we pick are privileged.
 
-We could give literals a single, arbitrary-precision type (say, `Integer` and
-`Rational`) that is usable only at compile time.
+### Use same type for all literals
+
+We could give literals a single, arbitrary-precision type (say, `Integer` for
+integer literals and `Rational` for real literals).
 
 Advantages:
 
@@ -264,10 +274,8 @@ Advantages:
     ```
     fn OneHigher(template L:! Integer);
     ```
-    However, this problem could be solved for `IntLiteral` by adding an
-    `AnyIntLiteral` interface if we think it's pressing. Also, with this
-    proposal, a function taking any integer expression that can be evaluated to
-    a constant can be written as
+    However, with this proposal, a function taking any integer expression that
+    can be evaluated to a constant can be written as
     ```
     fn F(template N:! BigInt);
     ```
@@ -281,14 +289,17 @@ Disadvantages:
     Supporting `impl` selection based on values would introduce substantial
     complexity.
 -   If we introduce an arbitrary-precision integer type, it would be
-    inconsistent to support it only during compilation.
--   Such a type would be expensive, and programs may use it accidentally. For
-    example, `var x: auto = 123;` would result in `x` having an
-    infinite-precision type, possibly involving invisible dynamic allocation.
-    Under this proposal, the type of `x` is a type that can only represent the
-    value `123`; as such, `x` is effectively immutable. The arbitrary-precision
-    integer type introduced in this proposal can only be used explicitly by
-    programs naming it.
+    inconsistent to support it only during compilation. However, if we allow its
+    use at runtime, programs may use it accidentally, with an invisible
+    performance cost. For example, `var x: auto = 123;` would result in `x`
+    having an infinite-precision type, possibly involving invisible dynamic
+    allocation.
+    -   Under this proposal, the type of `x` is a type that can only represent
+        the value `123`; as such, `x` is effectively immutable. The
+        arbitrary-precision integer type introduced in this proposal can only be
+        used explicitly by programs naming it.
+
+### Allow leading `-` in literal tokens
 
 We could treat a leading `-` character as part of a numeric literal token, so
 that -- for example -- `-123` would be a single `-123` token rather than a unary


### PR DESCRIPTION
This proposal provides semantics for numeric literals.

* Numeric literals have a type derived from their value, and can be converted to any type that can represent that value.

* Simple operations such as arithmetic that involve only literals also produce values of literal types.

* Literals implicitly convert to types that can represent them.

* The Carbon prelude provides:
    * An arbitrary-precision integer type `BigInt`.
    * A rational number type `Rational(T:! Type)` with constraints on `T` not yet determined.
    * A family of integer literal types, `IntLiteral(N:! BigInt)`.
    * A family of real literal types, `RealLiteral(N:! Rational(BigInt))`.

### Examples:

`42` has type `IntLiteral(42 as BigInt)`.
`5.2` has type `RealLiteral(5.2 as Rational(BigInt))`.

```
// This is OK: the initializer is of the integer literal type with value
// -2147483648 despite being written as a unary `-` applied to a literal.
var x: i32 = -2147483648;

// This initializes y to 2^60.
var y: i64 = 1 << 60;

// This forms a rational literal whose value is one third, and converts it to
// the nearest representable value of type `f64`.
var z: f64 = 1.0 / 3.0;

// This is an error: 300 cannot be represented in type `i8`.
var c: i8 = 300;
```