### PR TITLE
Direct/indirect member access -> simple/compound member access.

### DIFF
--- a/docs/design/expressions/README.md
+++ b/docs/design/expressions/README.md
@@ -135,11 +135,11 @@ keyword and is not preceded by a period (`.`).
 
 ### Qualified names and member access
 
-A _qualified name_ is a word that is prefixed by a period. Qualified names
-appear in the following contexts:
+A _qualified name_ is a word that appears immediately after a period. Qualified
+names appear in the following contexts:
 
 -   [Designators](/docs/design/classes.md#literals): `.` _word_
--   [Direct member access expressions](member_access.md): _expression_ `.`
+-   [Simple member access expressions](member_access.md): _expression_ `.`
     _word_
 
 ```
@@ -183,10 +183,10 @@ fn J() {
 ```
 
 Member access expressions associate left-to-right. If the member name is more
-complex than a single _word_, an indirect member access expression can be used,
+complex than a single _word_, a compound member access expression can be used,
 with parentheses around the member name:
 
--   _expression_ `.` `(` _member-access-expression_ `)`
+-   _expression_ `.` `(` _expression_ `)`
 
 ```
 interface I { fn F[me: Self](); }


### PR DESCRIPTION
Plus some minor fixups to improve the readability and precision of the
summary in README.md.