### PR TITLE
More testdata formatting fixes

### DIFF
--- a/executable_semantics/testdata/assignment_copy/destruct_original.carbon
+++ b/executable_semantics/testdata/assignment_copy/destruct_original.carbon
@@ -16,9 +16,9 @@ package ExecutableSemanticsTest api;
 fn Main() -> i32 {
   var x: i32 = -1;
   {
-     var y: i32 = 0;
-     x = y;
-     // y dies here
+    var y: i32 = 0;
+    x = y;
+    // y dies here
   }
   return x;
 }

--- a/executable_semantics/testdata/basic_syntax/choice.carbon
+++ b/executable_semantics/testdata/basic_syntax/choice.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 choice Ints {
   None,
   One(i32),
-  Two(i32,i32)
+  Two(i32, i32)
 }
 
 fn Main() -> i32 {
@@ -44,5 +44,5 @@ fn Main() -> i32 {
 choice MoreInts {
   None(),
   One(i32),
-  Two(i32,i32),
+  Two(i32, i32),
 }

--- a/executable_semantics/testdata/basic_syntax/record.carbon
+++ b/executable_semantics/testdata/basic_syntax/record.carbon
@@ -14,5 +14,6 @@ package ExecutableSemanticsTest api;
 fn Main() -> i32 {
   var t2: {.x: i32, .y: i32} = {.x = 2, .y = 5};
   t2.y = 3;
-  return t2.y - t2.x - 1; // 3 - 2 - 1
+  // 3 - 2 - 1
+  return t2.y - t2.x - 1;
 }

--- a/executable_semantics/testdata/class/bound_method.carbon
+++ b/executable_semantics/testdata/class/bound_method.carbon
@@ -24,6 +24,6 @@ class Point {
 
 fn Main() -> i32 {
   var p: Point = Point.Origin();
-  var f: __Fn()-> i32 = p.GetX;
+  var f: __Fn() -> i32 = p.GetX;
   return f();
 }

--- a/executable_semantics/testdata/class/class_function_value.carbon
+++ b/executable_semantics/testdata/class/class_function_value.carbon
@@ -21,6 +21,6 @@ class Point {
 }
 
 fn Main() -> i32 {
-  var f: __Fn()->Point = Point.Origin;
+  var f: __Fn() -> Point = Point.Origin;
   return f().x;
 }

--- a/executable_semantics/testdata/experimental_continuation/fail_lifetime.carbon
+++ b/executable_semantics/testdata/experimental_continuation/fail_lifetime.carbon
@@ -25,6 +25,7 @@ fn capture() -> __Continuation {
 
 fn Main() -> i32 {
   var k: __Continuation = capture();
-  __run k; // error, lifetime of x is over
+  // error, lifetime of x is over
+  __run k;
   return 0;
 }

--- a/executable_semantics/testdata/function/multiple_args.carbon
+++ b/executable_semantics/testdata/function/multiple_args.carbon
@@ -17,5 +17,5 @@ fn f(x: i32, y: i32) -> i32 {
 }
 
 fn Main() -> i32 {
-  return f(2,3) - 5;
+  return f(2, 3) - 5;
 }

--- a/executable_semantics/testdata/function/param_lifetime.carbon
+++ b/executable_semantics/testdata/function/param_lifetime.carbon
@@ -20,7 +20,8 @@ fn f(x: i32) -> i32 {
 }
 
 fn Main() -> i32 {
-  var a: i32 = 0; var b: i32 = 1;
+  var a: i32 = 0;
+  var b: i32 = 1;
   f(a);
   b = a;
   return b;

--- a/executable_semantics/testdata/function/type_match.carbon
+++ b/executable_semantics/testdata/function/type_match.carbon
@@ -12,6 +12,6 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  var t: (auto, (i32, i32)) = ((1,2),(3,4));
+  var t: (auto, (i32, i32)) = ((1, 2), (3, 4));
   return t[0][0] + t[1][1] - 5;
 }

--- a/executable_semantics/testdata/interface/generic_with_two_params.carbon
+++ b/executable_semantics/testdata/interface/generic_with_two_params.carbon
@@ -46,7 +46,7 @@ fn ScaleGeneric[U:! Vector](c: U, s: i32) -> U {
   return c.Scale(s);
 }
 
-fn AddAndScaleGeneric[T:! Vector, V:! Vector](a: T, b: V, s: i32) -> (T,V) {
+fn AddAndScaleGeneric[T:! Vector, V:! Vector](a: T, b: V, s: i32) -> (T, V) {
   return (ScaleGeneric(a.Add(a), s),
   	  ScaleGeneric(b.Add(b), s));
 }

--- a/executable_semantics/testdata/let/fail_match_choice.carbon
+++ b/executable_semantics/testdata/let/fail_match_choice.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 choice Ints {
   None,
   One(i32),
-  Two(i32,i32)
+  Two(i32, i32)
 }
 
 fn Main() -> i32 {

--- a/executable_semantics/testdata/let/fail_method_args.carbon
+++ b/executable_semantics/testdata/let/fail_method_args.carbon
@@ -16,7 +16,7 @@ class Point {
     return {.x = 0, .y = 0};
   }
 
-  fn SetX[me: Point](x :i32) {
+  fn SetX[me: Point](x: i32) {
     x = 10;
   }
 

--- a/executable_semantics/testdata/let/fail_tuple_pattern_let_context.carbon
+++ b/executable_semantics/testdata/let/fail_tuple_pattern_let_context.carbon
@@ -7,13 +7,14 @@
 // RUN: %{not} %{executable_semantics} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{executable_semantics} %s
-// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/let/fail_tuple_pattern_let_context.carbon:17: Cannot assign to rvalue 'c'
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/let/fail_tuple_pattern_let_context.carbon:18: Cannot assign to rvalue 'c'
 
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  let (var a: auto, b: auto, c:auto, d: auto) = (1, 2, 3, 4);
+  let (var a: auto, b: auto, c: auto, d: auto) = (1, 2, 3, 4);
   a = 0;
-  c = 0; // should fail
+  // should fail
+  c = 0;
   return 0;
 }

--- a/executable_semantics/testdata/let/fail_tuple_pattern_let_context_nested.carbon
+++ b/executable_semantics/testdata/let/fail_tuple_pattern_let_context_nested.carbon
@@ -12,6 +12,7 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  let (var a: auto, b: auto, c:auto, var (d: auto, let e:auto)) = (1, 2, 3, (4, 5));
+  let (var a: auto, b: auto, c: auto, var (d: auto, let e: auto)) =
+      (1, 2, 3, (4, 5));
   return 0;
 }

--- a/executable_semantics/testdata/let/fail_tuple_pattern_let_in_var.carbon
+++ b/executable_semantics/testdata/let/fail_tuple_pattern_let_in_var.carbon
@@ -12,6 +12,6 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  var (var a: auto, b: auto, let c:auto, d: auto) = (1, 2, 3, 4);
+  var (var a: auto, b: auto, let c: auto, d: auto) = (1, 2, 3, 4);
   return 0;
 }

--- a/executable_semantics/testdata/let/nested_tuple_pattern.carbon
+++ b/executable_semantics/testdata/let/nested_tuple_pattern.carbon
@@ -14,11 +14,13 @@ package ExecutableSemanticsTest api;
 choice Ints {
   None,
   One(i32),
-  Two(i32,i32)
+  Two(i32, i32)
 }
 
 fn Main() -> i32 {
-  let (var Ints.Two(a1: auto, var a2: auto), ((b: auto, var c:auto), var (d: auto, e:auto))) = (Ints.Two(1, 10), ((2, 3), (4, 5)));
+  let (var Ints.Two(a1: auto, var a2: auto),
+       ((b: auto, var c: auto), var (d: auto, e: auto))) =
+      (Ints.Two(1, 10), ((2, 3), (4, 5)));
   a1 = 0;
   a2 = 0;
   c = 0;

--- a/executable_semantics/testdata/pointer/basic.carbon
+++ b/executable_semantics/testdata/pointer/basic.carbon
@@ -13,11 +13,14 @@ package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
   var x: i32 = 5;
-  x = 10; // changes x to 10
+  // changes x to 10
+  x = 10;
   var p: i32* = &x;
-  *p = 7; // changes x to 7
+  // changes x to 7
+  *p = 7;
   var q: i32* = &*p;
-  *q = 0; // changes x to 0
+  // changes x to 0
+  *q = 0;
   var y: i32 = *p;
 
   return y;

--- a/executable_semantics/testdata/tuple/equality.carbon
+++ b/executable_semantics/testdata/tuple/equality.carbon
@@ -12,8 +12,8 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  var t1: (i32,i32) = (5, 2);
-  var t2: (i32,i32) = (5, 2);
+  var t1: (i32, i32) = (5, 2);
+  var t2: (i32, i32) = (5, 2);
   if (t1 == t2) {
     return 0;
   } else {

--- a/executable_semantics/testdata/tuple/equality_false.carbon
+++ b/executable_semantics/testdata/tuple/equality_false.carbon
@@ -12,8 +12,8 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  var t1: (i32,i32) = (5, 2);
-  var t2: (i32,i32) = (5, 4);
+  var t1: (i32, i32) = (5, 2);
+  var t2: (i32, i32) = (5, 4);
   if (t1 == t2) {
     return 1;
   } else {

--- a/executable_semantics/testdata/tuple/fail_equality_type.carbon
+++ b/executable_semantics/testdata/tuple/fail_equality_type.carbon
@@ -11,7 +11,7 @@
 package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
-  var t1: (i32,i32) = (5, 2);
+  var t1: (i32, i32) = (5, 2);
   var t2: (i32,) = (5,);
   if (t1 == t2) {
     return 1;

--- a/executable_semantics/testdata/tuple/match_nested.carbon
+++ b/executable_semantics/testdata/tuple/match_nested.carbon
@@ -14,7 +14,7 @@ package ExecutableSemanticsTest api;
 // Test matching of a tuple inside a tuple.
 
 fn Main() -> i32 {
-  var t: auto = ((1,2),(3,4));
+  var t: auto = ((1, 2), (3, 4));
   match (t) {
     case ((a: auto, b: auto), c: auto) =>
       return a - b + c[0] - c[1] + 2;

--- a/executable_semantics/testdata/tuple/no_ending_comma.carbon
+++ b/executable_semantics/testdata/tuple/no_ending_comma.carbon
@@ -13,7 +13,7 @@ package ExecutableSemanticsTest api;
 
 fn Main() -> i32 {
   var x: i32 = (1);
-  var t2: (i32,i32) = (5, 2);
+  var t2: (i32, i32) = (5, 2);
   t2[0] = 3;
   return t2[0] - t2[1] - x;
 }


### PR DESCRIPTION
We can't use clang-format yet, but it did find some things when I looked through its output.