### PR TITLE
Make the jekyll build components manual.

### DIFF
--- a/website/jekyll/BUILD
+++ b/website/jekyll/BUILD
@@ -54,6 +54,7 @@ genrule(
     ],
     outs = ["jekyll_site.tgz"],
     cmd = "$(location jekyll_site.sh) $(location :gen_sidebar.html) $@",
+    tags = ["manual"],
     tools = ["jekyll_site.sh"],
 )
 
@@ -64,10 +65,12 @@ sh_binary(
         ":configs",
         ":jekyll_site.tgz",
     ],
+    tags = ["manual"],
 )
 
 sh_binary(
     name = "publish",
     srcs = ["publish.sh"],
     data = [":jekyll_site.tgz"],
+    tags = ["manual"],
 )


### PR DESCRIPTION
Without this, `rbenv` and `jekyll` need to be installed to make `//...`
build and test cleanly, which seems low-value to require for
contributors. The python tests seem more useful to keep running as they
exercise code that contributors are likely to utilize.