### PR TITLE
Fix missing actions in our Bazel toolchain.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -25,15 +25,10 @@ load(
     "sysroot_dir",
 )
 
-all_compile_actions = [
+all_c_compile_actions = [
     ACTION_NAMES.c_compile,
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
     ACTION_NAMES.assemble,
     ACTION_NAMES.preprocess_assemble,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-    ACTION_NAMES.cpp_module_codegen,
 ]
 
 all_cpp_compile_actions = [
@@ -43,6 +38,8 @@ all_cpp_compile_actions = [
     ACTION_NAMES.cpp_module_compile,
     ACTION_NAMES.cpp_module_codegen,
 ]
+
+all_compile_actions = all_c_compile_actions + all_cpp_compile_actions
 
 preprocessor_compile_actions = [
     ACTION_NAMES.c_compile,
@@ -84,7 +81,7 @@ def _impl(ctx):
 
     action_configs = [
         action_config(action_name = name, enabled = True, tools = [tool(path = llvm_bindir + "/clang")])
-        for name in [ACTION_NAMES.c_compile]
+        for name in all_c_compile_actions
     ] + [
         action_config(action_name = name, enabled = True, tools = [tool(path = llvm_bindir + "/clang++")])
         for name in all_cpp_compile_actions


### PR DESCRIPTION
There were compile actions that should use `clang` that we didn't
include because they aren't *technically* C compile actions. For our
toolchain though, we treat them as such, so create a list of actions
that we compile equivalently to C, and use that to set it up.

This will fix a problem with top-of-tree LLVM where we need to handle
preprocessed assembly files.