### PR TITLE
Preserve the order of expressions in deduced_param_list

### DIFF
--- a/executable_semantics/syntax/parser.ypp
+++ b/executable_semantics/syntax/parser.ypp
@@ -783,20 +783,20 @@ deduced_param_list:
       $$ = std::vector<Nonnull<AstNode*>>();
       $$.push_back($1);
     }
-| generic_binding COMMA deduced_param_list
+| deduced_param_list COMMA generic_binding
     {
-      $$ = $3;
-      $$.push_back($1);
+      $$ = $1;
+      $$.push_back($3);
     }
 | variable_declaration
     {
       $$ = std::vector<Nonnull<AstNode*>>();
       $$.push_back($1);
     }
-| variable_declaration COMMA deduced_param_list
+| deduced_param_list COMMA variable_declaration
     {
-      $$ = $3;
-      $$.push_back($1);
+      $$ = $1;
+      $$.push_back($3);
     }
 ;
 deduced_params:


### PR DESCRIPTION
This came up in the context of #1155, where the current implementation was causing this diff in proto_to_carbon_test:

```
-fn AddAndScaleGeneric [T:! Vector, V:! Vector](a: T, b: V, s: i32)-> (T, V) {
+fn AddAndScaleGeneric [V:! Vector, T:! Vector](a: T, b: V, s: i32)-> (T, V) {
```