### PR TITLE
Add syntax highlighting for vim and neovim

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,6 +163,11 @@ repos:
           - '/*'
           - ''
           - '*/'
+          - --custom_format
+          - '\.vim$'
+          - ''
+          - '" '
+          - ''
         exclude: |
           (?x)^(
               .bazelversion|

--- a/utils/vim/README.md
+++ b/utils/vim/README.md
@@ -1,10 +1,11 @@
+# Carbon Syntax Highlighting for Vim & Neovim
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-# Carbon Syntax Highlighting for Vim & Neovim
 
 For Carbon devs using Vim or Neovim, this plugin provides syntax highlighting for .carbon files found throughout `explorer/testdata`
 

--- a/utils/vim/README.md
+++ b/utils/vim/README.md
@@ -1,0 +1,29 @@
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+# Carbon Syntax Highlighting for Vim & Neovim
+
+For Carbon devs using Vim or Neovim, this plugin provides syntax highlighting for .carbon files found throughout `explorer/testdata`
+
+# Manual Installation
+
+## Vim Users
+
+From the current directory `utils/vim`, please run the following commands to install the syntax file.
+
+```
+mkdir -p ~/.vim/syntax && cp syntax/carbon.vim ~/.vim/syntax/
+mkdir -p ~/.vim/ftdetect && cp ftdetect/carbon.vim ~/.vim/ftdetect/
+```
+
+## Neovim Users
+
+Instead of copying to the `~/.vim` directory, please use the `~/.config/nvim` directory, or your custom Neovim root directory.
+
+```
+mkdir -p ~/.config/nvim/syntax && cp syntax/carbon.vim ~/.config/nvim/syntax/
+mkdir -p ~/.config/nvim/ftdetect && cp ftdetect/carbon.vim ~/.config/nvim/ftdetect/
+```

--- a/utils/vim/README.md
+++ b/utils/vim/README.md
@@ -9,9 +9,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 For Carbon devs using Vim or Neovim, this plugin provides syntax highlighting for .carbon files found throughout `explorer/testdata`
 
-# Manual Installation
+## Manual Installation
 
-## Vim Users
+### Vim Users
 
 From the current directory `utils/vim`, please run the following commands to install the syntax file.
 
@@ -20,7 +20,7 @@ mkdir -p ~/.vim/syntax && cp syntax/carbon.vim ~/.vim/syntax/
 mkdir -p ~/.vim/ftdetect && cp ftdetect/carbon.vim ~/.vim/ftdetect/
 ```
 
-## Neovim Users
+### Neovim Users
 
 Instead of copying to the `~/.vim` directory, please use the `~/.config/nvim` directory, or your custom Neovim root directory.
 

--- a/utils/vim/README.md
+++ b/utils/vim/README.md
@@ -6,14 +6,15 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-
-For Carbon devs using Vim or Neovim, this plugin provides syntax highlighting for .carbon files found throughout `explorer/testdata`
+For Carbon devs using Vim or Neovim, this plugin provides syntax highlighting
+for .carbon files found throughout `explorer/testdata`
 
 ## Manual Installation
 
 ### Vim Users
 
-From the current directory `utils/vim`, please run the following commands to install the syntax file.
+From the current directory `utils/vim`, please run the following commands to
+install the syntax file.
 
 ```
 mkdir -p ~/.vim/syntax && cp syntax/carbon.vim ~/.vim/syntax/
@@ -22,7 +23,8 @@ mkdir -p ~/.vim/ftdetect && cp ftdetect/carbon.vim ~/.vim/ftdetect/
 
 ### Neovim Users
 
-Instead of copying to the `~/.vim` directory, please use the `~/.config/nvim` directory, or your custom Neovim root directory.
+Instead of copying to the `~/.vim` directory, please use the `~/.config/nvim`
+directory, or your custom Neovim root directory.
 
 ```
 mkdir -p ~/.config/nvim/syntax && cp syntax/carbon.vim ~/.config/nvim/syntax/

--- a/utils/vim/ftdetect/carbon.vim
+++ b/utils/vim/ftdetect/carbon.vim
@@ -1,5 +1,5 @@
-# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-# Exceptions. See /LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+" Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+" Exceptions. See /LICENSE for license information.
+" SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 autocmd BufNewFile,BufRead *.carbon setfiletype carbon

--- a/utils/vim/ftdetect/carbon.vim
+++ b/utils/vim/ftdetect/carbon.vim
@@ -1,0 +1,5 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+autocmd BufNewFile,BufRead *.carbon setfiletype carbon

--- a/utils/vim/syntax/carbon.vim
+++ b/utils/vim/syntax/carbon.vim
@@ -1,6 +1,6 @@
-# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-# Exceptions. See /LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+" Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+" Exceptions. See /LICENSE for license information.
+" SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 if exists("b:current_syntax")
   finish

--- a/utils/vim/syntax/carbon.vim
+++ b/utils/vim/syntax/carbon.vim
@@ -1,0 +1,117 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match carbonIdentifier '[a-zA-Z0-9_]\+' contained
+syn match carbonNominalType '[a-zA-Z0-9_]\+' contained
+syn match carbonComment "//.*$" contains=carbonTodo,carbonPreprocess
+syn keyword carbonTodo TODO contained
+syn keyword carbonPreprocess RUN AUTOUPDATE CHECK contained
+
+" carbon primitive types and literals
+syn keyword carbonBooleanType bool
+syn keyword carbonIntType i8 i16 i32 i64 i128
+syn keyword carbonUnsignedIntType u8 u16 u32 u64 u128
+syn keyword carbonFloatType f16 f32 f64
+syn keyword carbonStringType String
+syn keyword carbonBoolean true false
+syn match carbonInt '\<\d\+\>'
+syn match carbonHexLiteral '\<0x[0-9A-F]\+\>'
+syn match carbonBinLiteral '\<0b[01]\+\>'
+syn match carbonFloat '\<\d\+\.\d\+\>'
+syn match carbonFloatExponent '\<\d\+\.\d\+e[+-]\?\d\+\>'
+syn region carbonStringLiteral start=+"+ end=+"+ skip=+\\"+
+syn region carbonBlockStringLiteral start=+"""+ end=+"""+ skip=+\\"""+
+
+" carbon declaration introducers
+syn keyword carbonNamespaceDeclaration namespace
+syn keyword carbonVariableDeclaration var nextgroup=carbonIdentifier skipwhite
+syn keyword carbonVariableDeclarationMod returned
+syn keyword carbonConstantDeclaration let nextgroup=carbonIdentifier skipwhite
+syn keyword carbonFunctionDeclaration fn
+syn keyword carbonClassDeclaration class  nextgroup=carbonNominalType skipwhite
+syn keyword carbonClassDeclarationMod base abstract final
+syn keyword carbonClassMethodDeclaration fn destructor
+syn keyword carbonClassMethodDeclarationMod private virtual abstract protected impl
+syn keyword carbonAliasDeclaration alias nextgroup=carbonNominalType skipwhite
+syn keyword carbonInterfaceDeclaration interface nextgroup=carbonNominalType skipwhite
+syn keyword carbonChoiceDeclaration choice nextgroup=carbonNominalType skipwhite
+syn keyword carbonPackageDeclaration package nextgroup=carbonIdentifier skipwhite
+syn keyword carbonLibraryDeclaration library nextgroup=carbonStringLiteral skipwhite
+
+" carbon control flow
+syn keyword carbonConditional if then else
+syn keyword carbonLoop while for in
+syn keyword carbonSwitch match case default
+syn keyword carbonControlFlowStatement break continue return
+
+" carbon operators
+syn keyword carbonLogicalOperator and or not
+
+" handle any other keywords
+syn keyword carbonKeywordExtends extends nextgroup=carbonNominalType skipwhite
+syn keyword carbonKeywordSelf Self
+syn keyword carbonKeywordAs as
+syn keyword carbonKeywordTemplate template
+syn keyword carbonKeywordExternal external
+syn keyword carbonKeywordForAll forall
+syn keyword carbonKeywordAPI api
+syn keyword carbonKeywordImport import nextgroup=carbonIdentifier skipwhite
+
+hi def link carbonIdentifier Identifier
+hi def link carbonNominalType Type
+hi def link carbonComment Comment
+hi def link carbonTodo Todo
+hi def link carbonPreprocess PreProc
+hi def link carbonBooleanType carbonType
+hi def link carbonIntType carbonType
+hi def link carbonUnsignedIntType carbonType
+hi def link carbonFloatType carbonType
+hi def link carbonStringType carbonType
+hi def link carbonType Type
+hi def link carbonBoolean Boolean
+hi def link carbonInt carbonNumber
+hi def link carbonHexLiteral carbonNumber
+hi def link carbonBinLiteral carbonNumber
+hi def link carbonFloat carbonNumber
+hi def link carbonFloatExponent carbonNumber
+hi def link carbonNumber Number
+hi def link carbonStringLiteral carbonString
+hi def link carbonBlockStringLiteral carbonString
+hi def link carbonString String
+hi def link carbonNamespaceDeclaration carbonDeclaration
+hi def link carbonVariableDeclaration carbonDeclaration
+hi def link carbonVariableDeclarationMod carbonDeclaration
+hi def link carbonConstantDeclaration carbonDeclaration
+hi def link carbonFunctionDeclaration carbonDeclaration
+hi def link carbonClassDeclaration carbonDeclaration
+hi def link carbonClassDeclarationMod carbonDeclaration
+hi def link carbonClassMethodDeclaration carbonDeclaration
+hi def link carbonClassMethodDeclarationMod carbonDeclaration
+hi def link carbonAliasDeclaration carbonDeclaration
+hi def link carbonInterfaceDeclaration carbonDeclaration
+hi def link carbonChoiceDeclaration carbonDeclaration
+hi def link carbonPackageDeclaration Include
+hi def link carbonLibraryDeclaration Include
+hi def link carbonDeclaration Structure
+hi def link carbonKeywordExtends carbonKeyword
+hi def link carbonKeywordSelf carbonKeyword
+hi def link carbonKeywordAs carbonKeyword
+hi def link carbonKeywordTemplate carbonKeyword
+hi def link carbonKeywordExternal carbonKeyword
+hi def link carbonKeywordForAll carbonKeyword
+hi def link carbonKeywordAPI Structure
+hi def link carbonKeywordImport Include
+hi def link carbonKeyword Keyword
+hi def link carbonConditional Conditional
+hi def link carbonLoop Repeat
+hi def link carbonSwitch Repeat
+hi def link carbonControlFlowStatement Statement
+hi def link carbonLogicalOperator carbonOperator
+hi def link carbonOperator Operator
+
+let b:current_syntax = "carbon"

--- a/utils/vim/syntax/carbon.vim
+++ b/utils/vim/syntax/carbon.vim
@@ -14,16 +14,14 @@ syn keyword carbonPreprocess RUN AUTOUPDATE CHECK contained
 
 " carbon primitive types and literals
 syn keyword carbonBooleanType bool
-syn keyword carbonIntType i8 i16 i32 i64 i128
-syn keyword carbonUnsignedIntType u8 u16 u32 u64 u128
-syn keyword carbonFloatType f16 f32 f64
+syn match carbonIntType 'i\d\+'
+syn match carbonUnsignedIntType 'u\d\+'
+syn match carbonFloatType 'f\d\+'
 syn keyword carbonStringType String
 syn keyword carbonBoolean true false
-syn match carbonInt '\<\d\+\>'
-syn match carbonHexLiteral '\<0x[0-9A-F]\+\>'
-syn match carbonBinLiteral '\<0b[01]\+\>'
-syn match carbonFloat '\<\d\+\.\d\+\>'
-syn match carbonFloatExponent '\<\d\+\.\d\+e[+-]\?\d\+\>'
+syn match carbonNumber '\<[0-9][_0-9]*\(\.[_0-9]\+\(e[-+]\?[1-9][0-9]*\)\?\)\?\>'
+syn match carbonHexLiteral '\<0x[_0-9A-F]\+\(\.[_0-9A-F]\+\(p[+-]\?[1-9][0-9]*\)\?\)\?\>'
+syn match carbonBinLiteral '\<0b[_01]\+\>'
 syn region carbonStringLiteral start=+"+ end=+"+ skip=+\\"+
 syn region carbonBlockStringLiteral start=+"""+ end=+"""+ skip=+\\"""+
 
@@ -74,11 +72,8 @@ hi def link carbonFloatType carbonType
 hi def link carbonStringType carbonType
 hi def link carbonType Type
 hi def link carbonBoolean Boolean
-hi def link carbonInt carbonNumber
 hi def link carbonHexLiteral carbonNumber
 hi def link carbonBinLiteral carbonNumber
-hi def link carbonFloat carbonNumber
-hi def link carbonFloatExponent carbonNumber
 hi def link carbonNumber Number
 hi def link carbonStringLiteral carbonString
 hi def link carbonBlockStringLiteral carbonString


### PR DESCRIPTION
PR to add a vim syntax file to support syntax highlighting for .carbon files. Since the Carbon language specification is still in progress, a single syntax file is easier to maintain and adapt to design changes in Carbon. After the language syntax has matured and stabilized, advanced tooling such as Treesitter and Language Servers can take over the syntax highlighting in neovim.

### Highlighting Support
- comments and preprocessors (RUN, CHECK, etc)
- string and numeric literals
- primitive type names, classes, aliases
- control flow constructs
- identifier names
- package and library declarations
- most keywords mentioned in `docs/design/README.md`

### With a Dark Colorscheme:
![carbon01](https://user-images.githubusercontent.com/78875280/181017032-e2c140c8-e98a-46d3-8f94-b8dc0f28ce49.png)

This image is longer than I thought, so I'm not posting what it looks like in a light colorscheme, but it should look fine as long as vim highlight-groups are properly defined.