### PR TITLE
Attempt to download a prebuilt toolchain.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,6 @@
 build --crosstool_top=@bazel_cc_toolchain
 build --host_crosstool_top=@bazel_cc_toolchain
 
-build:force_local_bootstrap --repo_env=BAZEL_FORCE_LOCAL_BOOTSTRAP_BUILD=1
+build:force_local_bootstrap --repo_env=CARBON_FORCE_LOCAL_BOOTSTRAP_BUILD=1
 
 build:fuzzer --features=fuzzer

--- a/bazel/cc_toolchains/clang_bootstrap.bzl
+++ b/bazel/cc_toolchains/clang_bootstrap.bzl
@@ -8,7 +8,7 @@ These rules are loaded as part of the `WORKSPACE`, and used by
 `clang_configuration.bzl`. The llvm-project submodule is used for the build.
 """
 
-FORCE_LOCAL_BOOTSTRAP_ENV = "BAZEL_FORCE_LOCAL_BOOTSTRAP_BUILD"
+FORCE_LOCAL_BOOTSTRAP_ENV = "CARBON_FORCE_LOCAL_BOOTSTRAP_BUILD"
 
 def _run(
         repository_ctx,


### PR DESCRIPTION
This is an alternative approach to #297 where instead of having separate toolchain repositories, where one always builds locally and the other always downloads, we have a single repository and attempt to download but fallback to a local build.

The goal here is to make this more seamless and a bit more resilient if/when we need to disable the download approach. We can add any further detection we need for incompatible host systems, and reliably have a fallback path available without needing to document different instructions for users.

The downside of this approach is that forcing the local build is a bit ugly as Bazel doesn't currently have any system for cleanly passing command line flags into repository rules. Instead, we use Bazel's support for manipulating their environment and a specially named environment variable to do this.