### PR TITLE
Enable software development from any device via https://gitpod.io

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,14 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# install and configure llvm/bazelisk
+RUN brew update && brew install bazelisk llvm pre-commit
+RUN echo 'export PATH="$(brew --prefix llvm)/bin:${PATH}"' >> /home/gitpod/.bashrc
+
+# store the blaze cache in a place where it will be persisted
+RUN mkdir -p /home/gitpod/.cache/bazel && ln -s /home/gitpod/.cache/bazel /workspace/.bazel

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,149 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+## Learn more about this file at 'https://www.gitpod.io/docs/references/gitpod-yml'
+##
+## This '.gitpod.yml' file when placed at the root of a project instructs
+## Gitpod how to prepare & build the project, start development environments
+## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## like a CI server so you can start coding right away - no more waiting for
+## dependencies to download and builds to finish when reviewing pull-requests
+## or hacking on something new.
+##
+## With Gitpod you can develop software from any device (even iPads) via
+## desktop or browser based versions of VS Code or any JetBrains IDE and
+## customise it to your individual needs - from themes to extensions, you
+## have full control.
+##
+## The easiest way to try out Gitpod is install the browser extenion:
+## 'https://www.gitpod.io/docs/browser-extension' or by prefixing
+## 'https://gitpod.io#' to the source control URL of any project.
+##
+## For example: 'https://gitpod.io#https://github.com/gitpod-io/gitpod'
+
+## The 'image' section defines which Docker image Gitpod should use.
+## By default, Gitpod uses a standard Docker Image called 'workspace-full'
+## which can be found at 'https://github.com/gitpod-io/workspace-images'
+##
+## Workspaces started based on this default image come pre-installed with
+## Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as
+## tools such as Homebrew, Tailscale, Nginx and several more.
+##
+## If this image does not include the tools needed for your project then
+## a public Docker image or your own Docker file can be configured.
+##
+## Learn more about images at 'https://www.gitpod.io/docs/config-docker'
+
+#image: node:buster                        # use 'https://hub.docker.com/_/node'
+#
+#image:                                    # leave image undefined if using a Dockerfile
+#  file: .gitpod.Dockerfile                # relative path to the Dockerfile from the
+#                                          # root of the project
+
+image:
+  file: .gitpod.Dockerfile
+
+## The 'tasks' section defines how Gitpod prepares and builds this project
+## or how Gitpod can start development servers. With Gitpod, there are three
+## types of tasks:
+##
+## - before: Use this for tasks that need to run before init and before command.
+## - init: Use this to configure prebuilds of heavy-lifting tasks such as
+##         downloading dependencies or compiling source code.
+## - command: Use this to start your database or application when the workspace starts.
+##
+## Learn more about these tasks at 'https://www.gitpod.io/docs/config-start-tasks'
+
+#tasks:
+#  - before: |
+#      # commands to execute...
+#
+#  - init: |
+#      # sudo apt-get install python3     # can be used to install operating system
+#                                         # dependencies but these are not kept after the
+#                                         # prebuild completes thus Gitpod recommends moving
+#                                         # operating system dependency installation steps
+#                                         # to a custom Dockerfile to make prebuilds faster
+#                                         # and to keep your codebase DRY.
+#                                         # 'https://www.gitpod.io/docs/config-docker'
+#
+#      # pip install -r requirements.txt  # install codebase dependencies
+#      # cmake                            # precompile codebase
+#
+#  - name: Web Server
+#    openMode: split-left
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     python3 -m http.server $WEBSERVER_PORT
+#
+#  - name: Web Browser
+#    openMode: split-right
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     gp await-port $WEBSERVER_PORT
+#     lynx `gp url`
+
+tasks:
+  - init: |
+      bazel build //explorer --
+
+  - name: //explorer
+    command: |
+      pre-commit
+      bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
+
+## The 'ports' section defines various ports your may listen on are
+## configured in Gitpod on an authenticated URL. By default, all ports
+## are in private visibility state.
+##
+## Learn more about ports at 'https://www.gitpod.io/docs/config-ports'
+
+#ports:
+#  - port: 8080 # alternatively configure entire ranges via '8080-8090'
+#    visibility: private # either 'public' or 'private' (default)
+#    onOpen: open-browser # either 'open-browser', 'open-preview' or 'ignore'
+
+## The 'vscode' section defines a list of Visual Studio Code extensions from
+## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
+## is an open alternative to the proprietary Visual Studio Code Marketplace
+## and extensions can be added by sending a pull-request with the extension
+## identifier to https://github.com/open-vsx/publish-extensions
+##
+## The identifier of an extension is always ${publisher}.${name}.
+##
+## For example: 'vscodevim.vim'
+##
+## Learn more at 'https://www.gitpod.io/docs/ides-and-editors/vscode'
+
+#vscode:
+#  extensions:
+#    - vscodevim.vim
+#    - esbenp.prettier-vscode@9.5.0
+#    - https://example.com/abc/releases/extension-0.26.0.vsix
+
+## The 'github' section defines configuration of continuous prebuilds
+## for GitHub repositories when the GitHub application
+## 'https://github.com/apps/gitpod-io' is installed in GitHub and granted
+## permissions to access the repository.
+##
+## Learn more at 'https://www.gitpod.io/docs/prebuilds'
+
+github:
+  prebuilds:
+    # enable for the default branch
+    master: true
+    # enable for all branches in this repo
+    branches: true
+    # enable for pull requests coming from this repo
+    pullRequests: true
+    # enable for pull requests coming from forks
+    pullRequestsFromForks: true
+    # add a check to pull requests
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description
+    addBadge: true

