### PR TITLE
Modify the contents of arrays and slices that update the README.md documentation

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -540,7 +540,7 @@ the array may be deduced, it may be omitted, as in:
 ```carbon
 var i: i32 = 1;
 // [i32;N] [i32;N] is an array representing N values, the numerical type of each value is the data type of i32, the size of the array is determined, and new elements cannot be added, nor can the elements of the array be reduced.
-var a:[i32;5] = (2,4,5,7,9);
+   var a:[i32;5] = (2,4,5,7,9);
 // `[i32;]` equivalent to `[i32; 3]` here.
 var a: [i32;] = (i,j,k);
 ```

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -539,15 +539,21 @@ the array may be deduced, it may be omitted, as in:
 
 ```carbon
 var i: i32 = 1;
+// [i32;N] [i32;N] is an array representing N values, the numerical type of each value is the data type of i32, the size of the array is determined, and new elements cannot be added, nor can the elements of the array be reduced.
+var a:[i32;5] = (2,4,5,7,9);
 // `[i32;]` equivalent to `[i32; 3]` here.
-var a: [i32;] = (i, i, i);
+var a: [i32;] = (i,j,k);
 ```
 
 Elements of an array may be accessed using square brackets (`[`...`]`), as in
-`a[i]`:
+`a[0]`:
 
 ```carbon
-a[i] = 2;
+// a[i] = 2;error,The subscript value of a[i] is a definite number, not i
+var a:[i32;3] = (1,4,7);
+a[0] = 1;
+a[1] = 4;
+a[2] = 7;
 Console.Print(a[0]);
 ```
 


### PR DESCRIPTION
Some of the array and slice documents are not specific, I added to explain the principle and use of [i32;N], and a[i] = 2; This is not specific, if you access the array subscript in the array, i is a number, like a[1] = 2;