### PR TITLE
Run brew install on all platforms, and stop searching for clang-format

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,7 @@ jobs:
       # issues fetching and installing the toolchain.
       - name: Setup LLVM and Clang
         run: |
+          brew update
           brew install --force-bottle --only-dependencies llvm
           brew install --force-bottle --force --verbose llvm
           brew info llvm


### PR DESCRIPTION
This was noticed because macos stopped installing the brew llvm, and they don't have clang-format. However, our tests don't actually _need_ clang-format (and even if they did, we should probably match the pre-commit version), so it seems superfluous to check for.

Keeping brew because there's an advantage to consistency on tool versions, just running it on all platforms instead of linux-only.
