### PR TITLE
Prove that we don't need a heap of optional<Value>...

### DIFF
--- a/executable_semantics/interpreter/interpreter.cpp
+++ b/executable_semantics/interpreter/interpreter.cpp
@@ -177,13 +177,10 @@ void PrintStack(Stack<Frame*> ls, std::ostream& out) {
   }
 }
 
-void PrintHeap(const std::vector<const Value*>& heap, std::ostream& out) {
-  for (auto& iter : heap) {
-    if (iter) {
-      PrintValue(iter, out);
-    } else {
-      out << "_";
-    }
+void PrintHeap(const VectorOfNonNull<Value>& heap, std::ostream& out) {
+  for (auto iter : heap) {
+    assert(iter && "null Value* in heap");
+    PrintValue(iter, out);
     out << ", ";
   }
 }
@@ -496,7 +493,7 @@ auto PatternMatch(const Value* p, const Value* v, Env env,
 void PatternAssignment(const Value* pat, const Value* val, int line_num) {
   switch (pat->tag) {
     case ValKind::PtrV:
-      state->heap[ValToPtr(pat, line_num)] = val;
+      state->heap.SetElement(ValToPtr(pat, line_num), val);
       break;
     case ValKind::TupleV: {
       switch (val->tag) {

--- a/executable_semantics/interpreter/interpreter.h
+++ b/executable_semantics/interpreter/interpreter.h
@@ -38,9 +38,41 @@ struct Frame {
       : name(std::move(std::move(n))), scopes(s), todo(c) {}
 };
 
+// Transitional declaration that helps us prove that the heap doesn't need to
+// represent null `Value*`s.  Goes away when const Value* is replaced by Value.
+template <class T>
+struct VectorOfNonNull {
+  VectorOfNonNull() = default;
+  auto push_back(const T* t) {
+    assert(t != nullptr);
+    impl.push_back(t);
+  }
+
+  auto size() -> typename std::vector<const T*>::size_type {
+    return impl.size();
+  }
+  auto begin() const -> typename std::vector<const T*>::const_iterator {
+    return impl.begin();
+  }
+  auto end() const -> typename std::vector<const T*>::const_iterator {
+    return impl.end();
+  }
+  auto operator[](typename std::vector<const T*>::difference_type i)
+      -> const T* {
+    return impl[i];
+  }
+  auto SetElement(typename std::vector<const T*>::difference_type i,
+                  const T* x) {
+    assert(x != nullptr);
+    impl[i] = x;
+  }
+
+  std::vector<const T*> impl;
+};
+
 struct State {
   Stack<Frame*> stack;
-  std::vector<const Value*> heap;
+  VectorOfNonNull<Value> heap;
   std::vector<bool> alive;
 };
 


### PR DESCRIPTION
...once we replace Value* with Value.

Temporarily replace the heap with a collection that asserts the invariant