### PR TITLE
Add missing clang includes to compile_flags.txt

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -75,6 +75,8 @@ bazel-bin/external/llvm-project/llvm/utils/unittest/googletest/include
 -nostdinc++
 -isystem
 bazel-clang-toolchain/include/c++/v1
+-isystem
+bazel-clang-toolchain/lib/clang/12.0.0/include
 -no-canonical-prefixes
 -Wno-builtin-macro-redefined
 -D__DATE__="redacted"


### PR DESCRIPTION
This is needed to fix issues like:

```
bazel-clang-toolchain/include/c++/v1/cstddef:44:15: fatal error: 'stddef.h' file not found
#include_next <stddef.h>
              ^~~~~~~~~~
```