### PR TITLE
Add check for LLVM tools in build config script

### DIFF
--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -128,6 +128,16 @@ def _configure_clang_toolchain_impl(repository_ctx):
         sysroot_dir,
     )
 
+    # Ensure the detected clang path has some LLVM tools in it, in attempt to
+    # warn the user if they don't have these necessary LLVM tools in their PATH.
+    # This check isn't exhaustive, only a best attempt at warning the developer.
+    llvm_check_result = repository_ctx.execute([
+        clang.dirname.get_child("llvm-ar"),
+        "--version"
+    ])
+    if llvm_check_result.return_code != 0:
+        fail("`llvm-ar` not found beside clang: is LLVM in PATH?")
+
     repository_ctx.template(
         "clang_detected_variables.bzl",
         repository_ctx.attr._clang_detected_variables_template,


### PR DESCRIPTION
By adding a small, proactive safety check, the hope is that this will better point developers in the direction of a fix and reduce the volume of duplicate issues filed for this common troubleshooting question.

This change seems to be safe in the present as this check mirrors the current behavior in `clang_cc_toolchain_config.bzl`, finding these tools in the same directory beside `clang`. Non-standard builds using the same bazel toolchain config should not be affected for this reason. If that behavior ever changes in the future, this check will become out of sync.

Open to ideas for better heuristics here! However, checking for `llvm-ar` seems to satisfactory for right now. Verified this change worked locally (macOS) with and without Homebrew's LLVM in `PATH`.

Might want to wait on review from @chandlerc.

Fixes #1842.