### PR TITLE
Publish interop goals

### DIFF
--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -17,11 +17,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Philsophy and goals
 
-The C++ interoperability layer of Carbon allows a
-subset of C++ APIs to be accessed in
-Carbon code, and similarly a subset of Carbon APIs to be accessed in C++ code. This requires expressing one
-language as a subset of the other. Bridge code may be needed to map some APIs into the relevant subset, but the constraints on expressivity should be
-loose enough to keep the amount of such bridge code sustainable.
+The C++ interoperability layer of Carbon allows a subset of C++ APIs to be
+accessed from Carbon code, and similarly a subset of Carbon APIs to be accessed
+from C++ code. This requires expressing one language as a subset of the other.
+Bridge code may be needed to map some APIs into the relevant subset, but the
+constraints on expressivity should be loose enough to keep the amount of such
+bridge code sustainable.
 
 The [interoperability philosophy and goals](philosophy_and_goals.md) provide
 more detail.

--- a/docs/design/interoperability/philosophy_and_goals.md
+++ b/docs/design/interoperability/philosophy_and_goals.md
@@ -82,11 +82,12 @@ Other language interoperability layers that may offer useful examples are:
 
 ## Philosophy
 
-The C++ interoperability layer of Carbon is the section wherein a specific,
-restricted set of C++ APIs can be expressed in a way that's callable from
-Carbon, and similar for calling Carbon from C++. This requires expressing one
-language as a subset of the other. The constraint of expressivity should be
-loose enough that the resulting amount of bridge code is sustainable.
+The C++ interoperability layer of Carbon allows a subset of C++ APIs to be
+accessed from Carbon code, and similarly a subset of Carbon APIs to be accessed
+from C++ code. This requires expressing one language as a subset of the other.
+Bridge code may be needed to map some APIs into the relevant subset, but the
+constraints on expressivity should be loose enough to keep the amount of such
+bridge code sustainable.
 
 The design for interoperability between Carbon and C++ hinges on:
 


### PR DESCRIPTION
This takes #175 and publishes it as interop goals. I've made a few small editorial changes, but the main addition is the "Offer equivalent support for languages other than C++" non-goal which I thought may be useful (in particular, it can be used to clarify why this directory is "interoperability" and not "interoperability_cpp").