### PR TITLE
Add bazel query flag to work around bug

### DIFF
--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -71,6 +71,7 @@ source_files_query = subprocess.run(
         "query",
         "--keep_going",
         "--output=location",
+        # Workaround for https://github.com/bazelbuild/bazel/issues/8900
         "--incompatible_display_source_file_location",
         'filter(".*\\.(h|cpp|cc|c|cxx)$", kind("source file", deps(//...)))',
     ],


### PR DESCRIPTION
Due to a [bug](https://github.com/bazelbuild/bazel/issues/8900), `--output=locations` does not behave as specified in some versions of Bazel, with the result that the generated `compile_commands.json` contains `BUILD` files in place of all non-generated C++ source files. This is [fixed](https://github.com/bazelbuild/bazel/commit/ac8b7490afc2c07b85cac281f3d9a4394b63c3bc) in Bazel 4.0.0, but only behind the `--incompatible_display_source_file_location` flag.