### PR TITLE
auto keyword for vars

### DIFF
--- a/proposals/p0851.md
+++ b/proposals/p0851.md
@@ -236,7 +236,7 @@ Some caveats should be considered for pattern matching tests inside `if`:
 
 -   There is syntax overlap with C++, which allows code such as:
 
-    ```carbon
+    ```cpp
     if (Derived* derived = dynamic_cast<Derived*>(base)) {
       // dynamic_cast succeeded, `derived` is initialized.
     } else {


### PR DESCRIPTION
Allow `var <identifier>: auto = <expression>;` syntax.