### PR TITLE
Tidy bazel-execroot

### DIFF
--- a/bazel-execroot
+++ b/bazel-execroot
@@ -1,1 +1,0 @@
-bazel-out/../../carbon


### PR DESCRIPTION
This will tidy generated bazel-execroot link file.