### PR TITLE
Trivial lexer cleanup

### DIFF
--- a/executable_semantics/syntax.lpp
+++ b/executable_semantics/syntax.lpp
@@ -9,11 +9,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "executable_semantics/syntax.tab.h"
 %}
 
-// Turn off legacy bits we don't need
+/* Turn off legacy bits we don't need */
 %option noyywrap nounput nodefault noinput
 
-// maintains the number of the current line read from input in the
-// global variable yylineno.
+/* maintains the number of the current line read from input in the
+   global variable yylineno.
+*/
 %option yylineno
 
 AND      "and"


### PR DESCRIPTION
Capturing progress before I move all of executable semantics syntax to a subdirectory