### PR TITLE
Remove FunctionDefinition's default constructor

### DIFF
--- a/executable_semantics/ast/declaration.h
+++ b/executable_semantics/ast/declaration.h
@@ -72,18 +72,18 @@ class Declaration {
 
 class FunctionDeclaration : public Declaration {
  public:
-  FunctionDeclaration(FunctionDefinition definition)
-      : Declaration(Kind::FunctionDeclaration, definition.line_num),
-        definition(std::move(definition)) {}
+  FunctionDeclaration(const FunctionDefinition* definition)
+      : Declaration(Kind::FunctionDeclaration, definition->line_num),
+        definition(definition) {}
 
   static auto classof(const Declaration* decl) -> bool {
     return decl->Tag() == Kind::FunctionDeclaration;
   }
 
-  auto Definition() const -> const FunctionDefinition& { return definition; }
+  auto Definition() const -> const FunctionDefinition& { return *definition; }
 
  private:
-  FunctionDefinition definition;
+  const FunctionDefinition* definition;
 };
 
 class StructDeclaration : public Declaration {

--- a/executable_semantics/ast/function_definition.h
+++ b/executable_semantics/ast/function_definition.h
@@ -21,7 +21,6 @@ struct GenericBinding {
 };
 
 struct FunctionDefinition {
-  FunctionDefinition() = default;
   FunctionDefinition(int line_num, std::string name,
                      std::vector<GenericBinding> deduced_params,
                      const TuplePattern* param_pattern,

--- a/executable_semantics/interpreter/typecheck.cpp
+++ b/executable_semantics/interpreter/typecheck.cpp
@@ -978,7 +978,7 @@ auto MakeTypeChecked(const Declaration& d, const TypeEnv& types,
                      const Env& values) -> const Declaration* {
   switch (d.Tag()) {
     case Declaration::Kind::FunctionDeclaration:
-      return global_arena->New<FunctionDeclaration>(*TypeCheckFunDef(
+      return global_arena->New<FunctionDeclaration>(TypeCheckFunDef(
           &cast<FunctionDeclaration>(d).Definition(), types, values));
 
     case Declaration::Kind::StructDeclaration: {

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -93,8 +93,8 @@ void Carbon::Parser::error(const location_type&, const std::string& message) {
 %token <std::string> string_literal
 %type <std::string> designator
 %type <const Declaration*> declaration
-%type <FunctionDefinition> function_declaration
-%type <FunctionDefinition> function_definition
+%type <const FunctionDefinition*> function_declaration
+%type <const FunctionDefinition*> function_definition
 %type <std::list<const Declaration*>> declaration_list
 %type <const Statement*> statement
 %type <const Statement*> if_statement
@@ -509,7 +509,7 @@ deduced_params:
 function_definition:
   FN identifier deduced_params maybe_empty_tuple_pattern return_type block
     {
-      $$ = FunctionDefinition(
+      $$ = global_arena->New<FunctionDefinition>(
           yylineno, $2, $3, $4,
           global_arena->New<ExpressionPattern>($5.first),
           $5.second, $6);
@@ -518,7 +518,7 @@ function_definition:
     {
       // The return type is not considered "omitted" because it's automatic from
       // the expression.
-      $$ = FunctionDefinition(
+      $$ = global_arena->New<FunctionDefinition>(
           yylineno, $2, $3, $4,
           global_arena->New<AutoPattern>(yylineno), true,
           global_arena->New<Return>(yylineno, $6, true));
@@ -527,7 +527,7 @@ function_definition:
 function_declaration:
   FN identifier deduced_params maybe_empty_tuple_pattern return_type ";"
     {
-      $$ = FunctionDefinition(
+      $$ = global_arena->New<FunctionDefinition>(
           yylineno, $2, $3, $4,
           global_arena->New<ExpressionPattern>($5.first),
           $5.second, nullptr); }
@@ -566,9 +566,9 @@ alternative_list:
 ;
 declaration:
   function_definition
-    { $$ = global_arena->New<FunctionDeclaration>(std::move($1)); }
+    { $$ = global_arena->New<FunctionDeclaration>($1); }
 | function_declaration
-    { $$ = global_arena->New<FunctionDeclaration>(std::move($1)); }
+    { $$ = global_arena->New<FunctionDeclaration>($1); }
 | STRUCT identifier "{" member_list "}"
     {
       $$ = global_arena->New<StructDeclaration>(yylineno, $2, $4);

--- a/executable_semantics/syntax/syntax_helpers.cpp
+++ b/executable_semantics/syntax/syntax_helpers.cpp
@@ -26,11 +26,13 @@ static void AddIntrinsics(std::list<const Declaration*>* fs) {
                                 global_arena->New<IntrinsicExpression>(
                                     IntrinsicExpression::IntrinsicKind::Print),
                                 false);
-  auto* print = global_arena->New<FunctionDeclaration>(FunctionDefinition(
-      -1, "Print", std::vector<GenericBinding>(),
-      global_arena->New<TuplePattern>(-1, print_fields),
-      global_arena->New<ExpressionPattern>(global_arena->New<TupleLiteral>(-1)),
-      /*is_omitted_return_type=*/false, print_return));
+  auto* print = global_arena->New<FunctionDeclaration>(
+      global_arena->New<FunctionDefinition>(
+          -1, "Print", std::vector<GenericBinding>(),
+          global_arena->New<TuplePattern>(-1, print_fields),
+          global_arena->New<ExpressionPattern>(
+              global_arena->New<TupleLiteral>(-1)),
+          /*is_omitted_return_type=*/false, print_return));
   fs->insert(fs->begin(), print);
 }
 


### PR DESCRIPTION
This opens up a path for switching `int line_num` to a `Location loc`, which I want to do for tracking filenames of code. But I don't think we should have a default constructor on `Location` to avoid mistakes, and switching FunctionDefinition to an arena alloc seems more consistent anyways.