### PR TITLE
Fix source code location on dynamic unformed check of `ReturnVar`.

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1720,7 +1720,8 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
         return todo_.FinishAction();
       }
     case StatementKind::ReturnVar: {
-      const ValueNodeView& value_node = cast<ReturnVar>(stmt).value_node();
+      const auto& ret_var = cast<ReturnVar>(stmt);
+      const ValueNodeView& value_node = ret_var.value_node();
       if (trace_stream_) {
         **trace_stream_ << "--- step returned var "
                         << cast<BindingPattern>(value_node.base()).name()
@@ -1731,8 +1732,7 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
                               todo_.ValueOfNode(value_node, stmt.source_loc()));
       if (const auto* lvalue = dyn_cast<LValue>(value)) {
         CARBON_ASSIGN_OR_RETURN(
-            value,
-            heap_.Read(lvalue->address(), value_node.base().source_loc()));
+            value, heap_.Read(lvalue->address(), ret_var.source_loc()));
       }
       const FunctionDeclaration& function = cast<Return>(stmt).function();
       CARBON_ASSIGN_OR_RETURN(

--- a/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
@@ -11,11 +11,11 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/unformed/dynamic/fail_returned_var.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   returned var x: i32;
   if (0 == 1) {
     x = 0;
   }
   // Static analysis thinks `x` may be formed, defer the check to run-time.
+  // CHECK: RUNTIME ERROR: {{.*}}/explorer/testdata/unformed/dynamic/fail_returned_var.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return var;
 }


### PR DESCRIPTION
The error message should point to the source code location of `ReturnVar`, instead of the declaration of the `returned var`.