--- a/README.md
+++ b/README.md
@@ -280,6 +280,11 @@ These instructions assume [Homebrew](https://brew.sh/); see our
 [contribution tools documentation](/docs/project/contribution_tools.md) for more
 extensive tooling instructions.
 
+If you do not wish to install software on your computer to try out or contribute
+to Carbon then you can also
+[open the project in Gitpod](https://gitpod.io#https://github.com/carbon-language/carbon-lang)
+which automates all of the steps above.
+
 Learn more about the Carbon project:
 
 -   [Project goals](/docs/project/goals.md)

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -63,6 +63,14 @@ typical tool setup flow is:
 
 <!-- google-doc-style-resume -->
 
+An alternative to manually configuring tooling to is to use a cloud development
+environment such as Gitpod which automates the setup instructions below. A
+pre-configured Gitpod workspace can be launched by pressing the button below.
+
+<a href="https://gitpod.io#https://github.com/carbon-language/carbon-lang">
+  <img src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod" alt="Contribute with Gitpod" />
+</a>
+
 ## Package managers
 
 Instructions for installing tools can be helpful for installing tooling. These


### PR DESCRIPTION
👋 Carbon from [Gitpod](https://www.gitpod.io/blog/gitpod-for-opensource). Congratulations [on today's launch](https://twitter.com/blelbach/status/1549385011828252674) which caught my eye. I'm sending in this speculative pull-request that makes it easier for people to try out (and/or contribute to) carbon from their browser without having to install anything on their local computer.

<img width="1440" alt="2022-07-20_12-27-19" src="https://user-images.githubusercontent.com/127353/179883091-d45a61e9-8414-4f17-8fda-d624f5a9a4d7.png">

You can try out and test this pull-request right now by clicking on this button btw 🚀 

<hr/>

  <a href="https://gitpod.io#https://github.com/carbon-language/carbon-lang/pull/1441">
    <img src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod" alt="Contribute with Gitpod" />
  </a>

<hr/>

ps. If you make your GitHub members public (and/or [fill out this form](https://www.gitpod.io/for/opensource)) then I can reconfigure Gitpod to automatically upgrade your maintainers/co-contributors to our complementary opensource plan.

Lemme know if you have any questions or feedback.