### PR TITLE
More minor cleanup - test_helpers

### DIFF
--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -40,6 +40,7 @@ cc_library(
     deps = [
         "//common:check",
         "//toolchain/diagnostics:diagnostic_emitter",
+        "@com_google_googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/lexer/test_helpers.h
+++ b/toolchain/lexer/test_helpers.h
@@ -5,11 +5,12 @@
 #ifndef TOOLCHAIN_LEXER_TEST_HELPERS_H_
 #define TOOLCHAIN_LEXER_TEST_HELPERS_H_
 
+#include <gmock/gmock.h>
+
 #include <array>
 #include <string>
 
 #include "common/check.h"
-#include "gmock/gmock.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"


### PR DESCRIPTION
Added gtest build dep for toolchain/lexer:test_helpers and switched to use system include style for gmock header.