### PR TITLE
Try a convention from Jorg Brown that clarifies mutation.

### DIFF
--- a/executable_semantics/ast/declaration.h
+++ b/executable_semantics/ast/declaration.h
@@ -43,7 +43,7 @@ class Declaration {
   }
   void InitGlobals(Env& globals) const { return box->InitGlobals(globals); }
   auto TopLevel(ExecutionEnvironment& e) const -> void {
-    return box->TopLevel(e);
+    return box->TopLevel(*&e);
   }
 
  private:  // types
@@ -78,10 +78,10 @@ class Declaration {
       return content.TypeChecked(env, ct_env);
     }
     auto InitGlobals(Env& globals) const -> void override {
-      content.InitGlobals(globals);
+      content.InitGlobals(*&globals);
     }
     auto TopLevel(ExecutionEnvironment& e) const -> void override {
-      content.TopLevel(e);
+      content.TopLevel(*&e);
     }
   };
 

--- a/executable_semantics/interpreter/interpreter.cpp
+++ b/executable_semantics/interpreter/interpreter.cpp
@@ -262,7 +262,7 @@ Env globals;
 
 void InitGlobals(std::list<Declaration>* fs) {
   for (auto const& d : *fs) {
-    d.InitGlobals(globals);
+    d.InitGlobals(*&globals);
   }
 }
 

--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -650,7 +650,7 @@ auto TopLevel(std::list<Declaration>* fs) -> std::pair<TypeEnv, Env> {
     if (d.Name() == "main") {
       found_main = true;
     }
-    d.TopLevel(tops);
+    d.TopLevel(*&tops);
   }
 
   if (found_main == false) {

--- a/executable_semantics/main.cpp
+++ b/executable_semantics/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
   std::optional<Carbon::AST> parsedInput = std::nullopt;
 
   // Parse and handle syntax errors
-  auto syntaxErrorCode = yyparse(parsedInput);
+  auto syntaxErrorCode = yyparse(*&parsedInput);
   if (syntaxErrorCode != 0) {
     return syntaxErrorCode;
   }


### PR DESCRIPTION
Most mutating methods can be (and some operators are) named in a way that makes
the mutation obvious, but for other mutable reference (inout) parameters, it's
usually much less clear at the call site.  This commit uses a convention
suggested by Jorg Brown to mark arguments passed for mutation so they can be
easily seen.

(original push went to wrong repo).