### PR TITLE
Update pre-commit configuration to match changes to prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,8 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
         exclude: ^src/jekyll/theme/


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/9459 for details. Unclear whether this is a prettier bug or an npm bug, but pre-commit fails with new repositories without this change.