### PR TITLE
Use is_constructible to correct New error lines

### DIFF
--- a/executable_semantics/common/arena.h
+++ b/executable_semantics/common/arena.h
@@ -6,6 +6,7 @@
 #define EXECUTABLE_SEMANTICS_COMMON_ARENA_H_
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "executable_semantics/common/nonnull.h"
@@ -15,7 +16,9 @@ namespace Carbon {
 class Arena {
  public:
   // Allocates an object in the arena, returning a pointer to it.
-  template <typename T, typename... Args>
+  template <
+      typename T, typename... Args,
+      typename std::enable_if_t<std::is_constructible_v<T, Args...>>* = nullptr>
   auto New(Args&&... args) -> Nonnull<T*> {
     auto smart_ptr =
         std::make_unique<ArenaEntryTyped<T>>(std::forward<Args>(args)...);


### PR DESCRIPTION
With:

```
executable_semantics/interpreter/exec_program.cpp:21:57: error: no matching member function for call to 'New'
  std::vector<Nonnull<Pattern*>> print_params = {arena->New<BindingPattern>(
                                                 ~~~~~~~^~~~~~~~~~~~~~~~~~~
./executable_semantics/common/arena.h:22:8: note: candidate template ignored: requirement 'std::is_constructible_v<Carbon::BindingPattern, Carbon::SourceLocation &, char const (&)[11], Carbon::ExpressionPattern &>' was not satisfied [with T = Carbon::BindingPattern, Args = <Carbon::SourceLocation &, char const (&)[11], Carbon::ExpressionPattern &>]
  auto New(Args&&... args) -> Nonnull<T*> {
       ^
```

Without:

```
./executable_semantics/common/arena.h:43:11: error: no matching constructor for initialization of 'Carbon::BindingPattern'
        : instance_(std::forward<Args>(args)...) {}
          ^         ~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/google/home/jperkins/.linuxbrew/Cellar/llvm/13.0.0_1/bin/../include/c++/v1/__memory/unique_ptr.h:728:32: note: in instantiation of function template specialization 'Carbon::Arena::ArenaEntryTyped<Carbon::BindingPattern>::ArenaEntryTyped<Carbon::SourceLocation &, char const (&)[11], Carbon::ExpressionPattern &>' requested here
    return unique_ptr<_Tp>(new _Tp(_VSTD::forward<_Args>(__args)...));
                               ^
./executable_semantics/common/arena.h:23:14: note: in instantiation of function template specialization 'std::make_unique<Carbon::Arena::ArenaEntryTyped<Carbon::BindingPattern>, Carbon::SourceLocation &, char const (&)[11], Carbon::ExpressionPattern &>' requested here
        std::make_unique<ArenaEntryTyped<T>>(std::forward<Args>(args)...);
             ^
executable_semantics/interpreter/exec_program.cpp:21:57: note: in instantiation of function template specialization 'Carbon::Arena::New<Carbon::BindingPattern, Carbon::SourceLocation &, char const (&)[11], Carbon::ExpressionPattern &>' requested here
  std::vector<Nonnull<Pattern*>> print_params = {arena->New<BindingPattern>(
                                                        ^
./executable_semantics/ast/pattern.h:105:3: note: candidate constructor not viable: no known conversion from 'Carbon::ExpressionPattern' to 'Nonnull<Carbon::Pattern *>' (aka 'Carbon::Pattern *') for 3rd argument; take the address of the argument with &
  BindingPattern(SourceLocation source_loc, std::optional<std::string> name,
  ^
./executable_semantics/ast/pattern.h:103:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
class BindingPattern : public Pattern {
      ^
1 error generated.
```