### PR TITLE
fsync cache file

### DIFF
--- a/scripts/scripts_utils.py
+++ b/scripts/scripts_utils.py
@@ -81,6 +81,8 @@ def _download(url: str, local_path: Path) -> Optional[int]:
             return int(response.code)
         with local_path.open("wb") as f:
             shutil.copyfileobj(response, f)
+            # Run fsync because of "Text file busy" in GH Actions.
+            os.fsync(f.fileno())
     return None
 
 


### PR DESCRIPTION
Trying to address "Text file busy", e.g. https://github.com/carbon-language/carbon-lang/runs/5308493549?check_suite_focus=true. Searching around I get the impression it's a sync issue, I'm hoping this will fix it (otherwise, I might try running /bin/sync before returning from get_release)