### PR TITLE
docs: fix typo in generics overview.md

### DIFF
--- a/docs/design/generics/overview.md
+++ b/docs/design/generics/overview.md
@@ -493,7 +493,7 @@ cast from `T` to `CDCover`.
 
 ### Adapting types
 
-Carbon has a mechanism called [adapting types](terminology.md#adapting-a-type))
+Carbon has a mechanism called [adapting types](terminology.md#adapting-a-type)
 to create new types that are [compatible](terminology.md#compatible-types) with
 existing types but with different interface implementations. This could be used
 to add or replace implementations, or define implementations for reuse.


### PR DESCRIPTION
PR for tiny fix to generics overview doc, as suggest here: https://github.com/carbon-language/carbon-lang/pull/1885/files#r943743464