### PR TITLE
[highlightjs] Add support for `var` and `let`.

### DIFF
--- a/docs/design/lexical_conventions/words.md
+++ b/docs/design/lexical_conventions/words.md
@@ -53,10 +53,12 @@ The following words are interpreted as keywords:
 -   `final`
 -   `fn`
 -   `for`
+-   `forall`
 -   `friend`
 -   `if`
 -   `impl`
 -   `import`
+-   `in`
 -   `interface`
 -   `is`
 -   `let`


### PR DESCRIPTION
This required reworking how `=` and `;` were handled as well as more
general surgery on patterns.

This looks for initializers at the top level of parameters and at the
end of `var` or `let` declarations. It supports fancy nested `var`
patterns within `let` declarations, etc.