### PR TITLE
Rename main to Main for Carbon style consistency

### DIFF
--- a/executable_semantics/interpreter/exec_program.cpp
+++ b/executable_semantics/interpreter/exec_program.cpp
@@ -62,9 +62,9 @@ void ExecProgram(Nonnull<Arena*> arena, AST ast, bool trace) {
     llvm::outs() << "********** starting execution **********\n";
   }
 
-  SourceLocation source_loc("<main()>", 0);
+  SourceLocation source_loc("<Main()>", 0);
   Nonnull<Expression*> call_main = arena->New<CallExpression>(
-      source_loc, arena->New<IdentifierExpression>(source_loc, "main"),
+      source_loc, arena->New<IdentifierExpression>(source_loc, "Main"),
       arena->New<TupleLiteral>(source_loc));
   int result =
       Interpreter(arena, trace).InterpProgram(ast.declarations, call_main);

--- a/executable_semantics/interpreter/type_checker.cpp
+++ b/executable_semantics/interpreter/type_checker.cpp
@@ -1044,8 +1044,8 @@ auto TypeChecker::TypeCheckFunDef(FunctionDeclaration* f, TypeEnv types,
       TypeCheckPattern(&f->param_pattern(), types, values, std::nullopt);
   // Evaluate the return type expression
   auto return_type = interpreter_.InterpPattern(values, &f->return_type());
-  if (f->name() == "main") {
-    ExpectExactType(f->source_loc(), "return type of `main`",
+  if (f->name() == "Main") {
+    ExpectExactType(f->source_loc(), "return type of `Main`",
                     arena_->New<IntType>(), return_type);
     // TODO: Check that main doesn't have any parameters.
   }
@@ -1230,7 +1230,7 @@ auto TypeChecker::TopLevel(std::vector<Nonnull<Declaration*>>* fs)
   bool found_main = false;
 
   for (auto const& d : *fs) {
-    if (GetName(*d) == "main") {
+    if (GetName(*d) == "Main") {
       found_main = true;
     }
     TopLevel(d, &tops);
@@ -1238,7 +1238,7 @@ auto TypeChecker::TopLevel(std::vector<Nonnull<Declaration*>>* fs)
 
   if (found_main == false) {
     FATAL_COMPILATION_ERROR_NO_LINE()
-        << "program must contain a function named `main`";
+        << "program must contain a function named `Main`";
   }
   return tops;
 }

--- a/executable_semantics/testdata/assignment_copy/destruct_original.carbon
+++ b/executable_semantics/testdata/assignment_copy/destruct_original.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test that assignment performs a copy and does not create an alias.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = -1;
   {
      var y: i32 = 0;

--- a/executable_semantics/testdata/assignment_copy/reassign_original.carbon
+++ b/executable_semantics/testdata/assignment_copy/reassign_original.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test that assignment performs a copy and does not create an alias.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   var y: i32 = x;
   x = 1;

--- a/executable_semantics/testdata/basic_syntax/choice.carbon
+++ b/executable_semantics/testdata/basic_syntax/choice.carbon
@@ -17,7 +17,7 @@ choice Ints {
   Two(i32,i32)
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = Ints.None();
   var y: auto = Ints.One(42);
   var n: auto = 0;

--- a/executable_semantics/testdata/basic_syntax/fail_missing_var.carbon
+++ b/executable_semantics/testdata/basic_syntax/fail_missing_var.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   // error
   x : i32;
   return 1;

--- a/executable_semantics/testdata/basic_syntax/next.carbon
+++ b/executable_semantics/testdata/basic_syntax/next.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main () -> i32
+fn Main () -> i32
 {
   var x: i32 = 0;
   return x;

--- a/executable_semantics/testdata/basic_syntax/placeholder_variable.carbon
+++ b/executable_semantics/testdata/basic_syntax/placeholder_variable.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var _: auto = 1;
   return 0;
 }

--- a/executable_semantics/testdata/basic_syntax/print.carbon
+++ b/executable_semantics/testdata/basic_syntax/print.carbon
@@ -12,7 +12,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var s: auto = "Hello world!\n";
   Print(s);
   return 0;

--- a/executable_semantics/testdata/basic_syntax/record.carbon
+++ b/executable_semantics/testdata/basic_syntax/record.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t2: {.x: i32, .y: i32} = {.x = 2, .y = 5};
   t2.y = 3;
   return t2.y - t2.x - 1; // 3 - 2 - 1

--- a/executable_semantics/testdata/basic_syntax/star.carbon
+++ b/executable_semantics/testdata/basic_syntax/star.carbon
@@ -20,6 +20,6 @@ fn F(n: i32, p: i32*, q: i32***) -> i32* {
   return **q;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/basic_syntax/var_tuple.carbon
+++ b/executable_semantics/testdata/basic_syntax/var_tuple.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var (x: auto, y: auto) = (2, 3);
   return y - x - 1;
 }

--- a/executable_semantics/testdata/basic_syntax/zero.carbon
+++ b/executable_semantics/testdata/basic_syntax/zero.carbon
@@ -11,6 +11,6 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/block/empty.carbon
+++ b/executable_semantics/testdata/block/empty.carbon
@@ -15,7 +15,7 @@ fn DoNothing() {
   // Empty block
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   DoNothing();
   return x;

--- a/executable_semantics/testdata/block/shadowing.carbon
+++ b/executable_semantics/testdata/block/shadowing.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   {
     var x: i32 = 1;

--- a/executable_semantics/testdata/class/assign.carbon
+++ b/executable_semantics/testdata/class/assign.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p1: Point = {.x = 1, .y = 2};
   var p2: auto = p1;
   p2 = {.x = 3, .y = 2};

--- a/executable_semantics/testdata/class/assign_member.carbon
+++ b/executable_semantics/testdata/class/assign_member.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p1: Point = {.x = 1, .y = 2};
   var p2: auto = p1;
   p2.x = 3;

--- a/executable_semantics/testdata/class/fail_field_access_mismatch.carbon
+++ b/executable_semantics/testdata/class/fail_field_access_mismatch.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p: Point = {.x = 1, .y = 2};
   return p.z - 1;
 }

--- a/executable_semantics/testdata/class/fail_field_mismatch.carbon
+++ b/executable_semantics/testdata/class/fail_field_mismatch.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p: Point = {.x = 1, .z = 2};
   return p.x - 1;
 }

--- a/executable_semantics/testdata/class/fail_field_missing.carbon
+++ b/executable_semantics/testdata/class/fail_field_missing.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p: Point = {.x = 1};
   return p.x - 1;
 }

--- a/executable_semantics/testdata/class/function_param.carbon
+++ b/executable_semantics/testdata/class/function_param.carbon
@@ -20,6 +20,6 @@ fn GetX(p: Point) -> i32 {
   return p.x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return GetX({.x = 1, .y = 2}) - 1;
 }

--- a/executable_semantics/testdata/class/global_var.carbon
+++ b/executable_semantics/testdata/class/global_var.carbon
@@ -18,6 +18,6 @@ class Point {
 
 var p: Point = {.x = 1, .y = 2};
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return p.y - p.x - 1;
 }

--- a/executable_semantics/testdata/class/temp.carbon
+++ b/executable_semantics/testdata/class/temp.carbon
@@ -20,6 +20,6 @@ fn MakePoint() -> Point {
   return {.x = 1, .y = 2};
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return MakePoint().x - 1;
 }

--- a/executable_semantics/testdata/class/var.carbon
+++ b/executable_semantics/testdata/class/var.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p: Point = {.x = 1, .y = 2};
   return p.y - p.x - 1;
 }

--- a/executable_semantics/testdata/experimental_continuation/await_maintains_scope.carbon
+++ b/executable_semantics/testdata/experimental_continuation/await_maintains_scope.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test access to block-scoped variables upon resuming a continuation.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var y: i32 = 0;
   __continuation k {
     var x: i32 = 0;

--- a/executable_semantics/testdata/experimental_continuation/creation_is_noop.carbon
+++ b/executable_semantics/testdata/experimental_continuation/creation_is_noop.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test that creating a continuation doesn't do anything.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   __continuation k {
     x = x + 1;

--- a/executable_semantics/testdata/experimental_continuation/fail_continuation_syntax.carbon
+++ b/executable_semantics/testdata/experimental_continuation/fail_continuation_syntax.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   __continuation k x = 3;
   __run k;

--- a/executable_semantics/testdata/experimental_continuation/fail_lifetime.carbon
+++ b/executable_semantics/testdata/experimental_continuation/fail_lifetime.carbon
@@ -23,7 +23,7 @@ fn capture() -> __Continuation {
   return k;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var k: __Continuation = capture();
   __run k; // error, lifetime of x is over
   return 0;

--- a/executable_semantics/testdata/experimental_continuation/recursive.carbon
+++ b/executable_semantics/testdata/experimental_continuation/recursive.carbon
@@ -27,7 +27,7 @@ fn CountUpTo(x: i32) -> i32 {
   }
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   __continuation k {
     CountUpTo(5);
   }

--- a/executable_semantics/testdata/experimental_continuation/run.carbon
+++ b/executable_semantics/testdata/experimental_continuation/run.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test creating and running a continuation.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   __continuation k {
     x = x + 1;

--- a/executable_semantics/testdata/experimental_continuation/run_with_await.carbon
+++ b/executable_semantics/testdata/experimental_continuation/run_with_await.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 // Test pausing a continuation with `__await` and restarting it with
 // `__run`.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   __continuation k {
     x = x + 1;

--- a/executable_semantics/testdata/experimental_continuation/shallow_copy.carbon
+++ b/executable_semantics/testdata/experimental_continuation/shallow_copy.carbon
@@ -22,7 +22,7 @@ fn Foo() {
   x = x + 2;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   __continuation k1 {
     Foo();
   }

--- a/executable_semantics/testdata/function/auto_return/add.carbon
+++ b/executable_semantics/testdata/function/auto_return/add.carbon
@@ -13,6 +13,6 @@ package ExecutableSemanticsTest api;
 
 fn add(x: i32, y: i32) -> auto { return x + y; }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return add(1, 2) - 3;
 }

--- a/executable_semantics/testdata/function/auto_return/fail_direct_recurse.carbon
+++ b/executable_semantics/testdata/function/auto_return/fail_direct_recurse.carbon
@@ -20,6 +20,6 @@ fn Recurse(x: i32, do_recurse: Bool) -> auto {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return Recurse(1, true) - 3;
 }

--- a/executable_semantics/testdata/function/auto_return/fail_multiple_returns.carbon
+++ b/executable_semantics/testdata/function/auto_return/fail_multiple_returns.carbon
@@ -21,6 +21,6 @@ fn Add(x: i32, y: i32) -> auto {
   }
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return Add(1, 2) - 3;
 }

--- a/executable_semantics/testdata/function/auto_return/fail_no_return.carbon
+++ b/executable_semantics/testdata/function/auto_return/fail_no_return.carbon
@@ -14,6 +14,6 @@ package ExecutableSemanticsTest api;
 fn NoReturn() -> auto {
 }
 
-fn main() {
+fn Main() {
   NoReturn();
 }

--- a/executable_semantics/testdata/function/auto_return/fail_separate_decl.carbon
+++ b/executable_semantics/testdata/function/auto_return/fail_separate_decl.carbon
@@ -16,6 +16,6 @@ fn Add(x: i32, y: i32) -> auto;
 
 fn Add(x: i32, y: i32) -> auto { return x + y; }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return Add(1, 2) - 3;
 }

--- a/executable_semantics/testdata/function/auto_return/modify_arg_type.carbon
+++ b/executable_semantics/testdata/function/auto_return/modify_arg_type.carbon
@@ -19,6 +19,6 @@ fn f(x: Id(i32)) -> i32 {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return f(0);
 }

--- a/executable_semantics/testdata/function/auto_return/modify_return_type.carbon
+++ b/executable_semantics/testdata/function/auto_return/modify_return_type.carbon
@@ -15,6 +15,6 @@ fn Id(t: Type) -> auto { return t; }
 
 // Test non-trivial type expression in return type.
 
-fn main() -> Id(i32) {
+fn Main() -> Id(i32) {
   return 0;
 }

--- a/executable_semantics/testdata/function/auto_return/type.carbon
+++ b/executable_semantics/testdata/function/auto_return/type.carbon
@@ -15,7 +15,7 @@ fn Id(t: Type) -> auto { return t; }
 
 // Test non-trivial type expression in variable declaration statement.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: Id(i32) = 0;
   return x;
 }

--- a/executable_semantics/testdata/function/empty_params.carbon
+++ b/executable_semantics/testdata/function/empty_params.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 // Test empty parameters and return type
 fn f() { }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   f();
   return 0;
 }

--- a/executable_semantics/testdata/function/fail_call_with_tuple.carbon
+++ b/executable_semantics/testdata/function/fail_call_with_tuple.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 fn f(x: i32, y: i32) -> i32 { return x + y; }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var xy: (i32, i32) = (1, 2);
   // should fail to type-check
   return f(xy);

--- a/executable_semantics/testdata/function/fail_match_no_return.carbon
+++ b/executable_semantics/testdata/function/fail_match_no_return.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   match(0) {
     case 1 => { x = 1; }

--- a/executable_semantics/testdata/function/fail_match_partial_return.carbon
+++ b/executable_semantics/testdata/function/fail_match_partial_return.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   match (0) {
     case 1 => { x = 1; }

--- a/executable_semantics/testdata/function/fail_non_exhaustive_match.carbon
+++ b/executable_semantics/testdata/function/fail_non_exhaustive_match.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   match (0) {
     case 1 => return 0;
   }

--- a/executable_semantics/testdata/function/fnty.carbon
+++ b/executable_semantics/testdata/function/fnty.carbon
@@ -15,7 +15,7 @@ fn add1(x: i32) -> i32 {
   return x + 1;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var f: __Fn(i32)->i32 = add1;
   return f(-1);
 }

--- a/executable_semantics/testdata/function/ignored_parameter.carbon
+++ b/executable_semantics/testdata/function/ignored_parameter.carbon
@@ -15,6 +15,6 @@ fn ReturnSecond(_: i32, x: i32) -> i32 {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return ReturnSecond(1, 0);
 }

--- a/executable_semantics/testdata/function/multiple_args.carbon
+++ b/executable_semantics/testdata/function/multiple_args.carbon
@@ -16,6 +16,6 @@ fn f(x: i32, y: i32) -> i32 {
   return x + y;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return f(2,3) - 5;
 }

--- a/executable_semantics/testdata/function/param_lifetime.carbon
+++ b/executable_semantics/testdata/function/param_lifetime.carbon
@@ -19,7 +19,7 @@ fn f(x: i32) -> i32 {
   return 0;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var a: i32 = 0; var b: i32 = 1;
   f(a);
   b = a;

--- a/executable_semantics/testdata/function/recursive.carbon
+++ b/executable_semantics/testdata/function/recursive.carbon
@@ -19,6 +19,6 @@ fn f(x: i32) -> i32 {
   }
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return f(2);
 }

--- a/executable_semantics/testdata/function/return.carbon
+++ b/executable_semantics/testdata/function/return.carbon
@@ -15,6 +15,6 @@ fn f(x: i32) -> i32 {
   return x - 1;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return f(1);
 }

--- a/executable_semantics/testdata/function/return_exhaustive_match.carbon
+++ b/executable_semantics/testdata/function/return_exhaustive_match.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   match (0) {
     case _: auto => return 1;
   }

--- a/executable_semantics/testdata/function/type_match.carbon
+++ b/executable_semantics/testdata/function/type_match.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: (auto, (i32, i32)) = ((1,2),(3,4));
   return t[0][0] + t[1][1] - 5;
 }

--- a/executable_semantics/testdata/generic_function/apply.carbon
+++ b/executable_semantics/testdata/generic_function/apply.carbon
@@ -23,6 +23,6 @@ fn positive(x: Bool) -> i32 {
   }
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return apply(positive, false);
 }

--- a/executable_semantics/testdata/generic_function/fail_not_addable.carbon
+++ b/executable_semantics/testdata/generic_function/fail_not_addable.carbon
@@ -17,6 +17,6 @@ fn id[T:! Type](x: T) -> T {
   return x + 0;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return id(0);
 }

--- a/executable_semantics/testdata/generic_function/fail_type_deduction_mismatch.carbon
+++ b/executable_semantics/testdata/generic_function/fail_type_deduction_mismatch.carbon
@@ -17,6 +17,6 @@ fn fst[T:! Type](x: T, y: T) -> T {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return fst(0, true);
 }

--- a/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -15,6 +15,6 @@ fn id[T:! Type](x: i32) -> i32 {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return id(0);
 }

--- a/executable_semantics/testdata/generic_function/non_generic_param.carbon
+++ b/executable_semantics/testdata/generic_function/non_generic_param.carbon
@@ -15,6 +15,6 @@ fn snd[T:! Type](x: i32, y: T) -> T {
   return y;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return snd(0, 1);
 }

--- a/executable_semantics/testdata/generic_function/return_val.carbon
+++ b/executable_semantics/testdata/generic_function/return_val.carbon
@@ -15,6 +15,6 @@ fn id[T:! Type](x: T) -> T {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return id(0);
 }

--- a/executable_semantics/testdata/generic_function/swap.carbon
+++ b/executable_semantics/testdata/generic_function/swap.carbon
@@ -15,6 +15,6 @@ fn swap[T:! Type, U:! Type](tuple: (T, U)) -> (U, T) {
   return (tuple[1], tuple[0]);
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return swap((0, true))[1];
 }

--- a/executable_semantics/testdata/generic_function/tuple_map.carbon
+++ b/executable_semantics/testdata/generic_function/tuple_map.carbon
@@ -17,6 +17,6 @@ fn map[T:! Type](f: __Fn (T) -> T, tuple: (T, T)) -> (T, T) {
 
 fn inc(x: i32) -> i32 { return x + 1; }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return map(inc, (0, 2))[0];
 }

--- a/executable_semantics/testdata/generic_function/type_matching.carbon
+++ b/executable_semantics/testdata/generic_function/type_matching.carbon
@@ -15,6 +15,6 @@ fn fst[T:! Type](x: T, y: T) -> T {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return fst(0, 1);
 }

--- a/executable_semantics/testdata/global_variable/fail_init_order.carbon
+++ b/executable_semantics/testdata/global_variable/fail_init_order.carbon
@@ -18,6 +18,6 @@ var x: i32 = y;
 
 var y: i32 = 0;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return x;
 }

--- a/executable_semantics/testdata/global_variable/fail_init_type_mismatch.carbon
+++ b/executable_semantics/testdata/global_variable/fail_init_type_mismatch.carbon
@@ -15,6 +15,6 @@ package ExecutableSemanticsTest api;
 
 var flag: i32 = true;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/global_variable/init_and_read.carbon
+++ b/executable_semantics/testdata/global_variable/init_and_read.carbon
@@ -15,6 +15,6 @@ package ExecutableSemanticsTest api;
 
 var zero: i32 = 0;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return zero;
 }

--- a/executable_semantics/testdata/global_variable/init_from_function.carbon
+++ b/executable_semantics/testdata/global_variable/init_from_function.carbon
@@ -19,6 +19,6 @@ fn f() -> i32 {
 
 var y: i32 = f();
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return y;
 }

--- a/executable_semantics/testdata/global_variable/init_order.carbon
+++ b/executable_semantics/testdata/global_variable/init_order.carbon
@@ -17,6 +17,6 @@ var x: i32 = 0;
 
 var y: i32 = x;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return y;
 }

--- a/executable_semantics/testdata/global_variable/shadowing.carbon
+++ b/executable_semantics/testdata/global_variable/shadowing.carbon
@@ -19,6 +19,6 @@ fn identity(x: i32) -> i32 {
   return x;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return identity(0);
 }

--- a/executable_semantics/testdata/global_variable/write.carbon
+++ b/executable_semantics/testdata/global_variable/write.carbon
@@ -15,7 +15,7 @@ package ExecutableSemanticsTest api;
 
 var zero: i32 = 1;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   zero = 0;
   return zero;
 }

--- a/executable_semantics/testdata/global_variable/write_from_function.carbon
+++ b/executable_semantics/testdata/global_variable/write_from_function.carbon
@@ -20,7 +20,7 @@ fn flipFlag() {
   flag = 0;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   flipFlag();
   return flag;
 }

--- a/executable_semantics/testdata/if_else/if_else.carbon
+++ b/executable_semantics/testdata/if_else/if_else.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (0 == 1) {
     return 1;
   } else {

--- a/executable_semantics/testdata/if_else/if_else_if.carbon
+++ b/executable_semantics/testdata/if_else/if_else_if.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (0 == 1) {
     return 1;
   } else if (0 == 0) {

--- a/executable_semantics/testdata/if_else/if_else_if_else.carbon
+++ b/executable_semantics/testdata/if_else/if_else_if_else.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (0 == 1) {
     return 1;
   } else if (0 == 2) {

--- a/executable_semantics/testdata/if_else/if_false.carbon
+++ b/executable_semantics/testdata/if_else/if_false.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (0 == 1) {
     return 1;
   }

--- a/executable_semantics/testdata/if_else/if_nesting.carbon
+++ b/executable_semantics/testdata/if_else/if_nesting.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (0 == 0) {
     if (0 == 1) {
       return 1;

--- a/executable_semantics/testdata/if_else/if_true.carbon
+++ b/executable_semantics/testdata/if_else/if_true.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   if (1 == 1) {
     return 0;
   }

--- a/executable_semantics/testdata/import/fail_nonexistent_library.carbon
+++ b/executable_semantics/testdata/import/fail_nonexistent_library.carbon
@@ -15,6 +15,6 @@ package ExecutableSemanticsTest api;
 
 import Nonexistent;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/import/fail_nonexistent_package.carbon
+++ b/executable_semantics/testdata/import/fail_nonexistent_package.carbon
@@ -15,6 +15,6 @@ package ExecutableSemanticsTest api;
 
 import ExecutableSemanticsTest library "Nonexistent";
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/import/fail_order.carbon
+++ b/executable_semantics/testdata/import/fail_order.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }
 

--- a/executable_semantics/testdata/match/any_int.carbon
+++ b/executable_semantics/testdata/match/any_int.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = 5;
   match (t) {
     case x: i32 =>

--- a/executable_semantics/testdata/match/int.carbon
+++ b/executable_semantics/testdata/match/int.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = 5;
   match (t) {
     case 5 =>

--- a/executable_semantics/testdata/match/int_default.carbon
+++ b/executable_semantics/testdata/match/int_default.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = 5;
   match (t) {
     case 3 =>

--- a/executable_semantics/testdata/match/no_match.carbon
+++ b/executable_semantics/testdata/match/no_match.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   match (x) {
     case 1 =>

--- a/executable_semantics/testdata/match/placeholder.carbon
+++ b/executable_semantics/testdata/match/placeholder.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = (1, 2, 3, 4);
   match (t) {
     case (_: i32, _: auto, x: i32, y: auto) =>

--- a/executable_semantics/testdata/package/fail_missing.carbon
+++ b/executable_semantics/testdata/package/fail_missing.carbon
@@ -9,6 +9,6 @@
 // AUTOUPDATE: executable_semantics %s
 // CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/package/fail_missing.carbon:12: syntax error, unexpected FN, expecting PACKAGE
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/package/with_library.carbon
+++ b/executable_semantics/testdata/package/with_library.carbon
@@ -11,6 +11,6 @@
 
 package ExecutableSemanticsTest library "Foo" api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return 0;
 }

--- a/executable_semantics/testdata/return/explicit_empty.carbon
+++ b/executable_semantics/testdata/return/explicit_empty.carbon
@@ -15,7 +15,7 @@ fn F() -> () {
   return ();
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/return/fail_explicit_with_no_return.carbon
+++ b/executable_semantics/testdata/return/fail_explicit_with_no_return.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 fn F() -> () {
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/return/fail_explicit_with_plain_return.carbon
+++ b/executable_semantics/testdata/return/fail_explicit_with_plain_return.carbon
@@ -15,7 +15,7 @@ fn F() -> () {
   return;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/return/fail_implicit_with_explicit_return.carbon
+++ b/executable_semantics/testdata/return/fail_implicit_with_explicit_return.carbon
@@ -15,7 +15,7 @@ fn F() {
   return ();
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/return/implicit_with_no_return.carbon
+++ b/executable_semantics/testdata/return/implicit_with_no_return.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 fn F() {
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/return/implicit_with_plain_return.carbon
+++ b/executable_semantics/testdata/return/implicit_with_plain_return.carbon
@@ -15,7 +15,7 @@ fn F() {
   return;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   F();
   return 0;
 }

--- a/executable_semantics/testdata/string/basic.carbon
+++ b/executable_semantics/testdata/string/basic.carbon
@@ -18,6 +18,6 @@ fn CompareStr(s: String) -> i32 {
   return 1;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return CompareStr("str");
 }

--- a/executable_semantics/testdata/string/fail_hex_lower.carbon
+++ b/executable_semantics/testdata/string/fail_hex_lower.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("str\xaa");
   return 0;
 }

--- a/executable_semantics/testdata/string/fail_hex_truncated.carbon
+++ b/executable_semantics/testdata/string/fail_hex_truncated.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("str\x");
   return 0;
 }

--- a/executable_semantics/testdata/string/fail_invalid_escape.carbon
+++ b/executable_semantics/testdata/string/fail_invalid_escape.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("str\e");
   return 0;
 }

--- a/executable_semantics/testdata/string/fail_newline.carbon
+++ b/executable_semantics/testdata/string/fail_newline.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("new
 line");
   return 0;

--- a/executable_semantics/testdata/string/fail_octal.carbon
+++ b/executable_semantics/testdata/string/fail_octal.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("str\01");
   return 0;
 }

--- a/executable_semantics/testdata/string/fail_tab.carbon
+++ b/executable_semantics/testdata/string/fail_tab.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   Print("new	line");
   return 0;
 }

--- a/executable_semantics/testdata/string/hex.carbon
+++ b/executable_semantics/testdata/string/hex.carbon
@@ -18,6 +18,6 @@ fn CompareStr(s: String) -> i32 {
   return 1;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return CompareStr("\x73\x74\x72\x3B");
 }

--- a/executable_semantics/testdata/string/newline.carbon
+++ b/executable_semantics/testdata/string/newline.carbon
@@ -18,6 +18,6 @@ fn CompareStr(s: String) -> i32 {
   return 1;
 }
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return CompareStr("str\n");
 }

--- a/executable_semantics/testdata/struct/assign.carbon
+++ b/executable_semantics/testdata/struct/assign.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = {.x = 0, .y = 1};
   x = {.x = 5, .y = -5};
   return x.x + x.y;

--- a/executable_semantics/testdata/struct/assign_member.carbon
+++ b/executable_semantics/testdata/struct/assign_member.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p1: auto = {.x = 1, .y = 2};
   var p2: auto = p1;
   p2.x = 3;

--- a/executable_semantics/testdata/struct/empty.carbon
+++ b/executable_semantics/testdata/struct/empty.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var empty: {} = {};
   empty = {};
   if (not (empty == {})) {

--- a/executable_semantics/testdata/struct/ending_comma.carbon
+++ b/executable_semantics/testdata/struct/ending_comma.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: {.x: i32,} = {.x = 5,};
   var t2: {.x: i32, .y: i32} = {.x = 2, .y = 3,};
   return t1.x - t2.x - t2.y;

--- a/executable_semantics/testdata/struct/equality.carbon
+++ b/executable_semantics/testdata/struct/equality.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
   var t2: {.x: i32, .y: i32} = {.x = 5, .y = 2};
   if (t1 == t2) {

--- a/executable_semantics/testdata/struct/equality_false.carbon
+++ b/executable_semantics/testdata/struct/equality_false.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
   var t2: {.x: i32, .y: i32} = {.x = 5, .y = 4};
   if (t1 == t2) {

--- a/executable_semantics/testdata/struct/fail_equality_type.carbon
+++ b/executable_semantics/testdata/struct/fail_equality_type.carbon
@@ -10,7 +10,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
   var t2: {.x: i32,} = {.x = 5,};
   if (t1 == t2) {

--- a/executable_semantics/testdata/struct/fail_field_access_mismatch.carbon
+++ b/executable_semantics/testdata/struct/fail_field_access_mismatch.carbon
@@ -11,6 +11,6 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return {.x = 1, .y = 2}.z - 1;
 }

--- a/executable_semantics/testdata/struct/name_order.carbon
+++ b/executable_semantics/testdata/struct/name_order.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test the that field order doesn't matter for structs.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: {.x: i32, .y: i32} = {.y = 2, .x = 3};
   return 0;
 }

--- a/executable_semantics/testdata/struct/temp.carbon
+++ b/executable_semantics/testdata/struct/temp.carbon
@@ -11,6 +11,6 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   return {.x = 1, .y = 2}.x - 1;
 }

--- a/executable_semantics/testdata/struct/var.carbon
+++ b/executable_semantics/testdata/struct/var.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var p: {.x: i32, .y: i32} = {.x = 1, .y = 2};
   return p.y - p.x - 1;
 }

--- a/executable_semantics/testdata/tuple/assign.carbon
+++ b/executable_semantics/testdata/tuple/assign.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = 0;
   var y: auto = 1;
   (x, y) = (5, -5);

--- a/executable_semantics/testdata/tuple/ending_comma.carbon
+++ b/executable_semantics/testdata/tuple/ending_comma.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: (i32,) = (5,);
   var t2: (i32, i32) = (2, 3,);
   return t1[0] - t2[0] - t2[1];

--- a/executable_semantics/testdata/tuple/equality.carbon
+++ b/executable_semantics/testdata/tuple/equality.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: (i32,i32) = (5, 2);
   var t2: (i32,i32) = (5, 2);
   if (t1 == t2) {

--- a/executable_semantics/testdata/tuple/equality_false.carbon
+++ b/executable_semantics/testdata/tuple/equality_false.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: (i32,i32) = (5, 2);
   var t2: (i32,i32) = (5, 4);
   if (t1 == t2) {

--- a/executable_semantics/testdata/tuple/fail_equality_type.carbon
+++ b/executable_semantics/testdata/tuple/fail_equality_type.carbon
@@ -10,7 +10,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t1: (i32,i32) = (5, 2);
   var t2: (i32,) = (5,);
   if (t1 == t2) {

--- a/executable_semantics/testdata/tuple/fail_index.carbon
+++ b/executable_semantics/testdata/tuple/fail_index.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = (0, 1);
   return x[2];
 }

--- a/executable_semantics/testdata/tuple/fail_index_var.carbon
+++ b/executable_semantics/testdata/tuple/fail_index_var.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = (0, 1);
   var index: i32 = 0;
   return x[index];

--- a/executable_semantics/testdata/tuple/index.carbon
+++ b/executable_semantics/testdata/tuple/index.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = (0, 1);
   return x[0];
 }

--- a/executable_semantics/testdata/tuple/match.carbon
+++ b/executable_semantics/testdata/tuple/match.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = (5, 2);
   match (t) {
     case (a: auto, b: auto) =>

--- a/executable_semantics/testdata/tuple/match_nested.carbon
+++ b/executable_semantics/testdata/tuple/match_nested.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 // Test matching of a tuple inside a tuple.
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var t: auto = ((1,2),(3,4));
   match (t) {
     case ((a: auto, b: auto), c: auto) =>

--- a/executable_semantics/testdata/tuple/no_ending_comma.carbon
+++ b/executable_semantics/testdata/tuple/no_ending_comma.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = (1);
   var t2: (i32,i32) = (5, 2);
   t2[0] = 3;

--- a/executable_semantics/testdata/while/basic.carbon
+++ b/executable_semantics/testdata/while/basic.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = 2;
   while (not (x == 0)) {
     x = x - 1;

--- a/executable_semantics/testdata/while/break.carbon
+++ b/executable_semantics/testdata/while/break.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 2;
   while (true) {
     if (x == 0) {

--- a/executable_semantics/testdata/while/continue.carbon
+++ b/executable_semantics/testdata/while/continue.carbon
@@ -11,7 +11,7 @@
 
 package ExecutableSemanticsTest api;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: auto = 2;
   while (not (x == 0)) {
     x = x - 1;


### PR DESCRIPTION
Main() is more consistency with Carbon's naming guidelines. C# offers some precedent: https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/main-command-line