### PR TITLE
pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: 6e2418c5521b7d606e72914dced3253f9ace1205 # frozen: v3.4.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,7 +25,7 @@ repos:
         args: ['--fix=lf']
       - id: trailing-whitespace
   - repo: https://github.com/google/pre-commit-tool-hooks
-    rev: v1.1.1
+    rev: 1d04a2848ac54d64bd6474ccec69aac45fa88414 # frozen: v1.1.1
     hooks:
       - id: check-copyright
         args:
@@ -38,7 +38,7 @@ repos:
       - id: check-google-doc-style
       - id: markdown-toc
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: 67c489d36dd4c52cbb9e4755d90c35c6231842ef # frozen: v2.0.0
     hooks:
       - id: codespell
         args: ['-I', '.codespell_ignore']
@@ -54,7 +54,7 @@ repos:
         pass_filenames: false
   # Formatters should be run late so that they can re-format any prior changes.
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: e66be67b9b6811913470f70c28b4d50f94d05b22 # frozen: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/jlebar/pre-commit-hooks.git
@@ -64,13 +64,13 @@ repos:
       - id: clang-format-whole-file
         types: [c++]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: 8e0d199f4004a7f226ed7974fc3883d9c702bded # frozen: v2.2.1
     hooks:
       - id: prettier
         exclude: ^website/jekyll/theme/
   # Run linters last, as formatters and other checks may fix issues.
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: bb6a530e28acab8d3551043b3e8709db8bcbac6b # frozen: 3.8.4
     hooks:
       - id: flake8
 


### PR DESCRIPTION
Revs are from `pre-commit autoupdate` (jlebar isn't providing versions, thus the sha, but this does silence a warning from `pre-commit`).

The migration to the new prettier location is manual, but noted at https://github.com/prettier/pre-commit

Manually validated with `pre-commit run --all-files`