### PR TITLE
[WIP] Implement Emacs major-mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,6 +159,11 @@ repos:
           - '// '
           - ''
           - --custom_format
+          - '\.el$' # Emacs Lisp
+          - ''
+          - ';; '
+          - ''
+          - --custom_format
           - '\.(l|lpp|y)$'
           - '/*'
           - ''

--- a/utils/emacs/README.md
+++ b/utils/emacs/README.md
@@ -1,0 +1,20 @@
+# Carbon-mode
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+`carbon-mode` provides Carbon syntax highlighting for Emacs.
+
+## Installation
+
+Currently only manual installation is supported.
+
+### Manual installation
+
+```elisp
+(add-to-list 'load-path "/path/to/carbon-mode/")
+(autoload carbon-mode "carbon-mode" nil t)
+```

--- a/utils/emacs/carbon-mode.el
+++ b/utils/emacs/carbon-mode.el
@@ -1,0 +1,127 @@
+;;; carbon-mode.el --- major mode for editing Carbon source code  -*- lexical-binding: t; -*-
+
+;; Version: 0.0.0
+;; Author: Lesley Lai
+;; Url: https://github.com/rust-lang/rust-mode
+;; Keywords: languages
+;; Package-Requires: ((emacs "28.0"))
+
+;; Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+;; Exceptions. See /LICENSE for license information.
+;; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+;;; Commentary:
+
+;; This package implements a major-mode for editing Carbon source code.
+
+;; TODOs
+;; Highlighting for variable definition
+
+;;; Code:
+
+(eval-when-compile
+  (require 'rx))
+
+;;; Customization
+
+(defgroup carbon-mode nil
+  "Support for Carbon code."
+  :link '(url-link "https://github.com/carbon-language/carbon-lang")
+  :group 'languages)
+
+(defface carbon-function-face '((t :inherit font-lock-function-name-face))
+  "Face for the function definitions."
+  :group 'carbon-mode)
+
+(defface carbon-class-face '((t :inherit font-lock-type-face))
+  "Face for the class/interface/constraint definitions."
+  :group 'carbon-mode)
+
+;;; Utils
+
+;; Create a capture group for inner
+(defun carbon-re-grab (inner)
+  (concat "\\(" inner "\\)"))
+
+;; Create a non-capturing group for inner
+(defun carbon-re-shy (inner)
+  (concat "\\(?:" inner "\\)"))
+
+;;; Syntax
+
+(defconst carbon-keywords
+  '(      "abstract" "addr" "alias" "and" "api" "as" "auto" "base" "break" "case" "class"
+          "constraint" "continue" "default" "else" "extends" "external" "final" "fn" "for" "forall"
+          "friend" "if" "impl" "import" "in" "interface" "is" "let" "library" "like" "match" "me"
+          "namespace" "not" "observe" "or" "override" "package" "partial" "private" "protected"
+          "return" "returned" "then" "_" "var" "virtual" "where" "while"))
+
+(defconst carbon-literals '("false" "true"))
+
+(defconst carbon-re-identifier "[_A-Za-z][_A-Za-z0-9]*")
+
+(defconst carbon-re-number-literal
+  (rx (or (regex "[1-9][_0-9]*\\(\\.[_0-9]+\\(e[-+]?[1-9][0-9]*\\)\\)?")
+          (regex "0x[_0-9A-F]+\\(\\.[_0-9A-F]+\\(p[-+]?[1-9][0-9]*\\)?\\)?")
+          (regex "0b[_01]+"))))
+
+(defconst carbon-re-class-def
+  (concat (carbon-re-shy (rx (seq (or "class"
+                                      "interface"
+                                      "constraint")
+                                  (+ space))))
+          (carbon-re-grab carbon-re-identifier)))
+
+(defconst carbon-re-fn-def
+  (concat (carbon-re-shy "fn[[:space:]]+")
+          (carbon-re-grab carbon-re-identifier)))
+
+(defconst carbon-re-builtin-types (rx (seq (or "i"
+                                               "u"
+                                               "f")
+                                           (or "8"
+                                               "16"
+                                               "32"
+                                               "64"
+                                               "128"))))
+
+(defvar carbon-font-lock-keywords
+  `((,carbon-re-builtin-types . 'font-lock-type-face)
+    (,carbon-re-number-literal . 'font-lock-constant-face)
+    (,(regexp-opt carbon-literals 'words) . 'font-lock-constant-face)
+    (,(regexp-opt carbon-keywords 'words) . 'font-lock-keyword-face)
+    (,carbon-re-fn-def 1 'carbon-function-face)
+    (,carbon-re-class-def 1 'carbon-class-face)))
+
+;; Syntax table
+(defvar carbon-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    ;; Strings
+    (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\\ "\\" table)
+
+    ;; Comments
+    (modify-syntax-entry ?/  ". 12b" table)
+    (modify-syntax-entry ?\n "> b"    table)
+    (modify-syntax-entry ?\^m "> b"   table) table)
+  "Syntax definitions and helpers.")
+
+;; Put everything together
+(define-derived-mode carbon-mode prog-mode
+  "Carbon"
+  "Major mode for editing code in the Carbon programming language."
+  :syntax-table carbon-mode-syntax-table
+
+  ;; Highlighting
+  (setq-local font-lock-defaults '((carbon-font-lock-keywords)))
+
+  ;; Comment insertion
+  (setq-local comment-start "// ")
+  (setq-local comment-end   ""))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.carbon\\'" . carbon-mode))
+
+(provide 'carbon-mode)
+
+;; carbon-mode.el ends here


### PR DESCRIPTION
Currently, syntax highlighting of comments, keywords, functions, classes, and numeric literals are implemented.

Light             |  Dark
:-------------------------:|:-------------------------:
![Demo of the syntax highlighting or Carbon under a light mode](https://user-images.githubusercontent.com/8359374/181000240-dd563955-9a4a-49a0-b1a5-65555f38b157.png) | ![Demo of the syntax highlighting or Carbon under a dark mode](https://user-images.githubusercontent.com/8359374/181000141-ddc1de87-ffb0-44c6-b3c1-154f9dddabad.png)

