### PR TITLE
Fix return_term dep on Expression

### DIFF
--- a/executable_semantics/ast/BUILD
+++ b/executable_semantics/ast/BUILD
@@ -93,6 +93,7 @@ cc_library(
     name = "return_term",
     hdrs = ["return_term.h"],
     deps = [
+        ":expression",
         ":source_location",
         "//common:check",
         "//common:ostream",

--- a/executable_semantics/ast/return_term.h
+++ b/executable_semantics/ast/return_term.h
@@ -10,13 +10,13 @@
 
 #include "common/check.h"
 #include "common/ostream.h"
+#include "executable_semantics/ast/expression.h"
 #include "executable_semantics/ast/source_location.h"
 #include "executable_semantics/common/nonnull.h"
 
 namespace Carbon {
 
 class Value;
-class Expression;
 
 // The syntactic representation of a function declaration's return type.
 // This syntax can take one of three forms:


### PR DESCRIPTION
Line 91 has:
```
        source_loc_(type_expression->source_loc()) {}
```

Which requires the Expression definition. This probably compiles accidentally due to #include ordering, but I ran into a case that needs correct #includes.