### PR TITLE
Allow operator overload for `and`, `or`, and `not`.

### DIFF
--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -83,6 +83,26 @@ interface ModWith(U:! Type) {
 }
 // TODO: constraint Mod { ... }
 
+interface LogAndWith(U:! Type) {
+  // TODO: = Self
+  let Result:! Type;
+  fn Op[me: Self](other: U) -> Result;
+}
+// TODO: constraint LogAnd { ... }
+
+interface LogOrWith(U:! Type) {
+  // TODO: = Self
+  let Result:! Type;
+  fn Op[me: Self](other: U) -> Result;
+}
+// TODO: constraint LogOr { ... }
+
+interface Not {
+  // TODO: = Self
+  let Result:! Type;
+  fn Op[me: Self]() -> Result;
+}
+
 // Note, these impls use the builtin addition for i32.
 external impl i32 as Negate where .Result == i32 {
   fn Op[me: i32]() -> i32 { return -me; }
@@ -99,6 +119,18 @@ external impl i32 as MulWith(i32) where .Result == i32 {
 external impl i32 as ModWith(i32) where .Result == i32 {
   fn Op[me: i32](other: i32) -> i32 { return me % other; }
 }
+
+// Note, these impls use the builtin logical operators for bool.
+external impl Bool as LogAndWith(Bool) where .Result == Bool {
+  fn Op[me: Bool](other: Bool) -> Bool { return me && other; }
+}
+external impl Bool as LogOrWith(Bool) where .Result == Bool {
+  fn Op[me: Bool](other: Bool) -> Bool { return me || other; }
+}
+external impl Bool as Not where .Result == Bool {
+  fn Op[me: Bool]() -> Bool { return !me; }
+}
+
 // Note that Print is experimental, and not part of an accepted proposal, but
 // is included here for printing state in tests.
 // TODO: Remove Print special casing once we have variadics or overloads.

--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -122,13 +122,13 @@ external impl i32 as ModWith(i32) where .Result == i32 {
 
 // Note, these impls use the builtin logical operators for bool.
 external impl Bool as LogAndWith(Bool) where .Result == Bool {
-  fn Op[me: Bool](other: Bool) -> Bool { return me && other; }
+  fn Op[me: Bool](other: Bool) -> Bool { return me and other; }
 }
 external impl Bool as LogOrWith(Bool) where .Result == Bool {
-  fn Op[me: Bool](other: Bool) -> Bool { return me || other; }
+  fn Op[me: Bool](other: Bool) -> Bool { return me or other; }
 }
 external impl Bool as Not where .Result == Bool {
-  fn Op[me: Bool]() -> Bool { return !me; }
+  fn Op[me: Bool]() -> Bool { return not me; }
 }
 
 // Note that Print is experimental, and not part of an accepted proposal, but

--- a/explorer/interpreter/builtins.h
+++ b/explorer/interpreter/builtins.h
@@ -32,7 +32,12 @@ class Builtins {
     MulWith,
     ModWith,
 
-    Last = ModWith
+    // Logical.
+    LogAndWith,
+    LogOrWith,
+    Not,
+
+    Last = Not
   };
   // TODO: In C++20, replace with `using enum Builtin;`.
   static constexpr Builtin As = Builtin::As;
@@ -42,6 +47,9 @@ class Builtins {
   static constexpr Builtin SubWith = Builtin::SubWith;
   static constexpr Builtin MulWith = Builtin::MulWith;
   static constexpr Builtin ModWith = Builtin::ModWith;
+  static constexpr Builtin LogAndWith = Builtin::LogAndWith;
+  static constexpr Builtin LogOrWith = Builtin::LogOrWith;
+  static constexpr Builtin Not = Builtin::Not;
 
   // Register a declaration that might be a builtin.
   void Register(Nonnull<const Declaration*> decl);
@@ -58,7 +66,9 @@ class Builtins {
  private:
   static constexpr int NumBuiltins = static_cast<int>(Builtin::Last) + 1;
   static constexpr const char* BuiltinNames[NumBuiltins] = {
-      "As", "ImplicitAs", "Negate", "AddWith", "SubWith", "MulWith", "ModWith"};
+      "As", "ImplicitAs", "Negate", "AddWith", "SubWith", "MulWith", "ModWith",
+      "LogAndWith", "LogOrWith", "Not"
+    };
 
   std::optional<Nonnull<const Declaration*>> builtins_[NumBuiltins] = {};
 };

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -1957,7 +1957,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
           }
           op.set_rewritten_form(*result);
           return Success();
-      }
+      };
 
       auto handle_binary_overload_operator =
           [&](Builtins::Builtin builtin) -> ErrorOr<Success> {
@@ -1984,7 +1984,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
           return Success();
         }
         // Now try an overloaded negation.
