### PR TITLE
Fix infinite recursion in PrintList.

### DIFF
--- a/executable_semantics/interpreter/action.cpp
+++ b/executable_semantics/interpreter/action.cpp
@@ -102,7 +102,7 @@ void Action::Print(std::ostream& out) {
 
 void Action::PrintList(Stack<Action*> ls, std::ostream& out) {
   if (!ls.IsEmpty()) {
-    PrintList(ls.Pop(), out);
+    ls.Pop()->Print(out);
     if (!ls.IsEmpty()) {
       out << " :: ";
       PrintList(ls, out);

--- a/executable_semantics/interpreter/stack.h
+++ b/executable_semantics/interpreter/stack.h
@@ -57,7 +57,7 @@ struct Stack {
   Stack() { head = nullptr; }
 
   // Creates an instance containing just `x`.
-  Stack(T x) : Stack() { Push(x); }
+  explicit Stack(T x) : Stack() { Push(x); }
 
   // Pushes `x` onto the top of the stack.
   void Push(T x) { head = new ListNode<T>(x, head); }


### PR DESCRIPTION
Also make `Stack`'s single-argument constructor explicit, which would have helped catch this at compile time.