### PR TITLE
Switch from manually tracking whether we've emitted any errors to asking the diagnostic machinery

### DIFF
--- a/diagnostics/diagnostic_emitter_test.cpp
+++ b/diagnostics/diagnostic_emitter_test.cpp
@@ -14,6 +14,7 @@ namespace Carbon {
 namespace {
 
 using Testing::DiagnosticAt;
+using Testing::DiagnosticLevel;
 using Testing::DiagnosticMessage;
 using Testing::DiagnosticShortName;
 using ::testing::ElementsAre;
@@ -47,12 +48,14 @@ TEST(DiagTest, EmitErrors) {
   Testing::MockDiagnosticConsumer consumer;
   DiagnosticEmitter<int> emitter(translator, consumer);
 
-  EXPECT_CALL(consumer, HandleDiagnostic(AllOf(
-                            DiagnosticAt(1, 1), DiagnosticMessage("error: M1"),
-                            DiagnosticShortName("fake-diagnostic"))));
-  EXPECT_CALL(consumer, HandleDiagnostic(AllOf(
-                            DiagnosticAt(1, 2), DiagnosticMessage("error: M2"),
-                            DiagnosticShortName("fake-diagnostic"))));
+  EXPECT_CALL(consumer, HandleDiagnostic(
+                            AllOf(DiagnosticLevel(Diagnostic::Error),
+                                  DiagnosticAt(1, 1), DiagnosticMessage("M1"),
+                                  DiagnosticShortName("fake-diagnostic"))));
+  EXPECT_CALL(consumer, HandleDiagnostic(
+                            AllOf(DiagnosticLevel(Diagnostic::Error),
+                                  DiagnosticAt(1, 2), DiagnosticMessage("M2"),
+                                  DiagnosticShortName("fake-diagnostic"))));
 
   emitter.EmitError<FakeDiagnostic>(1, {.message = "M1"});
   emitter.EmitError<FakeDiagnostic>(2, {.message = "M2"});
@@ -65,14 +68,14 @@ TEST(DiagTest, EmitWarnings) {
   Testing::MockDiagnosticConsumer consumer;
   DiagnosticEmitter<int> emitter(translator, consumer);
 
-  EXPECT_CALL(consumer,
-              HandleDiagnostic(AllOf(DiagnosticAt(1, 3),
-                                     DiagnosticMessage("warning: M1"),
-                                     DiagnosticShortName("fake-diagnostic"))));
-  EXPECT_CALL(consumer,
-              HandleDiagnostic(AllOf(DiagnosticAt(1, 5),
-                                     DiagnosticMessage("warning: M3"),
-                                     DiagnosticShortName("fake-diagnostic"))));
+  EXPECT_CALL(consumer, HandleDiagnostic(
+                            AllOf(DiagnosticLevel(Diagnostic::Warning),
+                                  DiagnosticAt(1, 3), DiagnosticMessage("M1"),
+                                  DiagnosticShortName("fake-diagnostic"))));
+  EXPECT_CALL(consumer, HandleDiagnostic(
+                            AllOf(DiagnosticLevel(Diagnostic::Warning),
+                                  DiagnosticAt(1, 5), DiagnosticMessage("M3"),
+                                  DiagnosticShortName("fake-diagnostic"))));
 
   emitter.EmitWarningIf<FakeDiagnostic>(3, [](FakeDiagnostic& diagnostic) {
     diagnostic.message = "M1";

--- a/diagnostics/mocks.h
+++ b/diagnostics/mocks.h
@@ -35,6 +35,10 @@ MATCHER_P2(DiagnosticAt, line, column, "") {
   return true;
 }
 
+auto DiagnosticLevel(Diagnostic::Level level) -> auto {
+  return testing::Field(&Diagnostic::level, level);
+}
+
 template <typename Matcher>
 auto DiagnosticMessage(Matcher&& inner_matcher) -> auto {
   return testing::Field(&Diagnostic::message,

--- a/lexer/numeric_literal.h
+++ b/lexer/numeric_literal.h
@@ -57,19 +57,11 @@ class LexedNumericLiteral::Parser {
     return literal.radix_point == static_cast<int>(literal.text.size());
   }
 
-  enum CheckResult {
-    // The token is valid.
-    Valid,
-    // The token is invalid, but we've diagnosed and recovered from the error.
-    RecoverableError,
-    // The token is invalid, and we've diagnosed, but we can't assign meaning
-    // to it.
-    UnrecoverableError,
-  };
-
   // Check that the numeric literal token is syntactically valid and
-  // meaningful, and diagnose if not.
-  auto Check() -> CheckResult;
+  // meaningful, and diagnose if not. Returns `true` if the token was
+  // sufficiently valid that we could determine its meaning. If `false` is
+  // returned, a diagnostic has already been issued.
+  auto Check() -> bool;
 
   // Get the radix of this token. One of 2, 10, or 16.
   auto GetRadix() -> int { return radix; }
@@ -119,9 +111,6 @@ class LexedNumericLiteral::Parser {
 
   // True if we found a `-` before `exponent_part`.
   bool exponent_is_negative = false;
-
-  // True if we produced an error but recovered.
-  bool recovered_from_error = false;
 };
 
 }  // namespace Carbon

--- a/lexer/numeric_literal_fuzzer.cpp
+++ b/lexer/numeric_literal_fuzzer.cpp
@@ -24,7 +24,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
 
   LexedNumericLiteral::Parser parser(NullDiagnosticEmitter<const char*>(),
                                      *token);
-  if (parser.Check() == LexedNumericLiteral::Parser::UnrecoverableError) {
+  if (!parser.Check()) {
     // Lexically OK, but token is meaningless.
     return 0;
   }

--- a/lexer/string_literal.h
+++ b/lexer/string_literal.h
@@ -23,16 +23,10 @@ class LexedStringLiteral {
   static auto Lex(llvm::StringRef source_text)
       -> llvm::Optional<LexedStringLiteral>;
 
-  // The result of expanding escape sequences in a string literal.
-  struct ExpandedValue {
-    std::string result;
-    bool has_errors;
-  };
-
   // Expand any escape sequences in the given string literal and compute the
-  // resulting value.
+  // resulting value. This handles error recovery internally and cannot fail.
   auto ComputeValue(DiagnosticEmitter<const char*>& emitter) const
-      -> ExpandedValue;
+      -> std::string;
 
  private:
   LexedStringLiteral(llvm::StringRef text, llvm::StringRef content,


### PR DESCRIPTION
This should be less error-prone and less repetitive than following up each `EmitError` call by setting a "saw an error" flag. To support this, start tracking the diagnostic level on the `Diagnostic` object.