### PR TITLE
Disable modernize-use-emplace in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks:
   misc-redundant-expression, misc-static-assert,
   misc-unconventional-assign-operator, misc-uniqueptr-reset-release,
   misc-unused-*, modernize-*, -modernize-avoid-c-arrays,
-  -modernize-use-default-member-init, performance-*,
+  -modernize-use-default-member-init, -modernize-use-emplace, performance-*,
   readability-braces-around-statements, readability-identifier-naming
 WarningsAsErrors: true
 CheckOptions:


### PR DESCRIPTION
Because we prefer `.push_back({...})` over `.emplace_back(...)`, as noted at https://github.com/carbon-language/carbon-lang/pull/615/files#r662540681