### PR TITLE
Update pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3
+  python: python3 # Defaults to python2, so override it.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
Sets the default_language_version to python3 because all of pre-commit-hooks needs it, and we're already specifying the same below in individual hooks. Everything (`pre-commit run --all-files` and `git commit`) seems to run fine with this configuration.