### PR TITLE
Function return type inference

### DIFF
--- a/proposals/p0826.md
+++ b/proposals/p0826.md
@@ -275,8 +275,7 @@ Thus, although a separate declaration would be insufficient for a call, we could
 allow using `auto` with a separate declaration and definition when the caller
 can see _both_.
 
-For example, this example would be valid because `CallAdd` can see the `Add`
-definition:
+This example would be valid because `CallAdd` can see the `Add` definition:
 
 ```
 fn Add(x: i32, y: i32) -> auto;


### PR DESCRIPTION
Allow `auto` as a return type for functions. Only support functions with one `return` statement for now (open question).

This explicitly suggests removing the executable semantics `fn name(args) => expression` syntax, and is motivated by reconciling executable semantics with approved Carbon state. [example](https://github.com/carbon-language/carbon-lang/blob/7b706ad7446fe5ac8dc9c092155c8df371d49a71/executable_semantics/testdata/fun_named_params.carbon) This aspect is a decision that may be affected by lambda syntax, but we might also choose to keep lambda syntax and function syntax separate -- I don't think there's enough benefit to providing the alternate function syntax right now.