### PR TITLE
CARBON_ header guards

### DIFF
--- a/common/check.h
+++ b/common/check.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_CHECK_H_
-#define COMMON_CHECK_H_
+#ifndef CARBON_COMMON_CHECK_H_
+#define CARBON_COMMON_CHECK_H_
 
 #include "common/check_internal.h"
 
@@ -47,4 +47,4 @@ namespace Carbon {
 
 }  // namespace Carbon
 
-#endif  // COMMON_CHECK_H_
+#endif  // CARBON_COMMON_CHECK_H_

--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_CHECK_INTERNAL_H_
-#define COMMON_CHECK_INTERNAL_H_
+#ifndef CARBON_COMMON_CHECK_INTERNAL_H_
+#define CARBON_COMMON_CHECK_INTERNAL_H_
 
 #include <unistd.h>
 
@@ -78,4 +78,4 @@ class ExitingStream {
 
 }  // namespace Carbon::Internal
 
-#endif  // COMMON_CHECK_INTERNAL_H_
+#endif  // CARBON_COMMON_CHECK_INTERNAL_H_

--- a/common/error.h
+++ b/common/error.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_ERROR_H_
-#define COMMON_ERROR_H_
+#ifndef CARBON_COMMON_ERROR_H_
+#define CARBON_COMMON_ERROR_H_
 
 #include <string>
 
@@ -160,4 +160,4 @@ class ErrorBuilder {
       CARBON_MAKE_UNIQUE_NAME(_llvm_expected_line, __LINE__, __COUNTER__), \
       var, expr)
 
-#endif  // COMMON_ERROR_H_
+#endif  // CARBON_COMMON_ERROR_H_

--- a/common/fuzzing/proto_to_carbon.h
+++ b/common/fuzzing/proto_to_carbon.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_FUZZING_PROTO_TO_CARBON_H_
-#define COMMON_FUZZING_PROTO_TO_CARBON_H_
+#ifndef CARBON_COMMON_FUZZING_PROTO_TO_CARBON_H_
+#define CARBON_COMMON_FUZZING_PROTO_TO_CARBON_H_
 
 #include "common/fuzzing/carbon.pb.h"
 
@@ -19,4 +19,4 @@ auto ProtoToCarbon(const Fuzzing::CompilationUnit& compilation_unit)
 
 }  // namespace Carbon
 
-#endif  // COMMON_FUZZING_PROTO_TO_CARBON_H_
+#endif  // CARBON_COMMON_FUZZING_PROTO_TO_CARBON_H_

--- a/common/indirect_value.h
+++ b/common/indirect_value.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_INDIRECT_VALUE_H_
-#define COMMON_INDIRECT_VALUE_H_
+#ifndef CARBON_COMMON_INDIRECT_VALUE_H_
+#define CARBON_COMMON_INDIRECT_VALUE_H_
 
 #include <memory>
 #include <type_traits>
@@ -106,4 +106,4 @@ auto CreateIndirectValue(Callable callable)
 
 }  // namespace Carbon
 
-#endif  // COMMON_INDIRECT_VALUE_H_
+#endif  // CARBON_COMMON_INDIRECT_VALUE_H_

--- a/common/metaprogramming.h
+++ b/common/metaprogramming.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_METAPROGRAMMING_H_
-#define COMMON_METAPROGRAMMING_H_
+#ifndef CARBON_COMMON_METAPROGRAMMING_H_
+#define CARBON_COMMON_METAPROGRAMMING_H_
 
 #include <type_traits>
 
@@ -31,4 +31,4 @@ constexpr auto Requires(F /* f */) -> bool {
 
 }  // namespace Carbon
 
-#endif  // COMMON_METAPROGRAMMING_H_
+#endif  // CARBON_COMMON_METAPROGRAMMING_H_

--- a/common/ostream.h
+++ b/common/ostream.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_OSTREAM_H_
-#define COMMON_OSTREAM_H_
+#ifndef CARBON_COMMON_OSTREAM_H_
+#define CARBON_COMMON_OSTREAM_H_
 
 #include <ostream>
 
@@ -93,4 +93,4 @@ auto operator<<(S& standard_out, const T& value) -> S& {
 
 }  // namespace llvm
 
-#endif  // COMMON_OSTREAM_H_
+#endif  // CARBON_COMMON_OSTREAM_H_

--- a/common/string_helpers.h
+++ b/common/string_helpers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef COMMON_STRING_HELPERS_H_
-#define COMMON_STRING_HELPERS_H_
+#ifndef CARBON_COMMON_STRING_HELPERS_H_
+#define CARBON_COMMON_STRING_HELPERS_H_
 
 #include <optional>
 #include <string>
@@ -32,4 +32,4 @@ auto StringRefContainsPointer(llvm::StringRef ref, const char* ptr) -> bool;
 
 }  // namespace Carbon
 
-#endif  // COMMON_STRING_HELPERS_H_
+#endif  // CARBON_COMMON_STRING_HELPERS_H_

--- a/explorer/ast/ast.h
+++ b/explorer/ast/ast.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_AST_H_
-#define EXPLORER_AST_AST_H_
+#ifndef CARBON_EXPLORER_AST_AST_H_
+#define CARBON_EXPLORER_AST_AST_H_
 
 #include <vector>
 
