### PR TITLE
Separate parsing from type-checking and evaluation.

### DIFF
--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -14,20 +14,29 @@
 }
 
 %code requires {
+#include <optional>
+
 #include "executable_semantics/ast/declaration.h"
 #include "executable_semantics/ast/field_list.h"
 #include "executable_semantics/ast/function_definition.h"
+
+namespace Carbon {
+// A representation of the parsed program.
+using AST = std::list<Carbon::Declaration>*;
+}
+
 }
 
 %code {
 extern int yylineno;
 extern int yylex();
 
-void yyerror(char* error) {
+void yyerror(std::optional<Carbon::AST> const& parsedProgram, char* error) {
   Carbon::PrintSyntaxError(error, yylineno);
 }
-// void yyerror(char* error, ...);
 }
+
+%parse-param {std::optional<Carbon::AST>& parsedProgram}
 
 %union {
    char* str;
@@ -109,7 +118,7 @@ void yyerror(char* error) {
 %locations
 %%
 input: declaration_list
-    { Carbon::ExecProgram($1); }
+    { parsedProgram = $1; }
 ;
 pattern:
   expression

--- a/executable_semantics/testdata/undef2.golden
+++ b/executable_semantics/testdata/undef2.golden
@@ -1,4 +1,2 @@
-********** source program **********
-********** type checking **********
-error, program must contain a function named `main`
+executable_semantics/testdata/undef2.6c:7: syntax error
 EXIT CODE: 255


### PR DESCRIPTION
This change caused the syntax error in undef2.6c ("fun" instead of "fn") to be detected as one would expect, thus the changed golden file.