### PR TITLE
Add sentinel precedence levels for the top-level expression context and for an expression with no operators.

### DIFF
--- a/parser/parser_impl.h
+++ b/parser/parser_impl.h
@@ -157,7 +157,7 @@ class ParseTree::Parser {
 
   // Parses an expression involving operators, in a context with the given
   // precedence.
-  auto ParseOperatorExpression(llvm::Optional<PrecedenceGroup> precedence)
+  auto ParseOperatorExpression(PrecedenceGroup precedence)
       -> llvm::Optional<Node>;
 
   // Parses an expression.

--- a/parser/precedence.h
+++ b/parser/precedence.h
@@ -37,6 +37,14 @@ class PrecedenceGroup {
   // functions below.
   PrecedenceGroup() = delete;
 
+  // Get the sentinel precedence level for a postfix expression. All operators
+  // should have lower precedence than this.
+  static auto ForPostfixExpression() -> PrecedenceGroup;
+
+  // Get the sentinel precedence level for a top-level expression context. All
+  // operators should have higher precedence than this.
+  static auto ForTopLevelExpression() -> PrecedenceGroup;
+
   // Look up the operator information of the given prefix operator token, or
   // return llvm::None if the given token is not a prefix operator.
   static auto ForLeading(TokenKind kind) -> llvm::Optional<PrecedenceGroup>;


### PR DESCRIPTION
Depends on #464.