### PR TITLE
clang-tidy without config changes

### DIFF
--- a/executable_semantics/ast/declaration.h
+++ b/executable_semantics/ast/declaration.h
@@ -132,7 +132,7 @@ class FunctionDeclaration : public Declaration {
     constant_value_ = value;
   }
 
-  bool is_method() const { return me_pattern_.has_value(); }
+  auto is_method() const -> bool { return me_pattern_.has_value(); }
 
  private:
   void ResolveDeducedAndReceiver(const std::vector<Nonnull<AstNode*>>&);
@@ -268,7 +268,7 @@ class VariableDeclaration : public Declaration {
   auto initializer() -> Expression& { return **initializer_; }
   auto value_category() const -> ValueCategory { return value_category_; }
 
-  bool has_initializer() const { return initializer_.has_value(); }
+  auto has_initializer() const -> bool { return initializer_.has_value(); }
 
  private:
   // TODO: split this into a non-optional name and a type, initialized by
@@ -335,7 +335,7 @@ class ImplDeclaration : public Declaration {
         kind_(kind),
         impl_type_(impl_type),
         interface_(interface),
-        members_(members) {}
+        members_(std::move(members)) {}
 
   static auto classof(const AstNode* node) -> bool {
     return InheritsFromImplDeclaration(node->kind());

--- a/executable_semantics/interpreter/impl_scope.cpp
+++ b/executable_semantics/interpreter/impl_scope.cpp
@@ -56,7 +56,7 @@ auto ImplScope::TryResolve(Nonnull<const Value*> iface_type,
 
 auto ImplScope::ResolveHere(Nonnull<const Value*> iface_type,
                             Nonnull<const Value*> impl_type,
-                            SourceLocation source_loc) const
+                            SourceLocation /*source_loc*/) const
     -> std::optional<ValueNodeView> {
   switch (iface_type->kind()) {
     case Value::Kind::InterfaceType: {

--- a/executable_semantics/interpreter/interpreter.cpp
+++ b/executable_semantics/interpreter/interpreter.cpp
@@ -309,8 +309,7 @@ void Interpreter::StepLvalue() {
       }
     }
     case ExpressionKind::PrimitiveOperatorExpression: {
-      const PrimitiveOperatorExpression& op =
-          cast<PrimitiveOperatorExpression>(exp);
+      const auto& op = cast<PrimitiveOperatorExpression>(exp);
       if (op.op() != Operator::Deref) {
         FATAL() << "Can't treat primitive operator expression as lvalue: "
                 << exp;
@@ -319,7 +318,7 @@ void Interpreter::StepLvalue() {
         return todo_.Spawn(
             std::make_unique<ExpressionAction>(op.arguments()[0]));
       } else {
-        const PointerValue& res = cast<PointerValue>(*act.results()[0]);
+        const auto& res = cast<PointerValue>(*act.results()[0]);
         return todo_.FinishAction(arena_->New<LValue>(res.address()));
       }
       break;
@@ -580,7 +579,7 @@ void Interpreter::StepExp() {
               Nonnull<const Value*> witness =
                   todo_.ValueOfNode(impl_node, exp.source_loc());
               if (witness->kind() == Value::Kind::LValue) {
-                const LValue& lval = cast<LValue>(*witness);
+                const auto& lval = cast<LValue>(*witness);
                 witness = heap_.Read(lval.address(), exp.source_loc());
               }
               function_scope.Initialize(impl_bind, witness);
@@ -595,8 +594,7 @@ void Interpreter::StepExp() {
                 std::move(function_scope));
           }
           case Value::Kind::BoundMethodValue: {
-            const BoundMethodValue& m =
-                cast<BoundMethodValue>(*act.results()[0]);
+            const auto& m = cast<BoundMethodValue>(*act.results()[0]);
             const FunctionDeclaration& method = m.declaration();
             Nonnull<const Value*> converted_args = Convert(
                 act.results()[1], &method.param_pattern().static_type());
@@ -689,7 +687,7 @@ void Interpreter::StepExp() {
         return todo_.Spawn(
             std::make_unique<ExpressionAction>(if_expr.condition()));
       } else if (act.pos() == 1) {
-        const BoolValue& condition = cast<BoolValue>(*act.results()[0]);
+        const auto& condition = cast<BoolValue>(*act.results()[0]);
         return todo_.Spawn(std::make_unique<ExpressionAction>(
             condition.value() ? if_expr.then_expression()
                               : if_expr.else_expression()));

--- a/executable_semantics/interpreter/type_checker.cpp
+++ b/executable_semantics/interpreter/type_checker.cpp
@@ -551,11 +551,11 @@ void TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
           }
         }
         case Value::Kind::VariableType: {
-          const VariableType& var_type = cast<VariableType>(aggregate_type);
+          const auto& var_type = cast<VariableType>(aggregate_type);
           const Value& typeof_var = var_type.binding().static_type();
           switch (typeof_var.kind()) {
             case Value::Kind::InterfaceType: {
-              const InterfaceType& iface_type = cast<InterfaceType>(typeof_var);
+              const auto& iface_type = cast<InterfaceType>(typeof_var);
               const InterfaceDeclaration& iface_decl = iface_type.declaration();
               if (std::optional<Nonnull<const Declaration*>> member =
                       FindMember(access.field(), iface_decl.members());

--- a/executable_semantics/interpreter/value.cpp
+++ b/executable_semantics/interpreter/value.cpp
@@ -60,14 +60,13 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
       return *field;
     }
     case Value::Kind::NominalClassValue: {
-      const NominalClassValue& object = cast<NominalClassValue>(*v);
+      const auto& object = cast<NominalClassValue>(*v);
       // Look for a field
       std::optional<Nonnull<const Value*>> field =
           cast<StructValue>(object.inits()).FindField(f);
       if (field == std::nullopt) {
         // Look for a method in the object's class
-        const NominalClassType& class_type =
-            cast<NominalClassType>(object.type());
+        const auto& class_type = cast<NominalClassType>(object.type());
         std::optional<Nonnull<const FunctionValue*>> func =
             class_type.FindFunction(f);
         if (func == std::nullopt) {
@@ -75,7 +74,7 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
               << "member " << f << " not in " << *v << " or its " << class_type;
         } else if ((*func)->declaration().is_method()) {
           // Found a method. Turn it into a bound method.
-          const FunctionValue& m = cast<FunctionValue>(**func);
+          const auto& m = cast<FunctionValue>(**func);
           return arena->New<BoundMethodValue>(&m.declaration(), &object);
         } else {
           // Found a class function
@@ -93,7 +92,7 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
       return arena->New<AlternativeConstructorValue>(f, choice.name());
     }
     case Value::Kind::NominalClassType: {
-      const NominalClassType& class_type = cast<NominalClassType>(*v);
+      const auto& class_type = cast<NominalClassType>(*v);
       std::optional<Nonnull<const FunctionValue*>> fun =
           class_type.FindFunction(f);
       if (fun == std::nullopt) {
@@ -283,12 +282,12 @@ void Value::Print(llvm::raw_ostream& out) const {
       break;
     }
     case Value::Kind::NominalClassType: {
-      const NominalClassType& class_type = cast<NominalClassType>(*this);
+      const auto& class_type = cast<NominalClassType>(*this);
       out << "class " << class_type.declaration().name();
       break;
     }
     case Value::Kind::InterfaceType: {
-      const InterfaceType& iface_type = cast<InterfaceType>(*this);
+      const auto& iface_type = cast<InterfaceType>(*this);
       out << "interface " << iface_type.declaration().name();
       break;
     }
@@ -486,8 +485,8 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2) -> bool {
              (!body1.has_value() || *body1 == *body2);
     }
     case Value::Kind::BoundMethodValue: {
-      const BoundMethodValue& m1 = cast<BoundMethodValue>(*v1);
-      const BoundMethodValue& m2 = cast<BoundMethodValue>(*v2);
+      const auto& m1 = cast<BoundMethodValue>(*v1);
+      const auto& m2 = cast<BoundMethodValue>(*v2);
       std::optional<Nonnull<const Statement*>> body1 = m1.declaration().body();
       std::optional<Nonnull<const Statement*>> body2 = m2.declaration().body();
       return ValueEqual(m1.receiver(), m2.receiver()) &&
@@ -606,8 +605,9 @@ auto FindMember(const std::string& name,
   for (Nonnull<const Declaration*> member : members) {
     if (std::optional<std::string> mem_name = GetName(*member);
         mem_name.has_value()) {
-      if (*mem_name == name)
+      if (*mem_name == name) {
         return member;
+      }
     }
   }
   return std::nullopt;

--- a/executable_semantics/interpreter/value.h
+++ b/executable_semantics/interpreter/value.h
@@ -465,7 +465,7 @@ class StructType : public Value {
 // A class type.
 class NominalClassType : public Value {
  public:
-  NominalClassType(Nonnull<const ClassDeclaration*> declaration)
+  explicit NominalClassType(Nonnull<const ClassDeclaration*> declaration)
       : Value(Kind::NominalClassType), declaration_(declaration) {}
 
   static auto classof(const Value* value) -> bool {
@@ -492,7 +492,7 @@ auto FindMember(const std::string& name,
 // An interface type.
 class InterfaceType : public Value {
  public:
-  InterfaceType(Nonnull<const InterfaceDeclaration*> declaration)
+  explicit InterfaceType(Nonnull<const InterfaceDeclaration*> declaration)
       : Value(Kind::InterfaceType), declaration_(declaration) {}
 
   static auto classof(const Value* value) -> bool {
@@ -510,7 +510,7 @@ class InterfaceType : public Value {
 // The witness table for an impl.
 class Witness : public Value {
  public:
-  Witness(Nonnull<const ImplDeclaration*> declaration)
+  explicit Witness(Nonnull<const ImplDeclaration*> declaration)
       : Value(Kind::Witness), declaration_(declaration) {}
 
   static auto classof(const Value* value) -> bool {

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -69,7 +69,7 @@ auto Driver::RunFullCommand(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   llvm_unreachable("All subcommands handled!");
 }
 
-auto Driver::RunHelpSubcommand(DiagnosticConsumer& consumer,
+auto Driver::RunHelpSubcommand(DiagnosticConsumer& /*consumer*/,
                                llvm::ArrayRef<llvm::StringRef> args) -> bool {
   // FIXME: We should support getting detailed help on a subcommand by looking
   // for it as a positional parameter here.


### PR DESCRIPTION
Separating out existing fixes because of #1148 which turns on more.