### PR TITLE
Add continuation name to name resolution after processing continuation body

### DIFF
--- a/explorer/fuzzing/fuzzer_corpus/3e9392fe2e7d549f249dff5f7e74dfb0ba6b912c.textproto
+++ b/explorer/fuzzing/fuzzer_corpus/3e9392fe2e7d549f249dff5f7e74dfb0ba6b912c.textproto
@@ -1,0 +1,22 @@
+compilation_unit {
+  declarations {
+    function {
+      body {
+        statements {
+          continuation {
+            body {
+              statements {
+                run {
+                  argument {
+                    identifier {
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -297,13 +297,13 @@ static auto ResolveNames(Statement& statement, StaticScope& enclosing_scope)
       break;
     }
     case StatementKind::Continuation: {
-      auto& continuation = cast<Continuation>(statement);
-      CARBON_RETURN_IF_ERROR(
-          enclosing_scope.Add(continuation.name(), &continuation));
       StaticScope continuation_scope;
       continuation_scope.AddParent(&enclosing_scope);
-      CARBON_RETURN_IF_ERROR(ResolveNames(cast<Continuation>(statement).body(),
-                                          continuation_scope));
+      auto& continuation = cast<Continuation>(statement);
+      CARBON_RETURN_IF_ERROR(
+          ResolveNames(continuation.body(), continuation_scope));
+      CARBON_RETURN_IF_ERROR(
+          enclosing_scope.Add(continuation.name(), &continuation));
       break;
     }
     case StatementKind::Run:


### PR DESCRIPTION
Fixes #1263

This makes the continuation behave similar to this C++ lambda construct - `auto f = []() { f(); };` which doesn't compile. 

However, another option for the continuation in this example is to behave more like a recursive function.
Which option is correct?