### PR TITLE
C++ Interop: Reserved identifiers

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1827,6 +1827,13 @@ and starts with a letter. We intend to follow
 identifier characters, but a concrete set of valid characters has not been
 selected yet.
 
+The following names are reserved for internal Carbon implementation specifics,
+and to allow seamless interoperability with C++ codebases:
+
+-   Names with a double underscore anywhere are reserved;
+-   Names that begin with an underscore followed by an uppercase letter are
+    reserved.
+
 > References:
 >
 > -   [Lexical conventions](lexical_conventions)
@@ -1836,7 +1843,8 @@ selected yet.
 > -   Question-for-leads issue
 >     [#472: Open question: Calling functions defined later in the same file](https://github.com/carbon-language/carbon-lang/issues/472)
 > -   Proposal
->     [#875: Principle: information accumulation](https://github.com/carbon-language/carbon-lang/pull/875)
+>     [#875: Principle: information accumulation](https://github.com/carbon-language/carbon-lang/pull/875) >
+>     [#2029: C++ Interop: Reserved identifiers](https://github.com/carbon-language/carbon-lang/pull/2029)
 
 ### Files, libraries, packages
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1825,14 +1825,8 @@ A name in Carbon is formed from a sequence of letters, numbers, and underscores,
 and starts with a letter. We intend to follow
 [Unicode's Annex 31](https://unicode.org/reports/tr31/) in selecting valid
 identifier characters, but a concrete set of valid characters has not been
-selected yet.
-
-The following names are reserved for internal Carbon implementation specifics,
-and to allow seamless interoperability with C++ codebases:
-
--   Names with a double underscore anywhere are reserved;
--   Names that begin with an underscore followed by an uppercase letter are
-    reserved.
+selected yet. Carbon reserves certain sets of names for C++ interoperability and
+internal implementation purposes.
 
 > References:
 >

--- a/docs/design/lexical_conventions/words.md
+++ b/docs/design/lexical_conventions/words.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 -   [Overview](#overview)
 -   [Keywords](#keywords)
+-   [Identifiers](#identifiers)
 -   [Alternatives considered](#alternatives-considered)
 -   [References](#references)
 
@@ -81,6 +82,15 @@ The following words are interpreted as keywords:
 -   `virtual`
 -   `where`
 -   `while`
+
+## Identifiers
+
+The following identifiers are reserved for internal Carbon implementation
+specifics, and to allow seamless interoperability with C++ codebases:
+
+-   Identifiers with a double underscore anywhere are reserved;
+-   Identifiers that begin with an underscore followed by an uppercase letter
+    are reserved.
 
 ## Alternatives considered
 

--- a/proposals/p2029.md
+++ b/proposals/p2029.md
@@ -1,0 +1,64 @@
+# C++ Interop: Reserved identifiers
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2029)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2029.md
+++ b/proposals/p2029.md
@@ -23,42 +23,81 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+C++ reserves certain sets of identifiers for implementation-specific use. Carbon
+must ensure it respects these reserved identifiers to enable seamless and
+error-free interoperability with C++. Equally, it would be prudent to define a
+set of identifiers which are reserved for internal Carbon implementation usage.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+The full set of C++ reserved identifiers is listed
+[here](https://en.cppreference.com/w/cpp/language/identifiers). This proposal is
+solely considering the set of user-definable identifiers which are considered
+names in C++:
+
+-   Identifiers with a double underscore anywhere are reserved;
+-   Identifiers that begin with an underscore followed by an uppercase letter
+    are reserved;
+-   Identifiers that begin with an underscore are reserved in the global
+    namespace.
+
+Considerations for reserved keywords are discussed in
+[p0093](https://github.com/carbon-language/carbon-lang/pull/93).
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Carbon reserves the following identifiers in the specified contexts:
+
+-   Identifiers with a double underscore anywhere are reserved;
+-   Identifiers that begin with an underscore followed by an uppercase letter
+    are reserved.
+
+Carbon toolchains are expected to emit an error when a reserved identifier is
+encountered. This will remove the risk of undefined / unexpected runtime
+behaviour, or name resolution clashes when linking with C++ libraries.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+This proposal makes use of three assumptions:
+
+1. A Carbon package exporting a C++ header will be scoped in a C++ namespace
+   following the package name;
+2. All C++ imports to Carbon will exist within the package `Cpp` which
+   represents the root of the C++ global namespace.
+3. The default Carbon package can not be exported to C++, following the
+   [no other library can import this library even from within the default package](/docs/design/README.md#files-libraries-packages)
+   rule.
+
+The stated reserved identifiers for Carbon ensure that there will be no
+user-defined identifier clashes between Carbon and C++ in either
+interoperability direction. As Carbon does not have a global namespace, and
+assumption 2 above explicitly gives the C++ global namespace a named scope
+within Carbon, there is no need to consider a Carbon equivalent of the C++
+_Identifiers that begin with an underscore are reserved in the global namespace_
+reservation.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+This proposal supports the
+[Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+goal. It also provides a reserved identifier space for Carbon internal
+implementation specifics.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+It was considered to not place any user-visible restrictions on identifiers, and
+handle conflict resolution or avoidance at interop boundaries. This was
+dismissed as this would require automatic re-writing of reserved-in-C++
+identifiers, deferring identification of name resolution issues to link time, or
+allowing undefined behaviour to occur.
+
+Re-writing identifiers raises a number of issues: This would need strong
+guarantees to be deterministic across compilation units; it would result in
+unexpected-to-the-user identifiers being present when using binary inspection
+tools; it would need programmers to track re-written names manually in C++ code
+importing Carbon export headers; and would add complication to tooling to
+provide user-friendly interpretation of the re-written identfiers (especially
+for debugging).
+
+Undefined behaviour due to unrecognised identifier clashes would be counter to
+the seamless C++ interoperability goal.


### PR DESCRIPTION
This proposal reserves a space of identifiers to enable smooth and error-free C++ interop, and to provide a reserved namespace for internal Carbon implementation specifics.