### PR TITLE
Changed CARBON_CHECK back to use std::abort()

### DIFF
--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -12,11 +12,14 @@ namespace {
 TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 
 TEST(CheckTest, CheckFalse) {
-  // TODO: figure out why we can't use \\d+ instead of .+ in these patterns.
+  // TODO: Carbon version of googletest uses Posix RE, so can't use \d.
+  // RE2 was added to googletest in e33c2b24ca3e13df961ed369f7ed21e4cfcf9eec.
   ASSERT_DEATH({ CARBON_CHECK(false); },
-               "Stack trace:\n"
-               ".+\n"
-               "CHECK failure at common/check_test.cpp:.+: false\n");
+               "CHECK failure at common/check_test.cpp:[0-9]+: false\n"
+               "Please report issues to "
+               "https://github.com/carbon-language/carbon-lang/issues and "
+               "include the crash backtrace.\n"
+               ".*Stack dump:\n");
 }
 
 TEST(CheckTest, CheckTrueCallbackNotUsed) {


### PR DESCRIPTION
Fixes #1338

std::abort() in CARBON_CHECK was changed to _exit in PR #1216 so that crash message is printed at the bottom on stack trace for ease of debugging. However, this change made CARBON_CHECK() invisible to fuzzers, and also makes it a bit harder to debug in e.g. `lldb` as detailed in Option 3 of #1338.