### PR TITLE
Implement unformed state of `returned var`.

### DIFF
--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -788,6 +788,12 @@ statement:
           context.source_loc(), $2, $4, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }
+| RETURNED VAR variable_declaration SEMICOLON
+    {
+      $$ = arena->New<VariableDefinition>(
+          context.source_loc(), $3, std::nullopt, ValueCategory::Var,
+          VariableDefinition::DefinitionType::Returned);
+    }
 | RETURNED VAR variable_declaration EQUAL expression SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -866,6 +866,12 @@ statement:
           context.source_loc(), $2, $4, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }
+| RETURNED VAR variable_declaration SEMICOLON
+    {
+      $$ = arena->New<VariableDefinition>(
+          context.source_loc(), $3, std::nullopt, ValueCategory::Var,
+          VariableDefinition::DefinitionType::Returned);
+    }
 | RETURNED VAR variable_declaration EQUAL expression SEMICOLON
     {
       $$ = arena->New<VariableDefinition>(

--- a/explorer/testdata/uninitialized/declare_returned_var.carbon
+++ b/explorer/testdata/uninitialized/declare_returned_var.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  returned var x: i32;
+  x = 1;
+  return var;
+}

--- a/explorer/testdata/uninitialized/fail_uninitialized_returned_var.carbon
+++ b/explorer/testdata/uninitialized/fail_uninitialized_returned_var.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/uninitialized/fail_uninitialized_returned_var.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  returned var x: i32;
+  return var;
+}


### PR DESCRIPTION
Added parsing and test casts for unformed `returned var`.