### PR TITLE
Disable bugprone-easily-swappable-parameters

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,14 +8,15 @@
 # - performance-unnecessary-value-param is disabled because it duplicate
 #   modernize-pass-by-value.
 Checks:
-  -*, bugprone-*, -bugprone-narrowing-conversions, google-*,
-  -google-readability-todo, misc-definitions-in-headers, misc-misplaced-const,
-  misc-redundant-expression, misc-static-assert,
-  misc-unconventional-assign-operator, misc-uniqueptr-reset-release,
-  misc-unused-*, modernize-*, -modernize-avoid-c-arrays,
-  -modernize-use-default-member-init, -modernize-use-emplace,
-  -modernize-use-nodiscard, performance-*, -performance-unnecessary-value-param,
-  readability-braces-around-statements, readability-identifier-naming
+  -*, bugprone-*, -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions, google-*, -google-readability-todo,
+  misc-definitions-in-headers, misc-misplaced-const, misc-redundant-expression,
+  misc-static-assert, misc-unconventional-assign-operator,
+  misc-uniqueptr-reset-release, misc-unused-*, modernize-*,
+  -modernize-avoid-c-arrays, -modernize-use-default-member-init,
+  -modernize-use-emplace, -modernize-use-nodiscard, performance-*,
+  -performance-unnecessary-value-param, readability-braces-around-statements,
+  readability-identifier-naming
 WarningsAsErrors: true
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase, value: CamelCase }


### PR DESCRIPTION
This warning is looking low value; for example:

```
/usr/local/google/home/jperkins/dev/carbon-lang/executable_semantics/interpreter/value.h:199:21: warning: 2 adjacent parameters of 'NominalClassValue' of similar type ('Nonnull<const Carbon::Value *>') are easily swapped by mistake [bugprone-easily-swappable-parameters]
  NominalClassValue(Nonnull<const Value*> type, Nonnull<const Value*> inits)
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/google/home/jperkins/dev/carbon-lang/executable_semantics/interpreter/value.h:199:43: note: the first parameter in the range is 'type'
  NominalClassValue(Nonnull<const Value*> type, Nonnull<const Value*> inits)
                                          ^~~~
/usr/local/google/home/jperkins/dev/carbon-lang/executable_semantics/interpreter/value.h:199:71: note: the last parameter in the range is 'inits'
  NominalClassValue(Nonnull<const Value*> type, Nonnull<const Value*> inits)
                                                                      ^~~~~
```