### PR TITLE
Workaround for libtool_check_unique errors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -128,8 +128,16 @@ jobs:
 
       # Build all targets first to isolate build failures.
       - name: Build (${{ matrix.build_mode }})
+        env:
+          # 'libtool_check_unique failed to generate' workaround.
+          # https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586
+          BAZEL_USE_CPP_ONLY_TOOLCHAIN: 1
         run: bazelisk build -c ${{ matrix.build_mode }} //...:all
 
       # Run all test targets.
       - name: Test (${{ matrix.build_mode }})
+        env:
+          # 'libtool_check_unique failed to generate' workaround.
+          # https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586
+          BAZEL_USE_CPP_ONLY_TOOLCHAIN: 1
         run: bazelisk test -c ${{ matrix.build_mode }} //...:all


### PR DESCRIPTION
e.g. https://github.com/carbon-language/carbon-lang/runs/4768894988?check_suite_focus=true -- I'm seeing this too frequently and wondering if we can duck it per https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586