-        return handle_binary_overload_operator(buildin);
+        return handle_binary_overload_operator(builtin);
       };
 
       switch (op.op()) {

--- a/explorer/testdata/operators/fail_no_logand.carbon
+++ b/explorer/testdata/operators/fail_no_logand.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+class A {}
+
+fn Main() -> i32 {
+  var a: A = {};
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logand.carbon:[[@LINE+2]]: type error in `&&`:
+  // CHECK: could not find implementation of interface LogAndWith(U = i32) for class A
+  a && 1;
+  return 0;
+}

--- a/explorer/testdata/operators/fail_no_logand.carbon
+++ b/explorer/testdata/operators/fail_no_logand.carbon
@@ -14,8 +14,8 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logand.carbon:[[@LINE+2]]: type error in `&&`:
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logand.carbon:[[@LINE+2]]: type error in `and`:
   // CHECK: could not find implementation of interface LogAndWith(U = i32) for class A
-  a && 1;
+  a and 1;
   return 0;
 }

--- a/explorer/testdata/operators/fail_no_logor.carbon
+++ b/explorer/testdata/operators/fail_no_logor.carbon
@@ -14,8 +14,8 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logor.carbon:[[@LINE+2]]: type error in `||`:
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logor.carbon:[[@LINE+2]]: type error in `or`:
   // CHECK: could not find implementation of interface LogOrWith(U = i32) for class A
-  a || 1;
+  a or 1;
   return 0;
 }

--- a/explorer/testdata/operators/fail_no_logor.carbon
+++ b/explorer/testdata/operators/fail_no_logor.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+class A {}
+
+fn Main() -> i32 {
+  var a: A = {};
+  // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/operators/fail_no_logor.carbon:[[@LINE+2]]: type error in `||`:
+  // CHECK: could not find implementation of interface LogOrWith(U = i32) for class A
+  a || 1;
+  return 0;
+}

--- a/explorer/testdata/operators/logand.carbon
+++ b/explorer/testdata/operators/logand.carbon
@@ -14,11 +14,11 @@ package ExplorerTest api;
 class A { var n: Bool; }
 
 external impl A as LogAndWith(Bool) where .Result == A {
-  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n && rhs}; }
+  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n and rhs}; }
 }
 
 fn Main() -> i32 {
   var a: A = {.n = true};
-  a = a && false;
+  a = a and false;
   return a.n;
 }

--- a/explorer/testdata/operators/logand.carbon
+++ b/explorer/testdata/operators/logand.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: false
+// CHECK: result: 1
 
 package ExplorerTest api;
 
@@ -20,5 +20,8 @@ external impl A as LogAndWith(Bool) where .Result == A {
 fn Main() -> i32 {
   var a: A = {.n = true};
   a = a and false;
-  return a.n;
+  if(a.n) {
+    return 0;
+  }
+  return 1;
 }

--- a/explorer/testdata/operators/logand.carbon
+++ b/explorer/testdata/operators/logand.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: false
+
+package ExplorerTest api;
+
+class A { var n: Bool; }
+
+external impl A as LogAndWith(Bool) where .Result == A {
+  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n && rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = true};
+  a = a && false;
+  return a.n;
+}

--- a/explorer/testdata/operators/logand_builtin.carbon
+++ b/explorer/testdata/operators/logand_builtin.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: true
+
+package ExplorerTest api;
+
+// TODO: T:! LogAnd
+fn DoAdd[T:! LogAndWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x && y; }
+
+fn Main() -> i32 {
+  return DoAdd(true, true);
+}

--- a/explorer/testdata/operators/logand_builtin.carbon
+++ b/explorer/testdata/operators/logand_builtin.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: true
+// CHECK: result: 0
 
 package ExplorerTest api;
 
@@ -15,5 +15,8 @@ package ExplorerTest api;
 fn DoAdd[T:! LogAndWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x and y; }
 
 fn Main() -> i32 {
-  return DoAdd(true, true);
+  if(DoAdd(true, true)) {
+    return 0;
+  }
+  return 1;
 }

--- a/explorer/testdata/operators/logand_builtin.carbon
+++ b/explorer/testdata/operators/logand_builtin.carbon
@@ -12,7 +12,7 @@
 package ExplorerTest api;
 
 // TODO: T:! LogAnd
-fn DoAdd[T:! LogAndWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x && y; }
+fn DoAdd[T:! LogAndWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x and y; }
 
 fn Main() -> i32 {
   return DoAdd(true, true);

--- a/explorer/testdata/operators/logor.carbon
+++ b/explorer/testdata/operators/logor.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: true
+// CHECK: result: 0
 
 package ExplorerTest api;
 
@@ -20,5 +20,8 @@ external impl A as LogOrWith(Bool) where .Result == A {
 fn Main() -> i32 {
   var a: A = {.n = true};
   a = a or false;
-  return a.n;
+  if(a.n) {
+    return 0;
+  }
+  return 1;
 }

--- a/explorer/testdata/operators/logor.carbon
+++ b/explorer/testdata/operators/logor.carbon
@@ -14,11 +14,11 @@ package ExplorerTest api;
 class A { var n: Bool; }
 
 external impl A as LogOrWith(Bool) where .Result == A {
-  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n || rhs}; }
+  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n or rhs}; }
 }
 
 fn Main() -> i32 {
   var a: A = {.n = true};
-  a = a || false;
+  a = a or false;
   return a.n;
 }

