### PR TITLE
Cleanup debug flags and enable libc++ debugging on Linux.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -169,13 +169,11 @@ def _impl(ctx):
                 flag_groups = ([
                     flag_group(
                         flags = [
-                            "-DNDEBUG",
                             "-ffunction-sections",
                             "-fdata-sections",
                         ],
                     ),
                 ]),
-                with_features = [with_feature_set(features = ["opt"])],
             ),
             flag_set(
                 actions = codegen_compile_actions,
@@ -284,12 +282,20 @@ def _impl(ctx):
         name = "default_optimization_flags",
         enabled = True,
         requires = [feature_set(["opt"])],
-        flag_sets = [flag_set(
-            actions = codegen_compile_actions,
-            flag_groups = [flag_group(flags = [
-                "-O3",
-            ])],
-        )],
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-DNDEBUG",
+                ])],
+            ),
+            flag_set(
+                actions = codegen_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-O3",
+                ])],
+            ),
+        ],
     )
 
     # Handle different levels and forms of debug info emission with individual
@@ -517,6 +523,17 @@ def _impl(ctx):
                         ],
                     ),
                 ]),
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    # Enable libc++'s debug features.
+                    "-D_LIBCXX_DEBUG=1",
+                ])],
+                with_features = [
+                    with_feature_set(features = ["dbg"]),
+                    with_feature_set(features = ["fastbuild"]),
+                ],
             ),
         ],
     )


### PR DESCRIPTION
The big change here is to enable libc=+'s debug mode in `-c dbg` and `-c
fastbuild` modes on Linux where it seems to work well with the Homebrew
installed toolchain. I'm restricting it to Linux as early indications
are that macOS may not work well.

This also tidies up how `-NDEBUG` is set to include non-codegen compile
actions, and consolidates some optimization flags in a single location.
This part has no functionality change, but would likely invalidate
caches so bundled here where both a) I noticed and b) we already had
a cache invalidation.