### PR TITLE
Changed fuzzer_util_test to ignore parsing errors to to minimize friction when making fuzzer proto changes

### DIFF
--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -86,6 +86,7 @@ cc_test(
     ],
     data = [
         ":fuzzer_corpus_files",
+        "//explorer:standard_libraries",
     ],
     deps = [
         ":fuzzer_util",


### PR DESCRIPTION
At least one successful parse is still required for the test to pass.