### PR TITLE
Factor out base class of Heap for allocation

### DIFF
--- a/executable_semantics/interpreter/BUILD
+++ b/executable_semantics/interpreter/BUILD
@@ -75,6 +75,7 @@ cc_library(
     deps = [
         ":action_and_value",
         ":address",
+        ":raw_heap",
         "//common:ostream",
         "@llvm-project//llvm:Support",
     ],
@@ -98,6 +99,17 @@ cc_library(
         "//executable_semantics/ast:expression",
         "//executable_semantics/common:arena",
         "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "raw_heap",
+    srcs = ["raw_heap.cpp"],
+    hdrs = ["raw_heap.h"],
+    deps = [
+        ":address",
+        "//executable_semantics/common:error",
+        "//executable_semantics/common:nonnull",
     ],
 )
 

--- a/executable_semantics/interpreter/action.h
+++ b/executable_semantics/interpreter/action.h
@@ -18,7 +18,7 @@
 
 namespace Carbon {
 
-using Env = Dictionary<std::string, Address>;
+using Env = Dictionary<std::string, AllocationId>;
 
 struct Scope {
   explicit Scope(Env values) : Scope(values, std::vector<std::string>()) {}

--- a/executable_semantics/interpreter/address.h
+++ b/executable_semantics/interpreter/address.h
@@ -15,32 +15,48 @@
 
 namespace Carbon {
 
+// An AllocationId identifies an allocation produced by a RawHeap.
+class AllocationId {
+ public:
+  AllocationId(const AllocationId&) = default;
+  auto operator=(const AllocationId&) -> AllocationId& = default;
+
+  // Prints a human-readable representation of *this to `out`.
+  //
+  // Currently that representation consists of an integer index.
+  void Print(llvm::raw_ostream& out) const {
+    out << "Allocation(" << index_ << ")";
+  }
+
+ private:
+  // The representation of AllocationId describes how to locate an object within
+  // a RawHeap, so its implementation details are tied to the implementation
+  // details of RawHeap.
+  friend class RawHeap;
+
+  AllocationId(size_t index) : index_(index) {}
+
+  size_t index_;
+};
+
 // An Address represents a memory address in the Carbon virtual machine.
-// Addresses are used to access values stored in a Heap, and are obtained
-// from a Heap (or by deriving them from other Addresses).
+// Addresses are used to access values stored in a Heap.
 class Address {
  public:
+  // Constructs an `Address` that refers to the value stored in `allocation`.
+  explicit Address(AllocationId allocation) : allocation_(allocation) {}
+
   Address(const Address&) = default;
   Address(Address&&) = default;
   auto operator=(const Address&) -> Address& = default;
   auto operator=(Address&&) -> Address& = default;
 
-  // Returns true if the two addresses refer to the same memory location.
-  friend auto operator==(const Address& lhs, const Address& rhs) -> bool {
-    return lhs.index_ == rhs.index_;
-  }
-
-  friend auto operator!=(const Address& lhs, const Address& rhs) -> bool {
-    return !(lhs == rhs);
-  }
-
   // Prints a human-readable representation of `a` to `out`.
   //
-  // Currently, that representation consists of an integer index identifying
-  // the whole memory allocation, and an optional FieldPath specifying a
-  // particular field within that allocation.
+  // Currently, that representation consists of an AllocationId followed by an
+  // optional FieldPath specifying a particular field within that allocation.
   void Print(llvm::raw_ostream& out) const {
-    out << "Address(" << index_ << ")" << field_path_;
+    out << allocation_ << field_path_;
   }
 
   LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }
@@ -59,9 +75,7 @@ class Address {
   // details of the Heap.
   friend class Heap;
 
-  explicit Address(uint64_t index) : index_(index) {}
-
-  uint64_t index_;
+  AllocationId allocation_;
   FieldPath field_path_;
 };
 

--- a/executable_semantics/interpreter/heap.cpp
+++ b/executable_semantics/interpreter/heap.cpp
@@ -5,64 +5,46 @@
 #include "executable_semantics/interpreter/heap.h"
 
 #include "executable_semantics/common/error.h"
+#include "executable_semantics/interpreter/raw_heap.h"
 #include "llvm/ADT/StringExtras.h"
 
 namespace Carbon {
 
-auto Heap::AllocateValue(Nonnull<const Value*> v) -> Address {
-  // Putting the following two side effects together in this function
-  // ensures that we don't do anything else in between, which is really bad!
-  // Consider whether to include a copy of the input v in this function
-  // or to leave it up to the caller.
-  Address a(values_.size());
-  values_.push_back(v);
-  alive_.push_back(true);
-  return a;
-}
-
 auto Heap::Read(const Address& a, SourceLocation source_loc)
     -> Nonnull<const Value*> {
-  this->CheckAlive(a, source_loc);
-  return values_[a.index_]->GetField(arena_, a.field_path_, source_loc);
+  CheckAlive(a.allocation_, source_loc);
+  return RawRead(a.allocation_)->GetField(arena_, a.field_path_, source_loc);
 }
 
 void Heap::Write(const Address& a, Nonnull<const Value*> v,
                  SourceLocation source_loc) {
-  this->CheckAlive(a, source_loc);
-  values_[a.index_] =
-      values_[a.index_]->SetField(arena_, a.field_path_, v, source_loc);
+  CheckAlive(a.allocation_, source_loc);
+  Nonnull<const Value*> new_allocation_value =
+      RawRead(a.allocation_)->SetField(arena_, a.field_path_, v, source_loc);
+  RawWrite(a.allocation_, new_allocation_value);
 }
 
-void Heap::CheckAlive(const Address& address, SourceLocation source_loc) {
-  if (!alive_[address.index_]) {
+void Heap::CheckAlive(AllocationId allocation, SourceLocation source_loc) {
+  if (!IsAlive(allocation)) {
     FATAL_RUNTIME_ERROR(source_loc)
-        << "undefined behavior: access to dead value "
-        << *values_[address.index_];
-  }
-}
-
-void Heap::Deallocate(const Address& address) {
-  CHECK(address.field_path_.IsEmpty());
-  if (alive_[address.index_]) {
-    alive_[address.index_] = false;
-  } else {
-    FATAL_RUNTIME_ERROR_NO_LINE() << "deallocating an already dead value";
+        << "undefined behavior: access to dead value " << *RawRead(allocation);
   }
 }
 
 void Heap::Print(llvm::raw_ostream& out) const {
   llvm::ListSeparator sep;
-  for (size_t i = 0; i < values_.size(); ++i) {
+  for (AllocationId allocation : AllAllocations()) {
     out << sep;
-    PrintAddress(Address(i), out);
+    PrintAllocation(allocation, out);
   }
 }
 
-void Heap::PrintAddress(const Address& a, llvm::raw_ostream& out) const {
-  if (!alive_[a.index_]) {
+void Heap::PrintAllocation(AllocationId allocation,
+                           llvm::raw_ostream& out) const {
+  if (!IsAlive(allocation)) {
     out << "!!";
   }
-  out << *values_[a.index_];
+  out << *RawRead(allocation);
 }
 
 }  // namespace Carbon

--- a/executable_semantics/interpreter/heap.h
+++ b/executable_semantics/interpreter/heap.h
@@ -2,23 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXECUTABLE_SEMANTICS_INTERPRETER_MEMORY_H_
-#define EXECUTABLE_SEMANTICS_INTERPRETER_MEMORY_H_
+#ifndef EXECUTABLE_SEMANTICS_INTERPRETER_HEAP_H_
+#define EXECUTABLE_SEMANTICS_INTERPRETER_HEAP_H_
 
 #include <vector>
 
 #include "common/ostream.h"
 #include "executable_semantics/interpreter/address.h"
+#include "executable_semantics/interpreter/raw_heap.h"
 #include "executable_semantics/interpreter/value.h"
 #include "llvm/Support/Compiler.h"
 
 namespace Carbon {
 
-// A Heap represents the abstract machine's dynamically allocated memory.
-class Heap {
+// A Heap represents the abstract machine's dynamically allocated memory. It
+// extends `RawHeap` with the ability to read and write individual addresses,
+// not just whole allocations. It also provides some convenience functionality
+// such as printing that can't be in `RawHeap` for layering reasons.
+class Heap : public RawHeap {
  public:
   // Constructs an empty Heap.
-  explicit Heap(Nonnull<Arena*> arena) : arena_(arena){};
+  explicit Heap(Nonnull<Arena*> arena) : RawHeap(), arena_(arena){};
 
   Heap(const Heap&) = delete;
   auto operator=(const Heap&) -> Heap& = delete;
@@ -33,29 +37,21 @@ class Heap {
   void Write(const Address& a, Nonnull<const Value*> v,
              SourceLocation source_loc);
 
-  // Put the given value on the heap and mark it as alive.
-  auto AllocateValue(Nonnull<const Value*> v) -> Address;
+  // Print the value at the given allocation to the stream `out`.
+  void PrintAllocation(AllocationId allocation, llvm::raw_ostream& out) const;
 
-  // Marks the object at this address, and all of its sub-objects, as dead.
-  void Deallocate(const Address& address);
-
-  // Print the value at the given address to the stream `out`.
-  void PrintAddress(const Address& a, llvm::raw_ostream& out) const;
-
-  // Print all the values on the heap to the stream `out`.
+  // Print all the allocations on the heap to the stream `out`.
   void Print(llvm::raw_ostream& out) const;
 
   LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }
 
  private:
-  // Signal an error if the address is no longer alive.
-  void CheckAlive(const Address& address, SourceLocation source_loc);
+  // Signal an error if the allocation is no longer alive.
+  void CheckAlive(AllocationId allocation, SourceLocation source_loc);
 
   Nonnull<Arena*> arena_;
-  std::vector<Nonnull<const Value*>> values_;
-  std::vector<bool> alive_;
 };
 
 }  // namespace Carbon
 
-#endif  // EXECUTABLE_SEMANTICS_INTERPRETER_MEMORY_H_
+#endif  // EXECUTABLE_SEMANTICS_INTERPRETER_HEAP_H_

--- a/executable_semantics/interpreter/interpreter.h
+++ b/executable_semantics/interpreter/interpreter.h
@@ -44,7 +44,7 @@ class Interpreter {
                     SourceLocation source_loc) -> std::optional<Env>;
 
   // Support TypeChecker allocating values on the heap.
-  auto AllocateValue(Nonnull<const Value*> v) -> Address {
+  auto AllocateValue(Nonnull<const Value*> v) -> AllocationId {
     return heap_.AllocateValue(v);
   }
 

--- a/executable_semantics/interpreter/raw_heap.cpp
+++ b/executable_semantics/interpreter/raw_heap.cpp
@@ -1,0 +1,47 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "executable_semantics/interpreter/raw_heap.h"
+
+#include "executable_semantics/common/error.h"
+
+namespace Carbon {
+
+auto RawHeap::AllocateValue(Nonnull<const Value*> v) -> AllocationId {
+  // Putting the following two side effects together in this function
+  // ensures that we don't do anything else in between, which is really bad!
+  // Consider whether to include a copy of the input v in this function
+  // or to leave it up to the caller.
+  AllocationId a(values_.size());
+  values_.push_back(v);
+  alive_.push_back(true);
+  return a;
+}
+
+auto RawHeap::RawRead(AllocationId a) const -> Nonnull<const Value*> {
+  return values_[a.index_];
+}
+
+void RawHeap::RawWrite(AllocationId a, Nonnull<const Value*> v) {
+  CHECK(alive_[a.index_]);
+  values_[a.index_] = v;
+}
+
+void RawHeap::Deallocate(AllocationId address) {
+  if (alive_[address.index_]) {
+    alive_[address.index_] = false;
+  } else {
+    FATAL_RUNTIME_ERROR_NO_LINE() << "deallocating an already dead value";
+  }
+}
+
+auto RawHeap::AllAllocations() const -> std::vector<AllocationId> {
+  std::vector<AllocationId> result;
+  for (size_t i = 0; i < values_.size(); ++i) {
+    result.push_back(AllocationId(i));
+  }
+  return result;
+}
+
+}  // namespace Carbon

--- a/executable_semantics/interpreter/raw_heap.h
+++ b/executable_semantics/interpreter/raw_heap.h
@@ -1,0 +1,59 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_
+#define EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_
+
+#include <vector>
+
+#include "executable_semantics/common/nonnull.h"
+#include "executable_semantics/interpreter/address.h"
+
+namespace Carbon {
+
+class Value;
+
+// A RawHeap represents the abstract machine's dynamically allocated memory as
+// a collection of _allocations_, each of which has a `Value`, and may be alive
+// or dead. An allocation is analogous to the C++ notion of a complete object:
+// the the `Value` in an allocation is not a sub-part of any other `Value`.
+class RawHeap {
+ public:
+  RawHeap(const RawHeap&) = delete;
+  auto operator=(const RawHeap&) = delete;
+
+  // Put the given value on the heap and mark it as alive.
+  auto AllocateValue(Nonnull<const Value*> v) -> AllocationId;
+
+  // Marks the object at this address, and all of its sub-objects, as dead.
+  void Deallocate(AllocationId allocation);
+
+ protected:
+  RawHeap() = default;
+  ~RawHeap() = default;
+
+  // Returns true if the given allocation is alive.
+  auto IsAlive(AllocationId allocation) const -> bool {
+    return alive_[allocation.index_];
+  }
+
+  // Returns the value stored in the given allocation. In order to support
+  // logging and tracing use cases, the allocation is permitted to be dead,
+  // in which case the last value stored is returned.
+  auto RawRead(AllocationId allocation) const -> Nonnull<const Value*>;
+
+  // Writes `value` into the given allocation, which must be alive.
+  void RawWrite(AllocationId allocation, Nonnull<const Value*> value);
+
+  // Returns all allocations in this heap (both alive and dead).
+  auto AllAllocations() const -> std::vector<AllocationId>;
+
+ private:
+  std::vector<Nonnull<const Value*>> values_;
+  std::vector<bool> alive_;
+};
+
+}  // namespace Carbon
+
+#endif  // EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_

--- a/executable_semantics/interpreter/type_checker.cpp
+++ b/executable_semantics/interpreter/type_checker.cpp
@@ -1048,7 +1048,7 @@ auto TypeChecker::TypeCheckFunDef(FunctionDeclaration* f, TypeEnv types,
   for (const auto& deduced : f->deduced_parameters()) {
     // auto t = interpreter_.InterpExp(values, deduced.type);
     types.Set(deduced.name, arena_->New<VariableType>(deduced.name));
-    Address a = interpreter_.AllocateValue(*types.Get(deduced.name));
+    AllocationId a = interpreter_.AllocateValue(*types.Get(deduced.name));
     values.Set(deduced.name, a);
   }
   // Type check the parameter pattern
@@ -1089,7 +1089,7 @@ auto TypeChecker::TypeOfFunDef(TypeEnv types, Env values,
   for (const auto& deduced : fun_def->deduced_parameters()) {
     // auto t = interpreter_.InterpExp(values, deduced.type);
     types.Set(deduced.name, arena_->New<VariableType>(deduced.name));
-    Address a = interpreter_.AllocateValue(*types.Get(deduced.name));
+    AllocationId a = interpreter_.AllocateValue(*types.Get(deduced.name));
     values.Set(deduced.name, a);
   }
   // Type check the parameter pattern
@@ -1202,7 +1202,7 @@ void TypeChecker::TopLevel(Nonnull<Declaration*> d, TypeCheckContext* tops) {
     case Declaration::Kind::ClassDeclaration: {
       const auto& class_def = cast<ClassDeclaration>(*d).definition();
       auto st = TypeOfClassDef(&class_def, tops->types, tops->values);
-      Address a = interpreter_.AllocateValue(st);
+      AllocationId a = interpreter_.AllocateValue(st);
       tops->values.Set(class_def.name(), a);  // Is this obsolete?
       tops->types.Set(class_def.name(), st);
       break;
@@ -1216,7 +1216,7 @@ void TypeChecker::TopLevel(Nonnull<Declaration*> d, TypeCheckContext* tops) {
         alts.push_back(std::make_pair(alternative.name(), t));
       }
       auto ct = arena_->New<ChoiceType>(choice.name(), std::move(alts));
-      Address a = interpreter_.AllocateValue(ct);
+      AllocationId a = interpreter_.AllocateValue(ct);
       tops->values.Set(choice.name(), a);  // Is this obsolete?
       tops->types.Set(choice.name(), ct);
       break;

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -389,8 +389,6 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
       return cast<IntValue>(*v1).value() == cast<IntValue>(*v2).value();
     case Value::Kind::BoolValue:
       return cast<BoolValue>(*v1).value() == cast<BoolValue>(*v2).value();
-    case Value::Kind::PointerValue:
-      return cast<PointerValue>(*v1).value() == cast<PointerValue>(*v2).value();
     case Value::Kind::FunctionValue: {
       std::optional<Nonnull<const Statement*>> body1 =
           cast<FunctionValue>(*v1).declaration().body();
@@ -437,6 +435,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
     case Value::Kind::BindingPlaceholderValue:
     case Value::Kind::AlternativeConstructorValue:
     case Value::Kind::ContinuationValue:
+    case Value::Kind::PointerValue:
       FATAL() << "ValueEqual does not support this kind of value: " << *v1;
   }
 }


### PR DESCRIPTION
This was initially motivated by a layering issue: in an upcoming PR I'm going to want `Action` to be able to deallocate from the heap, but without this refactoring that would create a dependency cycle. However, it's had a spinoff benefit that I think is valuable on its own terms: it lets us statically distinguish between code that works with arbitrary `Address`es and code that can only work with pointers to separately-allocated storage, and so we no longer need to worry about the latter code crashing at run-time (as `Heap::Deallocate` did) or silently doing the wrong thing (as `Heap::PrintAddress` did) if it's given the wrong kind of `Address`.