### PR TITLE
Change raw string literal syntax: `[#]*"` represents single-line string and `[#]*'''` represents block string

### DIFF
--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -98,19 +98,19 @@ This sequence is enclosed in `"`s. For example, this is a simple string literal:
 var String: lucius = "The strings, my lord, are false.";
 ```
 
-A _block string literal_ starts with `"""`, followed by an optional file type
-indicator, followed by a newline, and ends at the next instance of three double
-quotation marks whose first `"` is not part of a `\"` escape sequence. The
-closing `"""` shall be the first non-whitespace characters on that line. The
-lines between the opening line and the closing line (exclusive) are _content
-lines_. The content lines shall not contain `\` characters that do not form part
-of an escape sequence. Three consecutive quotes (`"""`) always start a _block
-string literal_. For example, this is an invalid block string literal, rather
-than 3 simple literals.
+A _block string_ literal starts with `"""`. Characters on the same line
+following the `"""` are an optional file type indicator. The literal ends at the
+next instance of three double quotation marks whose first `"` is not part of a
+`\"` escape sequence. The closing `"""` shall be the first non-whitespace
+characters on that line. The lines between the opening line and the closing line
+(exclusive) are _content lines_. The content lines shall not contain `\`
+characters that do not form part of an escape sequence.
+
+This is an invalid block string literal, rather than 3 simple literals.
 
 ```carbon
-// This string literal is invalid because it starts with `"""` but does not contain
-//  a new line. It does not represent the three tokens `""`, `"abc"` and `""`.
+// This string literal is invalid because `abc"""` does not form a valid file
+// type indicator. It does not represent the three tokens `""`, `"abc"` and `""`.
 var String: block = """abc""";
 ```
 
@@ -300,10 +300,15 @@ var String: z = ##"Raw strings #"nesting"#"##;
 var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
 ```
 
