### PR TITLE
clang-tidy pass on executable_semantics

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,10 +13,10 @@ Checks:
   misc-definitions-in-headers, misc-misplaced-const, misc-redundant-expression,
   misc-static-assert, misc-unconventional-assign-operator,
   misc-uniqueptr-reset-release, misc-unused-*, modernize-*,
-  -modernize-avoid-c-arrays, -modernize-use-default-member-init,
-  -modernize-use-emplace, -modernize-use-nodiscard, performance-*,
-  -performance-unnecessary-value-param, readability-braces-around-statements,
-  readability-identifier-naming
+  -modernize-avoid-c-arrays, -modernize-return-braced-init-list,
+  -modernize-use-default-member-init, -modernize-use-emplace,
+  -modernize-use-nodiscard, performance-*, -performance-unnecessary-value-param,
+  readability-braces-around-statements, readability-identifier-naming
 WarningsAsErrors: true
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase, value: CamelCase }

--- a/executable_semantics/ast/ast_node.h
+++ b/executable_semantics/ast/ast_node.h
@@ -81,7 +81,7 @@ namespace llvm {
 template <typename To>
 struct cast_convert_val<To, const Carbon::AstNode*, const Carbon::AstNode*> {
   using ResultType = typename cast_retty<To, const Carbon::AstNode*>::ret_type;
-  static ResultType doit(const Carbon::AstNode* node) {
+  static auto doit(const Carbon::AstNode* node) -> ResultType {
     return dynamic_cast<ResultType>(node);
   }
 };
@@ -89,7 +89,7 @@ struct cast_convert_val<To, const Carbon::AstNode*, const Carbon::AstNode*> {
 template <typename To>
 struct cast_convert_val<To, Carbon::AstNode*, Carbon::AstNode*> {
   using ResultType = typename cast_retty<To, Carbon::AstNode*>::ret_type;
-  static ResultType doit(Carbon::AstNode* node) {
+  static auto doit(Carbon::AstNode* node) -> ResultType {
     return dynamic_cast<ResultType>(node);
   }
 };
@@ -97,7 +97,7 @@ struct cast_convert_val<To, Carbon::AstNode*, Carbon::AstNode*> {
 template <typename To>
 struct cast_convert_val<To, const Carbon::AstNode, const Carbon::AstNode> {
   using ResultType = typename cast_retty<To, const Carbon::AstNode>::ret_type;
-  static ResultType doit(const Carbon::AstNode& node) {
+  static auto doit(const Carbon::AstNode& node) -> ResultType {
     return dynamic_cast<ResultType>(node);
   }
 };
@@ -105,7 +105,7 @@ struct cast_convert_val<To, const Carbon::AstNode, const Carbon::AstNode> {
 template <typename To>
 struct cast_convert_val<To, Carbon::AstNode, Carbon::AstNode> {
   using ResultType = typename cast_retty<To, Carbon::AstNode>::ret_type;
-  static ResultType doit(Carbon::AstNode& node) {
+  static auto doit(Carbon::AstNode& node) -> ResultType {
     return dynamic_cast<ResultType>(node);
   }
 };

--- a/executable_semantics/ast/ast_test_matchers_internal.cpp
+++ b/executable_semantics/ast/ast_test_matchers_internal.cpp
@@ -7,8 +7,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace Carbon {
-namespace TestingInternal {
+namespace Carbon::TestingInternal {
 
 AstNodeMatcherBase::~AstNodeMatcherBase() = default;
 
@@ -210,5 +209,4 @@ void MatchesUnimplementedExpressionMatcher::DescribeToImpl(std::ostream* out,
   children_matcher_.DescribeTo(out);
 }
 
-}  // namespace TestingInternal
-}  // namespace Carbon
+}  // namespace Carbon::TestingInternal

--- a/executable_semantics/ast/ast_test_matchers_internal.h
+++ b/executable_semantics/ast/ast_test_matchers_internal.h
@@ -19,8 +19,7 @@
 #include "executable_semantics/ast/statement.h"
 #include "llvm/Support/Casting.h"
 
-namespace Carbon {
-namespace TestingInternal {
+namespace Carbon::TestingInternal {
 
 // Abstract GoogleMock matcher which matches AstNodes, and is agnostic to
 // whether they are passed by pointer or reference. Derived classes specify what
@@ -28,6 +27,7 @@ namespace TestingInternal {
 // MatchAndExplainImpl.
 class AstNodeMatcherBase {
  public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using is_gtest_matcher = void;
 
   virtual ~AstNodeMatcherBase();
@@ -202,6 +202,7 @@ class MatchesUnimplementedExpressionMatcher : public AstNodeMatcherBase {
 // Matches an `AST`.
 class ASTDeclarationsMatcher {
  public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using is_gtest_matcher = void;
 
   // Constructs a matcher which matches an `AST` whose `declarations` member
@@ -231,7 +232,6 @@ class ASTDeclarationsMatcher {
   ::testing::Matcher<std::vector<Nonnull<Declaration*>>> declarations_matcher_;
 };
 
-}  // namespace TestingInternal
-}  // namespace Carbon
+}  // namespace Carbon::TestingInternal
 
 #endif  // EXECUTABLE_SEMANTICS_AST_AST_TEST_MATCHERS_INTERNAL_H_

--- a/executable_semantics/ast/declaration.h
+++ b/executable_semantics/ast/declaration.h
@@ -107,7 +107,7 @@ struct GenericBinding : public virtual AstNode, public NamedEntity {
 class ReturnTerm {
  public:
   ReturnTerm(const ReturnTerm&) = default;
-  ReturnTerm& operator=(const ReturnTerm&) = default;
+  auto operator=(const ReturnTerm&) -> ReturnTerm& = default;
 
   // Represents an omitted return term at `source_loc`.
   static auto Omitted(SourceLocation source_loc) -> ReturnTerm {

--- a/executable_semantics/ast/statement.h
+++ b/executable_semantics/ast/statement.h
@@ -5,6 +5,7 @@
 #ifndef EXECUTABLE_SEMANTICS_AST_STATEMENT_H_
 #define EXECUTABLE_SEMANTICS_AST_STATEMENT_H_
 
+#include <utility>
 #include <vector>
 
 #include "common/ostream.h"
@@ -45,7 +46,8 @@ class Statement : public virtual AstNode {
 class Block : public Statement {
  public:
   Block(SourceLocation source_loc, std::vector<Nonnull<Statement*>> statements)
-      : AstNode(AstNodeKind::Block, source_loc), statements_(statements) {}
+      : AstNode(AstNodeKind::Block, source_loc),
+        statements_(std::move(statements)) {}
 
   static auto classof(const AstNode* node) -> bool {
     return InheritsFromBlock(node->kind());

--- a/executable_semantics/ast/static_scope.h
+++ b/executable_semantics/ast/static_scope.h
@@ -18,7 +18,7 @@ namespace Carbon {
 
 class NamedEntity : public virtual AstNode {
  public:
-  virtual ~NamedEntity() = 0;
+  ~NamedEntity() override = 0;
 
   NamedEntity() = default;
 

--- a/executable_semantics/interpreter/action.h
+++ b/executable_semantics/interpreter/action.h
@@ -209,7 +209,7 @@ class StatementAction : public Action {
 // with AST nodes.
 class ScopeAction : public Action {
  public:
-  ScopeAction(Scope scope) : Action(Kind::ScopeAction) {
+  explicit ScopeAction(Scope scope) : Action(Kind::ScopeAction) {
     StartScope(std::move(scope));
   }
 

--- a/executable_semantics/interpreter/address.h
+++ b/executable_semantics/interpreter/address.h
@@ -36,7 +36,7 @@ class AllocationId {
   // details of Heap.
   friend class Heap;
 
-  AllocationId(size_t index) : index_(index) {}
+  explicit AllocationId(size_t index) : index_(index) {}
 
   size_t index_;
 };

--- a/executable_semantics/interpreter/resolve_names.cpp
+++ b/executable_semantics/interpreter/resolve_names.cpp
@@ -113,8 +113,7 @@ void PopulateNamesInStatement(Arena* arena,
 
 // Populates names for a member. See PopulateNamesInDeclaration for overall
 // flow.
-void PopulateNamesInMember(Arena* arena, const Member& member,
-                           StaticScope& static_scope) {
+void PopulateNamesInMember(const Member& member, StaticScope& static_scope) {
   switch (member.kind()) {
     case MemberKind::FieldMember: {
       const auto& field = cast<FieldMember>(member);
@@ -148,7 +147,7 @@ void PopulateNamesInDeclaration(Arena* arena, Declaration& declaration,
       class_decl.static_scope().AddParent(&static_scope);
       static_scope.Add(class_decl.name(), &declaration);
       for (auto* member : class_decl.members()) {
-        PopulateNamesInMember(arena, *member, class_decl.static_scope());
+        PopulateNamesInMember(*member, class_decl.static_scope());
       }
       break;
     }

--- a/executable_semantics/interpreter/value.h
+++ b/executable_semantics/interpreter/value.h
@@ -117,7 +117,7 @@ class IntValue : public Value {
 // A function value.
 class FunctionValue : public Value {
  public:
-  FunctionValue(Nonnull<const FunctionDeclaration*> declaration)
+  explicit FunctionValue(Nonnull<const FunctionDeclaration*> declaration)
       : Value(Kind::FunctionValue), declaration_(declaration) {}
 
   static auto classof(const Value* value) -> bool {
@@ -495,7 +495,7 @@ class ContinuationValue : public Value {
     ~StackFragment();
 
     StackFragment(StackFragment&&) = delete;
-    StackFragment& operator=(StackFragment&&) = delete;
+    auto operator=(StackFragment&&) -> StackFragment& = delete;
 
     // Store the given partial todo stack in *this, which must currently be
     // empty. The stack is represented with the top of the stack at the

--- a/executable_semantics/syntax/parse_test_matchers_internal.h
+++ b/executable_semantics/syntax/parse_test_matchers_internal.h
@@ -13,12 +13,12 @@
 
 #include "executable_semantics/syntax/parse.h"
 
-namespace Carbon {
-namespace TestingInternal {
+namespace Carbon::TestingInternal {
 
 // Implementation of ParsedAs(). See there for detailed documentation.
 class ParsedAsMatcher {
  public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
   using is_gtest_matcher = void;
 
   explicit ParsedAsMatcher(::testing::Matcher<AST> ast_matcher)
@@ -53,7 +53,6 @@ class ParsedAsMatcher {
   ::testing::Matcher<AST> ast_matcher_;
 };
 
-}  // namespace TestingInternal
-}  // namespace Carbon
+}  // namespace Carbon::TestingInternal
 
 #endif  // EXECUTABLE_SEMANTICS_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_


### PR DESCRIPTION
Replaces #942 