### PR TITLE
Rename "PatternVariable" names for clarity

### DIFF
--- a/executable_semantics/ast/expression.cpp
+++ b/executable_semantics/ast/expression.cpp
@@ -22,9 +22,8 @@ auto Expression::GetIndexExpression() const -> const IndexExpression& {
   return std::get<IndexExpression>(value);
 }
 
-auto Expression::GetPatternVariableExpression() const
-    -> const PatternVariableExpression& {
-  return std::get<PatternVariableExpression>(value);
+auto Expression::GetBindingExpression() const -> const BindingExpression& {
+  return std::get<BindingExpression>(value);
 }
 
 auto Expression::GetIntLiteral() const -> int {
@@ -106,12 +105,12 @@ auto Expression::MakeIdentifierExpression(int line_num, std::string var)
   return v;
 }
 
-auto Expression::MakePatternVariableExpression(int line_num, std::string var,
-                                               const Expression* type)
+auto Expression::MakeBindingExpression(int line_num, std::string var,
+                                       const Expression* type)
     -> const Expression* {
   auto* v = new Expression();
   v->line_num = line_num;
-  v->value = PatternVariableExpression({.name = std::move(var), .type = type});
+  v->value = BindingExpression({.name = std::move(var), .type = type});
   return v;
 }
 
@@ -281,10 +280,10 @@ void PrintExp(const Expression* e) {
     case ExpressionKind::IdentifierExpression:
       std::cout << e->GetIdentifierExpression().name;
       break;
-    case ExpressionKind::PatternVariableExpression:
-      PrintExp(e->GetPatternVariableExpression().type);
+    case ExpressionKind::BindingExpression:
+      PrintExp(e->GetBindingExpression().type);
       std::cout << ": ";
-      std::cout << e->GetPatternVariableExpression().name;
+      std::cout << e->GetBindingExpression().name;
       break;
     case ExpressionKind::CallExpression:
       PrintExp(e->GetCallExpression().function);

--- a/executable_semantics/ast/expression.h
+++ b/executable_semantics/ast/expression.h
@@ -33,7 +33,7 @@ enum class ExpressionKind {
   IntTypeLiteral,
   ContinuationTypeLiteral,  // The type of a continuation value.
   IntLiteral,
-  PatternVariableExpression,
+  BindingExpression,
   PrimitiveOperatorExpression,
   TupleLiteral,
   TypeTypeLiteral,
@@ -72,9 +72,8 @@ struct IndexExpression {
   const Expression* offset;
 };
 
-struct PatternVariableExpression {
-  static constexpr ExpressionKind Kind =
-      ExpressionKind::PatternVariableExpression;
+struct BindingExpression {
+  static constexpr ExpressionKind Kind = ExpressionKind::BindingExpression;
   std::string name;
   const Expression* type;
 };
@@ -140,8 +139,8 @@ struct Expression {
 
   static auto MakeIdentifierExpression(int line_num, std::string var)
       -> const Expression*;
-  static auto MakePatternVariableExpression(int line_num, std::string var,
-                                            const Expression* type)
+  static auto MakeBindingExpression(int line_num, std::string var,
+                                    const Expression* type)
       -> const Expression*;
   static auto MakeIntLiteral(int line_num, int i) -> const Expression*;
   static auto MakeBoolLiteral(int line_num, bool b) -> const Expression*;
@@ -168,7 +167,7 @@ struct Expression {
   auto GetIdentifierExpression() const -> const IdentifierExpression&;
   auto GetFieldAccessExpression() const -> const FieldAccessExpression&;
   auto GetIndexExpression() const -> const IndexExpression&;
-  auto GetPatternVariableExpression() const -> const PatternVariableExpression&;
+  auto GetBindingExpression() const -> const BindingExpression&;
   auto GetIntLiteral() const -> int;
   auto GetBoolLiteral() const -> bool;
   auto GetTupleLiteral() const -> const TupleLiteral&;
@@ -179,7 +178,7 @@ struct Expression {
 
  private:
   std::variant<IdentifierExpression, FieldAccessExpression, IndexExpression,
-               PatternVariableExpression, IntLiteral, BoolLiteral, TupleLiteral,
+               BindingExpression, IntLiteral, BoolLiteral, TupleLiteral,
                PrimitiveOperatorExpression, CallExpression, FunctionTypeLiteral,
                AutoTypeLiteral, BoolTypeLiteral, IntTypeLiteral,
                ContinuationTypeLiteral, TypeTypeLiteral>

--- a/executable_semantics/interpreter/interpreter.cpp
+++ b/executable_semantics/interpreter/interpreter.cpp
@@ -124,7 +124,7 @@ auto CopyVal(const Value* val, int line_num) -> const Value* {
       return Value::MakeContinuationType();
     case ValKind::StructType:
     case ValKind::ChoiceType:
-    case ValKind::PatternVariableValue:
+    case ValKind::BindingPlaceholderValue:
     case ValKind::AlternativeConstructorValue:
       return val;  // no need to copy these because they are immutable?
       // No, they need to be copied so they don't get killed. -Jeremy
@@ -448,10 +448,10 @@ auto PatternMatch(const Value* p, const Value* v, Env values,
                   std::list<std::string>* vars, int line_num)
     -> std::optional<Env> {
   switch (p->tag) {
-    case ValKind::PatternVariableValue: {
+    case ValKind::BindingPlaceholderValue: {
       Address a = state->heap.AllocateValue(CopyVal(v, line_num));
-      vars->push_back(*p->GetPatternVariableValue().name);
-      values.Set(*p->GetPatternVariableValue().name, a);
+      vars->push_back(*p->GetBindingPlaceholderValue().name);
+      values.Set(*p->GetBindingPlaceholderValue().name, a);
       return values;
     }
     case ValKind::TupleValue:
@@ -715,7 +715,7 @@ void StepLvalue() {
     case ExpressionKind::FunctionTypeLiteral:
     case ExpressionKind::AutoTypeLiteral:
     case ExpressionKind::ContinuationTypeLiteral:
-    case ExpressionKind::PatternVariableExpression: {
+    case ExpressionKind::BindingExpression: {
       frame->todo.Pop();
       frame->todo.Push(MakeExpToLvalAct());
       frame->todo.Push(MakeExpAct(exp));
@@ -735,13 +735,13 @@ void StepExp() {
     std::cout << " --->" << std::endl;
   }
   switch (exp->tag()) {
-    case ExpressionKind::PatternVariableExpression: {
+    case ExpressionKind::BindingExpression: {
       if (act->pos == 0) {
-        frame->todo.Push(MakeExpAct(exp->GetPatternVariableExpression().type));
+        frame->todo.Push(MakeExpAct(exp->GetBindingExpression().type));
         act->pos++;
       } else {
-        auto v = Value::MakePatternVariableValue(
-            exp->GetPatternVariableExpression().name, act->results[0]);
+        auto v = Value::MakeBindingPlaceholderValue(
+            exp->GetBindingExpression().name, act->results[0]);
         frame->todo.Pop(1);
         frame->todo.Push(MakeValAct(v));
       }

--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -135,7 +135,7 @@ auto TypeCheckExp(const Expression* e, TypeEnv types, Env values,
     std::cout << std::endl;
   }
   switch (e->tag()) {
-    case ExpressionKind::PatternVariableExpression: {
+    case ExpressionKind::BindingExpression: {
       if (context != TCContext::PatternContext) {
         std::cerr
             << e->line_num
@@ -144,7 +144,7 @@ auto TypeCheckExp(const Expression* e, TypeEnv types, Env values,
             << std::endl;
         exit(-1);
       }
-      auto t = InterpExp(values, e->GetPatternVariableExpression().type);
+      auto t = InterpExp(values, e->GetBindingExpression().type);
       if (t->tag == ValKind::AutoType) {
         if (expected == nullptr) {
           std::cerr << e->line_num
@@ -157,10 +157,10 @@ auto TypeCheckExp(const Expression* e, TypeEnv types, Env values,
       } else if (expected) {
         ExpectType(e->line_num, "pattern variable", t, expected);
       }
-      auto new_e = Expression::MakePatternVariableExpression(
-          e->line_num, e->GetPatternVariableExpression().name,
+      auto new_e = Expression::MakeBindingExpression(
+          e->line_num, e->GetBindingExpression().name,
           ReifyType(t, e->line_num));
-      types.Set(e->GetPatternVariableExpression().name, t);
+      types.Set(e->GetBindingExpression().name, t);
       return TCResult(new_e, t, types);
     }
     case ExpressionKind::IndexExpression: {

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -57,8 +57,8 @@ std::string* Value::GetVariableType() const {
   return u.var_type;
 }
 
-PatternVariableValue Value::GetPatternVariableValue() const {
-  CHECK(tag == ValKind::PatternVariableValue);
+BindingPlaceholderValue Value::GetBindingPlaceholderValue() const {
+  CHECK(tag == ValKind::BindingPlaceholderValue);
   return u.var_pat;
 }
 
@@ -202,10 +202,10 @@ auto Value::MakeContinuationValue(std::vector<Frame*> stack) -> Value* {
   return v;
 }
 
-auto Value::MakePatternVariableValue(std::string name, const Value* type)
+auto Value::MakeBindingPlaceholderValue(std::string name, const Value* type)
     -> const Value* {
   auto* v = new Value();
-  v->tag = ValKind::PatternVariableValue;
+  v->tag = ValKind::BindingPlaceholderValue;
   v->u.var_pat.name = new std::string(std::move(name));
   v->u.var_pat.type = type;
   return v;
@@ -300,9 +300,9 @@ auto PrintValue(const Value* val, std::ostream& out) -> void {
           << *val->GetAlternativeConstructorValue().alt_name;
       break;
     }
-    case ValKind::PatternVariableValue: {
-      PrintValue(val->GetPatternVariableValue().type, out);
-      out << ": " << *val->GetPatternVariableValue().name;
+    case ValKind::BindingPlaceholderValue: {
+      PrintValue(val->GetBindingPlaceholderValue().type, out);
+      out << ": " << *val->GetBindingPlaceholderValue().name;
       break;
     }
     case ValKind::AlternativeValue: {
@@ -495,7 +495,7 @@ auto ValueEqual(const Value* v1, const Value* v2, int line_num) -> bool {
       return TypeEqual(v1, v2);
     case ValKind::StructValue:
     case ValKind::AlternativeValue:
-    case ValKind::PatternVariableValue:
+    case ValKind::BindingPlaceholderValue:
     case ValKind::AlternativeConstructorValue:
     case ValKind::ContinuationValue:
       std::cerr << "ValueEqual does not support this kind of value."

--- a/executable_semantics/interpreter/value.h
+++ b/executable_semantics/interpreter/value.h
@@ -54,7 +54,7 @@ enum class ValKind {
   StructType,
   ChoiceType,
   ContinuationType,  // The type of a continuation.
-  PatternVariableValue,
+  BindingPlaceholderValue,
   AlternativeConstructorValue,
   ContinuationValue  // A first-class continuation value.
 };
@@ -87,7 +87,7 @@ struct TupleValue {
   std::vector<TupleElement>* elements;
 };
 
-struct PatternVariableValue {
+struct BindingPlaceholderValue {
   std::string* name;
   const Value* type;
 };
@@ -138,7 +138,7 @@ struct Value {
   static auto MakeAlternativeConstructorValue(std::string alt_name,
                                               std::string choice_name)
       -> const Value*;
-  static auto MakePatternVariableValue(std::string name, const Value* type)
+  static auto MakeBindingPlaceholderValue(std::string name, const Value* type)
       -> const Value*;
   static auto MakeVarTypeVal(std::string name) -> const Value*;
   static auto MakeIntType() -> const Value*;
@@ -164,7 +164,7 @@ struct Value {
   TupleValue GetTupleValue() const;
   Address GetPointerValue() const;
   std::string* GetVariableType() const;
-  PatternVariableValue GetPatternVariableValue() const;
+  BindingPlaceholderValue GetBindingPlaceholderValue() const;
   FunctionType GetFunctionType() const;
   PointerType GetPointerType() const;
   StructType GetStructType() const;
@@ -182,7 +182,7 @@ struct Value {
     TupleValue tuple;
     Address ptr;
     std::string* var_type;
-    PatternVariableValue var_pat;
+    BindingPlaceholderValue var_pat;
     FunctionType fun_type;
     PointerType ptr_type;
     StructType struct_type;

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -208,7 +208,7 @@ expression:
     { $$ = Carbon::Expression::MakeIndexExpression(yylineno, $1, $3); }
 | identifier ":" expression
     {
-      $$ = Carbon::Expression::MakePatternVariableExpression(yylineno, $1, $3);
+      $$ = Carbon::Expression::MakeBindingExpression(yylineno, $1, $3);
     }
 | integer_literal
     { $$ = Carbon::Expression::MakeIntLiteral(yylineno, $1); }
@@ -310,7 +310,7 @@ clause:
     { $$ = new std::pair<const Carbon::Expression*, const Carbon::Statement*>($2, $4); }
 | DEFAULT DBLARROW statement
     {
-      auto vp = Carbon::Expression::MakePatternVariableExpression(
+      auto vp = Carbon::Expression::MakeBindingExpression(
           yylineno, "_", Carbon::Expression::MakeAutoTypeLiteral(yylineno));
       $$ = new std::pair<const Carbon::Expression*, const Carbon::Statement*>(vp, $3);
     }


### PR DESCRIPTION
Pretty much any names will be awkward, since these types represent cases where an `Expression` is not an expression, and a `Value` is not a value, but we can at least be more explicit about the fact that they represent bindings rather than variable usages.