### PR TITLE
Weaken digit separator placement rules

### DIFF
--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -61,6 +61,10 @@ Some issues with this approach have been raised:
     in byte pairs (`00-B0-D0-63-C2-26`) and UUIDs have particular groupings
     (`123e4567-e89b-12d3-a456-426614174000`).
 
+This was asked on
+[Issue #1485: Reconsider digit separators](https://github.com/carbon-language/carbon-lang/issues/1485),
+where a proposal was requested.
+
 ## Proposal
 
 Switch to simple rules: a single digit separator can appear between any two

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -83,7 +83,7 @@ digits. For example:
         groupings.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
     -   Reduces migration hurdles for C++ code by providing a rule that's more
-        consistent.
+        consistent with the C++ rule.
 
 ## Alternatives considered
 

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -32,7 +32,7 @@ this, remove placement rules for numeric literals.
 
 ## Problem
 
-Digit separator placement rules may be too strict.
+Digit separator placement rules are too strict.
 
 ## Background
 

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -1,0 +1,64 @@
+# Digit separators
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/1983)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -102,7 +102,7 @@ Disadvantages:
 -   Indian, Chinese, Japanese, and Korean digit grouping conventions don't fit
     under this rule.
     -   These are worth considering similar to how Carbon allows
-        [unicode identifiers](/docs/design/lexical_conventions/words.md):
+        [Unicode identifiers](/docs/design/lexical_conventions/words.md):
         although keywords are in English, we can be more flexible for both
         identifiers and literals.
 -   Microformats could also pose issues. For example, microseconds (`1_00000`),

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -57,10 +57,8 @@ Some issues with this approach have been raised:
     is likely due to the description on
     [wikipedia](https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping):
     "but the delimiter commonly separates every three digits".
