### PR TITLE
Update links to visible copies of docs

### DIFF
--- a/docs/design/classes.md
+++ b/docs/design/classes.md
@@ -1814,9 +1814,9 @@ Some discussion on this topic has occurred in:
 
 -   [question-for-leads issue #505 on named parameters](https://github.com/carbon-language/carbon-lang/issues/505)
 -   labeled params brainstorming docs
-    [1](https://docs.google.com/document/d/1a1wI8SHGh3HYV8SUWPIKhg48ZW2glUlAMIIS3aec5dY/edit),
-    [2](https://docs.google.com/document/d/1u6GORSkcgThMAiYKOqsgALcEviEtcghGb5TTVT-U-N0/edit)
--   ["match" in syntax choices doc](https://docs.google.com/document/d/1iuytei37LPg_tEd6xe-O6P_bpN7TIbEjNtFMLYW2Nno/edit#heading=h.y566d16ivoy2)
+    [1](https://docs.google.com/document/d/1Ui2OEHLwa9LZ6ktc1joJqE7_N-ZHX2gBvBpaFw6DUy8/edit?usp=sharing&resourcekey=0-6bEnyc03QePVcttPRSFoew),
+    [2](https://docs.google.com/document/d/1kK_tti4DwPqa3Oh5CgA5pWSx0g3bKlZG1yREMpq9uiU/edit?usp=sharing&resourcekey=0-oFV6tXtCVu1bcHz4oCMyMQ)
+-   ["match" in syntax choices doc](https://docs.google.com/document/d/1EhZA3AlY9TaCMho9jz2ynFxK-6eS6BwMAkE5jNYQzEA/edit?usp=sharing&resourcekey=0-QXEoh-b4_sQG2u636gIa1A#heading=h.y566d16ivoy2)
 
 ### Inheritance
 

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -1123,7 +1123,7 @@ for adding requirements for interfaces used for
 interface is enough to be able to use the operator to access the functionality.
 
 **Alternatives considered:** See
-[Carbon: Access to interface methods](https://docs.google.com/document/d/1u_i_s31OMI_apPur7WmVxcYq6MUXsG3oCiKwH893GRI/edit?usp=sharing&resourcekey=0-0lzSNebBMtUBi4lStL825g).
+[Carbon: Access to interface methods](https://docs.google.com/document/d/17IXDdu384x1t9RimQ01bhx4-nWzs4ZEeke4eO6ImQNc/edit?resourcekey=0-Fe44R-0DhQBlw0gs2ujNJA).
 
 **Comparison with other languages:** This `&` operation on interfaces works very
 similarly to Rust's `+` operation, with the main difference being how you
@@ -1243,7 +1243,7 @@ Examples:
     [Boost.Graph library](https://www.boost.org/doc/libs/1_74_0/libs/graph/doc/)
     [graph concepts](https://www.boost.org/doc/libs/1_74_0/libs/graph/doc/graph_concepts.html#fig:graph-concepts)
     has many refining relationships between concepts.
-    [Carbon generics use case: graph library](https://docs.google.com/document/d/1xk0GLtpBl2OOnf3F_6Z-A3DtTt-r7wdOZ5wPipYUSO0/edit?usp=sharing&resourcekey=0-mBSmwn6b6jwbLaQw2WG6OA)
+    [Carbon generics use case: graph library](https://docs.google.com/document/d/15Brjv8NO_96jseSesqer5HbghqSTJICJ_fTaZOH0Mg4/edit?usp=sharing&resourcekey=0-CYSbd6-xF8vYHv9m1rolEQ)
     shows how those concepts might be translated into Carbon interfaces.
 -   The [C++ concepts](https://en.cppreference.com/w/cpp/named_req) for
     containers, iterators, and concurrency include many requirement
@@ -1372,7 +1372,7 @@ interface MovieCodec {
 #### Diamond dependency issue
 
 Consider this set of interfaces, simplified from
-[this example generic graph library doc](https://docs.google.com/document/d/1xk0GLtpBl2OOnf3F_6Z-A3DtTt-r7wdOZ5wPipYUSO0/edit?resourcekey=0-mBSmwn6b6jwbLaQw2WG6OA#):
+[this example generic graph library doc](https://docs.google.com/document/d/15Brjv8NO_96jseSesqer5HbghqSTJICJ_fTaZOH0Mg4/edit?usp=sharing&resourcekey=0-CYSbd6-xF8vYHv9m1rolEQ):
 
 ```
 interface Graph {

--- a/proposals/p0618.md
+++ b/proposals/p0618.md
@@ -56,7 +56,7 @@ As stated by on
 
 Background may be found in the related
 [#542](https://github.com/carbon-language/carbon-lang/issues/542) and
-[Docs](https://docs.google.com/document/d/1iuytei37LPg_tEd6xe-O6P_bpN7TIbEjNtFMLYW2Nno).
+[Docs](https://docs.google.com/document/d/1EhZA3AlY9TaCMho9jz2ynFxK-6eS6BwMAkE5jNYQzEA/edit?usp=sharing&resourcekey=0-QXEoh-b4_sQG2u636gIa1A).
 
 ## Proposal
 
@@ -79,7 +79,7 @@ understanding and parsing.
 ### Type ordering
 
 Alternatives are pulled from
-[Docs](https://docs.google.com/document/d/1iuytei37LPg_tEd6xe-O6P_bpN7TIbEjNtFMLYW2Nno).
+[Docs](https://docs.google.com/document/d/1EhZA3AlY9TaCMho9jz2ynFxK-6eS6BwMAkE5jNYQzEA/edit?usp=sharing&resourcekey=0-QXEoh-b4_sQG2u636gIa1A).
 
 #### `<type>: <name>`
 
@@ -124,7 +124,7 @@ Disadvantages:
 
 Currently hard to see how we can make this work, since it isn't compatible with
 other choices, detailed in
-[Docs](https://docs.google.com/document/d/1iuytei37LPg_tEd6xe-O6P_bpN7TIbEjNtFMLYW2Nno).
+[Docs](https://docs.google.com/document/d/1EhZA3AlY9TaCMho9jz2ynFxK-6eS6BwMAkE5jNYQzEA/edit?usp=sharing&resourcekey=0-QXEoh-b4_sQG2u636gIa1A).
 
 #### `<name>: <type>`
 


### PR DESCRIPTION
I've manually copied some Google docs that were referenced in our design .md files so they may be publicly viewable.