### PR TITLE
Apply clang-tidy fixes to the common dir

### DIFF
--- a/executable_semantics/common/error.h
+++ b/executable_semantics/common/error.h
@@ -23,17 +23,19 @@ namespace Carbon {
 
 #define FATAL_PROGRAM_ERROR_NO_LINE() RAW_EXITING_STREAM() << "PROGRAM ERROR: "
 
-#define FATAL_PROGRAM_ERROR(line) FATAL_PROGRAM_ERROR_NO_LINE() << line << ": "
+#define FATAL_PROGRAM_ERROR(line) \
+  FATAL_PROGRAM_ERROR_NO_LINE() << (line) << ": "
 
 #define FATAL_COMPILATION_ERROR_NO_LINE() \
   RAW_EXITING_STREAM() << "COMPILATION ERROR: "
 
 #define FATAL_COMPILATION_ERROR(line) \
-  FATAL_COMPILATION_ERROR_NO_LINE() << line << ": "
+  FATAL_COMPILATION_ERROR_NO_LINE() << (line) << ": "
 
 #define FATAL_RUNTIME_ERROR_NO_LINE() RAW_EXITING_STREAM() << "RUNTIME ERROR: "
 
-#define FATAL_RUNTIME_ERROR(line) FATAL_RUNTIME_ERROR_NO_LINE() << line << ": "
+#define FATAL_RUNTIME_ERROR(line) \
+  FATAL_RUNTIME_ERROR_NO_LINE() << (line) << ": "
 
 }  // namespace Carbon
 


### PR DESCRIPTION
(the dir is mostly clean according to clang-tidy, actually)