### PR TITLE
Make platform-specific mmap flags the exception.

### DIFF
--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -79,10 +79,10 @@ auto SourceBuffer::CreateFromFile(llvm::StringRef filename)
 
   errno = 0;
   void* mapped_text = mmap(nullptr, size, PROT_READ,
-#ifdef __APPLE__
-                           MAP_PRIVATE,
-#else
+#if defined(__linux__)
                            MAP_PRIVATE | MAP_POPULATE,
+#else
+                           MAP_PRIVATE,
 #endif
                            file_descriptor, /*offset=*/0);
   // The `MAP_FAILED` macro may expand to a cast to pointer that `clang-tidy`


### PR DESCRIPTION
MAP_POPULATE is a Linux mmap flag that optionally assists read-ahead on
the mapping. It is nonstandard and omission does not affect the
underlying mapping, so fall back to not including the flag, rather than
the reverse.