### PR TITLE
Add parsing (only) support for class prefix and 'extends'

### DIFF
--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/check.h"
 #include "common/ostream.h"
 #include "explorer/ast/ast_node.h"
 #include "explorer/ast/impl_binding.h"
@@ -179,18 +180,23 @@ class SelfDeclaration : public Declaration {
   auto value_category() const -> ValueCategory { return ValueCategory::Let; }
 };
 
+enum class ClassPrefix { StandardClass, BaseClass, AbstractClass };
+
 class ClassDeclaration : public Declaration {
  public:
   using ImplementsCarbonValueNode = void;
 
   ClassDeclaration(SourceLocation source_loc, std::string name,
-                   Nonnull<SelfDeclaration*> self_decl,
+                   Nonnull<SelfDeclaration*> self_decl, ClassPrefix prefix,
                    std::optional<Nonnull<TuplePattern*>> type_params,
+                   std::optional<Nonnull<Expression*>> extends,
                    std::vector<Nonnull<Declaration*>> members)
       : Declaration(AstNodeKind::ClassDeclaration, source_loc),
         name_(std::move(name)),
+        prefix_(prefix),
         self_decl_(self_decl),
         type_params_(type_params),
+        extends_(extends),
         members_(std::move(members)) {}
 
   static auto classof(const AstNode* node) -> bool {
@@ -198,11 +204,15 @@ class ClassDeclaration : public Declaration {
   }
 
   auto name() const -> const std::string& { return name_; }
+  auto prefix() const -> ClassPrefix { return prefix_; }
   auto type_params() const -> std::optional<Nonnull<const TuplePattern*>> {
     return type_params_;
   }
   auto type_params() -> std::optional<Nonnull<TuplePattern*>> {
     return type_params_;
+  }
+  auto extends() const -> std::optional<Nonnull<Expression*>> {
+    return extends_;
   }
   auto self() const -> Nonnull<const SelfDeclaration*> { return self_decl_; }
   auto self() -> Nonnull<SelfDeclaration*> { return self_decl_; }
@@ -215,8 +225,10 @@ class ClassDeclaration : public Declaration {
 
  private:
   std::string name_;
+  ClassPrefix prefix_;
   Nonnull<SelfDeclaration*> self_decl_;
   std::optional<Nonnull<TuplePattern*>> type_params_;
+  std::optional<Nonnull<Expression*>> extends_;
   std::vector<Nonnull<Declaration*>> members_;
 };
 

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -180,20 +180,21 @@ class SelfDeclaration : public Declaration {
   auto value_category() const -> ValueCategory { return ValueCategory::Let; }
 };
 
-enum class ClassPrefix { StandardClass, BaseClass, AbstractClass };
+enum class ClassExtensibility { None, Base, Abstract };
 
 class ClassDeclaration : public Declaration {
  public:
   using ImplementsCarbonValueNode = void;
 
   ClassDeclaration(SourceLocation source_loc, std::string name,
-                   Nonnull<SelfDeclaration*> self_decl, ClassPrefix prefix,
+                   Nonnull<SelfDeclaration*> self_decl,
+                   ClassExtensibility extensibility,
                    std::optional<Nonnull<TuplePattern*>> type_params,
                    std::optional<Nonnull<Expression*>> extends,
                    std::vector<Nonnull<Declaration*>> members)
       : Declaration(AstNodeKind::ClassDeclaration, source_loc),
         name_(std::move(name)),
-        prefix_(prefix),
+        extensibility_(extensibility),
         self_decl_(self_decl),
         type_params_(type_params),
         extends_(extends),
@@ -204,7 +205,7 @@ class ClassDeclaration : public Declaration {
   }
 
   auto name() const -> const std::string& { return name_; }
-  auto prefix() const -> ClassPrefix { return prefix_; }
+  auto extensibility() const -> ClassExtensibility { return extensibility_; }
   auto type_params() const -> std::optional<Nonnull<const TuplePattern*>> {
     return type_params_;
   }
@@ -225,7 +226,7 @@ class ClassDeclaration : public Declaration {
 
  private:
   std::string name_;
-  ClassPrefix prefix_;
+  ClassExtensibility extensibility_;
   Nonnull<SelfDeclaration*> self_decl_;
   std::optional<Nonnull<TuplePattern*>> type_params_;
   std::optional<Nonnull<Expression*>> extends_;

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -3205,7 +3205,7 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
   ImplScope class_scope;
   class_scope.AddParent(scope_info.innermost_scope);
 
-  if (class_decl->prefix() != ClassPrefix::StandardClass) {
+  if (class_decl->extensibility() != ClassExtensibility::None) {
     return CompilationError(class_decl->source_loc())
            << "Class prefixes `base` and `abstract` are not supported yet";
   }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -3205,6 +3205,15 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
   ImplScope class_scope;
   class_scope.AddParent(scope_info.innermost_scope);
 
+  if (class_decl->prefix() != ClassPrefix::StandardClass) {
+    return CompilationError(class_decl->source_loc())
+           << "Class prefixes `base` and `abstract` are not supported yet";
+  }
+  if (class_decl->extends()) {
+    return CompilationError(class_decl->source_loc())
+           << "Class extension with `extends` is not supported yet";
+  }
+
   std::vector<Nonnull<const GenericBinding*>> bindings = scope_info.bindings;
   if (class_decl->type_params().has_value()) {
     Nonnull<TuplePattern*> type_params = *class_decl->type_params();

--- a/explorer/syntax/lexer.lpp
+++ b/explorer/syntax/lexer.lpp
@@ -31,6 +31,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 %s AFTER_OPERAND
 
 /* table-begin */
+ABSTRACT             "abstract"
 ADDR                 "addr"
 ALIAS                "alias"
 AMPERSAND            "&"
@@ -40,6 +41,7 @@ ARROW                "->"
 AS                   "as"
 AUTO                 "auto"
 AWAIT                "__await"
+BASE                 "base"
 BOOL                 "Bool"
 BREAK                "break"
 CARET                "^"
@@ -57,6 +59,7 @@ DOUBLE_ARROW         "=>"
 ELSE                 "else"
 EQUAL                "="
 EQUAL_EQUAL          "=="
+EXTENDS              "extends"
 EXTERNAL             "external"
 FALSE                "false"
 FN                   "fn"
@@ -124,6 +127,7 @@ operand_start         [(A-Za-z0-9_\"]
 %}
 
  /* table-begin */
+{ABSTRACT}            { return CARBON_SIMPLE_TOKEN(ABSTRACT);            }
 {ADDR}                { return CARBON_SIMPLE_TOKEN(ADDR);                }
 {ALIAS}               { return CARBON_SIMPLE_TOKEN(ALIAS);               }
 {AMPERSAND}           { return CARBON_SIMPLE_TOKEN(AMPERSAND);           }
@@ -133,6 +137,7 @@ operand_start         [(A-Za-z0-9_\"]
 {AS}                  { return CARBON_SIMPLE_TOKEN(AS);                  }
 {AUTO}                { return CARBON_SIMPLE_TOKEN(AUTO);                }
 {AWAIT}               { return CARBON_SIMPLE_TOKEN(AWAIT);               }
+{BASE}                { return CARBON_SIMPLE_TOKEN(BASE);                }
 {BOOL}                { return CARBON_SIMPLE_TOKEN(BOOL);                }
 {BREAK}               { return CARBON_SIMPLE_TOKEN(BREAK);               }
 {CARET}               { return CARBON_SIMPLE_TOKEN(CARET);               }
@@ -150,6 +155,7 @@ operand_start         [(A-Za-z0-9_\"]
 {ELSE}                { return CARBON_SIMPLE_TOKEN(ELSE);                }
 {EQUAL_EQUAL}         { return CARBON_SIMPLE_TOKEN(EQUAL_EQUAL);         }
 {EQUAL}               { return CARBON_SIMPLE_TOKEN(EQUAL);               }
+{EXTENDS}             { return CARBON_SIMPLE_TOKEN(EXTENDS);             }
 {EXTERNAL}            { return CARBON_SIMPLE_TOKEN(EXTERNAL);            }
 {FALSE}               { return CARBON_SIMPLE_TOKEN(FALSE);               }
 {FN_TYPE}             { return CARBON_SIMPLE_TOKEN(FN_TYPE);             }

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -104,6 +104,8 @@
 %type <std::vector<LibraryName>> import_directives
 %type <std::string> optional_library_path
 %type <bool> api_or_impl
+%type <ClassPrefix> class_declaration_prefix
+%type <std::optional<Nonnull<Expression*>>> class_declaration_extends
 %type <Nonnull<Declaration*>> declaration
 %type <Nonnull<FunctionDeclaration*>> function_declaration
 %type <Nonnull<AliasDeclaration*>> alias_declaration
@@ -192,6 +194,7 @@
 %token
   // Most tokens have their spelling defined in lexer.lpp.
   // table-begin
+  ABSTRACT
   ADDR
   ALIAS
   AMPERSAND
@@ -201,6 +204,7 @@
   AS
   AUTO
   AWAIT
+  BASE
   BOOL
   BREAK
   CARET
@@ -218,6 +222,7 @@
   ELSE
   EQUAL
   EQUAL_EQUAL
+  EXTENDS
   EXTERNAL
   FALSE
   FN
@@ -1059,14 +1064,28 @@ type_params:
 | tuple_pattern
     { $$ = $1; }
 ;
+class_declaration_prefix:
+  // Empty
+    { $$ = Carbon::ClassPrefix::StandardClass; }
+| ABSTRACT
+    { $$ = Carbon::ClassPrefix::AbstractClass; }
+| BASE
+    { $$ = Carbon::ClassPrefix::BaseClass; }
+;
+class_declaration_extends:
+  // Empty
+    { $$ = std::nullopt; }
+| EXTENDS expression
+    { $$ = $2; }
+;
 declaration:
   function_declaration
     { $$ = $1; }
-| CLASS identifier type_params LEFT_CURLY_BRACE declaration_list RIGHT_CURLY_BRACE
+| class_declaration_prefix CLASS identifier type_params class_declaration_extends LEFT_CURLY_BRACE declaration_list RIGHT_CURLY_BRACE
     {
       $$ = arena->New<ClassDeclaration>(
-          context.source_loc(), $2,
-          arena->New<SelfDeclaration>(context.source_loc()), $3, $5);
+          context.source_loc(), $3,
+          arena->New<SelfDeclaration>(context.source_loc()), $1, $4, $5, $7);
     }
 | CHOICE identifier LEFT_CURLY_BRACE alternative_list RIGHT_CURLY_BRACE
     { $$ = arena->New<ChoiceDeclaration>(context.source_loc(), $2, $4); }

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -104,7 +104,7 @@
 %type <std::vector<LibraryName>> import_directives
 %type <std::string> optional_library_path
 %type <bool> api_or_impl
-%type <ClassPrefix> class_declaration_prefix
+%type <ClassExtensibility> class_declaration_extensibility
 %type <std::optional<Nonnull<Expression*>>> class_declaration_extends
 %type <Nonnull<Declaration*>> declaration
 %type <Nonnull<FunctionDeclaration*>> function_declaration
@@ -1064,13 +1064,13 @@ type_params:
 | tuple_pattern
     { $$ = $1; }
 ;
-class_declaration_prefix:
+class_declaration_extensibility:
   // Empty
-    { $$ = Carbon::ClassPrefix::StandardClass; }
+    { $$ = Carbon::ClassExtensibility::None; }
 | ABSTRACT
-    { $$ = Carbon::ClassPrefix::AbstractClass; }
+    { $$ = Carbon::ClassExtensibility::Abstract; }
 | BASE
-    { $$ = Carbon::ClassPrefix::BaseClass; }
+    { $$ = Carbon::ClassExtensibility::Base; }
 ;
 class_declaration_extends:
   // Empty
@@ -1081,7 +1081,7 @@ class_declaration_extends:
 declaration:
   function_declaration
     { $$ = $1; }
-| class_declaration_prefix CLASS identifier type_params class_declaration_extends LEFT_CURLY_BRACE declaration_list RIGHT_CURLY_BRACE
+| class_declaration_extensibility CLASS identifier type_params class_declaration_extends LEFT_CURLY_BRACE declaration_list RIGHT_CURLY_BRACE
     {
       $$ = arena->New<ClassDeclaration>(
           context.source_loc(), $3,

--- a/explorer/testdata/class/fail_abstract_class.carbon
+++ b/explorer/testdata/class/fail_abstract_class.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+abstract class C {
+  fn F() {}
+// CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_class.carbon:[[@LINE+1]]: Class prefixes `base` and `abstract` are not supported yet
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_base_class.carbon
+++ b/explorer/testdata/class/fail_base_class.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+base class C {
+  fn F() {}
+// CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_base_class.carbon:[[@LINE+1]]: Class prefixes `base` and `abstract` are not supported yet
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_class_extends.carbon
+++ b/explorer/testdata/class/fail_class_extends.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+class A {
+  fn F() {}
+}
+
+class B extends A {
+  fn F() {}
+// CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_class_extends.carbon:[[@LINE+1]]: Class extension with `extends` is not supported yet
+}
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
Provides a first implementation iteration towards class prefix and extension, along with user-friendly error regarding missing implementation for #1881 

**Explorer behavior**
For class prefix `base` and `abstract`: 
```
Class prefixes `base` and `abstract` are not supported yet
```
For extension with `extends`: 
```
Class extension with `extends` is not supported yet
```

**Motivation**
* Provides user-friendly error for these unsupported features
* First implementation increment in supporting class prefix and extension.