### PR TITLE
Make update_checks.py treat RUNTIME ERROR lines as containing a line number too.

### DIFF
--- a/explorer/testdata/array/fail_index.carbon
+++ b/explorer/testdata/array/fail_index.carbon
@@ -7,11 +7,11 @@
 // RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/array/fail_index.carbon:16: index 2 out of range in (0, 1)
 
 package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: [i32; 2] = (0, 1);
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/array/fail_index.carbon:[[@LINE+1]]: index 2 out of range in (0, 1)
   return x[2];
 }

--- a/explorer/testdata/experimental_continuation/fail_lifetime.carbon
+++ b/explorer/testdata/experimental_continuation/fail_lifetime.carbon
@@ -7,7 +7,6 @@
 // RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/experimental_continuation/fail_lifetime.carbon:21: undefined behavior: access to dead value 1
 
 package ExplorerTest api;
 
@@ -18,6 +17,7 @@ package ExplorerTest api;
 fn capture() -> __Continuation {
   var x: i32 = 1;
   __continuation k {
+    // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/experimental_continuation/fail_lifetime.carbon:[[@LINE+1]]: undefined behavior: access to dead value 1
     var y: i32 = x;
   }
   return k;

--- a/explorer/testdata/global_variable/fail_init_order.carbon
+++ b/explorer/testdata/global_variable/fail_init_order.carbon
@@ -7,13 +7,13 @@
 // RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/global_variable/fail_init_order.carbon:17: could not find `y: i32`
 
 package ExplorerTest api;
 
 // Test that a global variable may not depend on a later global.
 // Error expected.
 
+// CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/global_variable/fail_init_order.carbon:[[@LINE+1]]: could not find `y: i32`
 var x: i32 = y;
 
 var y: i32 = 0;

--- a/explorer/testdata/tuple/fail_index_var.carbon
+++ b/explorer/testdata/tuple/fail_index_var.carbon
@@ -7,12 +7,12 @@
 // RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/tuple/fail_index_var.carbon:17: could not find `index: i32`
 
 package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: auto = (0, 1);
   var index: i32 = 0;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/tuple/fail_index_var.carbon:[[@LINE+1]]: could not find `index: i32`
   return x[index];
 }

--- a/explorer/update_checks.py
+++ b/explorer/update_checks.py
@@ -26,7 +26,7 @@ _AUTOUPDATE_MARKER = "// AUTOUPDATE: "
 _NOAUTOUPDATE_MARKER = "// NOAUTOUPDATE"
 
 # A regexp matching lines that contain line number references.
-_LINE_NUMBER_RE = r"(COMPILATION ERROR: [^:]*:)([1-9][0-9]*)(:.*)"
+_LINE_NUMBER_RE = r"((?:COMPILATION|RUNTIME) ERROR: [^:]*:)([1-9][0-9]*)(:.*)"
 
 
 def _get_tests() -> Set[str]:


### PR DESCRIPTION
Move the corresponding CHECK lines adjacent to their referenced line and use `[[@LINE+n]]`.