### PR TITLE
Move tests into Carbon::Testing, set small size

### DIFF
--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -33,6 +33,7 @@ cc_library(
 
 cc_test(
     name = "diagnostic_emitter_test",
+    size = "small",
     srcs = ["diagnostic_emitter_test.cpp"],
     deps = [
         ":diagnostic_emitter",

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -11,13 +11,8 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "toolchain/diagnostics/mocks.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
-
-using Testing::DiagnosticAt;
-using Testing::DiagnosticLevel;
-using Testing::DiagnosticMessage;
-using Testing::DiagnosticShortName;
 
 struct FakeDiagnostic {
   static constexpr llvm::StringLiteral ShortName = "fake-diagnostic";
@@ -91,4 +86,4 @@ TEST(DiagTest, EmitWarnings) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -22,6 +22,7 @@ cc_library(
 
 cc_test(
     name = "driver_test",
+    size = "small",
     srcs = ["driver_test.cpp"],
     deps = [
         ":driver",
@@ -34,6 +35,7 @@ cc_test(
 
 cc_fuzz_test(
     name = "driver_fuzzer",
+    size = "small",
     srcs = ["driver_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -12,7 +12,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "toolchain/driver/driver.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 
 static auto Read(const unsigned char*& data, size_t& size, int& output)
     -> bool {
@@ -79,4 +79,4 @@ extern "C" auto LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
   }
   return 0;
 }
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -12,13 +12,12 @@
 #include "llvm/Support/SourceMgr.h"
 #include "toolchain/common/yaml_test_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::StrEq;
-namespace Yaml = Carbon::Testing::Yaml;
 
 /// A raw_ostream that makes it easy to repeatedly check streamed output.
 class RawTestOstream : public llvm::raw_ostream {
@@ -235,4 +234,4 @@ TEST(DriverTest, DumpParseTree) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -19,6 +19,7 @@ cc_library(
 
 cc_test(
     name = "token_kind_test",
+    size = "small",
     srcs = ["token_kind_test.cpp"],
     deps = [
         ":token_kind",
@@ -58,6 +59,7 @@ cc_library(
 
 cc_test(
     name = "numeric_literal_test",
+    size = "small",
     srcs = ["numeric_literal_test.cpp"],
     deps = [
         ":numeric_literal",
@@ -71,6 +73,7 @@ cc_test(
 
 cc_fuzz_test(
     name = "numeric_literal_fuzzer",
+    size = "small",
     srcs = ["numeric_literal_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/numeric_literal/*"]),
     deps = [
@@ -95,6 +98,7 @@ cc_library(
 
 cc_test(
     name = "string_literal_test",
+    size = "small",
     srcs = ["string_literal_test.cpp"],
     deps = [
         ":string_literal",
@@ -108,6 +112,7 @@ cc_test(
 
 cc_fuzz_test(
     name = "string_literal_fuzzer",
+    size = "small",
     srcs = ["string_literal_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/string_literal/*"]),
     deps = [
@@ -148,6 +153,7 @@ cc_library(
 
 cc_test(
     name = "tokenized_buffer_test",
+    size = "small",
     srcs = ["tokenized_buffer_test.cpp"],
     deps = [
         ":tokenized_buffer",
@@ -162,6 +168,7 @@ cc_test(
 
 cc_fuzz_test(
     name = "tokenized_buffer_fuzzer",
+    size = "small",
     srcs = ["tokenized_buffer_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/tokenized_buffer/*"]),
     deps = [

--- a/toolchain/lexer/numeric_literal_fuzzer.cpp
+++ b/toolchain/lexer/numeric_literal_fuzzer.cpp
@@ -10,7 +10,7 @@
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/numeric_literal.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
@@ -28,4 +28,4 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   return 0;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/numeric_literal_test.cpp
+++ b/toolchain/lexer/numeric_literal_test.cpp
@@ -15,7 +15,7 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lexer/test_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 using ::testing::_;
@@ -338,4 +338,4 @@ TEST_F(NumericLiteralTest, TooManyDigits) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/string_literal_fuzzer.cpp
+++ b/toolchain/lexer/string_literal_fuzzer.cpp
@@ -10,7 +10,7 @@
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/string_literal.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
@@ -34,4 +34,4 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   return 0;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/string_literal_test.cpp
+++ b/toolchain/lexer/string_literal_test.cpp
@@ -11,7 +11,7 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lexer/test_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 class StringLiteralTest : public ::testing::Test {
@@ -291,4 +291,4 @@ TEST_F(StringLiteralTest, TabInBlockString) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/token_kind_test.cpp
+++ b/toolchain/lexer/token_kind_test.cpp
@@ -11,7 +11,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 using ::testing::MatchesRegex;
@@ -91,4 +91,4 @@ TEST(TokenKindTest, SymbolsInDescendingLength) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lexer/tokenized_buffer_fuzzer.cpp
@@ -11,7 +11,7 @@
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
@@ -62,4 +62,4 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   return 0;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -21,18 +21,13 @@
 #include "toolchain/diagnostics/mocks.h"
 #include "toolchain/lexer/tokenized_buffer_test_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
-using ::Carbon::Testing::DiagnosticAt;
-using ::Carbon::Testing::DiagnosticMessage;
-using ::Carbon::Testing::ExpectedToken;
-using ::Carbon::Testing::HasTokens;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::StrEq;
-namespace Yaml = Carbon::Testing::Yaml;
 
 class LexerTest : public ::testing::Test {
  protected:
@@ -1103,4 +1098,4 @@ TEST_F(LexerTest, PrintingAsYaml) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -16,6 +16,7 @@ cc_library(
 
 cc_test(
     name = "parse_node_kind_test",
+    size = "small",
     srcs = ["parse_node_kind_test.cpp"],
     deps = [
         ":parse_node_kind",
@@ -58,6 +59,7 @@ cc_library(
 
 cc_test(
     name = "parse_tree_test",
+    size = "small",
     srcs = ["parse_tree_test.cpp"],
     deps = [
         ":parse_node_kind",
@@ -75,6 +77,7 @@ cc_test(
 
 cc_fuzz_test(
     name = "parse_tree_fuzzer",
+    size = "small",
     srcs = ["parse_tree_fuzzer.cpp"],
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [
@@ -100,6 +103,7 @@ cc_library(
 
 cc_test(
     name = "precedence_test",
+    size = "small",
     srcs = ["precedence_test.cpp"],
     deps = [
         ":precedence",

--- a/toolchain/parser/parse_node_kind_test.cpp
+++ b/toolchain/parser/parse_node_kind_test.cpp
@@ -10,8 +10,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
-namespace Carbon {
-
+namespace Carbon::Testing {
 namespace {
 
 // Not much to test here, so just verify that the API compiles and returns the
@@ -23,4 +22,4 @@ namespace {
 #include "toolchain/parser/parse_node_kind.def"
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/parser/parse_test_helpers.h
+++ b/toolchain/parser/parse_test_helpers.h
@@ -271,9 +271,6 @@ inline auto MatchParseTreeNodes(
       new ExpectedNodesMatcher(std::move(expected_nodes)));
 }
 
-// Node matchers. Intended to be brought in by 'using namespace'.
-namespace NodeMatchers {
-
 // Matcher argument for a node with errors.
 struct HasErrorTag {};
 inline constexpr HasErrorTag HasError;
@@ -340,8 +337,6 @@ auto MatchFunctionWithBody(Args... args) -> ExpectedNode {
       MatchDeclaredName(), MatchParameters(),
       MatchCodeBlock(std::move(args)..., MatchCodeBlockEnd()));
 }
-
-}  // namespace NodeMatchers
 
 }  // namespace Testing
 }  // namespace Carbon

--- a/toolchain/parser/parse_tree_fuzzer.cpp
+++ b/toolchain/parser/parse_tree_fuzzer.cpp
@@ -13,7 +13,7 @@
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/parser/parse_tree.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
@@ -61,4 +61,4 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   return 0;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/parser/parse_tree_test.cpp
+++ b/toolchain/parser/parse_tree_test.cpp
@@ -19,18 +19,13 @@
 #include "toolchain/parser/parse_node_kind.h"
 #include "toolchain/parser/parse_test_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
-using Carbon::Testing::DiagnosticMessage;
-using Carbon::Testing::ExpectedNode;
-using Carbon::Testing::MatchParseTreeNodes;
-using namespace Carbon::Testing::NodeMatchers;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::Ne;
 using ::testing::StrEq;
-namespace Yaml = Carbon::Testing::Yaml;
 
 class ParseTreeTest : public ::testing::Test {
  protected:
@@ -1176,4 +1171,4 @@ TEST_F(ParseTreeTest, ParenMatchRegression) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/parser/precedence_test.cpp
+++ b/toolchain/parser/precedence_test.cpp
@@ -9,7 +9,7 @@
 
 #include "toolchain/lexer/token_kind.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 using ::testing::Eq;
@@ -154,4 +154,4 @@ TEST(PrecedenceTest, IncomparableOperators) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -16,6 +16,7 @@ cc_library(
 
 cc_test(
     name = "source_buffer_test",
+    size = "small",
     srcs = ["source_buffer_test.cpp"],
     deps = [
         ":source_buffer",

--- a/toolchain/source/source_buffer_test.cpp
+++ b/toolchain/source/source_buffer_test.cpp
@@ -11,7 +11,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace Carbon {
+namespace Carbon::Testing {
 namespace {
 
 TEST(SourceBufferTest, StringRep) {
@@ -59,4 +59,4 @@ TEST(SourceBufferTest, FileRep) {
 }
 
 }  // namespace
-}  // namespace Carbon
+}  // namespace Carbon::Testing


### PR DESCRIPTION
The small size is for the 1m vs 5m time limit -- all these tests _should_ be fast so a lower limit seems consistent, and the 5m timeout was getting in my way when trying to debug *actual* timeouts.

The Carbon::Testing bit is for convenience -- test libraries are generally using it, it seems like the tests should too. Note this reduces the need for `using`.

This does push NodeMatchers into Carbon::Testing -- I don't think this was benefiting from having its own namespace; `using namespace` is discouraged [under style](https://google.github.io/styleguide/cppguide.html#Namespaces), we wouldn't support an equivalent in Carbon, and it feels like it's not helping to avoid name collisions. (also tidy was bugging about it, and while I could NOLINT that, this felt like the better approach)