### PR TITLE
Update versions of archives in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@ rules_python_version = "0.3.0"
 # Add Bazel's python rules and set up pip.
 http_archive(
     name = "rules_python",
-    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+    sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
     url = "https://github.com/bazelbuild/rules_python/releases/download/%s/rules_python-%s.tar.gz" % (
         rules_python_version,
         rules_python_version,


### PR DESCRIPTION
The m4/flex/bison commits are in, unreleased, but we can still go back to the canonical repo. Also updates the python version.

This pulls out the version statement mainly because it's typically repeated, not due to the m4/flex/bison verbosity. Pulling it out makes it more obvious and easier to change.