### PR TITLE
Move paren_contents under ast and restrict syntax BUILD visibility

### DIFF
--- a/executable_semantics/ast/BUILD
+++ b/executable_semantics/ast/BUILD
@@ -28,11 +28,11 @@ cc_library(
     srcs = ["expression.cpp"],
     hdrs = ["expression.h"],
     deps = [
+        ":paren_contents",
         "//common:indirect_value",
         "//common:ostream",
         "//executable_semantics/common:arena",
         "//executable_semantics/common:error",
-        "//executable_semantics/syntax:paren_contents",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -42,7 +42,7 @@ cc_test(
     srcs = ["expression_test.cpp"],
     deps = [
         ":expression",
-        "//executable_semantics/syntax:paren_contents",
+        ":paren_contents",
         "@llvm-project//llvm:gtest",
         "@llvm-project//llvm:gtest_main",
     ],
@@ -70,6 +70,11 @@ cc_library(
 )
 
 cc_library(
+    name = "paren_contents",
+    hdrs = ["paren_contents.h"],
+)
+
+cc_library(
     name = "pattern",
     srcs = ["pattern.cpp"],
     hdrs = ["pattern.h"],
@@ -86,8 +91,8 @@ cc_test(
     name = "pattern_test",
     srcs = ["pattern_test.cpp"],
     deps = [
+        ":paren_contents",
         ":pattern",
-        "//executable_semantics/syntax:paren_contents",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:gtest",
         "@llvm-project//llvm:gtest_main",

--- a/executable_semantics/ast/expression.h
+++ b/executable_semantics/ast/expression.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "common/ostream.h"
-#include "executable_semantics/syntax/paren_contents.h"
+#include "executable_semantics/ast/paren_contents.h"
 #include "llvm/Support/Compiler.h"
 
 namespace Carbon {

--- a/executable_semantics/ast/expression_test.cpp
+++ b/executable_semantics/ast/expression_test.cpp
@@ -6,8 +6,8 @@
 
 #include <string>
 
+#include "executable_semantics/ast/paren_contents.h"
 #include "executable_semantics/common/arena.h"
-#include "executable_semantics/syntax/paren_contents.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "llvm/Support/Casting.h"

--- a/executable_semantics/ast/paren_contents.h
+++ b/executable_semantics/ast/paren_contents.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXECUTABLE_SEMANTICS_SYNTAX_PAREN_CONTENTS_H_
-#define EXECUTABLE_SEMANTICS_SYNTAX_PAREN_CONTENTS_H_
+#ifndef EXECUTABLE_SEMANTICS_AST_PAREN_CONTENTS_H_
+#define EXECUTABLE_SEMANTICS_AST_PAREN_CONTENTS_H_
 
 #include <optional>
 #include <string>
@@ -83,4 +83,4 @@ auto ParenContents<Term>::TupleElements(int line_num) const
 
 }  // namespace Carbon
 
-#endif  // EXECUTABLE_SEMANTICS_SYNTAX_PAREN_CONTENTS_H_
+#endif  // EXECUTABLE_SEMANTICS_AST_PAREN_CONTENTS_H_

--- a/executable_semantics/ast/pattern_test.cpp
+++ b/executable_semantics/ast/pattern_test.cpp
@@ -5,8 +5,8 @@
 #include "executable_semantics/ast/pattern.h"
 
 #include "executable_semantics/ast/expression.h"
+#include "executable_semantics/ast/paren_contents.h"
 #include "executable_semantics/common/arena.h"
-#include "executable_semantics/syntax/paren_contents.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "llvm/Support/Casting.h"

--- a/executable_semantics/syntax/BUILD
+++ b/executable_semantics/syntax/BUILD
@@ -4,7 +4,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-package(default_visibility = ["//executable_semantics:__subpackages__"])
+package(default_visibility = ["//executable_semantics:__pkg__"])
 
 cc_library(
     name = "syntax",
@@ -28,23 +28,18 @@ cc_library(
         "-Wno-writable-strings",
     ],
     deps = [
-        ":paren_contents",
         "//common:check",
         "//common:ostream",
         "//common:string_helpers",
         "//executable_semantics/ast:declaration",
         "//executable_semantics/ast:expression",
+        "//executable_semantics/ast:paren_contents",
         "//executable_semantics/common:arena",
         "//executable_semantics/common:error",
         "//executable_semantics/common:tracing_flag",
         "//executable_semantics/interpreter",
         "//executable_semantics/interpreter:typecheck",
     ],
-)
-
-cc_library(
-    name = "paren_contents",
-    hdrs = ["paren_contents.h"],
 )
 
 genrule(

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -69,7 +69,7 @@
 #include "executable_semantics/ast/function_definition.h"
 #include "executable_semantics/ast/pattern.h"
 #include "executable_semantics/common/arena.h"
-#include "executable_semantics/syntax/paren_contents.h"
+#include "executable_semantics/ast/paren_contents.h"
 
 namespace Carbon {
 class ParseAndLexContext;


### PR DESCRIPTION
Trying to straighten out the BUILD graph; the dependency of ast pieces on paren_contents makes me think this is the right direction.