### PR TITLE
Add a link the the stacked pull request docs

### DIFF
--- a/docs/project/code_review.md
+++ b/docs/project/code_review.md
@@ -218,10 +218,10 @@ far. It is still possible to shrink a change so much that it becomes nonsensical
 in isolation. For example, a change without appropriate tests is not
 self-contained.
 
-You may want to use a set of stacked pull requests rather than a single, larger
-pull request in order to keep changes easy to review.
-
-> TODO: link to the stacked pull request documentation when available.
+You may want to use a set of
+[stacked pull requests](pull_request_workflow.md#stacking-dependent-pull-requests)
+rather than a single, larger pull request in order to keep changes easy to
+review.
 
 ### Responding to review comments
 


### PR DESCRIPTION
The stacked pull request documentation exists now, so remove the TODO
and add a link to it.