### PR TITLE
Add a not-fully-functional C++ config for darwin

### DIFF
--- a/bazel/cc_toolchains/clang_toolchain.BUILD
+++ b/bazel/cc_toolchains/clang_toolchain.BUILD
@@ -20,8 +20,24 @@ filegroup(
 cc_toolchain_suite(
     name = "bazel_cc_toolchain",
     toolchains = {
+        "darwin": ":cc-compiler-darwin",
         "k8": ":cc-compiler-k8",
     },
+)
+
+cc_toolchain(
+    name = "cc-compiler-darwin",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 1,
+    toolchain_config = ":local",
+    toolchain_identifier = "local",
 )
 
 cc_toolchain(


### PR DESCRIPTION
This is necessary to be able to use bazel, even for non-C++ tooling (I'm trying to write some Python). I may try to get this to work better, but it's not trivial (for me at least) and I'd like to be able to work on the Python build.