@@ -29,4 +29,4 @@ struct AST {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_AST_H_
+#endif  // CARBON_EXPLORER_AST_AST_H_

--- a/explorer/ast/ast_node.h
+++ b/explorer/ast/ast_node.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_AST_NODE_H_
-#define EXPLORER_AST_AST_NODE_H_
+#ifndef CARBON_EXPLORER_AST_AST_NODE_H_
+#define CARBON_EXPLORER_AST_AST_NODE_H_
 
 #include "explorer/ast/ast_rtti.h"
 #include "explorer/common/source_location.h"
@@ -76,4 +76,4 @@ class AstNode {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_AST_NODE_H_
+#endif  // CARBON_EXPLORER_AST_AST_NODE_H_

--- a/explorer/ast/ast_test_matchers.h
+++ b/explorer/ast/ast_test_matchers.h
@@ -9,8 +9,8 @@
 // TODO: Provide matchers for all node Kinds, and establish more uniform
 // conventions for them.
 
-#ifndef EXPLORER_AST_AST_TEST_MATCHERS_H_
-#define EXPLORER_AST_AST_TEST_MATCHERS_H_
+#ifndef CARBON_EXPLORER_AST_AST_TEST_MATCHERS_H_
+#define CARBON_EXPLORER_AST_AST_TEST_MATCHERS_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -129,4 +129,4 @@ inline auto ASTDeclarations(
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_AST_TEST_MATCHERS_H_
+#endif  // CARBON_EXPLORER_AST_AST_TEST_MATCHERS_H_

--- a/explorer/ast/ast_test_matchers_internal.h
+++ b/explorer/ast/ast_test_matchers_internal.h
@@ -4,8 +4,8 @@
 
 // Implementation details of the functions in ast_test_matchers.h.
 
-#ifndef EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_
-#define EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_
+#ifndef CARBON_EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_
+#define CARBON_EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -234,4 +234,4 @@ class ASTDeclarationsMatcher {
 
 }  // namespace Carbon::TestingInternal
 
-#endif  // EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_
+#endif  // CARBON_EXPLORER_AST_AST_TEST_MATCHERS_INTERNAL_H_

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_DECLARATION_H_
-#define EXPLORER_AST_DECLARATION_H_
+#ifndef CARBON_EXPLORER_AST_DECLARATION_H_
+#define CARBON_EXPLORER_AST_DECLARATION_H_
 
 #include <string>
 #include <utility>
@@ -422,4 +422,4 @@ auto GetName(const Declaration&) -> std::optional<std::string>;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_DECLARATION_H_
+#endif  // CARBON_EXPLORER_AST_DECLARATION_H_

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_EXPRESSION_H_
-#define EXPLORER_AST_EXPRESSION_H_
+#ifndef CARBON_EXPLORER_AST_EXPRESSION_H_
+#define CARBON_EXPLORER_AST_EXPRESSION_H_
 
 #include <map>
 #include <optional>
@@ -653,4 +653,4 @@ auto TupleExpressionFromParenContents(
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_EXPRESSION_H_
+#endif  // CARBON_EXPLORER_AST_EXPRESSION_H_

--- a/explorer/ast/impl_binding.h
+++ b/explorer/ast/impl_binding.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_IMPL_BINDING_H_
-#define EXPLORER_AST_IMPL_BINDING_H_
+#ifndef CARBON_EXPLORER_AST_IMPL_BINDING_H_
+#define CARBON_EXPLORER_AST_IMPL_BINDING_H_
 
 #include <map>
 
@@ -75,4 +75,4 @@ class ImplBinding : public AstNode {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_IMPL_BINDING_H_
+#endif  // CARBON_EXPLORER_AST_IMPL_BINDING_H_

--- a/explorer/ast/library_name.h
+++ b/explorer/ast/library_name.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_LIBRARY_NAME_H_
-#define EXPLORER_AST_LIBRARY_NAME_H_
+#ifndef CARBON_EXPLORER_AST_LIBRARY_NAME_H_
+#define CARBON_EXPLORER_AST_LIBRARY_NAME_H_
 
 #include <string>
 
@@ -22,4 +22,4 @@ struct LibraryName {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_LIBRARY_NAME_H_
+#endif  // CARBON_EXPLORER_AST_LIBRARY_NAME_H_

--- a/explorer/ast/paren_contents.h
+++ b/explorer/ast/paren_contents.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_PAREN_CONTENTS_H_
-#define EXPLORER_AST_PAREN_CONTENTS_H_
+#ifndef CARBON_EXPLORER_AST_PAREN_CONTENTS_H_
+#define CARBON_EXPLORER_AST_PAREN_CONTENTS_H_
 
 #include <optional>
 #include <string>
@@ -48,4 +48,4 @@ auto ParenContents<Term>::SingleTerm() const -> std::optional<Nonnull<Term*>> {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_PAREN_CONTENTS_H_
+#endif  // CARBON_EXPLORER_AST_PAREN_CONTENTS_H_

--- a/explorer/ast/pattern.h
+++ b/explorer/ast/pattern.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_PATTERN_H_
-#define EXPLORER_AST_PATTERN_H_
+#ifndef CARBON_EXPLORER_AST_PATTERN_H_
+#define CARBON_EXPLORER_AST_PATTERN_H_
 
 #include <optional>
 #include <string>
@@ -346,4 +346,4 @@ class ExpressionPattern : public Pattern {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_PATTERN_H_
+#endif  // CARBON_EXPLORER_AST_PATTERN_H_

--- a/explorer/ast/return_term.h
+++ b/explorer/ast/return_term.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_RETURN_TERM_H_
-#define EXPLORER_AST_RETURN_TERM_H_
+#ifndef CARBON_EXPLORER_AST_RETURN_TERM_H_
+#define CARBON_EXPLORER_AST_RETURN_TERM_H_
 
 #include <optional>
 #include <utility>
@@ -97,4 +97,4 @@ class ReturnTerm {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_RETURN_TERM_H_
+#endif  // CARBON_EXPLORER_AST_RETURN_TERM_H_

--- a/explorer/ast/statement.h
+++ b/explorer/ast/statement.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_STATEMENT_H_
-#define EXPLORER_AST_STATEMENT_H_
+#ifndef CARBON_EXPLORER_AST_STATEMENT_H_
+#define CARBON_EXPLORER_AST_STATEMENT_H_
 
 #include <utility>
 #include <vector>
@@ -395,4 +395,4 @@ class Await : public Statement {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_STATEMENT_H_
+#endif  // CARBON_EXPLORER_AST_STATEMENT_H_

--- a/explorer/ast/static_scope.h
+++ b/explorer/ast/static_scope.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_STATIC_SCOPE_H_
-#define EXPLORER_AST_STATIC_SCOPE_H_
+#ifndef CARBON_EXPLORER_AST_STATIC_SCOPE_H_
+#define CARBON_EXPLORER_AST_STATIC_SCOPE_H_
 
 #include <functional>
 #include <string>
@@ -183,4 +183,4 @@ class StaticScope {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_STATIC_SCOPE_H_
+#endif  // CARBON_EXPLORER_AST_STATIC_SCOPE_H_

--- a/explorer/ast/value_category.h
+++ b/explorer/ast/value_category.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_AST_VALUE_CATEGORY_H_
-#define EXPLORER_AST_VALUE_CATEGORY_H_
+#ifndef CARBON_EXPLORER_AST_VALUE_CATEGORY_H_
+#define CARBON_EXPLORER_AST_VALUE_CATEGORY_H_
 
 namespace Carbon {
 
@@ -19,4 +19,4 @@ enum class ValueCategory {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_AST_VALUE_CATEGORY_H_
+#endif  // CARBON_EXPLORER_AST_VALUE_CATEGORY_H_

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_COMMON_ARENA_H_
-#define EXPLORER_COMMON_ARENA_H_
+#ifndef CARBON_EXPLORER_COMMON_ARENA_H_
+#define CARBON_EXPLORER_COMMON_ARENA_H_
 
 #include <memory>
 #include <type_traits>
@@ -55,4 +55,4 @@ class Arena {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_COMMON_ARENA_H_
+#endif  // CARBON_EXPLORER_COMMON_ARENA_H_

--- a/explorer/common/error_builders.h
+++ b/explorer/common/error_builders.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_COMMON_ERROR_BUILDERS_H_
-#define EXPLORER_COMMON_ERROR_BUILDERS_H_
+#ifndef CARBON_EXPLORER_COMMON_ERROR_BUILDERS_H_
+#define CARBON_EXPLORER_COMMON_ERROR_BUILDERS_H_
 
 #include "common/error.h"
 #include "explorer/common/source_location.h"
@@ -41,4 +41,4 @@ inline auto RuntimeError(SourceLocation loc) -> ErrorBuilder {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_COMMON_ERROR_BUILDERS_H_
+#endif  // CARBON_EXPLORER_COMMON_ERROR_BUILDERS_H_

--- a/explorer/common/nonnull.h
+++ b/explorer/common/nonnull.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_COMMON_NONNULL_H_
-#define EXPLORER_COMMON_NONNULL_H_
+#ifndef CARBON_EXPLORER_COMMON_NONNULL_H_
+#define CARBON_EXPLORER_COMMON_NONNULL_H_
 
 #include <type_traits>
 
@@ -19,4 +19,4 @@ using Nonnull = T _Nonnull;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_COMMON_NONNULL_H_
+#endif  // CARBON_EXPLORER_COMMON_NONNULL_H_

--- a/explorer/common/source_location.h
+++ b/explorer/common/source_location.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_COMMON_SOURCE_LOCATION_H_
-#define EXPLORER_COMMON_SOURCE_LOCATION_H_
+#ifndef CARBON_EXPLORER_COMMON_SOURCE_LOCATION_H_
+#define CARBON_EXPLORER_COMMON_SOURCE_LOCATION_H_
 
 #include <string>
 #include <string_view>
@@ -42,4 +42,4 @@ class SourceLocation {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_COMMON_SOURCE_LOCATION_H_
+#endif  // CARBON_EXPLORER_COMMON_SOURCE_LOCATION_H_

--- a/explorer/fuzzing/ast_to_proto.h
+++ b/explorer/fuzzing/ast_to_proto.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_FUZZING_AST_TO_PROTO_H_
-#define EXPLORER_FUZZING_AST_TO_PROTO_H_
+#ifndef CARBON_EXPLORER_FUZZING_AST_TO_PROTO_H_
+#define CARBON_EXPLORER_FUZZING_AST_TO_PROTO_H_
 
 #include "common/fuzzing/carbon.pb.h"
 #include "explorer/ast/ast.h"
@@ -15,4 +15,4 @@ auto AstToProto(const AST& ast) -> Fuzzing::CompilationUnit;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_FUZZING_AST_TO_PROTO_H_
+#endif  // CARBON_EXPLORER_FUZZING_AST_TO_PROTO_H_

--- a/explorer/fuzzing/fuzzer_util.h
+++ b/explorer/fuzzing/fuzzer_util.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_FUZZING_FUZZER_UTIL_H_
-#define EXPLORER_FUZZING_FUZZER_UTIL_H_
+#ifndef CARBON_EXPLORER_FUZZING_FUZZER_UTIL_H_
+#define CARBON_EXPLORER_FUZZING_FUZZER_UTIL_H_
 
 #include "common/error.h"
 #include "common/fuzzing/carbon.pb.h"
@@ -27,4 +27,4 @@ auto GetRunfilesFile(const std::string& file) -> ErrorOr<std::string>;
 }  // namespace Internal
 }  // namespace Carbon
 
-#endif  // EXPLORER_FUZZING_FUZZER_UTIL_H_
+#endif  // CARBON_EXPLORER_FUZZING_FUZZER_UTIL_H_

--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_ACTION_H_
-#define EXPLORER_INTERPRETER_ACTION_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_ACTION_H_
+#define CARBON_EXPLORER_INTERPRETER_ACTION_H_
 
 #include <map>
 #include <vector>
@@ -251,4 +251,4 @@ class ScopeAction : public Action {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_ACTION_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_ACTION_H_

--- a/explorer/interpreter/action_stack.h
+++ b/explorer/interpreter/action_stack.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_ACTION_STACK_H_
-#define EXPLORER_INTERPRETER_ACTION_STACK_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_ACTION_STACK_H_
+#define CARBON_EXPLORER_INTERPRETER_ACTION_STACK_H_
 
 #include <memory>
 #include <optional>
@@ -128,4 +128,4 @@ class ActionStack {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_ACTION_STACK_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_ACTION_STACK_H_

--- a/explorer/interpreter/address.h
+++ b/explorer/interpreter/address.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_ADDRESS_H_
-#define EXPLORER_INTERPRETER_ADDRESS_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_ADDRESS_H_
+#define CARBON_EXPLORER_INTERPRETER_ADDRESS_H_
 
 #include <cstdint>
 #include <string>
@@ -84,4 +84,4 @@ class Address {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_ADDRESS_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_ADDRESS_H_

--- a/explorer/interpreter/dictionary.h
+++ b/explorer/interpreter/dictionary.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_DICTIONARY_H_
-#define EXPLORER_INTERPRETER_DICTIONARY_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_DICTIONARY_H_
+#define CARBON_EXPLORER_INTERPRETER_DICTIONARY_H_
 
 #include <iterator>
 #include <optional>
@@ -101,4 +101,4 @@ class Dictionary {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_DICTIONARY_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_DICTIONARY_H_

--- a/explorer/interpreter/exec_program.h
+++ b/explorer/interpreter/exec_program.h
@@ -6,8 +6,8 @@
 // statement. The intent is to minimize the amount of C++ in the .ypp file, to
 // improve ease of maintenance.
 
-#ifndef EXPLORER_INTERPRETER_EXEC_PROGRAM_H_
-#define EXPLORER_INTERPRETER_EXEC_PROGRAM_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_EXEC_PROGRAM_H_
+#define CARBON_EXPLORER_INTERPRETER_EXEC_PROGRAM_H_
 
 #include "explorer/ast/ast.h"
 #include "llvm/Support/raw_ostream.h"
@@ -21,4 +21,4 @@ auto ExecProgram(Nonnull<Arena*> arena, AST ast,
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_EXEC_PROGRAM_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_EXEC_PROGRAM_H_

--- a/explorer/interpreter/field_path.h
+++ b/explorer/interpreter/field_path.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_FIELD_PATH_H_
-#define EXPLORER_INTERPRETER_FIELD_PATH_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_FIELD_PATH_H_
+#define CARBON_EXPLORER_INTERPRETER_FIELD_PATH_H_
 
 #include <string>
 #include <vector>
@@ -91,4 +91,4 @@ class FieldPath {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_FIELD_PATH_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_FIELD_PATH_H_

--- a/explorer/interpreter/heap.h
+++ b/explorer/interpreter/heap.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_HEAP_H_
-#define EXPLORER_INTERPRETER_HEAP_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_HEAP_H_
+#define CARBON_EXPLORER_INTERPRETER_HEAP_H_
 
 #include <vector>
 
@@ -60,4 +60,4 @@ class Heap : public HeapAllocationInterface {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_HEAP_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_HEAP_H_

--- a/explorer/interpreter/heap_allocation_interface.h
+++ b/explorer/interpreter/heap_allocation_interface.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_
-#define EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_
+#define CARBON_EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_
 
 #include "explorer/common/arena.h"
 #include "explorer/common/nonnull.h"
@@ -37,4 +37,4 @@ class HeapAllocationInterface {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_HEAP_ALLOCATION_INTERFACE_H_

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_IMPL_SCOPE_H_
-#define EXPLORER_INTERPRETER_IMPL_SCOPE_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_IMPL_SCOPE_H_
+#define CARBON_EXPLORER_INTERPRETER_IMPL_SCOPE_H_
 
 #include "explorer/ast/declaration.h"
 
@@ -110,4 +110,4 @@ class ImplScope {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_IMPL_SCOPE_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_IMPL_SCOPE_H_

--- a/explorer/interpreter/interpreter.h
+++ b/explorer/interpreter/interpreter.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_INTERPRETER_H_
-#define EXPLORER_INTERPRETER_INTERPRETER_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_INTERPRETER_H_
+#define CARBON_EXPLORER_INTERPRETER_INTERPRETER_H_
 
 #include <optional>
 #include <utility>
@@ -57,4 +57,4 @@ auto InterpPattern(Nonnull<const Pattern*> p, Nonnull<Arena*> arena,
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_INTERPRETER_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_INTERPRETER_H_

--- a/explorer/interpreter/resolve_control_flow.h
+++ b/explorer/interpreter/resolve_control_flow.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_
-#define EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_
+#define CARBON_EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_
 
 #include "explorer/ast/ast.h"
 #include "explorer/common/nonnull.h"
@@ -18,4 +18,4 @@ auto ResolveControlFlow(AST& ast) -> ErrorOr<Success>;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_RESOLVE_CONTROL_FLOW_H_

--- a/explorer/interpreter/resolve_names.h
+++ b/explorer/interpreter/resolve_names.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_RESOLVE_NAMES_H_
-#define EXPLORER_INTERPRETER_RESOLVE_NAMES_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_RESOLVE_NAMES_H_
+#define CARBON_EXPLORER_INTERPRETER_RESOLVE_NAMES_H_
 
 #include "explorer/ast/ast.h"
 #include "explorer/common/arena.h"
@@ -17,4 +17,4 @@ auto ResolveNames(AST& ast) -> ErrorOr<Success>;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_RESOLVE_NAMES_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_RESOLVE_NAMES_H_

--- a/explorer/interpreter/stack.h
+++ b/explorer/interpreter/stack.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_STACK_H_
-#define EXPLORER_INTERPRETER_STACK_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_STACK_H_
+#define CARBON_EXPLORER_INTERPRETER_STACK_H_
 
 #include <cstddef>
 #include <iterator>
@@ -72,4 +72,4 @@ struct Stack {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_STACK_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_STACK_H_

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_TYPE_CHECKER_H_
-#define EXPLORER_INTERPRETER_TYPE_CHECKER_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_TYPE_CHECKER_H_
+#define CARBON_EXPLORER_INTERPRETER_TYPE_CHECKER_H_
 
 #include <set>
 
@@ -233,4 +233,4 @@ class TypeChecker {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_TYPE_CHECKER_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_TYPE_CHECKER_H_

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_INTERPRETER_VALUE_H_
-#define EXPLORER_INTERPRETER_VALUE_H_
+#ifndef CARBON_EXPLORER_INTERPRETER_VALUE_H_
+#define CARBON_EXPLORER_INTERPRETER_VALUE_H_
 
 #include <optional>
 #include <string>
@@ -938,4 +938,4 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2) -> bool;
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_INTERPRETER_VALUE_H_
+#endif  // CARBON_EXPLORER_INTERPRETER_VALUE_H_

--- a/explorer/main.h
+++ b/explorer/main.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_MAIN_H_
-#define EXPLORER_MAIN_H_
+#ifndef CARBON_EXPLORER_MAIN_H_
+#define CARBON_EXPLORER_MAIN_H_
 
 #include "llvm/ADT/StringRef.h"
 
@@ -15,4 +15,4 @@ auto ExplorerMain(llvm::StringRef default_prelude_file, int argc, char** argv)
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_MAIN_H_
+#endif  // CARBON_EXPLORER_MAIN_H_

--- a/explorer/syntax/bison_wrap.h
+++ b/explorer/syntax/bison_wrap.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_BISON_WRAP_H_
-#define EXPLORER_SYNTAX_BISON_WRAP_H_
+#ifndef CARBON_EXPLORER_SYNTAX_BISON_WRAP_H_
+#define CARBON_EXPLORER_SYNTAX_BISON_WRAP_H_
 
 #include <optional>
 
@@ -42,4 +42,4 @@ class BisonWrap {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_SYNTAX_BISON_WRAP_H_
+#endif  // CARBON_EXPLORER_SYNTAX_BISON_WRAP_H_

--- a/explorer/syntax/parse.h
+++ b/explorer/syntax/parse.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_PARSE_H_
-#define EXPLORER_SYNTAX_PARSE_H_
+#ifndef CARBON_EXPLORER_SYNTAX_PARSE_H_
+#define CARBON_EXPLORER_SYNTAX_PARSE_H_
 
 #include <string>
 #include <variant>
@@ -27,4 +27,4 @@ auto ParseFromString(Nonnull<Arena*> arena, std::string_view input_file_name,
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_SYNTAX_PARSE_H_
+#endif  // CARBON_EXPLORER_SYNTAX_PARSE_H_

--- a/explorer/syntax/parse_and_lex_context.h
+++ b/explorer/syntax/parse_and_lex_context.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_
-#define EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_
+#ifndef CARBON_EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_
+#define CARBON_EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_
 
 #include <variant>
 
@@ -62,4 +62,4 @@ class ParseAndLexContext {
 // Declares yylex for the parser's sake.
 YY_DECL;
 
-#endif  // EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_
+#endif  // CARBON_EXPLORER_SYNTAX_PARSE_AND_LEX_CONTEXT_H_

--- a/explorer/syntax/parse_test_matchers.h
+++ b/explorer/syntax/parse_test_matchers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_
-#define EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_
+#ifndef CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_
+#define CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -20,4 +20,4 @@ inline auto ParsedAs(::testing::Matcher<AST> ast_matcher) {
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_
+#endif  // CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_H_

--- a/explorer/syntax/parse_test_matchers_internal.h
+++ b/explorer/syntax/parse_test_matchers_internal.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_
-#define EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_
+#ifndef CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_
+#define CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -57,4 +57,4 @@ class ParsedAsMatcher {
 
 }  // namespace Carbon::TestingInternal
 
-#endif  // EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_
+#endif  // CARBON_EXPLORER_SYNTAX_PARSE_TEST_MATCHERS_INTERNAL_H_

--- a/explorer/syntax/prelude.h
+++ b/explorer/syntax/prelude.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef EXPLORER_SYNTAX_PRELUDE_H_
-#define EXPLORER_SYNTAX_PRELUDE_H_
+#ifndef CARBON_EXPLORER_SYNTAX_PRELUDE_H_
+#define CARBON_EXPLORER_SYNTAX_PRELUDE_H_
 
 #include <string_view>
 
@@ -19,4 +19,4 @@ void AddPrelude(std::string_view prelude_file_name, Nonnull<Arena*> arena,
 
 }  // namespace Carbon
 
-#endif  // EXPLORER_SYNTAX_PRELUDE_H_
+#endif  // CARBON_EXPLORER_SYNTAX_PRELUDE_H_

--- a/migrate_cpp/cpp_refactoring/fn_inserter.h
+++ b/migrate_cpp/cpp_refactoring/fn_inserter.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_
-#define MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_
 
 #include "migrate_cpp/cpp_refactoring/matcher.h"
 
@@ -25,4 +25,4 @@ class FnInserterFactory : public MatcherFactoryBase<FnInserter> {
 
 }  // namespace Carbon
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_FN_INSERTER_H_

--- a/migrate_cpp/cpp_refactoring/for_range.h
+++ b/migrate_cpp/cpp_refactoring/for_range.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_
-#define MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_
 
 #include "migrate_cpp/cpp_refactoring/matcher.h"
 
@@ -28,4 +28,4 @@ class ForRangeFactory : public MatcherFactoryBase<ForRange> {
 
 }  // namespace Carbon
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_FOR_RANGE_H_

--- a/migrate_cpp/cpp_refactoring/matcher.h
+++ b/migrate_cpp/cpp_refactoring/matcher.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_
-#define MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_
 
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Lex/Lexer.h"
@@ -92,4 +92,4 @@ class MatcherFactoryBase : public MatcherFactory {
 
 }  // namespace Carbon
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_H_

--- a/migrate_cpp/cpp_refactoring/matcher_manager.h
+++ b/migrate_cpp/cpp_refactoring/matcher_manager.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_
-#define MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_
 
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Tooling/Core/Replacement.h"
@@ -55,4 +55,4 @@ class MatcherManager {
 
 }  // namespace Carbon
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_MANAGER_H_

--- a/migrate_cpp/cpp_refactoring/matcher_test_base.h
+++ b/migrate_cpp/cpp_refactoring/matcher_test_base.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_
-#define MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -63,4 +63,4 @@ class MatcherTestBase : public ::testing::Test {
 
 }  // namespace Carbon::Testing
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_MATCHER_TEST_BASE_H_

--- a/migrate_cpp/cpp_refactoring/var_decl.h
+++ b/migrate_cpp/cpp_refactoring/var_decl.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_
-#define MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_
+#ifndef CARBON_MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_
+#define CARBON_MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_
 
 #include "migrate_cpp/cpp_refactoring/matcher.h"
 
@@ -28,4 +28,4 @@ class VarDeclFactory : public MatcherFactoryBase<VarDecl> {
 
 }  // namespace Carbon
 
-#endif  // MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_
+#endif  // CARBON_MIGRATE_CPP_CPP_REFACTORING_VAR_DECL_H_

--- a/scripts/check_header_guards.py
+++ b/scripts/check_header_guards.py
@@ -56,7 +56,8 @@ def check_path(path: Path) -> bool:
     with path.open() as f:
         lines = f.readlines()
 
-    guard = str(path).upper().replace("/", "_").replace(".", "_") + "_"
+    guard_path = str(path).upper().replace("/", "_").replace(".", "_")
+    guard = f"CARBON_{guard_path}_"
     ifndef = find_guard(lines, "#ifndef ([A-Z_]+_H_)", False)
     define = find_guard(lines, "#define ([A-Z_]+_H_)", False)
     endif = find_guard(lines, "#endif(?:  // ([A-Z_]+_H_))?", True)

--- a/toolchain/common/yaml_test_helpers.h
+++ b/toolchain/common/yaml_test_helpers.h
@@ -44,8 +44,8 @@
 // On match failure, Yaml::Values are printed as C++ code that can be used to
 // recreate the value, for easy copy-pasting into test expectations.
 
-#ifndef TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_
-#define TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_
+#ifndef CARBON_TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_
+#define CARBON_TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -146,4 +146,4 @@ MATCHER_P(Scalar, value,
 
 }  // namespace Carbon::Testing::Yaml
 
-#endif  // TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_
+#endif  // CARBON_TOOLCHAIN_COMMON_YAML_TEST_HELPERS_H_

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_
-#define TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_
+#ifndef CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_
+#define CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_
 
 #include <functional>
 #include <string>
@@ -227,4 +227,4 @@ class ErrorTrackingDiagnosticConsumer : public DiagnosticConsumer {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_
+#endif  // CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_EMITTER_H_

--- a/toolchain/diagnostics/diagnostic_kind.h
+++ b/toolchain/diagnostics/diagnostic_kind.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_
-#define TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_
+#ifndef CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_
+#define CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_
 
 #include "common/ostream.h"
 #include "llvm/ADT/StringRef.h"
@@ -34,4 +34,4 @@ inline auto operator<<(std::ostream& out, DiagnosticKind kind)
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_
+#endif  // CARBON_TOOLCHAIN_DIAGNOSTICS_DIAGNOSTIC_KIND_H_

--- a/toolchain/diagnostics/mocks.h
+++ b/toolchain/diagnostics/mocks.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DIAGNOSTICS_MOCKS_H_
-#define TOOLCHAIN_DIAGNOSTICS_MOCKS_H_
+#ifndef CARBON_TOOLCHAIN_DIAGNOSTICS_MOCKS_H_
+#define CARBON_TOOLCHAIN_DIAGNOSTICS_MOCKS_H_
 
 #include <gmock/gmock.h>
 
@@ -52,4 +52,4 @@ void PrintTo(DiagnosticLevel level, std::ostream* os);
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DIAGNOSTICS_MOCKS_H_
+#endif  // CARBON_TOOLCHAIN_DIAGNOSTICS_MOCKS_H_

--- a/toolchain/diagnostics/null_diagnostics.h
+++ b/toolchain/diagnostics/null_diagnostics.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_
-#define TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_
+#ifndef CARBON_TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_
+#define CARBON_TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_
 
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
@@ -38,4 +38,4 @@ inline auto NullDiagnosticEmitter() -> DiagnosticEmitter<LocationT>& {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_
+#endif  // CARBON_TOOLCHAIN_DIAGNOSTICS_NULL_DIAGNOSTICS_H_

--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_
-#define TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_
+#ifndef CARBON_TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_
+#define CARBON_TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_
 
 #include "common/check.h"
 #include "llvm/ADT/STLExtras.h"
@@ -43,4 +43,4 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_
+#endif  // CARBON_TOOLCHAIN_DIAGNOSTICS_SORTING_DIAGNOSTIC_CONSUMER_H_

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_DRIVER_DRIVER_H_
-#define TOOLCHAIN_DRIVER_DRIVER_H_
+#ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_H_
+#define CARBON_TOOLCHAIN_DRIVER_DRIVER_H_
 
 #include <cstdint>
 
@@ -81,4 +81,4 @@ class Driver {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_DRIVER_DRIVER_H_
+#endif  // CARBON_TOOLCHAIN_DRIVER_DRIVER_H_

--- a/toolchain/lexer/character_set.h
+++ b/toolchain/lexer/character_set.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_CHARACTER_SET_H_
-#define TOOLCHAIN_LEXER_CHARACTER_SET_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_CHARACTER_SET_H_
+#define CARBON_TOOLCHAIN_LEXER_CHARACTER_SET_H_
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -74,4 +74,4 @@ inline auto IsSpace(char c) -> bool {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_CHARACTER_SET_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_CHARACTER_SET_H_

--- a/toolchain/lexer/lex_helpers.h
+++ b/toolchain/lexer/lex_helpers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_LEX_HELPERS_H_
-#define TOOLCHAIN_LEXER_LEX_HELPERS_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_LEX_HELPERS_H_
+#define CARBON_TOOLCHAIN_LEXER_LEX_HELPERS_H_
 
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
@@ -16,4 +16,4 @@ auto CanLexInteger(DiagnosticEmitter<const char*>& emitter,
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_LEX_HELPERS_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_LEX_HELPERS_H_

--- a/toolchain/lexer/numeric_literal.h
+++ b/toolchain/lexer/numeric_literal.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
-#define TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
+#define CARBON_TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
 
 #include <utility>
 #include <variant>
@@ -74,4 +74,4 @@ class LexedNumericLiteral {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_

--- a/toolchain/lexer/string_literal.h
+++ b/toolchain/lexer/string_literal.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_STRING_LITERAL_H_
-#define TOOLCHAIN_LEXER_STRING_LITERAL_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_STRING_LITERAL_H_
+#define CARBON_TOOLCHAIN_LEXER_STRING_LITERAL_H_
 
 #include <string>
 
@@ -62,4 +62,4 @@ class LexedStringLiteral {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_STRING_LITERAL_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_STRING_LITERAL_H_

--- a/toolchain/lexer/test_helpers.h
+++ b/toolchain/lexer/test_helpers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_TEST_HELPERS_H_
-#define TOOLCHAIN_LEXER_TEST_HELPERS_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_TEST_HELPERS_H_
+#define CARBON_TOOLCHAIN_LEXER_TEST_HELPERS_H_
 
 #include <gmock/gmock.h>
 
@@ -53,4 +53,4 @@ class SingleTokenDiagnosticTranslator
 
 }  // namespace Carbon::Testing
 
-#endif  // TOOLCHAIN_LEXER_TEST_HELPERS_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_TEST_HELPERS_H_

--- a/toolchain/lexer/token_kind.h
+++ b/toolchain/lexer/token_kind.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_TOKEN_KIND_H_
-#define TOOLCHAIN_LEXER_TOKEN_KIND_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_TOKEN_KIND_H_
+#define CARBON_TOOLCHAIN_LEXER_TOKEN_KIND_H_
 
 #include <cstdint>
 #include <initializer_list>
@@ -111,4 +111,4 @@ class TokenKind {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_TOKEN_KIND_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_TOKEN_KIND_H_

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_
-#define TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_
+#define CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_
 
 #include <cstdint>
 #include <iterator>
@@ -496,4 +496,4 @@ using TokenDiagnosticEmitter = DiagnosticEmitter<TokenizedBuffer::Token>;
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_

--- a/toolchain/lexer/tokenized_buffer_test_helpers.h
+++ b/toolchain/lexer/tokenized_buffer_test_helpers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_
-#define TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_
+#ifndef CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_
+#define CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_
 
 #include <gmock/gmock.h>
 
@@ -156,4 +156,4 @@ MATCHER_P(HasTokens, raw_all_expected, "") {
 }  // namespace Testing
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_
+#endif  // CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_TEST_HELPERS_H_

--- a/toolchain/parser/parse_node_kind.h
+++ b/toolchain/parser/parse_node_kind.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
-#define TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
+#ifndef CARBON_TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
+#define CARBON_TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
 
 #include <cstdint>
 #include <iterator>
@@ -71,4 +71,4 @@ static_assert(sizeof(ParseNodeKind) == 1, "Kind objects include padding!");
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
+#endif  // CARBON_TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_

--- a/toolchain/parser/parse_test_helpers.h
+++ b/toolchain/parser/parse_test_helpers.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_
-#define TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_
+#ifndef CARBON_TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_
+#define CARBON_TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_
 
 #include <gmock/gmock.h>
 
@@ -343,4 +343,4 @@ auto MatchFunctionWithBody(Args... args) -> ExpectedNode {
 }  // namespace Testing
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_
+#endif  // CARBON_TOOLCHAIN_PARSER_PARSE_TEST_HELPERS_H_

--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_PARSER_PARSE_TREE_H_
-#define TOOLCHAIN_PARSER_PARSE_TREE_H_
+#ifndef CARBON_TOOLCHAIN_PARSER_PARSE_TREE_H_
+#define CARBON_TOOLCHAIN_PARSER_PARSE_TREE_H_
 
 #include <iterator>
 
@@ -376,4 +376,4 @@ class ParseTree::SiblingIterator
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_PARSER_PARSE_TREE_H_
+#endif  // CARBON_TOOLCHAIN_PARSER_PARSE_TREE_H_

--- a/toolchain/parser/parser_impl.h
+++ b/toolchain/parser/parser_impl.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_PARSER_PARSER_IMPL_H_
-#define TOOLCHAIN_PARSER_PARSER_IMPL_H_
+#ifndef CARBON_TOOLCHAIN_PARSER_PARSER_IMPL_H_
+#define CARBON_TOOLCHAIN_PARSER_PARSER_IMPL_H_
 
 #include "llvm/ADT/Optional.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
@@ -286,4 +286,4 @@ class ParseTree::Parser {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_PARSER_PARSER_IMPL_H_
+#endif  // CARBON_TOOLCHAIN_PARSER_PARSER_IMPL_H_

--- a/toolchain/parser/precedence.h
+++ b/toolchain/parser/precedence.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_PARSER_PRECEDENCE_H_
-#define TOOLCHAIN_PARSER_PRECEDENCE_H_
+#ifndef CARBON_TOOLCHAIN_PARSER_PRECEDENCE_H_
+#define CARBON_TOOLCHAIN_PARSER_PRECEDENCE_H_
 
 #include "llvm/ADT/Optional.h"
 #include "toolchain/lexer/token_kind.h"
@@ -97,4 +97,4 @@ struct PrecedenceGroup::Trailing {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_PARSER_PRECEDENCE_H_
+#endif  // CARBON_TOOLCHAIN_PARSER_PRECEDENCE_H_

--- a/toolchain/semantics/function.h
+++ b/toolchain/semantics/function.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_SEMANTICS_FUNCTION_H_
-#define TOOLCHAIN_SEMANTICS_FUNCTION_H_
+#ifndef CARBON_TOOLCHAIN_SEMANTICS_FUNCTION_H_
+#define CARBON_TOOLCHAIN_SEMANTICS_FUNCTION_H_
 
 #include "toolchain/parser/parse_tree.h"
 
@@ -28,4 +28,4 @@ class Function {
 
 }  // namespace Carbon::Semantics
 
-#endif  // TOOLCHAIN_SEMANTICS_FUNCTION_H_
+#endif  // CARBON_TOOLCHAIN_SEMANTICS_FUNCTION_H_

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_
-#define TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_
+#ifndef CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_
+#define CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
@@ -75,4 +75,4 @@ class SemanticsIR {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_
+#endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_

--- a/toolchain/semantics/semantics_ir_factory.h
+++ b/toolchain/semantics/semantics_ir_factory.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_
-#define TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_
+#ifndef CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_
+#define CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_
 
 #include <optional>
 
@@ -37,4 +37,4 @@ class SemanticsIRFactory {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_
+#endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FACTORY_H_

--- a/toolchain/source/source_buffer.h
+++ b/toolchain/source/source_buffer.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_
-#define TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_
+#ifndef CARBON_TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_
+#define CARBON_TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_
 
 #include <string>
 #include <utility>
@@ -74,4 +74,4 @@ class SourceBuffer {
 
 }  // namespace Carbon
 
-#endif  // TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_
+#endif  // CARBON_TOOLCHAIN_SOURCE_SOURCE_BUFFER_H_


### PR DESCRIPTION
This modifies scripts/check_header_guards.py to add the CARBON_ prefix; everything else is pre-commit.