### PR TITLE
Format Bazel files and add argument to run buildifier on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,10 @@ repos:
       - id: buildifier
         name: Bazel buildifier
         entry: scripts/run_buildifier.py
+        args: ['-r', '.']
         language: python
         files: |
-          (?x)^(
+          '(?x)^(
             .*BUILD.*|
             .*WORKSPACE.*|
             .*\.bzl

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,8 +92,10 @@ http_archive(
     name = "llvm-raw",
     build_file_content = "# empty",
     patch_args = ["-p1"],
-    patches = ["@//:bazel/llvm-patches/0001-Patch-for-mallinfo2-when-using-Bazel-build-system.patch",
-               "@//:bazel/llvm-patches/0002-Added-Bazel-build-for-compiler-rt-fuzzer.patch"],
+    patches = [
+        "@//:bazel/llvm-patches/0001-Patch-for-mallinfo2-when-using-Bazel-build-system.patch",
+        "@//:bazel/llvm-patches/0002-Added-Bazel-build-for-compiler-rt-fuzzer.patch",
+    ],
     sha256 = "0a3929c5f2fe756820277be7b10e95f7480e7cb7f297ec574d3e9ddeac9068d7",
     strip_prefix = "llvm-project-%s" % llvm_version,
     urls = ["https://github.com/llvm/llvm-project/archive/%s.tar.gz" % llvm_version],

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -19,9 +19,9 @@ load(
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     ":clang_detected_variables.bzl",
+    "clang_bindir",
     "clang_include_dirs_list",
     "clang_resource_dir",
-    "clang_bindir",
     "llvm_bindir",
     "sysroot_dir",
 )

--- a/bazel/fuzzing/rules.bzl
+++ b/bazel/fuzzing/rules.bzl
@@ -40,7 +40,7 @@ def cc_fuzz_test(
     if "fuzzer" not in features:
         features = features + ["fuzzer"]
     if "@llvm-project//compiler-rt:FuzzerMain" not in deps:
-      deps = deps + ["@llvm-project//compiler-rt:FuzzerMain"]
+        deps = deps + ["@llvm-project//compiler-rt:FuzzerMain"]
 
     # Append the corpus files to the test arguments. When run on a list of
     # files rather than a directory, libFuzzer-based fuzzers will perform a


### PR DESCRIPTION
# Changes
- Format Bazel files
- Run buildifier in recursive mode