### PR TITLE
Update vscode recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "daohong-emilio.yash",
     "esbenp.prettier-vscode",
     "llvm-vs-code-extensions.vscode-clangd",
-    "ms-python.python",
-    "ms-vscode.cpptools"
+    "ms-python.python"
   ]
 }


### PR DESCRIPTION
I think the MS C++ extension is what was causing vscode to hang for me. I've been trying clangd and it seems to work better.

yash is syntax highlighting for ypp/lpp. The builtin markdown support's gotten better, so I'm removing the non-standard recommendation.