### PR TITLE
fix typo in QuickSort code

### DIFF
--- a/docs/images/snippets.md
+++ b/docs/images/snippets.md
@@ -36,8 +36,8 @@ fn QuickSort[T:! Comparable & Movable](s: Slice(T)) {
     return;
   }
   let p: i64 = Partition(s);
-  QuickSort(s[:p - 1]));
-  QuickSort(s[p + 1:]));
+  QuickSort(s[:p - 1]);
+  QuickSort(s[p + 1:]);
 }
 ```
 


### PR DESCRIPTION
Seems there were 1 too many closing round brackets when calling QuickSort.