### PR TITLE
Add explicit note about changes to the CoC team

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -142,6 +142,9 @@ currently has the following members:
 -   Richard Smith (@zygoloid on Discord and
     [GitHub](https://github.com/zygoloid))
 
+If the composition of the code of conduct team changes, reports will not be
+shared with new members without the permission of the reporter.
+
 ### Reporting conduct
 
 If you believe someone is violating the code of conduct, you can report it


### PR DESCRIPTION
If the CoC team changes, new people don't get to see existing complaints / reports.