### PR TITLE
Initial implementation of unformed state for local variables.

### DIFF
--- a/common/fuzzing/proto_to_carbon.cpp
+++ b/common/fuzzing/proto_to_carbon.cpp
@@ -518,8 +518,10 @@ static auto StatementToCarbon(const Fuzzing::Statement& statement,
       }
       out << "var ";
       PatternToCarbon(def.pattern(), out);
-      out << " = ";
-      ExpressionToCarbon(def.init(), out);
+      if (def.has_init()) {
+        out << " = ";
+        ExpressionToCarbon(def.init(), out);
+      }
       out << ";";
       break;
     }

--- a/explorer/ast/statement.cpp
+++ b/explorer/ast/statement.cpp
@@ -53,7 +53,11 @@ void Statement::PrintDepth(int depth, llvm::raw_ostream& out) const {
       if (var.is_returned()) {
         out << "returned ";
       }
-      out << "var " << var.pattern() << " = " << var.init() << ";";
+      out << "var " << var.pattern();
+      if (var.has_init()) {
+        out << " = " << var.init();
+      }
+      out << ";";
       break;
     }
     case StatementKind::ExpressionStatement:

--- a/explorer/ast/statement.h
+++ b/explorer/ast/statement.h
@@ -117,8 +117,8 @@ class VariableDefinition : public Statement {
   };
 
   VariableDefinition(SourceLocation source_loc, Nonnull<Pattern*> pattern,
-                     Nonnull<Expression*> init, ValueCategory value_category,
-                     DefinitionType def_type)
+                     std::optional<Nonnull<Expression*>> init,
+                     ValueCategory value_category, DefinitionType def_type)
       : Statement(AstNodeKind::VariableDefinition, source_loc),
         pattern_(pattern),
         init_(init),
@@ -131,17 +131,21 @@ class VariableDefinition : public Statement {
 
   auto pattern() const -> const Pattern& { return *pattern_; }
   auto pattern() -> Pattern& { return *pattern_; }
-  auto init() const -> const Expression& { return *init_; }
-  auto init() -> Expression& { return *init_; }
+  auto init() const -> const Expression& { return **init_; }
+  auto init() -> Expression& { return **init_; }
   auto value_category() const -> ValueCategory { return value_category_; }
   auto is_returned() const -> bool { return def_type_ == Returned; };
+  auto has_init() const -> bool { return init_.has_value(); }
 
   // Can only be called by type-checking, if a conversion was required.
-  void set_init(Nonnull<Expression*> init) { init_ = init; }
+  void set_init(Nonnull<Expression*> init) {
+    CARBON_CHECK(has_init()) << "should not add a new initializer";
+    init_ = init;
+  }
 
  private:
   Nonnull<Pattern*> pattern_;
-  Nonnull<Expression*> init_;
+  std::optional<Nonnull<Expression*>> init_;
   ValueCategory value_category_;
   const DefinitionType def_type_;
 };

