### PR TITLE
[highlightjs] Add virtual method keywords.

### DIFF
--- a/highlighting/highlightjs_carbon_lang.js
+++ b/highlighting/highlightjs_carbon_lang.js
@@ -371,8 +371,8 @@ export default function (hljs) {
   };
   const FUNCTION = {
     scope: 'carbon-function',
-    begin: /fn/,
-    beginScope: 'keyword',
+    begin: [/(\b(virtual|abstract|impl)\b)?/, /\s*/, /\bfn\b/],
+    beginScope: { 1: 'keyword', 3: 'keyword' },
     end: /\s*[;{]/,
     returnEnd: true,
     contains: [FUNCTION_NAME_COMPONENT, RETURN_SPECIFIER],
@@ -406,7 +406,7 @@ export default function (hljs) {
     variants: [
       {
         scope: 'carbon-class',
-        begin: [/(base|abstract)?/, /\s*/, /class/],
+        begin: [/(\b(base|abstract)\b)?/, /\s*/, /\bclass\b/],
         beginScope: {
           1: 'keyword',
           3: 'keyword',

--- a/highlighting/highlightjs_example.html
+++ b/highlighting/highlightjs_example.html
@@ -49,8 +49,12 @@ interface WidgetI {
 constraint WidgetC {
 }
 
+abstract class Abstract {
+  abstract fn DoSomething[me: Self]();
+}
+
 base class Widget {
-  fn Print[addr me: Self*](var i: i64, x: f32 = 4.2, _: bool);
+  virtual fn Print[addr me: Self*](var i: i64, x: f32 = 4.2, _: bool);
 }
 
 fn Widget.Print[addr me: Self*](var i: i64, x: f32, _: bool, 47) {
@@ -68,7 +72,7 @@ fn Widget.Print[addr me: Self*](var i: i64, x: f32, _: bool, 47) {
 }
 
 class FancyWidget(T:! Type) extends Widget {
-  fn Print[me: Self]();
+  impl fn Print[me: Self]();
 
   impl as Add(T) {
     fn Op[me: Self]();


### PR DESCRIPTION
This also tidies up the keyword detection for classes a bit so we won't
highlight bizarre things like `allyourbase class`, or `base classy` etc.