### PR TITLE
Naming conventions

### DIFF
--- a/proposals/p0861.md
+++ b/proposals/p0861.md
@@ -198,19 +198,19 @@ discussed were:
 
 Taking that into consideration, and that we are likely to keep
 `lower_snake_case` for keywords and type literals in particular, a couple
-options discussed would have mainly affect `self`, `super`, and `string`:
+options discussed would have mainly affect `self`, `base`, and `string`:
 
 -   Anything language-provided without needing an `import` is always
     `lower_snake_case`.
-    -   `i32`, `bool`, `true`, `self`, `super`, `string.is_empty()`
+    -   `i32`, `bool`, `true`, `self`, `base`, `string.is_empty()`
 -   As above, but prelude class members follow standard naming conventions.
-    -   `i32`, `bool`, `true`, `self`, `super`, `string.IsEmpty()`
+    -   `i32`, `bool`, `true`, `self`, `base`, `string.IsEmpty()`
 
 The understanding is that the difference between `bool` being treated similarly
 to a keyword and `Self` being treated similarly to a type (both regardless of
 implementation) is somewhat arbitrary. The decision not to use
 `lower_snake_case` consistently depends mainly on the leaning of the leads, that
-`self` and `super` felt like they shouldn't strictly be treated as keywords, and
+`self` and `base` felt like they shouldn't strictly be treated as keywords, and
 `string` felt like the point where users should expect something more like an
 idiomatic class. Future borderline cases may need to be decided by leads whether
 they should be treated as more keyword-like or type-like.


### PR DESCRIPTION
-   For idiomatic Carbon code:
    -   `UpperCamelCase` will be used when the identifier can be resolved to a
        specific value at compile-time.
    -   `lower_snake_case` will be used when the identifier's value won't be
        known until runtime, such as for variables.
-   For Carbon-provided features:
    -   Keywords and type literals will use `lower_snake_case`.
    -   Other code will use the guidelines for idiomatic Carbon code.