### PR TITLE
Delete empty diagnostic_emitter.cpp

### DIFF
--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -6,7 +6,6 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "diagnostic_emitter",
-    srcs = ["diagnostic_emitter.cpp"],
     hdrs = ["diagnostic_emitter.h"],
     deps = ["@llvm-project//llvm:Support"],
 )

--- a/toolchain/diagnostics/diagnostic_emitter.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter.cpp
@@ -1,7 +1,0 @@
-// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-// Exceptions. See /LICENSE for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-#include "toolchain/diagnostics/diagnostic_emitter.h"
-
-namespace Carbon {}  // namespace Carbon


### PR DESCRIPTION
I don't _think_ I'm missing a reason to keep this? (proposing deleting so that I don't keep wondering if I'm missing a reason)