### PR TITLE
Fix casing and clang-tidy issues

### DIFF
--- a/executable_semantics/ast/abstract_syntax_tree.h
+++ b/executable_semantics/ast/abstract_syntax_tree.h
@@ -10,7 +10,9 @@
 #include "executable_semantics/ast/declaration.h"
 
 namespace Carbon {
+
 using AST = std::list<Carbon::Declaration>*;
-}
+
+}  // namespace Carbon
 
 #endif  // EXECUTABLE_SEMANTICS_AST_ABSTRACT_SYNTAX_TREE_H_

--- a/executable_semantics/interpreter/dictionary.h
+++ b/executable_semantics/interpreter/dictionary.h
@@ -40,17 +40,19 @@ class Dictionary {
     head = new ListNode<std::pair<K, V>>(std::make_pair(k, v), head);
   }
 
-  typedef ListNodeIterator<std::pair<K, V>> Iterator;
+  using Iterator = ListNodeIterator<std::pair<K, V>>;
 
   // The position of the first element of the dictionary
   // or `end()` if the dictionary is empty.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   auto begin() const -> Iterator { return Iterator(head); }
 
   // The position one past that of the last element.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   auto end() const -> Iterator { return Iterator(nullptr); }
 
  private:
-  Dictionary(ListNode<std::pair<K, V>>* h) : head(h) {}
+  explicit Dictionary(ListNode<std::pair<K, V>>* h) : head(h) {}
 
   ListNode<std::pair<K, V>>* head;
 };

