### PR TITLE
Fix: Replace `Int: x` -> `x: Int`

### DIFF
--- a/explorer/README.md
+++ b/explorer/README.md
@@ -225,7 +225,7 @@ so the expected result of this program is `2`.
 
 ```carbon
 fn Main() -> Int {
-  var Int: x = 0;
+  var x: Int = 0;
   __continuation k {
     x = x + 1;
     __await;

--- a/explorer/README.md
+++ b/explorer/README.md
@@ -224,8 +224,8 @@ The first time increments `x` to `1` and the second time increments `x` to `2`,
 so the expected result of this program is `2`.
 
 ```carbon
-fn Main() -> Int {
-  var x: Int = 0;
+fn Main() -> i32 {
+  var x: i32 = 0;
   __continuation k {
     x = x + 1;
     __await;


### PR DESCRIPTION
Declaring variables should use `var x: Int`.