### PR TITLE
Update test assertions to match update_checks.py

### DIFF
--- a/executable_semantics/testdata/basic_syntax/not_compare_precedence.carbon
+++ b/executable_semantics/testdata/basic_syntax/not_compare_precedence.carbon
@@ -7,10 +7,10 @@
 // RUN: %{not} %{executable_semantics} --trace %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{executable_semantics} %s
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/basic_syntax/not_compare_precedence.carbon:15: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
 
 package ExecutableSemanticsTest api;
 
 fn CompareBools(a: Bool, b: Bool) -> Bool {
-  // CHECK: COMPILATION ERROR: {{.*}}.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
   return not a == b;
 }

--- a/executable_semantics/testdata/generic_class/fail_argument_deduction.carbon
+++ b/executable_semantics/testdata/generic_class/fail_argument_deduction.carbon
@@ -7,7 +7,9 @@
 // RUN: %{not} %{executable_semantics} --trace %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{executable_semantics} %s
-// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_class/fail_argument_deduction.carbon:26: type error in argument deduction
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_class/fail_argument_deduction.carbon:28: type error in argument deduction
+// CHECK: expected: i32
+// CHECK: actual: Bool
 
 package ExecutableSemanticsTest api;
 

--- a/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -7,7 +7,8 @@
 // RUN: %{not} %{executable_semantics} --trace %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{executable_semantics} %s
-// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon:19: could not deduce type argument for type parameter T
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_function/fail_type_deduction_unused.carbon:20: could not deduce type argument for type parameter T
+// CHECK: in id(0)
 
 package ExecutableSemanticsTest api;
 


### PR DESCRIPTION
This restores us to a state where running update_checks.py is a no-op.