### PR TITLE
Remove non-needed Python 2.x inherit from `object`

### DIFF
--- a/github_tools/github_helpers.py
+++ b/github_tools/github_helpers.py
@@ -43,7 +43,7 @@ def add_access_token_arg(
     )
 
 
-class Client(object):
+class Client:
     """A GitHub GraphQL client."""
 
     def __init__(self, parsed_args: argparse.Namespace):

--- a/github_tools/pr_comments.py
+++ b/github_tools/pr_comments.py
@@ -110,7 +110,7 @@ _QUERY_REVIEW_THREADS = """
 """
 
 
-class _Comment(object):
+class _Comment:
     """A comment, either on a review thread or top-level on the PR."""
 
     def __init__(self, author: str, timestamp: str, body: str):
@@ -183,7 +183,7 @@ class _PRComment(_Comment):
         return "%s\n%s" % (self.url, super().format(long))
 
 
-class _Thread(object):
+class _Thread:
     """A review thread on a line of code."""
 
     def __init__(self, parsed_args: argparse.Namespace, thread: Dict):

--- a/migrate_cpp/migrate_cpp.py
+++ b/migrate_cpp/migrate_cpp.py
@@ -18,7 +18,7 @@ _H_EXTS = {".h", ".hpp"}
 _CPP_EXTS = {".c", ".cc", ".cpp", ".cxx"}
 
 
-class _Workflow(object):
+class _Workflow:
     _parsed_args: argparse.Namespace
     _data_dir: str
     _cpp_files: Optional[List[str]]


### PR DESCRIPTION
In Python 3.x it is not necessary to have `object` inheritance in classes, it may be useful to have `object` inheritance in classes if the code has support for Python 3.x, 2.x, but currently the present code does not contain support for python 2.x.