### PR TITLE
Workaround LLVM compiler bug when fuzzing.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -266,14 +266,27 @@ def _impl(ctx):
     # both are enabled.
     minimal_optimization_flags = feature(
         name = "minimal_optimization_flags",
-        flag_sets = [flag_set(
-            actions = codegen_compile_actions,
-            flag_groups = [flag_group(flags = [
-                "-O1",
-                "-mllvm",
-                "-fast-isel",
-            ])],
-        )],
+        flag_sets = [
+            flag_set(
+                actions = codegen_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-O1",
+                ])],
+            ),
+            # Use a conditional flag set for enabling the fast instruction
+            # selector to work around an LLVM bug:
+            # https://github.com/llvm/llvm-project/issues/56133
+            flag_set(
+                actions = codegen_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-mllvm",
+                    "-fast-isel",
+                ])],
+                with_features = [
+                    with_feature_set(not_features = ["fuzzer"]),
+                ],
+            ),
+        ],
     )
     default_optimization_flags = feature(
         name = "default_optimization_flags",


### PR DESCRIPTION
Fixes #1173

There is a long standing crash in the LLVM code generator that we manage
to hit when fuzzing. Disable the fast instruction selector in the
fuzzing config to avoid it. I reduced a test case and filed the LLVM bug
here: https://github.com/llvm/llvm-project/issues/56133