--- a/explorer/ast/statement.h
+++ b/explorer/ast/statement.h
@@ -131,12 +131,17 @@ class VariableDefinition : public Statement {
 
   auto pattern() const -> const Pattern& { return *pattern_; }
   auto pattern() -> Pattern& { return *pattern_; }
-  auto init() const -> const Expression& { return **init_; }
-  auto init() -> Expression& { return **init_; }
   auto value_category() const -> ValueCategory { return value_category_; }
   auto is_returned() const -> bool { return def_type_ == Returned; };
   auto has_init() const -> bool { return init_.has_value(); }
-
+  auto init() const -> const Expression& {
+    CARBON_CHECK(has_init());
+    return **init_;
+  }
+  auto init() -> Expression& {
+    CARBON_CHECK(has_init());
+    return **init_;
+  }
   // Can only be called by type-checking, if a conversion was required.
   void set_init(Nonnull<Expression*> init) {
     CARBON_CHECK(has_init()) << "should not add a new initializer";

--- a/explorer/ast/statement.h
+++ b/explorer/ast/statement.h
@@ -131,9 +131,7 @@ class VariableDefinition : public Statement {
 
   auto pattern() const -> const Pattern& { return *pattern_; }
   auto pattern() -> Pattern& { return *pattern_; }
-  auto value_category() const -> ValueCategory { return value_category_; }
-  auto is_returned() const -> bool { return def_type_ == Returned; };
-  auto has_init() const -> bool { return init_.has_value(); }
+
   auto init() const -> const Expression& {
     CARBON_CHECK(has_init());
     return **init_;
@@ -142,11 +140,18 @@ class VariableDefinition : public Statement {
     CARBON_CHECK(has_init());
     return **init_;
   }
+
+  auto has_init() const -> bool { return init_.has_value(); }
+
   // Can only be called by type-checking, if a conversion was required.
   void set_init(Nonnull<Expression*> init) {
     CARBON_CHECK(has_init()) << "should not add a new initializer";
     init_ = init;
   }
+
+  auto value_category() const -> ValueCategory { return value_category_; }
+
+  auto is_returned() const -> bool { return def_type_ == Returned; };
 
  private:
   Nonnull<Pattern*> pattern_;

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -411,7 +411,9 @@ static auto StatementToProto(const Statement& statement) -> Fuzzing::Statement {
       const auto& def = cast<VariableDefinition>(statement);
       auto* def_proto = statement_proto.mutable_variable_definition();
       *def_proto->mutable_pattern() = PatternToProto(def.pattern());
-      *def_proto->mutable_init() = ExpressionToProto(def.init());
+      if (def.has_init()) {
+        *def_proto->mutable_init() = ExpressionToProto(def.init());
+      }
       def_proto->set_is_returned(def.is_returned());
       break;
     }

--- a/explorer/interpreter/heap.cpp
+++ b/explorer/interpreter/heap.cpp
@@ -5,6 +5,7 @@
 #include "explorer/interpreter/heap.h"
 
 #include "explorer/common/error_builders.h"
+#include "explorer/interpreter/value.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Error.h"
 
@@ -17,12 +18,17 @@ auto Heap::AllocateValue(Nonnull<const Value*> v) -> AllocationId {
   // or to leave it up to the caller.
   AllocationId a(values_.size());
   values_.push_back(v);
-  alive_.push_back(true);
+  if (v->kind() == Carbon::Value::Kind::UninitializedValue) {
+    states_.push_back(Uninitialized);
+  } else {
+    states_.push_back(Alive);
+  }
   return a;
 }
 
 auto Heap::Read(const Address& a, SourceLocation source_loc) const
     -> ErrorOr<Nonnull<const Value*>> {
+  CARBON_RETURN_IF_ERROR(this->CheckInit(a.allocation_, source_loc));
   CARBON_RETURN_IF_ERROR(this->CheckAlive(a.allocation_, source_loc));
   Nonnull<const Value*> value = values_[a.allocation_.index_];
   return value->GetMember(arena_, a.field_path_, source_loc, value);
@@ -31,6 +37,9 @@ auto Heap::Read(const Address& a, SourceLocation source_loc) const
 auto Heap::Write(const Address& a, Nonnull<const Value*> v,
                  SourceLocation source_loc) -> ErrorOr<Success> {
   CARBON_RETURN_IF_ERROR(this->CheckAlive(a.allocation_, source_loc));
+  if (states_[a.allocation_.index_] == Uninitialized) {
+    states_[a.allocation_.index_] = Alive;
+  }
   CARBON_ASSIGN_OR_RETURN(values_[a.allocation_.index_],
                           values_[a.allocation_.index_]->SetField(
                               arena_, a.field_path_, v, source_loc));
@@ -39,7 +48,7 @@ auto Heap::Write(const Address& a, Nonnull<const Value*> v,
 
 auto Heap::CheckAlive(AllocationId allocation, SourceLocation source_loc) const
     -> ErrorOr<Success> {
-  if (!alive_[allocation.index_]) {
+  if (states_[allocation.index_] == Dead) {
     return RuntimeError(source_loc)
            << "undefined behavior: access to dead value "
            << *values_[allocation.index_];
@@ -47,9 +56,19 @@ auto Heap::CheckAlive(AllocationId allocation, SourceLocation source_loc) const
   return Success();
 }
 
+auto Heap::CheckInit(AllocationId allocation, SourceLocation source_loc) const
+    -> ErrorOr<Success> {
+  if (states_[allocation.index_] == Uninitialized) {
+    return RuntimeError(source_loc)
+           << "undefined behavior: access to uninitialized value "
+           << *values_[allocation.index_];
+  }
+  return Success();
+}
+
 void Heap::Deallocate(AllocationId allocation) {
-  if (alive_[allocation.index_]) {
-    alive_[allocation.index_] = false;
+  if (states_[allocation.index_] != Dead) {
+    states_[allocation.index_] = Dead;
   } else {
     CARBON_FATAL() << "deallocating an already dead value: "
                    << *values_[allocation.index_];
@@ -63,7 +82,9 @@ void Heap::Print(llvm::raw_ostream& out) const {
   for (size_t i = 0; i < values_.size(); ++i) {
     out << sep;
     out << i << ": ";
-    if (!alive_[i]) {
+    if (states_[i] == Uninitialized) {
+      out << "!";
+    } else if (states_[i] == Dead) {
       out << "!!";
     }
     out << *values_[i];

--- a/explorer/interpreter/heap.h
+++ b/explorer/interpreter/heap.h
@@ -19,6 +19,12 @@ namespace Carbon {
 // A Heap represents the abstract machine's dynamically allocated memory.
 class Heap : public HeapAllocationInterface {
  public:
+  enum ValueState {
+    Uninitialized,
+    Alive,
+    Dead,
+  };
+
   // Constructs an empty Heap.
   explicit Heap(Nonnull<Arena*> arena) : arena_(arena){};
 
@@ -35,7 +41,8 @@ class Heap : public HeapAllocationInterface {
   auto Write(const Address& a, Nonnull<const Value*> v,
              SourceLocation source_loc) -> ErrorOr<Success>;
 
-  // Put the given value on the heap and mark it as alive.
+  // Put the given value on the heap and mark its state.
+  // Mark UninitializedValue as uninitialized and other values as alive.
   auto AllocateValue(Nonnull<const Value*> v) -> AllocationId override;
 
   // Marks this allocation, and all of its sub-objects, as dead.
@@ -54,9 +61,13 @@ class Heap : public HeapAllocationInterface {
   auto CheckAlive(AllocationId allocation, SourceLocation source_loc) const
       -> ErrorOr<Success>;
 
+  // Signal an error if the allocation has not been initialized.
+  auto CheckInit(AllocationId allocation, SourceLocation source_loc) const
+      -> ErrorOr<Success>;
+
   Nonnull<Arena*> arena_;
   std::vector<Nonnull<const Value*>> values_;
-  std::vector<bool> alive_;
+  std::vector<ValueState> states_;
 };
 
 }  // namespace Carbon

--- a/explorer/interpreter/heap.h
+++ b/explorer/interpreter/heap.h
@@ -19,7 +19,7 @@ namespace Carbon {
 // A Heap represents the abstract machine's dynamically allocated memory.
 class Heap : public HeapAllocationInterface {
  public:
-  enum ValueState {
+  enum class ValueState {
     Uninitialized,
     Alive,
     Dead,

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1320,8 +1320,12 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
       if (act.pos() == 0) {
         //    { {(var x = e) :: C, E, F} :: S, H}
         // -> { {e :: (var x = []) :: C, E, F} :: S, H}
-        return todo_.Spawn(
-            std::make_unique<ExpressionAction>(&definition.init()));
+        if (definition.has_init()) {
+          return todo_.Spawn(
+              std::make_unique<ExpressionAction>(&definition.init()));
+        } else {
+          return todo_.FinishAction();
+        }
       } else {
         //    { { v :: (x = []) :: C, E, F} :: S, H}
         // -> { { C, E(x := a), F} :: S, H(a := copy(v))}

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -286,8 +286,7 @@ auto PatternMatch(Nonnull<const Value*> p, Nonnull<const Value*> v,
                          << *v;
       }
     case Value::Kind::UninitializedValue:
-      // UninitializedValue matches any type.
-      return true;
+      CARBON_FATAL() << "uninitialized value is not allowed in pattern";
     case Value::Kind::FunctionType:
       switch (v->kind()) {
         case Value::Kind::FunctionType: {

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -251,6 +251,18 @@ auto PatternMatch(Nonnull<const Value*> p, Nonnull<const Value*> v,
           }  // for
           return true;
         }
+        case Value::Kind::UninitializedValue: {
+          const auto& p_tup = cast<TupleValue>(*p);
+          for (size_t i = 0; i < p_tup.elements().size(); ++i) {
+            if (!PatternMatch(
+                    p_tup.elements()[i],
+                    arena->New<UninitializedValue>(p_tup.elements()[i]),
+                    source_loc, bindings, generic_args, trace_stream, arena)) {
+              return false;
+            }
+          }
+          return true;
+        }
         default:
           CARBON_FATAL() << "expected a tuple value in pattern, not " << *v;
       }

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -253,11 +253,10 @@ auto PatternMatch(Nonnull<const Value*> p, Nonnull<const Value*> v,
         }
         case Value::Kind::UninitializedValue: {
           const auto& p_tup = cast<TupleValue>(*p);
-          for (size_t i = 0; i < p_tup.elements().size(); ++i) {
-            if (!PatternMatch(
-                    p_tup.elements()[i],
-                    arena->New<UninitializedValue>(p_tup.elements()[i]),
-                    source_loc, bindings, generic_args, trace_stream, arena)) {
+          for (auto& ele : p_tup.elements()) {
+            if (!PatternMatch(ele, arena->New<UninitializedValue>(ele),
+                              source_loc, bindings, generic_args, trace_stream,
+                              arena)) {
               return false;
             }
           }

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -338,7 +338,9 @@ static auto ResolveNames(Statement& statement, StaticScope& enclosing_scope)
     }
     case StatementKind::VariableDefinition: {
       auto& def = cast<VariableDefinition>(statement);
-      CARBON_RETURN_IF_ERROR(ResolveNames(def.init(), enclosing_scope));
+      if (def.has_init()) {
+        CARBON_RETURN_IF_ERROR(ResolveNames(def.init(), enclosing_scope));
+      }
       CARBON_RETURN_IF_ERROR(ResolveNames(def.pattern(), enclosing_scope));
       if (def.is_returned()) {
         CARBON_CHECK(def.pattern().kind() == PatternKind::BindingPattern)

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
-#include <optional>
 #include <set>
 #include <vector>
 

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -369,6 +369,8 @@ void Value::Print(llvm::raw_ostream& out) const {
       break;
     }
     case Value::Kind::UninitializedValue: {
+      const auto& uninit = cast<UninitializedValue>(*this);
+      out << "Uninit<" << uninit.pattern() << ">";
       break;
     }
     case Value::Kind::NominalClassType: {

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 
 #include "common/check.h"
-#include "explorer/ast/expression.h"
 #include "explorer/common/arena.h"
 #include "explorer/common/error_builders.h"
 #include "explorer/interpreter/action.h"

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include "common/check.h"
+#include "explorer/ast/expression.h"
 #include "explorer/common/arena.h"
 #include "explorer/common/error_builders.h"
 #include "explorer/interpreter/action.h"
@@ -368,6 +369,9 @@ void Value::Print(llvm::raw_ostream& out) const {
       out << "}";
       break;
     }
+    case Value::Kind::UninitializedValue: {
+      break;
+    }
     case Value::Kind::NominalClassType: {
       const auto& class_type = cast<NominalClassType>(*this);
       out << "class ";
@@ -687,6 +691,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2) -> bool {
     case Value::Kind::BindingPlaceholderValue:
     case Value::Kind::AddrValue:
     case Value::Kind::ContinuationValue:
+    case Value::Kind::UninitializedValue:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
     case Value::Kind::TypeOfParameterizedEntityName:
@@ -805,6 +810,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2) -> bool {
     case Value::Kind::ContinuationValue:
     case Value::Kind::PointerValue:
     case Value::Kind::LValue:
+    case Value::Kind::UninitializedValue:
     case Value::Kind::MemberName:
       // TODO: support pointer comparisons once we have a clearer distinction
       // between pointers and lvalues.

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -410,11 +410,17 @@ class AddrValue : public Value {
 // Value for uninitialized local variables.
 class UninitializedValue : public Value {
  public:
-  UninitializedValue() : Value(Kind::UninitializedValue) {}
+  explicit UninitializedValue(Nonnull<const Value*> pattern)
+      : Value(Kind::UninitializedValue), pattern_(pattern) {}
 
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::UninitializedValue;
   }
+
+  auto pattern() const -> const Value& { return *pattern_; }
+
+ private:
+  Nonnull<const Value*> pattern_;
 };
 
 // The int type.

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -46,6 +46,7 @@ class Value {
     NominalClassValue,
     AlternativeValue,
     TupleValue,
+    UninitializedValue,
     ImplWitness,
     SymbolicWitness,
     IntType,
@@ -404,6 +405,16 @@ class AddrValue : public Value {
 
  private:
   Nonnull<const Value*> pattern_;
+};
+
+// Value for uninitialized local variables.
+class UninitializedValue : public Value {
+ public:
+  UninitializedValue() : Value(Kind::UninitializedValue) {}
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::UninitializedValue;
+  }
 };
 
 // The int type.

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,6 +756,7 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
+      $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,7 +756,6 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
-    {
       $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,7 +756,6 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
-      $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,7 +756,6 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
-| VAR pattern SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,6 +756,7 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
+    {
       $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,6 +756,13 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
+
+| VAR pattern SEMICOLON
+    {
+      $$ = arena->New<VariableDefinition>(
+          context.source_loc(), $2, std::nullopt, ValueCategory::Var,
+          VariableDefinition::DefinitionType::Var);
+    }
 | VAR pattern EQUAL expression SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,7 +756,6 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
-
 | VAR pattern SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -756,6 +756,7 @@ clause_list:
 statement:
   statement_expression EQUAL expression SEMICOLON
     { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
+| VAR pattern SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(
           context.source_loc(), $2, std::nullopt, ValueCategory::Var,

--- a/explorer/testdata/declare/local_declare.carbon
+++ b/explorer/testdata/declare/local_declare.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+// Test that assignment performs a copy and does not create an alias.
+
+fn Main() -> i32 {
+  var x: i32;
+  x = 1;
+  return x;
+}

--- a/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon
@@ -11,10 +11,9 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // Error: can't use keyword `Self` as the name of a variable.
-  // TODO: Current error message is unclear, better would be to say
-  // something like: unexpected `Self`, expecting identifier
-  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_var_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL or SEMICOLON
-  var Self : i32 = 0;
-  return Self;
+  var x: i32;
+  var y: i32;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  y = x;
+  return y;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon
@@ -13,7 +13,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: i32;
   var y: i32;
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_assign.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   y = x;
   return y;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_init.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_init.carbon
@@ -12,7 +12,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_init.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_init.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   var y: i32 = x;
   return x;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_init.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_init.carbon
@@ -11,10 +11,8 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // Error: can't use keyword `Self` as the name of a variable.
-  // TODO: Current error message is unclear, better would be to say
-  // something like: unexpected `Self`, expecting identifier
-  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_var_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL or SEMICOLON
-  var Self : i32 = 0;
-  return Self;
+  var x: i32;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_init.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  var y: i32 = x;
+  return x;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_param.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_param.carbon
@@ -2,19 +2,20 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
+// RUN: %{not} %{explorer} %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 1
 
 package ExplorerTest api;
 
-// Test that assignment performs a copy and does not create an alias.
+fn AddInt(a: i32, b: i32) -> auto {
+  return a + b;
+}
 
 fn Main() -> i32 {
   var x: i32;
-  x = 1;
-  return x;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_param.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  return AddInt(x, 2);
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_param.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_param.carbon
@@ -16,6 +16,6 @@ fn AddInt(a: i32, b: i32) -> auto {
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_param.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_param.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return AddInt(x, 2);
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_pattern.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_pattern.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: i32, y: i32);
+  x = 1;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_tuple.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<y>>
+  return y;
+}

--- a/explorer/testdata/uninitialized/fail_uninitialized_pattern.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_pattern.carbon
@@ -13,6 +13,6 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var (x: i32, y: i32);
   x = 1;
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_tuple.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<y>>
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_pattern.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<y>>
   return y;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_return.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_return.carbon
@@ -11,10 +11,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // Error: can't use keyword `Self` as the name of a variable.
-  // TODO: Current error message is unclear, better would be to say
-  // something like: unexpected `Self`, expecting identifier
-  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_var_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL or SEMICOLON
-  var Self : i32 = 0;
-  return Self;
+  var x: i32;
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_return.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  return x;
 }

--- a/explorer/testdata/uninitialized/fail_uninitialized_return.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_return.carbon
@@ -12,6 +12,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_return.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_return.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return x;
 }

--- a/explorer/testdata/uninitialized/local_declare.carbon
+++ b/explorer/testdata/uninitialized/local_declare.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  x = 1;
+  return x;
+}

--- a/explorer/testdata/uninitialized/local_declare_pattern.carbon
+++ b/explorer/testdata/uninitialized/local_declare_pattern.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: i32, y: i32);
+  x = 1;
+  return x;
+}

--- a/explorer/testdata/uninitialized/local_uninit_without_use.carbon
+++ b/explorer/testdata/uninitialized/local_uninit_without_use.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  return 1;
+}

--- a/explorer/testdata/uninitialized/uninitialized_escape.carbon
+++ b/explorer/testdata/uninitialized/uninitialized_escape.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 42
+
+package ExplorerTest api;
+
+fn AssignIntTo(x: i32, destination: i32*) {
+  *destination = x;
+}
+
+fn Main() -> i32 {
+  var y: i32;
+  // `y` is unformed here.
+  AssignIntTo(42, &y);
+  // `y` is fully formed and usable.
+  return y;
+}


### PR DESCRIPTION
Allows unformed state for local variables. Reports a run-time error when an unformed local variable is used.
- Added declaration without initialization for local variables in the parser.
- Made the init expression of VariableDefinition optional.
- Expanded (alive, dead) to (uninitialized, alive, dead) in the Heap.