### PR TITLE
Fix markdown around link to BFloat16

### DIFF
--- a/docs/design/primitive_types.md
+++ b/docs/design/primitive_types.md
@@ -71,7 +71,7 @@ those sized IEEE-754 formats, and have the semantics defined by IEEE-754.
 ### BFloat16
 
 Carbon also supports the
-`[BFloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format)`
+[`BFloat16`](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format)
 format, a 16-bit truncation of a "binary32" IEEE-754 format floating point
 number.
 


### PR DESCRIPTION
I spotted what appears to be an unintentional backtick pair around the whole link, instead of just around the `BFloat16` part. Testing out the PR thing too!