### PR TITLE
Make NamedEntityInterface non-movable

### DIFF
--- a/executable_semantics/ast/declaration.cpp
+++ b/executable_semantics/ast/declaration.cpp
@@ -30,8 +30,9 @@ void Declaration::Print(llvm::raw_ostream& out) const {
     case Kind::ChoiceDeclaration: {
       const auto& choice = cast<ChoiceDeclaration>(*this);
       out << "choice " << choice.name() << " {\n";
-      for (const auto& alt : choice.alternatives()) {
-        out << "alt " << alt.name() << " " << alt.signature() << ";\n";
+      for (Nonnull<const ChoiceDeclaration::Alternative*> alt :
+           choice.alternatives()) {
+        out << "alt " << alt->name() << " " << alt->signature() << ";\n";
       }
       out << "}\n";
       break;
@@ -50,12 +51,12 @@ void FunctionDeclaration::PrintDepth(int depth, llvm::raw_ostream& out) const {
   if (!deduced_parameters_.empty()) {
     out << "[";
     unsigned int i = 0;
-    for (const auto& deduced : deduced_parameters_) {
+    for (Nonnull<const GenericBinding*> deduced : deduced_parameters_) {
       if (i != 0) {
         out << ", ";
       }
-      out << deduced.name() << ":! ";
-      deduced.type().Print(out);
+      out << deduced->name() << ":! ";
+      deduced->type().Print(out);
       ++i;
     }
     out << "]";

--- a/executable_semantics/ast/declaration.h
+++ b/executable_semantics/ast/declaration.h
@@ -108,7 +108,7 @@ struct GenericBinding : public NamedEntityInterface {
 class FunctionDeclaration : public Declaration {
  public:
   FunctionDeclaration(SourceLocation source_loc, std::string name,
-                      std::vector<GenericBinding> deduced_params,
+                      std::vector<Nonnull<GenericBinding*>> deduced_params,
                       Nonnull<TuplePattern*> param_pattern,
                       Nonnull<Pattern*> return_type,
                       bool is_omitted_return_type,
@@ -128,7 +128,8 @@ class FunctionDeclaration : public Declaration {
   void PrintDepth(int depth, llvm::raw_ostream& out) const;
 
   auto name() const -> const std::string& { return name_; }
-  auto deduced_parameters() const -> llvm::ArrayRef<GenericBinding> {
+  auto deduced_parameters() const
+      -> llvm::ArrayRef<Nonnull<const GenericBinding*>> {
     return deduced_parameters_;
   }
   auto param_pattern() const -> const TuplePattern& { return *param_pattern_; }
@@ -147,7 +148,7 @@ class FunctionDeclaration : public Declaration {
 
  private:
   std::string name_;
-  std::vector<GenericBinding> deduced_parameters_;
+  std::vector<Nonnull<GenericBinding*>> deduced_parameters_;
   Nonnull<TuplePattern*> param_pattern_;
   Nonnull<Pattern*> return_type_;
   bool is_omitted_return_type_;
@@ -198,7 +199,7 @@ class ChoiceDeclaration : public Declaration {
   };
 
   ChoiceDeclaration(SourceLocation source_loc, std::string name,
-                    std::vector<Alternative> alternatives)
+                    std::vector<Nonnull<Alternative*>> alternatives)
       : Declaration(Kind::ChoiceDeclaration, source_loc),
         name_(std::move(name)),
         alternatives_(std::move(alternatives)) {}
@@ -208,7 +209,7 @@ class ChoiceDeclaration : public Declaration {
   }
 
   auto name() const -> const std::string& { return name_; }
-  auto alternatives() const -> llvm::ArrayRef<Alternative> {
+  auto alternatives() const -> llvm::ArrayRef<Nonnull<const Alternative*>> {
     return alternatives_;
   }
 
@@ -218,7 +219,7 @@ class ChoiceDeclaration : public Declaration {
 
  private:
   std::string name_;
-  std::vector<Alternative> alternatives_;
+  std::vector<Nonnull<Alternative*>> alternatives_;
   StaticScope static_scope_;
 };
 

--- a/executable_semantics/ast/static_scope.h
+++ b/executable_semantics/ast/static_scope.h
@@ -33,7 +33,12 @@ class NamedEntityInterface {
     Member,
   };
 
+  NamedEntityInterface() = default;
   virtual ~NamedEntityInterface() = default;
+
+  NamedEntityInterface(NamedEntityInterface&&) = delete;
+  auto operator=(NamedEntityInterface&&) -> NamedEntityInterface& = delete;
+
   // TODO: This is unused, but is intended for casts after lookup.
   virtual auto named_entity_kind() const -> NamedEntityKind = 0;
   virtual auto source_loc() const -> SourceLocation = 0;

--- a/executable_semantics/interpreter/exec_program.cpp
+++ b/executable_semantics/interpreter/exec_program.cpp
@@ -30,7 +30,7 @@ static void AddIntrinsics(Nonnull<Arena*> arena,
                           IntrinsicExpression::Intrinsic::Print),
                       false)}));
   auto print = arena->New<FunctionDeclaration>(
-      source_loc, "Print", std::vector<GenericBinding>(),
+      source_loc, "Print", std::vector<Nonnull<GenericBinding*>>(),
       arena->New<TuplePattern>(source_loc, print_params),
       arena->New<ExpressionPattern>(arena->New<TupleLiteral>(source_loc)),
       /*is_omitted_return_type=*/false, print_return);

--- a/executable_semantics/interpreter/resolve_names.cpp
+++ b/executable_semantics/interpreter/resolve_names.cpp
@@ -133,8 +133,8 @@ void PopulateNamesInDeclaration(Arena* arena, Declaration& declaration,
     case Declaration::Kind::FunctionDeclaration: {
       auto& func = cast<FunctionDeclaration>(declaration);
       static_scope.Add(func.name(), &declaration);
-      for (const auto& param : func.deduced_parameters()) {
-        func.static_scope().Add(param.name(), &param);
+      for (Nonnull<const GenericBinding*> param : func.deduced_parameters()) {
+        func.static_scope().Add(param->name(), param);
       }
       PopulateNamesInPattern(func.param_pattern(), func.static_scope());
       PopulateNamesInStatement(arena, func.body(), static_scope);
@@ -151,8 +151,9 @@ void PopulateNamesInDeclaration(Arena* arena, Declaration& declaration,
     case Declaration::Kind::ChoiceDeclaration: {
       auto& choice = cast<ChoiceDeclaration>(declaration);
       static_scope.Add(choice.name(), &declaration);
-      for (auto& alt : choice.alternatives()) {
-        choice.static_scope().Add(alt.name(), &alt);
+      for (Nonnull<const ChoiceDeclaration::Alternative*> alt :
+           choice.alternatives()) {
+        choice.static_scope().Add(alt->name(), alt);
       }
       // Populate name into declared_names.
       // Init the choice's declared_names, and populate it with the

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -213,11 +213,11 @@ void Value::Print(llvm::raw_ostream& out) const {
       if (fn_type.deduced().size() > 0) {
         out << "[";
         unsigned int i = 0;
-        for (const auto& deduced : fn_type.deduced()) {
+        for (Nonnull<const GenericBinding*> deduced : fn_type.deduced()) {
           if (i != 0) {
             out << ", ";
           }
-          out << deduced.name() << ":! " << deduced.type();
+          out << deduced->name() << ":! " << deduced->type();
           ++i;
         }
         out << "]";

--- a/executable_semantics/interpreter/value.h
+++ b/executable_semantics/interpreter/value.h
@@ -335,7 +335,7 @@ class TypeType : public Value {
 // A function type.
 class FunctionType : public Value {
  public:
-  FunctionType(std::vector<GenericBinding> deduced,
+  FunctionType(std::vector<Nonnull<const GenericBinding*>> deduced,
                Nonnull<const Value*> parameters,
                Nonnull<const Value*> return_type)
       : Value(Kind::FunctionType),
@@ -347,12 +347,14 @@ class FunctionType : public Value {
     return value->kind() == Kind::FunctionType;
   }
 
-  auto deduced() const -> llvm::ArrayRef<GenericBinding> { return deduced_; }
+  auto deduced() const -> llvm::ArrayRef<Nonnull<const GenericBinding*>> {
+    return deduced_;
+  }
   auto parameters() const -> const Value& { return *parameters_; }
   auto return_type() const -> const Value& { return *return_type_; }
 
  private:
-  std::vector<GenericBinding> deduced_;
+  std::vector<Nonnull<const GenericBinding*>> deduced_;
   Nonnull<const Value*> parameters_;
   Nonnull<const Value*> return_type_;
 };

--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -108,9 +108,9 @@
 %type <Nonnull<Block*>> block
 %type <std::vector<Nonnull<Statement*>>> statement_list
 %type <Nonnull<Expression*>> expression
-%type <BisonWrap<GenericBinding>> generic_binding
-%type <std::vector<GenericBinding>> deduced_params
-%type <std::vector<GenericBinding>> deduced_param_list
+%type <Nonnull<GenericBinding*>> generic_binding
+%type <std::vector<Nonnull<GenericBinding*>>> deduced_params
+%type <std::vector<Nonnull<GenericBinding*>>> deduced_param_list
 %type <Nonnull<Pattern*>> pattern
 %type <Nonnull<Pattern*>> non_expression_pattern
 %type <std::pair<Nonnull<Expression*>, bool>> return_type
@@ -131,9 +131,9 @@
 %type <Nonnull<TuplePattern*>> maybe_empty_tuple_pattern
 %type <ParenContents<Pattern>> paren_pattern_base
 %type <ParenContents<Pattern>> paren_pattern_contents
-%type <BisonWrap<ChoiceDeclaration::Alternative>> alternative
-%type <std::vector<ChoiceDeclaration::Alternative>> alternative_list
-%type <std::vector<ChoiceDeclaration::Alternative>> alternative_list_contents
+%type <Nonnull<ChoiceDeclaration::Alternative*>> alternative
+%type <std::vector<Nonnull<ChoiceDeclaration::Alternative*>>> alternative_list
+%type <std::vector<Nonnull<ChoiceDeclaration::Alternative*>>> alternative_list_contents
 %type <BisonWrap<Match::Clause>> clause
 %type <std::vector<Match::Clause>> clause_list
 
@@ -632,14 +632,16 @@ return_type:
 ;
 generic_binding:
   identifier COLON_BANG expression
-    { $$ = GenericBinding(context.source_loc(), std::move($1), $3); }
+    {
+      $$ = arena->New<GenericBinding>(context.source_loc(), std::move($1), $3);
+    }
 ;
 deduced_param_list:
   // Empty
-    { $$ = std::vector<GenericBinding>(); }
+    { $$ = std::vector<Nonnull<GenericBinding*>>(); }
 | generic_binding
     {
-      $$ = std::vector<GenericBinding>();
+      $$ = std::vector<Nonnull<GenericBinding*>>();
       $$.push_back($1);
     }
 | generic_binding COMMA deduced_param_list
@@ -650,7 +652,7 @@ deduced_param_list:
 ;
 deduced_params:
   // Empty
-    { $$ = std::vector<GenericBinding>(); }
+    { $$ = std::vector<Nonnull<GenericBinding*>>(); }
 | LEFT_SQUARE_BRACKET deduced_param_list RIGHT_SQUARE_BRACKET
     { $$ = $2; }
 ;
@@ -696,10 +698,13 @@ member_list:
 ;
 alternative:
   identifier tuple
-    { $$ = ChoiceDeclaration::Alternative(context.source_loc(), $1, $2); }
+    {
+      $$ = arena->New<ChoiceDeclaration::Alternative>(context.source_loc(), $1,
+                                                      $2);
+    }
 | identifier
     {
-      $$ = ChoiceDeclaration::Alternative(
+      $$ = arena->New<ChoiceDeclaration::Alternative>(
           context.source_loc(), $1,
           arena->New<TupleLiteral>(context.source_loc()));
     }


### PR DESCRIPTION
If we're going to be forming persistent pointers to these, they'll need to have stable addresses.