### PR TITLE
Tweak UBSan options to reduce object file size.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -441,6 +441,13 @@ def _impl(ctx):
             flag_groups = [flag_group(flags = [
                 "-fsanitize=address,undefined",
                 "-fsanitize-address-use-after-scope",
+                # We don't need the recovery behavior of UBSan as we expect
+                # builds to be clean. Not recoverying is a bit cheaper.
+                "-fno-sanitize-recover=undefined",
+                # Force some expensive UBSan checks to the cheaper trap mode.
+                # The dedicated debugging message is unlikely to be critical for
+                # these.
+                "-fsanitize-trap=alignment,null,return,unreachable",
                 # Needed due to clang AST issues, such as in
                 # clang/AST/Redeclarable.h line 199.
                 "-fno-sanitize=vptr",


### PR DESCRIPTION
The recovery is mostly useful when triaging multiple failures, it seems
easy for us to skip. Giving up the nice diagnostics doesn't lose much
for some types of error where there isn't any real information to
convey, so seems worth doing that for a few cases.

Removing the nice diagnostics from the rest of UBSan saves another
20%-ish of output size on LLVM, but seems like it would be giving up
usability. I think there are other approaches we can use instead so this
PR just focuses on the easy wins.