### PR TITLE
Code cleanup & fix typos

### DIFF
--- a/installers/local/carbon.cpp
+++ b/installers/local/carbon.cpp
@@ -1,3 +1,7 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include "explorer/main.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"

--- a/installers/local/carbon.cpp
+++ b/installers/local/carbon.cpp
@@ -1,7 +1,3 @@
-// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-// Exceptions. See /LICENSE for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 #include "explorer/main.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"
@@ -12,16 +8,19 @@ namespace path = llvm::sys::path;
 
 auto main(int argc, char** argv) -> int {
   llvm::StringRef bin = path::filename(argv[0]);
+
   if (bin == "carbon-explorer") {
-    static int static_for_main_addr;
+    static int static_for_main_address;
+
     std::string exe = fs::getMainExecutable(
-        argv[0], static_cast<void*>(&static_for_main_addr));
+            argv[0], static_cast<void *>(&static_for_main_address)
+    );
     llvm::StringRef install_path = path::parent_path(exe);
     llvm::SmallString<256> prelude_file(install_path);
     path::append(prelude_file, "data", "prelude.carbon");
+    
     return Carbon::ExplorerMain(prelude_file, argc, argv);
   } else {
-    fprintf(stderr, "Unrecognized Carbon binary requested: %s", argv[0]);
-    return 1;
+    return fprintf(stderr, "Unrecognized Carbon binary requested: %s", argv[0]), 1;
   }
 }

--- a/installers/local/carbon.cpp
+++ b/installers/local/carbon.cpp
@@ -13,14 +13,14 @@ auto main(int argc, char** argv) -> int {
     static int static_for_main_address;
 
     std::string exe = fs::getMainExecutable(
-            argv[0], static_cast<void *>(&static_for_main_address)
-    );
+            argv[0], static_cast<void *>(&static_for_main_address));
     llvm::StringRef install_path = path::parent_path(exe);
     llvm::SmallString<256> prelude_file(install_path);
     path::append(prelude_file, "data", "prelude.carbon");
     
     return Carbon::ExplorerMain(prelude_file, argc, argv);
   } else {
-    return fprintf(stderr, "Unrecognized Carbon binary requested: %s", argv[0]), 1;
+    return fprintf(stderr, "Unrecognized Carbon binary requested: %s", argv[0]),
+           1;
   }
 }

--- a/migrate_cpp/cpp_refactoring/fn_inserter.cpp
+++ b/migrate_cpp/cpp_refactoring/fn_inserter.cpp
@@ -27,9 +27,9 @@ void FnInserter::Run() {
   llvm::SmallVector<llvm::StringRef> split;
   GetSourceText(range).split(split, ' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
   std::string new_text = "fn ";
-  for (llvm::StringRef t : split) {
-    if (t != "auto" && t != "void") {
-      new_text += t.str() + " ";
+  for (llvm::StringRef text : split) {
+    if (text != "auto" && text != "void") {
+      new_text += text.str() + ' ';
     }
   }
   AddReplacement(range, new_text);

--- a/migrate_cpp/cpp_refactoring/var_decl.cpp
+++ b/migrate_cpp/cpp_refactoring/var_decl.cpp
@@ -54,7 +54,7 @@ auto VarDecl::GetTypeStr(const clang::VarDecl& decl) -> std::string {
     } else if (range_str.empty()) {
       segments.push_back({type_loc_class, qual_str});
     } else {
-      segments.push_back({type_loc_class, qual_str + " " + range_str});
+      segments.push_back({type_loc_class, qual_str + ' ' + range_str});
     }
 
     type_loc = type_loc.getNextTypeLoc();
@@ -72,10 +72,10 @@ auto VarDecl::GetTypeStr(const clang::VarDecl& decl) -> std::string {
         break;
       case clang::TypeLoc::Qualified:
         if (prev_class == clang::TypeLoc::Pointer) {
-          type_str += " " + text;
+          type_str += ' ' + text;
         } else {
           if (!type_str.empty()) {
-            type_str.insert(0, " ");
+            type_str.insert(0, ' ');
           }
           type_str.insert(0, text);
         }

--- a/migrate_cpp/cpp_refactoring/var_decl.cpp
+++ b/migrate_cpp/cpp_refactoring/var_decl.cpp
@@ -75,7 +75,7 @@ auto VarDecl::GetTypeStr(const clang::VarDecl& decl) -> std::string {
           type_str += ' ' + text;
         } else {
           if (!type_str.empty()) {
-            type_str.insert(0, ' ');
+            type_str.insert(0, " ");
           }
           type_str.insert(0, text);
         }


### PR DESCRIPTION
Small efficiency boost by replacing "\n" into '\n',
change variable name to make it easier to read and understand,
added extra spaces to make it easier to read.