### PR TITLE
Switch to depend on LLVM 13's Clang.

### DIFF
--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -33,7 +33,7 @@ def _detect_system_clang(repository_ctx):
         return repository_ctx.path(cc)
 
     # Try looking on the path. We check for the specific versioned name and then the normal name.
-    system_clang = repository_ctx.which("clang-12")
+    system_clang = repository_ctx.which("clang-13")
     if not system_clang:
         system_clang = repository_ctx.which("clang")
         if not system_clang:


### PR DESCRIPTION
The LLVM-13 release is now on Homebrew, so switch to it. This is
important because our CI only installs the latest version currently.

If you hit issues after this, make sure to update your Homebrew install
to get the latest Clang release. You can always directly set `CC` in
your environment to use a specific `clang` compiler.