### PR TITLE
Add back `synchronize` events for deps.

### DIFF
--- a/.github/workflows/dependent-issues.yaml
+++ b/.github/workflows/dependent-issues.yaml
@@ -15,6 +15,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
   schedule:
     - cron: '0 0 * * *' # daily
 


### PR DESCRIPTION
This probably isn't exactly right, but it at least gives *some* low
latency way to update when all the dependencies have been addressed.
Right now, I think only the cron run will unblock dependent PRs.