### PR TITLE
Add missing value_category dep to syntax

### DIFF
--- a/executable_semantics/syntax/BUILD
+++ b/executable_semantics/syntax/BUILD
@@ -66,6 +66,7 @@ cc_library(
         "//executable_semantics/ast:expression",
         "//executable_semantics/ast:paren_contents",
         "//executable_semantics/ast:pattern",
+        "//executable_semantics/ast:value_category",
         "//executable_semantics/common:arena",
         "//executable_semantics/common:error",
         "//executable_semantics/common:nonnull",


### PR DESCRIPTION
Minor, manual because we don't handle generated code (parser.ypp here) when automating deps for strict evaluation.