### PR TITLE
Character Literals (#1934)

### DIFF
--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -120,23 +120,22 @@ by only looking at the types:
 let allowed: Char8 = 'a';
 ```
 
-The above is allowed because the type of 'a' indicates that it can be converted
-to `Char8`. Here, `Char8` is a type that can represent a single 8-bit character,
-like C++'s `char8_t`. `Char8` is used for exposition and is not part of this
-proposal.
-
+The above is allowed because the type of `'a'` indicates that it can be
+converted to `Char8`. Here, `Char8` is a type that can represent a single 8-bit
+character, like C++'s `char8_t`. `Char8` is used for exposition and is not part
+of this proposal.
 
 ```
 let error1: Char8 = '😃';
 let error2: Char8 = 'AB';
 ```
 
-However these should produce errors, the types of '😃' and 'AB' indicate that
-they cannot be converted to the declared type `Char8`. It is important to point out
-that any `'\n'` and `'\u{A}'` would be of the same type, as they are the same
-unicode entities `%0A`. It is worth noting that `'\x0A'` will be slightly
-different as any character following the `\x...` sequence representation is not
-the same as a Unicode character. For example:
+However these should produce errors, the types of `'😃'` and `'AB'` indicate
+that they cannot be converted to the declared type `Char8`. It is important to
+point out that any `'\n'` and `'\u{A}'` would be of the same type, as they are
+the same unicode entities `%0A`. It is worth noting that `'\x0A'` will be
+slightly different as any character following the `\x...` sequence
+representation is not the same as a Unicode character. For example:
 
 ```
 var c1: EBCDICChar = '\x0A';

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -64,10 +64,16 @@ more examples showing more appropriate use of characters over using strings.
 
 ## Background
 
-TODO: Briefly describe character literals in other languages (particularly C++,
-but it's often also useful to compare to Rust, Swift, Java, Python, and any
-other common languages that have made interesting choices in this area) and/or
-provide a link to an external description.
+Character Literals by definition is a type of literal in programming for the
+representation of a single character's value within the source code of a
+computer program. Character literals between languages have some minor nuances
+but are fundamentally designed for the same purpose. Languages that have a
+dedicated character data type generally include character literals, for example
+C++, Java, Swift to name a few. Whereas other languages that lack distinct
+character type, like Python use strings of length one to serve the same purpose
+a character data type. For more information see
+[Character Literals Wiki](https://en.wikipedia.org/wiki/Character_literal),
+[Character Literals DBpedia](https://dbpedia.org/page/Character_literal)
 
 ## Proposal
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -24,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Alternatives considered](#alternatives-considered)
     -   [No distinct character literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
+    -   [Disallowing numeric escape sequences](#disallowing-numeric-escape-sequences)
 
 <!-- tocstop -->
 
@@ -258,9 +259,17 @@ interopability.
 
 ### Supporting Prefix Declarations
 
--   No support is proposed for prefix declarations like `u`, `U`, or `L`. In
-    practice they are used to specify the character literal types in languages
-    like C and C++, supporting these could help with the familiarity of coming
-    to Carbon with a more C++ or C background. Supporting this will help support
-    a much cleaner and readable syntax that is more inline with Carbon's goals,
-    i.e [Rationale](#rationale).
+No support is proposed for prefix declarations like `u`, `U`, or `L`. In
+practice they are used to specify the character literal types in languages like
+C and C++, supporting these could help with the familiarity of coming to Carbon
+with a more C++ or C background. Supporting this will help support a much
+cleaner and readable syntax that is more inline with Carbon's goals, i.e
+[Rationale](#rationale).
+
+### Disallowing numeric escape sequences
+
+Not support escaping numeric sequences. This would simplify some of the design
+choices seen above, specifically how we manage [Types](#types) and of the
+`EBCDIC` type, disallowing the `\x...` pattern. This would restrict users by
+having to use the specific hex value, restrict when to use operations between
+character literals and impact the readablilty of Carbon in some use cases.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -142,16 +142,27 @@ the C++ character types and the correct associated encoding.
 ### No distinct character literal
 
 In principle a character literal can be represented by reusing string literals.
-For example: `var s: String = "c"` We would simply this as a single element
-string. However it terms of readablility, if we had a distinct lexical syntax
-for character literals versus string literals, this would be more inline with
-Carbon's language design goals related to self documenting code, easy to read,
-understand, write and C++ interopability.
+//TODO: Add Description
+
+```
+    var b: String = "b";
+    var c: String = "c";
+    if (c > b) {
+        b = c + b;
+    }
+```
+
+We would simply this as a single element string. However it terms of
+readablility, if we had a distinct lexical syntax for character literals versus
+string literals, this would be more inline with Carbon's language design goals
+related to self documenting code, easy to read, understand, write and C++
+interopability.
 
 ### Supporting Prefix Declarations
 
 -   No support is proposed for prefix declarations like `u`, `U`, or `L`. In
     practice they are used to specify the character literal types in languages
-    like C and C++, supporting these could help with interoperability.
-    Supporting this will help support a much cleaner and readable syntax that is
-    more inline with Carbon's goals, i.e [Rationale](#rationale).
+    like C and C++, supporting these could help with the familiarity of coming
+    to Carbon with a more C++ or C background. Supporting this will help support
+    a much cleaner and readable syntax that is more inline with Carbon's goals,
+    i.e [Rationale](#rationale).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -106,7 +106,6 @@ We will not support:
     arithmetic, producing another code point, or a runtime CodePoint (Type name
     TBD) value if necessary. For more information about source encoding see
     [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
-    .
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
     literal, if the value can be determined at compile time, or a runtime

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -167,8 +167,7 @@ be the EBCDIC NL character (0x15)
 
 ### Operations
 
-If a character literal encodes exactly one code point, then it supports
-arithmetic operations:
+From the previous examples, we should be able to use the following operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
     -   If any of the comparison operators are used between a code point and a

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -1,0 +1,161 @@
+# Character literals
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/1964)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+    -   [Types](#types)
+    -   [Operations](#operations)
+    -   [Encoding](#encoding)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [No distinct Character literal](#no-distinct-character-literal)
+    -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
+
+<!-- tocstop -->
+
+## Abstract
+
+Put character literals in single quotes, like `'a'`. Character literals work
+like numeric literals:
+
+-   Every different literal value has its own type.
+-   The bit width is determined by the type of the variable the literal is
+    assigned to, not the literal itself. Follows the plan from #1934.
+
+## Problem
+
+This proposal specifies lexical rules for constant characters in Carbon.
+
+## Background
+
+We wish to provide a distinct lexical syntax for character literals versus
+string literals.
+
+## Proposal
+
+The advantage of having an explicit character type fundimentally comes down to
+characters being represented as integers whereas strings are represented as
+buffers. This will allow characters to have different operations, and be more
+familiar to use. For example:
+
+```
+if (c >= 'A' and c <= 'Z') {
+  c += 'a' - 'A';
+}
+```
+
+The example above shows how we would be able to use operations similar to
+integers. Being able to use the comparison operations and supporting arithmetic
+operations provides intuitve approach to using characters. This allows us to
+remove unnecessary logic of type conversion and other control flow logic, that
+is needed to work with a single element string.
+
+We will not support:
+
+-   Multi-line literals
+-   "raw" literals (using #'x'#)
+-   Empty character literals (`''`)
+-   ASCII Control codes (0...31), except for `\` when used for an escape
+    sequence. See
+    [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
+
+## Details
+
+A character literal is a sequence enclosed with single quotes delimiter ('),
+excluding:
+
+-   New line
+-   Single quote (`'`), but can write `'` character as `'\''`
+-   Back-slash (`\`), except when used to form an escape sequence. See
+    [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
+
+### Types
+
+The different character literal types are based on the value of the character.
+Meaning the type depends on the the contents, so that `'c'` and `'b'`. However
+any `'\n'` and `'\u{A}'` would be of the same type, as they are the same unicode
+entities `%0A`. It is worth noting that `'\x0A'` will be slightly different as
+any character following the `\x...` sequence representation are not the same as
+a Unicode character. For example:
+
+```
+var c1: EBCDICChar = '\x0A';
+var c2: EBCDICChar = '\n';
+```
+
+Here we assume that `c1` will be the EBCDIC RPT character (0xA) and for `c2` to
+be the EBCDIC NL character (0x15)
+
+### Operations
+
+From the previous examples, we should be able to use the following operators:
+
+-   Comparison: `<`, `>`, `<=`, `>=` `==`
+-   Plus: `+`. However the behaviour of this operator is distinctly compared to
+    its use with Strings. Rather then a concatenation, this will add the value
+    of the two characters.
+-   Subtract: `-` Similar to the plus operator, this will subtract the value of
+    the two characters.
+
+### Encoding
+
+Character literals written will be UTF-8 encoded, as all of Carbon source code
+is UTF-8 encoded. See
+[Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)
+
+## Rationale
+
+This proposal supports the goal of making Carbon code
+[easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
+Adding support for a specific character literal supports clean, readable,
+concises use and is a much more familiar concept that will make it easier to
+adopt Carbon coming from other languages. As well as following other standards
+set in place by previous proposals. For example following the
+[String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
+and representing characters as integers with the behaviour inline with
+[Integer Literals](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0143.md).
+This also supports our goal for
+[Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+by ensuring that every kind of character literal that exists in C++ can be
+represented in a Carbon character literal. This is done in a way that is natural
+to adopt, understand, easy to read by having explicit character types mapped to
+the C++ character types and the correct associated encoding.
+
+## Alternatives considered
+
+### No distinct Character literal
+
+-   In principle a character literal can be represented by reusing string
+    literals. For example:
+    ```
+    var s: String = "c"
+    ```
+    We would simply this as a single element string. However it terms of
+    readablility, if we had a distinct lexical syntax for character literals
+    versus string literals, this would be more inline with Carbon's language
+    design goals related to self documenting code, easy to read, understand,
+    write and C++ interopability.
+
+### Supporting Prefix Declarations
+
+-   No support is proposed for prefix declarations like `u`, `U`, or `L`. In
+    practice they are used to specify the character literal types in languages
+    like C and C++, supporting these could help with interopability. However the
+    proposal above supports the ideas that when a character is declared, its
+    type is dependent on the value of the character itself, See [Types](#types).
+    Supporting this will help support a much cleaner and readable syntanx that
+    is more inline with Carbons goals, i.e [Rationale](#rationale).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -29,6 +29,37 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
+This proposal specifies lexical rules for constant characters in Carbon.
+
+## Problem
+
+Carbon currently has no lexical syntax for character literals, and only provides
+string literals and numeric literals. We wish to provide a distinct lexical syntax
+for character literals versus string literals.
+
+The advantage of having an explicit character type fundamentally comes down to
+characters being represented as integers whereas strings are represented as
+buffers. This will allow characters to have different operations, and be more
+familiar to use. For example:
+
+\```
+if (c >= 'A' and c <= 'Z') {
+  c += 'a' - 'A';
+}
+\```
+
+The example above shows how we would be able to use operations similar to
+integers. Being able to use the comparison operations and supporting arithmetic
+operations provides an intuitive approach to using characters. This allows us to
+remove unnecessary logic of type conversion and other control flow logic, that
+is needed to work with a single element string.
+
+## Background
+
+TODO: Briefly describe character literals in other languages (particularly C++, but it's often also useful to compare to Rust, Swift, Java, Python, and any other common languages that have made interesting choices in this area) and/or provide a link to an external description.
+
+## Proposal
+
 Put character literals in single quotes, like `'a'`. Character literals work
 like numeric literals:
 
@@ -36,33 +67,6 @@ like numeric literals:
 -   The bit width is determined by the type of the variable the literal is
     assigned to, not the literal itself. Follows the plan from #1934.
 
-## Problem
-
-This proposal specifies lexical rules for constant characters in Carbon.
-
-## Background
-
-We wish to provide a distinct lexical syntax for character literals versus
-string literals.
-
-## Proposal
-
-The advantage of having an explicit character type fundimentally comes down to
-characters being represented as integers whereas strings are represented as
-buffers. This will allow characters to have different operations, and be more
-familiar to use. For example:
-
-```
-if (c >= 'A' and c <= 'Z') {
-  c += 'a' - 'A';
-}
-```
-
-The example above shows how we would be able to use operations similar to
-integers. Being able to use the comparison operations and supporting arithmetic
-operations provides intuitve approach to using characters. This allows us to
-remove unnecessary logic of type conversion and other control flow logic, that
-is needed to work with a single element string.
 
 We will not support:
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -101,7 +101,8 @@ We will not support:
 ## Details
 
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
-    of UTF-8 code units that may or may not be a valid encoding.
+    of UTF-8 code units that may or may not be a valid encoding. This matches
+    [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
     literal, if the value can be determined at compile time, or a runtime
@@ -152,7 +153,7 @@ let allowed: Char8 = 'a';
 
 The above is allowed because the type of `'a'` is the character literal
 consisting of the single Unicode code point 97, which can be converted to
-`Char8` since 97 fits it is less than or equal to 0x7F.
+`Char8` since 97 is less than or equal to 0x7F.
 
 ```
 let error1: Char8 = '😃';
@@ -258,7 +259,7 @@ This reflects the
 
 ### No distinct character types
 
-Unlike C++, Carbon will separate the integer and the character types, Carbon
+Unlike C++, Carbon will separate the integer and the character types. Carbon
 character types add the information that the represented integer is a code unit
 of some particular encoding. Whereas C++'s types `u8`, `u16`, and `u32` have the
 wrong arithmetic semantics: we dont want wrapping. And many `uN` operations are

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -173,7 +173,7 @@ From the previous examples, we should be able to use the following operators:
 
     In other use cases where the `+` and `-` operators are used, in theory we
     should convert the character literal to some other type first. For example
-    if we want to call `x - 'a'`, where `w` is of type `char` we would want to
+    if we want to call `w - 'a'`, where `w` is of type `char` we would want to
     convert the `'a'` literal to a `char`.
 
 ### Encoding

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -170,7 +170,7 @@ From the previous examples, we should be able to use the following operators:
     -   If the `-` is used between a character literal and an integer literal,
         this should produce a character literal.
     -   If the `-` is used between two character literals, which are either both
-        a single code point or both a single code unit, this should produce and
+        a single code point or both a single code unit, this should produce an
         integer literal representing the difference between the code points or
         code units.
     -   If the `-` is used between a character literal and an integer

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -123,10 +123,11 @@ We will not support:
 
 ### Types
 
-For the time being we will support a type `CharN` that will hold both code units
+For the time being we will support character types `Char8`,
+ `Char16`, and `Char32` that will hold both code units
 and code points, and will leave the different UTF-encoding code unit types to
 another proposal. See
-[UTF code unit types proposal](#utf-code-unit-types-proposal))
+[UTF code unit types proposal](#utf-code-unit-types-proposal).
 
 We will have the type `CharN` and only support literals that map directly to the
 complete value of a code point.
@@ -154,10 +155,11 @@ operators:
         point, it is an error.
 -   Subtract: `-`. This will subtract the value of the two characters, or a
     character followed by an integer literal:
-    -   If the `-` is used between two character literals, the result will be a
-        character constant `'z' - 4`.
-    -   If the `-` is used between a character literal, followed by a integer
-        literal this will produce an integer constant `'z' - 'a'`.
+    -   If the `-` is used between two character literals, the result will be an
+        integer constant. For example, `'z' - 'a'` is equivalent to `25`.
+    -   If the `-` is used between a character literal followed by a integer
+        literal, this will produce a character constant. For example `'z' - 4`
+        is equivalent to `'v'`.
     -   If the `-` is used between a integer literal followed by a character
         literal `100 - 'a'`, this will be rejected unless the integer is cast to
         a character.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Encoding](#encoding)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [No distinct Character literal](#no-distinct-character-literal)
+    -   [No distinct character literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
 
 <!-- tocstop -->
@@ -34,19 +34,15 @@ This proposal specifies lexical rules for constant characters in Carbon.
 ## Problem
 
 Carbon currently has no lexical syntax for character literals, and only provides
-string literals and numeric literals. We wish to provide a distinct lexical syntax
-for character literals versus string literals.
+string literals and numeric literals. We wish to provide a distinct lexical
+syntax for character literals versus string literals.
 
 The advantage of having an explicit character type fundamentally comes down to
 characters being represented as integers whereas strings are represented as
 buffers. This will allow characters to have different operations, and be more
 familiar to use. For example:
 
-\```
-if (c >= 'A' and c <= 'Z') {
-  c += 'a' - 'A';
-}
-\```
+\``` if (c >= 'A' and c <= 'Z') { c += 'a' - 'A'; } \```
 
 The example above shows how we would be able to use operations similar to
 integers. Being able to use the comparison operations and supporting arithmetic
@@ -56,7 +52,10 @@ is needed to work with a single element string.
 
 ## Background
 
-TODO: Briefly describe character literals in other languages (particularly C++, but it's often also useful to compare to Rust, Swift, Java, Python, and any other common languages that have made interesting choices in this area) and/or provide a link to an external description.
+TODO: Briefly describe character literals in other languages (particularly C++,
+but it's often also useful to compare to Rust, Swift, Java, Python, and any
+other common languages that have made interesting choices in this area) and/or
+provide a link to an external description.
 
 ## Proposal
 
@@ -66,7 +65,6 @@ like numeric literals:
 -   Every different literal value has its own type.
 -   The bit width is determined by the type of the variable the literal is
     assigned to, not the literal itself. Follows the plan from #1934.
-
 
 We will not support:
 
@@ -158,8 +156,6 @@ the C++ character types and the correct associated encoding.
 
 -   No support is proposed for prefix declarations like `u`, `U`, or `L`. In
     practice they are used to specify the character literal types in languages
-    like C and C++, supporting these could help with interoperability. However the
-    proposal above supports the ideas that when a character is declared, its
-    type is dependent on the value of the character itself, see [Types](#types).
-    Supporting this will help support a much cleaner and readable syntax that
-    is more inline with Carbon's goals, i.e [Rationale](#rationale).
+    like C and C++, supporting these could help with interoperability.
+    Supporting this will help support a much cleaner and readable syntax that is
+    more inline with Carbon's goals, i.e [Rationale](#rationale).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -25,6 +25,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [No Distinct Character Literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
     -   [Allowing Numeric Escape Sequences](#allowing-numeric-escape-sequences)
+    -   [Supporting Formulations of grapheme clusters and non-code-point code-units.](#supporting-formulations-of-grapheme-clusters-and-non-code-point-code-units)
 
 <!-- tocstop -->
 
@@ -88,18 +89,10 @@ like numeric literals:
 -   Every different literal value has its own type.
 -   The bit width is determined by the type of the variable the literal is
     assigned to, not the literal itself. Follows the plan from #1934.
-
-We will not support:
-
--   Multi-line literals
--   "raw" literals (using #'x'#)
--   Empty character literals (`''`)
--   `\x` escape sequences
--   Character literals that don't contain exactly one code point.
--   ASCII Control codes (0...31), except when specified with an escape sequence.
--   Whitespace characters other than word space: tab, line feed, carriage
-    return, form feed, and vertical tab. See
-    [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
+-   A character literal will model single Unicode code points that have a single
+    concrete numerical representation. We will not be supporting other
+    formulations like code unit sequences or grampheme clusters as these will be
+    modeled with normal string literals.
 
 ## Details
 
@@ -109,24 +102,22 @@ We will not support:
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
     literal, otherwise it will be rejected and produce an error.
--   For most purposes a character should be viewed as representing a grapheme
-    cluster.
--   Value-preserving implicit conversions from character literals to code point
-    or code unit types are permitted. In particular, a character literal
-    converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
-    UTF-16 code unit if it is less than or equal to 0xFFFF.
 -   Support for `\u` escape sequences.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
-Character literals cannot be written with these characters:
+    We will not support:
 
--   New line
+-   Character literals that don't contain exactly one Unicode code point.
+-   New line and multi-line literals
+-   "raw" literals (using #'x'#)
+-   `\x` escape sequences
 -   Single quote (`'`), but can write `'` character as `'\''`
--   Back-slash (`\`), except when used to form an escape sequence. See
+-   Empty character literals (`''`)
+-   ASCII Control codes (0...31), except when specified with an escape sequence.
+-   Whitespace characters other than word space: tab, line feed, carriage
+    return, form feed, and vertical tab. And Back-slash (`\`), see
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
--   Whitespace characters other than space (` `).
--   ASCII control codes (0...31).
 
 ### Types
 
@@ -349,3 +340,25 @@ would assume we support initializing character types from integer literals
 implicit conversion from non-constant integer-valued expressions to character
 types. This diminishes our ability to distinguish between numbers and characters
 in our type system.
+
+### Supporting Formulations of grapheme clusters and non-code-point code-units.
+
+Rather than explicitly limiting characters literals to a more integer like
+representation of single Unicode units, we could repsent characters literal
+formulations of grapheme clusters and non-code point code units. What humans
+tend to think of as a "character" is more a "grapheme cluster" that is an
+arbitrarily long and complex encoding, which generally makes a more Unicode and
+text friendly model while sacrificing the accesability of an integer like
+representation. If we wanted to add support for these other character
+formulations we need to use separate spellings to represent a small set of
+operations that are today expressed with integer-based math on C++'s character
+literals, for example things like converting an integer between 0 and 9 into the
+corresponding digit character, or computing the difference between two
+digits/two other characters. We would also need to provide a way to extract an
+actual integer from a codepoint in such a literal to handle esoteric needs, an
+additional type with some augmented API to handle the few common cases where C++
+uses arithmetic. For these reasons we have decided to start out by representing
+character literals as single Unicode code points following a more integer-like
+model. However this topic should be revisited, if we find that there is a
+significant need for the additional functionality and attendant complexity for
+these other character formulations.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -277,7 +277,7 @@ cleaner and readable syntax that is more inline with Carbon's goals, i.e
 ### Disallowing Numeric Escape Sequences
 
 Not support escaping numeric sequences. This would simplify some of the design
-choices seen above by making types, the resctrictions and behavior of character
+choices seen above by making types, the restrictions and behavior of character
 literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
 `\x...` pattern. This would restrict users by having to use the specific hex
 value, and when to use operations between character literals and benifitying the

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -17,7 +17,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Background](#background)
 -   [Proposal](#proposal)
 -   [Details](#details)
-    -   [Excluding](#excluding)
     -   [Types](#types)
     -   [Operations](#operations)
     -   [Encoding](#encoding)
@@ -100,25 +99,8 @@ We will not support:
 
 ## Details
 
--   A character literal is a sequence enclosed with single quotes delimiter (')
-
--   It is a sequence of UTF-8 code units that may or may not be a valid
-    encoding. If a character literal is encodes exactly one code point, then it
-    supports arithmetic, producing another code point, or a runtime CodePoint
-    (Type name TBD) value if necessary.
--   Value-preserving implicit conversions from character literals to code point
-    or code unit types are permitted. In particular, a character literal
-    converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
-    UTF-16 code unit if it is less than or equal to 0xFFFF.
--   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
-    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
-    point so arithmetic on it is permitted.
--   Conversions from string or character literals to a non-value-preserving
-    encoding are explicit.
--   Conversions from string literals to Unicode strings are implicit, even
-    though the numeric values of the encoding may change.
-
-### Excluding
+A character literal is a sequence enclosed with single quotes delimiter ('),
+excluding:
 
 -   New line
 -   Single quote (`'`), but can write `'` character as `'\''`
@@ -129,11 +111,26 @@ We will not support:
 
 ### Types
 
-We will represent a character literal as a sequence consisting of elements that
-are each either a unicode code-point or a hex-encoded byte value.
+We will have the types `Char8`, `Char16`, and `Char32` representing code units
+in UTF-8, UTF-16, and UTF-32. `Char32` will represent a valid code point that
+align with the rules stated in [encoding](#encoding)
+
+-   We will represent a character literal as a sequence consisting of elements
+    that are each either a unicode code-point or a hex-encoded byte value.
+-   We will support value preserving implicit conversions from character
+    literals to code point or code unit types. In particular, a character
+    literal converts to a UTF-8 code unit if it is less than or equal to 0x7F,
+    and UTF-16 code unit if it is less than or equal to 0xFFFF.
+-   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
+    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
+    point.
+-   Conversions from string or character literals to a non-value-preserving
+    encoding are explicit.
+-   Conversions from string literals to Unicode strings are implicit, even
+    though the numeric values of the encoding may change.
 
 We can see whether the particular literal is represented in the variable's type
-by only looking at the types:
+by only looking at the types.
 
 ```
 let allowed: Char8 = 'a';
@@ -170,7 +167,8 @@ be the EBCDIC NL character (0x15)
 
 ### Operations
 
-From the previous examples, we should be able to use the following operators:
+If a character literal encodes exactly one code point, then it supports
+arithmetic operations:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
     -   If any of the comparison operators are used between a code point and a
@@ -209,9 +207,12 @@ Carbon will separate the integer types from character types entirely.
 
 ### Encoding
 
-Character literals written will be UTF-8 encoded, as all of Carbon source code
-is UTF-8 encoded. See
-[Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)
+-   A character literal is a sequence of UTF-8 code units that may or may not be
+    a valid encoding. If a character literal encodes exactly one code point
+    `Char32`, then it supports arithmetic, producing another code point, or a
+    runtime CodePoint (Type name TBD) value if necessary. For more information
+    about source encoding see
+    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 
 ## Rationale
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -176,11 +176,11 @@ Adding support for a specific character literal supports clean, readable,
 concise use and is a much more familiar concept that will make it easier to
 adopt Carbon coming from other languages. Have a distinct character literal will
 also allow us support useful operations designed to manipulate the literal's
-value. When working with `String`, we use the `+` operator to concatenate
-multiple `String`s, but say we wanted to advance a character to the next
-literal. Using a `String` will produce a type error, as we are misusing the `+`
-operator: `"a" + 1`. However with a character literal, we can support operations
-for these use cases:
+value. When working with an explicit character type we can use operators that
+have unique behavior, for example say we wanted to advance a character to the
+next literal. In other languages the `+` operator is often used for
+concatenation, so using a `String` will produce a type error: `"a" + 1`. However
+with a character literal, we can support operations for these use cases:
 
 ```
 var b: u8;

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -145,9 +145,13 @@ Character literals representing a single code point support the following
 operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
--   Plus: `+`. This doesn't concatenate, but allows numerically adjusting the value:
-    -   Only one operand may be a character literal, the other must be an integer literal.
-    -   The result is the character literal whose numeric value is the sum of numeric value of the operands. If that sum is not a valid Unicode code point, it is an error.
+-   Plus: `+`. This doesn't concatenate, but allows numerically adjusting the
+    value:
+    -   Only one operand may be a character literal, the other must be an
+        integer literal.
+    -   The result is the character literal whose numeric value is the sum of
+        numeric value of the operands. If that sum is not a valid Unicode code
+        point, it is an error.
 -   Subtract: `-`. This will subtract the value of the two characters, or a
     character followed by an integer literal:
     -   If the `-` is used between two character literals, the result will be a
@@ -233,6 +237,9 @@ disadvantages:
     would be expected to print `"A"`.
 -   It's useful for developers to document the intended meaning of a value, and
     using a distinct type is one way to do that.
+
+See [UTF code unit types proposal](#utf-code-unit-types-proposal) for more
+information about UTF encoding
 
 ### No distinct character literal
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -101,11 +101,7 @@ We will not support:
 ## Details
 
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
-    of UTF-8 code units that may or may not be a valid encoding, if a character
-    literal encodes exactly one code point `Char32`, then it supports
-    arithmetic, producing another code point, or a runtime CodePoint (Type name
-    TBD) value if necessary. For more information about source encoding see
-    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
+    of UTF-8 code units that may or may not be a valid encoding.
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
     literal, if the value can be determined at compile time, or a runtime
@@ -292,6 +288,12 @@ fn DigitToChar(digit: i32) -> Char8 {
 
 Furthermore, many properties of Unicode characters are defined on ranges of code
 points, motivating supporting comparison operators on code points.
+
+```
+  var acute1: Char32 = "\u{E9}";
+  var acute2: Char32 = "\u{301}\u{65}";
+  var matching: auto = if acute1 == acute2 then true else false; //output false
+```
 
 ### Supporting Prefix Declarations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Encoding](#encoding)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Separate character and integer types](#separate-character-and-integer-types)
     -   [No Distinct Character Literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
     -   [Disallowing Numeric Escape Sequences](#disallowing-numeric-escape-sequences)
@@ -120,26 +121,24 @@ by only looking at the types:
 let allowed: Char8 = 'a';
 ```
 
-The above is allowed because the type of `'a'` is the character literal consisting
-of the single Unicode code point 97, which can be converted to `Char8` since
-97 fits in 8 bits. Here, `Char8` is a type that can represent a single 8-bit
-character, like C++'s `char8_t`. `Char8` is used for exposition and is not part
-of this proposal.
+The above is allowed because the type of `'a'` is the character literal
+consisting of the single Unicode code point 97, which can be converted to
+`Char8` since 97 fits in 8 bits. Here, `Char8` is a type that can represent a
+single 8-bit character, like C++'s `char8_t`. `Char8` is used for exposition and
+is not part of this proposal.
 
 ```
 let error1: Char8 = '😃';
 let error2: Char8 = 'AB';
 ```
 
-However these should produce errors. The type of `'😃'` is the character
-literal consisting of the single Unicode code point `0x1F603`, which is too big
-to fit in 8 bits. The type of `'AB'` is a character literal that is a sequence
-of two Unicode code points, which has no conversion to a type that only
-handles one.
+However these should produce errors. The type of `'😃'` is the character literal
+consisting of the single Unicode code point `0x1F603`, which is too big to fit
+in 8 bits. The type of `'AB'` is a character literal that is a sequence of two
+Unicode code points, which has no conversion to a type that only handles one.
 
-It is important to
-point out that any `'\n'` and `'\u{A}'` would be of the same type, as they are
-the same unicode entities `%0A`. However, `'\x0A'` will be
+It is important to point out that any `'\n'` and `'\u{A}'` would be of the same
+type, as they are the same unicode entities `%0A`. However, `'\x0A'` will be
 slightly different as any character following the `\x...` sequence
 representation is not the same as a Unicode character. For example:
 
@@ -161,10 +160,11 @@ From the previous examples, we should be able to use the following operators:
 -   Plus: `+`. However the behaviour of this operator is distinct compared to
     its use with Strings. Rather than a concatenation, this will add the value
     of the two characters:
-    -   If the `+` is used between a character literal and an integer literal,
-        this should produce a character literal if the result fits into a
-        Unicode code point or for a unicode hex code like `'\xAB'`, a single
-        byte.
+    -   If the `+` is used between a character literal representing a single
+        Unicode code point and an integer literal, this should produce a
+        character literal if the result fits in a Unicode code point. Similarly,
+        `+` between a hex code like `'\xAB'` and an integer literal results in a
+        character literal if the result fits in a single byte.
     -   If the `+` is used between a character literal and an integer
         non-literal this will produce an error.
     -   If the `+` is used between two character literals this will produce an
@@ -172,8 +172,9 @@ From the previous examples, we should be able to use the following operators:
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
     the two characters.
 
-    -   If the `-` is used between a character literal and an integer literal,
-        this should produce a character literal.
+    -   If the `-` is used between a character literal representing a single
+        code point or code unit and an integer literal, this should produce a
+        character literal as long as the result of the difference is in range.
     -   If the `-` is used between two character literals, which are either both
         a single code point or both a single code unit, this should produce an
         integer literal representing the difference between the code points or
@@ -183,13 +184,14 @@ From the previous examples, we should be able to use the following operators:
     -   If the `-` operator is used between a code point and a code unit, this
         will produce an error.
 
-    In other use cases where the `+` and `-` operators are used, in theory we
-    should convert the character literal to some other type first. For example
-    if we want to call `w - 'a'`, where `w` is of type `char` we would want to
-    convert the `'a'` literal to a `char`.
+    In cases where the `+` and `-` operators are used with a character literal
+    and a non-integer non-literal, the character literal should be converted to
+    the type of the other operand if possible. For example, in the expression
+    `w - 'a'`, where `w` is of type `Char`, the `'a'` literal will be converted
+    to type `Char`.
 
 There is intentionally no conversion from character literals to integer types.
-Carbon will separate the integer types from character types entirely. 
+Carbon will separate the integer types from character types entirely.
 
 ### Encoding
 
@@ -203,8 +205,8 @@ This proposal supports the goal of making Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 Adding support for a specific character literal supports clean, readable,
 concise use and is a much more familiar concept that will make it easier to
-adopt Carbon coming from other languages. Have a distinct character literal
-will also allow us support useful operations designed to manipulate the literal's
+adopt Carbon coming from other languages. Have a distinct character literal will
+also allow us support useful operations designed to manipulate the literal's
 value. When working with `String`, we use the `+` operator to concatenate
 multiple `String`s, but say we wanted to advance a character to the next
 literal. Using a `String` will produce a type error, as we are misusing the `+`
@@ -236,9 +238,12 @@ represented in a Carbon character literal. This is done in a way that is natural
 to adopt, understand, easy to read by having explicit character types mapped to
 the C++ character types and the correct associated encoding.
 
-Finally, the choice to use Unicode and UTF-8 by default reflects the Carbon goal to prioritize
+Finally, the choice to use Unicode and UTF-8 by default reflects the Carbon goal
+to prioritize
 [modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments).
-This reflects the [growing adoption of UTF-8](https://en.wikipedia.org/wiki/UTF-8#Adoption).
+This reflects the
+[growing adoption of UTF-8](https://en.wikipedia.org/wiki/UTF-8#Adoption).
+
 ## Alternatives considered
 
 ### Separate character and integer types
@@ -263,19 +268,6 @@ value.
     if (a < b) {
         a += 1;
     }
-```
-
-Another example of this would be looking at the `==` and other comparison
-operators when working with characters represented with code points. Below is an
-example of representing the character `é` with code points. `acute1` is using
-the single code point representation and `acute2` is combining the `e` and
-`acute accent mark` code points to represent the character. However when they
-are evaluated with the `==` operator the result is `false`.
-
-```
-  var acute1: String = "\u{E9}";
-  var acute2: String = "\u{301}\u{65}";
-  var matching: auto = if acute1 == acute2 then true else false; //output false
 ```
 
 When working with code points, there is an advantage to having a distinct

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -21,11 +21,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Operations](#operations)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [No Distinct Character Types](#no-distinct-character-types)
-    -   [No Distinct Character Literal](#no-distinct-character-literal)
-    -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
-    -   [Allowing Numeric Escape Sequences](#allowing-numeric-escape-sequences)
-    -   [Supporting Formulations of grapheme clusters and non-code-point code-units.](#supporting-formulations-of-grapheme-clusters-and-non-code-point-code-units)
+    -   [No distinct character types](#no-distinct-character-types)
+    -   [No distinct character literal](#no-distinct-character-literal)
+    -   [Supporting prefix declarations](#supporting-prefix-declarations)
+    -   [Allowing numeric escape sequences](#allowing-numeric-escape-sequences)
+    -   [Supporting formulations of grapheme clusters and non-code-point code-units](#supporting-formulations-of-grapheme-clusters-and-non-code-point-code-units)
 
 <!-- tocstop -->
 
@@ -100,11 +100,10 @@ like numeric literals:
     of UTF-8 code units that must be a valid encoding. This matches
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   A character literal must encode exactly one code point.
--   It supports
-    addition and subtraction. These operations produce another code point
-    literal, or produce an error if the result is out of range.
--   Character literals support some back-slash (`\`) escape sequences, including `\t`,
-    `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
+-   It supports addition and subtraction. These operations produce another code
+    point literal, or produce an error if the result is out of range.
+-   Character literals support some back-slash (`\`) escape sequences, including
+    `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
@@ -115,12 +114,12 @@ We will not support:
 -   multi-line literals;
 -   "raw" literals (using #'x'#);
 -   `\x` escape sequences;
--   character literals with a single quote (`'`) or back-slash (`\`), except as part
-    of an escape sequence
+-   character literals with a single quote (`'`) or back-slash (`\`), except as
+    part of an escape sequence
 -   empty character literals (`''`);
--   ASCII control codes (0...31), including whitespace characters other than word
-    space (tab, line feed, carriage return, form feed, and vertical tab), except when
-    specified with an escape sequence.
+-   ASCII control codes (0...31), including whitespace characters other than
+    word space (tab, line feed, carriage return, form feed, and vertical tab),
+    except when specified with an escape sequence.
 -   Whitespace characters other than word space: tab, line feed, carriage
     return, form feed, and vertical tab. And Back-slash (`\`), see
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
@@ -204,9 +203,9 @@ operators:
     to type `Char8`.
 
 There is intentionally no implicit conversion from character literals to integer
-types, but explicit conversions are permitted between character literals
-and integer types. Carbon will separate the
-integer types from character types entirely.
+types, but explicit conversions are permitted between character literals and
+integer types. Carbon will separate the integer types from character types
+entirely.
 
 ## Rationale
 
@@ -333,29 +332,29 @@ sequences for character literals, that diverges from the `String` type which
 does allow for numeric escape sequences so we would essentially have the
 functionality to declare character literals but within a string literal.
 
-This approach has the additional concern that if character literals don't support
-numeric escape sequences, developers may choose to use numeric literals instead,
-at a cost of type-safety and readability. For example, it isn't clear in
-`var first_digit: Char8 = 0;` whether `0` is supposed to be a `NUL` character or the
-encoding of the `'0'` character (48). We addressed this concern, and type safety
-concerns about distinguishing numbers and characters, by making the integer to
-character conversions explicit.
+This approach has the additional concern that if character literals don't
+support numeric escape sequences, developers may choose to use numeric literals
+instead, at a cost of type-safety and readability. For example, it isn't clear
+in `var first_digit: Char8 = 0;` whether `0` is supposed to be a `NUL` character
+or the encoding of the `'0'` character (48). We addressed this concern, and type
+safety concerns about distinguishing numbers and characters, by making the
+integer to character conversions explicit.
 
 ### Supporting formulations of grapheme clusters and non-code-point code-units
 
 Rather than explicitly limiting characters literals to a more integer-like
-representation of a single Unicode code point, we could represent characters literal
-formulations of grapheme clusters and non-code-point code units. What humans
-tend to think of as a "character" corresponds to a "grapheme cluster." The encoding of
-a grapheme cluster can be arbitrarily long and complex, which would sacrifice the
-ability to perform integer operations. If we wanted to add support for other character
-formulations, we would need to use separate spellings to represent a small set of
-operations that are today expressed with integer-based math on C++'s character
-literals. This includes things like converting an integer between 0 and 9 into the
-corresponding digit character, or computing the difference between two
-digits/two other characters. For these reasons, we have decided to start out by
-representing
-character literals as single Unicode code points following a more integer-like
-model. However this topic should be revisited if we find that there is a
-significant need for the additional functionality and attendant complexity for
-these other character formulations.
+representation of a single Unicode code point, we could represent characters
+literal formulations of grapheme clusters and non-code-point code units. What
+humans tend to think of as a "character" corresponds to a "grapheme cluster."
+The encoding of a grapheme cluster can be arbitrarily long and complex, which
+would sacrifice the ability to perform integer operations. If we wanted to add
+support for other character formulations, we would need to use separate
+spellings to represent a small set of operations that are today expressed with
+integer-based math on C++'s character literals. This includes things like
+converting an integer between 0 and 9 into the corresponding digit character, or
+computing the difference between two digits/two other characters. For these
+reasons, we have decided to start out by representing character literals as
+single Unicode code points following a more integer-like model. However this
+topic should be revisited if we find that there is a significant need for the
+additional functionality and attendant complexity for these other character
+formulations.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -21,10 +21,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Operations](#operations)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [No distinct character types](#no-distinct-character-types)
+    -   [No Distinct Character Types](#no-distinct-character-types)
     -   [No Distinct Character Literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
-    -   [Disallowing Numeric Escape Sequences](#disallowing-numeric-escape-sequences)
+    -   [Allowing Numeric Escape Sequences](#allowing-numeric-escape-sequences)
 
 <!-- tocstop -->
 
@@ -93,6 +93,8 @@ We will not support:
 -   Multi-line literals
 -   "raw" literals (using #'x'#)
 -   Empty character literals (`''`)
+-   `\x` escape sequences
+-   Character literals that don't contain exactly one code point.
 -   ASCII Control codes (0...31), except when specified with an escape sequence.
 -   Whitespace characters other than word space: tab, line feed, carriage
     return, form feed, and vertical tab. See
@@ -105,18 +107,14 @@ We will not support:
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
-    literal, if the value can be determined at compile time, or a runtime
-    `Char32` code point value.
+    literal, otherwise it will be rejected and produce an error.
 -   For most purposes a character should be viewed as representing a grapheme
     cluster.
 -   Value-preserving implicit conversions from character literals to code point
     or code unit types are permitted. In particular, a character literal
     converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
     UTF-16 code unit if it is less than or equal to 0xFFFF.
--   `\x` escape sequences produce the given code unit. Character literals are
-    assumed to use a UTF-8 encoding. So `'\xC3\x89'` is the same thing as `'É'`,
-    a valid encoding of a single code point, and so allows addition and
-    subtraction.
+-   Support for `\u` escape sequences.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
@@ -166,15 +164,15 @@ consisting of the single Unicode code point `0x1F603`, which is greater than
 Unicode code points, which has no conversion to a type that only handles a
 single UTF-8 code unit.
 
-All of `'\n'`, `'\u{A}'`, and `'\x0A'` represent the same character and so have
-the same type. However, explicitly converting this character literal to another
-character set might result in a character with a different value, but that still
+All of `'\n'`, and `'\u{A}'` represent the same character and so have the same
+type. However, explicitly converting this character literal to another character
+set might result in a character with a different value, but that still
 represents the newline character.
 
 ```
 // 0x15 is the new line character in EBCDIC.
 Assert('\n' as EBCDICChar == EBCDICChar.Make(0x15));
-Assert('\x0A' as EBCDICChar != EBCDICChar.Make(0x0A));
+Assert('\u{A}' as EBCDICChar != EBCDICChar.Make(0x0A));
 ```
 
 ### Operations
@@ -207,8 +205,10 @@ operators:
     `w - 'a'`, where `w` is of type `Char8`, the `'a'` literal will be converted
     to type `Char8`.
 
-There is intentionally no implicit conversion from character literals to integer types, but explicit conversions are permitted between character literals representing a single code point and integer types.
-Carbon will separate the integer types from character types entirely.
+There is intentionally no implicit conversion from character literals to integer
+types, but explicit conversions are permitted between character literals
+representing a single code point and integer types. Carbon will separate the
+integer types from character types entirely.
 
 ## Rationale
 
@@ -257,7 +257,7 @@ This reflects the
 
 ## Alternatives considered
 
-### No distinct character types
+### No Distinct Character Types
 
 Unlike C++, Carbon will separate the integer and the character types. We
 considered using `u8`, `u16`, and `u32` instead of `Char8`, `Char16`, and
@@ -276,7 +276,7 @@ disadvantages:
     are intended to be UTF-8 instead of having no specified encoding.
 -   Some operations want to be able to know that they've been given text rather
     than random bytes of data. For example, `Print(0x41 as u8)` would be
-    expected to print `"65"` while `Print('\x41')` and `Print(0x41 as Char8)`
+    expected to print `"65"` while `Print('\u0041')` and `Print(0x41 as Char8)`
     would be expected to print `"A"`.
 -   It's useful for developers to document the intended meaning of a value, and
     using a distinct type is one way to do that.
@@ -324,25 +324,27 @@ states all of Carbon source code should be UTF-8 encoded. Prefix declarations
 would detract the readability of the character literals and increase the
 complexity of character literal [Types](#types).
 
-### Disallowing Numeric Escape Sequences
+### Allowing Numeric Escape Sequences
 
-Not support escaping numeric sequences. This would simplify some of the design
-choices seen above by making types, the restrictions and behavior of character
-literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
-`\x...` pattern. However this would affect the readability, type-safety and
-consistency of character literals. If we were to disallow numeric escape
+We will not be support escaping numeric sequences. This simplifies some of the
+design choices by making types, the restrictions and behavior of character
+literals simpler. Specifically [Types](#types) of `EBCDIC` by disallowing the
+`\x...` pattern. However this does affect the readability, type-safety and
+consistency of character literals. Since we are disallowing numeric escape
 sequences for character literals, that diverges from the `String` type which
 does allow for numeric escape sequences so we would essentially have the
 functionality to declare character literals but within a string literal.
-Additiaonlly, we could remove numeric escape sequences from string liteals, but
-there are other draw backs to discuss in that arena. In terms of type-safety and
-readability, if we take a look at `var first_digit: char = 0;` it's hard to see
-the intention, is this supposed to be a `NUL` character or is it supposed to be
-the character zero `'0'`? Whereas supporting numeric escape sequences, we can
-write `var first_digit: char = '0'` or `var first_digit: char = '\0'` where the
-intention is clear and defined. Further, if we use integer literals instead of
-code unit escape sequences a user would assume we support initializing character
-types from integer literals `first_digit: char = 0;`, leading to assumptions
-surrounding how we'll permit implicit conversion from non-constant
-integer-valued expressions to character types. This would essentially diminish
-our ability to distinguish between numbers and characters in our type system.
+
+Additiaonlly, there are other draw backs to discuss in that arena. In terms of
+type-safety and readability, if we take a look at `var first_digit: char = 0;`
+it's hard to see the intention, is this supposed to be a `NUL` character or is
+it supposed to be the character zero `'0'`? Whereas supporting numeric escape
+sequences, we can write `var first_digit: char = '0'` or
+`var first_digit: char = 'x\0'` where the intention is clear and defined.
+
+Further, using integer literals instead of code unit escape sequences a user
+would assume we support initializing character types from integer literals
+`first_digit: char = 0;`, leading to assumptions surrounding how we'll permit
+implicit conversion from non-constant integer-valued expressions to character
+types. This diminishes our ability to distinguish between numbers and characters
+in our type system.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -149,8 +149,50 @@ This proposal supports the goal of making Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 Adding support for a specific character literal supports clean, readable,
 concises use and is a much more familiar concept that will make it easier to
-adopt Carbon coming from other languages. As well as following other standards
-set in place by previous proposals. For example following the
+adopt Carbon coming from other languages. For Example when working with literals
+represented as hex, having a distinct character literal type makes this much
+simpler to work:
+
+```
+fn getSingleEAcuteHex(var combinedAcute: EBCDICChar) -> EBCDICChar {
+    var eAcute: EBCDICChar = '\u{E0}';
+
+    while (eAcute != combinedAcute) {
+        eAcute += 1;
+    }
+    return eAcute;
+}
+
+    var combinedEAcute: EBCDICChar = '\u{65}\u{300}';
+    var a: auto = getSingleEAcuteHex(combinedEAcute);
+```
+
+This allows us to use specific operations designed to manipulate the literals
+value. Whereas with a String, we would need to have additional logic to store,
+check and assign the specific value:
+
+```
+fn getSingleEAcuteHex(var combinedAcute: String) -> String {
+    var eAcute: String = "\u{E0}";
+    var accentValue: i32 = 0;
+
+    while (eAcute != combinedAcute) {
+        accentValue = accentValue + 1;
+        eAcute = "\u{E{accentValue}}";
+    }
+    return eAcute;
+}
+
+    var combinedEAcute: String = "\u{65}\u{300}";
+    var a: auto = getSingleEAcuteHex(combinedEAcute);
+```
+
+Using a `String` also leads to further issues regarding familiarty with other
+languages and and leaves the logic generally open to errors, needing further
+logic to check for a valid input.
+
+As well as following other standards set in place by previous proposals. For
+example following the
 [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 and representing characters as integers with the behaviour inline with
 [Integer Literals](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0143.md).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -191,8 +191,8 @@ Using a `String` also leads to further issues regarding familiarty with other
 languages and and leaves the logic generally open to errors, needing further
 logic to check for a valid input.
 
-As well as following other standards set in place by previous proposals. For
-example following the
+Further, this design follows other standards set in place by previous proposals.
+For example following the
 [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 and representing characters as integers with the behaviour inline with
 [Integer Literals](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0143.md).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -115,11 +115,14 @@ We can see whether the particular literal is represented in the variable's type
 by only looking at the types:
 
 ```
-let allowed: u8 = 'a';
+let allowed: Char8 = 'a';
 ```
 
 The above is allowed because the type of 'a' indicates that it can be converted
-to `u8`.
+to `Char8`. Here, `Char8` is a type that can represent a single 8-bit character,
+like C++'s `char8_t`. `Char8` is used for exposition and is not part of this
+proposal.
+
 
 ```
 let error1: u8 = '😃';

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -109,9 +109,29 @@ From the previous examples, we should be able to use the following operators:
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
 -   Plus: `+`. However the behaviour of this operator is distinctly compared to
     its use with Strings. Rather then a concatenation, this will add the value
-    of the two characters.
+    of the two characters:
+    -   If the `+` is used between a character literal and an integer literal,
+        this should produce a character literal if the result fits into a
+        Unicode code point or for a unicode hex code like `'\xAB'`, a single
+        byte.
+    -   If the `+` is used between a character literal and an integer
+        non-literal this will produce and error.
+    -   If the `+` is used between two character literals this will produce and
+        error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
     the two characters.
+
+    -   If the `-` is used between a character literal and an integer literal,
+        this should produce a character literal.
+    -   If the `-` is used between two character literals this should produce
+        and integer literal.
+    -   If the `-` is used between a character literal and an integer
+        non-literal this will produce and error.
+
+    In other use cases where the `+` and `-` operators are used, in theory we
+    should convert the character literal to some other type first. For example
+    if we want to call `x - 'a'`, where `w` is of type `char` we would want to
+    convert the `'a'` literal to a `char`.
 
 ### Encoding
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -292,7 +292,7 @@ points, motivating supporting comparison operators on code points.
 ```
   var acute1: Char32 = "\u{E9}";
   var acute2: Char32 = "\u{301}\u{65}";
-  var matching: auto = if acute1 == acute2 then true else false; //output false
+  var matching: auto = if acute1 == acute2 then true else false; //output true
 ```
 
 ### Supporting Prefix Declarations

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -90,8 +90,8 @@ We will not support:
 -   Multi-line literals
 -   "raw" literals (using #'x'#)
 -   Empty character literals (`''`)
--   ASCII Control codes (0...31), except for `\` when used for an escape
-    sequence. See
+-   ASCII Control codes (0...31), except when specified with an escape sequence.
+    See
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 
 ## Details

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -26,6 +26,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Supporting prefix declarations](#supporting-prefix-declarations)
     -   [Allowing numeric escape sequences](#allowing-numeric-escape-sequences)
     -   [Supporting formulations of grapheme clusters and non-code-point code-units](#supporting-formulations-of-grapheme-clusters-and-non-code-point-code-units)
+-   [Future Work](#future-work)
+    -   [UTF code unit types proposal](#utf-code-unit-types-proposal)
 
 <!-- tocstop -->
 
@@ -105,8 +107,6 @@ like numeric literals:
 -   Character literals support some back-slash (`\`) escape sequences, including
     `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
--   Character literals implicitly convert to Unicode strings, even though the
-    numeric values of the encoding may change.
 
 We will not support:
 
@@ -115,7 +115,7 @@ We will not support:
 -   "raw" literals (using #'x'#);
 -   `\x` escape sequences;
 -   character literals with a single quote (`'`) or back-slash (`\`), except as
-    part of an escape sequence;
+    part of an escape sequence
 -   empty character literals (`''`);
 -   ASCII control codes (0...31), including whitespace characters other than
     word space (tab, line feed, carriage return, form feed, and vertical tab),
@@ -123,51 +123,21 @@ We will not support:
 
 ### Types
 
-We will have the types `Char8`, `Char16`, and `Char32` representing code units
-in UTF-8, UTF-16, and UTF-32, but we will not support all code units, but only
-those which map directly to the complete value of a code point. However,
-character literals will use their own types distinct from these:
+For the time being we will support a type `CharN` that will hold both code units
+and code points, and will leave the different UTF-encoding code unit types to
+another proposal. See
+[UTF code unit types proposal](#utf-code-unit-types-proposal))
 
--   We will support value preserving implicit conversions from character
-    literals to code point or code unit types. In particular, a character
-    literal converts to a `Char8` UTF-8 code unit if it is less than or equal to
-    0x7F, and `Char16` UTF-16 code unit if it is less than or equal to 0xFFFF.
--   Conversions from string or character literals to a non-value-preserving
-    encoding must be explicit.
--   Conversions from string literals to Unicode strings are implicit, even
-    though the numeric values of the encoding may change.
-
-We can see whether the particular literal is represented in the variable's type
-by only looking at the types.
+We will have the type `CharN` and only support literals that map directly to the
+complete value of a code point.
 
 ```
-let allowed: Char8 = 'a';
+let allowed: CharN = 'a';
 ```
 
 The above is allowed because the type of `'a'` is the character literal
 consisting of the single Unicode code point 97, which can be converted to
-`Char8` since 97 is less than or equal to 0x7F.
-
-```
-let error1: Char8 = '😃';
-let error2: Char8 = 'AB';
-```
-
-However these should produce errors. The type of `'😃'` is the character literal
-consisting of the single Unicode code point `0x1F603`, which is greater than
-0x7F. The type of `'AB'` is a character literal that is a sequence of two
-Unicode code points, which is not valid.
-
-Literals `'\n'` and `'\u{A}'` represent the same character and so have the same
-type. However, explicitly converting this character literal to another character
-set might result in a character with a different value, but that still
-represents the newline character.
-
-```
-// 0x15 is the new line character in EBCDIC.
-Assert('\n' as EBCDICChar == EBCDICChar.Make(0x15));
-Assert('\u{A}' as EBCDICChar != EBCDICChar.Make(0x0A));
-```
+`CharN` since 97 is less than or equal to 0x7F.
 
 ### Operations
 
@@ -354,3 +324,53 @@ single Unicode code points following a more integer-like model. However this
 topic should be revisited if we find that there is a significant need for the
 additional functionality and attendant complexity for these other character
 formulations.
+
+## Future Work
+
+### UTF code unit types proposal
+
+There have been several ideas and discussions around how we would like to handle
+UTF code units. This section will hopefully provide some guidance for a future
+proposal when the topic is revisited for how we would like to build out
+encoding/decoding for character literals.
+
+We will have the types `Char8`, `Char16`, and `Char32` representing code units
+in UTF-8, UTF-16, and UTF-32, but we will not support all code units, but only
+those which map directly to the complete value of a code point. However,
+character literals will use their own types distinct from these:
+
+-   We will support value preserving implicit conversions from character
+    literals to code point or code unit types. In particular, a character
+    literal converts to a `Char8` UTF-8 code unit if it is less than or equal to
+    0x7F, and `Char16` UTF-16 code unit if it is less than or equal to 0xFFFF.
+-   Conversions from string or character literals to a non-value-preserving
+    encoding must be explicit.
+-   Conversions from string literals to Unicode strings are implicit, even
+    though the numeric values of the encoding may change.
+
+We can see whether the particular literal is represented in the variable's type
+by only looking at the types.
+
+```
+let allowed: Char8 = 'a';
+```
+
+The above is allowed because the type of `'a'` is the character literal
+consisting of the single Unicode code point 97, which can be converted to
+`Char8` since 97 is less than or equal to 0x7F.
+
+```
+let error1: Char8 = '😃';
+let error2: Char8 = 'AB';
+```
+
+However these should produce errors. The type of `'😃'` is the character literal
+consisting of the single Unicode code point `0x1F603`, which is greater than
+0x7F. The type of `'AB'` is a character literal that is a sequence of two
+Unicode code points, which has no conversion to a type that only handles a
+single UTF-8 code unit.
+
+All of `'\n'`, and `'\u{A}'` represent the same character and so have the same
+type. However, explicitly converting this character literal to another character
+set might result in a character with a different value, but that still
+represents the newline character.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -239,7 +239,7 @@ disadvantages:
     using a distinct type is one way to do that.
 
 See [UTF code unit types proposal](#utf-code-unit-types-proposal) for more
-information about UTF encoding
+information about UTF encoding types for a future proposal.
 
 ### No distinct character literal
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -19,7 +19,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
     -   [Types](#types)
     -   [Operations](#operations)
-    -   [Encoding](#encoding)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
     -   [No distinct character types](#no-distinct-character-types)
@@ -119,6 +118,12 @@ We will not support:
     subtraction.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
+-   A character literal is a sequence of UTF-8 code units that may or may not be
+    a valid encoding. If a character literal encodes exactly one code point
+    `Char32`, then it supports arithmetic, producing another code point, or a
+    runtime CodePoint (Type name TBD) value if necessary. For more information
+    about source encoding see
+    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 
 Character literals cannot be written with these characters:
 
@@ -209,15 +214,6 @@ operators:
 
 There is intentionally no conversion from character literals to integer types.
 Carbon will separate the integer types from character types entirely.
-
-### Encoding
-
--   A character literal is a sequence of UTF-8 code units that may or may not be
-    a valid encoding. If a character literal encodes exactly one code point
-    `Char32`, then it supports arithmetic, producing another code point, or a
-    runtime CodePoint (Type name TBD) value if necessary. For more information
-    about source encoding see
-    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 
 ## Rationale
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -284,9 +284,9 @@ characters `L'`. This would be more familiar for individuals coming to Carbon
 from a C++ background, and simplify our approach for C++ Interoperability. At
 the cost of diverge from existing standards, for example
 [Proposal 142](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)
-states all of Carbon source code should be UTF-8 encoded, this would impact the
-readability of the character literals and increase the complexity of character
-literal [Types](#types).
+states all of Carbon source code should be UTF-8 encoded. Prefix declarations
+would detract the readability of the character literals and increase the
+complexity of character literal [Types](#types).
 
 ### Disallowing Numeric Escape Sequences
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -250,37 +250,64 @@ the C++ character types and the correct associated encoding.
 
 ### No Distinct Character Literal
 
-In principle a character literal can be represented by reusing string literals.
-//TODO: Add Description
+In principle a character literal can be represented by reusing string literals
+similar to how Python handles character literals, however this would lead to
+some disadvatages. There are situations where using operations can be given more
+practical use. When using `Strings` the `+` operator, is used for concatenating
+two `String` objects, essentially rendering it useless when working with
+characters. With a distinct character literal we can support more useful
+operations, for example by using the `+` operator to advance the character
+literal to the next representable literal:
 
 ```
-    var b: String = "b";
-    var c: String = "c";
-    if (c > b) {
-        b = c + b;
+    var a: u8 = 'a';
+    var b: u8 = 'b';
+
+    if (a < b) {
+        a += 1;
     }
+
 ```
 
-We would simply this as a single element string. However it terms of
-readablility, if we had a distinct lexical syntax for character literals versus
-string literals, this would be more inline with Carbon's language design goals
-related to self documenting code, easy to read, understand, write and C++
-interopability.
+Another example of this would be looking at the `==` and other comparison
+operators when working with characters represented with code points. Below is an
+example of representing the character `é` with code points. `acute1` is using
+the single code point representation and `acute2` is combining the `e` and
+`tilde` code points to represent the character. However when they are evaluated
+with the `==` operator the result is `false`.
+
+```
+  var acute1: String = "\u{E9}";
+  var acute2: String = "\u{301}\u{65}";
+  var matching: auto = if acute1 == acute2 then true else false; //output false
+
+```
+
+When working with code points, there is an advantage to having a distinct
+character literal. Primarily when discussing the readablity of the design
+choice, and working with code points similar to the example above. When looking
+at the two variables it is clear that `acute2` contains two code points, but
+when using a `String` is no way to evaluate if it is a single valid character of
+multiple code points or two characters. `\u{301}\u{65}` is a valid single
+character comprised of multiple code points resulting in `é`, however this could
+easily be mistaken as a `String` comprised of two code points `\u{400}\u{65}`
+which is `Ѐe`
 
 ### Supporting Prefix Declarations
 
-No support is proposed for prefix declarations like `u`, `U`, or `L`. In
-practice they are used to specify the character literal types in languages like
-C and C++, supporting these could help with the familiarity of coming to Carbon
-with a more C++ or C background. Supporting this will help support a much
-cleaner and readable syntax that is more inline with Carbon's goals, i.e
-[Rationale](#rationale).
+`//TODO: pro-con descriptions + examples` No support is proposed for prefix
+declarations like `u`, `U`, or `L`. In practice they are used to specify the
+character literal types in languages like C and C++, supporting these could help
+with the familiarity of coming to Carbon with a more C++ or C background.
+Supporting this will help support a much cleaner and readable syntax that is
+more inline with Carbon's goals, i.e [Rationale](#rationale).
 
 ### Disallowing Numeric Escape Sequences
 
-Not support escaping numeric sequences. This would simplify some of the design
-choices seen above by making types, the restrictions and behavior of character
-literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
-`\x...` pattern. This would restrict users by having to use the specific hex
-value, and when to use operations between character literals and benefiting the
-readability of Carbon in some use cases.
+`//TODO: pro-con descriptions + examples` Not support escaping numeric
+sequences. This would simplify some of the design choices seen above by making
+types, the restrictions and behavior of character literals simpler. Specifically
+[Types](#types) of `EBCDIC`, by disallowing the `\x...` pattern. This would
+restrict users by having to use the specific hex value, and when to use
+operations between character literals and benefiting the readability of Carbon
+in some use cases.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -228,7 +228,7 @@ fn getSingleEAcuteHex(var combinedAcute: String) -> String {
     var a: auto = getSingleEAcuteHex(combinedEAcute);
 ```
 
-Using a `String` also leads to further issues regarding familiarty with other
+Using a `String` also leads to further issues regarding familiarity with other
 languages and and leaves the logic generally open to errors, needing further
 logic to check for a valid input.
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -191,48 +191,26 @@ is UTF-8 encoded. See
 This proposal supports the goal of making Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 Adding support for a specific character literal supports clean, readable,
-concises use and is a much more familiar concept that will make it easier to
-adopt Carbon coming from other languages. For example when working with literals
-represented as hex, having a distinct character literal type makes this much
-simpler to work:
+concise use and is a much more familiar concept that will make it easier to
+adopt Carbon coming from other languages. Have a distinct character literally
+will also allow us support useful operations designed to manipulate the literals
+value. When working with `String`, we use the `+` operator to concatenate
+multiple `String`s, but say we wanted to advance a character to the next
+literal. Using a `String` will produce a type error, as we are misusing the `+`
+operator: `"a" + 1`. However with a character literal, we can support operations
+for these use cases:
 
 ```
-fn getSingleEAcuteHex(var combinedAcute: EBCDICChar) -> EBCDICChar {
-    var eAcute: EBCDICChar = '\u{E0}';
+var b: u8;
 
-    while (eAcute != combinedAcute) {
-        eAcute += 1;
-    }
-    return eAcute;
-}
-
-    var combinedEAcute: EBCDICChar = '\u{65}\u{300}';
-    var a: auto = getSingleEAcuteHex(combinedEAcute);
-```
-
-This allows us to use specific operations designed to manipulate the literals
-value. Whereas with a String, we would need to have additional logic to store,
-check and assign the specific value:
+b = 'a' + 1;
+b + 1 == 'c';
 
 ```
-fn getSingleEAcuteHex(var combinedAcute: String) -> String {
-    var eAcute: String = "\u{E0}";
-    var accentValue: i32 = 0;
 
-    while (eAcute != combinedAcute) {
-        accentValue += 1;
-        eAcute = "\u{E{accentValue}}";
-    }
-    return eAcute;
-}
-
-    var combinedEAcute: String = "\u{65}\u{300}";
-    var a: auto = getSingleEAcuteHex(combinedEAcute);
-```
-
-Using a `String` also leads to further issues regarding familiarity with other
-languages and and leaves the logic generally open to errors, needing further
-logic to check for a valid input.
+See [Operations](#operations) and
+[No Distinct Character Literal](#no-distinct-character-literal) for more
+information.
 
 Further, this design follows other standards set in place by previous proposals.
 For example following the

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -99,8 +99,23 @@ We will not support:
 
 ## Details
 
-A character literal is a sequence enclosed with single quotes delimiter ('),
-excluding:
+-   A character literal is a sequence enclosed with single quotes delimiter ('),
+    of UTF-8 code units that may or may not be a valid encoding. If a character
+    literal is encodes exactly one code point, then it supports arithmetic,
+    producing another code point, or a runtime CodePoint (Type name TBD) value
+    if necessary, however for most purposes a character should be viewed as a
+    grapheme cluster.
+-   Value-preserving implicit conversions from character literals to code point
+    or code unit types are permitted. In particular, a character literal
+    converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
+    UTF-16 code unit if it is less than or equal to 0xFFFF.
+-   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
+    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
+    point so arithmetic on it is permitted. encoding are explicit.
+-   Conversions from string literals to Unicode strings are implicit, even
+    though the numeric values of the encoding may change.
+
+    A character literal will exclude:
 
 -   New line
 -   Single quote (`'`), but can write `'` character as `'\''`

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -259,18 +259,27 @@ This reflects the
 
 ### No distinct character types
 
-Unlike C++, Carbon will separate the integer and the character types. Carbon
-character types add the information that the represented integer is a code unit
-of some particular encoding. Whereas C++'s types `u8`, `u16`, and `u32` have the
-wrong arithmetic semantics: we dont want wrapping. And many `uN` operations are
-not meaningful on code units, unless you are implementing a conversion from code
-units. Generally these cases should pierce the viel of abstraction and it's
-probably reasonable to work with a `u8`, then explicitly convert it to the code
-unit type when finished. Further, some operations want to be able to infer a
-provided, intended to be UTF-8 string, rather than a unspecified encoded string
-and to know if they have been given actual text or random bytes of data. For
-these reasons, it will be useful for developer to document the meaning of a
-value, so using a distinct type is one way to do that.
+Unlike C++, Carbon will separate the integer and the character types. We
+considered using `u8`, `u16`, and `u32` instead of `Char8`, `Char16`, and
+`Char32`to reduce the number of different types users needed to be aware of and
+convert between. We decided against it because it came with a number of
+disadvantages:
+
+-   `u8`, `u16`, and `u32` have the wrong arithmetic semantics: we don't want
+    wrapping, and many `uN` operations, like multiplication, division, and
+    shift, are not meaningful on code units. There may be rare cases where you
+    want to use those operations, such as if you're implementing a conversion to
+    or from code units. But in those rare cases it would be reasonable for the
+    user to convert to an integer type to perform that operation and convert
+    back when done.
+-   Some operations want to be able to tell the difference between values that
+    are intended to be UTF-8 instead of having no specified encoding.
+-   Some operations want to be able to know that they've been given text rather
+    than random bytes of data. For example, `Print(0x41 as u8)` would be
+    expected to print `"65"` while `Print('\x41')` and `Print(0x41 as Char8)`
+    would be expected to print `"A"`.
+-   It's useful for developers to document the intended meaning of a value, and
+    using a distinct type is one way to do that.
 
 ### No Distinct Character Literal
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -97,24 +97,30 @@ like numeric literals:
 ## Details
 
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
-    of UTF-8 code units that may or may not be a valid encoding. This matches
+    of UTF-8 code units that must be a valid encoding. This matches
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
--   If a character literal encodes exactly one code point, then it supports
+-   A character literal must encode exactly one code point.
+-   It supports
     addition and subtraction. These operations produce another code point
-    literal, otherwise it will be rejected and produce an error.
--   Support for `\u` escape sequences.
+    literal, or produce an error if the result is out of range.
+-   Character literals support some back-slash (`\`) escape sequences, including `\t`,
+    `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
+    [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
-    We will not support:
+We will not support:
 
--   Character literals that don't contain exactly one Unicode code point.
--   New line and multi-line literals
--   "raw" literals (using #'x'#)
--   `\x` escape sequences
--   Single quote (`'`), but can write `'` character as `'\''`
--   Empty character literals (`''`)
--   ASCII Control codes (0...31), except when specified with an escape sequence.
+-   character literals that don't contain exactly one Unicode code point;
+-   multi-line literals;
+-   "raw" literals (using #'x'#);
+-   `\x` escape sequences;
+-   character literals with a single quote (`'`) or back-slash (`\`), except as part
+    of an escape sequence
+-   empty character literals (`''`);
+-   ASCII control codes (0...31), including whitespace characters other than word
+    space (tab, line feed, carriage return, form feed, and vertical tab), except when
+    specified with an escape sequence.
 -   Whitespace characters other than word space: tab, line feed, carriage
     return, form feed, and vertical tab. And Back-slash (`\`), see
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
@@ -199,7 +205,7 @@ operators:
 
 There is intentionally no implicit conversion from character literals to integer
 types, but explicit conversions are permitted between character literals
-representing a single code point and integer types. Carbon will separate the
+and integer types. Carbon will separate the
 integer types from character types entirely.
 
 ## Rationale
@@ -249,7 +255,7 @@ This reflects the
 
 ## Alternatives considered
 
-### No Distinct Character Types
+### No distinct character types
 
 Unlike C++, Carbon will separate the integer and the character types. We
 considered using `u8`, `u16`, and `u32` instead of `Char8`, `Char16`, and
@@ -268,12 +274,12 @@ disadvantages:
     are intended to be UTF-8 instead of having no specified encoding.
 -   Some operations want to be able to know that they've been given text rather
     than random bytes of data. For example, `Print(0x41 as u8)` would be
-    expected to print `"65"` while `Print('\u0041')` and `Print(0x41 as Char8)`
+    expected to print `"65"` while `Print('\u{41}')` and `Print(0x41 as Char8)`
     would be expected to print `"A"`.
 -   It's useful for developers to document the intended meaning of a value, and
     using a distinct type is one way to do that.
 
-### No Distinct Character Literal
+### No distinct character literal
 
 In principle, a character literal can be represented by reusing string literals
 similar to how Python handles character literals, however this would prevent
@@ -297,7 +303,7 @@ fn IsDingBatCodePoint(c: Char32) -> bool {
 }
 ```
 
-### Supporting Prefix Declarations
+### Supporting prefix declarations
 
 No support is proposed for prefix declarations like `u`, `U`, or `L`. In
 practice they are used to specify the character literal types and their encoding
@@ -316,7 +322,7 @@ states all of Carbon source code should be UTF-8 encoded. Prefix declarations
 would detract the readability of the character literals and increase the
 complexity of character literal [Types](#types).
 
-### Allowing Numeric Escape Sequences
+### Allowing numeric escape sequences
 
 We will not be support escaping numeric sequences. This simplifies some of the
 design choices by making types, the restrictions and behavior of character
@@ -327,38 +333,29 @@ sequences for character literals, that diverges from the `String` type which
 does allow for numeric escape sequences so we would essentially have the
 functionality to declare character literals but within a string literal.
 
-Additiaonlly, there are other draw backs to discuss in that arena. In terms of
-type-safety and readability, if we take a look at `var first_digit: char = 0;`
-it's hard to see the intention, is this supposed to be a `NUL` character or is
-it supposed to be the character zero `'0'`? Whereas supporting numeric escape
-sequences, we can write `var first_digit: char = '0'` or
-`var first_digit: char = 'x\0'` where the intention is clear and defined.
+This approach has the additional concern that if character literals don't support
+numeric escape sequences, developers may choose to use numeric literals instead,
+at a cost of type-safety and readability. For example, it isn't clear in
+`var first_digit: Char8 = 0;` whether `0` is supposed to be a `NUL` character or the
+encoding of the `'0'` character (48). We addressed this concern, and type safety
+concerns about distinguishing numbers and characters, by making the integer to
+character conversions explicit.
 
-Further, using integer literals instead of code unit escape sequences a user
-would assume we support initializing character types from integer literals
-`first_digit: char = 0;`, leading to assumptions surrounding how we'll permit
-implicit conversion from non-constant integer-valued expressions to character
-types. This diminishes our ability to distinguish between numbers and characters
-in our type system.
+### Supporting formulations of grapheme clusters and non-code-point code-units
 
-### Supporting Formulations of grapheme clusters and non-code-point code-units.
-
-Rather than explicitly limiting characters literals to a more integer like
-representation of single Unicode units, we could repsent characters literal
-formulations of grapheme clusters and non-code point code units. What humans
-tend to think of as a "character" is more a "grapheme cluster" that is an
-arbitrarily long and complex encoding, which generally makes a more Unicode and
-text friendly model while sacrificing the accesability of an integer like
-representation. If we wanted to add support for these other character
-formulations we need to use separate spellings to represent a small set of
+Rather than explicitly limiting characters literals to a more integer-like
+representation of a single Unicode code point, we could represent characters literal
+formulations of grapheme clusters and non-code-point code units. What humans
+tend to think of as a "character" corresponds to a "grapheme cluster." The encoding of
+a grapheme cluster can be arbitrarily long and complex, which would sacrifice the
+ability to perform integer operations. If we wanted to add support for other character
+formulations, we would need to use separate spellings to represent a small set of
 operations that are today expressed with integer-based math on C++'s character
-literals, for example things like converting an integer between 0 and 9 into the
+literals. This includes things like converting an integer between 0 and 9 into the
 corresponding digit character, or computing the difference between two
-digits/two other characters. We would also need to provide a way to extract an
-actual integer from a codepoint in such a literal to handle esoteric needs, an
-additional type with some augmented API to handle the few common cases where C++
-uses arithmetic. For these reasons we have decided to start out by representing
+digits/two other characters. For these reasons, we have decided to start out by
+representing
 character literals as single Unicode code points following a more integer-like
-model. However this topic should be revisited, if we find that there is a
+model. However this topic should be revisited if we find that there is a
 significant need for the additional functionality and attendant complexity for
 these other character formulations.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Background](#background)
 -   [Proposal](#proposal)
 -   [Details](#details)
+    -   [Excluding](#excluding)
     -   [Types](#types)
     -   [Operations](#operations)
     -   [Encoding](#encoding)
@@ -99,8 +100,25 @@ We will not support:
 
 ## Details
 
-A character literal is a sequence enclosed with single quotes delimiter ('),
-excluding:
+-   A character literal is a sequence enclosed with single quotes delimiter (')
+
+-   It is a sequence of UTF-8 code units that may or may not be a valid
+    encoding. If a character literal is encodes exactly one code point, then it
+    supports arithmetic, producing another code point, or a runtime CodePoint
+    (Type name TBD) value if necessary.
+-   Value-preserving implicit conversions from character literals to code point
+    or code unit types are permitted. In particular, a character literal
+    converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
+    UTF-16 code unit if it is less than or equal to 0xFFFF.
+-   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
+    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
+    point so arithmetic on it is permitted.
+-   Conversions from string or character literals to a non-value-preserving
+    encoding are explicit.
+-   Conversions from string literals to Unicode strings are implicit, even
+    though the numeric values of the encoding may change.
+
+### Excluding
 
 -   New line
 -   Single quote (`'`), but can write `'` character as `'\''`
@@ -165,8 +183,6 @@ From the previous examples, we should be able to use the following operators:
         character literal if the result fits in a Unicode code point. Similarly,
         `+` between a hex code like `'\xAB'` and an integer literal results in a
         character literal if the result fits in a single byte.
-    -   If the `+` is used between a character literal and an integer
-        non-literal this will produce an error.
     -   If the `+` is used between two character literals this will produce an
         error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
@@ -179,8 +195,6 @@ From the previous examples, we should be able to use the following operators:
         a single code point or both a single code unit, this should produce an
         integer literal representing the difference between the code points or
         code units.
-    -   If the `-` is used between a character literal and an integer
-        non-literal this will produce an error.
     -   If the `-` operator is used between a code point and a code unit, this
         will produce an error.
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -141,7 +141,7 @@ the C++ character types and the correct associated encoding.
 
 ## Alternatives considered
 
-### No distinct Character literal
+### No distinct character literal
 
 -   In principle a character literal can be represented by reusing string
     literals. For example:
@@ -158,8 +158,8 @@ the C++ character types and the correct associated encoding.
 
 -   No support is proposed for prefix declarations like `u`, `U`, or `L`. In
     practice they are used to specify the character literal types in languages
-    like C and C++, supporting these could help with interopability. However the
+    like C and C++, supporting these could help with interoperability. However the
     proposal above supports the ideas that when a character is declared, its
-    type is dependent on the value of the character itself, See [Types](#types).
-    Supporting this will help support a much cleaner and readable syntanx that
-    is more inline with Carbons goals, i.e [Rationale](#rationale).
+    type is dependent on the value of the character itself, see [Types](#types).
+    Supporting this will help support a much cleaner and readable syntax that
+    is more inline with Carbon's goals, i.e [Rationale](#rationale).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -60,7 +60,7 @@ integers. Being able to use the comparison operations and supporting arithmetic
 operations provides an intuitive approach to using characters. This allows us to
 remove unnecessary logic of type conversion and other control flow logic, that
 is needed to work with a single element string. See [Rationale](#rationale) for
-more examples showing more appropriate use of characters over using a string.
+more examples showing more appropriate use of characters over using strings.
 
 ## Background
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -115,16 +115,13 @@ We will not support:
 -   "raw" literals (using #'x'#);
 -   `\x` escape sequences;
 -   character literals with a single quote (`'`) or back-slash (`\`), except as
-    part of an escape sequence
+    part of an escape sequence;
 -   empty character literals (`''`);
 -   ASCII control codes (0...31), including whitespace characters other than
     word space (tab, line feed, carriage return, form feed, and vertical tab),
     except when specified with an escape sequence.
 
 ### Types
-
-We will not support all code units in UTF-8 or UTF-16, but only those which map
-directly to the complete value of a code point
 
 We will have the types `Char8`, `Char16`, and `Char32` representing code units
 in UTF-8, UTF-16, and UTF-32, but we will not support all code units, but only

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -290,12 +290,10 @@ on strings is used for concatenation, but `+` on a character would change its
 value.
 
 ```
-    var a: Char8 = 'a';
-    var b: Char8 = 'b';
-
-    if (a < b) {
-        a += 1;
-    }
+// `digit` must be in the range 0..9.
+fn DigitToChar(digit: i32) -> Char8 {
+  return '0' + digit;
+}
 ```
 
 Furthermore, many properties of Unicode characters are defined on ranges of code

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -153,21 +153,15 @@ operators:
         character literal if the result fits in a Unicode code point.
     -   If the `+` is used between two character literals this will produce an
         error.
--   Subtract: `-` Similar to the plus operator, this will subtract the value of
-    the two characters.
-
-    -   If the `-` is used between a character literal representing a single
-        code point or code unit and an integer literal, this should produce a
-        character literal as long as the result of the difference is in range.
-    -   If the `-` is used between two character literals, which are both a
-        single code point, this should produce an integer literal representing
-        the difference between the code points.
-
-    In cases where the `+` and `-` operators are used with a character literal
-    and a non-integer non-literal, the character literal should be converted to
-    the type of the other operand if possible. For example, in the expression
-    `w - 'a'`, where `w` is of type `Char8`, the `'a'` literal will be converted
-    to type `Char8`.
+-   Subtract: `-`. This will subtract the value of the two characters, or a
+    character followed by an integer literal:
+    -   If the `-` is used between two character literals, the result will be a
+        character constant `'z' - 4`.
+    -   If the `-` is used between a character literal, followed by a integer
+        literal this will produce an integer constant `'z' - 'a'`.
+    -   If the `-` is used between a integer literal followed by a character
+        literal `100 - 'a'`, this will be rejected unless the integer is cast to
+        a character.
 
 There is intentionally no implicit conversion from character literals to integer
 types, but explicit conversions are permitted between character literals and

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -176,7 +176,7 @@ From the previous examples, we should be able to use the following operators:
     -   If the `-` is used between a character literal and an integer
         non-literal this will produce an error.
     -   If the `-` operator is used between a code point and a code unit, this
-        will produce and error.
+        will produce an error.
 
     In other use cases where the `+` and `-` operators are used, in theory we
     should convert the character literal to some other type first. For example

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -145,14 +145,9 @@ Character literals representing a single code point support the following
 operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
--   Plus: `+`. However the behavior of this operator is different from its use
-    with strings. Rather than a concatenation, this will add the value of the
-    two characters:
-    -   If the `+` is used between a character literal representing a single
-        Unicode code point and an integer literal, this should produce a
-        character literal if the result fits in a Unicode code point.
-    -   If the `+` is used between two character literals this will produce an
-        error.
+-   Plus: `+`. This doesn't concatenate, but allows numerically adjusting the value:
+    -   Only one operand may be a character literal, the other must be an integer literal.
+    -   The result is the character literal whose numeric value is the sum of numeric value of the operands. If that sum is not a valid Unicode code point, it is an error.
 -   Subtract: `-`. This will subtract the value of the two characters, or a
     character followed by an integer literal:
     -   If the `-` is used between two character literals, the result will be a

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -42,7 +42,11 @@ characters being represented as integers whereas strings are represented as
 buffers. This will allow characters to have different operations, and be more
 familiar to use. For example:
 
-\``` if (c >= 'A' and c <= 'Z') { c += 'a' - 'A'; } \```
+```
+if (c >= 'A' and c <= 'Z') {
+    c += 'a' - 'A';
+}
+```
 
 The example above shows how we would be able to use operations similar to
 integers. Being able to use the comparison operations and supporting arithmetic

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -164,8 +164,6 @@ From the previous examples, we should be able to use the following operators:
         non-literal this will produce an error.
     -   If the `+` is used between two character literals this will produce an
         error.
-    -   If the `+` operator is used between a code point and a code unit, this
-        will produce an error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
     the two characters.
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -92,7 +92,8 @@ We will not support:
 -   "raw" literals (using #'x'#)
 -   Empty character literals (`''`)
 -   ASCII Control codes (0...31), except when specified with an escape sequence.
-    See
+-   Whitespace characters other than word space: tab, line feed, carriage
+    return, form feed, and vertical tab. See
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 
 ## Details

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -168,9 +168,11 @@ bits, it can be assigned to a variable of type `Char16`.
 In this case, the character literal `’🎵’` corresponds to the musical note emoji
 with the Unicode code point `127925`. Since `127925` falls within the range that
 can be represented by `Char32`, it can be assigned to a variable of type
-`Char32`. By restricting character literals to those that can be directly mapped
-to code points within the specific character types, we ensure accurate
-representation and compatibility with the chosen character encoding scheme.
+`Char32`.
+
+By restricting character literals to those that can be directly mapped to code
+points within the specific character types, we ensure accurate representation
+and compatibility with the chosen character encoding scheme.
 
 ### Operations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -32,7 +32,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 This proposal specifies lexical rules for constant characters in Carbon:
 
-Put character literals in single quotes, like 'a'. Character literals work like
+Put character literals in single quotes, like `'a'`. Character literals work like
 numeric literals:
 
 Every different literal value has its own type. The bit width is determined by

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -99,20 +99,8 @@ excluding:
 
 ### Types
 
-The different character literal types are based on the value of the character.
-Meaning the type depends on the the contents, so that `'c'` and `'b'`. However
-any `'\n'` and `'\u{A}'` would be of the same type, as they are the same unicode
-entities `%0A`. It is worth noting that `'\x0A'` will be slightly different as
-any character following the `\x...` sequence representation are not the same as
-a Unicode character. For example:
-
-```
-var c1: EBCDICChar = '\x0A';
-var c2: EBCDICChar = '\n';
-```
-
-Here we assume that `c1` will be the EBCDIC RPT character (0xA) and for `c2` to
-be the EBCDIC NL character (0x15)
+Since we will be representing the character literal as a sequence consisting of
+elements that are each either a unicode code-point or a hex-encoded byte value.
 
 We can see whether the particular literal is represented in the variable's type
 by only looking at the types:
@@ -131,6 +119,21 @@ let error2: u8 = 'AB';
 
 However these should produce errors, the types of '😃' and 'AB' indicate that
 they cannot be converted to the declared type `u8`.
+
+The different character literal types are based on the value of the character.
+Meaning the type depends on the the contents, so that `'c'` and `'b'`. However
+any `'\n'` and `'\u{A}'` would be of the same type, as they are the same unicode
+entities `%0A`. It is worth noting that `'\x0A'` will be slightly different as
+any character following the `\x...` sequence representation are not the same as
+a Unicode character. For example:
+
+```
+var c1: EBCDICChar = '\x0A';
+var c2: EBCDICChar = '\n';
+```
+
+Here we assume that `c1` will be the EBCDIC RPT character (0xA) and for `c2` to
+be the EBCDIC NL character (0x15)
 
 ### Operations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -290,10 +290,23 @@ complexity of character literal [Types](#types).
 
 ### Disallowing Numeric Escape Sequences
 
-`//TODO: pro-con descriptions + examples` Not support escaping numeric
-sequences. This would simplify some of the design choices seen above by making
-types, the restrictions and behavior of character literals simpler. Specifically
-[Types](#types) of `EBCDIC`, by disallowing the `\x...` pattern. This would
-restrict users by having to use the specific hex value, and when to use
-operations between character literals and benefiting the readability of Carbon
-in some use cases.
+Not support escaping numeric sequences. This would simplify some of the design
+choices seen above by making types, the restrictions and behavior of character
+literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
+`\x...` pattern. However this would affect the readability, type-safety and
+consistency of character literals. If we were disallow numeric escape sequences
+here, that diverges from the `String` type which does allow for numeric escape
+sequences which means we would essentially have the functionality to declare
+character literals within a string literal. Additiaonlly, we could discuss
+removing numeric escape sequences from string liteals, but there are other draw
+backs to discuss in that arena. In terms of type-safety and readability, if we
+take a look at `var first_digit: char = 0;` it's hard to see the intention, is
+this supposed to be a `NUL` character or is it supposed to be the character zero
+`'0'`? Whereas supporting numeric escape sequences, we can write
+`var first_digit: char = '0'` or `var first_digit: char = '\0'` where the
+intention is clear and defined. Further, if we use integer literals instead of
+code unit escape sequences a user would assume we support initializing character
+types from integer literals `first_digit: char = 0;`, leading to assumptions
+surrounding how we'll permit implicit conversion from non-constant
+integer-valued expressions to character types. This would essentially diminish
+our ability to distinguish between numbers and characters in our type system.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -141,16 +141,12 @@ the C++ character types and the correct associated encoding.
 
 ### No distinct character literal
 
--   In principle a character literal can be represented by reusing string
-    literals. For example:
-    ```
-    var s: String = "c"
-    ```
-    We would simply this as a single element string. However it terms of
-    readablility, if we had a distinct lexical syntax for character literals
-    versus string literals, this would be more inline with Carbon's language
-    design goals related to self documenting code, easy to read, understand,
-    write and C++ interopability.
+In principle a character literal can be represented by reusing string literals.
+For example: `var s: String = "c"` We would simply this as a single element
+string. However it terms of readablility, if we had a distinct lexical syntax
+for character literals versus string literals, this would be more inline with
+Carbon's language design goals related to self documenting code, easy to read,
+understand, write and C++ interopability.
 
 ### Supporting Prefix Declarations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -207,7 +207,7 @@ operators:
     `w - 'a'`, where `w` is of type `Char8`, the `'a'` literal will be converted
     to type `Char8`.
 
-There is intentionally no conversion from character literals to integer types.
+There is intentionally no implicit conversion from character literals to integer types, but explicit conversions are permitted between character literals representing a single code point and integer types.
 Carbon will separate the integer types from character types entirely.
 
 ## Rationale

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -210,7 +210,7 @@ fn getSingleEAcuteHex(var combinedAcute: String) -> String {
     var accentValue: i32 = 0;
 
     while (eAcute != combinedAcute) {
-        accentValue = accentValue + 1;
+        accentValue += 1;
         eAcute = "\u{E{accentValue}}";
     }
     return eAcute;

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -127,12 +127,12 @@ proposal.
 
 
 ```
-let error1: u8 = '😃';
-let error2: u8 = 'AB';
+let error1: Char8 = '😃';
+let error2: Char8 = 'AB';
 ```
 
 However these should produce errors, the types of '😃' and 'AB' indicate that
-they cannot be converted to the declared type `u8`. It is important to point out
+they cannot be converted to the declared type `Char8`. It is important to point out
 that any `'\n'` and `'\u{A}'` would be of the same type, as they are the same
 unicode entities `%0A`. It is worth noting that `'\x0A'` will be slightly
 different as any character following the `\x...` sequence representation is not

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -38,6 +38,7 @@ like numeric literals:
 -   Every different literal value has its own type.
 -   The bit width is determined by the type of the variable the literal is
     assigned to, not the literal itself.
+-   A character literal must contain exactly one code point.
 
 Follows the plan from open design idea
 [#1934: Character Literals](https://github.com/carbon-language/carbon-lang/issues/1934).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -283,7 +283,7 @@ other exlpicit type checks like in C++; a UTF-16 `u'`, UTF-32 `U'`, and wide
 characters `L'`. This would be more familiar for individuals coming to Carbon
 from a C++ background, and simplify our approach for C++ Interoperability. At
 the cost of diverge from existing standards, for example
-[Proposal 142](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)]
+[Proposal 142](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)
 states all of Carbon source code should be UTF-8 encoded, this would impact the
 readability of the character literals and increase the complexity of character
 literal [Types](#types).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -93,7 +93,7 @@ like numeric literals:
     assigned to, not the literal itself. Follows the plan from #1934.
 -   A character literal will model single Unicode code points that have a single
     concrete numerical representation. We will not be supporting other
-    formulations like code unit sequences or grampheme clusters as these will be
+    formulations like code unit sequences or grapheme clusters as these will be
     modeled with normal string literals.
 
 ## Details
@@ -102,8 +102,7 @@ like numeric literals:
     of UTF-8 code units that must be a valid encoding. This matches
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   A character literal must encode exactly one code point.
--   It supports addition and subtraction. These operations produce another code
-    point literal, or produce an error if the result is out of range.
+-   It supports addition and subtraction, [as described below](#operations).
 -   Character literals support some back-slash (`\`) escape sequences, including
     `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -39,7 +39,9 @@ Put character literals in single quotes, like `'a'`. Character literals work
 like numeric literals:
 
 -   Every different literal value has its own type.
--   The literal itself doesn't have a bit width as a consequence. Instead, variables use explicitly sized character types and character literals can be converted to these types when representable.
+-   The literal itself doesn't have a bit width as a consequence. Instead,
+    variables use explicitly sized character types and character literals can be
+    converted to these types when representable.
 -   A character literal must contain exactly one code point.
 
 Follows the plan from open design idea
@@ -88,8 +90,9 @@ Put character literals in single quotes, like `'a'`. Character literals work
 like numeric literals:
 
 -   Every different literal value has its own type.
--   The bit width is determined by the type of the variable the literal is
-    assigned to, not the literal itself. Follows the plan from #1934.
+-   The literal itself doesn't have a bit width as a consequence. Instead,
+    variables use explicitly sized character types and character literals can be
+    converted to these types when representable. Follows the plan from #1934.
 -   A character literal will model single Unicode code points that have a single
     concrete numerical representation. We will not be supporting other
     formulations like code unit sequences or grapheme clusters as these will be
@@ -102,11 +105,14 @@ like numeric literals:
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   A character literal must encode exactly one code point.
 -   It supports addition and subtraction, [as described below](#operations).
--   Character literals will support the relevant subset of the backslash (`\`) escape sequences in string literals, including
-    `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
+-   Character literals will support the relevant subset of the backslash (`\`)
+    escape sequences in string literals, including `\t`, `\n`, `\r`, `\"`, `\'`,
+    `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
-    -   Escape sequences which would result in non-UTF-8 encodings or more than one code point are not included.
-    -   The escape of an embedded newline is also excluded as it isn't expected to be relevant for character literals.
+    -   Escape sequences which would result in non-UTF-8 encodings or more than
+        one code point are not included.
+    -   The escape of an embedded newline is also excluded as it isn't expected
+        to be relevant for character literals.
 
 We will not support:
 
@@ -124,21 +130,47 @@ We will not support:
 
 ### Types
 
-For the time being we will support character types `Char8`, `Char16`, and
-`Char32` that will hold both code units and code points, and will leave the
-different UTF-encoding code unit types to another proposal. See
-[UTF code unit types proposal](#utf-code-unit-types-proposal).
+For the time being, Carbon will support three character types: `Char8`,
+`Char16`, and `Char32`. These types are capable of representing both code units
+and code points. It’s important to note that the support for different
+UTF-encoding code unit types will be addressed in a separate proposal. Please
+refer to the [UTF code unit types proposal](#utf-code-unit-types-proposal)for
+more information on that topic.
 
-We will have the type `CharN` and only support literals that map directly to the
-complete value of a code point.
+In Carbon, the type `CharN` represents a character, where `N` corresponds to the
+bit size of the character type (`8`, `16`, or `32`). We will only allow
+character literals that map directly to a complete value of a code point. Here
+are examples of character literals for each specific type:
 
-```
-let allowed: CharN = 'a';
-```
+-   `Char8`: The character literal consists of a single Unicode code point that
+    can be represented within 8 bits. For example:
 
-The above is allowed because the type of `'a'` is the character literal
-consisting of the single Unicode code point 97, which can be converted to
-`CharN` since 97 is less than or equal to 0x7F.
+`let allowed: Char8 = ‘a’ `
+
+In this example, the character literal `’a’` corresponds to the Unicode code
+point `97`, which is within the valid range of `Char8` since `97` is less than
+or equal to `0x7F`.
+
+-   `Char16`: The character literal represents a Unicode code point that can be
+    represented within 16 bits. Here’s an example:
+
+`let smiley: Char16 = ‘\u{1F600}’`
+
+The character literal `’\u{1F600}’` represents the smiley face emoji, which has
+the Unicode code point `128512`. Since `128512` can be represented within 16
+bits, it can be assigned to a variable of type `Char16`.
+
+-   `Char32`: This character type allows the representation of Unicode code
+    points within 32 bits. Here’s an example:
+
+`let musicalNote: Char32 = ‘🎵’`
+
+In this case, the character literal `’🎵’` corresponds to the musical note emoji
+with the Unicode code point `127925`. Since `127925` falls within the range that
+can be represented by `Char32`, it can be assigned to a variable of type
+`Char32`. By restricting character literals to those that can be directly mapped
+to code points within the specific character types, we ensure accurate
+representation and compatibility with the chosen character encoding scheme.
 
 ### Operations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -263,11 +263,11 @@ When working with code points, there is an advantage to having a distinct
 character literal. Primarily when discussing the readablity of the design
 choice, and working with code points similar to the example above. When looking
 at the two variables it is clear that `acute2` contains two code points, but
-when using a `String` is no way to evaluate if it is a single valid character of
-multiple code points or two characters. `\u{301}\u{65}` is a valid single
-character comprised of multiple code points resulting in `é`, however this could
-easily be mistaken as a `String` comprised of two code points `\u{400}\u{65}`
-which is `Ѐe`
+when using a `String` there is no way to evaluate if it is a single valid
+character of multiple code points or two characters. `\u{301}\u{65}` is a valid
+single character comprised of multiple code points resulting in `é`, however
+this could easily be mistaken as a `String` comprised of two code points, for
+example `\u{400}\u{65}` which is two characters resulting in `Ѐe`.
 
 ### Supporting Prefix Declarations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -294,16 +294,16 @@ Not support escaping numeric sequences. This would simplify some of the design
 choices seen above by making types, the restrictions and behavior of character
 literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
 `\x...` pattern. However this would affect the readability, type-safety and
-consistency of character literals. If we were disallow numeric escape sequences
-here, that diverges from the `String` type which does allow for numeric escape
-sequences which means we would essentially have the functionality to declare
-character literals within a string literal. Additiaonlly, we could discuss
-removing numeric escape sequences from string liteals, but there are other draw
-backs to discuss in that arena. In terms of type-safety and readability, if we
-take a look at `var first_digit: char = 0;` it's hard to see the intention, is
-this supposed to be a `NUL` character or is it supposed to be the character zero
-`'0'`? Whereas supporting numeric escape sequences, we can write
-`var first_digit: char = '0'` or `var first_digit: char = '\0'` where the
+consistency of character literals. If we were to disallow numeric escape
+sequences for character literals, that diverges from the `String` type which
+does allow for numeric escape sequences so we would essentially have the
+functionality to declare character literals but within a string literal.
+Additiaonlly, we could remove numeric escape sequences from string liteals, but
+there are other draw backs to discuss in that arena. In terms of type-safety and
+readability, if we take a look at `var first_digit: char = 0;` it's hard to see
+the intention, is this supposed to be a `NUL` character or is it supposed to be
+the character zero `'0'`? Whereas supporting numeric escape sequences, we can
+write `var first_digit: char = '0'` or `var first_digit: char = '\0'` where the
 intention is clear and defined. Further, if we use integer literals instead of
 code unit escape sequences a user would assume we support initializing character
 types from integer literals `first_digit: char = 0;`, leading to assumptions

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -37,7 +37,8 @@ like numeric literals:
 
 Every different literal value has its own type. The bit width is determined by
 the type of the variable the literal is assigned to, not the literal itself.
-Follows the plan from Open design idea: character literals #1934.
+Follows the plan from Open design idea:
+[Character Literals](https://github.com/carbon-language/carbon-lang/issues/1934).
 
 ## Problem
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -38,7 +38,7 @@ like numeric literals:
 Every different literal value has its own type. The bit width is determined by
 the type of the variable the literal is assigned to, not the literal itself.
 Follows the plan from Open design idea:
-[Character Literals](https://github.com/carbon-language/carbon-lang/issues/1934).
+[#1934: Character Literals](https://github.com/carbon-language/carbon-lang/issues/1934).
 
 ## Problem
 
@@ -120,8 +120,9 @@ by only looking at the types:
 let allowed: Char8 = 'a';
 ```
 
-The above is allowed because the type of `'a'` indicates that it can be
-converted to `Char8`. Here, `Char8` is a type that can represent a single 8-bit
+The above is allowed because the type of `'a'` is the character literal consisting
+of the single Unicode code point 97, which can be converted to `Char8` since
+97 fits in 8 bits. Here, `Char8` is a type that can represent a single 8-bit
 character, like C++'s `char8_t`. `Char8` is used for exposition and is not part
 of this proposal.
 
@@ -130,10 +131,15 @@ let error1: Char8 = '😃';
 let error2: Char8 = 'AB';
 ```
 
-However these should produce errors, the types of `'😃'` and `'AB'` indicate
-that they cannot be converted to the declared type `Char8`. It is important to
+However these should produce errors. The type of `'😃'` is the character
+literal consisting of the single Unicode code point `0x1F603`, which is too big
+to fit in 8 bits. The type of `'AB'` is a character literal that is a sequence
+of two Unicode code points, which has no conversion to a type that only
+handles one.
+
+It is important to
 point out that any `'\n'` and `'\u{A}'` would be of the same type, as they are
-the same unicode entities `%0A`. It is worth noting that `'\x0A'` will be
+the same unicode entities `%0A`. However, `'\x0A'` will be
 slightly different as any character following the `\x...` sequence
 representation is not the same as a Unicode character. For example:
 
@@ -182,6 +188,9 @@ From the previous examples, we should be able to use the following operators:
     if we want to call `w - 'a'`, where `w` is of type `char` we would want to
     convert the `'a'` literal to a `char`.
 
+There is intentionally no conversion from character literals to integer types.
+Carbon will separate the integer types from character types entirely. 
+
 ### Encoding
 
 Character literals written will be UTF-8 encoded, as all of Carbon source code
@@ -194,8 +203,8 @@ This proposal supports the goal of making Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 Adding support for a specific character literal supports clean, readable,
 concise use and is a much more familiar concept that will make it easier to
-adopt Carbon coming from other languages. Have a distinct character literally
-will also allow us support useful operations designed to manipulate the literals
+adopt Carbon coming from other languages. Have a distinct character literal
+will also allow us support useful operations designed to manipulate the literal's
 value. When working with `String`, we use the `+` operator to concatenate
 multiple `String`s, but say we wanted to advance a character to the next
 literal. Using a `String` will produce a type error, as we are misusing the `+`
@@ -219,6 +228,7 @@ For example following the
 [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 and representing characters as integers with the behaviour inline with
 [Integer Literals](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0143.md).
+
 This also supports our goal for
 [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
 by ensuring that every kind of character literal that exists in C++ can be
@@ -226,22 +236,29 @@ represented in a Carbon character literal. This is done in a way that is natural
 to adopt, understand, easy to read by having explicit character types mapped to
 the C++ character types and the correct associated encoding.
 
+Finally, the choice to use Unicode and UTF-8 by default reflects the Carbon goal to prioritize
+[modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments).
+This reflects the [growing adoption of UTF-8](https://en.wikipedia.org/wiki/UTF-8#Adoption).
 ## Alternatives considered
+
+### Separate character and integer types
+
+Unlike C++, Carbon will separate the integer and the character types. Carbon
+character types add the information that the represented integer is a code unit
+of some particular encoding. Without knowing the encoding, it is ambiguous how
+to interpret an integer value.
 
 ### No Distinct Character Literal
 
-In principle a character literal can be represented by reusing string literals
-similar to how Python handles character literals, however this would lead to
-some disadvatages. There are situations where using operations can be given more
-practical use. When using `Strings` the `+` operator, is used for concatenating
-two `String` objects, essentially rendering it useless when working with
-characters. With a distinct character literal we can support more useful
-operations, for example by using the `+` operator to advance the character
-literal to the next representable literal:
+In principle, a character literal can be represented by reusing string literals
+similar to how Python handles character literals, however this would prevent
+performing operations on characters as integers. For example, the `+` operator
+on strings is used for concatenation, but `+` on a character would change its
+value.
 
 ```
-    var a: u8 = 'a';
-    var b: u8 = 'b';
+    var a: Char8 = 'a';
+    var b: Char8 = 'b';
 
     if (a < b) {
         a += 1;
@@ -277,7 +294,7 @@ No support is proposed for prefix declarations like `u`, `U`, or `L`. In
 practice they are used to specify the character literal types and their encoding
 in languages like C and C++. There are a several benefits to omitting prefix
 declarations; improved readablitly, simplifying how a character's type is
-determened, and how we are encoding character literals. When declaring a
+determined, and how we are encoding character literals. When declaring a
 character literal, the type is based on the contents of the character so that
 `var c: u8 = 'a'` is a valid character that can be converted to `u8`, in order
 to support prefix declarations we would need to extend our type system to have

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -156,10 +156,9 @@ let error2: Char8 = 'AB';
 However these should produce errors. The type of `'😃'` is the character literal
 consisting of the single Unicode code point `0x1F603`, which is greater than
 0x7F. The type of `'AB'` is a character literal that is a sequence of two
-Unicode code points, which has no conversion to a type that only handles a
-single UTF-8 code unit.
+Unicode code points, which is not valid.
 
-All of `'\n'`, and `'\u{A}'` represent the same character and so have the same
+Literals `'\n'` and `'\u{A}'` represent the same character and so have the same
 type. However, explicitly converting this character literal to another character
 set might result in a character with a different value, but that still
 represents the newline character.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -266,7 +266,6 @@ literal to the next representable literal:
     if (a < b) {
         a += 1;
     }
-
 ```
 
 Another example of this would be looking at the `==` and other comparison
@@ -280,7 +279,6 @@ are evaluated with the `==` operator the result is `false`.
   var acute1: String = "\u{E9}";
   var acute2: String = "\u{301}\u{65}";
   var matching: auto = if acute1 == acute2 then true else false; //output false
-
 ```
 
 When working with code points, there is an advantage to having a distinct

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -164,8 +164,10 @@ From the previous examples, we should be able to use the following operators:
 
     -   If the `-` is used between a character literal and an integer literal,
         this should produce a character literal.
-    -   If the `-` is used between two character literals this should produce
-        and integer literal.
+    -   If the `-` is used between two character literals, which are either
+        both a single code point or both a single code unit, this should produce
+        and integer literal representing the difference between the code points
+        or code units.
     -   If the `-` is used between a character literal and an integer
         non-literal this will produce and error.
     -   If the `-` operator is used between a code point and a code unit, this

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -128,7 +128,7 @@ However these should produce errors, the types of '😃' and 'AB' indicate that
 they cannot be converted to the declared type `u8`. However any `'\n'` and
 `'\u{A}'` would be of the same type, as they are the same unicode entities
 `%0A`. It is worth noting that `'\x0A'` will be slightly different as any
-character following the `\x...` sequence representation are not the same as a
+character following the `\x...` sequence representation is not the same as a
 Unicode character. For example:
 
 ```

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -280,5 +280,5 @@ Not support escaping numeric sequences. This would simplify some of the design
 choices seen above by making types, the restrictions and behavior of character
 literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
 `\x...` pattern. This would restrict users by having to use the specific hex
-value, and when to use operations between character literals and benifitying the
+value, and when to use operations between character literals and benefiting the
 readability of Carbon in some use cases.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -39,8 +39,7 @@ Put character literals in single quotes, like `'a'`. Character literals work
 like numeric literals:
 
 -   Every different literal value has its own type.
--   The bit width is determined by the type of the variable the literal is
-    assigned to, not the literal itself.
+-   The literal itself doesn't have a bit width as a consequence. Instead, variables use explicitly sized character types and character literals can be converted to these types when representable.
 -   A character literal must contain exactly one code point.
 
 Follows the plan from open design idea
@@ -103,9 +102,11 @@ like numeric literals:
     [the UTF-8 encoding of Carbon source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 -   A character literal must encode exactly one code point.
 -   It supports addition and subtraction, [as described below](#operations).
--   Character literals support some back-slash (`\`) escape sequences, including
+-   Character literals will support the relevant subset of the backslash (`\`) escape sequences in string literals, including
     `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
+    -   Escape sequences which would result in non-UTF-8 encodings or more than one code point are not included.
+    -   The escape of an embedded newline is also excluded as it isn't expected to be relevant for character literals.
 
 We will not support:
 
@@ -114,8 +115,9 @@ We will not support:
 -   "raw" literals (using #'x'#);
 -   `\x` escape sequences;
 -   character literals with a single quote (`'`) or back-slash (`\`), except as
-    part of an escape sequence
+    part of an escape sequence;
 -   empty character literals (`''`);
+-   a backslash followed by an (unescaped) newline;
 -   ASCII control codes (0...31), including whitespace characters other than
     word space (tab, line feed, carriage return, form feed, and vertical tab),
     except when specified with an escape sequence.
@@ -186,7 +188,6 @@ var b: u8;
 
 b = 'a' + 1;
 b + 1 == 'c';
-
 ```
 
 See [Operations](#operations) and
@@ -218,7 +219,7 @@ This reflects the
 
 Unlike C++, Carbon will separate the integer and the character types. We
 considered using `u8`, `u16`, and `u32` instead of `Char8`, `Char16`, and
-`Char32`to reduce the number of different types users needed to be aware of and
+`Char32` to reduce the number of different types users needed to be aware of and
 convert between. We decided against it because it came with a number of
 disadvantages:
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -281,4 +281,4 @@ choices seen above by making types, the resctrictions and behavior of character
 literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
 `\x...` pattern. This would restrict users by having to use the specific hex
 value, and when to use operations between character literals and benifitying the
-readablilty of Carbon in some use cases.
+readability of Carbon in some use cases.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -114,6 +114,24 @@ var c2: EBCDICChar = '\n';
 Here we assume that `c1` will be the EBCDIC RPT character (0xA) and for `c2` to
 be the EBCDIC NL character (0x15)
 
+We can see whether the particular literal is represented in the variable's type
+by only looking at the types:
+
+```
+let allowed: u8 = 'a';
+```
+
+The above is allowed because the type of 'a' indicates that it can be converted
+to `u8`.
+
+```
+let error1: u8 = '😃';
+let error2: u8 = 'AB';
+```
+
+However these should produce errors, the types of '😃' and 'AB' indicate that
+they cannot be converted to the declared type `u8`.
+
 ### Operations
 
 From the previous examples, we should be able to use the following operators:

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -105,6 +105,8 @@ excluding:
 -   Single quote (`'`), but can write `'` character as `'\''`
 -   Back-slash (`\`), except when used to form an escape sequence. See
     [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
+-   Whitespace characters other than space (` `).
+-   ASCII control codes (0...31).
 
 ### Types
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -29,7 +29,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-This proposal specifies lexical rules for constant characters in Carbon.
+This proposal specifies lexical rules for constant characters in Carbon:
+
+Put character literals in single quotes, like 'a'. Character literals work like
+numeric literals:
+
+Every different literal value has its own type. The bit width is determined by
+the type of the variable the literal is assigned to, not the literal itself.
+Follows the plan from Open design idea: character literals #1934.
 
 ## Problem
 
@@ -52,7 +59,8 @@ The example above shows how we would be able to use operations similar to
 integers. Being able to use the comparison operations and supporting arithmetic
 operations provides an intuitive approach to using characters. This allows us to
 remove unnecessary logic of type conversion and other control flow logic, that
-is needed to work with a single element string.
+is needed to work with a single element string. See [Rationale](#rationale) for
+more examples showing more appropriate use of characters over using a string.
 
 ## Background
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -118,14 +118,11 @@ let error2: u8 = 'AB';
 ```
 
 However these should produce errors, the types of '😃' and 'AB' indicate that
-they cannot be converted to the declared type `u8`.
-
-The different character literal types are based on the value of the character.
-Meaning the type depends on the the contents, so that `'c'` and `'b'`. However
-any `'\n'` and `'\u{A}'` would be of the same type, as they are the same unicode
-entities `%0A`. It is worth noting that `'\x0A'` will be slightly different as
-any character following the `\x...` sequence representation are not the same as
-a Unicode character. For example:
+they cannot be converted to the declared type `u8`. However any `'\n'` and
+`'\u{A}'` would be of the same type, as they are the same unicode entities
+`%0A`. It is worth noting that `'\x0A'` will be slightly different as any
+character following the `\x...` sequence representation are not the same as a
+Unicode character. For example:
 
 ```
 var c1: EBCDICChar = '\x0A';

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Encoding](#encoding)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [Separate character and integer types](#separate-character-and-integer-types)
+    -   [No distinct character types](#no-distinct-character-types)
     -   [No Distinct Character Literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
     -   [Disallowing Numeric Escape Sequences](#disallowing-numeric-escape-sequences)
@@ -104,18 +104,19 @@ We will not support:
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
     of UTF-8 code units that may or may not be a valid encoding.
 -   If a character literal encodes exactly one code point, then it supports
-    addition and subtraction. These operations produce another code
-    point literal, if the value can be determined at compile time, or a
-    runtime `Char32` code point value.
--   For most purposes a character should be viewed as representing a
-    grapheme cluster.
+    addition and subtraction. These operations produce another code point
+    literal, if the value can be determined at compile time, or a runtime
+    `Char32` code point value.
+-   For most purposes a character should be viewed as representing a grapheme
+    cluster.
 -   Value-preserving implicit conversions from character literals to code point
     or code unit types are permitted. In particular, a character literal
     converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
     UTF-16 code unit if it is less than or equal to 0xFFFF.
 -   `\x` escape sequences produce the given code unit. Character literals are
     assumed to use a UTF-8 encoding. So `'\xC3\x89'` is the same thing as `'É'`,
-    a valid encoding of a single code point, and so allows addition and subtraction.
+    a valid encoding of a single code point, and so allows addition and
+    subtraction.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
@@ -136,8 +137,8 @@ However, character literals will use their own types distinct from these:
 
 -   We will support value preserving implicit conversions from character
     literals to code point or code unit types. In particular, a character
-    literal converts to a `Char8` UTF-8 code unit if it is less than or equal to 0x7F,
-    and `Char16` UTF-16 code unit if it is less than or equal to 0xFFFF.
+    literal converts to a `Char8` UTF-8 code unit if it is less than or equal to
+    0x7F, and `Char16` UTF-16 code unit if it is less than or equal to 0xFFFF.
 -   Conversions from string or character literals to a non-value-preserving
     encoding must be explicit.
 -   Conversions from string literals to Unicode strings are implicit, even
@@ -175,14 +176,16 @@ represents the newline character.
 Assert('\n' as EBCDICChar == EBCDICChar.Make(0x15));
 Assert('\x0A' as EBCDICChar != EBCDICChar.Make(0x0A));
 ```
+
 ### Operations
 
-Character literals representing a single code point support the following operators:
+Character literals representing a single code point support the following
+operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
--   Plus: `+`. However the behavior of this operator is different from
-    its use with strings. Rather than a concatenation, this will add the value
-    of the two characters:
+-   Plus: `+`. However the behavior of this operator is different from its use
+    with strings. Rather than a concatenation, this will add the value of the
+    two characters:
     -   If the `+` is used between a character literal representing a single
         Unicode code point and an integer literal, this should produce a
         character literal if the result fits in a Unicode code point.
@@ -194,9 +197,9 @@ Character literals representing a single code point support the following operat
     -   If the `-` is used between a character literal representing a single
         code point or code unit and an integer literal, this should produce a
         character literal as long as the result of the difference is in range.
-    -   If the `-` is used between two character literals, which are both
-        a single code point, this should produce an
-        integer literal representing the difference between the code points.
+    -   If the `-` is used between two character literals, which are both a
+        single code point, this should produce an integer literal representing
+        the difference between the code points.
 
     In cases where the `+` and `-` operators are used with a character literal
     and a non-integer non-literal, the character literal should be converted to
@@ -265,10 +268,18 @@ This reflects the
 
 ### No distinct character types
 
-Unlike C++, Carbon will separate the integer and the character types. Carbon
+Unlike C++, Carbon will separate the integer and the character types, Carbon
 character types add the information that the represented integer is a code unit
-of some particular encoding. Without knowing the encoding, it is ambiguous how
-to interpret an integer value.
+of some particular encoding. Whereas C++'s types `u8`, `u16`, and `u32` have the
+wrong arithmetic semantics: we dont want wrapping. And many `uN` operations are
+not meaningful on code units, unless you are implementing a conversion from code
+units. Generally these cases should pierce the viel of abstraction and it's
+probably reasonable to work with a `u8`, then explicitly convert it to the code
+unit type when finished. Further, some operations want to be able to infer a
+provided, intended to be UTF-8 string, rather than a unspecified encoded string
+and to know if they have been given actual text or random bytes of data. For
+these reasons, it will be useful for developer to document the meaning of a
+value, so using a distinct type is one way to do that.
 
 ### No Distinct Character Literal
 
@@ -287,9 +298,8 @@ value.
     }
 ```
 
-Furthermore, many properties of Unicode characters are defined on ranges
-of code points, motivating supporting comparison operators on code points.
-
+Furthermore, many properties of Unicode characters are defined on ranges of code
+points, motivating supporting comparison operators on code points.
 
 ### Supporting Prefix Declarations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -290,9 +290,9 @@ Furthermore, many properties of Unicode characters are defined on ranges of code
 points, motivating supporting comparison operators on code points.
 
 ```
-  var acute1: Char32 = "\u{E9}";
-  var acute2: Char32 = "\u{301}\u{65}";
-  var matching: auto = if acute1 == acute2 then true else false; //output true
+fn IsDingBatCodePoint(c: Char32) -> bool {
+  return c >= '\u{2700}' and c <= '\u{27BF}';
+}
 ```
 
 ### Supporting Prefix Declarations

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -22,9 +22,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Encoding](#encoding)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [No distinct character literal](#no-distinct-character-literal)
+    -   [No Distinct Character Literal](#no-distinct-character-literal)
     -   [Supporting Prefix Declarations](#supporting-prefix-declarations)
-    -   [Disallowing numeric escape sequences](#disallowing-numeric-escape-sequences)
+    -   [Disallowing Numeric Escape Sequences](#disallowing-numeric-escape-sequences)
 
 <!-- tocstop -->
 
@@ -238,7 +238,7 @@ the C++ character types and the correct associated encoding.
 
 ## Alternatives considered
 
-### No distinct character literal
+### No Distinct Character Literal
 
 In principle a character literal can be represented by reusing string literals.
 //TODO: Add Description
@@ -266,7 +266,7 @@ with a more C++ or C background. Supporting this will help support a much
 cleaner and readable syntax that is more inline with Carbon's goals, i.e
 [Rationale](#rationale).
 
-### Disallowing numeric escape sequences
+### Disallowing Numeric Escape Sequences
 
 Not support escaping numeric sequences. This would simplify some of the design
 choices seen above, specifically how we manage [Types](#types) and of the

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -106,7 +106,7 @@ excluding:
 
 ### Types
 
-Since we will be representing the character literal as a sequence consisting of
+We will represent a character literal as a sequence consisting of
 elements that are each either a unicode code-point or a hex-encoded byte value.
 
 We can see whether the particular literal is represented in the variable's type

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -144,6 +144,8 @@ be the EBCDIC NL character (0x15)
 From the previous examples, we should be able to use the following operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
+    -   If any of the comparison operators are used between a code point and a
+        code unit, this will produce and error.
 -   Plus: `+`. However the behaviour of this operator is distinctly compared to
     its use with Strings. Rather then a concatenation, this will add the value
     of the two characters:
@@ -155,6 +157,8 @@ From the previous examples, we should be able to use the following operators:
         non-literal this will produce and error.
     -   If the `+` is used between two character literals this will produce and
         error.
+    -   If the `+` operator is used between a code point and a code unit, this
+        will produce and error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
     the two characters.
 
@@ -164,6 +168,8 @@ From the previous examples, we should be able to use the following operators:
         and integer literal.
     -   If the `-` is used between a character literal and an integer
         non-literal this will produce and error.
+    -   If the `-` operator is used between a code point and a code unit, this
+        will produce and error.
 
     In other use cases where the `+` and `-` operators are used, in theory we
     should convert the character literal to some other type first. For example
@@ -269,7 +275,8 @@ cleaner and readable syntax that is more inline with Carbon's goals, i.e
 ### Disallowing Numeric Escape Sequences
 
 Not support escaping numeric sequences. This would simplify some of the design
-choices seen above, specifically how we manage [Types](#types) and of the
-`EBCDIC` type, disallowing the `\x...` pattern. This would restrict users by
-having to use the specific hex value, restrict when to use operations between
-character literals and impact the readablilty of Carbon in some use cases.
+choices seen above by making types, the resctrictions and behavior of character
+literals simpler. Specifically [Types](#types) of `EBCDIC`, by disallowing the
+`\x...` pattern. This would restrict users by having to use the specific hex
+value, and when to use operations between character literals and benifitying the
+readablilty of Carbon in some use cases.

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -105,8 +105,8 @@ like numeric literals:
 -   Character literals support some back-slash (`\`) escape sequences, including
     `\t`, `\n`, `\r`, `\"`, `\'`, `\\`, `\0`, and `\u{HHHH...}`. See
     [String Literals: Escape sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences).
--   Conversions from string literals to Unicode strings are implicit, even
-    though the numeric values of the encoding may change.
+-   Character literals implicitly convert to Unicode strings, even though the
+    numeric values of the encoding may change.
 
 We will not support:
 
@@ -120,9 +120,6 @@ We will not support:
 -   ASCII control codes (0...31), including whitespace characters other than
     word space (tab, line feed, carriage return, form feed, and vertical tab),
     except when specified with an escape sequence.
--   Whitespace characters other than word space: tab, line feed, carriage
-    return, form feed, and vertical tab. And Back-slash (`\`), see
-    [String Literals: Escaping Sequence](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0199.md#escape-sequences-1)
 
 ### Types
 
@@ -323,14 +320,13 @@ complexity of character literal [Types](#types).
 
 ### Allowing numeric escape sequences
 
-We will not be support escaping numeric sequences. This simplifies some of the
-design choices by making types, the restrictions and behavior of character
-literals simpler. Specifically [Types](#types) of `EBCDIC` by disallowing the
-`\x...` pattern. However this does affect the readability, type-safety and
-consistency of character literals. Since we are disallowing numeric escape
-sequences for character literals, that diverges from the `String` type which
-does allow for numeric escape sequences so we would essentially have the
-functionality to declare character literals but within a string literal.
+This proposal does not support numeric escape sequences using `\x`. This
+simplifies the design of character types and literals, making them only
+represent code points and not code units. However this does come with the
+disadvantage of less consistency of character literals with string literals,
+since they now accept different escape sequences. We don't want to remove
+numeric escape sequence from string literals, so we can support string use cases
+like representing invalid encodings.
 
 This approach has the additional concern that if character literals don't
 support numeric escape sequences, developers may choose to use numeric literals

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -127,11 +127,11 @@ let error2: u8 = 'AB';
 ```
 
 However these should produce errors, the types of '😃' and 'AB' indicate that
-they cannot be converted to the declared type `u8`. However any `'\n'` and
-`'\u{A}'` would be of the same type, as they are the same unicode entities
-`%0A`. It is worth noting that `'\x0A'` will be slightly different as any
-character following the `\x...` sequence representation is not the same as a
-Unicode character. For example:
+they cannot be converted to the declared type `u8`. It is important to point out
+that any `'\n'` and `'\u{A}'` would be of the same type, as they are the same
+unicode entities `%0A`. It is worth noting that `'\x0A'` will be slightly
+different as any character following the `\x...` sequence representation is not
+the same as a Unicode character. For example:
 
 ```
 var c1: EBCDICChar = '\x0A';
@@ -271,12 +271,22 @@ example `\u{400}\u{65}` which is two characters resulting in `Ѐe`.
 
 ### Supporting Prefix Declarations
 
-`//TODO: pro-con descriptions + examples` No support is proposed for prefix
-declarations like `u`, `U`, or `L`. In practice they are used to specify the
-character literal types in languages like C and C++, supporting these could help
-with the familiarity of coming to Carbon with a more C++ or C background.
-Supporting this will help support a much cleaner and readable syntax that is
-more inline with Carbon's goals, i.e [Rationale](#rationale).
+No support is proposed for prefix declarations like `u`, `U`, or `L`. In
+practice they are used to specify the character literal types and their encoding
+in languages like C and C++. There are a several benefits to omitting prefix
+declarations; improved readablitly, simplifying how a character's type is
+determened, and how we are encoding character literals. When declaring a
+character literal, the type is based on the contents of the character so that
+`var c: u8 = 'a'` is a valid character that can be converted to `u8`, in order
+to support prefix declarations we would need to extend our type system to have
+other exlpicit type checks like in C++; a UTF-16 `u'`, UTF-32 `U'`, and wide
+characters `L'`. This would be more familiar for individuals coming to Carbon
+from a C++ background, and simplify our approach for C++ Interoperability. At
+the cost of diverge from existing standards, for example
+[Proposal 142](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding)]
+states all of Carbon source code should be UTF-8 encoded, this would impact the
+readability of the character literals and increase the complexity of character
+literal [Types](#types).
 
 ### Disallowing Numeric Escape Sequences
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -273,8 +273,8 @@ Another example of this would be looking at the `==` and other comparison
 operators when working with characters represented with code points. Below is an
 example of representing the character `é` with code points. `acute1` is using
 the single code point representation and `acute2` is combining the `e` and
-`tilde` code points to represent the character. However when they are evaluated
-with the `==` operator the result is `false`.
+`acute accent mark` code points to represent the character. However when they
+are evaluated with the `==` operator the result is `false`.
 
 ```
   var acute1: String = "\u{E9}";

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -36,9 +36,11 @@ This proposal specifies lexical rules for constant characters in Carbon:
 Put character literals in single quotes, like `'a'`. Character literals work
 like numeric literals:
 
-Every different literal value has its own type. The bit width is determined by
-the type of the variable the literal is assigned to, not the literal itself.
-Follows the plan from Open design idea:
+-   Every different literal value has its own type.
+-   The bit width is determined by the type of the variable the literal is
+    assigned to, not the literal itself.
+
+Follows the plan from open design idea
 [#1934: Character Literals](https://github.com/carbon-language/carbon-lang/issues/1934).
 
 ## Problem
@@ -100,22 +102,24 @@ We will not support:
 ## Details
 
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
-    of UTF-8 code units that may or may not be a valid encoding. If a character
-    literal is encodes exactly one code point, then it supports arithmetic,
-    producing another code point, or a runtime CodePoint (Type name TBD) value
-    if necessary, however for most purposes a character should be viewed as a
+    of UTF-8 code units that may or may not be a valid encoding.
+-   If a character literal encodes exactly one code point, then it supports
+    addition and subtraction. These operations produce another code
+    point literal, if the value can be determined at compile time, or a
+    runtime `Char32` code point value.
+-   For most purposes a character should be viewed as representing a
     grapheme cluster.
 -   Value-preserving implicit conversions from character literals to code point
     or code unit types are permitted. In particular, a character literal
     converts to a UTF-8 code unit if it is less than or equal to 0x7F, and
     UTF-16 code unit if it is less than or equal to 0xFFFF.
--   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
-    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
-    point so arithmetic on it is permitted. encoding are explicit.
+-   `\x` escape sequences produce the given code unit. Character literals are
+    assumed to use a UTF-8 encoding. So `'\xC3\x89'` is the same thing as `'É'`,
+    a valid encoding of a single code point, and so allows addition and subtraction.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
-    A character literal will exclude:
+Character literals cannot be written with these characters:
 
 -   New line
 -   Single quote (`'`), but can write `'` character as `'\''`
@@ -127,20 +131,15 @@ We will not support:
 ### Types
 
 We will have the types `Char8`, `Char16`, and `Char32` representing code units
-in UTF-8, UTF-16, and UTF-32. `Char32` will represent a valid code point that
-align with the rules stated in [encoding](#encoding)
+in UTF-8, UTF-16, and UTF-32. `Char32` will also represent a valid code point.
+However, character literals will use their own types distinct from these:
 
--   We will represent a character literal as a sequence consisting of elements
-    that are each either a unicode code-point or a hex-encoded byte value.
 -   We will support value preserving implicit conversions from character
     literals to code point or code unit types. In particular, a character
-    literal converts to a UTF-8 code unit if it is less than or equal to 0x7F,
-    and UTF-16 code unit if it is less than or equal to 0xFFFF.
--   `\x` escape sequences produce the given code unit. But UTF-8 is assumed, so
-    `'\xC3\x89'` is the same thing as `'É'`, and is valid encoded single code
-    point.
+    literal converts to a `Char8` UTF-8 code unit if it is less than or equal to 0x7F,
+    and `Char16` UTF-16 code unit if it is less than or equal to 0xFFFF.
 -   Conversions from string or character literals to a non-value-preserving
-    encoding are explicit.
+    encoding must be explicit.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
 
@@ -153,9 +152,7 @@ let allowed: Char8 = 'a';
 
 The above is allowed because the type of `'a'` is the character literal
 consisting of the single Unicode code point 97, which can be converted to
-`Char8` since 97 fits in 8 bits. Here, `Char8` is a type that can represent a
-single 8-bit character, like C++'s `char8_t`. `Char8` is used for exposition and
-is not part of this proposal.
+`Char8` since 97 fits it is less than or equal to 0x7F.
 
 ```
 let error1: Char8 = '😃';
@@ -163,38 +160,32 @@ let error2: Char8 = 'AB';
 ```
 
 However these should produce errors. The type of `'😃'` is the character literal
-consisting of the single Unicode code point `0x1F603`, which is too big to fit
-in 8 bits. The type of `'AB'` is a character literal that is a sequence of two
-Unicode code points, which has no conversion to a type that only handles one.
+consisting of the single Unicode code point `0x1F603`, which is greater than
+0x7F. The type of `'AB'` is a character literal that is a sequence of two
+Unicode code points, which has no conversion to a type that only handles a
+single UTF-8 code unit.
 
-It is important to point out that any `'\n'` and `'\u{A}'` would be of the same
-type, as they are the same unicode entities `%0A`. However, `'\x0A'` will be
-slightly different as any character following the `\x...` sequence
-representation is not the same as a Unicode character. For example:
+All of `'\n'`, `'\u{A}'`, and `'\x0A'` represent the same character and so have
+the same type. However, explicitly converting this character literal to another
+character set might result in a character with a different value, but that still
+represents the newline character.
 
 ```
-var c1: EBCDICChar = '\x0A';
-var c2: EBCDICChar = '\n';
+// 0x15 is the new line character in EBCDIC.
+Assert('\n' as EBCDICChar == EBCDICChar.Make(0x15));
+Assert('\x0A' as EBCDICChar != EBCDICChar.Make(0x0A));
 ```
-
-Here we assume that `c1` will be the EBCDIC RPT character (0xA) and for `c2` to
-be the EBCDIC NL character (0x15)
-
 ### Operations
 
-From the previous examples, we should be able to use the following operators:
+Character literals representing a single code point support the following operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
-    -   If any of the comparison operators are used between a code point and a
-        code unit, this will produce an error.
--   Plus: `+`. However the behaviour of this operator is distinct compared to
-    its use with Strings. Rather than a concatenation, this will add the value
+-   Plus: `+`. However the behavior of this operator is different from
+    its use with strings. Rather than a concatenation, this will add the value
     of the two characters:
     -   If the `+` is used between a character literal representing a single
         Unicode code point and an integer literal, this should produce a
-        character literal if the result fits in a Unicode code point. Similarly,
-        `+` between a hex code like `'\xAB'` and an integer literal results in a
-        character literal if the result fits in a single byte.
+        character literal if the result fits in a Unicode code point.
     -   If the `+` is used between two character literals this will produce an
         error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
@@ -203,18 +194,15 @@ From the previous examples, we should be able to use the following operators:
     -   If the `-` is used between a character literal representing a single
         code point or code unit and an integer literal, this should produce a
         character literal as long as the result of the difference is in range.
-    -   If the `-` is used between two character literals, which are either both
-        a single code point or both a single code unit, this should produce an
-        integer literal representing the difference between the code points or
-        code units.
-    -   If the `-` operator is used between a code point and a code unit, this
-        will produce an error.
+    -   If the `-` is used between two character literals, which are both
+        a single code point, this should produce an
+        integer literal representing the difference between the code points.
 
     In cases where the `+` and `-` operators are used with a character literal
     and a non-integer non-literal, the character literal should be converted to
     the type of the other operand if possible. For example, in the expression
-    `w - 'a'`, where `w` is of type `Char`, the `'a'` literal will be converted
-    to type `Char`.
+    `w - 'a'`, where `w` is of type `Char8`, the `'a'` literal will be converted
+    to type `Char8`.
 
 There is intentionally no conversion from character literals to integer types.
 Carbon will separate the integer types from character types entirely.
@@ -275,7 +263,7 @@ This reflects the
 
 ## Alternatives considered
 
-### Separate character and integer types
+### No distinct character types
 
 Unlike C++, Carbon will separate the integer and the character types. Carbon
 character types add the information that the represented integer is a code unit
@@ -299,15 +287,9 @@ value.
     }
 ```
 
-When working with code points, there is an advantage to having a distinct
-character literal. Primarily when discussing the readablity of the design
-choice, and working with code points similar to the example above. When looking
-at the two variables it is clear that `acute2` contains two code points, but
-when using a `String` there is no way to evaluate if it is a single valid
-character of multiple code points or two characters. `\u{301}\u{65}` is a valid
-single character comprised of multiple code points resulting in `é`, however
-this could easily be mistaken as a `String` comprised of two code points, for
-example `\u{400}\u{65}` which is two characters resulting in `Ѐe`.
+Furthermore, many properties of Unicode characters are defined on ranges
+of code points, motivating supporting comparison operators on code points.
+
 
 ### Supporting Prefix Declarations
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -101,7 +101,12 @@ We will not support:
 ## Details
 
 -   A character literal is a sequence enclosed with single quotes delimiter ('),
-    of UTF-8 code units that may or may not be a valid encoding.
+    of UTF-8 code units that may or may not be a valid encoding, if a character
+    literal encodes exactly one code point `Char32`, then it supports
+    arithmetic, producing another code point, or a runtime CodePoint (Type name
+    TBD) value if necessary. For more information about source encoding see
+    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
+    .
 -   If a character literal encodes exactly one code point, then it supports
     addition and subtraction. These operations produce another code point
     literal, if the value can be determined at compile time, or a runtime
@@ -118,12 +123,6 @@ We will not support:
     subtraction.
 -   Conversions from string literals to Unicode strings are implicit, even
     though the numeric values of the encoding may change.
--   A character literal is a sequence of UTF-8 code units that may or may not be
-    a valid encoding. If a character literal encodes exactly one code point
-    `Char32`, then it supports arithmetic, producing another code point, or a
-    runtime CodePoint (Type name TBD) value if necessary. For more information
-    about source encoding see
-    [Unicode source files](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0142.md#character-encoding).
 
 Character literals cannot be written with these characters:
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -190,7 +190,7 @@ This proposal supports the goal of making Carbon code
 [easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
 Adding support for a specific character literal supports clean, readable,
 concises use and is a much more familiar concept that will make it easier to
-adopt Carbon coming from other languages. For Example when working with literals
+adopt Carbon coming from other languages. For example when working with literals
 represented as hex, having a distinct character literal type makes this much
 simpler to work:
 

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -123,10 +123,9 @@ We will not support:
 
 ### Types
 
-For the time being we will support character types `Char8`,
- `Char16`, and `Char32` that will hold both code units
-and code points, and will leave the different UTF-encoding code unit types to
-another proposal. See
+For the time being we will support character types `Char8`, `Char16`, and
+`Char32` that will hold both code units and code points, and will leave the
+different UTF-encoding code unit types to another proposal. See
 [UTF code unit types proposal](#utf-code-unit-types-proposal).
 
 We will have the type `CharN` and only support literals that map directly to the

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -123,9 +123,13 @@ We will not support:
 
 ### Types
 
+We will not support all code units in UTF-8 or UTF-16, but only those which map
+directly to the complete value of a code point
+
 We will have the types `Char8`, `Char16`, and `Char32` representing code units
-in UTF-8, UTF-16, and UTF-32. `Char32` will also represent a valid code point.
-However, character literals will use their own types distinct from these:
+in UTF-8, UTF-16, and UTF-32, but we will not support all code units, but only
+those which map directly to the complete value of a code point. However,
+character literals will use their own types distinct from these:
 
 -   We will support value preserving implicit conversions from character
     literals to code point or code unit types. In particular, a character

--- a/proposals/p1964.md
+++ b/proposals/p1964.md
@@ -145,36 +145,34 @@ From the previous examples, we should be able to use the following operators:
 
 -   Comparison: `<`, `>`, `<=`, `>=` `==`
     -   If any of the comparison operators are used between a code point and a
-        code unit, this will produce and error.
--   Plus: `+`. However the behaviour of this operator is distinctly compared to
-    its use with Strings. Rather then a concatenation, this will add the value
+        code unit, this will produce an error.
+-   Plus: `+`. However the behaviour of this operator is distinct compared to
+    its use with Strings. Rather than a concatenation, this will add the value
     of the two characters:
     -   If the `+` is used between a character literal and an integer literal,
         this should produce a character literal if the result fits into a
         Unicode code point or for a unicode hex code like `'\xAB'`, a single
         byte.
     -   If the `+` is used between a character literal and an integer
-        non-literal this will produce and error.
-    -   If the `+` is used between two character literals this will produce and
+        non-literal this will produce an error.
+    -   If the `+` is used between two character literals this will produce an
         error.
     -   If the `+` operator is used between a code point and a code unit, this
-        will produce and error.
+        will produce an error.
 -   Subtract: `-` Similar to the plus operator, this will subtract the value of
     the two characters.
-
     -   If the `-` is used between a character literal and an integer literal,
         this should produce a character literal.
-    -   If the `-` is used between two character literals this should produce
-        and integer literal.
+    -   If the `-` is used between two character literals this should produce an
+        integer literal.
     -   If the `-` is used between a character literal and an integer
-        non-literal this will produce and error.
+        non-literal this will produce an error.
     -   If the `-` operator is used between a code point and a code unit, this
-        will produce and error.
-
-    In other use cases where the `+` and `-` operators are used, in theory we
-    should convert the character literal to some other type first. For example
-    if we want to call `x - 'a'`, where `w` is of type `char` we would want to
-    convert the `'a'` literal to a `char`.
+        will produce an error. In other use cases where the `+` and `-`
+        operators are used, in theory we should convert the character literal to
+        some other type first. For example if we want to call `x - 'a'`, where
+        `w` is of type `char` we would want to convert the `'a'` literal to a
+        `char`.
 
 ### Encoding
 


### PR DESCRIPTION
Put character literals in single quotes, like `'a'`. Character literals work
like numeric literals:

-   Every different literal value has its own type.
-   The bit width is determined by the type of the variable the literal is
    assigned to, not the literal itself. Follows the plan from #1934.