### PR TITLE
Update CODEOWNERS for the carbon-leads switch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,25 +4,20 @@
 
 # Most of the repository consists of implementation code or other supporting
 # material for the implementation of Carbon. Rather than enumerate these, we
-# default them to implementation team ownership, which will be overridden by later
-# lines.
+# default them to implementation team ownership, which will be overridden by
+# later lines.
 *                   @carbon-language/implementation-team
-
-# Co-own top-level config files. Ownership is actually mixed, but low value to
-# separate. Top-level docs will be overridden as core-team-owned files.
 /*                  @carbon-language/implementation-team
 
-# The core team owns the core language and project documentation. The
+# Carbon leads own the core language and project documentation. The
 # implementation team has access for small (non-evolution) edits.
-/*.md               @carbon-language/core-team @carbon-language/implementation-team
-/docs/              @carbon-language/core-team @carbon-language/implementation-team
+/*.md               @carbon-language/carbon-leads @carbon-language/implementation-team
+/docs/              @carbon-language/carbon-leads @carbon-language/implementation-team
 
-# The review managers own updates to the proposals.
-/proposals/         @carbon-language/review-managers
+# Carbon leads should review proposals and license changes.
+/proposals/         @carbon-language/carbon-leads
+/LICENSE            @carbon-language/carbon-leads
 
-# The core team should review license changes.
-/LICENSE            @carbon-language/core-team
-
-# ACLs are owned by the admin team and handled last to avoid accidentally being
-# overridden by later patterns.
-CODEOWNERS          @carbon-language/admin-team
+# Carbon leads own ACLs. This is last to prevent other rules from accidentally
+# overriding it.
+CODEOWNERS          @carbon-language/carbon-leads


### PR DESCRIPTION
Note this removes core-team (per #426), review-managers (also #426), and admin-team (because carbon-leads is now 1 different from admin-team, and switching just makes sense to me).