### PR TITLE
use a proof-of-work return type for Lex* functions

### DIFF
--- a/lexer/tokenized_buffer.cpp
+++ b/lexer/tokenized_buffer.cpp
@@ -601,7 +601,7 @@ class TokenizedBuffer::Lexer {
     // Consumes (and discard) a valid token to construct a result
     // indicating a token has been produced.
     LexResult(Token) : LexResult(true) {}
-    
+
     // Returns a result indicating no token was produced.
     static LexResult NoMatch() { return LexResult(false); }
 


### PR DESCRIPTION
It's not obvious what the `bool` return type from `Lex*` mean, so replace it with a proof-of-work type that requires the function to either provide a `Token` as evidence that it lexed something or to say "no match".

This is a trial balloon for a more general style I'd like us to consider adopting across the codebase. (For example, adding an `ErrorTag` type that can only be created by producing an error diagnostic, and that is necessary as input to a function to mark an AST node invalid or perform error recovery. This would have caught quite a few bugs in Clang.)