### PR TITLE
Fixed Broken Link

### DIFF
--- a/docs/project/faq.md
+++ b/docs/project/faq.md
@@ -114,7 +114,7 @@ Carbon can also be explored interactively on
 
 ## Why build Carbon?
 
-See the [project README](#why-build-carbon) for an overview of the motivation
+See the [project README](https://github.com/carbon-language/carbon-lang#readme) for an overview of the motivation
 for Carbon. This section dives into specific questions in that space.
 
 ### Why is performance critical?


### PR DESCRIPTION
Fixed the Link in section https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/faq.md#why-build-carbon to forward to the main readme of the project which before linked to the same section(#why-build-carbon)