### PR TITLE
Fix links from proposals to open discussion minutes

### DIFF
--- a/proposals/p0920.md
+++ b/proposals/p0920.md
@@ -354,5 +354,5 @@ deduced? In particular we were worried about evolution, and allowing users to
 add functions to an interface as long as they had defaults.
 
 These problems were discussed in
-[2021-12-08 open discussion](https://docs.google.com/document/d/1cRrhRrmaUf2hVi2lFcHsYo2j0jI6t9RGZoYjWhRxp14/edit?resourcekey=0-xWHBEZ8zIqnJiB4yfBSLfA#heading=h.njnqpdcjp5h0).
+[2021-12-08 open discussion](https://docs.google.com/document/d/105GsfmxOwcZ_iHkCXFnALB7e-_R3IgMpGKfeT84h1mc/edit?resourcekey=0-h3uVHObsJwChVg1MdaWfKQ#heading=h.njnqpdcjp5h0).
 We concluded that we will later find other mechanisms to support this use case.

--- a/proposals/p0950.md
+++ b/proposals/p0950.md
@@ -96,8 +96,8 @@ This design was the conclusion of a number of discussions and proposals:
     [Member lookup in generic and non-generic contexts](https://docs.google.com/document/d/1-vw39x5YARpUZ0uD2xmKepLEKG7_u122CUJ67hNz3hk/edit#)
 -   Nov 4, 2021 document by `josh11b` and `mconst` titled
     [Carbon: facets exposed from generics](https://docs.google.com/document/d/1C1eIzd6JY0ooE1rDjW1vx7e3i7sgGugCA9bPMRhwWM0/edit#)
--   [Open discussion on 2021-11-08](https://docs.google.com/document/d/1cRrhRrmaUf2hVi2lFcHsYo2j0jI6t9RGZoYjWhRxp14/edit?resourcekey=0-xWHBEZ8zIqnJiB4yfBSLfA#heading=h.ec285oam2okw)
--   [Open discussion 2021-11-11](https://docs.google.com/document/d/1cRrhRrmaUf2hVi2lFcHsYo2j0jI6t9RGZoYjWhRxp14/edit?resourcekey=0-xWHBEZ8zIqnJiB4yfBSLfA#heading=h.8vuatm82d1mk)
+-   [Open discussion on 2021-11-08](https://docs.google.com/document/d/105GsfmxOwcZ_iHkCXFnALB7e-_R3IgMpGKfeT84h1mc/edit?resourcekey=0-h3uVHObsJwChVg1MdaWfKQ#heading=h.ec285oam2okw)
+-   [Open discussion 2021-11-11](https://docs.google.com/document/d/105GsfmxOwcZ_iHkCXFnALB7e-_R3IgMpGKfeT84h1mc/edit?resourcekey=0-h3uVHObsJwChVg1MdaWfKQ#heading=h.8vuatm82d1mk)
 
 The main alternatives we evaluated are summarized below.
 

--- a/proposals/p0981.md
+++ b/proposals/p0981.md
@@ -74,7 +74,7 @@ This proposal advances Carbon's goals:
 Alternatives were considered in:
 
 -   [question-for-leads issue #710: Default comparison for data classes](https://github.com/carbon-language/carbon-lang/issues/710)
--   [open discussion on 2021-11-29](https://docs.google.com/document/d/1cRrhRrmaUf2hVi2lFcHsYo2j0jI6t9RGZoYjWhRxp14/edit?resourcekey=0-xWHBEZ8zIqnJiB4yfBSLfA#heading=h.6komy889g3hc)
+-   [open discussion on 2021-11-29](https://docs.google.com/document/d/105GsfmxOwcZ_iHkCXFnALB7e-_R3IgMpGKfeT84h1mc/edit?resourcekey=0-h3uVHObsJwChVg1MdaWfKQ#heading=h.6komy889g3hc)
 
 ### Field order is not significant
 

--- a/proposals/p0983.md
+++ b/proposals/p0983.md
@@ -164,5 +164,5 @@ as we determined there was a need for the greater expressivity of being able to
 mark individual items as `final`. This discussion occurred in:
 
 -   [Document examining an extended example using specialization](https://docs.google.com/document/d/1w-kRC338Jc1ibTu7Vf0pOlGKdrpumfz63bzUIxEj9jY/edit)
--   [2021-11-29 open discussion](https://docs.google.com/document/d/1cRrhRrmaUf2hVi2lFcHsYo2j0jI6t9RGZoYjWhRxp14/edit?resourcekey=0-xWHBEZ8zIqnJiB4yfBSLfA#heading=h.6komy889g3hc)
+-   [2021-11-29 open discussion](https://docs.google.com/document/d/105GsfmxOwcZ_iHkCXFnALB7e-_R3IgMpGKfeT84h1mc/edit?resourcekey=0-h3uVHObsJwChVg1MdaWfKQ#heading=h.6komy889g3hc)
 -   [Carbon's #typesystem channel on Discord](https://discord.com/channels/655572317891461132/708431657849585705/910681126236987495)


### PR DESCRIPTION
These links were broken when I moved the discussion notes from 2021 to an archive document to avoid any one document from getting too big.