### PR TITLE
Add caching to our tests to avoid clean rebuilds.

### DIFF
--- a/lexer/character_set.h
+++ b/lexer/character_set.h
@@ -14,16 +14,16 @@ namespace Carbon {
 // rules we pick. The function interfaces will need to change to accommodate
 // multi-byte characters.
 
-// Is this a decimal digit according to Carbon's lexical rules?
-//
-// This currently includes '0'..'9'.
-inline bool IsDecimalDigit(char c) { return llvm::isDigit(c); }
-
 // Is this an alphabetical character according to Carbon's lexical rules?
 //
 // Alphabetical characters are permitted at the start of identifiers. This
 // currently includes 'A'..'Z' and 'a'..'z'.
 inline bool IsAlpha(char c) { return llvm::isAlpha(c); }
+
+// Is this a decimal digit according to Carbon's lexical rules?
+//
+// This currently includes '0'..'9'.
+inline bool IsDecimalDigit(char c) { return llvm::isDigit(c); }
 
 // Is this an alphanumeric character according to Carbon's lexical rules?
 //


### PR DESCRIPTION
This is both a bit tricky and really easy with Bazel. The easy part,
especially compared to other build systems is that we can do this
regardless of the state of the repository -- Bazel will hermetically
check that everything is up-to-date, allowing the cache to be a bit
stale but still totally functional.

The easy part is that we can just ask Bazel to use an output base that
we cache and restore. This is super nice and even avoids most of the
Bazel installation bits.

The tricky part is that we need this to reconnect correctly to the
installed tree, so we need to exclude a crucial symlink that will then
get re-created at the right moment.

This gets really tricky due to LLVM and Clang (and this we would
struggle with no matter what build system we used). Building LLVM
creates a *ton* of object code. Just a huge amount. As a consequence,
we'd run into GitHub's limit for action cache size (5gb) really quickly
with 4 configurations.

So we can do another bit of tricky business and exclude the downloaded
`external` tree. This gets rebuilt easily, and there's no real need to
download it with the cached state -- its downloaded either way.

There are two follow-ups that I'd like to make here. One is to prod the
Bazel team to make things like persisting your output base a bit easier
to do reliably. Even better to make it easier to do *partial*
persisting.

Second follow-up is to work to make our usage of LLVM *much* less
wasteful. There are a bunch of steps here from changing how we use
sanitizers to how LLVM is built. Those will be follow-ups though.