### PR TITLE
Update github workflow actions' versions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,6 +13,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           stale-issue-message: >
             We triage inactive PRs and issues in order to make it easier to find

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,22 +36,22 @@ jobs:
       # Checkout the pull request head or the branch.
       - name: Checkout pull request
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout branch
         if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup Python and related tools.
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           # Match the min version listed in docs/project/contribution_tools.md
           python-version: '3.9'
 
       # On macOS we need Go and to use it to install Bazelisk.
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         if: matrix.os == 'macos-latest'
       - name: Install bazelisk
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
Update github workflow actions' versions

* actions/checkout: v2 -> v3
* actions/setup-python: v3 -> v4
* pre-commit/action: v2.0.2 -> v3.0.0
* actions/setup-go: v2 -> v3
* actions/stale: v4 -> v5

Reference links: 

* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases
* https://github.com/pre-commit/action/releases
* https://github.com/actions/setup-go#v3
* https://github.com/actions/stale#usage

`.github/workflows`:

* pre-commit.yaml
* stale.yaml
* tests.yaml
