### PR TITLE
Remove text about creating open question issues without a decision.

### DIFF
--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -344,9 +344,8 @@ approach.
 
 ##### Actions
 
--   **Author**:
-    -   Update the proposal and/or reply to comments to address feedback.
-    -   Create GitHub issues for any open questions to be revisited later.
+-   **Author**: Update the proposal and/or reply to comments to address
+    feedback.
 -   **Reviewing team and community**: Provide
     [constructive commentary](commenting_guidelines.md) for proposals.
 


### PR DESCRIPTION
This isn't reflected in the above text, not sure how it managed to remain. There is still a note about filing issues for open questions at https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/consensus_decision_making.md#formal-decision-content, but I think it's much clearer when it's part of the core team's decision, rather than during proposal iteration.