### PR TITLE
Exclude migrate_cpp from GH testing action due to build overhead

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,12 +63,12 @@ jobs:
       - name: Build (${{ matrix.build_mode }})
         run: |
           bazelisk build -c ${{ matrix.build_mode }} --verbose_failures \
-            --deleted_packages=migrate_cpp \
+            --deleted_packages=migrate_cpp,migrate_cpp/cpp_refactoring \
             //...:all
 
       # Run all test targets.
       - name: Test (${{ matrix.build_mode }})
         run: |
           bazelisk test -c ${{ matrix.build_mode }} --test_output errors \
-            --deleted_packages=migrate_cpp \
+            --deleted_packages=migrate_cpp,migrate_cpp/cpp_refactoring \
             --verbose_failures //...:all


### PR DESCRIPTION
This is mainly as a consequence of #530. I see linux opt completed in 70m, others are still running; >90m. I think that's versus ~30m in general today.