### PR TITLE
Fix memory safety link in faq.md

### DIFF
--- a/docs/project/faq.md
+++ b/docs/project/faq.md
@@ -347,7 +347,7 @@ space.
 
 ### How will Carbon achieve memory safety?
 
-See [memory safety in the project README](/#memory-safety).
+See [memory safety in the project README](/README.md#memory-safety).
 
 References:
 


### PR DESCRIPTION
The previous link resulted in a 404.