### PR TITLE
Exclude tab in string literals

### DIFF
--- a/executable_semantics/syntax/lexer.lpp
+++ b/executable_semantics/syntax/lexer.lpp
@@ -65,7 +65,7 @@ UNDERSCORE        "_"
 identifier    [A-Za-z_][A-Za-z0-9_]*
 sized_type_literal [iuf][1-9][0-9]*
 integer_literal   [0-9]+
-string_literal    \"([^\\\"\n]|\\.)*\"
+string_literal    \"([^\\\"\n\t]|\\.)*\"
 horizontal_whitespace [ \t\r]
 whitespace [ \t\r\n]
 operand_start [(A-Za-z0-9_"]

--- a/executable_semantics/test_list.bzl
+++ b/executable_semantics/test_list.bzl
@@ -83,6 +83,7 @@ TEST_LIST = [
     "string_fail3",
     "string_fail4",
     "string_fail5",
+    "string_fail6",
     "struct1",
     "struct2",
     "struct3",

--- a/executable_semantics/testdata/string_fail6.carbon
+++ b/executable_semantics/testdata/string_fail6.carbon
@@ -1,0 +1,8 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+fn main() -> i32 {
+  Print("new	line");
+  return 0;
+}

--- a/executable_semantics/testdata/string_fail6.golden
+++ b/executable_semantics/testdata/string_fail6.golden
@@ -1,0 +1,2 @@
+COMPILATION ERROR: 6: invalid character '\x22' in source file.
+EXIT CODE: 255


### PR DESCRIPTION
Noticed this while working on #732, seemed easiest to split changes though.