### PR TITLE
Factor out base class of Heap for allocation

### DIFF
--- a/executable_semantics/interpreter/BUILD
+++ b/executable_semantics/interpreter/BUILD
@@ -75,6 +75,7 @@ cc_library(
     deps = [
         ":action_and_value",
         ":address",
+        ":raw_heap",
         "//common:ostream",
         "@llvm-project//llvm:Support",
     ],
@@ -98,6 +99,17 @@ cc_library(
         "//executable_semantics/ast:expression",
         "//executable_semantics/common:arena",
         "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "raw_heap",
+    srcs = ["raw_heap.cpp"],
+    hdrs = ["raw_heap.h"],
+    deps = [
+        ":address",
+        "//executable_semantics/common:error",
+        "//executable_semantics/common:nonnull",
     ],
 )
 

--- a/executable_semantics/interpreter/address.h
+++ b/executable_semantics/interpreter/address.h
@@ -32,9 +32,9 @@ class AllocationId {
 
  private:
   // The representation of AllocationId describes how to locate an object within
-  // a Heap, so its implementation details are tied to the implementation
-  // details of Heap.
-  friend class Heap;
+  // a RawHeap, so its implementation details are tied to the implementation
+  // details of RawHeap.
+  friend class RawHeap;
 
   AllocationId(size_t index) : index_(index) {}
 

--- a/executable_semantics/interpreter/heap.cpp
+++ b/executable_semantics/interpreter/heap.cpp
@@ -5,65 +5,46 @@
 #include "executable_semantics/interpreter/heap.h"
 
 #include "executable_semantics/common/error.h"
+#include "executable_semantics/interpreter/raw_heap.h"
 #include "llvm/ADT/StringExtras.h"
 
 namespace Carbon {
 
-auto Heap::AllocateValue(Nonnull<const Value*> v) -> AllocationId {
-  // Putting the following two side effects together in this function
-  // ensures that we don't do anything else in between, which is really bad!
-  // Consider whether to include a copy of the input v in this function
-  // or to leave it up to the caller.
-  AllocationId a(values_.size());
-  values_.push_back(v);
-  alive_.push_back(true);
-  return a;
-}
-
 auto Heap::Read(const Address& a, SourceLocation source_loc)
     -> Nonnull<const Value*> {
-  this->CheckAlive(a.allocation_, source_loc);
-  return values_[a.allocation_.index_]->GetField(arena_, a.field_path_,
-                                                 source_loc);
+  CheckAlive(a.allocation_, source_loc);
+  return RawRead(a.allocation_)->GetField(arena_, a.field_path_, source_loc);
 }
 
 void Heap::Write(const Address& a, Nonnull<const Value*> v,
                  SourceLocation source_loc) {
-  this->CheckAlive(a.allocation_, source_loc);
-  values_[a.allocation_.index_] = values_[a.allocation_.index_]->SetField(
-      arena_, a.field_path_, v, source_loc);
+  CheckAlive(a.allocation_, source_loc);
+  Nonnull<const Value*> new_allocation_value =
+      RawRead(a.allocation_)->SetField(arena_, a.field_path_, v, source_loc);
+  RawWrite(a.allocation_, new_allocation_value);
 }
 
 void Heap::CheckAlive(AllocationId allocation, SourceLocation source_loc) {
-  if (!alive_[allocation.index_]) {
+  if (!IsAlive(allocation)) {
     FATAL_RUNTIME_ERROR(source_loc)
-        << "undefined behavior: access to dead value "
-        << *values_[allocation.index_];
-  }
-}
-
-void Heap::Deallocate(AllocationId allocation) {
-  if (alive_[allocation.index_]) {
-    alive_[allocation.index_] = false;
-  } else {
-    FATAL_RUNTIME_ERROR_NO_LINE() << "deallocating an already dead value";
+        << "undefined behavior: access to dead value " << *RawRead(allocation);
   }
 }
 
 void Heap::Print(llvm::raw_ostream& out) const {
   llvm::ListSeparator sep;
-  for (size_t i = 0; i < values_.size(); ++i) {
+  for (AllocationId allocation : AllAllocations()) {
     out << sep;
-    PrintAllocation(AllocationId(i), out);
+    PrintAllocation(allocation, out);
   }
 }
 
 void Heap::PrintAllocation(AllocationId allocation,
                            llvm::raw_ostream& out) const {
-  if (!alive_[allocation.index_]) {
+  if (!IsAlive(allocation)) {
     out << "!!";
   }
-  out << *values_[allocation.index_];
+  out << *RawRead(allocation);
 }
 
 }  // namespace Carbon

--- a/executable_semantics/interpreter/raw_heap.cpp
+++ b/executable_semantics/interpreter/raw_heap.cpp
@@ -1,0 +1,47 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "executable_semantics/interpreter/raw_heap.h"
+
+#include "executable_semantics/common/error.h"
+
+namespace Carbon {
+
+auto RawHeap::AllocateValue(Nonnull<const Value*> v) -> AllocationId {
+  // Putting the following two side effects together in this function
+  // ensures that we don't do anything else in between, which is really bad!
+  // Consider whether to include a copy of the input v in this function
+  // or to leave it up to the caller.
+  AllocationId a(values_.size());
+  values_.push_back(v);
+  alive_.push_back(true);
+  return a;
+}
+
+auto RawHeap::RawRead(AllocationId a) const -> Nonnull<const Value*> {
+  return values_[a.index_];
+}
+
+void RawHeap::RawWrite(AllocationId a, Nonnull<const Value*> v) {
+  CHECK(alive_[a.index_]);
+  values_[a.index_] = v;
+}
+
+void RawHeap::Deallocate(AllocationId address) {
+  if (alive_[address.index_]) {
+    alive_[address.index_] = false;
+  } else {
+    FATAL_RUNTIME_ERROR_NO_LINE() << "deallocating an already dead value";
+  }
+}
+
+auto RawHeap::AllAllocations() const -> std::vector<AllocationId> {
+  std::vector<AllocationId> result;
+  for (size_t i = 0; i < values_.size(); ++i) {
+    result.push_back(AllocationId(i));
+  }
+  return result;
+}
+
+}  // namespace Carbon

--- a/executable_semantics/interpreter/raw_heap.h
+++ b/executable_semantics/interpreter/raw_heap.h
@@ -1,0 +1,59 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_
+#define EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_
+
+#include <vector>
+
+#include "executable_semantics/common/nonnull.h"
+#include "executable_semantics/interpreter/address.h"
+
+namespace Carbon {
+
+class Value;
+
+// A RawHeap represents the abstract machine's dynamically allocated memory as
+// a collection of _allocations_, each of which has a `Value`, and may be alive
+// or dead. An allocation is analogous to the C++ notion of a complete object:
+// the the `Value` in an allocation is not a sub-part of any other `Value`.
+class RawHeap {
+ public:
+  RawHeap(const RawHeap&) = delete;
+  auto operator=(const RawHeap&) = delete;
+
+  // Put the given value on the heap and mark it as alive.
+  auto AllocateValue(Nonnull<const Value*> v) -> AllocationId;
+
+  // Marks the object at this address, and all of its sub-objects, as dead.
+  void Deallocate(AllocationId allocation);
+
+ protected:
+  RawHeap() = default;
+  ~RawHeap() = default;
+
+  // Returns true if the given allocation is alive.
+  auto IsAlive(AllocationId allocation) const -> bool {
+    return alive_[allocation.index_];
+  }
+
+  // Returns the value stored in the given allocation. In order to support
+  // logging and tracing use cases, the allocation is permitted to be dead,
+  // in which case the last value stored is returned.
+  auto RawRead(AllocationId allocation) const -> Nonnull<const Value*>;
+
+  // Writes `value` into the given allocation, which must be alive.
+  void RawWrite(AllocationId allocation, Nonnull<const Value*> value);
+
+  // Returns all allocations in this heap (both alive and dead).
+  auto AllAllocations() const -> std::vector<AllocationId>;
+
+ private:
+  std::vector<Nonnull<const Value*>> values_;
+  std::vector<bool> alive_;
+};
+
+}  // namespace Carbon
+
+#endif  // EXECUTABLE_SEMANTICS_INTERPRETER_RAW_HEAP_H_


### PR DESCRIPTION
This will enable `Action` to deallocate from the heap without creating a dependency cycle.

This is effectively #914, rebased on top of #916.