### PR TITLE
update readme install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ $ brew install bazelisk
 # Install Clang/LLVM using Homebrew.
 # Many Clang/LLVM releases aren't built with options we rely on.
 $ brew install llvm
+# MacOS only
 $ export PATH="$(brew --prefix llvm)/bin:${PATH}"
 
 # Download Carbon's code.


### PR DESCRIPTION
Update installation directions, when path variable is set on Linux it creates a build error for the explorer. Update installation instructions to add platform specific direction. 