--- a/explorer/testdata/operators/logor.carbon
+++ b/explorer/testdata/operators/logor.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: true
+
+package ExplorerTest api;
+
+class A { var n: Bool; }
+
+external impl A as LogOrWith(Bool) where .Result == A {
+  fn Op[me: Self](rhs: Bool) -> A { return {.n = me.n || rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = true};
+  a = a || false;
+  return a.n;
+}

--- a/explorer/testdata/operators/logor_builtin.carbon
+++ b/explorer/testdata/operators/logor_builtin.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: true
+
+package ExplorerTest api;
+
+// TODO: T:! LogOr
+fn DoAdd[T:! LogOrWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x || y; }
+
+fn Main() -> i32 {
+  return DoAdd(true, false);
+}

--- a/explorer/testdata/operators/logor_builtin.carbon
+++ b/explorer/testdata/operators/logor_builtin.carbon
@@ -12,7 +12,7 @@
 package ExplorerTest api;
 
 // TODO: T:! LogOr
-fn DoAdd[T:! LogOrWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x || y; }
+fn DoAdd[T:! LogOrWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x or y; }
 
 fn Main() -> i32 {
   return DoAdd(true, false);

--- a/explorer/testdata/operators/logor_builtin.carbon
+++ b/explorer/testdata/operators/logor_builtin.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: true
+// CHECK: result: 0
 
 package ExplorerTest api;
 
@@ -15,5 +15,8 @@ package ExplorerTest api;
 fn DoAdd[T:! LogOrWith(.Self) where .Result == .Self](x: T, y: T) -> T { return x or y; }
 
 fn Main() -> i32 {
-  return DoAdd(true, false);
+  if(DoAdd(true, false)) {
+    return 0;
+  }
+  return 1;
 }

--- a/explorer/testdata/operators/not.carbon
+++ b/explorer/testdata/operators/not.carbon
@@ -14,12 +14,12 @@ package ExplorerTest api;
 class A { var n: Bool; }
 
 external impl A as Not where .Result == A {
-  fn Op[me: Self]() -> A { return {.n = !me.n}; }
+  fn Op[me: Self]() -> A { return {.n = not me.n}; }
 }
 
 fn Main() -> Bool {
   var a: A = {.n = false};
-  a = !a;
+  a = not a;
   if(a.n) {
     return 0;
   }

--- a/explorer/testdata/operators/not.carbon
+++ b/explorer/testdata/operators/not.carbon
@@ -17,7 +17,7 @@ external impl A as Not where .Result == A {
   fn Op[me: Self]() -> A { return {.n = not me.n}; }
 }
 
-fn Main() -> Bool {
+fn Main() -> i32 {
   var a: A = {.n = false};
   a = not a;
   if(a.n) {

--- a/explorer/testdata/operators/not.carbon
+++ b/explorer/testdata/operators/not.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 0
+
+package ExplorerTest api;
+
+class A { var n: Bool; }
+
+external impl A as Not where .Result == A {
+  fn Op[me: Self]() -> A { return {.n = !me.n}; }
+}
+
+fn Main() -> Bool {
+  var a: A = {.n = false};
+  a = !a;
+  if(a.n) {
+    return 0;
+  }
+  return 1;
+}

--- a/explorer/testdata/operators/not_builtin.carbon
+++ b/explorer/testdata/operators/not_builtin.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: false
+
+package ExplorerTest api;
+
+fn DoNot[T:! Not where .Result == .Self](x: T) -> T { return !x; }
+
+fn Main() -> i32 {
+  return DoNot(true);
+}

--- a/explorer/testdata/operators/not_builtin.carbon
+++ b/explorer/testdata/operators/not_builtin.carbon
@@ -11,7 +11,7 @@
 
 package ExplorerTest api;
 
-fn DoNot[T:! Not where .Result == .Self](x: T) -> T { return !x; }
+fn DoNot[T:! Not where .Result == .Self](x: T) -> T { return not x; }
 
 fn Main() -> i32 {
   return DoNot(true);

--- a/explorer/testdata/operators/not_builtin.carbon
+++ b/explorer/testdata/operators/not_builtin.carbon
@@ -7,12 +7,15 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: false
+// CHECK: result: 1
 
 package ExplorerTest api;
 
 fn DoNot[T:! Not where .Result == .Self](x: T) -> T { return not x; }
 
 fn Main() -> i32 {
-  return DoNot(true);
+  if(DoNot(true)) {
+    return 0;
+  }
+  return 1;
 }


### PR DESCRIPTION
Provide builtin interfaces `LogAndWith`, `LogOrWith`, and `Not`.
Adds their primitive implementations to `Bool` in the prelude.

Maybe should be `LogNot`, but there is no bitwise not so chose just to keep it as `Not`.

Thanks!