--   For hexadecimal in particular, there are microformats where different
-    placement rules may be desirable. For example, MAC addresses are typically
-    in byte pairs (`00-B0-D0-63-C2-26`) and UUIDs have particular groupings
-    (`123e4567-e89b-12d3-a456-426614174000`).
+-   There are microformats where different placement rules may be desirable. See
+    [alternatives](#alternatives-considered) for more specific examples.
 
 This was asked on
 [Issue #1485: Reconsider digit separators](https://github.com/carbon-language/carbon-lang/issues/1485),

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -27,8 +27,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 [Proposal #143: Numeric literals](/proposals/p0143.md) added digit separators
 with strict rules for placement. It missed some use-cases. In order to address
-this, remove placement rules for integers, and change placement rules for
-hexadecimal to be byte-based but allowing irregular placement.
+this, remove placement rules for numeric literals.
 
 ## Problem
 

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -1,4 +1,4 @@
-# Digit separators
+# Weaken digit separator placement rules
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -12,53 +12,146 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
+-   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
--   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [3-digit decimal groupings](#3-digit-decimal-groupings)
+    -   [2-digit or 4-digit hexadecimal digit groupings](#2-digit-or-4-digit-hexadecimal-digit-groupings)
 
 <!-- tocstop -->
 
+## Abstract
+
+[Proposal #143: Numeric literals](/proposals/p0143.md) added digit separators
+with strict rules for placement. It missed some use-cases. In order to address
+this, remove placement rules for integers, and change placement rules for
+hexadecimal to be byte-based but allowing irregular placement.
+
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+Digit separator placement rules may be too strict.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+[Proposal #143: Numeric literals](/proposals/p0143.md) added digit separators
+with strict rules for placement:
+
+-   For decimal integers, the digit separators shall occur every three digits
+    starting from the right. For example, `2_147_483_648`.
+-   For hexadecimal integers, the digit separators shall occur every four digits
+    starting from the right. For example, `0x7FFF_FFFF`.
+-   For real number literals, digit separators can appear in the decimal and
+    hexadecimal integer portions (prior to the period and after the optional `e`
+    or mandatory `p`) as described in the previous bullets. For example,
+    `2_147.483648e12_345` or `0x1_00CA.FEF00Dp+24`
+-   For binary literals, digit separators can appear between any two digits. For
+    example, `0b1_000_101_11`.
+
+Some issues with this approach have been raised:
+
+-   For integers, while the original proposal mentioned Indian digit groupings,
+    Chinese, Japanese, and Korean cultures use 4-digit groupings. This oversight
+    is likely due to the description on
+    [wikipedia](https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping):
+    "but the delimiter commonly separates every three digits".
+-   For hexadecimal in particular, there are microformats where different
+    placement rules may be desirable. For example, MAC addresses are typically
+    in byte pairs (`00-B0-D0-63-C2-26`) and UUIDs have particular groupings
+    (`123e4567-e89b-12d3-a456-426614174000`).
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Switch to simple rules: a single digit separator can appear between any two
+digits. For example:
 
-## Details
-
-TODO: Fully explain the details of the proposed solution.
+-   Decimal literals: `1_2_3`
+-   Hexadecimal literals: `0xA_B_C`
+-   Real literals: `1_2.3_4e5_6`
+-   Binary literals are unaffected.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
 -   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+    -   Removing restrictions on decimal literals provides flexibility for
+        developers who don't use 3-digit groupings.
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+    -   This allows for mistakes in groupings, which is undesirable. However,
+        it's useful for microformats to be able to provide their own particular
+        groupings.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+    -   Reduces migration hurdles for C++ code by providing a rule that's more
+        consistent.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+### 3-digit decimal groupings
+
+For decimal separators, we could enforce 3-digit groupings if digit separators
+are used at all.
+
+Advantages:
+
+-   More enforcement of digit groupings can prevent bugs and misreadings
+    resulting from accidentally incorrect groupings.
+
+Disadvantages:
+
+-   Indian, Chinese, Japanese, and Korean digit grouping conventions don't fit
+    under this rule.
+-   Microformats could also pose issues. For example, microseconds (`1_00000`),
+    dates (`01_12_1983`), credit cards (`1234_5678_9012_3456`), or identity
+    numbers such as US social security numbers (`123_45_6789`).
+    -   As we look at this, we keep finding more.
+
+Note that any regular grouping rule can present similar issues for Indian digit
+grouping conventions.
+
+[Proposal #143: Numeric literals](/proposals/p0143.md) chose 3-digit decimal
+groupings.
+
+Given there are overall advantages to not enforcing regular digit conventions,
+including for hex digits, it seems unnecessary to conform to the currently
+established decimal conventions. While this removes the enforcement, the
+resulting accidents are considered a reasonable risk.
+
+In theory a code linter could be told to prefer certain formats with options to
+change behavior, although that may remain too low benefit to implement.
+
+### 2-digit or 4-digit hexadecimal digit groupings
+
+Hexadecimal digit groupings could be enforced along two axes:
+
+-   Every 2 (`F_FF`) or 4 (`F_FFFF`) characters, corresponding to one or two
+    bytes respectively.
+-   Regular or irregular placement. For example, if a digit separator is placed
+    every byte (every other digit), we could require regular placement every
+    byte as in `FF_FF_FF_FF`, or irregular as in `FF_FFFFF_FF` which skips one
+    placement.
+
+[Proposal #143: Numeric literals](/proposals/p0143.md) chose 4-digit with
+regular placement.
+
+Advantages:
+
+-   More enforcement of digit groupings can prevent bugs and misreadings
+    resulting from accidentally incorrect groupings.
+
+Disadvantages:
+
+-   Again, microformats become an issue.
+    -   As noted in background, MAC addresses are typically in byte pairs
+        (`00_B0_D0_63_C2_26`) and UUIDs have particular groupings
+        (`123E4567_E89B_12D3_A456_426614174000`).
+-   If all of the other literal formats (decimal, real, and binary) allow
+    arbitrary digit separator placement, enforcing placement in hexadecimal
+    numbers would be an outlier.
+
+While it may be that enforcing 2 character (one byte) groupings with irregular
+placement would prevent sufficient errors versus the developer inconvenience
+risks, it risks becoming an outlier and for only very loose enforcement.
+
+Similar to the preceding conclusion, leaving these issues to code linters may be
+best.

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -104,7 +104,7 @@ Disadvantages:
 -   Microformats could also pose issues. For example, microseconds (`1_00000`),
     dates (`01_12_1983`), credit cards (`1234_5678_9012_3456`), or identity
     numbers such as US social security numbers (`123_45_6789`).
-    -   As we look at this, we keep finding more.
+    -   Since the original proposal, more cases have been raised.
 
 Note that any regular grouping rule can present similar issues for Indian digit
 grouping conventions.

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -32,7 +32,15 @@ this, remove placement rules for numeric literals.
 
 ## Problem
 
-Digit separator placement rules are too strict.
+Digit separator placement rules are too strict:
+
+-   For integers, while the original proposal mentioned Indian digit groupings,
+    Chinese, Japanese, and Korean cultures use 4-digit groupings. This oversight
+    is likely due to the description on
+    [wikipedia](https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping):
+    "but the delimiter commonly separates every three digits".
+-   There are microformats where different placement rules may be desirable. See
+    [alternatives](#alternatives-considered) for more specific examples.
 
 ## Background
 
@@ -49,16 +57,6 @@ with strict rules for placement:
     `2_147.483648e12_345` or `0x1_00CA.FEF00Dp+24`
 -   For binary literals, digit separators can appear between any two digits. For
     example, `0b1_000_101_11`.
-
-Some issues with this approach have been raised:
-
--   For integers, while the original proposal mentioned Indian digit groupings,
-    Chinese, Japanese, and Korean cultures use 4-digit groupings. This oversight
-    is likely due to the description on
-    [wikipedia](https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping):
-    "but the delimiter commonly separates every three digits".
--   There are microformats where different placement rules may be desirable. See
-    [alternatives](#alternatives-considered) for more specific examples.
 
 This was asked on
 [Issue #1485: Reconsider digit separators](https://github.com/carbon-language/carbon-lang/issues/1485),

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Alternatives considered](#alternatives-considered)
     -   [3-digit decimal groupings](#3-digit-decimal-groupings)
     -   [2-digit or 4-digit hexadecimal digit groupings](#2-digit-or-4-digit-hexadecimal-digit-groupings)
+    -   [Disallow digit separators in fractions](#disallow-digit-separators-in-fractions)
 
 <!-- tocstop -->
 
@@ -158,3 +159,25 @@ risks, it risks becoming an outlier and for only very loose enforcement.
 
 Similar to the preceding conclusion, leaving these issues to code linters may be
 best.
+
+### Disallow digit separators in fractions
+
+[Proposal #143: Numeric literals](/proposals/p0143.md) appears to disallow digit
+separators in fractions. That is, in `1.2345`, `1.23_45` is disallowed. This
+proposal changes that.
+
+Advantages:
+
+-   Reduces the chance of confusion resulting from mistaking a `.` for another
+    `_` separator, as in `1_234_567.890_123_456`.
+
+Disadvantages:
+
+-   While sometimes commas aren't written for digit separators, it's notable
+    that SI advice is to use digit spacing instead
+    ([Digit spacing, rule #16](https://physics.nist.gov/cuu/Units/checklist.html)).
+    As a consequence, it's likely common to want some kind of digit separator
+    after the decimal point.
+-   Would create an inconsistency in placement rules.
+
+We won't disallow digit separators in fractions.

--- a/proposals/p1983.md
+++ b/proposals/p1983.md
@@ -103,6 +103,10 @@ Disadvantages:
 
 -   Indian, Chinese, Japanese, and Korean digit grouping conventions don't fit
     under this rule.
+    -   These are worth considering similar to how Carbon allows
+        [unicode identifiers](/docs/design/lexical_conventions/words.md):
+        although keywords are in English, we can be more flexible for both
+        identifiers and literals.
 -   Microformats could also pose issues. For example, microseconds (`1_00000`),
     dates (`01_12_1983`), credit cards (`1234_5678_9012_3456`), or identity
     numbers such as US social security numbers (`123_45_6789`).
@@ -178,4 +182,4 @@ Disadvantages:
     after the decimal point.
 -   Would create an inconsistency in placement rules.
 
-We won't disallow digit separators in fractions.
+We'll allow digit separators in fractions.


### PR DESCRIPTION
[Proposal #143: Numeric literals](https://github.com/carbon-language/carbon-lang/blob/trunk/proposals/p0143.md) added digit separators with strict rules for placement. It missed some use-cases. In order to address this, remove placement rules for numeric literals.

Related issue: #1485 