### PR TITLE
Update leads questions process for labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ information here in our contributing guide, especially the
 ### Help comment on proposals
 
 If you're looking for a quick way to contribute, commenting on proposals is a
-way to provide proposal authors with a breadth of feedback.
-[Issues for leads](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22)
+way to provide proposal authors with a breadth of feedback. The
+["leads questions" label](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22)
 has questions the community is looking for a decision on. The
 [list of open proposals](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aopen+label%3Aproposal+draft%3Afalse)
 will have more mature proposals that are nearing a decision. For more about the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ information here in our contributing guide, especially the
 
 If you're looking for a quick way to contribute, commenting on proposals is a
 way to provide proposal authors with a breadth of feedback.
-[Issues for leads](https://github.com/carbon-language/carbon-lang/projects/2)
+[Issues for leads](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22)
 has questions the community is looking for a decision on. The
 [list of open proposals](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aopen+label%3Aproposal+draft%3Afalse)
 will have more mature proposals that are nearing a decision. For more about the

--- a/docs/project/evolution.md
+++ b/docs/project/evolution.md
@@ -333,10 +333,9 @@ to the leads to resolve. You can even do this before sending the proposal for
 review. Even after it's resolved, an open question issue can be reopened if new
 information comes up during the RFC.
 
-When opening issues, add them to the
-["Issues for leads" project](https://github.com/carbon-language/carbon-lang/projects/2)
-under "Questions". Carbon leads use this to locate and prioritize the issue for
-resolution.
+When opening issues, label them as
+[leads questions](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22).
+Carbon leads use this to locate and prioritize the issue for resolution.
 
 ### Review and RFC on proposal PRs
 
@@ -409,10 +408,8 @@ forms both the primary discussion thread and where the leads signal how it is
 resolved. We use issues both to track that there is a specific resolution
 expected and that there may be dependencies.
 
-We add blocking issues to the
-["Issues for leads" project](https://github.com/carbon-language/carbon-lang/projects/2)
-under "Blocking issues". Carbon leads use this to locate and prioritize the
-issue for resolution.
+We label blocking issues as
+[leads questions](https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22).
 
 These issues can be created at any time and by any one. Issues can be created
 while the proposal is being drafted in order to help inform specific content


### PR DESCRIPTION
Separately working on labeling everything and filing tracking issues as discussed.

For project columns, the result is:

"Blocking issues" -> gone, we haven't been using it
"Questions" -> "leads questions" label, open: https://github.com/carbon-language/carbon-lang/issues?
q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22
"Resolved" -> "leads questions" label, closed: https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aclosed+label%3A%22leads+question%22+
"Needs proposal" -> file a tracking issue, remark on the linked issue
"Deferred" -> add the "long term" label: https://github.com/carbon-language/carbon-lang/issues?q=is%3Aissue+is%3Aopen+label%3A%22leads+question%22+label%3A%22long+term%22

Note the "long term" label overlaps with the automation that reminds people when we're inactive, so it's two birds, one stone.

Part of #1898 