### PR TITLE
Broaden prohibition on insults

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -86,9 +86,9 @@ spaces:
     kind when dealing with other members as well as with people outside the
     Carbon community.
 
--   **Be careful in the words that we choose and be kind to others.** Do not
-    insult or put down other participants. Harassment and other exclusionary
-    behaviors aren’t acceptable. This includes, but is not limited to:
+-   **Be careful in the words that we choose and be kind to others.** Do not use
+    insults or put downs. Harassment and other exclusionary behaviors aren’t
+    acceptable. This includes, but is not limited to:
 
     -   Violent threats or language directed against another person.
     -   Discriminatory jokes and language.


### PR DESCRIPTION
We shouldn't allow insults even when they're directed against people who aren't "participants", or when they're directed against ideas (because that indirectly attacks the people holding those ideas).