### PR TITLE
Use new name for "Google Meet"

### DIFF
--- a/docs/project/consensus_decision_making.md
+++ b/docs/project/consensus_decision_making.md
@@ -88,8 +88,7 @@ it can cite the now pertinent goals, priorities and principles.
 
 In order to ensure we can rapidly make decisions, each team will have a standing
 weekly meeting slot, which observers may attend. Members are expected to do
-their best to keep the slot available. Meetings will be held using Google
-Hangouts Meet.
+their best to keep the slot available. Meetings will be held using Google Meet.
 
 Each time a team needs to make a decision, for example, about a change to
 Carbon, it is expected that we'll try to make a decision without using a live

--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -79,8 +79,7 @@ We use several tools to coordinate changes to Carbon:
         get summarized on a relevant Discourse Forum topic.
 -   **Google Docs** may be used for early draft proposals. This facilitates
     collaborative editing and easy commenting about wording issues.
--   **Google Hangouts Meet** will be used for VC meetings, typically for
-    decisions.
+-   **Google Meet** will be used for VC meetings, typically for decisions.
     -   Meetings should typically be summarized on a relevant Discourse Forum
         topic.
 -   **Google Calendar** will be used to track team meeting and vacation times.


### PR DESCRIPTION
https://www.theverge.com/2020/4/8/21214059/google-hangouts-meet-rebrand-video-chat-conferencing