### PR TITLE
:white_check_mark: [explorer] Add tests for implicit tuple to array c…

### DIFF
--- a/explorer/testdata/tuple/fail_to_array.carbon
+++ b/explorer/testdata/tuple/fail_to_array.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: auto = (1, 2);
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/tuple/fail_to_array.carbon:[[@LINE+1]]: type error in name binding: '(i32, i32)' is not implicitly convertible to '[i32; 3]'
+  var a: [i32; 3] = t;
+}

--- a/explorer/testdata/tuple/to_array.carbon
+++ b/explorer/testdata/tuple/to_array.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 3
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: auto = (1, 2);
+  var a: [i32; 2] = t;
+  return a[0] + a[1];
+}


### PR DESCRIPTION
…onversion

Problem:
- explorer doesn't cover implicit tuple to array conversion

Solution:
- Add to_array.carbon which converts tuple to array with the same size.
- Add fail_to_array.carbon which doesn't compile becase the size of array doesn't match the size of tuple.