-Note that only a raw block string literal can begin with `#"""`.
+Extending simple block string literals, a valid raw block string literal opening
+delimiter (for example, #""") always results in block string handling. For
+example, #"""# begins a raw block string literal with a file type indicator of
+#, rather than the possible interpretation as a raw simple string literal. This
+is true even when the file type indicator is invalid, as with #"""foo"""#.
 
 ```carbon
-// This is an invalid raw block string literal with no new line.
+// This is an invalid raw block string literal with no new line before
+// the closing `"""#`.
 // It is not equivalent to "\"\"Invalid raw block string literal\"\"".
 var String: ambig1 = #"""Invalid raw block string literal"""#;
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -307,8 +307,9 @@ example, #"""# begins a raw block string literal with a file type indicator of
 is true even when the file type indicator is invalid, as with #"""foo"""#.
 
 ```carbon
-// This is an invalid raw block string literal with no new line before
-// the closing `"""#`.
+// This is an invalid raw block string literal with the first `"` of
+// the closing `"""#` not being the first non-whitespace character
+// of its line.
 // It is not equivalent to "\"\"Invalid raw block string literal\"\"".
 var String: ambig1 = #"""Invalid raw block string literal"""#;
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -111,7 +111,7 @@ than 3 simple literals.
 ```carbon
 // This string literal is invalid because it starts with `"""` but does not contain
 //  a new line. It does not represent the three tokens `""`, `"abc"` and `""`.
-var String: lucius = """abc""";
+var String: block = """abc""";
 ```
 
 The _indentation_ of a block string literal is the sequence of horizontal

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -104,7 +104,15 @@ quotation marks whose first `"` is not part of a `\"` escape sequence. The
 closing `"""` shall be the first non-whitespace characters on that line. The
 lines between the opening line and the closing line (exclusive) are _content
 lines_. The content lines shall not contain `\` characters that do not form part
-of an escape sequence.
+of an escape sequence. Three consecutive quotes (`"""`) always start a _block
+string literal_. For example, this is an invalid block string literal, rather
+than 3 simple literals.
+
+```carbon
+// This string literal is invalid because it starts with `"""` but does not contain
+//  a new line. It does not represent the three tokens `""`, `"abc"` and `""`.
+var String: lucius = """abc""";
+```
 
 The _indentation_ of a block string literal is the sequence of horizontal
 whitespace preceding the closing `"""`. Each non-empty content line shall begin
@@ -292,29 +300,19 @@ var String: z = ##"Raw strings #"nesting"#"##;
 var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
 ```
 
-Note that both a raw simple string literal and a raw block string literal can
-begin with `#"""`. These cases can be distinguished by the presence or absence
-of additional `"`s later in the same line:
-
--   In a raw simple string literal, there must be a `"` and one or more `#`s
-    later in the same line terminating the string.
--   In a raw block string literal, the rest of the line is a file type
-    indicator, which can contain neither `"` nor `#`.
+Note that only a raw block string literal can begin with `#"""`.
 
 ```carbon
-// This string is a single-line raw string literal.
-// The contents of this string start and end with exactly two "s.
-var String: ambig1 = #"""This is a raw string literal starting with """#;
+// This is an invalid raw block string literal with no new line.
+// It is not equivalent to "\"\"Invalid raw block string literal\"\"".
+var String: ambig1 = #"""Invalid raw block string literal"""#;
 
-// This string is a raw block string literal with file-type 'This', whose
-// contents start with "is a ".
-var String: ambig2 = #"""This
-  is a block string literal with file type 'This', first character 'i',
-  and last character 'X': X\#
-  """#;
+// This is an invalid raw block string literal with no closing `"""#`.
+// It is not equivalent to "\"".
+var String: ambig2 = #"""#;
 
 // This is a single-line raw string literal, equivalent to "\"".
-var String: ambig3 = #"""#;
+var String: clear = #"\#""#;
 ```
 
 ### Encoding

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -24,9 +24,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Overview
 
 Carbon supports both simple literals that are single-line using one double
-quotation mark (`"`) and block literals that are multi-line using three double
-quotation marks (`"""`). A block string literal may have a file type indicator
-after the first `"""`; this does not affect the string itself, but may assist
+quotation mark (`"`) and block literals that are multi-line using three single
+quotation marks (`'''`). A block string literal may have a file type indicator
+after the first `'''`; this does not affect the string itself, but may assist
 other tooling. For example:
 
 ```carbon
@@ -34,22 +34,22 @@ other tooling. For example:
 var simple: String = "example";
 
 // Block string literal:
-var block: String = """
+var block: String = '''
     The winds grow high; so do your stomachs, lords.
     How irksome is this music to my heart!
     When such strings jar, what hope of harmony?
     I pray, my lords, let me compound this strife.
         -- History of Henry VI, Part II, Act II, Scene 1, W. Shakespeare
-    """;
+    ''';
 
 // Block string literal with file type indicator:
-var code_block: String = """cpp
+var code_block: String = '''cpp
     #include <iostream>
     int main() {
         std::cout << "Hello world!";
         return 0;
     }
-    """
+    '''
 ```
 
 The indentation of a block string literal's terminating line is removed from all
@@ -72,7 +72,7 @@ var newline: String = "line one\nline two";
 var raw: String = #"line one\nstill line one"#;
 
 // Raw simple string literal with newline escape sequence:
-var raw_newline: String = "#line one\#nline two"#;
+var raw_newline: String = #"line one\#nline two"#;
 ```
 
 ## Details
@@ -98,22 +98,26 @@ This sequence is enclosed in `"`s. For example, this is a simple string literal:
 var String: lucius = "The strings, my lord, are false.";
 ```
 
-A _block string_ literal starts with `"""`. Characters on the same line
-following the `"""` are an optional file type indicator. The literal ends at the
-next instance of three double quotation marks whose first `"` is not part of a
-`\"` escape sequence. The closing `"""` shall be the first non-whitespace
+Adjacent string literals are disallowed, like the following:
+
+```carbon
+// The three adjacent simple string literals `""`, `"abc"` and `""` are invalid.
+var String: block = """abc""";
+```
+
+String literals starting with triple double quotation marks `"""` are adjacent
+string literals. It is important to reject and diagnose them.
+
+A _block string_ literal starts with `'''`. Characters on the same line
+following the `'''` are an optional file type indicator. The literal ends at the
+next instance of three single quotation marks whose first `'` is not part of a
+`\"` escape sequence. The closing `'''` shall be the first non-whitespace
 characters on that line. The lines between the opening line and the closing line
 (exclusive) are _content lines_. The content lines shall not contain `\`
 characters that do not form part of an escape sequence.
 
-```carbon
-// This string literal is invalid because `abc"""` does not form a valid file
-// type indicator. It does not represent the three tokens `""`, `"abc"` and `""`.
-var String: block = """abc""";
-```
-
 The _indentation_ of a block string literal is the sequence of horizontal
-whitespace preceding the closing `"""`. Each non-empty content line shall begin
+whitespace preceding the closing `'''`. Each non-empty content line shall begin
 with the indentation of the string literal. The content of the literal is formed
 as follows:
 
@@ -128,16 +132,16 @@ as follows:
 A content line is considered empty if it contains only whitespace characters.
 
 ```carbon
-var String: w = """
+var String: w = '''
   This is a string literal. Its first character is 'T' and its last character is
   a newline character. It contains another newline between 'is' and 'a'.
-  """;
+  ''';
 
-// This string literal is invalid because the """ after 'closing' terminates
+// This string literal is invalid because the ''' after 'closing' terminates
 // the literal, but is not at the start of the line.
-var String: invalid = """
-  error: closing """ is not on its own line.
-  """;
+var String: invalid = '''
+  error: closing ''' is not on its own line.
+  ''';
 ```
 
 A _file type indicator_ is any sequence of non-whitespace characters other than
@@ -149,10 +153,10 @@ the string literal's content.
 ```carbon
 // This is a block string literal. Its first two characters are spaces, and its
 // last character is a line feed. It has a file type of 'c++'.
-var String: starts_with_whitespace = """c++
+var String: starts_with_whitespace = '''c++
     int x = 1; // This line starts with two spaces.
     int y = 2; // This line starts with two spaces.
-  """;
+  ''';
 ```
 
 The file type indicator might contain semantic information beyond the file type
@@ -232,7 +236,7 @@ trailing whitespace is replaced by a line feed character, so a `\` followed by
 horizontal whitespace followed by a line terminator removes the whitespace up to
 and including the line terminator. Unlike in Rust, but like in Swift, leading
 whitespace on the line after an escaped newline is not removed, other than
-whitespace that matches the indentation of the terminating `"""`.
+whitespace that matches the indentation of the terminating `'''`.
 
 A character sequence starting with a backslash that doesn't match any known
 escape sequence is invalid. Whitespace characters other than space and, for
@@ -254,15 +258,15 @@ var String: fret = "I would 'twere something that would fret the string,\n" +
 var String: password = "\u{1F3F9}2";
 
 // This string contains no newline characters.
-var String: type_mismatch = """
+var String: type_mismatch = '''
   Shall I compare thee to a summer's day? Thou art \
   more lovely and more temperate.\
-  """;
+  ''';
 
-var String: trailing_whitespace = """
+var String: trailing_whitespace = '''
   This line ends in a space followed by a newline. \n\
       This line starts with four spaces.
-  """;
+  ''';
 ```
 
 ### Raw string literals
@@ -272,38 +276,31 @@ of string literals can be customized by prefixing the opening delimiter with _N_
 `#` characters. A closing delimiter for such a string is only recognized if it
 is followed by _N_ `#` characters, and similarly, escape sequences in such
 string literals are recognized only if the `\` is also followed by _N_ `#`
-characters. A `\`, `"`, or `"""` not followed by _N_ `#` characters has no
+characters. A `\`, `"`, or `'''` not followed by _N_ `#` characters has no
 special meaning.
 
 | Opening delimiter | Escape sequence introducer    | Closing delimiter |
 | ----------------- | ----------------------------- | ----------------- |
-| `"` / `"""`       | `\` (for example, `\n`)       | `"` / `"""`       |
-| `#"` / `#"""`     | `\#` (for example, `\#n`)     | `"#` / `"""#`     |
-| `##"` / `##"""`   | `\##` (for example, `\##n`)   | `"##` / `"""##`   |
-| `###"` / `###"""` | `\###` (for example, `\###n`) | `"###` / `"""###` |
+| `"` / `'''`       | `\` (for example, `\n`)       | `"` / `'''`       |
+| `#"` / `#'''`     | `\#` (for example, `\#n`)     | `"#` / `'''#`     |
+| `##"` / `##'''`   | `\##` (for example, `\##n`)   | `"##` / `'''##`   |
+| `###"` / `###'''` | `\###` (for example, `\###n`) | `"###` / `'''###` |
 | ...               | ...                           | ...               |
 
 For example:
 
 ```carbon
-var String: x = #"""
+var String: x = #'''
   This is the content of the string. The 'T' is the first character
   of the string.
-  """ <-- This is not the end of the string.
-  """#;
+  ''' <-- This is not the end of the string.
+  '''#;
   // But the preceding line does end the string.
 // OK, final character is \
 var String: y = #"Hello\"#;
 var String: z = ##"Raw strings #"nesting"#"##;
 var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
 ```
-
-Extending simple block string literals, a valid raw block string literal opening
-delimiter (for example, `#"""`) always results in block string handling. For
-example, `#"""#` begins a raw block string literal with a file type indicator of
-`#`, rather than the possible interpretation as a raw simple string literal.
-This is true even when the file type indicator is invalid, as with
-`#"""foo"""#`.
 
 ### Encoding
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -301,8 +301,9 @@ var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
 Extending simple block string literals, a valid raw block string literal opening
 delimiter (for example, `#"""`) always results in block string handling. For
 example, `#"""#` begins a raw block string literal with a file type indicator of
-`#`, rather than the possible interpretation as a raw simple string literal. This
-is true even when the file type indicator is invalid, as with `#"""foo"""#`.
+`#`, rather than the possible interpretation as a raw simple string literal.
+This is true even when the file type indicator is invalid, as with
+`#"""foo"""#`.
 
 ### Encoding
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -24,32 +24,32 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Overview
 
 Carbon supports both simple literals that are single-line using one double
-quotation mark (`"`) and block literals that are multi-line using three double
-quotation marks (`"""`). A block string literal may have a file type indicator
-after the first `"""`; this does not affect the string itself, but may assist
-other tooling. For example:
+quotation mark (`"`) and block literals that are multi-line using a hashtags
+followed by three double quotation marks (`#"""`). A block string literal may
+have a file type indicator after the first `#"""`; this does not affect the
+string itself, but may assist other tooling. For example:
 
 ```carbon
 // Simple string literal:
 var simple: String = "example";
 
 // Block string literal:
-var block: String = """
+var block: String = #"""
     The winds grow high; so do your stomachs, lords.
     How irksome is this music to my heart!
     When such strings jar, what hope of harmony?
     I pray, my lords, let me compound this strife.
         -- History of Henry VI, Part II, Act II, Scene 1, W. Shakespeare
-    """;
+    """#;
 
 // Block string literal with file type indicator:
-var code_block: String = """cpp
+var code_block: String = #"""cpp
     #include <iostream>
     int main() {
         std::cout << "Hello world!";
         return 0;
     }
-    """
+    """#
 ```
 
 The indentation of a block string literal's terminating line is removed from all
@@ -62,7 +62,9 @@ character or code unit sequences, such as `\n` for a newline character. Raw
 string literals are additionally delimited with one or more `#`; these require
 an equal number of hash symbols (`#`) after the `\` to indicate an escape
 sequence. Raw string literals are used to more easily write literal `\`s in
-strings. Both simple and block string literals have raw forms. For example:
+strings. Block string literals are raw string literals and have other raw forms
+by additionally delimited with one or more `#`. Simple string literals also have
+raw forms. For example:
 
 ```carbon
 // Raw simple string literal with newline escape sequence:
@@ -98,16 +100,16 @@ This sequence is enclosed in `"`s. For example, this is a simple string literal:
 var String: lucius = "The strings, my lord, are false.";
 ```
 
-A _block string literal_ starts with `"""`, followed by an optional file type
-indicator, followed by a newline, and ends at the next instance of three double
-quotation marks whose first `"` is not part of a `\"` escape sequence. The
-closing `"""` shall be the first non-whitespace characters on that line. The
-lines between the opening line and the closing line (exclusive) are _content
-lines_. The content lines shall not contain `\` characters that do not form part
-of an escape sequence.
+`#"""` marks the start of a _block string literal_, which ends at the next
+instance of `"""#` quotation marks whose first `"` is not part of a `\"` escape
+sequence. The starting `#"""` is followed by an optional file type indicator and
+a newline. The closing `"""#` shall be the first non-whitespace characters on
+its line. The lines between the opening line and the closing line (exclusive)
+are _content lines_. The content lines shall not contain `\#` characters that do
+not form part of an escape sequence.
 
 The _indentation_ of a block string literal is the sequence of horizontal
-whitespace preceding the closing `"""`. Each non-empty content line shall begin
+whitespace preceding the closing `"""#`. Each non-empty content line shall begin
 with the indentation of the string literal. The content of the literal is formed
 as follows:
 
@@ -122,16 +124,16 @@ as follows:
 A content line is considered empty if it contains only whitespace characters.
 
 ```carbon
-var String: w = """
+var String: w = #"""
   This is a string literal. Its first character is 'T' and its last character is
   a newline character. It contains another newline between 'is' and 'a'.
-  """;
+  """#;
 
-// This string literal is invalid because the """ after 'closing' terminates
+// This string literal is invalid because the """# after 'closing' terminates
 // the literal, but is not at the start of the line.
-var String: invalid = """
-  error: closing """ is not on its own line.
-  """;
+var String: invalid = #"""
+  error: closing """# is not on its own line.
+  """#;
 ```
 
 A _file type indicator_ is any sequence of non-whitespace characters other than
@@ -143,10 +145,10 @@ the string literal's content.
 ```carbon
 // This is a block string literal. Its first two characters are spaces, and its
 // last character is a line feed. It has a file type of 'c++'.
-var String: starts_with_whitespace = """c++
+var String: starts_with_whitespace = #"""c++
     int x = 1; // This line starts with two spaces.
     int y = 2; // This line starts with two spaces.
-  """;
+  """#;
 ```
 
 The file type indicator might contain semantic information beyond the file type
@@ -219,14 +221,14 @@ where a null byte should be followed by a decimal digit, `\x00` can be used
 instead: `"foo\x00123"`. The intent is to preserve the possibility of permitting
 decimal escape sequences in the future.
 
-A backslash followed by a line feed character is an escape sequence that
-produces no string contents. This escape sequence is _experimental_, and can
-only appear in block string literals. This escape sequence is processed after
-trailing whitespace is replaced by a line feed character, so a `\` followed by
+A `\#` followed by a line feed character is an escape sequence that produces no
+string contents. This escape sequence is _experimental_, and can only appear in
+block string literals. This escape sequence is processed after trailing
+whitespace is replaced by a line feed character, so a `\#` followed by
 horizontal whitespace followed by a line terminator removes the whitespace up to
 and including the line terminator. Unlike in Rust, but like in Swift, leading
 whitespace on the line after an escaped newline is not removed, other than
-whitespace that matches the indentation of the terminating `"""`.
+whitespace that matches the indentation of the terminating `"""#`.
 
 A character sequence starting with a backslash that doesn't match any known
 escape sequence is invalid. Whitespace characters other than space and, for
@@ -248,15 +250,15 @@ var String: fret = "I would 'twere something that would fret the string,\n" +
 var String: password = "\u{1F3F9}2";
 
 // This string contains no newline characters.
-var String: type_mismatch = """
+var String: type_mismatch = #"""
   Shall I compare thee to a summer's day? Thou art \
   more lovely and more temperate.\
-  """;
+  """#;
 
-var String: trailing_whitespace = """
+var String: trailing_whitespace = #"""
   This line ends in a space followed by a newline. \n\
       This line starts with four spaces.
-  """;
+  """#;
 ```
 
 ### Raw string literals
@@ -271,7 +273,7 @@ special meaning.
 
 | Opening delimiter | Escape sequence introducer    | Closing delimiter |
 | ----------------- | ----------------------------- | ----------------- |
-| `"` / `"""`       | `\` (for example, `\n`)       | `"` / `"""`       |
+| `"`               | `\` (for example, `\n`)       | `"`               |
 | `#"` / `#"""`     | `\#` (for example, `\#n`)     | `"#` / `"""#`     |
 | `##"` / `##"""`   | `\##` (for example, `\##n`)   | `"##` / `"""##`   |
 | `###"` / `###"""` | `\###` (for example, `\###n`) | `"###` / `"""###` |
@@ -280,41 +282,16 @@ special meaning.
 For example:
 
 ```carbon
-var String: x = #"""
+var String: x = ##"""
   This is the content of the string. The 'T' is the first character
   of the string.
   """ <-- This is not the end of the string.
-  """#;
+  """##;
   // But the preceding line does end the string.
 // OK, final character is \
 var String: y = #"Hello\"#;
 var String: z = ##"Raw strings #"nesting"#"##;
 var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
-```
-
-Note that both a raw simple string literal and a raw block string literal can
-begin with `#"""`. These cases can be distinguished by the presence or absence
-of additional `"`s later in the same line:
-
--   In a raw simple string literal, there must be a `"` and one or more `#`s
-    later in the same line terminating the string.
--   In a raw block string literal, the rest of the line is a file type
-    indicator, which can contain neither `"` nor `#`.
-
-```carbon
-// This string is a single-line raw string literal.
-// The contents of this string start and end with exactly two "s.
-var String: ambig1 = #"""This is a raw string literal starting with """#;
-
-// This string is a raw block string literal with file-type 'This', whose
-// contents start with "is a ".
-var String: ambig2 = #"""This
-  is a block string literal with file type 'This', first character 'i',
-  and last character 'X': X\#
-  """#;
-
-// This is a single-line raw string literal, equivalent to "\"".
-var String: ambig3 = #"""#;
 ```
 
 ### Encoding
@@ -347,3 +324,5 @@ string in the type system. In such string literals, we should consider rejecting
 
 -   Proposal
     [#199: String literals](https://github.com/carbon-language/carbon-lang/pull/199)
+-   Proposal
+    [#1360: Change raw string literal syntax: requiring """ to only be used for block strings](https://github.com/SlaterLatiao/carbon-lang/blob/raw_string_literal_proposal/proposals/p1360.md)

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -299,10 +299,10 @@ var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
 ```
 
 Extending simple block string literals, a valid raw block string literal opening
-delimiter (for example, #""") always results in block string handling. For
-example, #"""# begins a raw block string literal with a file type indicator of
-#, rather than the possible interpretation as a raw simple string literal. This
-is true even when the file type indicator is invalid, as with #"""foo"""#.
+delimiter (for example, `#"""`) always results in block string handling. For
+example, `#"""#` begins a raw block string literal with a file type indicator of
+`#`, rather than the possible interpretation as a raw simple string literal. This
+is true even when the file type indicator is invalid, as with `#"""foo"""#`.
 
 ### Encoding
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -106,8 +106,6 @@ characters on that line. The lines between the opening line and the closing line
 (exclusive) are _content lines_. The content lines shall not contain `\`
 characters that do not form part of an escape sequence.
 
-This is an invalid block string literal, rather than 3 simple literals.
-
 ```carbon
 // This string literal is invalid because `abc"""` does not form a valid file
 // type indicator. It does not represent the three tokens `""`, `"abc"` and `""`.
@@ -305,21 +303,6 @@ delimiter (for example, #""") always results in block string handling. For
 example, #"""# begins a raw block string literal with a file type indicator of
 #, rather than the possible interpretation as a raw simple string literal. This
 is true even when the file type indicator is invalid, as with #"""foo"""#.
-
-```carbon
-// This is an invalid raw block string literal with the first `"` of
-// the closing `"""#` not being the first non-whitespace character
-// of its line.
-// It is not equivalent to "\"\"Invalid raw block string literal\"\"".
-var String: ambig1 = #"""Invalid raw block string literal"""#;
-
-// This is an invalid raw block string literal with no closing `"""#`.
-// It is not equivalent to "\"".
-var String: ambig2 = #"""#;
-
-// This is a single-line raw string literal, equivalent to "\"".
-var String: clear = #"\#""#;
-```
 
 ### Encoding
 

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -24,32 +24,32 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Overview
 
 Carbon supports both simple literals that are single-line using one double
-quotation mark (`"`) and block literals that are multi-line using a hashtags
-followed by three double quotation marks (`#"""`). A block string literal may
-have a file type indicator after the first `#"""`; this does not affect the
-string itself, but may assist other tooling. For example:
+quotation mark (`"`) and block literals that are multi-line using three double
+quotation marks (`"""`). A block string literal may have a file type indicator
+after the first `"""`; this does not affect the string itself, but may assist
+other tooling. For example:
 
 ```carbon
 // Simple string literal:
 var simple: String = "example";
 
 // Block string literal:
-var block: String = #"""
+var block: String = """
     The winds grow high; so do your stomachs, lords.
     How irksome is this music to my heart!
     When such strings jar, what hope of harmony?
     I pray, my lords, let me compound this strife.
         -- History of Henry VI, Part II, Act II, Scene 1, W. Shakespeare
-    """#;
+    """;
 
 // Block string literal with file type indicator:
-var code_block: String = #"""cpp
+var code_block: String = """cpp
     #include <iostream>
     int main() {
         std::cout << "Hello world!";
         return 0;
     }
-    """#
+    """
 ```
 
 The indentation of a block string literal's terminating line is removed from all
@@ -62,9 +62,7 @@ character or code unit sequences, such as `\n` for a newline character. Raw
 string literals are additionally delimited with one or more `#`; these require
 an equal number of hash symbols (`#`) after the `\` to indicate an escape
 sequence. Raw string literals are used to more easily write literal `\`s in
-strings. Block string literals are raw string literals and have other raw forms
-by additionally delimited with one or more `#`. Simple string literals also have
-raw forms. For example:
+strings. Both simple and block string literals have raw forms. For example:
 
 ```carbon
 // Raw simple string literal with newline escape sequence:
@@ -100,16 +98,16 @@ This sequence is enclosed in `"`s. For example, this is a simple string literal:
 var String: lucius = "The strings, my lord, are false.";
 ```
 
-`#"""` marks the start of a _block string literal_, which ends at the next
-instance of `"""#` quotation marks whose first `"` is not part of a `\"` escape
-sequence. The starting `#"""` is followed by an optional file type indicator and
-a newline. The closing `"""#` shall be the first non-whitespace characters on
-its line. The lines between the opening line and the closing line (exclusive)
-are _content lines_. The content lines shall not contain `\#` characters that do
-not form part of an escape sequence.
+A _block string literal_ starts with `"""`, followed by an optional file type
+indicator, followed by a newline, and ends at the next instance of three double
+quotation marks whose first `"` is not part of a `\"` escape sequence. The
+closing `"""` shall be the first non-whitespace characters on that line. The
+lines between the opening line and the closing line (exclusive) are _content
+lines_. The content lines shall not contain `\` characters that do not form part
+of an escape sequence.
 
 The _indentation_ of a block string literal is the sequence of horizontal
-whitespace preceding the closing `"""#`. Each non-empty content line shall begin
+whitespace preceding the closing `"""`. Each non-empty content line shall begin
 with the indentation of the string literal. The content of the literal is formed
 as follows:
 
@@ -124,16 +122,16 @@ as follows:
 A content line is considered empty if it contains only whitespace characters.
 
 ```carbon
-var String: w = #"""
+var String: w = """
   This is a string literal. Its first character is 'T' and its last character is
   a newline character. It contains another newline between 'is' and 'a'.
-  """#;
+  """;
 
-// This string literal is invalid because the """# after 'closing' terminates
+// This string literal is invalid because the """ after 'closing' terminates
 // the literal, but is not at the start of the line.
-var String: invalid = #"""
-  error: closing """# is not on its own line.
-  """#;
+var String: invalid = """
+  error: closing """ is not on its own line.
+  """;
 ```
 
 A _file type indicator_ is any sequence of non-whitespace characters other than
@@ -145,10 +143,10 @@ the string literal's content.
 ```carbon
 // This is a block string literal. Its first two characters are spaces, and its
 // last character is a line feed. It has a file type of 'c++'.
-var String: starts_with_whitespace = #"""c++
+var String: starts_with_whitespace = """c++
     int x = 1; // This line starts with two spaces.
     int y = 2; // This line starts with two spaces.
-  """#;
+  """;
 ```
 
 The file type indicator might contain semantic information beyond the file type
@@ -221,14 +219,14 @@ where a null byte should be followed by a decimal digit, `\x00` can be used
 instead: `"foo\x00123"`. The intent is to preserve the possibility of permitting
 decimal escape sequences in the future.
 
-A `\#` followed by a line feed character is an escape sequence that produces no
-string contents. This escape sequence is _experimental_, and can only appear in
-block string literals. This escape sequence is processed after trailing
-whitespace is replaced by a line feed character, so a `\#` followed by
+A backslash followed by a line feed character is an escape sequence that
+produces no string contents. This escape sequence is _experimental_, and can
+only appear in block string literals. This escape sequence is processed after
+trailing whitespace is replaced by a line feed character, so a `\` followed by
 horizontal whitespace followed by a line terminator removes the whitespace up to
 and including the line terminator. Unlike in Rust, but like in Swift, leading
 whitespace on the line after an escaped newline is not removed, other than
-whitespace that matches the indentation of the terminating `"""#`.
+whitespace that matches the indentation of the terminating `"""`.
 
 A character sequence starting with a backslash that doesn't match any known
 escape sequence is invalid. Whitespace characters other than space and, for
@@ -250,15 +248,15 @@ var String: fret = "I would 'twere something that would fret the string,\n" +
 var String: password = "\u{1F3F9}2";
 
 // This string contains no newline characters.
-var String: type_mismatch = #"""
+var String: type_mismatch = """
   Shall I compare thee to a summer's day? Thou art \
   more lovely and more temperate.\
-  """#;
+  """;
 
-var String: trailing_whitespace = #"""
+var String: trailing_whitespace = """
   This line ends in a space followed by a newline. \n\
       This line starts with four spaces.
-  """#;
+  """;
 ```
 
 ### Raw string literals
@@ -273,7 +271,7 @@ special meaning.
 
 | Opening delimiter | Escape sequence introducer    | Closing delimiter |
 | ----------------- | ----------------------------- | ----------------- |
-| `"`               | `\` (for example, `\n`)       | `"`               |
+| `"` / `"""`       | `\` (for example, `\n`)       | `"` / `"""`       |
 | `#"` / `#"""`     | `\#` (for example, `\#n`)     | `"#` / `"""#`     |
 | `##"` / `##"""`   | `\##` (for example, `\##n`)   | `"##` / `"""##`   |
 | `###"` / `###"""` | `\###` (for example, `\###n`) | `"###` / `"""###` |
@@ -282,16 +280,41 @@ special meaning.
 For example:
 
 ```carbon
-var String: x = ##"""
+var String: x = #"""
   This is the content of the string. The 'T' is the first character
   of the string.
   """ <-- This is not the end of the string.
-  """##;
+  """#;
   // But the preceding line does end the string.
 // OK, final character is \
 var String: y = #"Hello\"#;
 var String: z = ##"Raw strings #"nesting"#"##;
 var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
+```
+
+Note that both a raw simple string literal and a raw block string literal can
+begin with `#"""`. These cases can be distinguished by the presence or absence
+of additional `"`s later in the same line:
+
+-   In a raw simple string literal, there must be a `"` and one or more `#`s
+    later in the same line terminating the string.
+-   In a raw block string literal, the rest of the line is a file type
+    indicator, which can contain neither `"` nor `#`.
+
+```carbon
+// This string is a single-line raw string literal.
+// The contents of this string start and end with exactly two "s.
+var String: ambig1 = #"""This is a raw string literal starting with """#;
+
+// This string is a raw block string literal with file-type 'This', whose
+// contents start with "is a ".
+var String: ambig2 = #"""This
+  is a block string literal with file type 'This', first character 'i',
+  and last character 'X': X\#
+  """#;
+
+// This is a single-line raw string literal, equivalent to "\"".
+var String: ambig3 = #"""#;
 ```
 
 ### Encoding
@@ -324,5 +347,3 @@ string in the type system. In such string literals, we should consider rejecting
 
 -   Proposal
     [#199: String literals](https://github.com/carbon-language/carbon-lang/pull/199)
--   Proposal
-    [#1360: Change raw string literal syntax: requiring """ to only be used for block strings](https://github.com/SlaterLatiao/carbon-lang/blob/raw_string_literal_proposal/proposals/p1360.md)

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -111,7 +111,7 @@ string literals. It is important to reject and diagnose them.
 A _block string_ literal starts with `'''`. Characters on the same line
 following the `'''` are an optional file type indicator. The literal ends at the
 next instance of three single quotation marks whose first `'` is not part of a
-`\"` escape sequence. The closing `'''` shall be the first non-whitespace
+`\'` escape sequence. The closing `'''` shall be the first non-whitespace
 characters on that line. The lines between the opening line and the closing line
 (exclusive) are _content lines_. The content lines shall not contain `\`
 characters that do not form part of an escape sequence.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -29,18 +29,19 @@ starting `[#]*"""` represents a block string and misunderstand the syntax.
 ## Background
 
 The design of
-[string literals](/docs/design/lexical_conventions/string_literals.md) specifies
-a block string literal to start with `[#]*"""`. Users may take for granted the
-other way around, where any string literal starting with `[#]*"""` is a block
-string literal. This does not hold true, however. There are two counter-cases,
-where `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
-which is equlivent to `"\""`. Neither is a block string literal and may be
-visually confusing.
+[string literals](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
+specifies a block string literal to start with `[#]*"""`. Users may take for
+granted the other way around, where any string literal starting with `[#]*"""`
+is a block string literal. This does not hold true, however. There are two
+counter-cases, where `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
+and `#"""#` which is equlivent to `"\""`. Neither is a block string literal and
+may be visually confusing.
 
 ## Proposal
 
 Enforce all block string literals to start with `[#]+"""` and always interpret
-`[#]+"""`, as the start of a block string literal.
+`[#]+"""`, as the start of a block string literal. This also means all block
+string literals are raw string literals.
 
 ## Details
 
@@ -50,7 +51,8 @@ the original design, but users won't mistake it as a block string literal
 because block string literals cannot start with `"""`. Second, a single-line
 string literal cannot start with `[#]+"""`. `"""abc"""` becomes an invalid block
 string literal, compared to a valid single-line string literal in the original
-design.
+design. More details can be found
+[here](/docs/design/lexical_conventions/string_literals.md).
 
 ## Rationale
 
@@ -61,11 +63,11 @@ because it avoids the confusions on the type of certain string literals.
 ## Alternatives considered
 
 The
-[current implementation](/docs/design/lexical_conventions/string_literals.md) is
-a considered alternative. Compared to this proposal, current implementation does
-not compromise on the convenience of using raw string literals by not requiring
-escaping of `"` that locates at the beginning of a single-line string literal.
-For example, as discussed in
+[current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
+is a considered alternative. Compared to this proposal, current implementation
+does not compromise on the convenience of using raw string literals by not
+requiring escaping of `"` that locates at the beginning of a single-line string
+literal. For example, as discussed in
 [issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
 `#"""#` is a natural way to write a string of `"`, but it becomes invalid with
 this proposal.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: block strings start with [#]+""" and [#]+""" only used for block strings
+# Change raw string literal syntax: requiring """ to only be used for block strings
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -29,19 +29,18 @@ starting `[#]*"""` represents a block string and misunderstand the syntax.
 ## Background
 
 The design of
-[string literals](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
-specifies a block string literal to start with `[#]*"""`. Users may take for
-granted the other way around, where any string literal starting with `[#]*"""`
-is a block string literal. This does not hold true, however. There are two
-counter-cases, where `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
-and `#"""#` which is equlivent to `"\""`. Neither is a block string literal and
-may be visually confusing.
+[string literals](/docs/design/lexical_conventions/string_literals.md) specifies
+a block string literal to start with `[#]*"""`. Users may take for granted the
+other way around, where any string literal starting with `[#]*"""` is a block
+string literal. This does not hold true, however. There are two counter-cases,
+where `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
+which is equlivent to `"\""`. Neither is a block string literal and may be
+visually confusing.
 
 ## Proposal
 
 Enforce all block string literals to start with `[#]+"""` and always interpret
-`[#]+"""`, as the start of a block string literal. This also means all block
-string literals are raw string literals.
+`[#]+"""`, as the start of a block string literal.
 
 ## Details
 
@@ -51,8 +50,7 @@ the original design, but users won't mistake it as a block string literal
 because block string literals cannot start with `"""`. Second, a single-line
 string literal cannot start with `[#]+"""`. `"""abc"""` becomes an invalid block
 string literal, compared to a valid single-line string literal in the original
-design. More details can be found
-[here](/docs/design/lexical_conventions/string_literals.md).
+design.
 
 ## Rationale
 
@@ -63,11 +61,11 @@ because it avoids the confusions on the type of certain string literals.
 ## Alternatives considered
 
 The
-[current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
-is a considered alternative. Compared to this proposal, current implementation
-does not compromise on the convenience of using raw string literals by not
-requiring escaping of `"` that locates at the beginning of a single-line string
-literal. For example, as discussed in
+[current implementation](/docs/design/lexical_conventions/string_literals.md) is
+a considered alternative. Compared to this proposal, current implementation does
+not compromise on the convenience of using raw string literals by not requiring
+escaping of `"` that locates at the beginning of a single-line string literal.
+For example, as discussed in
 [issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
 `#"""#` is a natural way to write a string of `"`, but it becomes invalid with
 this proposal.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: [#]\*""" always starts a block string
+# Change raw string literal syntax: `[#]\*"` represents single-line string and `[#]\*'''` represents block string
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -39,19 +39,17 @@ visually confusing.
 
 ## Proposal
 
-Always interpret `[#]*"""` as the start of a block string literal, even if the
-result is invalid code.
+Interpret `[#]*"` as the start of single-line string literals, and `[#]*'''` as
+the start of block string literals. Disallow adjacent string literals like
+`"""abc"""`.
 
 ## Details
 
-Two changes are made in this proposal. First, `"""` always starts a simple block
-string literal. Instead of the three tokens described above, `"""abc"""` will be
-parsed as an invalid simple block string literal due to quotes in the file type
-`abc"""`. Users can use extra spaces like `"" "abc" ""` to represent the three
-tokens represented in the original design. Second, `[#]+"""` always starts a raw
-block string literal. `#"""abc"""#` becomes an invalid block string literal,
-compared to a valid single-line string literal in the original design. More
-details can be found
+Users can easily distinguish single-line string literals from block string
+literals with the proposed change. Confusion on `"""abc"""` will be eliminated
+because adjacent string literals are invalid in the proposal. On the other hand,
+`#"""#` will be clear to the user of representing `"\""`, as `"""` does not
+represent a block string literal any more. More details can be found
 [here](/docs/design/lexical_conventions/string_literals.md).
 
 ## Rationale
@@ -64,22 +62,19 @@ because it avoids confusion on the type of certain string literals.
 
 The
 [current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
-is a considered alternative. Compared to this proposal, current implementation
-does not compromise on the convenience of using raw string literals by not
-requiring escaping of `"` that locates at the beginning of a single-line string
-literal. For example, as discussed in
+is a considered alternative. Compared to this proposal, the current
+implementation complicates the lexing. When the lexer sees `[#]+"""`, it
+temporarily accepts syntax of both string types because the type of the string
+is undecided. Specifically, it accepts vertical whitespaces even if they are not
+allowed in single-line strings. The type of the string won't be decided until
+the lexer sees a closing `"#` or a new line. In case of a closing `"#` where the
+string is single-line, the lexer will look back on the scanned characters for
+vertical whitespaces to decide if the single-line string is valid. The proposal
+simplifies the lexing without losing the convenience provided by the current
+implementation. For example, as discussed in
 [issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
-`#"""#` is a natural way to write a string of `"`, but it becomes invalid with
-this proposal.
-
-On the other hand, the current implementation complicates the lexing. When the
-lexer sees `[#]+"""`, it temporarily accepts syntax of both string types because
-the type of the string is undecided. Specifically, it accepts vertical
-whitespaces even if they are not allowed in single-line strings. The type of the
-string won't be decided until the lexer sees a closing `"#` or a new line. In
-case of a closing `"#` where the string is single-line, the lexer will look back
-on the scanned characters for vertical whitespaces to decide if the single-line
-string is valid.
+`#"""#` is a natural way to write a string of `"`. This is also supported by the
+proposal.
 
 The [proposal for string literals](/proposals/p0199.md) copmared string literals
 in different programming languages. C++ does not have the issue this PR trying

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -39,7 +39,7 @@ may be visually confusing.
 
 ## Proposal
 
-Always interpret `[#]*"""` as the start of a block string literal.
+Always interpret `[#]*"""` as the start of a block string literal, even if the result is invalid code.
 
 ## Details
 

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: requiring """ to only be used for block strings
+# Change raw string literal syntax: block strings start with [#]+""" and [#]+""" only used for block strings
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -32,24 +32,26 @@ The design of
 [string literals](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
 specifies a block string literal to start with `[#]*"""`. Users may take for
 granted the other way around, where any string literal starting with `[#]*"""`
-is a block string literal. This does not hold true, however. Two
-counter-cases are `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
-and `#"""#` which is equlivent to `"\""`. Neither is a block string literal and
-may be visually confusing.
+is a block string literal. This does not hold true, however. Two counter-cases
+are `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
+which is equlivent to `"\""`. Neither is a block string literal and may be
+visually confusing.
 
 ## Proposal
 
-Always interpret `[#]*"""` as the start of a block string literal, even if the result is invalid code.
+Always interpret `[#]*"""` as the start of a block string literal, even if the
+result is invalid code.
 
 ## Details
 
 Two changes are made in this proposal. First, `"""` always starts a simple block
 string literal. Instead of the three tokens described above, `"""abc"""` will be
-parsed as an invalid simple block string literal due to quotes in the file type `abc"""`. Users can use extra spaces
-like `"" "abc" ""` to represent the three tokens represented in the original
-design. Second, `[#]+"""` always starts a raw block string literal.
-`#"""abc"""#` becomes an invalid block string literal, compared to a valid
-single-line string literal in the original design. More details can be found
+parsed as an invalid simple block string literal due to quotes in the file type
+`abc"""`. Users can use extra spaces like `"" "abc" ""` to represent the three
+tokens represented in the original design. Second, `[#]+"""` always starts a raw
+block string literal. `#"""abc"""#` becomes an invalid block string literal,
+compared to a valid single-line string literal in the original design. More
+details can be found
 [here](/docs/design/lexical_conventions/string_literals.md).
 
 ## Rationale

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -45,7 +45,7 @@ Always interpret `[#]*"""` as the start of a block string literal, even if the r
 
 Two changes are made in this proposal. First, `"""` always starts a simple block
 string literal. Instead of the three tokens described above, `"""abc"""` will be
-parsed as an invalid simple block string literal. Users can use extra spaces
+parsed as an invalid simple block string literal due to quotes in the file type `abc"""`. Users can use extra spaces
 like `"" "abc" ""` to represent the three tokens represented in the original
 design. Second, `[#]+"""` always starts a raw block string literal.
 `#"""abc"""#` becomes an invalid block string literal, compared to a valid

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: block strings start with [#]+""" and [#]+""" only used for block strings
+# Change raw string literal syntax: [#]\*""" always starts a block string
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change Change raw string literal syntax: enforcing """ to be block string 
+# Change raw string literal syntax: enforcing """ to be block string 
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -56,7 +56,7 @@ single-line string literal in the original design. More details can be found
 
 This principle helps make Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
-because it avoids the confusions on the type of certain string literals.
+because it avoids confusion on the type of certain string literals.
 
 ## Alternatives considered
 

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -18,6 +18,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [The current implementation](#the-current-implementation)
+    -   [Using `"""` to start block string literals](#using--to-start-block-string-literals)
+    -   [Non-quote marker after the open quote](#non-quote-marker-after-the-open-quote)
+    -   [Use different quotes to allow `#'"'#`](#use-different-quotes-to-allow-)
 
 <!-- tocstop -->
 
@@ -60,26 +64,34 @@ because it avoids confusion on the type of certain string literals.
 
 ## Alternatives considered
 
-The
-[current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
-is a considered alternative. Compared to this proposal, the current
-implementation complicates the lexing. When the lexer sees `[#]+"""`, it
-temporarily accepts syntax of both string types because the type of the string
-is undecided. Specifically, it accepts vertical whitespaces even if they are not
-allowed in single-line strings. The type of the string won't be decided until
-the lexer sees a closing `"#` or a new line. In case of a closing `"#` where the
-string is single-line, the lexer will look back on the scanned characters for
-vertical whitespaces to decide if the single-line string is valid. The proposal
-simplifies the lexing without losing the convenience provided by the current
-implementation. For example, as discussed in
-[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
-`#"""#` is a natural way to write a string of `"`. This is also supported by the
-proposal.
+### The current implementation
 
-The [proposal for string literals](/proposals/p0199.md) copmared string literals
-in different programming languages. C++ does not have the issue this PR trying
-to address because the block string is represented by raw string. On the other
-hand, its syntax is potentially complex. For example, `R"(")"` is no simpler
-than `"\""`. Swift takes `#""""#` as
-[valid simple string](https://sourcegraph.com/search?q=context:global+file:%5C.swift%24+%23%22%22%22%22%23&patternType=literal)
-and the current implementation is inspired by it.
+In addition to the confusion described above, the
+[current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
+complicates the lexing. When the lexer sees `[#]+"""`, it temporarily accepts
+syntax of both string types because the type of the string is undecided.
+Specifically, it accepts vertical whitespaces even if they are not allowed in
+single-line strings. The type of the string won't be decided until the lexer
+sees a closing `"#` or a new line. In case of a closing `"#` where the string is
+single-line, the lexer will look back on the scanned characters for vertical
+whitespaces to decide if the single-line string is valid.
+
+### Using `"""` to start block string literals
+
+This approach loses some convenience in using raw string literals while
+addressing the problem. For example, as discussed in
+[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
+`#"""#` is a natural way to write a string of `"`.
+
+### Non-quote marker after the open quote
+
+Although something similar to C++ style like `"(` solves the problem, the syntax
+becomes complicated and hurts readability. In addition, `"(")"` is no simpler
+than `"\""` or `#"""#`.
+
+### Use different quotes to allow `#'"'#`
+
+When disallowing adjacent string literals, we can additionally allow `[#]+'` on
+single-line string literals. Another option is to use `[#]+'` for single-line
+string literals and `[#]+"` for block string literals. In general, `#'"'#` is
+visually confusing with character `'"'` and hurts readability.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -34,7 +34,7 @@ specifies a block string literal to start with `[#]*"""`. Users may take for
 granted the other way around, where any string literal starting with `[#]*"""`
 is a block string literal. This does not hold true, however. Two counter-cases
 are `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
-which is equlivent to `"\""`. Neither is a block string literal and may be
+which is equivalent to `"\""`. Neither is a block string literal and may be
 visually confusing.
 
 ## Proposal

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -80,3 +80,11 @@ string won't be decided until the lexer sees a closing `"#` or a new line. In
 case of a closing `"#` where the string is single-line, the lexer will look back
 on the scanned characters for vertical whitespaces to decide if the single-line
 string is valid.
+
+The [proposal for string literals](/proposals/p0199.md) copmared string literals
+in different programming languages. C++ does not have the issue this PR trying
+to address because the block string is represented by raw string. On the other
+hand, its syntax is potentially complex. For example, `R"(")"` is no simpler
+than `"\""`. Swift takes `#""""#` as
+[valid simple string](https://sourcegraph.com/search?q=context:global+file:%5C.swift%24+%23%22%22%22%22%23&patternType=literal)
+and the current implementation is inspired by it.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax
+# Change Change raw string literal syntax: enforcing """ to be block string 
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -23,42 +23,28 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+It may be confusing that 
+1. A string starting with three quotes is not a block string, like `#"""#`.
+2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents `""abc""` instead of `abc`.
+3. `#"""Not a file type indicator."""#` is not a block string and allows spaces on first line.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+The design of [string literals](/docs/design/lexical_conventions/string_literals.md) specifies a block string to start with `"""`. It also holds true the other way around, where a valid string literal starting with `"""` must be a block string. This is because a starting `"""` in a single-line string will be parsed as two tokens `""` and `"`, thus breaks the single-line string.
+
+However, this does not hold true on raw string literals. A valid string starting with `#"""` can also be a single-line string. For example, `#"""#` is equivalent to `"\""`. To decide whether a string starting with `#"""` is valid, both possibilities (single-line v.s. block) need to be considered.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Enforce a string starting with `#"""` to be a block string.
 
 ## Details
+This proposal also makes the lexing clearer. With current design of raw string literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces because the type of the string is undecided. If the string ends with a closing `"#` without a new line in between, the lexer will look back on the scanned characters for vertical whitespaces to decide if the single-line string is valid. The ambiguity and extra check can be eliminated by enforcing a string starting with `#"""` to be a block string.
 
-TODO: Fully explain the details of the proposed solution.
+The raw string literals provide a convenient approach to write characters that need escaping. This proposal compromises on the conveience because we will have to escape `"` if it's at the beginning of a single-line string literal. As discussed in [issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359), `#"""#` is a natural way to write a string of `"` and this proposal disallows it.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+This principle helps make Carbon code [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write), because it avoids the confusions on the type of certain string literals.
 
 ## Alternatives considered
-
-TODO: What alternative solutions have you considered?

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -32,8 +32,8 @@ The design of
 [string literals](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
 specifies a block string literal to start with `[#]*"""`. Users may take for
 granted the other way around, where any string literal starting with `[#]*"""`
-is a block string literal. This does not hold true, however. There are two
-counter-cases, where `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
+is a block string literal. This does not hold true, however. Two
+counter-cases are `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
 and `#"""#` which is equlivent to `"\""`. Neither is a block string literal and
 may be visually confusing.
 

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: enforcing """ to be block string 
+# Change raw string literal syntax: requiring """ to only be used for block strings
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -23,49 +23,34 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-It may be confusing that
-
-1. A string starting with three quotes is not a block string, like `#"""#`.
-2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents
-   `""abc""` instead of `abc`.
-3. `#"""Not a file type indicator."""#` is not a block string and allows spaces
-   on first line.
+Under current design of string literals, users may make assumptions that a
+starting `[#]*"""` represents a block string and misunderstand the syntax.
 
 ## Background
 
 The design of
 [string literals](/docs/design/lexical_conventions/string_literals.md) specifies
-a block string to start with `"""`. It also holds true the other way around,
-where a valid string literal starting with `"""` must be a block string. This is
-because a starting `"""` in a single-line string will be parsed as two tokens
-`""` and `"`, thus breaks the single-line string.
-
-However, this does not hold true on raw string literals. A valid string starting
-with `#"""` can also be a single-line string. For example, `#"""#` is equivalent
-to `"\""`. To decide whether a string starting with `#"""` is valid, both
-possibilities (single-line v.s. block) need to be considered.
+a block string literal to start with `[#]*"""`. Users may take for granted the
+other way around, where any string literal starting with `[#]*"""` is a block
+string literal. This does not hold true, however. There are two counter-cases,
+where `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
+which is equlivent to `"\""`. Neither is a block string literal and may be
+visually confusing.
 
 ## Proposal
 
-Enforce a string starting with `#"""` to be a block string.
+Enforce all block string literals to start with `[#]+"""` and always interpret
+`[#]+"""`, as the start of a block string literal.
 
 ## Details
 
-This proposal also makes the lexing clearer. With current design of raw string
-literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces
-because the type of the string is undecided. If the string ends with a closing
-`"#` without a new line in between, the lexer will look back on the scanned
-characters for vertical whitespaces to decide if the single-line string is
-valid. The ambiguity and extra check can be eliminated by enforcing a string
-starting with `#"""` to be a block string.
-
-The raw string literals provide a convenient approach to write characters that
-need escaping. This proposal compromises on the conveience because we will have
-to escape `"` if it's at the beginning of a single-line string literal. As
-discussed in
-[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
-`#"""#` is a natural way to write a string of `"` and this proposal disallows
-it.
+Two changes are made in this proposal. First, a block string literal cannot
+start with `"""`. Tokenization of `"""abc"""` remains the same three tokens as
+the original design, but users won't mistake it as a block string literal
+because block string literals cannot start with `"""`. Second, a single-line
+string literal cannot start with `[#]+"""`. `"""abc"""` becomes an invalid block
+string literal, compared to a valid single-line string literal in the original
+design.
 
 ## Rationale
 
@@ -74,3 +59,22 @@ This principle helps make Carbon code
 because it avoids the confusions on the type of certain string literals.
 
 ## Alternatives considered
+
+The
+[current implementation](/docs/design/lexical_conventions/string_literals.md) is
+a considered alternative. Compared to this proposal, current implementation does
+not compromise on the convenience of using raw string literals by not requiring
+escaping of `"` that locates at the beginning of a single-line string literal.
+For example, as discussed in
+[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
+`#"""#` is a natural way to write a string of `"`, but it becomes invalid with
+this proposal.
+
+On the other hand, the current implementation complicates the lexing. When the
+lexer sees `[#]+"""`, it temporarily accepts syntax of both string types because
+the type of the string is undecided. Specifically, it accepts vertical
+whitespaces even if they are not allowed in single-line strings. The type of the
+string won't be decided until the lexer sees a closing `"#` or a new line. In
+case of a closing `"#` where the string is single-line, the lexer will look back
+on the scanned characters for vertical whitespaces to decide if the single-line
+string is valid.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -46,10 +46,10 @@ Always interpret `[#]*"""` as the start of a block string literal.
 Two changes are made in this proposal. First, `"""` always starts a simple block
 string literal. Instead of the three tokens described above, `"""abc"""` will be
 parsed as an invalid simple block string literal. Users can use extra spaces
-like `"" "abc" ""` to represent the same three tokens. Second, `[#]+"""` always
-starts a raw block string literal. `#"""abc"""#` becomes an invalid block string
-literal, compared to a valid single-line string literal in the original design.
-More details can be found
+like `"" "abc" ""` to represent the three tokens represented in the original
+design. Second, `[#]+"""` always starts a raw block string literal.
+`#"""abc"""#` becomes an invalid block string literal, compared to a valid
+single-line string literal in the original design. More details can be found
 [here](/docs/design/lexical_conventions/string_literals.md).
 
 ## Rationale

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -23,34 +23,49 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-Under current design of string literals, users may make assumptions that a
-starting `[#]*"""` represents a block string and misunderstand the syntax.
+It may be confusing that
+
+1. A string starting with three quotes is not a block string, like `#"""#`.
+2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents
+   `""abc""` instead of `abc`.
+3. `#"""Not a file type indicator."""#` is not a block string and allows spaces
+   on first line.
 
 ## Background
 
 The design of
 [string literals](/docs/design/lexical_conventions/string_literals.md) specifies
-a block string literal to start with `[#]*"""`. Users may take for granted the
-other way around, where any string literal starting with `[#]*"""` is a block
-string literal. This does not hold true, however. There are two counter-cases,
-where `"""abc"""` represents three tokens `""`, `"abc"` and `""`, and `#"""#`
-which is equlivent to `"\""`. Neither is a block string literal and may be
-visually confusing.
+a block string to start with `"""`. It also holds true the other way around,
+where a valid string literal starting with `"""` must be a block string. This is
+because a starting `"""` in a single-line string will be parsed as two tokens
+`""` and `"`, thus breaks the single-line string.
+
+However, this does not hold true on raw string literals. A valid string starting
+with `#"""` can also be a single-line string. For example, `#"""#` is equivalent
+to `"\""`. To decide whether a string starting with `#"""` is valid, both
+possibilities (single-line v.s. block) need to be considered.
 
 ## Proposal
 
-Enforce all block string literals to start with `[#]+"""` and always interpret
-`[#]+"""`, as the start of a block string literal.
+Enforce a string starting with `#"""` to be a block string.
 
 ## Details
 
-Two changes are made in this proposal. First, a block string literal cannot
-start with `"""`. Tokenization of `"""abc"""` remains the same three tokens as
-the original design, but users won't mistake it as a block string literal
-because block string literals cannot start with `"""`. Second, a single-line
-string literal cannot start with `[#]+"""`. `"""abc"""` becomes an invalid block
-string literal, compared to a valid single-line string literal in the original
-design.
+This proposal also makes the lexing clearer. With current design of raw string
+literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces
+because the type of the string is undecided. If the string ends with a closing
+`"#` without a new line in between, the lexer will look back on the scanned
+characters for vertical whitespaces to decide if the single-line string is
+valid. The ambiguity and extra check can be eliminated by enforcing a string
+starting with `#"""` to be a block string.
+
+The raw string literals provide a convenient approach to write characters that
+need escaping. This proposal compromises on the conveience because we will have
+to escape `"` if it's at the beginning of a single-line string literal. As
+discussed in
+[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
+`#"""#` is a natural way to write a string of `"` and this proposal disallows
+it.
 
 ## Rationale
 
@@ -59,22 +74,3 @@ This principle helps make Carbon code
 because it avoids the confusions on the type of certain string literals.
 
 ## Alternatives considered
-
-The
-[current implementation](/docs/design/lexical_conventions/string_literals.md) is
-a considered alternative. Compared to this proposal, current implementation does
-not compromise on the convenience of using raw string literals by not requiring
-escaping of `"` that locates at the beginning of a single-line string literal.
-For example, as discussed in
-[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
-`#"""#` is a natural way to write a string of `"`, but it becomes invalid with
-this proposal.
-
-On the other hand, the current implementation complicates the lexing. When the
-lexer sees `[#]+"""`, it temporarily accepts syntax of both string types because
-the type of the string is undecided. Specifically, it accepts vertical
-whitespaces even if they are not allowed in single-line strings. The type of the
-string won't be decided until the lexer sees a closing `"#` or a new line. In
-case of a closing `"#` where the string is single-line, the lexer will look back
-on the scanned characters for vertical whitespaces to decide if the single-line
-string is valid.

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,0 +1,64 @@
+# Change raw string literal syntax
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/1360)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -23,28 +23,54 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-It may be confusing that 
+It may be confusing that
+
 1. A string starting with three quotes is not a block string, like `#"""#`.
-2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents `""abc""` instead of `abc`.
-3. `#"""Not a file type indicator."""#` is not a block string and allows spaces on first line.
+2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents
+   `""abc""` instead of `abc`.
+3. `#"""Not a file type indicator."""#` is not a block string and allows spaces
+   on first line.
 
 ## Background
 
-The design of [string literals](/docs/design/lexical_conventions/string_literals.md) specifies a block string to start with `"""`. It also holds true the other way around, where a valid string literal starting with `"""` must be a block string. This is because a starting `"""` in a single-line string will be parsed as two tokens `""` and `"`, thus breaks the single-line string.
+The design of
+[string literals](/docs/design/lexical_conventions/string_literals.md) specifies
+a block string to start with `"""`. It also holds true the other way around,
+where a valid string literal starting with `"""` must be a block string. This is
+because a starting `"""` in a single-line string will be parsed as two tokens
+`""` and `"`, thus breaks the single-line string.
 
-However, this does not hold true on raw string literals. A valid string starting with `#"""` can also be a single-line string. For example, `#"""#` is equivalent to `"\""`. To decide whether a string starting with `#"""` is valid, both possibilities (single-line v.s. block) need to be considered.
+However, this does not hold true on raw string literals. A valid string starting
+with `#"""` can also be a single-line string. For example, `#"""#` is equivalent
+to `"\""`. To decide whether a string starting with `#"""` is valid, both
+possibilities (single-line v.s. block) need to be considered.
 
 ## Proposal
 
 Enforce a string starting with `#"""` to be a block string.
 
 ## Details
-This proposal also makes the lexing clearer. With current design of raw string literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces because the type of the string is undecided. If the string ends with a closing `"#` without a new line in between, the lexer will look back on the scanned characters for vertical whitespaces to decide if the single-line string is valid. The ambiguity and extra check can be eliminated by enforcing a string starting with `#"""` to be a block string.
 
-The raw string literals provide a convenient approach to write characters that need escaping. This proposal compromises on the conveience because we will have to escape `"` if it's at the beginning of a single-line string literal. As discussed in [issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359), `#"""#` is a natural way to write a string of `"` and this proposal disallows it.
+This proposal also makes the lexing clearer. With current design of raw string
+literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces
+because the type of the string is undecided. If the string ends with a closing
+`"#` without a new line in between, the lexer will look back on the scanned
+characters for vertical whitespaces to decide if the single-line string is
+valid. The ambiguity and extra check can be eliminated by enforcing a string
+starting with `#"""` to be a block string.
+
+The raw string literals provide a convenient approach to write characters that
+need escaping. This proposal compromises on the conveience because we will have
+to escape `"` if it's at the beginning of a single-line string literal. As
+discussed in
+[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
+`#"""#` is a natural way to write a string of `"` and this proposal disallows
+it.
 
 ## Rationale
 
-This principle helps make Carbon code [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write), because it avoids the confusions on the type of certain string literals.
+This principle helps make Carbon code
+[easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
+because it avoids the confusions on the type of certain string literals.
 
 ## Alternatives considered

--- a/proposals/p1360.md
+++ b/proposals/p1360.md
@@ -1,4 +1,4 @@
-# Change raw string literal syntax: requiring """ to only be used for block strings
+# Change raw string literal syntax: block strings start with [#]+""" and [#]+""" only used for block strings
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -23,49 +23,34 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-It may be confusing that
-
-1. A string starting with three quotes is not a block string, like `#"""#`.
-2. `#"""abc"""#` is valid while `"""abc"""` is not, and `#"""abc"""#` represents
-   `""abc""` instead of `abc`.
-3. `#"""Not a file type indicator."""#` is not a block string and allows spaces
-   on first line.
+Under current design of string literals, users may make assumptions that a
+starting `[#]*"""` represents a block string and misunderstand the syntax.
 
 ## Background
 
 The design of
-[string literals](/docs/design/lexical_conventions/string_literals.md) specifies
-a block string to start with `"""`. It also holds true the other way around,
-where a valid string literal starting with `"""` must be a block string. This is
-because a starting `"""` in a single-line string will be parsed as two tokens
-`""` and `"`, thus breaks the single-line string.
-
-However, this does not hold true on raw string literals. A valid string starting
-with `#"""` can also be a single-line string. For example, `#"""#` is equivalent
-to `"\""`. To decide whether a string starting with `#"""` is valid, both
-possibilities (single-line v.s. block) need to be considered.
+[string literals](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
+specifies a block string literal to start with `[#]*"""`. Users may take for
+granted the other way around, where any string literal starting with `[#]*"""`
+is a block string literal. This does not hold true, however. There are two
+counter-cases, where `"""abc"""` represents three tokens `""`, `"abc"` and `""`,
+and `#"""#` which is equlivent to `"\""`. Neither is a block string literal and
+may be visually confusing.
 
 ## Proposal
 
-Enforce a string starting with `#"""` to be a block string.
+Always interpret `[#]*"""` as the start of a block string literal.
 
 ## Details
 
-This proposal also makes the lexing clearer. With current design of raw string
-literals, when the lexer sees `#"""`, it temporarily allows vertical whitespaces
-because the type of the string is undecided. If the string ends with a closing
-`"#` without a new line in between, the lexer will look back on the scanned
-characters for vertical whitespaces to decide if the single-line string is
-valid. The ambiguity and extra check can be eliminated by enforcing a string
-starting with `#"""` to be a block string.
-
-The raw string literals provide a convenient approach to write characters that
-need escaping. This proposal compromises on the conveience because we will have
-to escape `"` if it's at the beginning of a single-line string literal. As
-discussed in
-[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
-`#"""#` is a natural way to write a string of `"` and this proposal disallows
-it.
+Two changes are made in this proposal. First, `"""` always starts a simple block
+string literal. Instead of the three tokens described above, `"""abc"""` will be
+parsed as an invalid simple block string literal. Users can use extra spaces
+like `"" "abc" ""` to represent the same three tokens. Second, `[#]+"""` always
+starts a raw block string literal. `#"""abc"""#` becomes an invalid block string
+literal, compared to a valid single-line string literal in the original design.
+More details can be found
+[here](/docs/design/lexical_conventions/string_literals.md).
 
 ## Rationale
 
@@ -74,3 +59,22 @@ This principle helps make Carbon code
 because it avoids the confusions on the type of certain string literals.
 
 ## Alternatives considered
+
+The
+[current implementation](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/lexical_conventions/string_literals.md)
+is a considered alternative. Compared to this proposal, current implementation
+does not compromise on the convenience of using raw string literals by not
+requiring escaping of `"` that locates at the beginning of a single-line string
+literal. For example, as discussed in
+[issue #1359](https://github.com/carbon-language/carbon-lang/issues/1359),
+`#"""#` is a natural way to write a string of `"`, but it becomes invalid with
+this proposal.
+
+On the other hand, the current implementation complicates the lexing. When the
+lexer sees `[#]+"""`, it temporarily accepts syntax of both string types because
+the type of the string is undecided. Specifically, it accepts vertical
+whitespaces even if they are not allowed in single-line strings. The type of the
+string won't be decided until the lexer sees a closing `"#` or a new line. In
+case of a closing `"#` where the string is single-line, the lexer will look back
+on the scanned characters for vertical whitespaces to decide if the single-line
+string is valid.


### PR DESCRIPTION
Requiring `"""` to only be used for block string can avoid confusions.
Update: Use `"` for simple string literals and `'''` for block string literals.