### PR TITLE
add check for double instantiation of a generic class

### DIFF
--- a/executable_semantics/testdata/generic_class/fail_two_arg_lists.carbon
+++ b/executable_semantics/testdata/generic_class/fail_two_arg_lists.carbon
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{executable_semantics} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{executable_semantics} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{executable_semantics} %s
+// CHECK: COMPILATION ERROR: {{.*}}/executable_semantics/testdata/generic_class/fail_two_arg_lists.carbon:15: attempt to instantiate an already instantiated generic class: Point(T)(T)
+
+package ExecutableSemanticsTest api;
+
+class Point(T:! Type) {
+  fn Origin(zero: T) -> Point(T)(T) {
+    return {.x = zero, .y = zero};
+  }
+
+  fn GetX[me: Point(T)(T)]() -> T {
+    return me.x;
+  }
+
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = Point(i32).Origin(0);
+  return p.GetX();
+}


### PR DESCRIPTION
This PR adds code to catch the error of instantiating a generic class more than once, as in:
```
class Point(T:! Type) {
  fn Origin(zero: T) -> Point(T)(T) {
...
```
The PR includes the test created by @josh11b.