### PR TITLE
Fix test_env to use build, fixing analysis caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,7 @@ build:fuzzer --features=fuzzer
 
 # Always allow tests to symbolize themselves with whatever `llvm-symbolize` is
 # in the users environment.
-test --test_env=ASAN_SYMBOLIZER_PATH
+build --test_env=ASAN_SYMBOLIZER_PATH
 
 # Force actions to have a UTF-8 language encoding.
 # TODO: Need to investigate what this should be on Windows, but at least for


### PR DESCRIPTION
Per https://docs.bazel.build/versions/master/guide.html#option-defaults, test inherits from build, thus why this fixes caching.

The issue can be observed with `bazel build :all && bazel test :all`, the line:
`INFO: Build option --test_env has changed, discarding analysis cache.`