### PR TITLE
Add extra parens to avoid clang-format divergence

### DIFF
--- a/lexer/numeric_literal.cpp
+++ b/lexer/numeric_literal.cpp
@@ -26,9 +26,10 @@ struct InvalidDigit {
   int radix;
 
   auto Format() -> std::string {
-    return llvm::formatv("Invalid digit '{0}' in {1} numeric literal.", digit,
-                         radix == 2 ? "binary"
-                                    : (radix == 16 ? "hexadecimal" : "decimal"))
+    return llvm::formatv(
+               "Invalid digit '{0}' in {1} numeric literal.", digit,
+               (radix == 2 ? "binary"
+                           : (radix == 16 ? "hexadecimal" : "decimal")))
         .str();
   }
 };


### PR DESCRIPTION
`clang-format-11` formats this multiple-ternary-operator expression differently than `clang-format-10` and `clang-format` at (current) trunk. Adding an extra set of parentheses brings them all in agreement, avoiding oscillation as folks check the file locally then submit to CI.