### PR TITLE
Suggestion: 'Support status' page for language definition and support status

### DIFF
--- a/docs/design/support_status.md
+++ b/docs/design/support_status.md
@@ -1,0 +1,38 @@
+# Carbon language status
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Overview](#overview)
+-   [Status and features support](#status-and-features-support)
+
+<!-- tocstop -->
+
+## Overview
+
+Many details...
+
+## Status and features support
+
+The table below represents the current language definition status, and feature
+support for the [`explorer`](/explorer/README.md) and
+[`toolchain`](/toolchain/).
+
+| Category                           | Design phase   | Explorer | Toolchain |
+| ---------------------------------- | -------------- | -------- | --------- |
+| Control flow > Conditionals        | Frozen         | Partial  | No        |
+| Control flow > Loops               | Draft          | Partial  | No        |
+| Control flow > Return              | Support wanted | Partial  | No        |
+| Expressions > Arithmetic           | Not started    | Partial  | No        |
+| Expressions > As                   | Draft          | Yes      | No        |
+| Expressions > Bitwise              | Draft          | Yes      | No        |
+| Expressions > Comparison           | Draft          | Yes      | No        |
+| Expressions > Implicit conversions | Draft          | Yes      | No        |
+| ...                                | ...            | ...      | ...       |


### PR DESCRIPTION
Suggested initial & basic status documentation as a first step to documenting it.

**Why**

* Less surprises and unknowns for early adopters & testers
* Track overall progress, area left to define, and implement: i.e. where some more work/contributions are needed!
* Tie design/definition and implementation status together (but probably too high-level as-is)

**Limitations**

* Needs to maintain manually
* Very high level as-is

**Alternatives**

* Track within each `design` (or `spec`) file
* `spec` feature unique requirement ID in .md > code > tests > ... to be automatically reported
* Dedicated tools, etc.