### PR TITLE
Incomplete sentence in _`let` bindings_

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -698,7 +698,7 @@ A `let`-binding may trigger a copy of the original value, or a move if the
 original value is a temporary, or the binding may be a pointer to the original
 value, like a
 [`const` reference in C++](<https://en.wikipedia.org/wiki/Reference_(C%2B%2B)>).
-Which of these options (copy or move or pointer) is selected must not be observable to the programmer. For example, Carbon will
+Which of these options (copy, move, or pointer) is selected must not be observable to the programmer. For example, Carbon will
 not allow modifications to the original value when it is through a pointer. This
 choice may also be influenced by the type. For example, types that don't support
 being copied will be passed by pointer instead.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -698,10 +698,11 @@ A `let`-binding may trigger a copy of the original value, or a move if the
 original value is a temporary, or the binding may be a pointer to the original
 value, like a
 [`const` reference in C++](<https://en.wikipedia.org/wiki/Reference_(C%2B%2B)>).
-Which of these options (copy, move, or pointer) is selected must not be observable to the programmer. For example, Carbon will
-not allow modifications to the original value when it is through a pointer. This
-choice may also be influenced by the type. For example, types that don't support
-being copied will be passed by pointer instead.
+Which of these options (copy, move, or pointer) is selected must not be
+observable to the programmer. For example, Carbon will not allow modifications
+to the original value when it is through a pointer. This choice may also be
+influenced by the type. For example, types that don't support being copied will
+be passed by pointer instead.
 
 A [generic binding](#checked-and-template-parameters) uses `:!` instead of a
 colon (`:`) and can only match

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -698,7 +698,7 @@ A `let`-binding may trigger a copy of the original value, or a move if the
 original value is a temporary, or the binding may be a pointer to the original
 value, like a
 [`const` reference in C++](<https://en.wikipedia.org/wiki/Reference_(C%2B%2B)>).
-Which option must not be observable to the programmer. For example, Carbon will
+Which of these options (copy or move or pointer) is selected must not be observable to the programmer. For example, Carbon will
 not allow modifications to the original value when it is through a pointer. This
 choice may also be influenced by the type. For example, types that don't support
 being copied will be passed by pointer instead.


### PR DESCRIPTION
The original sentence was grammatically unsound, specified the three options of copy, move or pointer binding in parenthesis and some words around it.