### PR TITLE
Delete functions that are redundant with Get methods

### DIFF
--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -165,7 +165,8 @@ auto TypeCheckExp(const Expression* e, TypeEnv types, Env values,
       auto t = res.type;
       switch (t->tag()) {
         case ValKind::TupleValue: {
-          auto i = ToInteger(InterpExp(values, e->GetIndexExpression().offset));
+          auto i =
+              InterpExp(values, e->GetIndexExpression().offset)->GetIntValue();
           std::string f = std::to_string(i);
           const Value* field_t = t->GetTupleValue().FindField(f);
           if (field_t == nullptr) {

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -546,15 +546,4 @@ auto ValueEqual(const Value* v1, const Value* v2, int line_num) -> bool {
   }
 }
 
-auto ToInteger(const Value* v) -> int {
-  switch (v->tag()) {
-    case ValKind::IntValue:
-      return v->GetIntValue();
-    default:
-      std::cerr << "expected an integer, not ";
-      PrintValue(v, std::cerr);
-      exit(-1);
-  }
-}
-
 }  // namespace Carbon

--- a/executable_semantics/interpreter/value.h
+++ b/executable_semantics/interpreter/value.h
@@ -242,8 +242,6 @@ void PrintValue(const Value* val, std::ostream& out);
 auto TypeEqual(const Value* t1, const Value* t2) -> bool;
 auto ValueEqual(const Value* v1, const Value* v2, int line_num) -> bool;
 
-auto ToInteger(const Value* v) -> int;
-
 }  // namespace Carbon
 
 #endif  // EXECUTABLE_SEMANTICS_INTERPRETER_VALUE_H_


### PR DESCRIPTION
This change assumes that the Carbon typechecker will ensure that the corresponding Get calls are safe.