### PR TITLE
Design overview update part 4: C and C++ Interop

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2387,7 +2387,8 @@ When interoperating with already compiled C++ object code or shared libraries,
 the C++ interop may be significantly less feature rich than otherwise. This is
 an open area for us to explore, but we expect to require re-compiling C++ code
 in order to get the full ergonomic and performance benefits when interoperating
-with Carbon. For example, recompilation lets us ensure Carbon and C++ can use the same representation for key vocabulary types.
+with Carbon. For example, recompilation lets us ensure Carbon and C++ can use
+the same representation for key vocabulary types.
 
 However, we expect to have full support for the C ABI when interoperating with
 already-compiled C object code or shared libraries. We expect Carbon's bridge


### PR DESCRIPTION
This follows #1274 , #1325 , and #1328 . It fills in the "Bidirectional interoperability with C and C++" section.