### PR TITLE
Set issue report url

### DIFF
--- a/executable_semantics/main.cpp
+++ b/executable_semantics/main.cpp
@@ -13,6 +13,10 @@
 #include "llvm/Support/InitLLVM.h"
 
 int main(int argc, char* argv[]) {
+  llvm::setBugReportMsg(
+      "Please report issues to "
+      "https://github.com/carbon-language/carbon-lang/issues and include the "
+      "crash backtrace.\n");
   llvm::InitLLVM(argc, argv);
 
   // Printing to stderr should flush stdout. This is most noticeable when stderr


### PR DESCRIPTION
Defaults to llvm.org, which we definitely don't want