### PR TITLE
Finish removing ExpToLValAction and DeleteTmpAction.

### DIFF
--- a/executable_semantics/interpreter/action.h
+++ b/executable_semantics/interpreter/action.h
@@ -49,8 +49,6 @@ struct Action {
   static auto MakeExpressionAction(const Expression* e) -> Action*;
   static auto MakeStatementAction(const Statement* s) -> Action*;
   static auto MakeValAction(const Value* v) -> Action*;
-  static auto MakeExpToLValAction() -> Action*;
-  static auto MakeDeleteTmpAction(Address a) -> Action*;
 
   static void PrintList(Stack<Action*> ls, std::ostream& out);
 


### PR DESCRIPTION
PR #636 removed the definitions of these factory functions, but accidentally left their declarations in place.