### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,15 +49,15 @@ repos:
 
   # Formatters should be run late so that they can re-format any prior changes.
   - repo: https://github.com/psf/black
-    rev: fc0be6eb1e2a96091e6f64009ee5e9081bf8b6c6 # frozen: 22.1.0
+    rev: ae2c0758c9e61a385df9700dc9c231bf54887041 # frozen: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 1fc50313b6e8c2580c4736af57575e0b7de1501c # frozen: v13.0.0
+    rev: 306946aab6d5b1737ab4c24bb237c7e094ee9b83 # frozen: v13.0.1
     hooks:
       - id: clang-format
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: ea782651a7e32f40a3d13b76c79d5a2474ee8723 # frozen: v2.5.1
+    rev: 5e374fda194d7f7ce9eebbd582b2a5594838c85b # frozen: v2.6.2
     hooks:
       - id: prettier
   - repo: local


### PR DESCRIPTION
I think we're running into https://github.com/psf/black/issues/2964 per [this run](https://github.com/carbon-language/carbon-lang/runs/5821431868), this should fix it.