### PR TITLE
Disable auto-update on RAND test case.

### DIFF
--- a/explorer/testdata/random/random.carbon
+++ b/explorer/testdata/random/random.carbon
@@ -6,7 +6,7 @@
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
-// AUTOUPDATE: %{explorer} %s
+// NOAUTOUPDATE
 // CHECK: result: 0
 
 package ExplorerTest api;


### PR DESCRIPTION
Auto-update tries to add `CHECK: Nice!` or `CHECK: HALLO WELT` to the test case. As what's being printed is non-deterministic, the auto-update should be disabled.