### PR TITLE
Port Bazel toolchain and code to macOS (x86).

### DIFF
--- a/bazel/cc_toolchains/clang_toolchain.BUILD
+++ b/bazel/cc_toolchains/clang_toolchain.BUILD
@@ -26,21 +26,6 @@ cc_toolchain_suite(
 )
 
 cc_toolchain(
-    name = "cc-compiler-darwin",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local",
-    toolchain_identifier = "local",
-)
-
-cc_toolchain(
     name = "cc-compiler-k8",
     all_files = ":empty",
     ar_files = ":empty",
@@ -51,10 +36,31 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 1,
-    toolchain_config = ":local",
-    toolchain_identifier = "local",
+    toolchain_config = ":local-k8",
+    toolchain_identifier = "local-k8",
 )
 
 cc_toolchain_config(
-    name = "local",
+    name = "local-k8",
+    target_cpu = "k8",
+)
+
+cc_toolchain(
+    name = "cc-compiler-darwin",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 1,
+    toolchain_config = ":local-darwin",
+    toolchain_identifier = "local-darwin",
+)
+
+cc_toolchain_config(
+    name = "local-darwin",
+    target_cpu = "darwin",
 )

--- a/source/source_buffer.cpp
+++ b/source/source_buffer.cpp
@@ -54,7 +54,12 @@ auto SourceBuffer::CreateFromFile(llvm::StringRef filename)
   }
 
   errno = 0;
-  void* mapped_text = mmap(nullptr, size, PROT_READ, MAP_PRIVATE | MAP_POPULATE,
+  void* mapped_text = mmap(nullptr, size, PROT_READ,
+#ifdef __APPLE__
+                           MAP_PRIVATE,
+#else
+                           MAP_PRIVATE | MAP_POPULATE,
+#endif
                            file_descriptor, /*offset=*/0);
   if (mapped_text == MAP_FAILED) {
     return ErrnoToError(errno);


### PR DESCRIPTION
This updates the Bazel toolchain logic to work on macOS. Much like on
Linux, I'm not testing this against a *released* LLVM, but against
a from-source build. You can build and install LLVM from top-of-tree
locally with CMake, or on macOS maybe use Homebrew like:
```
brew install llvm --HEAD
```

You then need to point Bazel to the installed `clang` executable if it
is not placed onto your PATH (Homebrew doesn't):
```
bazel test --repo_env=CC=$HOME/homebrew/opt/llvm/bin/clang //parser:all
```

This builds and passes tests for me at least.

The fuzzer feature may not work (yet) with this setup, but that can be
improved incrementally as we proceed.