### PR TITLE
Rename `::yy::parser` to `::Carbon::Parser`.

### DIFF
--- a/executable_semantics/syntax/lexer.lpp
+++ b/executable_semantics/syntax/lexer.lpp
@@ -90,53 +90,53 @@ operand_start [(A-Za-z0-9_"]
   context.current_token_position.step();
 %}
 
-{AND}      { return yy::parser::make_AND(context.current_token_position); }
-{ARROW}    { return yy::parser::make_ARROW(context.current_token_position); }
-{AUTO}     { return yy::parser::make_AUTO(context.current_token_position); }
-{BOOL}     { return yy::parser::make_BOOL(context.current_token_position); }
-{BREAK}    { return yy::parser::make_BREAK(context.current_token_position); }
-{CASE}     { return yy::parser::make_CASE(context.current_token_position); }
-{CHOICE}   { return yy::parser::make_CHOICE(context.current_token_position); }
-{CONTINUE} { return yy::parser::make_CONTINUE(context.current_token_position); }
-{DBLARROW} { return yy::parser::make_DBLARROW(context.current_token_position); }
-{DEFAULT}  { return yy::parser::make_DEFAULT(context.current_token_position); }
-{ELSE}     { return yy::parser::make_ELSE(context.current_token_position); }
-"=="       { return yy::parser::make_EQUAL_EQUAL(context.current_token_position); }
-{FALSE}    { return yy::parser::make_FALSE(context.current_token_position); }
-{FN}       { return yy::parser::make_FN(context.current_token_position); }
-{FNTY}     { return yy::parser::make_FNTY(context.current_token_position); }
-{IF}       { return yy::parser::make_IF(context.current_token_position); }
-{INT}      { return yy::parser::make_INT(context.current_token_position); }
-{MATCH}    { return yy::parser::make_MATCH(context.current_token_position); }
-{NOT}      { return yy::parser::make_NOT(context.current_token_position); }
-{OR}       { return yy::parser::make_OR(context.current_token_position); }
-{RETURN}   { return yy::parser::make_RETURN(context.current_token_position); }
-{STRUCT}   { return yy::parser::make_STRUCT(context.current_token_position); }
-{TRUE}     { return yy::parser::make_TRUE(context.current_token_position); }
-{TYPE}     { return yy::parser::make_TYPE(context.current_token_position); }
-{VAR}      { return yy::parser::make_VAR(context.current_token_position); }
-{WHILE}    { return yy::parser::make_WHILE(context.current_token_position); }
-{CONTINUATION_TYPE} { return yy::parser::make_CONTINUATION_TYPE(context.current_token_position); }
-{CONTINUATION}    { return yy::parser::make_CONTINUATION(context.current_token_position); }
-{RUN}      { return yy::parser::make_RUN(context.current_token_position); }
-{AWAIT}    { return yy::parser::make_AWAIT(context.current_token_position); }
-{UNDERSCORE}      { return yy::parser::make_UNDERSCORE(context.current_token_position); }
+{AND}      { return Carbon::Parser::make_AND(context.current_token_position); }
+{ARROW}    { return Carbon::Parser::make_ARROW(context.current_token_position); }
+{AUTO}     { return Carbon::Parser::make_AUTO(context.current_token_position); }
+{BOOL}     { return Carbon::Parser::make_BOOL(context.current_token_position); }
+{BREAK}    { return Carbon::Parser::make_BREAK(context.current_token_position); }
+{CASE}     { return Carbon::Parser::make_CASE(context.current_token_position); }
+{CHOICE}   { return Carbon::Parser::make_CHOICE(context.current_token_position); }
+{CONTINUE} { return Carbon::Parser::make_CONTINUE(context.current_token_position); }
+{DBLARROW} { return Carbon::Parser::make_DBLARROW(context.current_token_position); }
+{DEFAULT}  { return Carbon::Parser::make_DEFAULT(context.current_token_position); }
+{ELSE}     { return Carbon::Parser::make_ELSE(context.current_token_position); }
+"=="       { return Carbon::Parser::make_EQUAL_EQUAL(context.current_token_position); }
+{FALSE}    { return Carbon::Parser::make_FALSE(context.current_token_position); }
+{FN}       { return Carbon::Parser::make_FN(context.current_token_position); }
+{FNTY}     { return Carbon::Parser::make_FNTY(context.current_token_position); }
+{IF}       { return Carbon::Parser::make_IF(context.current_token_position); }
+{INT}      { return Carbon::Parser::make_INT(context.current_token_position); }
+{MATCH}    { return Carbon::Parser::make_MATCH(context.current_token_position); }
+{NOT}      { return Carbon::Parser::make_NOT(context.current_token_position); }
+{OR}       { return Carbon::Parser::make_OR(context.current_token_position); }
+{RETURN}   { return Carbon::Parser::make_RETURN(context.current_token_position); }
+{STRUCT}   { return Carbon::Parser::make_STRUCT(context.current_token_position); }
+{TRUE}     { return Carbon::Parser::make_TRUE(context.current_token_position); }
+{TYPE}     { return Carbon::Parser::make_TYPE(context.current_token_position); }
+{VAR}      { return Carbon::Parser::make_VAR(context.current_token_position); }
+{WHILE}    { return Carbon::Parser::make_WHILE(context.current_token_position); }
+{CONTINUATION_TYPE} { return Carbon::Parser::make_CONTINUATION_TYPE(context.current_token_position); }
+{CONTINUATION}    { return Carbon::Parser::make_CONTINUATION(context.current_token_position); }
+{RUN}      { return Carbon::Parser::make_RUN(context.current_token_position); }
+{AWAIT}    { return Carbon::Parser::make_AWAIT(context.current_token_position); }
+{UNDERSCORE}      { return Carbon::Parser::make_UNDERSCORE(context.current_token_position); }
 
-"=" return yy::parser::make_EQUAL(context.current_token_position);
-"-" return yy::parser::make_MINUS(context.current_token_position);
-"+" return yy::parser::make_PLUS(context.current_token_position);
-"/" return yy::parser::make_SLASH(context.current_token_position);
-"(" return yy::parser::make_LEFT_PARENTHESIS(context.current_token_position);
-")" { BEGIN(AFTER_OPERAND); return yy::parser::make_RIGHT_PARENTHESIS(context.current_token_position); }
-"{" return yy::parser::make_LEFT_CURLY_BRACE(context.current_token_position);
-"}" { BEGIN(AFTER_OPERAND); return yy::parser::make_RIGHT_CURLY_BRACE(context.current_token_position); }
-"[" return yy::parser::make_LEFT_SQUARE_BRACKET(context.current_token_position);
-"]" { BEGIN(AFTER_OPERAND); return yy::parser::make_RIGHT_SQUARE_BRACKET(context.current_token_position); }
-"." return yy::parser::make_PERIOD(context.current_token_position);
-"," return yy::parser::make_COMMA(context.current_token_position);
-";" return yy::parser::make_SEMICOLON(context.current_token_position);
-":!" return yy::parser::make_COLON_BANG(context.current_token_position);
-":" return yy::parser::make_COLON(context.current_token_position);
+"=" return Carbon::Parser::make_EQUAL(context.current_token_position);
+"-" return Carbon::Parser::make_MINUS(context.current_token_position);
+"+" return Carbon::Parser::make_PLUS(context.current_token_position);
+"/" return Carbon::Parser::make_SLASH(context.current_token_position);
+"(" return Carbon::Parser::make_LEFT_PARENTHESIS(context.current_token_position);
+")" { BEGIN(AFTER_OPERAND); return Carbon::Parser::make_RIGHT_PARENTHESIS(context.current_token_position); }
+"{" return Carbon::Parser::make_LEFT_CURLY_BRACE(context.current_token_position);
+"}" { BEGIN(AFTER_OPERAND); return Carbon::Parser::make_RIGHT_CURLY_BRACE(context.current_token_position); }
+"[" return Carbon::Parser::make_LEFT_SQUARE_BRACKET(context.current_token_position);
+"]" { BEGIN(AFTER_OPERAND); return Carbon::Parser::make_RIGHT_SQUARE_BRACKET(context.current_token_position); }
+"." return Carbon::Parser::make_PERIOD(context.current_token_position);
+"," return Carbon::Parser::make_COMMA(context.current_token_position);
+";" return Carbon::Parser::make_SEMICOLON(context.current_token_position);
+":!" return Carbon::Parser::make_COLON_BANG(context.current_token_position);
+":" return Carbon::Parser::make_COLON(context.current_token_position);
 
  /*
 For a `*` operator, we look at whitespace and local context to determine the
@@ -160,31 +160,31 @@ operator and its operand, leading to three more cases:
 */
 <AFTER_WHITESPACE>"*"{whitespace}+ /*case 1*/ {
   BEGIN(AFTER_WHITESPACE);
-  return yy::parser::make_BINARY_STAR(context.current_token_position);
+  return Carbon::Parser::make_BINARY_STAR(context.current_token_position);
 }
 <AFTER_OPERAND>"*"/{operand_start} /*case 2*/ {
-  return yy::parser::make_BINARY_STAR(context.current_token_position);
+  return Carbon::Parser::make_BINARY_STAR(context.current_token_position);
 }
 <AFTER_WHITESPACE>"*" /*case 3*/ {
-  return yy::parser::make_PREFIX_STAR(context.current_token_position);
+  return Carbon::Parser::make_PREFIX_STAR(context.current_token_position);
 }
 <INITIAL,AFTER_OPERAND>"*"{whitespace}+ /*case 4*/ {
   BEGIN(AFTER_WHITESPACE);
-  return yy::parser::make_POSTFIX_STAR(context.current_token_position);
+  return Carbon::Parser::make_POSTFIX_STAR(context.current_token_position);
 }
 <INITIAL,AFTER_OPERAND>"*" /*case 5*/ {
-  return yy::parser::make_UNARY_STAR(context.current_token_position);
+  return Carbon::Parser::make_UNARY_STAR(context.current_token_position);
 }
 
 {identifier} {
   BEGIN(AFTER_OPERAND);
-  return yy::parser::make_identifier(yytext, context.current_token_position);
+  return Carbon::Parser::make_identifier(yytext, context.current_token_position);
 }
 
 {integer_literal} {
   BEGIN(AFTER_OPERAND);
   auto r = atof(yytext);
-  return yy::parser::make_integer_literal(r, context.current_token_position);
+  return Carbon::Parser::make_integer_literal(r, context.current_token_position);
 }
 
 {ONE_LINE_COMMENT} {
@@ -221,7 +221,7 @@ operator and its operand, leading to three more cases:
 
 <<EOF>>    {
   // A more modern Bison would give us make_EOF.
-  return yy::parser::make_END_OF_FILE(context.current_token_position);
+  return Carbon::Parser::make_END_OF_FILE(context.current_token_position);
 }
 
 %%

--- a/executable_semantics/syntax/parse.cpp
+++ b/executable_semantics/syntax/parse.cpp
@@ -30,7 +30,7 @@ auto parse(const std::string& input_file_name)
   std::optional<AST> parsed_input = std::nullopt;
   ParseAndLexContext context(input_file_name);
 
-  auto parser = yy::parser(parsed_input, context);
+  auto parser = Parser(parsed_input, context);
   if (tracing_output) {
     parser.set_debug_level(1);
   }

--- a/executable_semantics/syntax/parse_and_lex_context.h
+++ b/executable_semantics/syntax/parse_and_lex_context.h
@@ -25,7 +25,7 @@ class ParseAndLexContext {
   auto PrintDiagnostic(const std::string& message, int line_number) -> void;
 
   // The source range of the token being (or just) lex'd.
-  yy::location current_token_position;
+  location current_token_position;
 
  private:
   // A path to the file processed, relative to the current working directory
@@ -37,7 +37,7 @@ class ParseAndLexContext {
 
 // Gives flex the yylex prototype we want.
 #define YY_DECL \
-  yy::parser::symbol_type yylex(Carbon::ParseAndLexContext& context)
+  Carbon::Parser::symbol_type yylex(Carbon::ParseAndLexContext& context)
 
 // Declares yylex for the parser's sake.
 YY_DECL;

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -19,6 +19,10 @@
 // ‘make_YYEOF’, for the end of input.
 %define api.token.constructor
 
+// Generate the parser as `::Carbon::Parser`.
+%define api.namespace { Carbon }
+%define api.parser.class { Parser }
+
 // Make parse error messages more detailed
 %define parse.error verbose
 
@@ -32,10 +36,10 @@
 // thus available to its methods.
 
 // "out" parameter passed to the parser, where the AST is written.
-%parse-param {std::optional<Carbon::AST>& parsed_program}
+%parse-param {std::optional<AST>& parsed_program}
 
 // "inout" parameter passed to both the parser and the lexer.
-%param {Carbon::ParseAndLexContext& context}
+%param {ParseAndLexContext& context}
 
 // No shift-reduce conflicts are expected.
 %expect 0
@@ -76,7 +80,7 @@ class ParseAndLexContext;
 
 extern int yylineno;
 
-void yy::parser::error(const location_type&, const std::string& message) {
+void Carbon::Parser::error(const location_type&, const std::string& message) {
   context.PrintDiagnostic(message, yylineno);
 }
 
@@ -85,42 +89,42 @@ void yy::parser::error(const location_type&, const std::string& message) {
 %token <int> integer_literal
 %token <std::string> identifier
 %type <std::string> designator
-%type <Carbon::Declaration> declaration
-%type <Carbon::FunctionDefinition> function_declaration
-%type <Carbon::FunctionDefinition> function_definition
-%type <std::list<Carbon::Declaration>> declaration_list
-%type <const Carbon::Statement*> statement
-%type <const Carbon::Statement*> if_statement
-%type <const Carbon::Statement*> optional_else
-%type <std::pair<const Carbon::Expression*, bool>> return_expression
-%type <const Carbon::Statement*> block
-%type <const Carbon::Statement*> statement_list
-%type <const Carbon::Expression*> expression
-%type <Carbon::GenericBinding> generic_binding
-%type <std::vector<Carbon::GenericBinding>> deduced_params
-%type <std::vector<Carbon::GenericBinding>> deduced_param_list
-%type <const Carbon::Pattern*> pattern
-%type <const Carbon::Pattern*> non_expression_pattern
-%type <std::pair<const Carbon::Expression*, bool>> return_type
-%type <const Carbon::Expression*> paren_expression
-%type <const Carbon::Expression*> tuple
+%type <Declaration> declaration
+%type <FunctionDefinition> function_declaration
+%type <FunctionDefinition> function_definition
+%type <std::list<Declaration>> declaration_list
+%type <const Statement*> statement
+%type <const Statement*> if_statement
+%type <const Statement*> optional_else
+%type <std::pair<const Expression*, bool>> return_expression
+%type <const Statement*> block
+%type <const Statement*> statement_list
+%type <const Expression*> expression
+%type <GenericBinding> generic_binding
+%type <std::vector<GenericBinding>> deduced_params
+%type <std::vector<GenericBinding>> deduced_param_list
+%type <const Pattern*> pattern
+%type <const Pattern*> non_expression_pattern
+%type <std::pair<const Expression*, bool>> return_type
+%type <const Expression*> paren_expression
+%type <const Expression*> tuple
 %type <std::optional<std::string>> binding_lhs
-%type <const Carbon::BindingPattern*> variable_declaration
-%type <Carbon::Member*> member
-%type <std::list<Carbon::Member*>> member_list
-%type <Carbon::ParenContents<Carbon::Expression>::Element> paren_expression_element
-%type <Carbon::ParenContents<Carbon::Expression>> paren_expression_base
-%type <Carbon::ParenContents<Carbon::Expression>> paren_expression_contents
-%type <const Carbon::Pattern*> paren_pattern
-%type <const Carbon::TuplePattern*> tuple_pattern
-%type <const Carbon::TuplePattern*> maybe_empty_tuple_pattern
-%type <Carbon::ParenContents<Carbon::Pattern>> paren_pattern_base
-%type <Carbon::ParenContents<Carbon::Pattern>::Element> paren_pattern_element
-%type <Carbon::ParenContents<Carbon::Pattern>> paren_pattern_contents
-%type <std::pair<std::string, const Carbon::Expression*>> alternative
-%type <std::list<std::pair<std::string, const Carbon::Expression*>>> alternative_list
-%type <std::pair<const Carbon::Pattern*, const Carbon::Statement*>*> clause
-%type <std::list<std::pair<const Carbon::Pattern*, const Carbon::Statement*>>*> clause_list
+%type <const BindingPattern*> variable_declaration
+%type <Member*> member
+%type <std::list<Member*>> member_list
+%type <ParenContents<Expression>::Element> paren_expression_element
+%type <ParenContents<Expression>> paren_expression_base
+%type <ParenContents<Expression>> paren_expression_contents
+%type <const Pattern*> paren_pattern
+%type <const TuplePattern*> tuple_pattern
+%type <const TuplePattern*> maybe_empty_tuple_pattern
+%type <ParenContents<Pattern>> paren_pattern_base
+%type <ParenContents<Pattern>::Element> paren_pattern_element
+%type <ParenContents<Pattern>> paren_pattern_contents
+%type <std::pair<std::string, const Expression*>> alternative
+%type <std::list<std::pair<std::string, const Expression*>>> alternative_list
+%type <std::pair<const Pattern*, const Statement*>*> clause
+%type <std::list<std::pair<const Pattern*, const Statement*>>*> clause_list
 %token END_OF_FILE 0
 %token AND
 %token OR
@@ -206,75 +210,75 @@ input: declaration_list
 ;
 expression:
   identifier
-    { $$ = Carbon::Expression::MakeIdentifierExpression(yylineno, $1); }
+    { $$ = Expression::MakeIdentifierExpression(yylineno, $1); }
 | expression designator
-    { $$ = Carbon::Expression::MakeFieldAccessExpression(yylineno, $1, $2); }
+    { $$ = Expression::MakeFieldAccessExpression(yylineno, $1, $2); }
 | expression "[" expression "]"
-    { $$ = Carbon::Expression::MakeIndexExpression(yylineno, $1, $3); }
+    { $$ = Expression::MakeIndexExpression(yylineno, $1, $3); }
 | integer_literal
-    { $$ = Carbon::Expression::MakeIntLiteral(yylineno, $1); }
+    { $$ = Expression::MakeIntLiteral(yylineno, $1); }
 | TRUE
-    { $$ = Carbon::Expression::MakeBoolLiteral(yylineno, true); }
+    { $$ = Expression::MakeBoolLiteral(yylineno, true); }
 | FALSE
-    { $$ = Carbon::Expression::MakeBoolLiteral(yylineno, false); }
+    { $$ = Expression::MakeBoolLiteral(yylineno, false); }
 | INT
-    { $$ = Carbon::Expression::MakeIntTypeLiteral(yylineno); }
+    { $$ = Expression::MakeIntTypeLiteral(yylineno); }
 | BOOL
-    { $$ = Carbon::Expression::MakeBoolTypeLiteral(yylineno); }
+    { $$ = Expression::MakeBoolTypeLiteral(yylineno); }
 | TYPE
-    { $$ = Carbon::Expression::MakeTypeTypeLiteral(yylineno); }
+    { $$ = Expression::MakeTypeTypeLiteral(yylineno); }
 | CONTINUATION_TYPE
-    { $$ = Carbon::Expression::MakeContinuationTypeLiteral(yylineno); }
+    { $$ = Expression::MakeContinuationTypeLiteral(yylineno); }
 | paren_expression { $$ = $1; }
 | expression EQUAL_EQUAL expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Eq, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Eq, {$1, $3}); }
 | expression "+" expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Add, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Add, {$1, $3}); }
 | expression "-" expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Sub, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Sub, {$1, $3}); }
 | expression BINARY_STAR expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Mul, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Mul, {$1, $3}); }
 | expression AND expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::And, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::And, {$1, $3}); }
 | expression OR expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Or, {$1, $3}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Or, {$1, $3}); }
 | NOT expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Not, {$2}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Not, {$2}); }
 | "-" expression %prec UNARY_MINUS
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Neg, {$2}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Neg, {$2}); }
 | PREFIX_STAR expression
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Deref, {$2}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Deref, {$2}); }
 | UNARY_STAR expression %prec PREFIX_STAR
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Deref, {$2}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Deref, {$2}); }
 | expression tuple
