### PR TITLE
Fixed fuzzer crash caused by using nullptr instead of std::nullopt

### DIFF
--- a/executable_semantics/fuzzing/executable_semantics_fuzzer.cpp
+++ b/executable_semantics/fuzzing/executable_semantics_fuzzer.cpp
@@ -28,7 +28,7 @@ void ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit) {
   AddPrelude("executable_semantics/data/prelude.carbon", &arena,
              &ast->declarations);
   const ErrorOr<int> result =
-      ExecProgram(&arena, *ast, /*trace_stream=*/nullptr);
+      ExecProgram(&arena, *ast, /*trace_stream=*/std::nullopt);
   if (!result.ok()) {
     llvm::errs() << "Execution failed: " << result.error().message() << "\n";
     return;


### PR DESCRIPTION
exec_program.cpp:24:20: runtime error: member call on null pointer of type 'llvm::raw_ostream'.

Tested:
bazel test --config proto-fuzzer executable_semantics/fuzzing:executable_semantics_fuzzer