### PR TITLE
Fix flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,4 @@
 [flake8]
 max-line-length = 80
 # E203: This warning is not PEP 8 compliant.
-# E402: Allow the pythonpath modifications before repo-local imports.
-# W503: flake8 v3.8.4 is inconsistent with black v20.8b1 (pre-commit run -a).
-ignore = E203,E402,W503
+extend-ignore = E203


### PR DESCRIPTION
https://stackoverflow.com/questions/68161741/python-black-formatter-conflict-with-rule-flake8-w503-in-vscode and https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8 made me realize I should be using `extend-ignore` instead of `ignore`