### PR TITLE
Eliminate MakeUnOp and MakeBinOp

### DIFF
--- a/executable_semantics/ast/expression.cpp
+++ b/executable_semantics/ast/expression.cpp
@@ -130,23 +130,6 @@ auto Expression::MakeOp(int line_num, enum Operator op,
   return e;
 }
 
-auto Expression::MakeUnOp(int line_num, enum Operator op, const Expression* arg)
-    -> const Expression* {
-  auto* e = new Expression();
-  e->line_num = line_num;
-  e->value = PrimitiveOperator({.op = op, .arguments = {arg}});
-  return e;
-}
-
-auto Expression::MakeBinOp(int line_num, enum Operator op,
-                           const Expression* arg1, const Expression* arg2)
-    -> const Expression* {
-  auto* e = new Expression();
-  e->line_num = line_num;
-  e->value = PrimitiveOperator({.op = op, .arguments = {arg1, arg2}});
-  return e;
-}
-
 auto Expression::MakeCall(int line_num, const Expression* fun,
                           const Expression* arg) -> const Expression* {
   auto* e = new Expression();

--- a/executable_semantics/ast/expression.h
+++ b/executable_semantics/ast/expression.h
@@ -142,10 +142,6 @@ struct Expression {
   static auto MakeBool(int line_num, bool b) -> const Expression*;
   static auto MakeOp(int line_num, Operator op,
                      std::vector<const Expression*> args) -> const Expression*;
-  static auto MakeUnOp(int line_num, enum Operator op, const Expression* arg)
-      -> const Expression*;
-  static auto MakeBinOp(int line_num, enum Operator op, const Expression* arg1,
-                        const Expression* arg2) -> const Expression*;
   static auto MakeCall(int line_num, const Expression* fun,
                        const Expression* arg) -> const Expression*;
   static auto MakeGetField(int line_num, const Expression* exp,

--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -84,8 +84,8 @@ auto ReifyType(const Value* t, int line_num) -> const Expression* {
     case ValKind::ChoiceTV:
       return Expression::MakeVar(0, *t->GetChoiceType().name);
     case ValKind::PointerTV:
-      return Expression::MakeUnOp(
-          0, Operator::Ptr, ReifyType(t->GetPointerType().type, line_num));
+      return Expression::MakeOp(
+          0, Operator::Ptr, {ReifyType(t->GetPointerType().type, line_num)});
     default:
       std::cerr << line_num << ": expected a type, not ";
       PrintValue(t, std::cerr);

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -226,31 +226,31 @@ expression:
     { $$ = Carbon::Expression::MakeContinuationType(yylineno); }
 | paren_expression { $$ = $1; }
 | expression EQUAL_EQUAL expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::Eq, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Eq, {$1, $3}); }
 | expression "+" expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::Add, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Add, {$1, $3}); }
 | expression "-" expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::Sub, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Sub, {$1, $3}); }
 | expression BINARY_STAR expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::Mul, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Mul, {$1, $3}); }
 | expression AND expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::And, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::And, {$1, $3}); }
 | expression OR expression
-    { $$ = Carbon::Expression::MakeBinOp(yylineno, Carbon::Operator::Or, $1, $3); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Or, {$1, $3}); }
 | NOT expression
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Not, $2); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Not, {$2}); }
 | "-" expression %prec UNARY_MINUS
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Neg, $2); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Neg, {$2}); }
 | PREFIX_STAR expression
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Deref, $2); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Deref, {$2}); }
 | UNARY_STAR expression %prec PREFIX_STAR
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Deref, $2); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Deref, {$2}); }
 | expression tuple
     { $$ = Carbon::Expression::MakeCall(yylineno, $1, $2); }
 | expression POSTFIX_STAR
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Ptr, $1); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Ptr, {$1}); }
 | expression UNARY_STAR
-    { $$ = Carbon::Expression::MakeUnOp(yylineno, Carbon::Operator::Ptr, $1); }
+    { $$ = Carbon::Expression::MakeOp(yylineno, Carbon::Operator::Ptr, {$1}); }
 | FNTY tuple return_type
     { $$ = Carbon::Expression::MakeFunType(yylineno, $2, $3); }
 ;


### PR DESCRIPTION
MakeOp covers their use cases with minimal syntactic overhead now that it can take initializer list arguments, and this ensures that the factory functions correspond 1:1 with expression kinds. 