### PR TITLE
Add workaround for StatementBlock declaration circularity

### DIFF
--- a/toolchain/semantics/nodes/function.h
+++ b/toolchain/semantics/nodes/function.h
@@ -13,6 +13,11 @@
 #include "toolchain/semantics/nodes/declared_name.h"
 #include "toolchain/semantics/nodes/pattern_binding.h"
 
+// TODO: StatementBlock has some circularity in its forward declarations that
+// needs to be fixed. These includes are a workaround.
+#include "toolchain/semantics/nodes/expression_statement.h"
+#include "toolchain/semantics/nodes/return.h"
+
 namespace Carbon::Semantics {
 
 // Represents `fn name(params...) [-> return_expr] body`.


### PR DESCRIPTION
This won't be visible everywhere, but I think something's needed -- this workaround is temporary while I work on a bigger change to semantics.