### PR TITLE
Make the rules for braces on `if`s and loops simpler and more strict.

### DIFF
--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -121,13 +121,12 @@ these.
     -   Use `{}` initialization without the `=` only if the above options don't
         compile.
     -   Never mix `{}` initialization and `auto`.
--   Always use braces for conditional and loop statements, even when the body
-    is a single statement.
+-   Always use braces for conditional, `switch`, and loop statements, even when
+    the body is a single statement.
+    -   Within a `switch` statement, use braces after a `case` label when
+        necessary to create a scope for a variable.
     -   Always break the line immediately after an open brace except for empty
         loop bodies.
--   Always use braces for switch statements.
-    -   Always break the line immediately after an open brace.
-    -   Use braces in cases when necessary to create a scope for a variable.
 
 ### Copyable and movable types
 


### PR DESCRIPTION
This simply requires braces and doesn't allow single-line `if`s. There
is some minor readability loss here, but it seems minor and provides
extremely simple rules which I'd value.

I can also trivially get clang-tidy to both check for this and
automatically fix code to conform.

Just sending this as a code review as it seems fully in the direction of
the style guide approved by the core team and I've heard no real
objections. That said, if anyone is concerned, I'm happy to take it
through the proposal process.