### PR TITLE
Quick fix for master->main branch rename

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,8 +10,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # infrastructure that provides direct CMake interfacing support.
 http_archive(
     name = "rules_foreign_cc",
-    strip_prefix = "rules_foreign_cc-master",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/master.zip",
+    strip_prefix = "rules_foreign_cc-main",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/main.zip",
 )
 
 # Add Bazel's python rules.


### PR DESCRIPTION
Done in https://github.com/bazelbuild/rules_foreign_cc/issues/472, sounds like they'll add a workaround but this is probably de facto the new state.