### PR TITLE
Try to make some FAQ questions more inviting

### DIFF
--- a/docs/project/faq.md
+++ b/docs/project/faq.md
@@ -46,7 +46,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Who pays for Carbon's infrastructure?](#who-pays-for-carbons-infrastructure)
 -   [How can I contribute to Carbon?](#how-can-i-contribute-to-carbon)
     -   [What are the prerequisites for contributing to Carbon Language's design and tools?](#what-are-the-prerequisites-for-contributing-to-carbon-languages-design-and-tools)
-    -   [Why aren't people willing to discuss certain topics, like the file extension or syntax for specific constructs?](#why-arent-people-willing-to-discuss-certain-topics-like-the-file-extension-or-syntax-for-specific-constructs)
+    -   [When do we revisit decisions or reopen discussions?](#when-do-we-revisit-decisions-or-reopen-discussions)
+    -   [What can I do if I disagree with a design decision?](#what-can-i-do-if-i-disagree-with-a-design-decision)
+    -   [How can I best say "I like X" or "I don't like X"?](#how-can-i-best-say-i-like-x-or-i-dont-like-x)
 
 <!-- tocstop -->
 
@@ -486,36 +488,57 @@ other parts of LLVM will be advantageous, but not required.
 Our [contribution tools](/docs/project/contribution_tools.md) page documents
 specific tools we use when building.
 
-### Why aren't people willing to discuss certain topics, like the file extension or syntax for specific constructs?
+### When do we revisit decisions or reopen discussions?
 
-When it comes to designing a language, there are lots of decisions where there
-are many workable options, and all of them will get the job done without serious
-issues. We need to pick _one_ in order to make progress, and no choice is going
-to appeal to everyone's preferences. We try to base the decision on consistent
-rationale, which can be found in the proposals which are linked throughout the
-design.
-
-We understand that many decisions won't be universally popular. Different
-developers weigh factors differently. However, we need to commit to a choice in
-order to make progress on the language design as a whole. This doesn't mean that
-they're _definitely_ right or set in stone, it just means we need to focus our
-time and energy on other issues.
+Once a decision is made through the [evolution process](evolution.md) the
+community should treat it as _firmly_ decided. This doesn't mean that the
+decision is _definitely_ right or set in stone, it just means we'd like the
+community to focus time and energy on other issues in the name of progress.
 
 Sometimes, it will be appropriate to revisit a decision; for example, when there
 is new information introduced, a new community joins Carbon, or there is an
-order of magnitude growth in the community. We will do this by filing an issue
-for leads with what new information is available, and we will reevaluate the
-choice.
+order of magnitude growth in the community. These cases are handled as new
+proposals through the [evolution process](evolution.md).
 
-For example, we're doing this with digit separators: we missed important
+For example, we have done this with digit separators: we missed important
 _domain_ conventions and had overly restricted where separators are allowed,
 [an issue was filed with the new information](https://github.com/carbon-language/carbon-lang/issues/1485),
 and we're fixing the choice.
 
-When there is a discussion about options or disagreement with a decision,
-comments saying "I like X" and "I don't like X" do not contribute to the
-conversation. You should use the reactions to signal this kind of sentiment, and
-we'll pay attention to those. Beyond that, we encourage folks to either shrug
-and let quirky syntax be quirky, or look for the objective use case that was
-clearly missed in the previous decision and makes the current state _sharply_
-problematic before pushing for change.
+See also the related questions
+[What happens when a decision was wrong?](#what-happens-when-a-decision-was-wrong),
+[How does Carbon make decisions?](#how-does-carbon-make-decisions), and
+[What can I do if I disagree with a design decision?](#what-can-i-do-if-i-disagree-with-a-design-decision).
+
+### What can I do if I disagree with a design decision?
+
+We invite you to give us constructive feedback. Some of Carbon's design
+decisions are made with the _expectation_ of receiving community feedback. We
+understand that many decisions won't be universally popular, but we'd still like
+to understand the community's reaction to Carbon.
+
+We encourage you to investigate why Carbon came to be the way it is. Designs
+will include links to the proposals and important alternatives considered that
+led to them, typically linked at the bottom. Read through and understand the
+context and rationale behind the decisions you are concerned about. You may find
+that your concerns were already thoroughly discussed. If not, you will be in a
+better place to present your thoughts in a convincing way.
+
+Changing decisions that have come out of the [evolution process](evolution.md)
+involves a formal process. See
+[When do we revisit decisions or reopen discussions?](#when-do-we-revisit-decisions-or-reopen-discussions).
+For these issues in particular, please be aware that other community members may
+choose to not actively engage in detailed discussions, especially if the
+discussion seems to be revisiting points made in the past.
+
+If after reading this answer you are not sure how to proceed please feel free to
+ask (see
+[Where should I ask questions?](#where-should-i-ask-questions-about-carbon-language)).
+
+### How can I best say "I like X" or "I don't like X"?
+
+Both Discord and Github Discussions allow you to give an emoji "reaction" to
+individual posts. If you'd like to amplify what has already been said, please
+use these instead of posting messages that re-state substantially the same
+thing. These make conversations easier to follow and understand general
+sentiment in discussions involving many people.


### PR DESCRIPTION
Replace the "why we don't want to discuss things" question with three
questions covering substantially the same topic. Try to strike a balance
between inviting participation and feedback while still making it clear
that the evolution process produces "firm" decisions.

Address issue #1833.