### PR TITLE
Adjust pre-commit order and autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 38b88246ccc552bffaaf54259d064beeee434539 # frozen: v4.0.1
+    rev: 8fe62d14e0b4d7d845a7022c5c2c3ae41bdd3f26 # frozen: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -33,7 +33,51 @@ repos:
       - id: search-and-replace
         files: '\.md$'
   - repo: https://github.com/google/pre-commit-tool-hooks
-    rev: 26cc20f971cad7dee54e1fcccb960b4e19b2bdce # frozen: v1.2.1
+    rev: cb78d9293306d9f737c64d9702bbaa88e157caaa # frozen: v1.2.2
+    hooks:
+      - id: check-google-doc-style
+      - id: markdown-toc
+  - repo: local
+    hooks:
+      - id: executable-semantics-format-grammar
+        name: Format the executable_semantics grammar file
+        entry: executable_semantics/syntax/format_grammar.py
+        language: python
+        files: ^executable_semantics/syntax/(lexer.lpp|parser.ypp)$
+        pass_filenames: false
+      - id: fix-cc-deps
+        name: Fix missing C++ deps
+        entry: scripts/fix_cc_deps.py
+        language: python
+        files: ^.*/(BUILD|[^/]+\.(h|cpp))$
+        pass_filenames: false
+  # Formatters should be run late so that they can re-format any prior changes.
+  - repo: https://github.com/psf/black
+    rev: f1d4e742c91dd5179d742b0db9293c4472b765f8 # frozen: 21.12b0
+    hooks:
+      - id: black
+  - repo: https://github.com/jlebar/pre-commit-hooks.git
+    rev: fb5e481f35f5a9b32a06ccfc28b8d6dda4525f75
+    hooks:
+      - id: bazel-buildifier
+      - id: clang-format-whole-file
+        types: [c++]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: ea782651a7e32f40a3d13b76c79d5a2474ee8723 # frozen: v2.5.1
+    hooks:
+      - id: prettier
+  # Run linters last, as formatters and other checks may fix issues.
+  - repo: https://github.com/PyCQA/flake8
+    rev: cbeb4c9c4137cff1568659fcc48e8b85cddd0c8d # frozen: 4.0.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/codespell-project/codespell
+    rev: 01da43d753cdff4ea7dff952b4f5317450af31e3 # frozen: v2.1.0
+    hooks:
+      - id: codespell
+        args: ['-I', '.codespell_ignore', '--uri-ignore-words-list', '*']
+  - repo: https://github.com/google/pre-commit-tool-hooks
+    rev: cb78d9293306d9f737c64d9702bbaa88e157caaa # frozen: v1.2.2
     hooks:
       - id: check-copyright
         args:
@@ -76,7 +120,6 @@ repos:
               .*\.svg|
               .*/testdata/.*\.golden
           )$
-      - id: check-google-doc-style
       - id: check-links
         name: Check links in non-proposal files
         exclude: ^proposals/.*$
@@ -84,46 +127,6 @@ repos:
         name: Check links in proposal files
         args: ['--anchors-only']
         files: ^proposals/.*$
-      - id: markdown-toc
-  - repo: https://github.com/codespell-project/codespell
-    rev: 01da43d753cdff4ea7dff952b4f5317450af31e3 # frozen: v2.1.0
-    hooks:
-      - id: codespell
-        args: ['-I', '.codespell_ignore', '--uri-ignore-words-list', '*']
-  - repo: local
-    hooks:
-      - id: executable-semantics-format-grammar
-        name: Format the executable_semantics grammar file
-        entry: executable_semantics/syntax/format_grammar.py
-        language: python
-        files: ^executable_semantics/syntax/(lexer.lpp|parser.ypp)$
-        pass_filenames: false
-      - id: fix-cc-deps
-        name: Fix missing C++ deps
-        entry: scripts/fix_cc_deps.py
-        language: python
-        files: ^.*/(BUILD|[^/]+\.(h|cpp))$
-        pass_filenames: false
-  # Formatters should be run late so that they can re-format any prior changes.
-  - repo: https://github.com/psf/black
-    rev: 19f6aa8208154de4560ee1e4a3e638e120dcdba5 # frozen: 21.11b1
-    hooks:
-      - id: black
-  - repo: https://github.com/jlebar/pre-commit-hooks.git
-    rev: fb5e481f35f5a9b32a06ccfc28b8d6dda4525f75
-    hooks:
-      - id: bazel-buildifier
-      - id: clang-format-whole-file
-        types: [c++]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f69d0a4007f48ad4f144089973c56f6ecf53a5b5 # frozen: v2.5.0
-    hooks:
-      - id: prettier
-  # Run linters last, as formatters and other checks may fix issues.
-  - repo: https://github.com/PyCQA/flake8
-    rev: cbeb4c9c4137cff1568659fcc48e8b85cddd0c8d # frozen: 4.0.1
-    hooks:
-      - id: flake8
 
 # Most third-party code is in submodules; local commits are excluded here.
 # We fully exclude fuzzer corpus directories as they are generated binary data.


### PR DESCRIPTION
pre-commit autoupdate --freeze && pre-commit run -a is routine

Moving some checks later because they're lint-like: in particular, check-links was warning for toc header entries that are fixed by markdown-toc. The new order should eliminate that behavior.

The delta in GH looks a little misleading, I think because check-copyright is so long... but that's a lint check too and should be post-formatting. (this is only really moving codespell, check-copyright, and check-links)