### PR TITLE
Pin bazeliskrc to 4.1.0 which supports m1

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -2,5 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Keep pinned to a recent release.
+# Keep pinned to a recent release, listed at
+# https://github.com/bazelbuild/bazel.
 USE_BAZEL_VERSION=4.1.0


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/11628 is in Release 4.1 - May 2021 #13099

Pin vs rm for build repeatability.