### PR TITLE
Revert formatting suggestion from #906

### DIFF
--- a/executable_semantics/syntax/parse_and_lex_context.h
+++ b/executable_semantics/syntax/parse_and_lex_context.h
@@ -47,7 +47,7 @@ class ParseAndLexContext {
 #define YY_DECL                                                         \
   auto yylex(Carbon::Nonnull<Carbon::Arena*> arena, yyscan_t yyscanner, \
              Carbon::ParseAndLexContext& context)                       \
-      -> Carbon::Parser::symbol_type
+      ->Carbon::Parser::symbol_type
 
 // Declares yylex for the parser's sake.
 YY_DECL;


### PR DESCRIPTION
Clang-format insists on this, which seems like a bug to me.