### PR TITLE
Switch to a mypy fork that handles imports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,14 +38,25 @@ pip_install(
 # typing directly. If it's added, we will probably want to switch.
 
 # Add mypy
-mypy_integration_version = "0.2.0"
+mypy_integration_version = "e5f8071f33eca637cd90bf70cb45f749e63bf2ca"
+
+# TODO: Can switch back to the official repo when it includes:
+# https://github.com/thundergolfer/bazel-mypy-integration/pull/43
+#http_archive(
+#    name = "mypy_integration",
+#    sha256 = "621df076709dc72809add1f5fe187b213fee5f9b92e39eb33851ab13487bd67d",
+#    strip_prefix = "bazel-mypy-integration-%s" % mypy_integration_version,
+#    urls = [
+#        "https://github.com/thundergolfer/bazel-mypy-integration/archive/refs/tags/%s.tar.gz" % mypy_integration_version,
+#    ],
+#)
 
 http_archive(
     name = "mypy_integration",
-    sha256 = "621df076709dc72809add1f5fe187b213fee5f9b92e39eb33851ab13487bd67d",
+    sha256 = "481ec6f0953a84a36b8103286f04c4cd274ae689060099085c02ac187d007592",
     strip_prefix = "bazel-mypy-integration-%s" % mypy_integration_version,
     urls = [
-        "https://github.com/thundergolfer/bazel-mypy-integration/archive/refs/tags/%s.tar.gz" % mypy_integration_version,
+        "https://github.com/jonmeow/bazel-mypy-integration/archive/%s.zip" % mypy_integration_version,
     ],
 )
 

--- a/executable_semantics/syntax/BUILD
+++ b/executable_semantics/syntax/BUILD
@@ -96,5 +96,6 @@ py_test(
 
 mypy_test(
     name = "format_grammar_mypy_test",
+    include_imports = True,
     deps = [":format_grammar_lib"],
 )

--- a/github_tools/BUILD
+++ b/github_tools/BUILD
@@ -27,6 +27,7 @@ py_binary(
 
 mypy_test(
     name = "pr_comments_mypy_test",
+    include_imports = True,
     deps = [":pr_comments"],
 )
 
@@ -49,6 +50,7 @@ py_binary(
 
 mypy_test(
     name = "update_label_access_mypy_test",
+    include_imports = True,
     deps = [":update_label_access"],
 )
 

--- a/github_tools/github_helpers.py
+++ b/github_tools/github_helpers.py
@@ -14,9 +14,8 @@ import os
 from typing import Dict, Generator, Optional, Tuple
 
 # https://pypi.org/project/gql/
-# gql is missing type annotations, so disable checking on around it.
-import gql  # type: ignore
-import gql.transport.requests  # type: ignore
+import gql
+import gql.transport.requests
 
 _ENV_TOKEN = "GITHUB_ACCESS_TOKEN"
 
@@ -53,7 +52,7 @@ class Client(object):
             url="https://api.github.com/graphql",
             headers={"Authorization": "bearer %s" % parsed_args.access_token},
         )
-        self._client = gql.Client(transport=transport)
+        self._client = gql.Client(transport=transport)  # type: ignore
 
     def execute(self, query: str) -> Dict:
         """Runs a query."""

--- a/github_tools/update_label_access.py
+++ b/github_tools/update_label_access.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Set
 
 # https://github.com/PyGithub/PyGithub
 # GraphQL is preferred, but falling back to pygithub for unsupported mutations.
-import github  # type: ignore
+import github
 
 from github_tools import github_helpers
 
@@ -114,18 +114,18 @@ def _update_team(
 
     This switches to pygithub because GraphQL lacks equivalent mutation support.
     """
-    gh_team = gh.get_organization(_ORG).get_team_by_slug(_TEAM)
+    gh_team = gh.get_organization(_ORG).get_team_by_slug(_TEAM)  # type: ignore
     add_members = org_members - team_members
     if add_members:
         print("Adding members: %s" % ", ".join(add_members))
         for member in add_members:
-            gh_team.add_membership(gh.get_user(member))
+            gh_team.add_membership(gh.get_user(member))  # type: ignore
 
     remove_members = team_members - org_members
     if remove_members:
         print("Removing members: %s" % ", ".join(remove_members))
         for member in remove_members:
-            gh_team.remove_membership(gh.get_user(member))
+            gh_team.remove_membership(gh.get_user(member))  # type: ignore
 
 
 def main() -> None:
@@ -136,7 +136,7 @@ def main() -> None:
     org_members = _load_org_members(client)
     team_members = _load_team_members(client)
     if org_members != team_members:
-        gh = github.Github(parsed_args.access_token)
+        gh = github.Github(parsed_args.access_token)  # type: ignore
         _update_team(gh, org_members, team_members)
     print("Done!")
 

--- a/migrate_cpp/BUILD
+++ b/migrate_cpp/BUILD
@@ -16,5 +16,6 @@ py_binary(
 
 mypy_test(
     name = "migrate_cpp_mypy_test",
+    include_imports = True,
     deps = [":migrate_cpp"],
 )

--- a/proposals/scripts/BUILD
+++ b/proposals/scripts/BUILD
@@ -33,6 +33,7 @@ py_test(
 
 mypy_test(
     name = "new_proposal_mypy_test",
+    include_imports = True,
     deps = [":new_proposal"],
 )
 
@@ -45,5 +46,6 @@ py_library(
 
 mypy_test(
     name = "update_proposal_list_mypy_test",
+    include_imports = True,
     deps = [":update_proposal_list"],
 )


### PR DESCRIPTION
I'm seeing if I can upstream https://github.com/thundergolfer/bazel-mypy-integration/pull/43, but if you like we can also point at my fork for the time being.

This should resolve conflicts with mypy treating imports as non-hermetic, creating inconsistent behavior if packages are/aren't installed locally.