### PR TITLE
Add a script to clean the disk cache.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,10 @@ build --host_crosstool_top=@bazel_cc_toolchain
 # Default to using a disk cache to minimize re-building LLVM and Clang which we
 # try to avoid updating too frequently to minimize rebuild cost. The location
 # here can be overridden in the user configuration where needed.
+#
+# Note that this cache will grow without bound currently. You should
+# periodically run the `scripts/clean_disk_cache.sh` script or some equivalent.
+# https://github.com/bazelbuild/bazel/issues/5139 tracks fixing this in Bazel.
 build --disk_cache=~/.cache/carbon-lang-build-cache
 
 # Enable some safety when using the build cache, likely to be defaulted in

--- a/scripts/clean_disk_cache.sh
+++ b/scripts/clean_disk_cache.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+#
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Clean out any files in the Bazel disk cache which haven't been used for over
+# thirty days.
+
+# Default to the same directory in the project `.blazerc`, but you can set this
+# environment variable to override that.
+: ${BAZEL_DISK_CACHE_PATH:=~/.cache/carbon-lang-build-cache}
+
+# As a courtesy, compute and print some approximate stats.
+total_file_count=$(find "$BAZEL_DISK_CACHE_PATH" -type f | wc -l)
+stale_file_count=$(find "$BAZEL_DISK_CACHE_PATH" -type f -atime +30 | wc -l)
+echo "Removing $stale_file_count files out of $total_file_count total."
+
+# Just re-running the find is simpler than managing any state.
+find "$BAZEL_DISK_CACHE_PATH" -type f -atime +30 -delete


### PR DESCRIPTION
Currently, Bazel's disk cache grows without bound:
https://github.com/bazelbuild/bazel/issues/5139

Until this is fixed, provide a script to remove entries after 30 days.
If things are changing so rapidly that we need a more aggressive
threshold, we can adjust as we go. I'm somewhat hoping that we don't end
up with *that* many build artifacts, but let's see.