### PR TITLE
Added fuzzer crash samples from past issues as Carbon files in testdata

### DIFF
--- a/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+choice Ch {
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon:[[@LINE+1]]: could not resolve 'Ch'
+  Opt(Ch)
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
+++ b/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+fn f() -> auto {
+   // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
+   __await;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
+++ b/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+fn f() {
+  __continuation k {
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon:[[@LINE+1]]: could not resolve 'k'
+  __run k;
+  }
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/function/fail_invalid_fnty.carbon
+++ b/explorer/testdata/function/fail_invalid_fnty.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+// CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/function/fail_invalid_fnty.carbon:[[@LINE+3]]: type error in negation
+// CHECK: expected: i32
+// CHECK: actual: Bool
+fn f(g: __Fn(-true) -> true) {
+}
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
For issues #1248, #1249, #1257, #1263
Before the samples were only recorded as fuzzer corpus files which are less 'durable'