### PR TITLE
Format `WORKSPACE` with `buildifier`.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ llvm_zlib_system(name = "llvm_zlib")
 # Until then, this is pulling from that pull request's commit.
 http_archive(
     name = "rules_m4",
-    strip_prefix = "rules_m4-add-extra-copts",
     sha256 = "4d34917214e8890ad770bdf0c319c41c9201fffd770938b41a1d641d4b27e05c",
+    strip_prefix = "rules_m4-add-extra-copts",
     urls = ["https://github.com/chandlerc/rules_m4/archive/add-extra-copts.zip"],
 )
 
@@ -87,8 +87,8 @@ m4_register_toolchains(extra_copts = ["-w"])
 # Until then, this is pulling from that pull request's commit.
 http_archive(
     name = "rules_flex",
-    strip_prefix = "rules_flex-add-extra-copts",
     sha256 = "fd97c3ae23926507be1b95158a683cd41c628d201e852a325d38b5e9f821b752",
+    strip_prefix = "rules_flex-add-extra-copts",
     urls = ["https://github.com/chandlerc/rules_flex/archive/add-extra-copts.zip"],
 )
 
@@ -105,8 +105,8 @@ flex_register_toolchains(extra_copts = ["-w"])
 # Until then, this is pulling from that pull request's commit.
 http_archive(
     name = "rules_bison",
-    strip_prefix = "rules_bison-add-extra-copts",
     sha256 = "c6e926f15214d903966dc950d759ec69116db67f148be114c119e4def0551eaa",
+    strip_prefix = "rules_bison-add-extra-copts",
     urls = ["https://github.com/chandlerc/rules_bison/archive/add-extra-copts.zip"],
 )
 


### PR DESCRIPTION
This wasn't being caught by our `pre-commit` setup, I've sent the fix
here: https://github.com/jlebar/pre-commit-hooks/pull/9