### PR TITLE
Add test coverage for a trailing comma in the alternatives list

### DIFF
--- a/executable_semantics/testdata/choice1.6c
+++ b/executable_semantics/testdata/choice1.6c
@@ -30,3 +30,10 @@ fn main() -> Int {
   }
   return n;
 }
+
+// Test some alternate syntaxes
+choice MoreInts {
+  None(),
+  One(Int),
+  Two(Int,Int),
+}

--- a/executable_semantics/testdata/choice1.golden
+++ b/executable_semantics/testdata/choice1.golden
@@ -27,6 +27,11 @@ n = 5;
 return n;
 
 }
+choice MoreInts {
+alt None ();
+alt One Int;
+alt Two (0 = Int, 1 = Int);
+}
 ********** type checking **********
 --- step exp () --->
 --- step exp Int --->
@@ -36,6 +41,13 @@ return n;
 --- step exp Int --->
 --- handle value Int with (0 = Int, 1 = Int)<2>(Int,Int,) --->
 --- step exp Int --->
+--- step exp () --->
+--- step exp Int --->
+--- step exp (0 = Int, 1 = Int) --->
+--- step exp Int --->
+--- handle value Int with (0 = Int, 1 = Int)<1>(Int,) --->
+--- step exp Int --->
+--- handle value Int with (0 = Int, 1 = Int)<2>(Int,Int,) --->
 --- step exp Int --->
 --- step exp auto --->
 13: type error in call


### PR DESCRIPTION
… and empty parentheses in an alternative declaration.