### PR TITLE
Exclude our build and test action from doc-only changes.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,23 @@ name: test
 on:
   push:
     branches: [trunk]
+    paths:
+      # Conservatively run the tests. However, skip them if the only paths in
+      # the pull request match files that we know don't impact the build.
+      - '**'
+      - '!**/*.md'
+      - '!LICENSE'
+      - '!CODEOWNERS'
+      - '!.git*'
   pull_request:
+    paths:
+      # Conservatively run the tests. However, skip them if the only paths in
+      # the pull request match files that we know don't impact the build.
+      - '**'
+      - '!**/*.md'
+      - '!LICENSE'
+      - '!CODEOWNERS'
+      - '!.git*'
 
 jobs:
   test:


### PR DESCRIPTION
No since spending the GitHub action minutes (or waiting to merge) on
Bazel when only changing markdown or other files that aren't part of the
build and test.