### PR TITLE
Implement basic support for documentation tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,11 @@ pip_install(
     requirements = "//github_tools:requirements.txt",
 )
 
+pip_install(
+    name = "py_deps_doctests",
+    requirements = "//docs:tests/requirements.txt",
+)
+
 ###############################################################################
 # C++ rules
 ###############################################################################

--- a/bazel/testing/lit_test.py
+++ b/bazel/testing/lit_test.py
@@ -10,13 +10,19 @@ import argparse
 import os
 from pathlib import Path
 import subprocess
+import tarfile
+import tempfile
 
 
 def _parse_args():
     """Parses command line arguments, returning the result."""
     arg_parser = argparse.ArgumentParser(description=__doc__)
-    arg_parser.add_argument(
+    args_input = arg_parser.add_mutually_exclusive_group(required=True)
+    args_input.add_argument(
         "--package_name", help="The directory containing tests to run."
+    )
+    args_input.add_argument(
+        "--tarball_path", help="The tarball containing tests to run."
     )
     arg_parser.add_argument(
         "lit_args", nargs="*", help="Arguments to pass through to lit."
@@ -27,11 +33,27 @@ def _parse_args():
 def main():
     parsed_args = _parse_args()
 
-    args = [
-        str(Path(os.environ["TEST_SRCDIR"]).joinpath("llvm-project/llvm/lit")),
-        str(Path.cwd().joinpath(parsed_args.package_name)),
-        "-v",
-    ]
+    if parsed_args.package_name:
+        args = [
+            str(Path(os.environ["TEST_SRCDIR"]).joinpath("llvm-project/llvm/lit")),
+            str(Path.cwd().joinpath(parsed_args.package_name)),
+            "-v",
+        ]
+    else:
+        tar = tarfile.open(parsed_args.tarball_path)
+        for member in tar.getnames():
+            if member.endswith(".carbon"): # TODO: do not hardcode extension here
+                break
+        else:
+            exit(0) # there are no tests to run (which LIT would consider an error)
+        tmpdir = tempfile.TemporaryDirectory(dir=Path.cwd())
+        tmppath = Path.cwd().joinpath(tmpdir.name)
+        tar.extractall(tmppath)
+        args = [
+            str(Path(os.environ["TEST_SRCDIR"]).joinpath("llvm-project/llvm/lit")),
+            str(tmppath),
+            "-v",
+        ]
 
     # Force tests to be explicit about command paths.
     env = os.environ.copy()

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,21 @@
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+load("@py_deps_doctests//:requirements.bzl", "requirement")
+load("tests/md_tests.bzl", "generate_md_tests")
+
+py_binary(
+    name = "md_to_testdata",
+    srcs = ["tests/md_to_testdata.py"],
+    deps = [requirement("markdown")],
+)
+
+generate_md_tests(
+    tool = "md_to_testdata",
+    srcs = glob(["**/*.md"]),
+)
+
+# run with `bazel test docs/...`

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -29,6 +29,7 @@ quotation marks (`'''`). A block string literal may have a file type indicator
 after the first `'''`; this does not affect the string itself, but may assist
 other tooling. For example:
 
+<!-- test mo _ rc -->
 ```carbon
 // Simple string literal:
 var simple: String = "example";
@@ -49,7 +50,7 @@ var code_block: String = '''cpp
         std::cout << "Hello world!";
         return 0;
     }
-    '''
+    ''';
 ```
 
 The indentation of a block string literal's terminating line is removed from all
@@ -64,6 +65,7 @@ an equal number of hash symbols (`#`) after the `\` to indicate an escape
 sequence. Raw string literals are used to more easily write literal `\`s in
 strings. Both simple and block string literals have raw forms. For example:
 
+<!-- test mo _ rc -->
 ```carbon
 // Raw simple string literal with newline escape sequence:
 var newline: String = "line one\nline two";
@@ -131,15 +133,16 @@ as follows:
 
 A content line is considered empty if it contains only whitespace characters.
 
+<!-- test -8+4 mo _ rc -->
 ```carbon
-var String: w = '''
+var w: String = '''
   This is a string literal. Its first character is 'T' and its last character is
   a newline character. It contains another newline between 'is' and 'a'.
   ''';
 
 // This string literal is invalid because the ''' after 'closing' terminates
 // the literal, but is not at the start of the line.
-var String: invalid = '''
+var invalid: String = '''
   error: closing ''' is not on its own line.
   ''';
 ```
@@ -150,10 +153,11 @@ compiler, but some file type indicators are understood by the language tooling
 (for example, syntax highlighter, code formatter) as indicating the structure of
 the string literal's content.
 
+<!-- test mo _ rc -->
 ```carbon
 // This is a block string literal. Its first two characters are spaces, and its
 // last character is a line feed. It has a file type of 'c++'.
-var String: starts_with_whitespace = '''c++
+var starts_with_whitespace: String = '''c++
     int x = 1; // This line starts with two spaces.
     int y = 2; // This line starts with two spaces.
   ''';
@@ -249,21 +253,22 @@ can only be produced by `\x` escape sequences.
 The decision to disallow raw tab characters in string literals is
 _experimental_.
 
+<!-- test -->
 ```carbon
-var String: fret = "I would 'twere something that would fret the string,\n" +
+var fret: String = "I would 'twere something that would fret the string,\n" +
                    "The master-cord on's \u{2764}\u{FE0F}!";
 
 // This string contains two characters (prior to encoding in UTF-8):
 // U+1F3F9 (BOW AND ARROW) followed by U+0032 (DIGIT TWO)
-var String: password = "\u{1F3F9}2";
+var password: String = "\u{1F3F9}2";
 
 // This string contains no newline characters.
-var String: type_mismatch = '''
+var type_mismatch: String = '''
   Shall I compare thee to a summer's day? Thou art \
   more lovely and more temperate.\
   ''';
 
-var String: trailing_whitespace = '''
+var trailing_whitespace: String = '''
   This line ends in a space followed by a newline. \n\
       This line starts with four spaces.
   ''';
@@ -289,17 +294,18 @@ special meaning.
 
 For example:
 
+<!-- test mo _ rc -->
 ```carbon
-var String: x = #'''
+var x: String = #'''
   This is the content of the string. The 'T' is the first character
   of the string.
   ''' <-- This is not the end of the string.
   '''#;
   // But the preceding line does end the string.
 // OK, final character is \
-var String: y = #"Hello\"#;
-var String: z = ##"Raw strings #"nesting"#"##;
-var String: w = #"Tab is expressed as \t. Example: '\#t'"#;
+var y: String = #"Hello\"#;
+var z: String = ##"Raw strings #"nesting"#"##;
+var w: String = #"Tab is expressed as \t. Example: '\#t'"#;
 ```
 
 ### Encoding

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,200 @@
+# Documentation tests
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+This document describes a minimal DSL that can be used to transform markdown fenced code blocks into test cases for the Carbon Explorer interpreter.
+
+In order to test a fenced code block like
+
+````
+```
+for (var name: String in names) {
+  Console.Print(name);
+}
+```
+````
+
+The block must be preceded by a comment starting with `test`
+
+````
+<!-- test -->
+```
+for (var name: String in names) {
+  Console.Print(name);
+}
+```
+````
+
+Everything between `test` and the end of the comment is treated as a list of space-separated generator commands (described below). If this list is empty, like above, then no test case is actually generated. This (easily searchable) form can be used to express the intent that the snippet ought to be tested, but Explorer does not yet support the required functionality.
+
+Fenced blocks without a language tag are assumed to use Carbon syntax. Fenced blocks in other languages and blocks without `<!-- test ... --->` comments are ignored.
+
+## Generator commands
+
+Commands are executed in reading order (left to right). The following commands are available:
+
+### Paste current snippet
+
+`_`
+
+Writes the contents of the current snippet (and the result of any transformation command preceding the `_`) to the output buffer.
+
+#### Example
+
+````
+<!-- test _ -->
+```
+fn Main() -> i32 {
+  return 0;
+}
+```
+````
+
+### Paste literal or named code snippet
+
+`` `literalblock` `` or `namedblock`
+
+#### Example
+
+````
+<!-- test `fn Main() -> i32 {` _ `}` -->
+```
+return 0;
+```
+````
+or equivalently
+````
+<!-- test mo _ c -->
+```
+return 0;
+```
+````
+
+Where `mo` (main open) and `c` (close brace) are predefined named snippets.
+
+### Delete lines from current snippet
+
+`-N` or `-N+M`
+
+Delete `M` lines starting with line `N` (`M` is 1 if omitted). Can be used to delete lines that explain wrong syntax and should not be part of the current test case.
+
+#### Example
+
+````
+<!-- test -11 -8 _ -->
+```
+fn Main() -> i32 {
+  // ✅ Same as (1 | 2) | 4, evaluates to 7.
+  var a: i32 = 1 | 2 | 4;
+
+  // ❌ Error, parentheses are required to distinguish between
+  //    (3 | 5) & 6, which evaluates to 6, and
+  //    3 | (5 & 6), which evaluates to 7.
+  var b: i32 = 3 | 5 & 6;
+
+  // ❌ Error, can't repeat the `^` operator. Use `^(^4)` or simply `4`.
+  var d: i32 = ^^4;
+
+  return 0;
+}
+```
+````
+Note that lines are deleted bottom up to preserve numbering.
+
+### Insert lines in current snippet
+
+`` +L`code` `` or `+Lblockname`
+
+Insert the literal code `` `code` `` or the named code block `blockname` at line `L`.
+
+#### Example
+
+````
+<!-- test +5rc +4mo _ -->
+```
+fn Add(a: i64, b: i64) -> i64 {
+  return a + b;
+}
+Add(20, 22);
+```
+````
+
+Note that lines are inserted bottom up to preserve numbering, `rc` and `mo` are predefined named snippets.
+
+### Replace ellipsis in current snippet
+
+`` .`code` `` or `.blockname`
+
+Replaces successive occurrences of `...` with the contents of the specified block literal or named block. A special form `.` can be used to replace the ellipsis with an empty string.
+
+#### Example
+
+````
+<!-- test . .`return false;` .r . _ m -->
+```
+class Song {
+  fn Play[me: Self]() { ... }
+  fn Playing[me: Self]() -> bool { ... }
+  fn Duration[me: Self] -> i32 { ... }
+  fn Run[me: Self]() { ... }
+}
+```
+````
+
+### Save current snippet with name
+
+` =blockname `
+
+#### Example
+
+````
+<!-- test =point _ m -->
+```
+class Point {
+  var x: i32;
+  var y: i32;
+  fn Origin() -> Self {
+    return {.x = 0, .y = 0};
+  }
+}
+```
+
+then later in the same .md file
+
+<!-- test point mo _ rc -->
+```
+var p1: Point = Point.Origin();
+```
+
+````
+
+#### Predefined named snippets
+
+`m` means
+```
+fn Main() -> i32 { return 0; }
+```
+
+`mo` means
+```
+fn Main() -> i32 {
+```
+
+`rc` means
+```
+return 0; }
+```
+
+`r` means
+```
+return 0;
+```
+
+`c` means
+```
+}
+```

--- a/docs/tests/md_tests.bzl
+++ b/docs/tests/md_tests.bzl
@@ -1,0 +1,48 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+def generate_md_tests(srcs, tool):
+    """Macro to generate `lit` tests from Markdown fenced code blocks.
+
+    Args:
+      srcs: List of Markdown files to analyze.
+      tool: Executable target that generates Carbon testcases.
+    """
+    tests = []
+    testcfg = "//explorer/testdata:lit.cfg.py"
+    for src in srcs:
+        basepath = src.split(".")[0]
+        tarpath = basepath + ".tar"
+        genname = "generate_md_testdata_" + basepath.replace("/", "_")
+        native.genrule(
+            name = genname,
+            srcs = [src, testcfg],
+            outs = [tarpath],
+            tools = [tool],
+            cmd = "tarpath=$(location " + tarpath + ") \
+                && $(location " + tool + ") --input=$(location " + src + ") --output=$${tarpath%.*} \
+                && cp $(location " + testcfg + ") . \
+                && tar cf \"$@\" $${tarpath%.*} lit.cfg.py --remove-files",
+        )
+        test_data = [
+            "//explorer",
+            "@llvm-project//llvm:FileCheck",
+            "@llvm-project//llvm:not",
+            "@llvm-project//llvm:lit",
+            testcfg,
+            tarpath,
+        ]
+        test_name = basepath + ".test"
+        native.py_test(
+            name = test_name,
+            srcs = ["//bazel/testing:lit_test.py"],
+            main = "//bazel/testing:lit_test.py",
+            data = test_data,
+            args = ["--tarball_path=$(location " + tarpath + ")", "--"],
+        )
+        tests.append(test_name)
+    native.test_suite(
+        name = "doctests",
+        tests = tests,
+    )

--- a/docs/tests/md_tests.bzl
+++ b/docs/tests/md_tests.bzl
@@ -23,7 +23,7 @@ def generate_md_tests(srcs, tool):
             cmd = "tarpath=$(location " + tarpath + ") \
                 && $(location " + tool + ") --input=$(location " + src + ") --output=$${tarpath%.*} \
                 && cp $(location " + testcfg + ") . \
-                && tar cf \"$@\" $${tarpath%.*} lit.cfg.py --remove-files",
+                && tar cf \"$@\" $${tarpath%.*} lit.cfg.py",
         )
         test_data = [
             "//explorer",

--- a/docs/tests/md_to_testdata.py
+++ b/docs/tests/md_to_testdata.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+"""Generate Explorer test cases from Markdown code snippets"""
+
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import argparse
+import glob
+from html.parser import HTMLParser
+import os
+from pathlib import Path
+from markdown import Markdown, Extension, markdownFromFile
+from markdown.extensions.fenced_code import FencedCodeExtension
+from markdown.postprocessors import Postprocessor
+import re
+from typing import Any, Dict, List, Tuple
+
+TEST_HEADER = """
+// RUN: %{explorer} %s 2>&1 | \\
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \\
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+"""
+NAMED_SNIPPETS = {
+    "m": ["fn Main() -> i32 { return 0; }"],
+    "mo": ["fn Main() -> i32 {"],
+    "rc": ["return 0; }"],
+    "r": ["return 0;"],
+    "c": ["}"],
+}
+RE_TEST = re.compile(r"\s*test\s+")
+RE_TEST_COMMAND = re.compile(r"""\s*(?P<command>
+ (?P<out_buf>[_])
+|`(?P<out_code>[^`]+)`
+|(?P<out_name>[\w_][\w\d_]*)
+|[-](?P<del_line>[\d]+)([+](?P<del_lines>[\d]+))?
+|[+](?P<ins_line>[\d]+)(`(?P<ins_code>[^`]+)`|(?P<ins_name>[\w_][\w\d_]*))
+|[.]`(?P<dot_code>[^`]+)`
+|[.](?P<dot_name>[\w_][\w\d_]*)
+|(?P<dot_none>[.])
+|[=](?P<cpy_name>[\w_][\w\d_]*)
+)""", re.VERBOSE)
+RE_DOTS = re.compile(r"[.]{3}")
+
+def parse_test(text : str) -> List[Dict]:
+  if not (match := RE_TEST.match(text)):
+    return None
+  matches = []
+  while match := RE_TEST_COMMAND.match(text, match.end()):
+    matches.append(match.groupdict())
+  return matches
+
+class DocsSnippetParser(HTMLParser):
+    def __init__(self, outdir: Path) -> None:
+        super().__init__()
+        self.outdir = outdir
+        self.comm_lineno = 0
+        self.code_lineno = 0
+        self.code_text = None
+        self.code_lines = None
+        self.snippets = NAMED_SNIPPETS
+        self.test_text = None
+        self.test_cmds = None
+        self.test_lines = None
+        self.test_index = 0
+    def handle_comment(self, data: str) -> None:
+        self.test_text = data
+        self.comm_lineno = self.getpos()[0]
+        #TODO: keep track of line numbers in original document for error reporting
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, str]]) -> None:
+        langs = [v for k, v in attrs if k == "class" and v.startswith("lang-")]
+        if tag == "code" and (not langs or "lang-carbon" in langs):
+            self.code_lineno = self.getpos()[0]
+    def handle_data(self, data: str) -> None:
+        #TODO: there is no error handling
+        if self.code_lineno > 0 and self.comm_lineno >= self.code_lineno - 2 \
+          and self.test_text and (test_cmds := parse_test(self.test_text)):
+            self.code_text = data
+            self.code_lines = self.code_text.splitlines()
+            self.test_cmds = test_cmds
+            self.test_lines = []
+            for cmd in self.test_cmds:
+              if cmd["out_buf"]:
+                self.test_lines.extend(self.code_lines)
+              elif cmd["out_code"]:
+                lines = cmd["out_code"].splitlines()
+                self.test_lines.extend(lines)
+              elif cmd["out_name"]:
+                self.test_lines.extend(self.snippets[cmd["out_name"]])
+              elif cmd["del_lines"]:
+                del_line = int(cmd["del_line"]) - 1
+                del_count = int(cmd["del_lines"])
+                del self.code_lines[del_line:del_line + del_count - 1]
+              elif cmd["del_line"]:
+                del_line = int(cmd["del_line"]) - 1
+                del self.code_lines[del_line]
+              elif cmd["ins_code"]:
+                ins_line = int(cmd["ins_line"]) - 1
+                lines = cmd["ins_code"].splitlines()
+                self.code_lines = self.code_lines[:ins_line] + lines + self.code_lines[:ins_line]
+              elif cmd["ins_name"]:
+                ins_line = int(cmd["ins_line"]) - 1
+                lines = self.snippets[cmd["ins_name"]]
+                self.code_lines = self.code_lines[:ins_line] + lines + self.code_lines[ins_line:]
+              elif cmd["dot_code"]:
+                code = cmd["dot_code"]
+                self.code_text = RE_DOTS.sub(code, self.code_text)
+                self.code_lines = self.code_text.splitlines()
+              elif cmd["dot_name"]:
+                code = self.snippets[cmd["dot_name"]]
+                self.code_text = RE_DOTS.sub(code, self.code_text)
+                self.code_lines = self.code_text.splitlines()
+              elif cmd["dot_none"]:
+                self.code_text = RE_DOTS.sub("", self.code_text)
+                self.code_lines = self.code_text.splitlines()
+              elif cmd["cpy_name"]:
+                name = cmd["cpy_name"]
+                self.snippets[name] = self.code_lines
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.test_lines:
+            testpath = os.path.join(self.outdir, f"test_{self.test_index}.carbon")
+            with open(testpath, "w", encoding="utf-8") as testfile:
+                testfile.write(TEST_HEADER)
+                testfile.write(f"// CHECK: result: 0") #TODO: make configurable
+                testfile.write("\n")
+                testfile.write("package ExplorerTest api;\n")
+                testfile.write("\n")
+                testfile.writelines(map(lambda l: l + "\n", self.test_lines))
+                testfile.write("\n")
+            self.test_index += 1
+        self.code_lineno = 0
+        self.code_text = None
+        self.code_lines = None
+        self.test_text = None
+        self.test_data = None
+        self.test_lines = None
+
+class DocsSnippetProcessor(Postprocessor):
+    def __init__(self, md, outdir) -> None:
+        self.md = md
+        self.outdir = outdir
+    def run(self, text: str) -> str:
+        parser = DocsSnippetParser(self.outdir)
+        parser.feed(text)
+        return text
+
+class DocsSnippetToTest(Extension):
+    def __init__(self, path, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.path = path
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.postprocessors.register(DocsSnippetProcessor(md, self.path), "md_to_lit", 0)
+        md.registerExtension(self)
+
+def main() -> None:
+    arg_parser = argparse.ArgumentParser(description=__doc__)
+    arg_parser.add_argument(
+        "--debug", help="Test generator commands to debug."
+    )
+    arg_parser.add_argument(
+        "--input", help="Markdown file to parse."
+    )
+    arg_parser.add_argument(
+        "--output", help="Output directory. NOTE: contents will be cleared!"
+    )
+    args = arg_parser.parse_args()
+    if args.debug:
+      if matches := parse_test(args.debug):
+        for match in matches:
+          print({k: v for (k, v) in match.items() if v})
+      exit(0)
+
+    outpath = Path(args.output).resolve()
+    os.makedirs(outpath, exist_ok=True)
+    outfiles = glob.glob(f"{args.output}/*.carbon")
+    for f in outfiles:
+        os.remove(f)
+
+    md_extensions = [FencedCodeExtension(lang_prefix="lang-"), DocsSnippetToTest(outpath)]
+    markdownFromFile(input=args.input, extensions=md_extensions, output=os.devnull)
+
+if __name__ == "__main__":
+    main()

--- a/docs/tests/requirements.txt
+++ b/docs/tests/requirements.txt
@@ -1,0 +1,1 @@
+markdown

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -35,6 +35,7 @@ cc_binary(
         ":main",
         "@llvm-project//llvm:Support",
     ],
+    visibility = ["//visibility:public"] # for doctests
 )
 
 py_binary(

--- a/explorer/testdata/BUILD
+++ b/explorer/testdata/BUILD
@@ -19,3 +19,5 @@ filegroup(
     srcs = glob(["**/*.carbon"]),
     visibility = ["//visibility:public"],
 )
+
+exports_files(["lit.cfg.py"]) # for doctests


### PR DESCRIPTION
From the outside, it is currently very hard to find out how much of the syntax described in the documentation is actually implemented by the Explorer (as also evidenced by #1891). And even if this was known, documentation and implementation are likely to drift over time as things evolve.

This PR provides:
- a (very) minimal inline DSL to transform Markdown fenced code blocks into runnable tests
- a `py_binary` target implementing the above DSL
- enough Bazel plumbing to make `bazel test docs/...` automatically generate and execute these tests

The idea would then be, over time, to mark (at least some of) the example code in the documentation as tests, and have Bazel test automatically that the syntax used in the documentation is in fact valid.

### TODO
- [ ] better error handling (when a test fails, it's very hard to see why and trace the failure back to the corresponding Markdown line)
- [ ] review by someone with Bazel readability (I never used Bazel before yesterday, there might be better ways to generate targets and tests dynamically)
- [ ] friendlier DSL syntax (plus possibly some heuristics to avoid having to write it at all whenever possible)
