### PR TITLE
Fix `main` names that got past CI to fix tests.

### DIFF
--- a/executable_semantics/testdata/name_lookup/global_shadow.carbon
+++ b/executable_semantics/testdata/name_lookup/global_shadow.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 var x: i32 = 0;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   var x: i32 = 0;
   return 0;
 }

--- a/executable_semantics/testdata/name_lookup/match_shadow.carbon
+++ b/executable_semantics/testdata/name_lookup/match_shadow.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 var x: i32 = 0;
 
-fn main() -> i32 {
+fn Main() -> i32 {
   match (0) {
     case x: i32 => {
       var x: i32 = 0;


### PR DESCRIPTION
#939 switch to `Main`, but #919 predated it and didn't get updated
before merging. Its tests passed on the PR branch as a consequence, but
failed when landed.

This just updates the test cases. Trivial fix forward.