### PR TITLE
Disable ubsan vptr checks due to clang AST

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -441,6 +441,9 @@ def _impl(ctx):
             flag_groups = [flag_group(flags = [
                 "-fsanitize=address,undefined",
                 "-fsanitize-address-use-after-scope",
+                # Needed due to clang AST issues, such as in
+                # clang/AST/Redeclarable.h line 199.
+                "-fno-sanitize=vptr",
             ])],
         )],
     )


### PR DESCRIPTION
Sample error:

```
external/llvm-project/clang/include/clang/AST/Redeclarable.h:199:15: runtime error: downcast of address 0x621000017218 which does not point to an object of type 'clang::TypedefNameDecl'
0x621000017218: note: object is of type 'clang::TypeDecl'
 be be be be  d0 d5 1a 0c 00 00 00 00  00 00 00 00 00 00 00 00  30 69 01 00 10 62 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'clang::TypeDecl'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/llvm-project/clang/include/clang/AST/Redeclarable.h:199:15 in
```

Tested with https://github.com/carbon-language/carbon-lang/pull/512/files