### PR TITLE
Fix caching and correctness of --update_goldens

### DIFF
--- a/executable_semantics/tests.py
+++ b/executable_semantics/tests.py
@@ -136,6 +136,9 @@ def _update_goldens():
     # pyenv then modifies the PATH, which affects build caching. In order to
     # mimic the calling environment for bazel, this strips out PATH entries
     # which pyenv likely added.
+    # TODO: remove this when/if we're able to add
+    # `--incompatible_strict_action_env=true` to the project .bazelrc, because
+    # that will cause Bazel to ignore PATH.
     env = os.environ.copy()
     stripped_path = []
     for x in env["PATH"].split(":"):


### PR DESCRIPTION
- `PATH` is a caching issue, as commented.
- `exec.map` is a correctness issue, the reference to `test` was incorrect on threading so it wasn't updating all tests.