### PR TITLE
Update proposals list

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -61,5 +61,6 @@ request:
     -   [0196 - Decision](p0196_decision.md)
 -   [0198 - Comments](p0198.md)
 -   [0199 - String literals](p0199.md)
+    -   [0199 - Decision](p0199_decision.md)
 
 <!-- endproposals -->


### PR DESCRIPTION
PR #280 committed the decision for #199. #199 had the proposal and no decision
and modified `README.md`. #280 had a decision but no proposal, and *didn't*
update `README.md`. However, in a tree with both the proposal *and* its
decision, another modification is necessary.

Since only one PR modified `README.md`, there wasn't a merge conflict that
required a rebase. And since there was no rebase, each PR ran its own CI
blissfully unaware of the other.

For now, committing the results of `pre-commit run --all-files` on trunk.
Later, will look into ways to make the proposal+decision workflow less likely
to break trunk.