--- a/executable_semantics/interpreter/interpreter.cpp
+++ b/executable_semantics/interpreter/interpreter.cpp
@@ -268,7 +268,7 @@ void InitGlobals(std::list<Declaration>* fs) {
 
 auto ChoiceDeclaration::InitGlobals(Env& globals) const -> void {
   auto alts = new VarValues();
-  for (auto kv : alternatives) {
+  for (const auto& kv : alternatives) {
     auto t = ToType(line_num, InterpExp(Env(), kv.second));
     alts->push_back(make_pair(kv.first, t));
   }
@@ -280,13 +280,12 @@ auto ChoiceDeclaration::InitGlobals(Env& globals) const -> void {
 auto StructDeclaration::InitGlobals(Env& globals) const -> void {
   auto fields = new VarValues();
   auto methods = new VarValues();
-  for (auto i = definition.members->begin(); i != definition.members->end();
-       ++i) {
-    switch ((*i)->tag) {
+  for (auto& member : *definition.members) {
+    switch (member->tag) {
       case MemberKind::FieldMember: {
         auto t =
-            ToType(definition.line_num, InterpExp(Env(), (*i)->u.field.type));
-        fields->push_back(make_pair(*(*i)->u.field.name, t));
+            ToType(definition.line_num, InterpExp(Env(), member->u.field.type));
+        fields->push_back(make_pair(*member->u.field.name, t));
         break;
       }
     }
@@ -314,15 +313,15 @@ void CallFunction(int line_num, std::vector<Value*> operas, State* state) {
     case ValKind::FunV: {
       // Bind arguments to parameters
       std::list<std::string> params;
-      std::optional<Env> envWithMatches = PatternMatch(
+      std::optional<Env> env_with_matches = PatternMatch(
           operas[0]->u.fun.param, operas[1], globals, &params, line_num);
-      if (!envWithMatches) {
+      if (!env_with_matches) {
         std::cerr << "internal error in call_function, pattern match failed"
                   << std::endl;
         exit(-1);
       }
       // Create the new frame and push it on the stack
-      auto* scope = new Scope(*envWithMatches, params);
+      auto* scope = new Scope(*env_with_matches, params);
       auto* frame = new Frame(*operas[0]->u.fun.name, Stack(scope),
                               Stack(MakeStmtAct(operas[0]->u.fun.body)));
       state->stack.Push(frame);
@@ -351,7 +350,7 @@ void CallFunction(int line_num, std::vector<Value*> operas, State* state) {
   }
 }
 
-void KillScope(int line_num, Scope* scope) {
+void KillScope(int /*line_num*/, Scope* scope) {
   for (const auto& l : scope->locals) {
     std::optional<Address> a = scope->env.Get(l);
     if (!a) {
@@ -441,12 +440,12 @@ auto PatternMatch(Value* p, Value* v, Env env, std::list<std::string>* vars,
               std::cerr << std::endl;
               exit(-1);
             }
-            std::optional<Env> envWithMatches = PatternMatch(
+            std::optional<Env> env_with_matches = PatternMatch(
                 state->heap[elt.second], state->heap[*a], env, vars, line_num);
-            if (!envWithMatches) {
+            if (!env_with_matches) {
               return std::nullopt;
             }
-            env = *envWithMatches;
+            env = *env_with_matches;
           }  // for
           return env;
         }
@@ -464,12 +463,12 @@ auto PatternMatch(Value* p, Value* v, Env env, std::list<std::string>* vars,
               *p->u.alt.alt_name != *v->u.alt.alt_name) {
             return std::nullopt;
           }
-          std::optional<Env> envWithMatches =
+          std::optional<Env> env_with_matches =
               PatternMatch(p->u.alt.arg, v->u.alt.arg, env, vars, line_num);
-          if (!envWithMatches) {
+          if (!env_with_matches) {
             return std::nullopt;
           }
-          return *envWithMatches;
+          return *env_with_matches;
         }
         default:
           std::cerr
@@ -482,13 +481,13 @@ auto PatternMatch(Value* p, Value* v, Env env, std::list<std::string>* vars,
     case ValKind::FunctionTV:
       switch (v->tag) {
         case ValKind::FunctionTV: {
-          std::optional<Env> envWithMatches = PatternMatch(
+          std::optional<Env> env_with_matches = PatternMatch(
               p->u.fun_type.param, v->u.fun_type.param, env, vars, line_num);
-          if (!envWithMatches) {
+          if (!env_with_matches) {
             return std::nullopt;
           }
           return PatternMatch(p->u.fun_type.ret, v->u.fun_type.ret,
-                              *envWithMatches, vars, line_num);
+                              *env_with_matches, vars, line_num);
         }
         default:
           return std::nullopt;
@@ -928,14 +927,14 @@ auto GetMember(Address a, const std::string& f) -> Address {
   }
 }
 
-void InsertDelete(Action* del, Stack<Action*>& todo) {
-  if (!todo.IsEmpty()) {
-    switch (todo.Top()->tag) {
+void InsertDelete(Action* del, Stack<Action*>* todo) {
+  if (!todo->IsEmpty()) {
+    switch (todo->Top()->tag) {
       case ActionKind::StatementAction: {
         // This places the delete before the enclosing statement.
         // Not sure if that is OK. Conceptually it should go after
         // but that is tricky for some statements, like 'return'. -Jeremy
-        todo.Push(del);
+        todo->Push(del);
         break;
       }
       case ActionKind::LValAction:
@@ -943,13 +942,13 @@ void InsertDelete(Action* del, Stack<Action*>& todo) {
       case ActionKind::ValAction:
       case ActionKind::ExpToLValAction:
       case ActionKind::DeleteTmpAction:
-        auto top = todo.Pop();
+        auto top = todo->Pop();
         InsertDelete(del, todo);
-        todo.Push(top);
+        todo->Push(top);
         break;
     }
   } else {
-    todo.Push(del);
+    todo->Push(del);
   }
 }
 
@@ -980,7 +979,7 @@ void HandleValue() {
       Address a = AllocateValue(act->results[0]);
       auto del = MakeDeleteAct(a);
       frame->todo.Pop(2);
-      InsertDelete(del, frame->todo);
+      InsertDelete(del, &frame->todo);
       frame->todo.Push(MakeValAct(MakePtrVal(a)));
       break;
     }
@@ -1186,17 +1185,17 @@ void HandleValue() {
             Value* v = act->results[0];
             Value* p = act->results[1];
 
-            std::optional<Env> envWithMatches =
+            std::optional<Env> env_with_matches =
                 PatternMatch(p, v, frame->scopes.Top()->env,
                              &frame->scopes.Top()->locals, stmt->line_num);
-            if (!envWithMatches) {
+            if (!env_with_matches) {
               std::cerr
                   << stmt->line_num
                   << ": internal error in variable definition, match failed"
                   << std::endl;
               exit(-1);
             }
-            frame->scopes.Top()->env = *envWithMatches;
+            frame->scopes.Top()->env = *env_with_matches;
             frame->todo.Pop(2);
           }
           break;
@@ -1280,10 +1279,10 @@ void HandleValue() {
             auto pat = act->results[clause_num + 1];
             auto env = CurrentEnv(state);
             std::list<std::string> vars;
-            std::optional<Env> envWithMatches =
+            std::optional<Env> env_with_matches =
                 PatternMatch(pat, v, env, &vars, stmt->line_num);
-            if (envWithMatches) {  // we have a match, start the body
-              auto* new_scope = new Scope(*envWithMatches, vars);
+            if (env_with_matches) {  // we have a match, start the body
+              auto* new_scope = new Scope(*env_with_matches, vars);
               frame->scopes.Push(new_scope);
               Statement* body_block = MakeBlock(stmt->line_num, c->second);
               Action* body_act = MakeStmtAct(body_block);

--- a/executable_semantics/interpreter/list_node.h
+++ b/executable_semantics/interpreter/list_node.h
@@ -5,6 +5,9 @@
 #ifndef EXECUTABLE_SEMANTICS_INTERPRETER_LIST_NODE_H_
 #define EXECUTABLE_SEMANTICS_INTERPRETER_LIST_NODE_H_
 
+#include <cstddef>
+#include <iterator>
+
 namespace Carbon {
 
 template <class T>
@@ -16,34 +19,43 @@ struct ListNode {
 
   // ListNode cells are part of a "persistent data structure" and are thus
   // immutable.
-  ListNode& operator=(const ListNode&) = delete;
-  ListNode& operator=(ListNode&&) = delete;
+  auto operator=(const ListNode&) -> ListNode& = delete;
+  auto operator=(ListNode&&) -> ListNode& = delete;
 };
 
 // A forward iterator over elements of a `ListNode` list.
 template <class T>
 struct ListNodeIterator {
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using value_type = T;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using difference_type = std::ptrdiff_t;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using pointer = const T*;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using reference = const T&;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using iterator_category = std::forward_iterator_tag;
 
-  ListNodeIterator(ListNode<T>* x) : p(x) {}
+  explicit ListNodeIterator(ListNode<T>* x) : p(x) {}
   ListNodeIterator(const ListNodeIterator& iter) : p(iter.p) {}
-  ListNodeIterator& operator++() {
+  auto operator++() -> ListNodeIterator& {
     p = p->next;
     return *this;
   }
-  ListNodeIterator operator++(int) {
+  auto operator++(int) -> ListNodeIterator {
     ListNodeIterator tmp(*this);
     operator++();
     return tmp;
   }
-  bool operator==(const ListNodeIterator& rhs) const { return p == rhs.p; }
-  bool operator!=(const ListNodeIterator& rhs) const { return p != rhs.p; }
-  const T& operator*() { return p->curr; }
-  const T* operator->() { return &p->curr; }
+  auto operator==(const ListNodeIterator& rhs) const -> bool {
+    return p == rhs.p;
+  }
+  auto operator!=(const ListNodeIterator& rhs) const -> bool {
+    return p != rhs.p;
+  }
+  auto operator*() -> const T& { return p->curr; }
+  auto operator->() -> const T* { return &p->curr; }
 
  private:
   ListNode<T>* p;

--- a/executable_semantics/interpreter/stack.h
+++ b/executable_semantics/interpreter/stack.h
@@ -13,65 +13,72 @@
 
 namespace Carbon {
 
-/// A persistent stack data structure.
-///
-/// - Note: this data structure leaks memory.
+// A persistent stack data structure.
+//
+// - Note: this data structure leaks memory.
 template <class T>
 struct Stack {
-  /// A forward iterator over elements of a `Stack`.
+  // A forward iterator over elements of a `Stack`.
   struct Iterator {
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using value_type = T;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using difference_type = std::ptrdiff_t;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using pointer = const T*;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using reference = const T&;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using iterator_category = std::forward_iterator_tag;
 
-    Iterator(ListNode<T>* x) : p(x) {}
+    explicit Iterator(ListNode<T>* x) : p(x) {}
     Iterator(const Iterator& mit) : p(mit.p) {}
-    Iterator& operator++() {
+    auto operator++() -> Iterator& {
       p = p->next;
       return *this;
     }
-    Iterator operator++(int) {
+    auto operator++(int) -> Iterator {
       Iterator tmp(*this);
       operator++();
       return tmp;
     }
-    bool operator==(const Iterator& rhs) const { return p == rhs.p; }
-    bool operator!=(const Iterator& rhs) const { return p != rhs.p; }
-    const T& operator*() { return p->curr; }
-    const T* operator->() { return &p->curr; }
+    auto operator==(const Iterator& rhs) const -> bool { return p == rhs.p; }
+    auto operator!=(const Iterator& rhs) const -> bool { return p != rhs.p; }
+    auto operator*() -> const T& { return p->curr; }
+    auto operator->() -> const T* { return &p->curr; }
 
    private:
     ListNode<T>* p;
   };
 
-  /// The position of the first/`Top()` element, or `end()` if
-  /// `this->IsEmpty()`.
+  // The position of the first/`Top()` element, or `end()` if
+  // `this->IsEmpty()`.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   auto begin() const -> Iterator { return Iterator(head); }
 
-  /// The position one past that of the last element.
+  // The position one past that of the last element.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   auto end() const -> Iterator { return Iterator(nullptr); }
 
-  /// Creates an empty instance.
+  // Creates an empty instance.
   Stack() { head = nullptr; }
 
-  /// Creates an instance containing just `x`.
-  Stack(T x) : Stack() { Push(x); }
+  // Creates an instance containing just `x`.
+  explicit Stack(T x) : Stack() { Push(x); }
 
-  /// Pushes `x` onto the top of the stack.
+  // Pushes `x` onto the top of the stack.
   void Push(T x) { head = new ListNode<T>(x, head); }
 
-  /// Returns a copy of `*this`, with `x` pushed onto the top.
+  // Returns a copy of `*this`, with `x` pushed onto the top.
   auto Pushing(T x) const -> Stack {
     auto r = *this;
     r.Push(x);
     return r;
   }
 
-  /// Removes and returns the top element of the stack.
-  ///
-  /// - Requires: !this->IsEmpty()
+  // Removes and returns the top element of the stack.
+  //
+  // - Requires: !this->IsEmpty()
   auto Pop() -> T {
     assert(!IsEmpty() && "Can't pop from empty stack.");
     auto r = head->curr;
@@ -79,9 +86,9 @@ struct Stack {
     return r;
   }
 
-  /// Removes the top `n` elements of the stack.
-  ///
-  /// - Requires: n >= 0 && n <= Count()
+  // Removes the top `n` elements of the stack.
+  //
+  // - Requires: n >= 0 && n <= Count()
   void Pop(int n) {
     assert(n >= 0 && "Negative pop count disallowed.");
     while (n--) {
@@ -90,46 +97,50 @@ struct Stack {
     }
   }
 
-  /// Returns a copy of `*this`, sans the top element.
-  ///
-  /// - Requires: !this->IsEmpty()
+  // Returns a copy of `*this`, sans the top element.
+  //
+  // - Requires: !this->IsEmpty()
   auto Popped() const -> Stack {
     auto r = *this;
     r.Pop();
     return r;
   }
 
-  /// Returns the top element of the stack.
-  ///
-  /// - Requires: !this->IsEmpty()
+  // Returns the top element of the stack.
+  //
+  // - Requires: !this->IsEmpty()
   auto Top() const -> T {
     assert(!IsEmpty() && "Empty stack has no Top().");
     return head->curr;
   }
 
-  /// Returns `true` iff `Count() > 0`.
-  auto IsEmpty() const -> bool { return head == nullptr; }
+  // Returns `true` iff `Count() > 0`.
+  [[nodiscard]] auto IsEmpty() const -> bool { return head == nullptr; }
 
-  /// Returns `true` iff `Count() > n`.
-  ///
-  /// - Complexity: O(`n`)
-  auto CountExceeds(int n) const -> bool {
-    if (n < 0)
+  // Returns `true` iff `Count() > n`.
+  //
+  // - Complexity: O(`n`)
+  [[nodiscard]] auto CountExceeds(int n) const -> bool {
+    if (n < 0) {
       return true;
+    }
 
     for (auto p = head; p != nullptr; p = p->next) {
-      if (n-- == 0)
+      if (n-- == 0) {
         return true;
+      }
     }
 
     return false;
   }
 
-  /// Returns the number of elements in `*this`.
-  auto Count() const -> int { return std::distance(begin(), end()); }
+  // Returns the number of elements in `*this`.
+  [[nodiscard]] auto Count() const -> int {
+    return std::distance(begin(), end());
+  }
 
  private:
-  /// An linked list of cells containing the elements of self.
+  // An linked list of cells containing the elements of self.
   ListNode<T>* head;
 };
 

--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -620,7 +620,7 @@ auto StructDeclaration::Name() const -> std::string { return *definition.name; }
 
 auto ChoiceDeclaration::Name() const -> std::string { return name; }
 
-auto StructDeclaration::TypeChecked(TypeEnv env, Env ct_env) const
+auto StructDeclaration::TypeChecked(TypeEnv /*env*/, Env /*ct_env*/) const
     -> Declaration {
   auto fields = new std::list<Member*>();
   for (auto& m : *definition.members) {
@@ -637,7 +637,7 @@ auto FunctionDeclaration::TypeChecked(TypeEnv env, Env ct_env) const
   return FunctionDeclaration(TypeCheckFunDef(definition, env, ct_env));
 }
 
-auto ChoiceDeclaration::TypeChecked(TypeEnv env, Env ct_env) const
+auto ChoiceDeclaration::TypeChecked(TypeEnv /*env*/, Env /*ct_env*/) const
     -> Declaration {
   return *this;  // TODO.
 }
@@ -677,7 +677,7 @@ auto StructDeclaration::TopLevel(ExecutionEnvironment& tops) const -> void {
 
 auto ChoiceDeclaration::TopLevel(ExecutionEnvironment& tops) const -> void {
   auto alts = new VarValues();
-  for (auto a : alternatives) {
+  for (const auto& a : alternatives) {
     auto t = ToType(line_num, InterpExp(tops.second, a.second));
     alts->push_back(std::make_pair(a.first, t));
   }

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -5,6 +5,7 @@
 #include "executable_semantics/interpreter/value.h"
 
 #include <iostream>
+#include <utility>
 
 #include "executable_semantics/interpreter/interpreter.h"
 
@@ -204,7 +205,7 @@ auto MakeChoiceTypeVal(std::string name,
   v->alive = true;
   v->tag = ValKind::ChoiceTV;
   // Transitional leak: when we get rid of all pointers, this will disappear.
-  v->u.choice_type.name = new std::string(name);
+  v->u.choice_type.name = new std::string(std::move(name));
   v->u.choice_type.alternatives = alts;
   return v;
 }

--- a/executable_semantics/main.cpp
+++ b/executable_semantics/main.cpp
@@ -11,28 +11,28 @@
 #include "executable_semantics/tracing_flag.h"
 #include "llvm/Support/CommandLine.h"
 
-int main(int argc, char* argv[]) {
+auto main(int argc, char* argv[]) -> int {
   // yydebug = 1;
 
   using llvm::cl::desc;
   using llvm::cl::opt;
-  opt<bool> quietOption("quiet", desc("Disable tracing"));
-  opt<std::string> inputFileName(llvm::cl::Positional, desc("<input file>"),
-                                 llvm::cl::Required);
+  opt<bool> quiet_option("quiet", desc("Disable tracing"));
+  opt<std::string> input_filename(llvm::cl::Positional, desc("<input file>"),
+                                  llvm::cl::Required);
 
   llvm::cl::ParseCommandLineOptions(argc, argv);
-  if (quietOption) {
+  if (quiet_option) {
     Carbon::tracing_output = false;
   }
 
-  std::variant<Carbon::AST, Carbon::SyntaxErrorCode> astOrError =
-      Carbon::parse(inputFileName);
+  std::variant<Carbon::AST, Carbon::SyntaxErrorCode> ast_or_error =
+      Carbon::Parse(input_filename);
 
-  if (auto* error = std::get_if<Carbon::SyntaxErrorCode>(&astOrError)) {
+  if (auto* error = std::get_if<Carbon::SyntaxErrorCode>(&ast_or_error)) {
     // Diagnostic already reported to std::cerr; this is just a return code.
     return *error;
   }
 
   // Typecheck and run the parsed program.
-  Carbon::ExecProgram(std::get<Carbon::AST>(astOrError));
+  Carbon::ExecProgram(std::get<Carbon::AST>(ast_or_error));
 }

--- a/executable_semantics/syntax/parse.cpp
+++ b/executable_semantics/syntax/parse.cpp
@@ -17,29 +17,29 @@ namespace Carbon {
 // Returns an abstract representation of the program contained in the
 // well-formed input file, or if the file was malformed, a description of the
 // problem.
-auto parse(const std::string& inputFileName)
+auto Parse(const std::string& input_filename)
     -> std::variant<AST, SyntaxErrorCode> {
-  yyin = fopen(inputFileName.c_str(), "r");
+  yyin = fopen(input_filename.c_str(), "r");
   if (yyin == nullptr) {
-    std::cerr << "Error opening '" << inputFileName
+    std::cerr << "Error opening '" << input_filename
               << "': " << std::strerror(errno) << std::endl;
     exit(1);
   }
 
-  std::optional<AST> parsedInput = std::nullopt;
-  ParseAndLexContext context(inputFileName);
+  std::optional<AST> parsed_input = std::nullopt;
+  ParseAndLexContext context(input_filename);
 
-  auto syntaxErrorCode = yy::parser(parsedInput, context)();
-  if (syntaxErrorCode != 0) {
-    return syntaxErrorCode;
+  auto syntax_error_code = yy::parser(parsed_input, context)();
+  if (syntax_error_code != 0) {
+    return syntax_error_code;
   }
 
-  if (parsedInput == std::nullopt) {
+  if (parsed_input == std::nullopt) {
     std::cerr << "Internal error: parser validated syntax yet didn't produce "
                  "an AST.\n";
     exit(1);
   }
-  return *parsedInput;
+  return *parsed_input;
 }
 
 }  // namespace Carbon

--- a/executable_semantics/syntax/parse.h
+++ b/executable_semantics/syntax/parse.h
@@ -17,7 +17,7 @@ using SyntaxErrorCode = int;
 
 // Returns the AST representing the contents of the named file, or an error code
 // if parsing fails.
-auto parse(const std::string& inputFileName)
+auto Parse(const std::string& input_filename)
     -> std::variant<Carbon::AST, SyntaxErrorCode>;
 
 }  // namespace Carbon

--- a/executable_semantics/syntax/parse_and_lex_context.cpp
+++ b/executable_semantics/syntax/parse_and_lex_context.cpp
@@ -13,7 +13,8 @@
 // the given line, to standard error.
 auto Carbon::ParseAndLexContext::PrintDiagnostic(const std::string& message,
                                                  int line_num) -> void {
-  std::cerr << inputFileName << ":" << line_num << ": " << message << std::endl;
+  std::cerr << input_filename << ":" << line_num << ": " << message
+            << std::endl;
   exit(-1);  // TODO: do we really want this here?  It makes the comment and the
              // name a lie, and renders some of the other yyparse() result
              // propagation code moot.

--- a/executable_semantics/syntax/parse_and_lex_context.h
+++ b/executable_semantics/syntax/parse_and_lex_context.h
@@ -17,11 +17,12 @@ namespace Carbon {
 class ParseAndLexContext {
  public:
   // Creates an instance analyzing the given input file.
-  ParseAndLexContext(const std::string& inputFile) : inputFileName(inputFile) {}
+  explicit ParseAndLexContext(std::string input_file)
+      : input_filename(std::move(input_file)) {}
 
   // Writes a syntax error diagnostic, containing message, for the input file at
   // the given line, to standard error.
-  auto PrintDiagnostic(const std::string& message, int lineNumber) -> void;
+  auto PrintDiagnostic(const std::string& message, int line_number) -> void;
 
   // The source range of the token being (or just) lex'd.
   yy::location currentTokenPosition;
@@ -29,7 +30,7 @@ class ParseAndLexContext {
  private:
   // A path to the file processed, relative to the current working directory
   // when *this is called.
-  const std::string inputFileName;
+  const std::string input_filename;
 };
 
 }  // namespace Carbon

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -26,7 +26,7 @@
 // thus available to its methods.
 
 // "out" parameter passed to the parser, where the AST is written.
-%parse-param {std::optional<Carbon::AST>& parsedProgram}
+%parse-param {std::optional<Carbon::AST>& parsed_program}
 
 // "inout" parameter passed to both the parser and the lexer.
 %param {Carbon::ParseAndLexContext& context}
@@ -55,7 +55,7 @@
 
 namespace Carbon {
 class ParseAndLexContext;
-}
+}  // namespace Carbon
 
 }
 
@@ -63,9 +63,7 @@ class ParseAndLexContext;
 
 extern int yylineno;
 
-void yy::parser::error(
-    const location_type&, const std::string& message)
-{
+void yy::parser::error(const location_type&, const std::string& message) {
   context.PrintDiagnostic(message, yylineno);
 }
 
@@ -150,7 +148,7 @@ void yy::parser::error(
 %locations
 %%
 input: declaration_list
-    { parsedProgram = $1; }
+    { parsed_program = $1; }
 ;
 pattern:
   expression
@@ -208,7 +206,7 @@ paren_expression: "(" field_list ")"
 	 !$2->has_explicit_comma) {
 	$$ = $2->fields->front().second;
      } else {
-        auto vec = new std::vector<std::pair<std::string,Carbon::Expression*>>(
+        auto vec = new std::vector<std::pair<std::string, Carbon::Expression*>>(
             $2->fields->begin(), $2->fields->end());
         $$ = Carbon::MakeTuple(yylineno, vec);
       }
@@ -216,7 +214,7 @@ paren_expression: "(" field_list ")"
 ;
 tuple: "(" field_list ")"
     {
-     auto vec = new std::vector<std::pair<std::string,Carbon::Expression*>>(
+     auto vec = new std::vector<std::pair<std::string, Carbon::Expression*>>(
          $2->fields->begin(), $2->fields->end());
      $$ = Carbon::MakeTuple(yylineno, vec);
     }


### PR DESCRIPTION
clang-tidy finds the casing issues, so I ended up leaning on it and fixing other warnings at the same time. The one thing clang-tidy found that I didn't fix was the use of reference parameters in ast/declaration.h; those should probably be pointers.