### PR TITLE
Add a link to the CppNorth announcement video.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <a href="#join-us">Join us</a>
 </p>
 
+**See our announcement video from [CppNorth](https://cppnorth.ca/):
+https://youtu.be/omrY53kbVoA**
+
 <a href="docs/images/snippets.md#quicksort">
 <!--
 Edit snippet in docs/images/snippets.md and:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <a href="#join-us">Join us</a>
 </p>
 
-**See our [announcement video](https://youtu.be/omrY53kbVoA) from [CppNorth](https://cppnorth.ca/)**
+**See our [announcement video](https://youtu.be/omrY53kbVoA) from
+[CppNorth](https://cppnorth.ca/)**
 
 <a href="docs/images/snippets.md#quicksort">
 <!--

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <a href="#join-us">Join us</a>
 </p>
 
-**See our announcement video from [CppNorth](https://cppnorth.ca/):
-https://youtu.be/omrY53kbVoA**
+**See our [announcement video](https://youtu.be/omrY53kbVoA) from [CppNorth](https://cppnorth.ca/)**
 
 <a href="docs/images/snippets.md#quicksort">
 <!--


### PR DESCRIPTION
Happy to have suggestions on better ways to format or incorporate this into the site. Some quick research showed that you can't embed videos, and didn't necessarily seem worth using a linked image.