### PR TITLE
Remove uses of rules_cc

### DIFF
--- a/executable_semantics/BUILD
+++ b/executable_semantics/BUILD
@@ -2,7 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/testing:golden_test.bzl", "golden_test")
 load("test_list.bzl", "TEST_LIST")
 

--- a/executable_semantics/ast/BUILD
+++ b/executable_semantics/ast/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 package(default_visibility = ["//executable_semantics:__subpackages__"])
 
 cc_library(

--- a/executable_semantics/interpreter/BUILD
+++ b/executable_semantics/interpreter/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 package(default_visibility = ["//executable_semantics:__subpackages__"])
 
 cc_library(

--- a/executable_semantics/syntax/BUILD
+++ b/executable_semantics/syntax/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 package(default_visibility = ["//executable_semantics:__pkg__"])
 
 cc_library(

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/third_party/examples/woff2/BUILD.original
+++ b/third_party/examples/woff2/BUILD.original
@@ -4,8 +4,6 @@
 
 # Rules are adapted from CMakeLists.txt.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/third_party/examples/woff2/carbon/BUILD
+++ b/third_party/examples/woff2/carbon/BUILD
@@ -4,8 +4,6 @@
 
 # Rules are adapted from CMakeLists.txt.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/toolchain/common/BUILD
+++ b/toolchain/common/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -2,7 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -2,7 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -2,7 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -2,8 +2,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(default_visibility = ["//visibility:public"])
 
 cc_library(


### PR DESCRIPTION
Per https://github.com/bazelbuild/rules_cc this still isn't necessary. There's no build-time enforcement, so usage is inconsistent/incorrect. Rather than letting this linger, remove it pending Bazel tooling enforcing it.