-    { $$ = Carbon::Expression::MakeCallExpression(yylineno, $1, $2); }
+    { $$ = Expression::MakeCallExpression(yylineno, $1, $2); }
 | expression POSTFIX_STAR
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Ptr, {$1}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Ptr, {$1}); }
 | expression UNARY_STAR
-    { $$ = Carbon::Expression::MakePrimitiveOperatorExpression(
-        yylineno, Carbon::Operator::Ptr, {$1}); }
+    { $$ = Expression::MakePrimitiveOperatorExpression(
+        yylineno, Operator::Ptr, {$1}); }
 | FNTY tuple return_type
-    { $$ = Carbon::Expression::MakeFunctionTypeLiteral(
+    { $$ = Expression::MakeFunctionTypeLiteral(
         yylineno, $2, $3.first, $3.second); }
 ;
 designator: "." identifier { $$ = $2; }
 ;
 paren_expression: paren_expression_base
-    { $$ = Carbon::ExpressionFromParenContents(yylineno, $1); }
+    { $$ = ExpressionFromParenContents(yylineno, $1); }
 ;
 tuple: paren_expression_base
-    { $$ = Carbon::TupleExpressionFromParenContents(yylineno, $1); }
+    { $$ = TupleExpressionFromParenContents(yylineno, $1); }
 ;
 paren_expression_element:
   expression
@@ -313,24 +317,24 @@ pattern:
   non_expression_pattern
     { $$ = $1; }
 | expression
-    { $$ = Carbon::global_arena->New<Carbon::ExpressionPattern>($1); }
+    { $$ = global_arena->New<ExpressionPattern>($1); }
 ;
 non_expression_pattern:
   AUTO
-    { $$ = Carbon::global_arena->New<Carbon::AutoPattern>(yylineno); }
+    { $$ = global_arena->New<AutoPattern>(yylineno); }
 | binding_lhs ":" pattern
-    { $$ = Carbon::global_arena->New<Carbon::BindingPattern>(yylineno, $1, $3); }
+    { $$ = global_arena->New<BindingPattern>(yylineno, $1, $3); }
 | paren_pattern
     { $$ = $1; }
 | expression tuple_pattern
-    { $$ = Carbon::global_arena->New<Carbon::AlternativePattern>(yylineno, $1, $2); }
+    { $$ = global_arena->New<AlternativePattern>(yylineno, $1, $2); }
 ;
 binding_lhs:
   identifier { $$ = $1; }
 | UNDERSCORE { $$ = std::nullopt; }
 ;
 paren_pattern: paren_pattern_base
-    { $$ = Carbon::PatternFromParenContents(yylineno, $1); }
+    { $$ = PatternFromParenContents(yylineno, $1); }
 ;
 paren_pattern_base:
   "(" paren_pattern_contents ")"
@@ -351,13 +355,13 @@ paren_pattern_contents:
     { $$ = {.elements = {$1}, .has_trailing_comma = false }; }
 | paren_expression_contents "," paren_pattern_element
     {
-      $$ = Carbon::ParenExpressionToParenPattern($1);
+      $$ = ParenExpressionToParenPattern($1);
       $$.elements.push_back($3);
     }
 | paren_pattern_contents "," paren_expression_element
     {
       $$ = $1;
-      $$.elements.push_back({.name = $3.name, .term = Carbon::global_arena->New<Carbon::ExpressionPattern>($3.term)});
+      $$.elements.push_back({.name = $3.name, .term = global_arena->New<ExpressionPattern>($3.term)});
     }
 | paren_pattern_contents "," paren_pattern_element
     {
@@ -372,67 +376,67 @@ paren_pattern_element:
     { $$ = {.name = $1, .term = $3}; }
 ;
 tuple_pattern: paren_pattern_base
-    { $$ = Carbon::TuplePatternFromParenContents(yylineno, $1); }
+    { $$ = TuplePatternFromParenContents(yylineno, $1); }
 ;
 // Unlike most `pattern` nonterminals, this one overlaps with `expression`,
 // so it should be used only when prior context (such as an introducer)
 // rules out the possibility of an `expression` at this point.
 maybe_empty_tuple_pattern:
   "(" ")"
-    { $$ = Carbon::global_arena->New<Carbon::TuplePattern>(yylineno, std::vector<Carbon::TuplePattern::Field>()); }
+    { $$ = global_arena->New<TuplePattern>(yylineno, std::vector<TuplePattern::Field>()); }
 | tuple_pattern
     { $$ = $1; }
 ;
 clause:
   CASE pattern DBLARROW statement
-    { $$ = Carbon::global_arena->New<std::pair<const Carbon::Pattern*, const Carbon::Statement*>>($2, $4); }
+    { $$ = global_arena->New<std::pair<const Pattern*, const Statement*>>($2, $4); }
 | DEFAULT DBLARROW statement
     {
-      auto vp = Carbon::global_arena->New<Carbon::BindingPattern>(
-          yylineno, std::nullopt, Carbon::global_arena->New<Carbon::AutoPattern>(yylineno));
-      $$ = Carbon::global_arena->New<std::pair<const Carbon::Pattern*, const Carbon::Statement*>>(vp, $3);
+      auto vp = global_arena->New<BindingPattern>(
+          yylineno, std::nullopt, global_arena->New<AutoPattern>(yylineno));
+      $$ = global_arena->New<std::pair<const Pattern*, const Statement*>>(vp, $3);
     }
 ;
 clause_list:
   // Empty
     {
-      $$ = Carbon::global_arena->New<std::list<
-          std::pair<const Carbon::Pattern*, const Carbon::Statement*>>>();
+      $$ = global_arena->New<std::list<
+          std::pair<const Pattern*, const Statement*>>>();
     }
 | clause clause_list
     { $$ = $2; $$->push_front(*$1); }
 ;
 statement:
   expression "=" expression ";"
-    { $$ = Carbon::Statement::MakeAssign(yylineno, $1, $3); }
+    { $$ = Statement::MakeAssign(yylineno, $1, $3); }
 | VAR pattern "=" expression ";"
-    { $$ = Carbon::Statement::MakeVariableDefinition(yylineno, $2, $4); }
+    { $$ = Statement::MakeVariableDefinition(yylineno, $2, $4); }
 | expression ";"
-    { $$ = Carbon::Statement::MakeExpressionStatement(yylineno, $1); }
+    { $$ = Statement::MakeExpressionStatement(yylineno, $1); }
 | if_statement
     { $$ = $1; }
 | WHILE "(" expression ")" block
-    { $$ = Carbon::Statement::MakeWhile(yylineno, $3, $5); }
+    { $$ = Statement::MakeWhile(yylineno, $3, $5); }
 | BREAK ";"
-    { $$ = Carbon::Statement::MakeBreak(yylineno); }
+    { $$ = Statement::MakeBreak(yylineno); }
 | CONTINUE ";"
-    { $$ = Carbon::Statement::MakeContinue(yylineno); }
+    { $$ = Statement::MakeContinue(yylineno); }
 | RETURN return_expression ";"
-    { $$ = Carbon::Statement::MakeReturn(yylineno, $2.first, $2.second); }
+    { $$ = Statement::MakeReturn(yylineno, $2.first, $2.second); }
 | block
     { $$ = $1; }
 | MATCH "(" expression ")" "{" clause_list "}"
-    { $$ = Carbon::Statement::MakeMatch(yylineno, $3, $6); }
+    { $$ = Statement::MakeMatch(yylineno, $3, $6); }
 | CONTINUATION identifier statement
-    { $$ = Carbon::Statement::MakeContinuation(yylineno, $2, $3); }
+    { $$ = Statement::MakeContinuation(yylineno, $2, $3); }
 | RUN expression ";"
-    { $$ = Carbon::Statement::MakeRun(yylineno, $2); }
+    { $$ = Statement::MakeRun(yylineno, $2); }
 | AWAIT ";"
-    { $$ = Carbon::Statement::MakeAwait(yylineno); }
+    { $$ = Statement::MakeAwait(yylineno); }
 ;
 if_statement:
   IF "(" expression ")" block optional_else
-    { $$ = Carbon::Statement::MakeIf(yylineno, $3, $5, $6); }
+    { $$ = Statement::MakeIf(yylineno, $3, $5, $6); }
 ;
 optional_else:
   // Empty
@@ -444,7 +448,7 @@ optional_else:
 ;
 return_expression:
   // Empty
-    { $$ = {Carbon::Expression::MakeTupleLiteral(yylineno, {}), true}; }
+    { $$ = {Expression::MakeTupleLiteral(yylineno, {}), true}; }
 | expression
     { $$ = {$1, false}; }
 ;
@@ -452,30 +456,30 @@ statement_list:
   // Empty
     { $$ = 0; }
 | statement statement_list
-    { $$ = Carbon::Statement::MakeSequence(yylineno, $1, $2); }
+    { $$ = Statement::MakeSequence(yylineno, $1, $2); }
 ;
 block:
   "{" statement_list "}"
-    { $$ = Carbon::Statement::MakeBlock(yylineno, $2); }
+    { $$ = Statement::MakeBlock(yylineno, $2); }
 ;
 return_type:
   // Empty
-    { $$ = {Carbon::Expression::MakeTupleLiteral(yylineno, {}), true}; }
+    { $$ = {Expression::MakeTupleLiteral(yylineno, {}), true}; }
 | ARROW expression %prec FNARROW
     { $$ = {$2, false}; }
 ;
 generic_binding:
   identifier ":!" expression
     {
-      $$ = Carbon::GenericBinding({.name = std::move($1), .type = $3});
+      $$ = GenericBinding({.name = std::move($1), .type = $3});
     }
 ;
 deduced_param_list:
   // Empty
-    { $$ = std::vector<Carbon::GenericBinding>(); }
+    { $$ = std::vector<GenericBinding>(); }
 | generic_binding
     {
-      $$ = std::vector<Carbon::GenericBinding>();
+      $$ = std::vector<GenericBinding>();
       $$.push_back($1);
     }
 | generic_binding "," deduced_param_list
@@ -486,61 +490,61 @@ deduced_param_list:
 ;
 deduced_params:
   // Empty
-    { $$ = std::vector<Carbon::GenericBinding>(); }
+    { $$ = std::vector<GenericBinding>(); }
 | "[" deduced_param_list "]"
     { $$ = $2; }
 ;
 function_definition:
   FN identifier deduced_params maybe_empty_tuple_pattern return_type block
     {
-      $$ = Carbon::FunctionDefinition(
+      $$ = FunctionDefinition(
           yylineno, $2, $3, $4,
-          Carbon::global_arena->New<Carbon::ExpressionPattern>($5.first),
+          global_arena->New<ExpressionPattern>($5.first),
           $5.second, $6);
     }
 | FN identifier deduced_params maybe_empty_tuple_pattern DBLARROW expression ";"
     {
-      $$ = Carbon::FunctionDefinition(
+      $$ = FunctionDefinition(
           yylineno, $2, $3, $4,
-          Carbon::global_arena->New<Carbon::AutoPattern>(yylineno), true,
-          Carbon::Statement::MakeReturn(yylineno, $6, false));
+          global_arena->New<AutoPattern>(yylineno), true,
+          Statement::MakeReturn(yylineno, $6, false));
     }
 ;
 function_declaration:
   FN identifier deduced_params maybe_empty_tuple_pattern return_type ";"
     {
-      $$ = Carbon::FunctionDefinition(
+      $$ = FunctionDefinition(
           yylineno, $2, $3, $4,
-          Carbon::global_arena->New<Carbon::ExpressionPattern>($5.first),
+          global_arena->New<ExpressionPattern>($5.first),
           $5.second, nullptr); }
 ;
 variable_declaration: identifier ":" pattern
-    { $$ = Carbon::global_arena->New<Carbon::BindingPattern>(yylineno, $1, $3); }
+    { $$ = global_arena->New<BindingPattern>(yylineno, $1, $3); }
 ;
 member: VAR variable_declaration ";"
-    { $$ = Carbon::Member::MakeFieldMember(yylineno, $2); }
+    { $$ = Member::MakeFieldMember(yylineno, $2); }
 ;
 member_list:
   // Empty
-    { $$ = std::list<Carbon::Member*>(); }
+    { $$ = std::list<Member*>(); }
 | member member_list
     { $$ = $2; $$.push_front($1); }
 ;
 alternative:
   identifier tuple
-    { $$ = std::pair<std::string, const Carbon::Expression*>($1, $2); }
+    { $$ = std::pair<std::string, const Expression*>($1, $2); }
 | identifier
     {
-      $$ = std::pair<std::string, const Carbon::Expression*>(
-          $1, Carbon::Expression::MakeTupleLiteral(yylineno, {}));
+      $$ = std::pair<std::string, const Expression*>(
+          $1, Expression::MakeTupleLiteral(yylineno, {}));
     }
 ;
 alternative_list:
   // Empty
-    { $$ = std::list<std::pair<std::string, const Carbon::Expression*>>(); }
+    { $$ = std::list<std::pair<std::string, const Expression*>>(); }
 | alternative
     {
-      $$ = std::list<std::pair<std::string, const Carbon::Expression*>>();
+      $$ = std::list<std::pair<std::string, const Expression*>>();
       $$.push_front($1);
     }
 | alternative "," alternative_list
@@ -548,25 +552,25 @@ alternative_list:
 ;
 declaration:
   function_definition
-    { $$ = Carbon::Declaration::MakeFunctionDeclaration(std::move($1)); }
+    { $$ = Declaration::MakeFunctionDeclaration(std::move($1)); }
 | function_declaration
-    { $$ = Carbon::Declaration::MakeFunctionDeclaration(std::move($1)); }
+    { $$ = Declaration::MakeFunctionDeclaration(std::move($1)); }
 | STRUCT identifier "{" member_list "}"
     {
-      $$ = Carbon::Declaration::MakeStructDeclaration(yylineno, $2, $4);
+      $$ = Declaration::MakeStructDeclaration(yylineno, $2, $4);
     }
 | CHOICE identifier "{" alternative_list "}"
     {
-      $$ = Carbon::Declaration::MakeChoiceDeclaration(yylineno, $2, $4);
+      $$ = Declaration::MakeChoiceDeclaration(yylineno, $2, $4);
     }
 | VAR variable_declaration "=" expression ";"
     {
-      $$ = Carbon::Declaration::MakeVariableDeclaration(yylineno, $2, $4);
+      $$ = Declaration::MakeVariableDeclaration(yylineno, $2, $4);
     }
 ;
 declaration_list:
   // Empty
-    { $$ = std::list<Carbon::Declaration>(); }
+    { $$ = std::list<Declaration>(); }
 | declaration declaration_list
     {
       $$ = $2;


### PR DESCRIPTION
Not only is this more consistent with our style rules, it lets us omit a lot of noisy qualifiers in parser.ypp