### PR TITLE
Expand CI to cover migration tool.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,10 @@ build --incompatible_dont_enable_host_nonhost_crosstool_features=false
 # our builds.
 build --dynamic_mode=off
 
+# Always compile PIC code. There are few if any disadvantages on the platforms
+# and architectures we care about and it avoids the need to compile files twice.
+build --force_pic
+
 # Completely disable Bazel's automatic stripping of debug information. Removing
 # that information causes unhelpful backtraces from unittest failures and other
 # crashes. Optimized builds already avoid using debug information by default.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,14 +144,12 @@ jobs:
       - name: Build (${{ matrix.build_mode }})
         run: |
           bazelisk build -c ${{ matrix.build_mode }} --verbose_failures \
-            --deleted_packages=migrate_cpp,migrate_cpp/cpp_refactoring \
             //...:all
 
       # Run all test targets.
       - name: Test (${{ matrix.build_mode }})
         run: |
           bazelisk test -c ${{ matrix.build_mode }} --test_output errors \
-            --deleted_packages=migrate_cpp,migrate_cpp/cpp_refactoring \
             --verbose_failures //...:all
 
       # We manually shut down the Bazel server to make sure the cached files


### PR DESCRIPTION
Also add one more flag to our `.bazelrc` to improve the overall build
efficiency.

While the first build with this will be very slow (likely a couple of
hours), the caching layer we are using now should effectively cache this
for subsequent builds so that only the changed files have to be
recompiled. Updates to Clang and LLVM themselves will still result in
a slow rebuild, but normal development should remain fast.