### PR TITLE
Introduce `var`/`let`-`else`-statement

### DIFF
--- a/proposals/new-proposal.tmp.md
+++ b/proposals/new-proposal.tmp.md
@@ -1,0 +1,81 @@
+# TODO
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/####)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [TODO: Initial proposal setup](#todo-initial-proposal-setup)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## TODO: Initial proposal setup
+
+> TIP: Run `./new_proposal.py "TITLE"` to do new proposal setup.
+
+1. Copy this template to `new.md`, and create a commit.
+2. Create a GitHub pull request, to get a pull request number.
+    - Add the `proposal` and `WIP` labels to the pull request.
+3. Rename `new.md` to `/proposals/p####.md`, where `####` should be the pull
+   request number.
+4. Update the title of the proposal (the `TODO` on line 1).
+5. Update the link to the pull request (the `####` on line 11).
+6. Delete this section.
+
+TODOs indicate where content should be updated for a proposal. See
+[Carbon Governance and Evolution](/docs/project/evolution.md) for more details.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p1871.md
+++ b/proposals/p1871.md
@@ -12,7 +12,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
--   [TODO: Initial proposal setup](#todo-initial-proposal-setup)
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
@@ -22,22 +21,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <!-- tocstop -->
 
-## TODO: Initial proposal setup
-
-> TIP: Run `./new_proposal.py "TITLE"` to do new proposal setup.
-
-1. Copy this template to `new.md`, and create a commit.
-2. Create a GitHub pull request, to get a pull request number.
-    - Add the `proposal` and `WIP` labels to the pull request.
-3. Rename `new.md` to `/proposals/p####.md`, where `####` should be the pull
-   request number.
-4. Update the title of the proposal (the `TODO` on line 1).
-5. Update the link to the pull request (the `####` on line 11).
-6. Delete this section.
-
-TODOs indicate where content should be updated for a proposal. See
-[Carbon Governance and Evolution](/docs/project/evolution.md) for more details.
-
 ## Problem
 
 TODO: What problem are you trying to solve? How important is that problem? Who
@@ -45,36 +28,38 @@ is impacted by it?
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
-
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+A `let` or `var` declaration may be used with a
+[refutable pattern](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/README.md#refutable-patterns)
+if an `else` clause is supplied, as in:
+
+```carbon
+let (x: i32, true) = F(1) else {
+  // Can't use `x` here.
+  return false;
+}
+// `x` is an r-value
+var (y: i32, true) = F(x) else {
+  return false;
+}
+// `y` is an l-value
+y += 2;
+```
+
+If the pattern successfully matches the runtime value, values are bound
+according to the pattern, and execution skips over the `else` code block and
+proceeds to the next statement.
+
+If the pattern does not match, the `else` code block will be executed. None of
+the bindings from the pattern will be in scope in the `else` code block. No
+control flow path in the `else` code block may continue to the statement after.
+All paths must end with a `break`, `continue`, `return`, or call to a function
+that never returns.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
-
 ## Rationale
-
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
 
 ## Alternatives considered
 

--- a/proposals/p1871.md
+++ b/proposals/p1871.md
@@ -1,4 +1,4 @@
-# TODO
+# Introduce `var`/`let`-`else`-statement
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -6,7 +6,7 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-[Pull request](https://github.com/carbon-language/carbon-lang/pull/####)
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/1871)
 
 <!-- toc -->
 

--- a/proposals/p1871.md
+++ b/proposals/p1871.md
@@ -93,6 +93,7 @@ violated requirements next to the requirements.
 
 ## Alternatives considered
 
+-   `var`/`let` ... `or {...}`
 -   `var`/`let` ... `?: {...}` a short-circuited ternary operator
 -   `var`/`let` ... `otherwise {...}`
 -   introducer syntax: `guard var`/`let` ... `else {...}`

--- a/proposals/p1871.md
+++ b/proposals/p1871.md
@@ -23,8 +23,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+This statement is syntactic sugar for a set of other patterns. Actually, there
+is no problem.
 
 ## Background
 

--- a/proposals/p1871.md
+++ b/proposals/p1871.md
@@ -18,15 +18,39 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+-   [Unresolved questions](#unresolved-questions)
 
 <!-- tocstop -->
 
 ## Problem
 
-This statement is syntactic sugar for a set of other patterns. Actually, there
-is no problem.
+This statement is syntactic sugar for a set of other patterns, specifically it
+guards a code block if a requirement of this code block is violated. That is,
+there is actually no problem.
 
 ## Background
+
+The idea goes back to the prior art in
+[Swift](https://docs.swift.org/swift-book/LanguageGuide/ControlFlow.html#ID525)
+to allow the execution of a statement depending on the Boolean value of an
+expression. Swift used a **guard** statement to require that a condition must be
+true in order for all following code in the current code block to be executed.
+If the condition is not true, control needs to be transferred using a control
+transfer statement as `break`, `continue`, `return`, or a function that does not
+return.
+
+[Rust](https://github.com/rust-lang/rfcs/blob/master/text/3137-let-else.md)
+followed suit and introduced the **let-else statement**:
+
+```rust
+let PATTERN: TYPE = EXPRESSION else DIVERGING_BLOCK;
+```
+
+as a more or less natural counterpart to its
+[if-let expression](https://github.com/rust-lang/rfcs/blob/master/text/0160-if-let.md).
+
+This proposal adds this pattern as it seems to be rather popular and simplifies
+common error-handling patterns.
 
 ## Proposal
 
@@ -59,8 +83,21 @@ that never returns.
 
 ## Details
 
+TBD after enough C in this RFC.
+
 ## Rationale
+
+This pattern is said to improve the readability of code, compared to an
+equivalent `match` or `if` statement. It allows to keep code which handles
+violated requirements next to the requirements.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+-   `var`/`let` ... `?: {...}` a short-circuited ternary operator
+-   `var`/`let` ... `otherwise {...}`
+-   introducer syntax: `guard var`/`let` ... `else {...}`
+
+## Unresolved questions
+
+-   How often is this pattern actually used?
+-   Is it really more readable?


### PR DESCRIPTION
As implied in PR #1388 and requested in #1758 this proposal introduces the rationale behind the simplification of a common error-handling pattern, informally known as **let-else statement** (or **var-else statement**). It can be interpreted as syntactic sugar for a `match`-statement where the non-matched case diverges. Hence, the usage as error-handling pattern.