### PR TITLE
Disable performance-unnecessary-value-param

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ---
+# - modernize-use-nodiscard is disabled because it only fixes const methods,
+#   not non-const, which yields distracting results on accessors.
+# - performance-unnecessary-value-param is disabled because it duplicate
+#   modernize-pass-by-value.
 Checks:
   -*, bugprone-*, -bugprone-narrowing-conversions, google-*,
   -google-readability-todo, misc-definitions-in-headers, misc-misplaced-const,
@@ -10,8 +14,8 @@ Checks:
   misc-unconventional-assign-operator, misc-uniqueptr-reset-release,
   misc-unused-*, modernize-*, -modernize-avoid-c-arrays,
   -modernize-use-default-member-init, -modernize-use-emplace,
-  -modernize-use-nodiscard, performance-*, readability-braces-around-statements,
-  readability-identifier-naming
+  -modernize-use-nodiscard, performance-*, -performance-unnecessary-value-param,
+  readability-braces-around-statements, readability-identifier-naming
 WarningsAsErrors: true
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase, value: CamelCase }


### PR DESCRIPTION
You can observe this conflict at https://godbolt.org/z/5eeq6brfe: adding `--fix` to `clang-tidy` yields `std::move(std::move(...))`