### PR TITLE
Request for comments - one option to support compiling external deps with different flags than Carbon-owned sources

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -128,9 +128,6 @@ def _impl(ctx):
                             "-Wctad-maybe-unsupported",
                             # Unfortunately, LLVM isn't clean for this warning.
                             "-Wno-unused-parameter",
-                            # We use partial sets of designated initializers in
-                            # test code.
-                            "-Wno-missing-field-initializers",
                             # Compile actions shouldn't link anything.
                             "-c",
                         ],
@@ -262,6 +259,19 @@ def _impl(ctx):
                 ],
             ),
         ],
+    )
+
+    # Turns on the flags turned off by `default_flags_feature`.
+    # Intended for compiling Carbon-owned sources.
+    strict_cpp_compilation = feature(
+        enabled = False,
+        name = "strict_cpp_compilation",
+        flag_sets = [flag_set(
+            actions = all_compile_actions,
+            flag_groups = [flag_group(flags = [
+                "-Wunused-parameter",
+            ])],
+        )],
     )
 
     # Handle different levels of optimization with individual features so that
@@ -744,6 +754,7 @@ def _impl(ctx):
     # Start off adding the baseline features.
     features += [
         default_flags_feature,
+        strict_cpp_compilation,
         minimal_optimization_flags,
         default_optimization_flags,
         minimal_debug_info_flags,

--- a/common/BUILD
+++ b/common/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "check",

--- a/executable_semantics/BUILD
+++ b/executable_semantics/BUILD
@@ -4,10 +4,13 @@
 
 load("@mypy_integration//:mypy.bzl", "mypy_test")
 
-package(default_visibility = [
-    "//bazel/check_deps:__pkg__",
-    "//executable_semantics:__subpackages__",
-])
+package(
+    default_visibility = [
+        "//bazel/check_deps:__pkg__",
+        "//executable_semantics:__subpackages__",
+    ],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_binary(
     name = "executable_semantics",

--- a/executable_semantics/ast/BUILD
+++ b/executable_semantics/ast/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//executable_semantics:__subpackages__"])
+package(
+    default_visibility = ["//executable_semantics:__subpackages__"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "ast",

--- a/executable_semantics/common/BUILD
+++ b/executable_semantics/common/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//executable_semantics:__subpackages__"])
+package(
+    default_visibility = ["//executable_semantics:__subpackages__"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "arena",

--- a/executable_semantics/interpreter/BUILD
+++ b/executable_semantics/interpreter/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//executable_semantics:__pkg__"])
+package(
+    default_visibility = ["//executable_semantics:__pkg__"],
+    features = ["strict_cpp_compilation"],
+)
 
 # These currently have to be a single build rule because of a dependency cycle
 # in printing.

--- a/executable_semantics/interpreter/impl_scope.cpp
+++ b/executable_semantics/interpreter/impl_scope.cpp
@@ -70,7 +70,8 @@ auto ImplScope::ResolveHere(Nonnull<const Value*> iface_type,
       return std::nullopt;
     }
     default:
-      FATAL() << "expected an interface, not " << *iface_type;
+      FATAL() << "expected an interface, not " << *iface_type << " defined at "
+              << source_loc;
       break;
   }
 }

--- a/executable_semantics/interpreter/type_checker.cpp
+++ b/executable_semantics/interpreter/type_checker.cpp
@@ -1325,8 +1325,8 @@ void TypeChecker::DeclareChoiceDeclaration(Nonnull<ChoiceDeclaration*> choice,
   choice->set_static_type(arena_->New<TypeOfChoiceType>(ct));
 }
 
-void TypeChecker::TypeCheckChoiceDeclaration(Nonnull<ChoiceDeclaration*> choice,
-                                             const ImplScope& impl_scope) {
+void TypeChecker::TypeCheckChoiceDeclaration(
+    Nonnull<ChoiceDeclaration*> /*choice*/, const ImplScope& /*impl_scope*/) {
   // Nothing to do here, but perhaps that will change in the future?
 }
 

--- a/executable_semantics/syntax/BUILD
+++ b/executable_semantics/syntax/BUILD
@@ -4,7 +4,10 @@
 
 load("@mypy_integration//:mypy.bzl", "mypy_test")
 
-package(default_visibility = ["//executable_semantics:__pkg__"])
+package(
+    default_visibility = ["//executable_semantics:__pkg__"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "bison_wrap",
@@ -53,6 +56,7 @@ cc_library(
         "-Wno-unneeded-internal-declaration",
         "-Wno-unused-function",
         "-Wno-writable-strings",
+        "-Wno-unused-parameter",
     ],
     deps = [
         ":bison_wrap",

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_binary(
     name = "cpp_refactoring",

--- a/toolchain/common/BUILD
+++ b/toolchain/common/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "yaml_test_helpers",

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "diagnostic_emitter",

--- a/toolchain/diagnostics/null_diagnostics.h
+++ b/toolchain/diagnostics/null_diagnostics.h
@@ -21,7 +21,7 @@ inline auto NullDiagnosticLocationTranslator()
 
 inline auto NullDiagnosticConsumer() -> DiagnosticConsumer& {
   struct Consumer : DiagnosticConsumer {
-    auto HandleDiagnostic(const Diagnostic& d) -> void override {}
+    auto HandleDiagnostic(const Diagnostic& /*d*/) -> void override {}
   };
   static auto* consumer = new Consumer;
   return *consumer;

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -4,7 +4,10 @@
 
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "driver",

--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -4,7 +4,10 @@
 
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "token_kind",

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -4,7 +4,10 @@
 
 load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "parse_node_kind",

--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "semantics",

--- a/toolchain/semantics/semantics.cpp
+++ b/toolchain/semantics/semantics.cpp
@@ -6,8 +6,8 @@
 
 namespace Carbon {
 
-Semantics Semantics::Analyze(const ParseTree& parse_tree,
-                             DiagnosticConsumer& consumer) {
+Semantics Semantics::Analyze(const ParseTree& /*parse_tree*/,
+                             DiagnosticConsumer& /*consumer*/) {
   Semantics semantics;
   return semantics;
 }

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -2,7 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["strict_cpp_compilation"],
+)
 
 cc_library(
     name = "source_buffer",


### PR DESCRIPTION
- Defined a new strict_cpp_compilation c++ toolchain feature, off by default
- default_flags_feature to only have 'minimal' warning flags allowing to compile all third party repos 
- strict_cpp_compilation is explicitly enabled in Carbon BUILD files, and turns the flags back on
- Tested by adding -Wunused-parameter to strict_cpp_compilation feature

The hidden agenda here is that I tried to compile google protobuf library needed by the structured fuzzer implementation, and the library needs -Wno-implicit-fallthrough, and I don't feel like it's worth patching. Also there are already bison/flex/m4 workarounds in place in WORKSPACE to pass -w to them which refers to custom patches, plus there might be more third party repos in the future.

Is the overhead of requiring (via a pre-commit check for example) every eligible Carbon BUILD file to have features = ["strict_cpp_compilation"] acceptable?
