### PR TITLE
Test for mismatch in generic class argument list

### DIFF
--- a/executable_semantics/testdata/generic_class/fail_args_mismatch.carbon
+++ b/executable_semantics/testdata/generic_class/fail_args_mismatch.carbon
@@ -4,7 +4,8 @@
 //
 // RUN: %{not} %{executable_semantics} %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false --dump-input=always -v %s
-// CHECK: CHECK failure at executable_semantics/interpreter/interpreter.cpp:216: p_tup.elements().size() == v_tup.elements().size()
+// AUTOUPDATE: %{executable_semantics} %s
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_class/fail_args_mismatch.carbon:14: type error in call: '(Type, Type)' is not implicitly convertible to '(Type)'
 
 package ExecutableSemanticsTest api;
 


### PR DESCRIPTION
Diagnostic added for this case in #1200