### PR TITLE
Pin Homebrew's formulas to a specific commit.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,9 +69,17 @@ jobs:
       # For now, we rely on Homebrew to manage installing a correctly built
       # toolchain. We also take some care to be as resilient as possible to
       # issues fetching and installing the toolchain.
+      #
+      # TODO: We temporarily force Homebrew to an old version to retain bottles
+      # for LLVM while they are sorting out the GCC 12 update. This should be
+      # removed once things settle down.
       - name: Setup LLVM and Clang
         run: |
+          export HOMEBREW_NO_AUTO_UPDATE=1
           brew update
+          pushd "$(brew --repo homebrew/core)"
+          git checkout bf25543b2ee66033044774eb8d51a0efb1e97a48
+          popd
           brew install --force-bottle --only-dependencies llvm
           brew install --force-bottle --force --verbose llvm
           brew info llvm


### PR DESCRIPTION
This lets us workaround issues that came up where Homebrew removed the
LLVM bottles on Linux that we relied on to have reasonable install times
for our CI.

See Homebrew/homebrew-core#100411 for discussion of the challenges
they're facing here. We raised this issue and they've temporarily worked
around it for us so this PR isn't necessary. But I wanted to send it out
for reference in case we eventually do need to briefly pin and work
around things, we should know how.

If interested, I can generalize this a bit so that we just have a simply
commitish setting somewhere than enables and leverages this, and we can
poke a new commitish into that any time we hit something and need to
keep CI flowing.