### PR TITLE
Test --trace directly

### DIFF
--- a/executable_semantics/main.cpp
+++ b/executable_semantics/main.cpp
@@ -60,10 +60,6 @@ auto main(int argc, char* argv[]) -> int {
   using llvm::cl::desc;
   using llvm::cl::opt;
   opt<bool> trace_option("trace", desc("Enable tracing"));
-  opt<bool> trace_bison_option(
-      "trace_bison", llvm::cl::init(true),
-      desc("Controls whether bison tracing is enabled when --trace is passed. "
-           "Defaults to true."));
   opt<std::string> input_file_name(llvm::cl::Positional, desc("<input file>"),
                                    llvm::cl::Required);
 
@@ -71,8 +67,7 @@ auto main(int argc, char* argv[]) -> int {
 
   Carbon::Arena arena;
   std::variant<Carbon::AST, Carbon::SyntaxErrorCode> ast_or_error =
-      Carbon::Parse(&arena, input_file_name, trace_option,
-                    trace_option && trace_bison_option);
+      Carbon::Parse(&arena, input_file_name, trace_option);
 
   if (auto* error = std::get_if<Carbon::SyntaxErrorCode>(&ast_or_error)) {
     // Diagnostic already reported to std::cerr; this is just a return code.

--- a/executable_semantics/testdata/basic_syntax/trace.carbon
+++ b/executable_semantics/testdata/basic_syntax/trace.carbon
@@ -2,115 +2,20 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: executable_semantics --trace --trace_bison=false %s 2>&1 | \
-// RUN:   FileCheck --match-full-lines --allow-unused-prefixes=false %s
+// RUN: executable_semantics --trace %s 2>&1 | \
+// RUN:   FileCheck --match-full-lines --allow-unused-prefixes %s
 //
-// When reviewing trace changes, keep in mind that changes are okay; focus on correctness and
-// usefulness of output.
+// A lot of output is elided: this is only checking for a few things for simple
+// sanity checking on --trace output.
 //
-// AUTOUPDATE: executable_semantics --trace --trace_bison=false %s
+// NOAUTOUPDATE
 // CHECK: ********** source program **********
-// CHECK: fn Print (format_str: String) -> () {
-// CHECK: {
-// CHECK: return intrinsic_expression(print);
-// CHECK: }
-// CHECK-EMPTY:
-// CHECK: }
-// CHECK: fn Main () -> i32 {
-// CHECK: {
-// CHECK: return 0;
-// CHECK: }
-// CHECK-EMPTY:
-// CHECK: }
+// CHECK: fn Print (format_str: String) {
 // CHECK: ********** type checking **********
 // CHECK: checking pattern (format_str: String)
-// CHECK: types:
-// CHECK: values:
-// CHECK: checking pattern format_str: String
-// CHECK: types:
-// CHECK: values:
-// CHECK: checking pattern String
-// CHECK: types:
-// CHECK: values:
-// CHECK: checking expression String
-// CHECK: types:
-// CHECK: values:
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern (format_str: String) (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern (format_str: String) (<intrinsic>:0) --->
-// CHECK: --- step pattern () (<intrinsic>:0) --->
-// CHECK: --- step exp () (<intrinsic>:0) --->
-// CHECK: checking pattern ()
 // CHECK: types: Print: fn (String) -> ()
-// CHECK: values: Print: fun<Print>
-// CHECK: --- step pattern () ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: --- step pattern i32 ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: --- step exp i32 ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: checking pattern (format_str: String)
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: checking pattern format_str: String
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: checking pattern String
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: checking expression String
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern (format_str: String) (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern String (<intrinsic>:0) --->
-// CHECK: --- step exp String (<intrinsic>:0) --->
-// CHECK: --- step pattern format_str: String (<intrinsic>:0) --->
-// CHECK: --- step pattern (format_str: String) (<intrinsic>:0) --->
-// CHECK: --- step pattern () (<intrinsic>:0) --->
-// CHECK: --- step exp () (<intrinsic>:0) --->
-// CHECK: checking expression intrinsic_expression(print)
-// CHECK: types: format_str: String, Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: checking pattern ()
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: --- step pattern () ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: --- step pattern i32 ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: --- step exp i32 ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:190) --->
-// CHECK: checking expression 0
-// CHECK: types: Main: fn () -> i32, Print: fn (String) -> ()
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK-EMPTY:
 // CHECK: ********** type checking complete **********
-// CHECK: fn Print (format_str: String) -> () {
-// CHECK: {
-// CHECK: return intrinsic_expression(print);
-// CHECK: }
-// CHECK-EMPTY:
-// CHECK: }
-// CHECK: fn Main () -> i32 {
-// CHECK: {
-// CHECK: return 0;
-// CHECK: }
-// CHECK-EMPTY:
-// CHECK: }
+// CHECK: fn Print (format_str: String) {
 // CHECK: ********** starting execution **********
 // CHECK: ********** initializing globals **********
 // CHECK: ********** calling main function **********
@@ -119,70 +24,6 @@
 // CHECK: heap: fun<Print>, fun<Main>
 // CHECK: }
 // CHECK: --- step exp Main() (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: Main<0> :: Main()<1> :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp Main (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: Main()<1>(fun<Main>) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp Main() (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: ()<0> :: Main()<2>(fun<Main>) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp () (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: Main()<2>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp Main() (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: {return 0;}<0> :: ScopeAction<0> :: Main()<3>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step stmt {return 0;} ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:192) --->
-// CHECK: {
-// CHECK: stack: return 0;<0> :: {return 0;}<1> :: ScopeAction<0> :: Main()<3>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step stmt return 0; ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:191) --->
-// CHECK: {
-// CHECK: stack: 0<0> :: return 0;<1> :: {return 0;}<1> :: ScopeAction<0> :: Main()<3>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp 0 ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:191) --->
-// CHECK: {
-// CHECK: stack: return 0;<1>(0) :: {return 0;}<1> :: ScopeAction<0> :: Main()<3>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step stmt return 0; ({{.*}}/executable_semantics/testdata/basic_syntax/trace.carbon:191) --->
-// CHECK: {
-// CHECK: stack: ScopeAction<0>(0) :: Main()<3>(fun<Main>, ()) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: {
-// CHECK: stack: Main()<3>(fun<Main>, (), 0) :: ScopeAction<0>
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
-// CHECK: --- step exp Main() (<Main()>:0) --->
-// CHECK: {
-// CHECK: stack: ScopeAction<0>(0)
-// CHECK: heap: fun<Print>, fun<Main>
-// CHECK: values: Main: fun<Main>, Print: fun<Print>
-// CHECK: }
 // CHECK: result: 0
 
 package ExecutableSemanticsTest api;


### PR DESCRIPTION
This mostly modifies update_checks in order to use the command on the AUTOUPDATE line to generate output. It does also make update_checks do a two-pass run to deal with line number changes in output (easy enough to manually fix, but less confusing if it's hidden away).