### PR TITLE
Replaced "positive" with "constructive"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -67,11 +67,11 @@ spaces:
     lack thereof, and mental and physical ability.
 
 -   **Be friendly and patient.** We want to encourage people to participate in
-    our community in a constructive manner, so we can keep a friendly atmosphere. This is
-    especially important because many of our communication tools on the Internet
-    are low-fidelity and make it difficult to understand each other. Be patient,
-    assume good intent, and stay supportive so that we can learn how to
-    collaborate effectively as a group.
+    our community in a constructive manner, so we can keep a friendly
+    atmosphere. This is especially important because many of our communication
+    tools on the Internet are low-fidelity and make it difficult to understand
+    each other. Be patient, assume good intent, and stay supportive so that we
+    can learn how to collaborate effectively as a group.
 
 -   **Be considerate.** Your work will be used by other people, and you in turn
     will depend on the work of others. Any decision you make will affect users


### PR DESCRIPTION
Asking people to be “positive” is preventing us from creating psychological safety in our community. It may be weaponized against people seeking help from the CoC team.
So, I replaced instances in which we mentioned we'd expect "positivity" with the more accurate and less risky "constructivity".
Please see this document for more background information: [CLP CoC review July 2022](https://docs.google.com/document/d/1XzHMymzn3hxdlnaI44iukT24fy1MdwTXdebhzT45bCI/edit?usp=sharing)