### PR TITLE
Refactor to reduce namespace specifiers

### DIFF
--- a/executable_semantics/fuzzing/fuzzverter.cpp
+++ b/executable_semantics/fuzzing/fuzzverter.cpp
@@ -92,6 +92,8 @@ static auto CarbonToTextProto(std::string_view input_file_name,
 enum class ConversionMode { TextProtoToCarbon, CarbonToTextProto };
 
 auto Main(int argc, char* argv[]) -> ErrorOr<Success> {
+  llvm::InitLLVM init_llvm(argc, argv);
+
   cl::opt<ConversionMode> mode(
       "mode", cl::desc("Conversion mode"),
       cl::values(
@@ -117,9 +119,8 @@ auto Main(int argc, char* argv[]) -> ErrorOr<Success> {
 }  // namespace Carbon
 
 auto main(int argc, char* argv[]) -> int {
-  llvm::InitLLVM init_llvm(argc, argv);
   if (const auto result = Carbon::Main(argc, argv); !result.ok()) {
-    llvm::errs() << "fuzzverter failed: " << result.error().message() << "\n";
+    llvm::errs() << result.error().message() << "\n";
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
@pk19604014 IIUC -- you were avoiding this to keep GetEnumString, but the mode should be specified on the command line. I am adding `cl::Required` to `--mode`: it's not actually specified right now, and because there's no clear default, it's ambiguous looking at `fuzzverter -h` what the behavior would be. Once specified, I don't think `--mode` needs to be echoed back.
