### PR TITLE
Action needs public repo

### DIFF
--- a/.github/workflows/ready_for_review.yaml
+++ b/.github/workflows/ready_for_review.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update project column
-        uses: carbon-language/action-update-project@v1.0
+        uses: jonmeow/action-update-project@v1.0
         with:
           project_url: https://github.com/carbon-language/carbon-lang/projects/1
           column_name: RFC


### PR DESCRIPTION
Using `jonmeow` was how #496 was originally set up, but I tested with `carbon-language`. I assume we do not want a public repo under `carbon-language`, and so I've already transferred ownership back to `jonmeow` in order to have a public repo again.

https://github.com/carbon-language/carbon-lang/runs/2440951027?check_suite_focus=true