### PR TITLE
Clean up titles for a few docs, mainly to remove 'Carbon' prefixes

### DIFF
--- a/docs/design/generics/README.md
+++ b/docs/design/generics/README.md
@@ -1,4 +1,4 @@
-# Carbon: Generics
+# Generics
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -1,4 +1,4 @@
-# Carbon generics details
+# Generics: Details
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/docs/design/generics/goals.md
+++ b/docs/design/generics/goals.md
@@ -1,4 +1,4 @@
-# Carbon: Generics goals
+# Generics: Goals
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/docs/design/generics/overview.md
+++ b/docs/design/generics/overview.md
@@ -1,4 +1,4 @@
-# Carbon generics overview
+# Generics: Overview
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/docs/design/generics/terminology.md
+++ b/docs/design/generics/terminology.md
@@ -1,4 +1,4 @@
-# Carbon: Generics - Terminology
+# Generics: Terminology
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/docs/project/principles/low_context_sensitivity.md
+++ b/docs/project/principles/low_context_sensitivity.md
@@ -1,4 +1,4 @@
-# Carbon: Low context-sensitivity principle
+# Principle: Low context-sensitivity
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM


### PR DESCRIPTION
Note, most principle docs already have the `Principle:` prefix, context sensitivity and `Safety strategy` are/were outliers.