### PR TITLE
Fixed typo. farther => further

### DIFF
--- a/docs/project/principles/low_context_sensitivity.md
+++ b/docs/project/principles/low_context_sensitivity.md
@@ -190,7 +190,7 @@ if (x != None) {
 // x is back to type Optional(Int).
 ```
 
-This can be taken farther, this example has `x` taking on three different types:
+This can be taken further, this example has `x` taking on three different types:
 
 ```
 var x: Optional(Optional(Int)) = ...;


### PR DESCRIPTION
"Farther" refers to actual distance. "Further" refers to figurative distance.