### PR TITLE
Numeric type literal syntax

### DIFF
--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -12,12 +12,27 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
-- [Problem](#problem)
-- [Background](#background)
-- [Proposal](#proposal)
-- [Details](#details)
-- [Rationale](#rationale)
-- [Alternatives considered](#alternatives-considered)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+    -   [Non-goals](#non-goals)
+-   [Details](#details)
+    -   [Syntax](#syntax)
+    -   [Usage](#usage)
+    -   [Syntax examples and considerations](#syntax-examples-and-considerations)
+        -   [Syntax use in common fixed-size numeric types](#syntax-use-in-common-fixed-size-numeric-types)
+        -   [Syntax use in arbitrary fixed-size numeric types](#syntax-use-in-arbitrary-fixed-size-numeric-types)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [1. C++ LP64 convention](#1-c-lp64-convention)
+        -   [1.a. Advantages:](#1a-advantages)
+        -   [1.b. Disadvantages:](#1b-disadvantages)
+    -   [2. Type name with length suffix](#2-type-name-with-length-suffix)
+        -   [2.a. Advantages:](#2a-advantages)
+        -   [2.b. Disadvantages:](#2b-disadvantages)
+    -   [3. Uppercase suffixes](#3-uppercase-suffixes)
+        -   [3.a. Advantages:](#3a-advantages)
+        -   [3.b. Disadvantages:](#3b-disadvantages)
 
 <!-- tocstop -->
 
@@ -39,33 +54,34 @@ machine register widths. These sizes typically include 8-bit, 16-bit, 32-bit,
 For example, in [C++11+](https://en.cppreference.com/w/cpp/types/integer),
 integer types such as `int8_t` (8-bit two’s complement signed integer type) and
 `uint16_t` (16-bit unsigned integer type) exist, among similar types for 32- and
-64-bit values. Correspondingly, you have the `i8`
-and `u16` ([among others](https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types))
-scalar integer types in Rust. And in Swift, the `Int8` and `UInt16` ([among
-others](https://developer.apple.com/documentation/swift/uint8)) integer value
-types.
+64-bit values. Correspondingly, you have the `i8` and `u16`
+([among others](https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types))
+scalar integer types in Rust. And in Swift, the `Int8` and `UInt16`
+([among others](https://developer.apple.com/documentation/swift/uint8)) integer
+value types.
 
 In each case, the intent is to provide a clear and pragmatic syntax.
 
-Additional discussion around this proposal's background can be found
-in [#543](https://github.com/carbon-language/carbon-lang/issues/543).
+Additional discussion around this proposal's background can be found in
+[#543](https://github.com/carbon-language/carbon-lang/issues/543).
 
 ## Proposal
 
 We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two’s
 complement integers, unsigned integers, and floating-point numbers,
-respectively. Where `N` can map to common power-of-two sizes (e.g., `N = 8, 16,
-32`) or any other fixed-width value (e.g., `N = 42`). This structure follows the
-successful precedent set by Rust and LLVM development communities and
-potentially saves 40% or more on characters required compared to other options
-such as `IntN` (e.g., `i16` vs. `Int16`).
+respectively. Where `N` can map to common power-of-two sizes (for example,
+`N = 8, 16, 32`) or any other fixed-width value (for example, `N = 42`). This
+structure follows the successful precedent set by Rust and LLVM development
+communities and potentially saves 40% or more on characters required compared to
+other options such as `IntN` (for example, `i16` versus `Int16`).
 
 ### Non-goals
 
-- This does not address any considerations around the `bool` type
-- This does not provide a formal plan for the shape or mapping of the underlying
-  types ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
-- This does not prescribe an official grammar for parsing of these types
+-   This does not address any considerations around the `bool` type
+-   This does not provide a formal plan for the shape or mapping of the
+    underlying types
+    ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
+-   This does not prescribe an official grammar for parsing of these types
 
 ## Details
 
@@ -88,9 +104,9 @@ type. And capture group 2 specifies the width in bits.
 
 Examples of this syntax include:
 
-- `i32` - A 32-bit two’s complement signed integer type
-- `u16` - A 16-bit unsigned integer type
-- `f128` - A 128-bit IEEE 754 floating-point number type
+-   `i32` - A 32-bit two’s complement signed integer type
+-   `u16` - A 16-bit unsigned integer type
+-   `f128` - A 128-bit IEEE 754 floating-point number type
 
 ### Usage
 
@@ -119,12 +135,12 @@ These fixed-width sizes will naturally cover the common register widths of 8-,
 
 Which expand to:
 
-- `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
-  `Carbon.Int(N={8,16,32,64,128})`
-- `u8`, `u16`, `u32`, `u64`, and `u128` keyword aliases for
-  `Carbon.UInt(N={8,16,32,64,128})`
-- `f16`, `f32`, `f64`, and `f128` keyword aliases for
-  `Carbon.Float(N={16,32,64,128})`
+-   `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
+    `Carbon.Int(N={8,16,32,64,128})`
+-   `u8`, `u16`, `u32`, `u64`, and `u128` keyword aliases for
+    `Carbon.UInt(N={8,16,32,64,128})`
+-   `f16`, `f32`, `f64`, and `f128` keyword aliases for
+    `Carbon.Float(N={16,32,64,128})`
 
 #### Syntax use in arbitrary fixed-size numeric types
 
@@ -135,27 +151,26 @@ size-parameterized."
 
 This adds keywords that alias the following numeric types:
 
-- `iN` for `Carbon.Int(N)`, An N-width two’s complement signed integer type
-- `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
-- `fN` for `Carbon.Float(N)`, An N-width IEEE 754 floating-point number type
+-   `iN` for `Carbon.Int(N)`, An N-width two’s complement signed integer type
+-   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
+-   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 floating-point number type
 
 ## Rationale
 
-Following Carbon’s goal to
-facilitate ["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
+Following Carbon’s goal to facilitate
+["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
 an explicit goal is to provide excellent ergonomics.
 
 Highlighting relevant aspects of this from the project goals:
 
-- *Carbon should not use symbols that are difficult to type, see, or
-  differentiate from similar symbols in commonly used contexts.*
-- *Syntax should be easily parsed and scanned by any human in any development
-  environment, not just a machine or a human aided by semantic hints from an
-  IDE.*
-- *Explicitness must be balanced against conciseness, as verbosity and ceremony
-  add cognitive overhead for the reader, while explicitness reduces the amount
-  of
-  outside context the reader must have or assume.*
+-   _Carbon should not use symbols that are difficult to type, see, or
+    differentiate from similar symbols in commonly used contexts._
+-   _Syntax should be easily parsed and scanned by any human in any development
+    environment, not just a machine or a human aided by semantic hints from an
+    IDE._
+-   _Explicitness must be balanced against conciseness, as verbosity and
+    ceremony add cognitive overhead for the reader, while explicitness reduces
+    the amount of outside context the reader must have or assume._
 
 ## Alternatives considered
 
@@ -168,44 +183,44 @@ options were considered:
 Where `char` is the 8-bit type, `short` is the 16-bit type, `int` is the 32-bit
 type, `long` is the 64-bit type.
 
-#### Advantages:
+#### 1.a. Advantages:
 
-- The type name indicates its use to the reader
-- There is an existing precedent of this pattern in many programming languages,
-  including C++
+-   The type name indicates its use to the reader
+-   There is an existing precedent of this pattern in many programming
+    languages, including C++
 
-#### Disadvantages:
+#### 1.b. Disadvantages:
 
-- The type names themselves, as compared to the actual width and potentially
-  use, often can be arbitrary and confusing
-- The names themselves can be longer than the other syntax options
+-   The type names themselves, as compared to the actual width and potentially
+    use, often can be arbitrary and confusing
+-   The names themselves can be longer than the other syntax options
 
 ### 2. Type name with length suffix
 
 Complete type name with a length-specifying suffix - `int8`, `int16`, `int32`,
 `int64`, `uint32`, `float64`.
 
-#### Advantages:
+#### 2.a. Advantages:
 
-- Are more explicit than an abbreviated version
-- Stand out against similar variable names, e.g., `i8` vs. `i = 8`)
+-   Are more explicit than an abbreviated version
+-   Stand out against similar variable names, for example, `i8` versus `i = 8`)
 
-#### Disadvantages:
+#### 2.b. Disadvantages:
 
-- Contain additional verbosity for potentially a non-significant amount of
-  clarity
-- There are precedents from other communities (e.g., Rust) that indicate authors
-  enjoy a more compact syntax
+-   Contain additional verbosity for potentially a non-significant amount of
+    clarity
+-   There are precedents from other communities (for example, Rust) that
+    indicate authors enjoy a more compact syntax
 
 ### 3. Uppercase suffixes
 
 The suffix can be upper - `Int8`, `UInt8`, `Float16`; `I8`, `U8`, `F16`.
 
-#### Advantages:
+#### 3.a. Advantages:
 
-- May help screen readers distinguish the type
+-   May help screen readers distinguish the type
 
-#### Disadvantages:
+#### 3.b. Disadvantages:
 
-- Can be visually similar to other values, e.g., `I8` vs. `l8` (second is a
-  lowercase L)
+-   Can be visually similar to other values, for example, `I8` versus `l8`
+    (second is a lowercase L)

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Problem
 
 We want to establish a syntax for fixed-size scalar number types. These types
-include the two’s complement signed integer, the unsigned integer, and the
+include the two's complement signed integer, the unsigned integer, and the
 floating-point number.
 
 As these types are pervasive throughout the language, our goal here is to align
@@ -46,7 +46,7 @@ machine register widths. These sizes typically include 8-bit, 16-bit, 32-bit,
 64-bit, and, more recently, 128-bit widths.
 
 For example, in [C++11+](https://en.cppreference.com/w/cpp/types/integer),
-integer types such as `int8_t` (8-bit two’s complement signed integer type) and
+integer types such as `int8_t` (8-bit two's complement signed integer type) and
 `uint16_t` (16-bit unsigned integer type) exist, among similar types for 32- and
 64-bit values. Correspondingly, you have the `i8` and `u16`
 ([among others](https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types))
@@ -61,7 +61,7 @@ Additional discussion around this proposal's background can be found in
 
 ## Proposal
 
-We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two’s
+We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two's
 complement integers, unsigned integers, and floating-point numbers,
 respectively. Where `N` can map to common power-of-two sizes (for example,
 `N = 8, 16, 32`) or any other fixed-width value (for example, `N = 42`). This
@@ -81,8 +81,8 @@ other options such as `IntN` (for example, `i16` versus `Int16`).
 
 ### Syntax
 
-The syntax for a two’s complement signed integer, the unsigned integer, and the
-floating-point number corresponds to a lowercase ‘i’, ‘u’, or ‘f’ character,
+The syntax for a two's complement signed integer, the unsigned integer, and the
+floating-point number corresponds to a lowercase 'i', 'u', or 'f' character,
 respectively, indicating the type followed by a numeric value specifying the
 width.
 
@@ -92,13 +92,13 @@ As a regular expression, this can be illustrated as:
 ([iuf])([1-9][0-9]*)
 ```
 
-Capture group 1 indicates either an ‘i’ for a two’s complement signed integer
-type, a ‘u’ for an unsigned integer type, or a ‘f’ for a floating-point number
+Capture group 1 indicates either an 'i' for a two's complement signed integer
+type, a 'u' for an unsigned integer type, or a 'f' for a floating-point number
 type. And capture group 2 specifies the width in bits.
 
 Examples of this syntax include:
 
--   `i32` - A 32-bit two’s complement signed integer type
+-   `i32` - A 32-bit two's complement signed integer type
 -   `u16` - A 16-bit unsigned integer type
 -   `f128` - A 128-bit IEEE 754 floating-point number type
 
@@ -117,8 +117,8 @@ fn Main() -> i32 {
 ```
 
 In the above example, `Sum` has parameters `x` and `y`, each of which is typed
-as a 32-bit two’s complement signed integer. `Main` then returns the output of
-`Sum` as a 32-bit two’s complement signed integer.
+as a 32-bit two's complement signed integer. `Main` then returns the output of
+`Sum` as a 32-bit two's complement signed integer.
 
 ### Syntax examples and considerations
 
@@ -142,20 +142,19 @@ Which expand to:
     `Carbon.Int(N={8,16,32,64,128})`
 -   `u8`, `u16`, `u32`, `u64`, and `u128` keyword aliases for
     `Carbon.UInt(N={8,16,32,64,128})`
--   `f16`, `f32`, `f64`, and `f128` keyword aliases for
-    `Carbon.Float(N={16,32,64,128})`
+-   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
 
 #### Syntax example use in arbitrary fixed-size numeric types
 
 In the more general case, this syntax can express N-width types.
 
--   `iN` for `Carbon.Int(N)`, An N-width two’s complement signed integer type
+-   `iN` for `Carbon.Int(N)`, An N-width two's complement signed integer type
 -   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
 -   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 floating-point number type
 
 ## Rationale
 
-Following Carbon’s goal to facilitate
+Following Carbon's goal to facilitate
 ["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
 an explicit goal is to provide excellent ergonomics.
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -12,53 +12,201 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
--   [Problem](#problem)
--   [Background](#background)
--   [Proposal](#proposal)
--   [Details](#details)
--   [Rationale](#rationale)
--   [Alternatives considered](#alternatives-considered)
+- [Problem](#problem)
+- [Background](#background)
+- [Proposal](#proposal)
+- [Details](#details)
+- [Rationale](#rationale)
+- [Alternatives considered](#alternatives-considered)
 
 <!-- tocstop -->
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+We want to establish a syntax for fixed-size scalar number types. These types
+include the two’s complement signed integer, the unsigned integer, and the
+floating-point number.
+
+As these types are pervasive throughout the language, our goal here is to align
+on a terse, convenient, yet understandable, and ergonomic syntax to the author.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+For developer convenience, names are given to number types that map to native
+machine register widths. These sizes typically include 8-bit, 16-bit, 32-bit,
+64-bit, and, more recently, 128-bit widths.
+
+For example, in [C++11+](https://en.cppreference.com/w/cpp/types/integer),
+integer types such as `int8_t` (8-bit two’s complement signed integer type) and
+`uint16_t` (16-bit unsigned integer type) exist, among similar types for 32- and
+64-bit values. Correspondingly, you have the `i8`
+and `u16` ([among others](https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types))
+scalar integer types in Rust. And in Swift, the `Int8` and `UInt16` ([among
+others](https://developer.apple.com/documentation/swift/uint8)) integer value
+types.
+
+In each case, the intent is to provide a pragmatic shorthand syntax to alias
+more general interfaces.
+
+Additional discussion around this proposal's background can be found
+in [#543](https://github.com/carbon-language/carbon-lang/issues/543).
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two’s
+complement integers, unsigned integers, and floating-point numbers,
+respectively. Where `N` can map to common power-of-two sizes (e.g., `N = 8, 16,
+32`) or any other fixed-width value (e.g., `N = 42`). This structure follows the
+successful precedent set by Rust and LLVM development communities and
+potentially saves 40% or more on characters required compared to other options
+such as `IntN`.
+
+### Non-goals
+
+- This does not address any considerations around the `bool` type.
+- This does not provide a plan for the shape or mapping of the underlying
+  types ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
+- This does not prescribe an official grammar for parsing of these types
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+### Syntax
+
+The syntax for a two’s complement signed integer, the unsigned integer, and the
+floating-point number corresponds to a lowercase ‘i’, ‘u’, or ‘f’ character,
+respectively, indicating the type followed by a numeric value specifying the
+width.
+
+As a regular expression, this can be formally expressed as:
+
+```re
+^([iuf])(\d+)$
+```
+
+Capture group 1 indicates either an ‘i’ for a two’s complement signed integer
+type, a ‘u’ for an unsigned integer type, or a ‘f’ for a floating-point number
+type. And capture group 2 specifies the width in bits.
+
+Examples of this include:
+
+- `i32` - A 32-bit two’s complement signed integer type
+- `u16` - A 16-bit unsigned integer type
+- `f128` - A 128-bit IEEE 754 floating-point number type
+
+### Usage
+
+```carbon
+package sample api;
+
+fn Sum(x: i32, y: i32) -> i32 {
+  return x + y;
+}
+
+fn Main() -> i32 {
+  return Sum(4, 2);
+}
+```
+
+In the above example, `Sum` has parameters `x` and `y`, each of which is typed
+as a 32-bit two’s complement signed integer. `Main` then returns the output of
+`Sum` as a 32-bit two’s complement signed integer.
+
+### Syntax Examples and Considerations
+
+#### Syntax use in common fixed-size numeric types
+
+These fixed-width sizes will naturally cover the common register widths of 8-,
+16-, 32-, 64-, and 128-bits, as seen in other languages.
+
+Which expands to:
+
+- `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
+  `Carbon.Int(N={8,16,32,64,128})`
+- `u8`, `u16`, `u32`, `u64`, and `u128` keyword aliases for
+  `Carbon.UInt(N={8,16,32,64,128})`
+- `f16`, `f32`, `f64`, and `f128` keyword aliases for
+  `Carbon.Float(N={16,32,64,128})`
+
+#### Syntax use in arbitrary fixed-size numeric types
+
+[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894)
+, our heuristic for type qualification here will be "Any truly pervasive
+non-aggregate/composite/compound type that is also fundamentally
+size-parameterized."
+
+This adds keywords that alias the following numeric types:
+
+- `iN` for `Carbon.Int(N)`, An N-width two’s complement signed integer type
+- `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
+- `fN` for `Carbon.Float(N)`, An N-width IEEE 754 floating-point number type
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
+Following Carbon’s goal to
+facilitate ["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+, an explicit goal is to provide excellent ergonomics.
 
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+Highlighting relevant aspects of this from the project goals:
+
+- *Carbon should not use symbols that are difficult to type, see, or
+  differentiate from similar symbols in commonly used contexts.*
+- *Syntax should be easily parsed and scanned by any human in any development
+  environment, not just a machine or a human aided by semantic hints from an
+  IDE.*
+- *Explicitness must be balanced against conciseness, as verbosity and ceremony
+  add cognitive overhead for the reader, while explicitness reduces the amount
+  of
+  outside context the reader must have or assume.*
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+As discussed in
+[#543](https://github.com/carbon-language/carbon-lang/issues/543), three other
+options were considered:
+
+### 1. C++ LP64 convention
+
+Where `char` is the 8-bit type, `short` is the 16-bit type, `int` is the 32-bit
+type, `long` is the 64-bit type.
+
+#### Advantages:
+
+- The type name indicates its use to the reader
+- There is an existing precedent of this pattern in many programming languages,
+  including C++
+
+#### Disadvantages:
+
+- The type names themselves, as compared to the actual width and potentially
+- use, often can be arbitrary and confusing
+- The names themselves can be longer than the other syntax options
+
+### 2. Type name with length suffix
+
+Complete type name with a length-specifying suffix - `int8`, `int16`, `int32`,
+`int64`, `uint32`, `float64`.
+
+#### Advantages:
+
+- Are more explicit than an abbreviated version
+- Stand out against similar variable names, e.g., `i8` vs. `i = 8`)
+
+#### Disadvantages:
+
+- Contain additional verbosity for potentially a non-significant amount of
+  clarity
+- There are precedents from other communities (e.g., Rust) that indicate authors
+  enjoy a more compact syntax
+
+### 3. Uppercase suffixes
+
+The suffix can be upper - `Int8`, `UInt8`, `Float16`; `I8`, `U8`, `F16`.
+
+#### Advantages:
+
+- May help screen readers distinguish the type
+
+#### Disadvantages:
+
+- Can be visually similar to other values, e.g., `I8` vs. `l8` (second is a
+  lowercase L)

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -45,8 +45,7 @@ scalar integer types in Rust. And in Swift, the `Int8` and `UInt16` ([among
 others](https://developer.apple.com/documentation/swift/uint8)) integer value
 types.
 
-In each case, the intent is to provide a pragmatic shorthand syntax to alias
-more general interfaces.
+In each case, the intent is to provide a clear and pragmatic syntax.
 
 Additional discussion around this proposal's background can be found
 in [#543](https://github.com/carbon-language/carbon-lang/issues/543).
@@ -59,12 +58,12 @@ respectively. Where `N` can map to common power-of-two sizes (e.g., `N = 8, 16,
 32`) or any other fixed-width value (e.g., `N = 42`). This structure follows the
 successful precedent set by Rust and LLVM development communities and
 potentially saves 40% or more on characters required compared to other options
-such as `IntN`.
+such as `IntN` (e.g., `i16` vs. `Int16`).
 
 ### Non-goals
 
-- This does not address any considerations around the `bool` type.
-- This does not provide a plan for the shape or mapping of the underlying
+- This does not address any considerations around the `bool` type
+- This does not provide a formal plan for the shape or mapping of the underlying
   types ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
 - This does not prescribe an official grammar for parsing of these types
 
@@ -77,7 +76,7 @@ floating-point number corresponds to a lowercase ‘i’, ‘u’, or ‘f’ ch
 respectively, indicating the type followed by a numeric value specifying the
 width.
 
-As a regular expression, this can be formally expressed as:
+As a regular expression, this can be illustrated as:
 
 ```re
 ^([iuf])(\d+)$
@@ -87,7 +86,7 @@ Capture group 1 indicates either an ‘i’ for a two’s complement signed inte
 type, a ‘u’ for an unsigned integer type, or a ‘f’ for a floating-point number
 type. And capture group 2 specifies the width in bits.
 
-Examples of this include:
+Examples of this syntax include:
 
 - `i32` - A 32-bit two’s complement signed integer type
 - `u16` - A 16-bit unsigned integer type
@@ -111,14 +110,14 @@ In the above example, `Sum` has parameters `x` and `y`, each of which is typed
 as a 32-bit two’s complement signed integer. `Main` then returns the output of
 `Sum` as a 32-bit two’s complement signed integer.
 
-### Syntax Examples and Considerations
+### Syntax examples and considerations
 
 #### Syntax use in common fixed-size numeric types
 
 These fixed-width sizes will naturally cover the common register widths of 8-,
 16-, 32-, 64-, and 128-bits, as seen in other languages.
 
-Which expands to:
+Which expand to:
 
 - `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
   `Carbon.Int(N={8,16,32,64,128})`
@@ -143,8 +142,8 @@ This adds keywords that alias the following numeric types:
 ## Rationale
 
 Following Carbon’s goal to
-facilitate ["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
-, an explicit goal is to provide excellent ergonomics.
+facilitate ["Code that is easy to read, understand, and write"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write),
+an explicit goal is to provide excellent ergonomics.
 
 Highlighting relevant aspects of this from the project goals:
 
@@ -178,7 +177,7 @@ type, `long` is the 64-bit type.
 #### Disadvantages:
 
 - The type names themselves, as compared to the actual width and potentially
-- use, often can be arbitrary and confusing
+  use, often can be arbitrary and confusing
 - The names themselves can be longer than the other syntax options
 
 ### 2. Type name with length suffix

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -98,7 +98,8 @@ As a regular expression, this can be illustrated as:
 ```
 
 Capture group 1 indicates either an 'i' for a two's complement signed integer
-type, a 'u' for an unsigned integer type, or an 'f' for a floating-point number
+type, a 'u' for an unsigned integer type, or an 'f' for an
+[IEEE-754](https://en.wikipedia.org/wiki/IEEE_754) binary floating-point number
 type. Capture group 2 specifies the width in bits. Note that this bit width is
 restricted to a multiple of 8.
 
@@ -106,7 +107,7 @@ Examples of this syntax include:
 
 -   `i16` - A 16-bit two's complement signed integer type
 -   `u32` - A 32-bit unsigned integer type
--   `f64` - A 64-bit IEEE 754 floating-point number type
+-   `f64` - A 64-bit IEEE-754 binary floating-point number type
 
 ### Usage
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -24,15 +24,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         -   [Syntax example use in arbitrary fixed-size numeric types](#syntax-example-use-in-arbitrary-fixed-size-numeric-types)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [1. C++ LP64 convention](#1-c-lp64-convention)
-        -   [1.a. Advantages:](#1a-advantages)
-        -   [1.b. Disadvantages:](#1b-disadvantages)
-    -   [2. Type name with length suffix](#2-type-name-with-length-suffix)
-        -   [2.a. Advantages:](#2a-advantages)
-        -   [2.b. Disadvantages:](#2b-disadvantages)
-    -   [3. Uppercase suffixes](#3-uppercase-suffixes)
-        -   [3.a. Advantages:](#3a-advantages)
-        -   [3.b. Disadvantages:](#3b-disadvantages)
+    -   [C++ LP64 convention](#c-lp64-convention)
+    -   [Type name with length suffix](#type-name-with-length-suffix)
+    -   [Uppercase suffixes](#uppercase-suffixes)
 
 <!-- tocstop -->
 
@@ -134,8 +128,8 @@ underlying language semantics in future numeric type additions.
 
 #### Syntax example use in common fixed-size numeric types
 
-[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894)
-, our heuristic for type qualification here will be "Any truly pervasive
+[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894),
+our heuristic for type qualification here will be "Any truly pervasive
 non-aggregate/composite/compound type that is also fundamentally
 size-parameterized."
 
@@ -182,12 +176,12 @@ As discussed in
 [#543](https://github.com/carbon-language/carbon-lang/issues/543), three other
 options were considered:
 
-### 1. C++ LP64 convention
+### C++ LP64 convention
 
 Where `char` is the 8-bit type, `short` is the 16-bit type, `int` is the 32-bit
 type, `long` is the 64-bit type.
 
-#### 1.a. Advantages:
+Advantages:
 
 -   The type name indicates its use to the reader
 -   There is an existing precedent of this pattern in many programming
@@ -195,38 +189,38 @@ type, `long` is the 64-bit type.
 -   In the case of a typo, potentially better compiler checks versus an
     abbreviated form (for example, `i332`)
 
-#### 1.b. Disadvantages:
+Disadvantages:
 
 -   The type names themselves, as compared to the actual width and potentially
     use, often can be arbitrary and confusing
 -   The names themselves can be longer than the other syntax options
 
-### 2. Type name with length suffix
+### Type name with length suffix
 
 Complete type name with a length-specifying suffix - `int8`, `int16`, `int32`,
 `int64`, `uint32`, `float64`.
 
-#### 2.a. Advantages:
+Advantages:
 
 -   Are more explicit than an abbreviated version
 -   Stand out against similar variable names, for example, `i8` versus `i = 8`)
 
-#### 2.b. Disadvantages:
+Disadvantages:
 
 -   Contain additional verbosity for potentially a non-significant amount of
     clarity
 -   There are precedents from other communities (for example, Rust) that
     indicate authors enjoy a more compact syntax
 
-### 3. Uppercase suffixes
+### Uppercase suffixes
 
 The suffix can be upper - `Int8`, `UInt8`, `Float16`; `I8`, `U8`, `F16`.
 
-#### 3.a. Advantages:
+Advantages:
 
 -   May help screen readers distinguish the type
 
-#### 3.b. Disadvantages:
+Disadvantages:
 
 -   Can be visually similar to other values, for example, `I8` versus `l8`
     (second is a lowercase L)

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -144,6 +144,9 @@ Which expands to:
     `Carbon.UInt(N={8,16,32,64,128})`
 -   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
 
+Additionally, other type sizes may be available, depending on the platform (for
+example, `x85`), such as `f80`, `f128`, or `f256`.
+
 #### Syntax example use in arbitrary fixed-size numeric types
 
 In the more general case, this syntax can express N-width types.
@@ -168,6 +171,15 @@ Highlighting relevant aspects of this from the project goals:
 -   _Explicitness must be balanced against conciseness, as verbosity and
     ceremony add cognitive overhead for the reader, while explicitness reduces
     the amount of outside context the reader must have or assume._
+
+The type system syntax must also complement Carbon's target for
+["Performance-critical software"](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#performance-critical-software)
+
+Specifically, there should be "No need for a lower level language."
+
+-   _Developers should not need to leave the rules and structure of Carbon,
+    whether to gain control over performance problems or to gain access to
+    hardware facilities._
 
 ## Alternatives considered
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -19,9 +19,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
     -   [Syntax](#syntax)
     -   [Usage](#usage)
-    -   [Syntax examples and considerations](#syntax-examples-and-considerations)
-        -   [Syntax example use in common fixed-size numeric types](#syntax-example-use-in-common-fixed-size-numeric-types)
-        -   [Syntax example use in arbitrary fixed-size numeric types](#syntax-example-use-in-arbitrary-fixed-size-numeric-types)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
     -   [C++ LP64 convention](#c-lp64-convention)
@@ -65,7 +62,8 @@ Additional discussion around this proposal's background can be found in
 We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two's
 complement integers, unsigned integers, and floating-point numbers,
 respectively. Where `N` can be a positive multiple of 8, including the common
-power-of-two sizes (for example, `N = 8, 16, 32`). This structure follows the
+power-of-two sizes (for example, `N = 8, 16, 32`). We think of these as "type
+literals" just like `7` is a "numeric literal." This structure follows the
 successful precedent set by Rust and LLVM development communities and
 potentially saves 40% or more on characters required compared to other options
 such as `IntN` (for example, `i16` versus `Int16`). While bit sizes greater than
@@ -126,43 +124,6 @@ fn Main() -> i32 {
 In the above example, `Sum` has parameters `x` and `y`, each of which is typed
 as a 32-bit two's complement signed integer. `Main` then returns the output of
 `Sum` as a 32-bit two's complement signed integer.
-
-### Syntax examples and considerations
-
-These examples are not meant to be formal mappings. They are only used to
-illustrate to the reader how the numeric type syntax may connect to the
-underlying language semantics in future numeric type additions.
-
-#### Syntax example use in common fixed-size numeric types
-
-[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894),
-our heuristic for type qualification here will be "Any truly pervasive
-non-aggregate/composite/compound type that is also fundamentally
-size-parameterized."
-
-These fixed-width sizes can naturally cover the common register widths of 8-,
-16-, 32-, 64-, and 128-bits, as seen in other languages.
-
-Which expands to:
-
--   `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
-    `Carbon.Int(N={8,16,32,64,128})`
--   `u8`, `u16`, `u32`, `u64`, and `u128` keyword aliases for
-    `Carbon.UInt(N={8,16,32,64,128})`
--   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
-
-Additionally, other type sizes may be available, depending on the platform (for
-example, [x86](https://en.wikipedia.org/wiki/X86)), such as `f80`, `f128`, or
-`f256`.
-
-#### Syntax example use in arbitrary fixed-size numeric types
-
-In the more general case, this syntax can express N-width types.
-
--   `iN` for `Carbon.Int(N)`, An N-width two's complement signed integer type
--   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
--   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 binary floating-point number
-    type
 
 ## Rationale
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -1,0 +1,64 @@
+# Numeric type literal syntax
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2015)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -98,9 +98,9 @@ type. Capture group 2 specifies the width in bits.
 
 Examples of this syntax include:
 
--   `i32` - A 32-bit two's complement signed integer type
--   `u16` - A 16-bit unsigned integer type
--   `f128` - A 128-bit IEEE 754 floating-point number type
+-   `i16` - A 16-bit two's complement signed integer type
+-   `u32` - A 32-bit unsigned integer type
+-   `f64` - A 64-bit IEEE 754 floating-point number type
 
 ### Usage
 
@@ -145,7 +145,7 @@ Which expands to:
 -   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
 
 Additionally, other type sizes may be available, depending on the platform (for
-example, `x85`), such as `f80`, `f128`, or `f256`.
+example, `x86`), such as `f80`, `f128`, or `f256`.
 
 #### Syntax example use in arbitrary fixed-size numeric types
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -63,8 +63,8 @@ Additional discussion around this proposal's background can be found in
 
 We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two's
 complement integers, unsigned integers, and floating-point numbers,
-respectively. Where `N` can map to common power-of-two sizes (for example,
-`N = 8, 16, 32`) or any other fixed-width value (for example, `N = 42`). This
+respectively. Where `N` can be a positive multiple of 8, including the
+common power-of-two sizes (for example, `N = 8, 16, 32`). This
 structure follows the successful precedent set by Rust and LLVM development
 communities and potentially saves 40% or more on characters required compared to
 other options such as `IntN` (for example, `i16` versus `Int16`).
@@ -145,7 +145,7 @@ Which expands to:
 -   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
 
 Additionally, other type sizes may be available, depending on the platform (for
-example, `x86`), such as `f80`, `f128`, or `f256`.
+example, [x86](https://en.wikipedia.org/wiki/X86)), such as `f80`, `f128`, or `f256`.
 
 #### Syntax example use in arbitrary fixed-size numeric types
 
@@ -153,7 +153,7 @@ In the more general case, this syntax can express N-width types.
 
 -   `iN` for `Carbon.Int(N)`, An N-width two's complement signed integer type
 -   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
--   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 floating-point number type
+-   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 binary floating-point number type
 
 ## Rationale
 
@@ -205,6 +205,10 @@ Disadvantages:
 -   The type names themselves, as compared to the actual width and potentially
     use often can be arbitrary and confusing
 -   The names themselves can be longer than the other syntax options
+-   Some common C++ implementations use other models, which may create confusion
+    when interoperating with C++ code. For example, Windows uses the LLP64 model,
+    where `long` is a 32-bit type, so Carbon code and C++ on Windows would have
+    different and incompatible definitions for `long`.
 
 ### Type name with length suffix
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -20,8 +20,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Syntax](#syntax)
     -   [Usage](#usage)
     -   [Syntax examples and considerations](#syntax-examples-and-considerations)
-        -   [Syntax use in common fixed-size numeric types](#syntax-use-in-common-fixed-size-numeric-types)
-        -   [Syntax use in arbitrary fixed-size numeric types](#syntax-use-in-arbitrary-fixed-size-numeric-types)
+        -   [Syntax example use in common fixed-size numeric types](#syntax-example-use-in-common-fixed-size-numeric-types)
+        -   [Syntax example use in arbitrary fixed-size numeric types](#syntax-example-use-in-arbitrary-fixed-size-numeric-types)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
     -   [1. C++ LP64 convention](#1-c-lp64-convention)
@@ -95,7 +95,7 @@ width.
 As a regular expression, this can be illustrated as:
 
 ```re
-^([iuf])(\d+)$
+([iuf])([1-9][0-9]*)
 ```
 
 Capture group 1 indicates either an ‘i’ for a two’s complement signed integer
@@ -128,9 +128,18 @@ as a 32-bit two’s complement signed integer. `Main` then returns the output of
 
 ### Syntax examples and considerations
 
-#### Syntax use in common fixed-size numeric types
+These examples are not meant to be formal mappings. They are only used to
+illustrate to the reader how the numeric type syntax may connect to the
+underlying language semantics in future numeric type additions.
 
-These fixed-width sizes will naturally cover the common register widths of 8-,
+#### Syntax example use in common fixed-size numeric types
+
+[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894)
+, our heuristic for type qualification here will be "Any truly pervasive
+non-aggregate/composite/compound type that is also fundamentally
+size-parameterized."
+
+These fixed-width sizes can naturally cover the common register widths of 8-,
 16-, 32-, 64-, and 128-bits, as seen in other languages.
 
 Which expand to:
@@ -142,14 +151,9 @@ Which expand to:
 -   `f16`, `f32`, `f64`, and `f128` keyword aliases for
     `Carbon.Float(N={16,32,64,128})`
 
-#### Syntax use in arbitrary fixed-size numeric types
+#### Syntax example use in arbitrary fixed-size numeric types
 
-[As proposed by @chandlerc](https://github.com/carbon-language/carbon-lang/issues/543#issuecomment-845620894)
-, our heuristic for type qualification here will be "Any truly pervasive
-non-aggregate/composite/compound type that is also fundamentally
-size-parameterized."
-
-This adds keywords that alias the following numeric types:
+In the more general case, this syntax can express N-width types.
 
 -   `iN` for `Carbon.Int(N)`, An N-width two’s complement signed integer type
 -   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
@@ -188,6 +192,8 @@ type, `long` is the 64-bit type.
 -   The type name indicates its use to the reader
 -   There is an existing precedent of this pattern in many programming
     languages, including C++
+-   In the case of a typo, potentially better compiler checks versus an
+    abbreviated form (for example, `i332`)
 
 #### 1.b. Disadvantages:
 

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -75,7 +75,7 @@ other options such as `IntN` (for example, `i16` versus `Int16`).
 -   This does not provide a formal plan for the shape or mapping of the
     underlying types
     ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
--   This does not prescribe an official grammar for parsing of these types
+-   This does not prescribe an official grammar for parsing these types
 
 ## Details
 
@@ -93,8 +93,8 @@ As a regular expression, this can be illustrated as:
 ```
 
 Capture group 1 indicates either an 'i' for a two's complement signed integer
-type, a 'u' for an unsigned integer type, or a 'f' for a floating-point number
-type. And capture group 2 specifies the width in bits.
+type, a 'u' for an unsigned integer type, or an 'f' for a floating-point number
+type. Capture group 2 specifies the width in bits.
 
 Examples of this syntax include:
 
@@ -136,7 +136,7 @@ size-parameterized."
 These fixed-width sizes can naturally cover the common register widths of 8-,
 16-, 32-, 64-, and 128-bits, as seen in other languages.
 
-Which expand to:
+Which expands to:
 
 -   `i8`, `i16`, `i32`, `i64`, and `i128` keyword aliases for
     `Carbon.Int(N={8,16,32,64,128})`
@@ -191,7 +191,7 @@ Advantages:
 Disadvantages:
 
 -   The type names themselves, as compared to the actual width and potentially
-    use, often can be arbitrary and confusing
+    use often can be arbitrary and confusing
 -   The names themselves can be longer than the other syntax options
 
 ### Type name with length suffix

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -27,6 +27,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [C++ LP64 convention](#c-lp64-convention)
     -   [Type name with length suffix](#type-name-with-length-suffix)
     -   [Uppercase suffixes](#uppercase-suffixes)
+    -   [Additional bit sizes](#additional-bit-sizes)
 
 <!-- tocstop -->
 
@@ -63,11 +64,11 @@ Additional discussion around this proposal's background can be found in
 
 We introduce a simple keyword-like syntax of `iN`, `uN`, and `fN` for two's
 complement integers, unsigned integers, and floating-point numbers,
-respectively. Where `N` can be a positive multiple of 8, including the
-common power-of-two sizes (for example, `N = 8, 16, 32`). This
-structure follows the successful precedent set by Rust and LLVM development
-communities and potentially saves 40% or more on characters required compared to
-other options such as `IntN` (for example, `i16` versus `Int16`).
+respectively. Where `N` can be a positive multiple of 8, including the common
+power-of-two sizes (for example, `N = 8, 16, 32`). This structure follows the
+successful precedent set by Rust and LLVM development communities and
+potentially saves 40% or more on characters required compared to other options
+such as `IntN` (for example, `i16` versus `Int16`).
 
 ### Non-goals
 
@@ -76,6 +77,8 @@ other options such as `IntN` (for example, `i16` versus `Int16`).
     underlying types
     ([#767 comments](https://github.com/carbon-language/carbon-lang/issues/767#issuecomment-1214153375))
 -   This does not prescribe an official grammar for parsing these types
+-   This proposal does not address other, non-multiple of 8 bit sizes, such as
+    those used in a bit field
 
 ## Details
 
@@ -94,7 +97,8 @@ As a regular expression, this can be illustrated as:
 
 Capture group 1 indicates either an 'i' for a two's complement signed integer
 type, a 'u' for an unsigned integer type, or an 'f' for a floating-point number
-type. Capture group 2 specifies the width in bits.
+type. Capture group 2 specifies the width in bits. Note that this bit width is
+restricted to a multiple of 8.
 
 Examples of this syntax include:
 
@@ -145,7 +149,8 @@ Which expands to:
 -   `f16`, `f32`, and `f64` keyword aliases for `Carbon.Float(N={16,32,64})`
 
 Additionally, other type sizes may be available, depending on the platform (for
-example, [x86](https://en.wikipedia.org/wiki/X86)), such as `f80`, `f128`, or `f256`.
+example, [x86](https://en.wikipedia.org/wiki/X86)), such as `f80`, `f128`, or
+`f256`.
 
 #### Syntax example use in arbitrary fixed-size numeric types
 
@@ -153,7 +158,8 @@ In the more general case, this syntax can express N-width types.
 
 -   `iN` for `Carbon.Int(N)`, An N-width two's complement signed integer type
 -   `uN` for `Carbon.UInt(N)`, An N-width unsigned integer type
--   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 binary floating-point number type
+-   `fN` for `Carbon.Float(N)`, An N-width IEEE 754 binary floating-point number
+    type
 
 ## Rationale
 
@@ -184,7 +190,7 @@ Specifically, there should be "No need for a lower level language."
 ## Alternatives considered
 
 As discussed in
-[#543](https://github.com/carbon-language/carbon-lang/issues/543), three other
+[#543](https://github.com/carbon-language/carbon-lang/issues/543), four other
 options were considered:
 
 ### C++ LP64 convention
@@ -206,9 +212,9 @@ Disadvantages:
     use often can be arbitrary and confusing
 -   The names themselves can be longer than the other syntax options
 -   Some common C++ implementations use other models, which may create confusion
-    when interoperating with C++ code. For example, Windows uses the LLP64 model,
-    where `long` is a 32-bit type, so Carbon code and C++ on Windows would have
-    different and incompatible definitions for `long`.
+    when interoperating with C++ code. For example, Windows uses the LLP64
+    model, where `long` is a 32-bit type, so Carbon code and C++ on Windows
+    would have different and incompatible definitions for `long`.
 
 ### Type name with length suffix
 
@@ -239,3 +245,24 @@ Disadvantages:
 
 -   Can be visually similar to other values, for example, `I8` versus `l8`
     (second is a lowercase L)
+
+### Additional bit sizes
+
+Support for additional bit sizes such as all bit sizes or common powers of two.
+
+Advantages:
+
+-   Adds flexibility and convenience for further use cases such as bit fields
+
+Disadvantages:
+
+-   May increase chances of typos without strong compiler guards, for example,
+    `i32` versus `i22` versus `i23`
+-   Variables such as `i1` and `i2` already exist in C++ code in practice
+    ([example1](https://github.com/google/googletest/blob/main/googlemock/include/gmock/gmock-matchers.h#L878),
+    [example2](https://chromium.googlesource.com/external/github.com/abseil/abseil-cpp/+/HEAD/absl/container/btree_test.cc#2772),
+    [example3](https://sourcegraph.com/search?q=context:global+lang:c%2B%2B+%5Ei1%24+type:symbol&patternType=regexp&case=yes))
+-   Adds complexity through additional size rules, for example, we can't support
+    pointers to arbitrary bits
+-   Adds confusion in syntactical overlap, for example, `i1`, `il`, `i18`, and
+    `i18n`

--- a/proposals/p2015.md
+++ b/proposals/p2015.md
@@ -68,7 +68,9 @@ respectively. Where `N` can be a positive multiple of 8, including the common
 power-of-two sizes (for example, `N = 8, 16, 32`). This structure follows the
 successful precedent set by Rust and LLVM development communities and
 potentially saves 40% or more on characters required compared to other options
-such as `IntN` (for example, `i16` versus `Int16`).
+such as `IntN` (for example, `i16` versus `Int16`). While bit sizes greater than
+128-bits will be well-supported, some operations like division will not be
+available on these large sizes.
 
 ### Non-goals
 


### PR DESCRIPTION
This proposal aims to add a literal syntax for fixed-sized numeric types: integers, unsigned integers, and floating-point numbers.

Related issue: https://github.com/carbon-language/carbon-lang/issues/1998