### PR TITLE
Fix grammar errors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,12 +15,12 @@ If you're trying to learn more about Carbon, we recommend starting at
 
 ## Design
 
-The design of the Carbon language, and the rationale for that design, is
+The design of the Carbon language, and the rationale for that design, are
 documented in the [`design/` directory](design/README.md). This documentation is
-intended to support these audiences:
+intended to support the following audiences:
 
--   People who wish to determine whether Carbon would be the right choice to use
-    for a project compared to other existing languages.
+-   People who wish to determine whether Carbon would be the right choice for a
+    project compared to other existing languages.
 -   People working on the evolution of the Carbon language who wish to
     understand the rationale and motivation for existing design decisions.
 -   People working on a specification or implementation of the Carbon language

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,9 @@ If you're trying to learn more about Carbon, we recommend starting at
 
 ## Design
 
-The design of the Carbon language, and the rationale for that design, are
-documented in the [`design/` directory](design/README.md). This documentation is
-intended to support the following audiences:
+Carbon language's design and rationale are documented in the
+[`design/` directory](design/README.md). This documentation is intended to
+support the following audiences:
 
 -   People who wish to determine whether Carbon would be the right choice for a
     project compared to other existing languages.


### PR DESCRIPTION
Fix grammar errors:
- the following audiences sounds more natural.
- are instead of is.
- "to use" is wordy and superfluous.