### PR TITLE
Move an llvm::Error return value instead of copying it.

### DIFF
--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -36,7 +36,7 @@ auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
   std::string buffer = text.str();
   auto size_check = CheckContentSize(buffer.size());
   if (size_check) {
-    return size_check;
+    return std::move(size_check);
   }
   return SourceBuffer(filename.str(), std::move(buffer));
 }
@@ -74,7 +74,7 @@ auto SourceBuffer::CreateFromFile(llvm::StringRef filename)
   }
   auto size_check = CheckContentSize(size);
   if (size_check) {
-    return size_check;
+    return std::move(size_check);
   }
 
   errno = 0;


### PR DESCRIPTION
Summary:
Fixes a small compilation error where an llvm::Error variable was being
returned by copy rather than by move. The llvm::Error copy constructor
is deleted.