### PR TITLE
Implement minimal textmate language definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,6 +163,11 @@ repos:
           - '/*'
           - ''
           - '*/'
+          - --custom_format
+          - '\.(plist)$'
+          - '<!--'
+          - ''
+          - ' -->'
         exclude: |
           (?x)^(
               .bazelversion|

--- a/utils/highlightjs/highlightjs_carbon_lang.js
+++ b/utils/highlightjs/highlightjs_carbon_lang.js
@@ -140,7 +140,7 @@ export default function (hljs) {
     scope: 'number',
     variants: [
       { match: /[1-9][_0-9]*(\.[_0-9]+(e[-+]?[1-9][0-9]*)?)?/ },
-      { match: /0x[_0-9A-F]+(\.[_0-9A-F]+(p[-+]?[1-9][0-9]*)?)?/ },
+      { match: /0x[_0-9a-fA-F]+(\.[_0-9a-fA-F]+(p[-+]?[1-9][0-9]*)?)?/ },
       { match: /0b[_01]+/ },
     ],
   };
@@ -150,7 +150,7 @@ export default function (hljs) {
   };
   const ESCAPE_SEQUENCE = {
     scope: 'char.escape',
-    match: /\\([tnr'"0\\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})/,
+    match: /\\([tnr'"0\\0]|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{4,}\})/,
   };
   const BLOCK_STRING_LITERAL = {
     scope: 'string',

--- a/utils/highlightjs/highlightjs_carbon_lang.js
+++ b/utils/highlightjs/highlightjs_carbon_lang.js
@@ -140,7 +140,7 @@ export default function (hljs) {
     scope: 'number',
     variants: [
       { match: /[1-9][_0-9]*(\.[_0-9]+(e[-+]?[1-9][0-9]*)?)?/ },
-      { match: /0x[_0-9a-fA-F]+(\.[_0-9a-fA-F]+(p[-+]?[1-9][0-9]*)?)?/ },
+      { match: /0x[_0-9A-F]+(\.[_0-9A-F]+(p[-+]?[1-9][0-9]*)?)?/ },
       { match: /0b[_01]+/ },
     ],
   };
@@ -150,7 +150,7 @@ export default function (hljs) {
   };
   const ESCAPE_SEQUENCE = {
     scope: 'char.escape',
-    match: /\\([tnr'"0\\0]|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{4,}\})/,
+    match: /\\([tnr'"0\\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})/,
   };
   const BLOCK_STRING_LITERAL = {
     scope: 'string',

--- a/utils/textmate/README.md
+++ b/utils/textmate/README.md
@@ -7,5 +7,25 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 This directory contains a [TextMate](https://macromates.com/) bundle which can
-be used in various editors such as TextMate, VSCode, Atom or the IntelliJ family
-for syntax highlighting of Carbon source files.
+be used in various editors such as TextMate, Atom or the IntelliJ family for
+syntax highlighting of Carbon source files.
+
+If you are using TextMate, you can find documentation on how to use the bundle
+[here](https://macromates.com/manual/en/bundles#getting_more_bundles). Clone the
+repository with Git and symlink/copy the `utils/textmate` directory to any of
+the paths TextMate will search through (you can find these paths in the TextMate
+documentation above)
+
+If you are using IntelliJ or a JetBrains-family product, you can find
+documentation on how to install the bundle
+[here](https://www.jetbrains.com/help/idea/textmate.html#import-textmate-bundles).
+Clone the repository with Git and open the `utils/textmate` directory inside the
+IntelliJ TextMate Bundle window.
+
+If you are using Atom, you can convert the bundle to an Atom-compatible one. See
+the Atom documentation
+[here](https://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/)
+on how to do that.
+
+For other editors that support TextMate bundles you can consult your editors
+documentation to see how to use the bundle.

--- a/utils/textmate/README.md
+++ b/utils/textmate/README.md
@@ -7,25 +7,23 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 This directory contains a [TextMate](https://macromates.com/) bundle which can
-be used in various editors such as TextMate, Atom or the IntelliJ family for
+be used in various editors such as TextMate, Atom, or the IntelliJ family for
 syntax highlighting of Carbon source files.
 
-If you are using TextMate, you can find documentation on how to use the bundle
-[here](https://macromates.com/manual/en/bundles#getting_more_bundles). Clone the
-repository with Git and symlink/copy the `utils/textmate` directory to any of
-the paths TextMate will search through (you can find these paths in the TextMate
-documentation above)
+If you are using TextMate, see the documentation on
+[how to install TextMate bundles](https://macromates.com/manual/en/bundles#getting_more_bundles).
+Clone the repository with Git and symlink/copy the `utils/textmate` directory to
+any of the paths TextMate will search through (you can find these paths in the
+TextMate documentation above).
 
-If you are using IntelliJ or a JetBrains-family product, you can find
-documentation on how to install the bundle
-[here](https://www.jetbrains.com/help/idea/textmate.html#import-textmate-bundles).
+If you are using IntelliJ or a IntelliJ Platform product, you can find
+documentation on
+[how to install TextMate bundles in IntelliJ](https://www.jetbrains.com/help/idea/textmate.html#import-textmate-bundles).
 Clone the repository with Git and open the `utils/textmate` directory inside the
 IntelliJ TextMate Bundle window.
 
 If you are using Atom, you can convert the bundle to an Atom-compatible one. See
-the Atom documentation
-[here](https://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/)
-on how to do that.
+[the Atom documentation on how to do that.](https://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/)
 
 For other editors that support TextMate bundles you can consult your editors
 documentation to see how to use the bundle.

--- a/utils/textmate/README.md
+++ b/utils/textmate/README.md
@@ -1,0 +1,11 @@
+# Textmate Language Definition
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+This directory contains a [TextMate](https://macromates.com/) bundle which can
+be used in various editors such as TextMate, VSCode, Atom or the IntelliJ family
+for syntax highlighting of Carbon source files.

--- a/utils/textmate/Samples/main.carbon
+++ b/utils/textmate/Samples/main.carbon
@@ -4,13 +4,7 @@
 
 // More single line comments
 
-/* Multi line and closing comments */
-/* Spans
-   Multiple
-   Lines
-*/
-
-package Carbon /* between */ api;
+package Carbon api;
 
 interface HasValueParam(T:! Type, V:! T) {
   fn Go[me: Self]() -> T;

--- a/utils/textmate/Samples/main.carbon
+++ b/utils/textmate/Samples/main.carbon
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// More single line comments
+
+/* Multi line and closing comments */
+/* Spans
+   Multiple
+   Lines
+*/
+
+package Carbon /* between */ api;
+
+interface HasValueParam(T:! Type, V:! T) {
+  fn Go[me: Self]() -> T;
+}
+
+impl () as HasValueParam(i32, 5) {
+  fn Go[me: Self]() -> i32 { return 42; }
+}
+
+class Point {
+  fn Origin() -> Self {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Procedure() -> i32 {
+  returned var zoop: i32 = 0;
+  while (DoSomeJob() {
+    zoop += 1;
+  }
+
+  return var;
+}
+
+fn Main() -> i32 {
+  let str = "Hello world";
+  let hex = 0xabcdef1234567890;
+  let bin = 0b0000111001010010;
+  let dec = 123456789012345678;
+
+  let big: Carbon.Int(1024) = 1234;
+  let aaa: auto = "Carbon";
+  let view: StringView = "Carbon";
+
+  return Procedure();
+}

--- a/utils/textmate/Samples/main.carbon
+++ b/utils/textmate/Samples/main.carbon
@@ -40,7 +40,7 @@ fn Procedure() -> i32 {
 
 fn Main() -> i32 {
   let str = "Hello world";
-  let hex = 0xabcdef1234567890;
+  let hex = 0xABCDEF1234567890;
   let bin = 0b0000111001010010;
   let dec = 123456789012345678;
 

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -33,38 +33,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <array>
             <!-- Rule: comments -->
             <dict>
-                <key>include</key>
-                <string>#comments</string>
-            </dict>
-            <!-- Rule: control flow keywords -->
-            <dict>
-                <key>name</key>
-                <string>keyword.control.carbon</string>
-                <key>match</key>
-                <string>\b(break|case|continue|else|if|for|match|return|then|while)\b</string>
-            </dict>
-            <!-- Rule: other keywords -->
-            <dict>
-                <key>name</key>
-                <string>keyword.other.carbon</string>
-                <key>match</key>
-                <string>\b(abstract|addr|alias|and|api|as|auto|base|choice|class|destructor|extends|external|final|forall|fn|impl|import|interface|let|library|namespace|not|or|package|private|protected|returned|template|var|virtual|where)\b</string>
-            </dict>
-            <!-- Builtin types -->
-            <dict>
-                <key>name</key>
-                <string>storage.type.carbon</string>
-                <key>match</key>
-                <string>\b(bool|Carbon\.Int|Carbon\.UInt|f16|f32|f64|f128|i8|i16|i32|i64|i128|i256|Slice|String|StringView|Type|u8|u16|u32|u64|u128|u256)\b</string>
-            </dict>
-        </array>
-
-        <!-- Rule repository -->
-        <key>repository</key>
-        <dict>
-            <!-- Rule: comments -->
-            <key>comments</key>
-            <dict>
                 <key>patterns</key>
                 <array>
                     <!-- Multi-line comments -->
@@ -103,6 +71,102 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                         </array>
                     </dict>
                 </array>
+            </dict>
+            <!-- Rule: control flow keywords -->
+            <dict>
+                <key>name</key>
+                <string>keyword.control.carbon</string>
+                <key>match</key>
+                <string>\b(break|case|continue|default|else|if|for|match|return|then|while)\b</string>
+            </dict>
+            <!-- Rule: other keywords -->
+            <dict>
+                <key>name</key>
+                <string>keyword.other.carbon</string>
+                <key>match</key>
+                <string>\b(abstract|addr|alias|and|api|as|auto|base|choice|class|constraint|destructor|extends|external|final|forall|fn|friend|impl|import|interface|let|library|like|namespace|not|observe|or|override|package|partial|private|protected|returned|template|var|virtual|where|while|_)\b</string>
+            </dict>
+            <!-- Rule: builtin types -->
+            <dict>
+                <key>name</key>
+                <string>storage.type.carbon</string>
+                <key>match</key>
+                <string>\b(As|bool|Carbon\.Int|Carbon\.UInt|f16|f32|f64|f128|i8|i16|i32|i64|i128|i256|Slice|String|StringView|Type|u8|u16|u32|u64|u128|u256)\b</string>
+            </dict>
+            <!-- Rule: boolean literals - has keyword coloring -->
+            <dict>
+                <key>name</key>
+                <string>keyword.other.carbon</string>
+                <key>match</key>
+                <string>\b(true|false)\b</string>
+            </dict>
+            <!-- Rule: block string literals -->
+            <dict>
+                <key>name</key>
+                <string>string.quoted.triple.carbon</string>
+                <key>begin</key>
+                <string>"""</string>
+                <key>end</key>
+                <string>"""</string>
+
+                <key>patterns</key>
+                <array>
+                    <dict>
+                        <key>include</key>
+                        <string>#string_escapes</string>
+                    </dict>
+                </array>
+            </dict>
+            <!-- Rule: basic string literals -->
+            <dict>
+                <key>name</key>
+                <string>string.quoted.double.carbon</string>
+                <key>begin</key>
+                <string>"</string>
+                <key>end</key>
+                <string>"</string>
+
+                <key>patterns</key>
+                <array>
+                    <dict>
+                        <key>include</key>
+                        <string>#string_escapes</string>
+                    </dict>
+                </array>
+            </dict>
+            <!-- Rule: decimal number literals -->
+            <dict>
+                <key>name</key>
+                <string>constant.numeric.carbon</string>
+                <key>match</key>
+                <string>[1-9][_0-9]*(\.[_0-9]+(e[-+]?[1-9][0-9]*)?)?</string>
+            </dict>
+            <!-- Rule: hexadecimal number literals -->
+            <dict>
+                <key>name</key>
+                <string>constant.numeric.carbon</string>
+                <key>match</key>
+                <string>0x[_0-9A-F]+(\.[_0-9A-F]+(p[-+]?[1-9][0-9]*)?)?</string>
+            </dict>
+            <!-- Rule: binary number literals -->
+            <dict>
+                <key>name</key>
+                <string>constant.numeric.carbon</string>
+                <key>match</key>
+                <string>0b[_01]+</string>
+            </dict>
+        </array>
+
+        <!-- Rule repository -->
+        <key>repository</key>
+        <dict>
+            <!-- Rule: string escape sequences -->
+            <key>string_escapes</key>
+            <dict>
+                <key>name</key>
+                <string>constant.character.escape.carbon</string>
+                <key>match</key>
+                <string>\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -134,19 +134,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                     </dict>
                 </array>
             </dict>
-            <!-- Rule: decimal number literals -->
-            <dict>
-                <key>name</key>
-                <string>constant.numeric.carbon</string>
-                <key>match</key>
-                <string>[1-9][_0-9]*(\.[_0-9]+(e[-+]?[1-9][0-9]*)?)?</string>
-            </dict>
             <!-- Rule: hexadecimal number literals -->
             <dict>
                 <key>name</key>
                 <string>constant.numeric.carbon</string>
                 <key>match</key>
-                <string>0x[_0-9A-F]+(\.[_0-9A-F]+(p[-+]?[1-9][0-9]*)?)?</string>
+                <string>0x[_0-9a-fA-F]+(\.[_0-9a-fA-F]+(p[-+]?[1-9][0-9]*)?)?</string>
             </dict>
             <!-- Rule: binary number literals -->
             <dict>
@@ -154,6 +147,13 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <string>constant.numeric.carbon</string>
                 <key>match</key>
                 <string>0b[_01]+</string>
+            </dict>
+            <!-- Rule: decimal number literals -->
+            <dict>
+                <key>name</key>
+                <string>constant.numeric.carbon</string>
+                <key>match</key>
+                <string>[1-9][_0-9]*(\.[_0-9]+(e[-+]?[1-9][0-9]*)?)?</string>
             </dict>
         </array>
 
@@ -166,7 +166,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.character.escape.carbon</string>
                 <key>match</key>
-                <string>\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
+                <string>\([tnr'"0\0]|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -4,7 +4,7 @@
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
--->
+ -->
 
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
         "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -57,83 +57,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>match</key>
                 <string>\b(bool|Carbon\.Int|Carbon\.UInt|f16|f32|f64|f128|i8|i16|i32|i64|i128|i256|Slice|String|StringView|Type|u8|u16|u32|u64|u128|u256)\b</string>
             </dict>
-            <!-- Rule: numbers - derived from c.tmbundle -->
-            <dict>
-                <key>name</key>
-                <string>constant.numeric.carbon</string>
-                <key>captures</key>
-                <dict>
-                    <key>inc</key>
-                    <dict>
-                        <key>name</key>
-                        <string>invalid.illegal.digit-separator-should-not-be-last.carbon</string>
-                    </dict>
-                </dict>
-                <key>match</key>
-                <string>(?x)\b
-                    ( (?i:
-                    0x ( [0-9A-Fa-f]+ ( ' [0-9A-Fa-f]+ )* )? # Hexadecimal
-                    | 0b ( [0-1]+ ( ' [0-1]+ )* )? # Binary
-                    | 0 ( [0-7]+ ( ' [0-7]+ )* ) # Octal
-                    | ( [0-9]+ ( ' [0-9]+ )* ) # Decimal
-                    )
-                    ( ([uUfF] | u?ll? | U?LL?)\b | (?&lt;inc&gt;') | \b )
-                    | ( [0-9]+ ( ' [0-9]+ )* )?
-                    (?i:
-                    \. ( [0-9]+ ( ' [0-9]+ )* ) E(\+|-)? ( [0-9]+ ( ' [0-9]+ )*
-                    )
-                    | \. ( [0-9]+ ( ' [0-9]+ )* )
-                    | E(\+|-)? ( [0-9]+ ( ' [0-9]+ )* )
-                    )
-                    ( (?&lt;inc&gt;') | \b )
-                    )
-                </string>
-            </dict>
-            <!-- Rule: strings - derived from c.tmbundle -->
-            <dict>
-                <key>name</key>
-                <string>string.quoted.double.carbon</string>
-                <key>begin</key>
-                <string>"</string>
-                <key>beginCaptures</key>
-                <dict>
-                </dict>
-                <key>end</key>
-                <string>"</string>
-                <key>endCaptures</key>
-                <key>patterns</key>
-                <array>
-                    <dict>
-                        <key>include</key>
-                        <string>#string_escaped_char</string>
-                    </dict>
-                </array>
-            </dict>
         </array>
 
         <!-- Rule repository -->
         <key>repository</key>
         <dict>
-            <!-- Rule: string escapes -->
-            <key>string_escaped_char</key>
-            <dict>
-                <key>patterns</key>
-                <array>
-                    <dict>
-                        <key>name</key>
-                        <string>constant.character.escape.carbon</string>
-                        <key>match</key>
-                        <string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
-                    </dict>
-                    <dict>
-                        <key>name</key>
-                        <string>invalid.illegal.unknown-escape.carbon</string>
-                        <key>match</key>
-                        <string>\\.</string>
-                    </dict>
-                </array>
-            </dict>
-
             <!-- Rule: comments -->
             <key>comments</key>
             <dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -33,42 +33,19 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <array>
             <!-- Rule: comments -->
             <dict>
+                <key>begin</key>
+                <string>(^[ \t]+)?(?=//)</string>
+                <key>end</key>
+                <string>(?!\G)</string>
                 <key>patterns</key>
                 <array>
-                    <!-- Multi-line comments -->
                     <dict>
                         <key>name</key>
-                        <string>comment.block.carbon</string>
+                        <string>comment.line.carbon</string>
                         <key>begin</key>
-                        <string>/\*</string>
+                        <string>//</string>
                         <key>end</key>
-                        <string>\*/</string>
-                    </dict>
-                    <!-- Unterminated multi-line comments -->
-                    <dict>
-                        <key>name</key>
-                        <string>invalid.illegal.unterminated-multi-line.carbon
-                        </string>
-                        <key>match</key>
-                        <string>\*/</string>
-                    </dict>
-                    <!-- Single-line comments -->
-                    <dict>
-                        <key>begin</key>
-                        <string>(^[ \t]+)?(?=//)</string>
-                        <key>end</key>
-                        <string>(?!\G)</string>
-                        <key>patterns</key>
-                        <array>
-                            <dict>
-                                <key>name</key>
-                                <string>comment.line.carbon</string>
-                                <key>begin</key>
-                                <string>//</string>
-                                <key>end</key>
-                                <string>$</string>
-                            </dict>
-                        </array>
+                        <string>$</string>
                     </dict>
                 </array>
             </dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -139,7 +139,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.numeric.carbon</string>
                 <key>match</key>
-                <string>0x[_0-9a-fA-F]+(\.[_0-9a-fA-F]+(p[-+]?[1-9][0-9]*)?)?</string>
+                <string>0x[_0-9A-F]+(\.[_0-9A-F]+(p[-+]?[1-9][0-9]*)?)?</string>
             </dict>
             <!-- Rule: binary number literals -->
             <dict>
@@ -166,7 +166,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.character.escape.carbon</string>
                 <key>match</key>
-                <string>\([tnr'"0\0]|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]{4,}\})</string>
+                <string>\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <!-- Section metadata -->
+        <key>name</key>
+        <string>carbon</string>
+        <key>uuid</key>
+        <string>04F7F7E3-D5EE-40A4-9899-53CD34D28276</string>
+        <key>scopeName</key>
+        <string>source.carbon</string>
+        <key>fileTypes</key>
+        <array>
+            <string>carbon</string>
+        </array>
+
+        <!-- Folding markers -->
+        <key>foldingStartMarker</key>
+        <string>\{\s*$</string>
+        <key>foldingStopMarker</key>
+        <string>^\s*\}</string>
+
+        <!-- Active patterns from repository -->
+        <key>patterns</key>
+        <array>
+            <!-- Rule: comments -->
+            <dict>
+                <key>include</key>
+                <string>#comments</string>
+            </dict>
+            <!-- Rule: control flow keywords -->
+            <dict>
+                <key>name</key>
+                <string>keyword.control.carbon</string>
+                <key>match</key>
+                <string>\b(break|case|continue|else|if|for|match|return|then|while)\b</string>
+            </dict>
+            <!-- Rule: other keywords -->
+            <dict>
+                <key>name</key>
+                <string>keyword.other.carbon</string>
+                <key>match</key>
+                <string>\b(abstract|addr|alias|and|api|as|auto|base|choice|class|destructor|extends|external|final|forall|fn|impl|import|interface|let|library|namespace|not|or|package|private|protected|returned|template|var|virtual|where)\b</string>
+            </dict>
+            <!-- Builtin types -->
+            <dict>
+                <key>name</key>
+                <string>storage.type.carbon</string>
+                <key>match</key>
+                <string>\b(bool|Carbon\.Int|Carbon\.UInt|f16|f32|f64|f128|i8|i16|i32|i64|i128|i256|Slice|String|StringView|Type|u8|u16|u32|u64|u128|u256)\b</string>
+            </dict>
+            <!-- Rule: numbers - derived from c.tmbundle -->
+            <dict>
+                <key>name</key>
+                <string>constant.numeric.carbon</string>
+                <key>captures</key>
+                <dict>
+                    <key>inc</key>
+                    <dict>
+                        <key>name</key>
+                        <string>invalid.illegal.digit-separator-should-not-be-last.carbon</string>
+                    </dict>
+                </dict>
+                <key>match</key>
+                <string>(?x)\b
+                    ( (?i:
+                    0x ( [0-9A-Fa-f]+ ( ' [0-9A-Fa-f]+ )* )? # Hexadecimal
+                    | 0b ( [0-1]+ ( ' [0-1]+ )* )? # Binary
+                    | 0 ( [0-7]+ ( ' [0-7]+ )* ) # Octal
+                    | ( [0-9]+ ( ' [0-9]+ )* ) # Decimal
+                    )
+                    ( ([uUfF] | u?ll? | U?LL?)\b | (?&lt;inc&gt;') | \b )
+                    | ( [0-9]+ ( ' [0-9]+ )* )?
+                    (?i:
+                    \. ( [0-9]+ ( ' [0-9]+ )* ) E(\+|-)? ( [0-9]+ ( ' [0-9]+ )*
+                    )
+                    | \. ( [0-9]+ ( ' [0-9]+ )* )
+                    | E(\+|-)? ( [0-9]+ ( ' [0-9]+ )* )
+                    )
+                    ( (?&lt;inc&gt;') | \b )
+                    )
+                </string>
+            </dict>
+            <!-- Rule: strings - derived from c.tmbundle -->
+            <dict>
+                <key>name</key>
+                <string>string.quoted.double.carbon</string>
+                <key>begin</key>
+                <string>"</string>
+                <key>beginCaptures</key>
+                <dict>
+                </dict>
+                <key>end</key>
+                <string>"</string>
+                <key>endCaptures</key>
+                <key>patterns</key>
+                <array>
+                    <dict>
+                        <key>include</key>
+                        <string>#string_escaped_char</string>
+                    </dict>
+                </array>
+            </dict>
+        </array>
+
+        <!-- Rule repository -->
+        <key>repository</key>
+        <dict>
+            <!-- Rule: string escapes -->
+            <key>string_escaped_char</key>
+            <dict>
+                <key>patterns</key>
+                <array>
+                    <dict>
+                        <key>name</key>
+                        <string>constant.character.escape.carbon</string>
+                        <key>match</key>
+                        <string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+                    </dict>
+                    <dict>
+                        <key>name</key>
+                        <string>invalid.illegal.unknown-escape.carbon</string>
+                        <key>match</key>
+                        <string>\\.</string>
+                    </dict>
+                </array>
+            </dict>
+
+            <!-- Rule: comments -->
+            <key>comments</key>
+            <dict>
+                <key>patterns</key>
+                <array>
+                    <!-- Multi-line comments -->
+                    <dict>
+                        <key>name</key>
+                        <string>comment.block.carbon</string>
+                        <key>begin</key>
+                        <string>/\*</string>
+                        <key>end</key>
+                        <string>\*/</string>
+                    </dict>
+                    <!-- Unterminated multi-line comments -->
+                    <dict>
+                        <key>name</key>
+                        <string>invalid.illegal.unterminated-multi-line.carbon
+                        </string>
+                        <key>match</key>
+                        <string>\*/</string>
+                    </dict>
+                    <!-- Single-line comments -->
+                    <dict>
+                        <key>begin</key>
+                        <string>(^[ \t]+)?(?=//)</string>
+                        <key>end</key>
+                        <string>(?!\G)</string>
+                        <key>patterns</key>
+                        <array>
+                            <dict>
+                                <key>name</key>
+                                <string>comment.line.carbon</string>
+                                <key>begin</key>
+                                <string>//</string>
+                                <key>end</key>
+                                <string>$</string>
+                            </dict>
+                        </array>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </dict>
+</plist>

--- a/utils/textmate/info.plist
+++ b/utils/textmate/info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <key>contactName</key>
+    <string>Carbon Developers</string>
+
+    <key>description</key>
+    <string>Support for Carbon Language</string>
+
+    <key>name</key>
+    <string>carbon</string>
+
+    <key>ordering</key>
+    <array>
+        <string>04F7F7E3-D5EE-40A4-9899-53CD34D28276</string>
+    </array>
+
+    <key>uuid</key>
+    <string>6152A817-84AE-47A8-96DB-0B50DF2EEC10</string>
+</plist>

--- a/utils/textmate/info.plist
+++ b/utils/textmate/info.plist
@@ -4,7 +4,7 @@
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
--->
+ -->
 
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
TextMate is the go-to definition language for syntax highlighting for editors lack dedicated language support for a given programming language. This patch contains a very minimal, yet functional TextMate bundle definition for Carbon.

This allows Carbon users to import the TextMate bundle into their editors to get basic syntax highlighting for Carbon code until we have a more solid specification for the language (that's when the fun with dedicated plugins/extensions begins!).

**Support**
- String literals with escape codes (currently using C highlighting rules)
- Numeric literals in decimal, hexadecimal and binary (lacks _ separator support though)
- Single and multi-line comments
- Highlighting of all? (let me know if some are missing) keywords in the language

Here is an image of the highlighting in action in IntelliJ Dracula mode
![image](https://user-images.githubusercontent.com/42585241/180587912-23b5ae3e-2bdb-49a1-83e8-24e6e0b7cfb5.png)