### PR TITLE
Unicode char limit

### DIFF
--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -338,6 +338,10 @@ string in the type system. In such string literals, we should consider rejecting
     -   [Leading whitespace removal](/proposals/p0199.md#leading-whitespace-removal)
     -   [Terminating newline](/proposals/p0199.md#terminating-newline)
 -   [Escape sequences](/proposals/p0199.md#escape-sequences-1)
+    -   Unicode escape sequences:
+        -   [Allow zero digits](/proposals/p2040.md#allow-zero-digits)
+        -   [Allow any number of hexadecimal characters](/proposals/p2040.md#allow-any-number-of-hexadecimal-characters)
+        -   [Limiting to 6 digits versus 8](/proposals/p2040.md#limiting-to-6-digits-versus-8)
 -   [Raw string literals](/proposals/p0199.md#raw-string-literals-1)
     -   [Trailing whitespace](/proposals/p0199.md#trailing-whitespace)
     -   [Line separators](/proposals/p0199.md#line-separators)

--- a/docs/design/lexical_conventions/string_literals.md
+++ b/docs/design/lexical_conventions/string_literals.md
@@ -204,8 +204,8 @@ While octal escape sequences are expected to remain not permitted (even though
 In the above table, `H` represents an arbitrary hexadecimal character, `0`-`9`
 or `A`-`F` (case-sensitive). Unlike in C++, but like in Python, `\x` expects
 exactly two hexadecimal digits. As in JavaScript, Rust, and Swift, Unicode code
-points can be expressed by number using `\u{10FFFF}` notation, which accepts any
-number of hexadecimal characters. Any numeric code point in the ranges
+points can be expressed by number using `\u{10FFFF}` notation. This accepts
+between 1 and 8 hexadecimal characters. Any numeric code point in the ranges
 0<sub>16</sub>-D7FF<sub>16</sub> or E000<sub>16</sub>-10FFFF<sub>16</sub> can be
 expressed this way.
 
@@ -347,3 +347,5 @@ string in the type system. In such string literals, we should consider rejecting
 
 -   Proposal
     [#199: String literals](https://github.com/carbon-language/carbon-lang/pull/199)
+-   Proposal
+    [#2040: Unicode escape code length](https://github.com/carbon-language/carbon-lang/pull/2040)

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -1,0 +1,64 @@
+# Unicode char limit
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2040)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
+-   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
@@ -22,6 +23,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Limiting to 6 digits versus 8](#limiting-to-6-digits-versus-8)
 
 <!-- tocstop -->
+
+## Abstract
+
+The `\u{HHHH...}` can be an arbitrary length, potentially including `\u{}`.
+Restrict to 1 to 8 characters.
 
 ## Problem
 

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -15,50 +15,87 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
--   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Allow empty tokens](#allow-empty-tokens)
+    -   [Allow any number of hexadecimal characters](#allow-any-number-of-hexadecimal-characters)
+    -   [Limiting to 6 digits versus 8](#limiting-to-6-digits-versus-8)
 
 <!-- tocstop -->
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+[Proposal #199: String literals](https://github.com/carbon-language/carbon-lang/pull/199)
+says "any number of hexadecimal characters" is valid for `\u{HHHH}`. This is
+undesirable, because it means `\u{000 ... 000E9}` is a valid escape sequence,
+for any number of `0` characters. Additionally, it's not clear if `\u{}` is
+meant to be valid.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+[Proposal #199: String literals](https://github.com/carbon-language/carbon-lang/pull/199)
+says:
+
+> As in JavaScript, Rust, and Swift, Unicode code points can be expressed by
+> number using `\u{10FFFF}` notation, which accepts any number of hexadecimal
+> characters. Any numeric code point in the ranges
+> 0<sub>16</sub>-D7FF<sub>16</sub> or E000<sub>16</sub>-10FFFF<sub>16</sub> can
+> be expressed this way.
+
+When it comes to the number of digits, the languages differ:
+
+-   In [JavaScript](https://262.ecma-international.org/13.0/#prod-CodePoint),
+    between 1 and 6 digits are supported, and it must be less than or equal to
+    `10FFFF`.
+-   In [Rust](https://doc.rust-lang.org/reference/tokens.html), between 1 and 6
+    digits are supported.
+-   In
+    [Swift](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html),
+    between 1 and 8 digits are supported.
+
+Unicode's codespace is 0 to [`10FFFF`](https://unicode.org/glossary/#codespace).
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
-
-## Details
-
-TODO: Fully explain the details of the proposed solution.
+The `\u{H...}` syntax is only valid for 1 to 8 unicode characters.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+    -   This restriction does not affect the ability to write valid Unicode.
+        Instead, it restricts the ability to write confusing or invalid unicode,
+        which should make it easier to detect errors.
 -   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+    -   Simplifies tooling by reducing the number of syntaxes that need to be
+        supported, and allowing early failure on obviously invalid inputs.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+### Allow empty tokens
+
+We could allow `\u{}` as a version of `\u{0}`. However, as shorthand, it doesn't
+save much and `\x00` is both equal length and clearer.
+
+Rather than allowing this syntax, we prefer to disallow it for consistency with
+other languages.
+
+### Allow any number of hexadecimal characters
+
+We could allow any number of digits in the `\u` escape. However, this has the
+consequence of requiring parsing of escapes of completely arbitrary length. This
+creates unnecessary complexity in the parser because we need to consider what
+happens if the result is greater than 32 bits, significantly larger than
+unicode's current `10FFFF` limit.
+
+One way to do this would be to store the result in a 32-bit integer and keep
+parsing until the value goes above `10FFFF`, then error as valid if that's
+exceeded. However, it should make it easier to write a simple parser if we
+instead limit the number of digits to a reasonable amount.
+
+### Limiting to 6 digits versus 8
+
+A limit of 6 digits offers a reasonable limit as the minimum needed to represent
+Unicode's codespace. A limit of 8 digits offers a reasonable limit as a standard
+4-byte value, and roughly matches UTF-32.
+
+While it seems a weak advantage, this proposal leans towards 8.

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -94,7 +94,8 @@ This creates unnecessary complexity in the parser because we need to consider
 what happens if the result is greater than 32 bits, significantly larger than
 unicode's current `10FFFF` limit. One way to do this would be to store the
 result in a 32-bit integer and keep parsing until the value goes above `10FFFF`,
-then error as invalid if that's exceeded.
+then error as invalid if that's exceeded. This would allow an arbitrary number
+of leading `0`'s to correctly parse.
 
 It should make it easier to write a simple parser if we instead limit the number
 of digits to a reasonable amount.

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -1,4 +1,4 @@
-# Unicode char limit
+# Unicode escape code length
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -94,7 +94,7 @@ happens if the result is greater than 32 bits, significantly larger than
 unicode's current `10FFFF` limit.
 
 One way to do this would be to store the result in a 32-bit integer and keep
-parsing until the value goes above `10FFFF`, then error as valid if that's
+parsing until the value goes above `10FFFF`, then error as invalid if that's
 exceeded. However, it should make it easier to write a simple parser if we
 instead limit the number of digits to a reasonable amount.
 

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Proposal](#proposal)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
-    -   [Allow empty tokens](#allow-empty-tokens)
+    -   [Allow zero digits](#allow-zero-digits)
     -   [Allow any number of hexadecimal characters](#allow-any-number-of-hexadecimal-characters)
     -   [Limiting to 6 digits versus 8](#limiting-to-6-digits-versus-8)
 
@@ -77,7 +77,7 @@ The `\u{H...}` syntax is only valid for 1 to 8 unicode characters.
 
 ## Alternatives considered
 
-### Allow empty tokens
+### Allow zero digits
 
 We could allow `\u{}` as a version of `\u{0}`. However, as shorthand, it doesn't
 save much and `\x00` is both equal length and clearer.

--- a/proposals/p2040.md
+++ b/proposals/p2040.md
@@ -88,15 +88,16 @@ other languages.
 ### Allow any number of hexadecimal characters
 
 We could allow any number of digits in the `\u` escape. However, this has the
-consequence of requiring parsing of escapes of completely arbitrary length. This
-creates unnecessary complexity in the parser because we need to consider what
-happens if the result is greater than 32 bits, significantly larger than
-unicode's current `10FFFF` limit.
+consequence of requiring parsing of escapes of completely arbitrary length.
 
-One way to do this would be to store the result in a 32-bit integer and keep
-parsing until the value goes above `10FFFF`, then error as invalid if that's
-exceeded. However, it should make it easier to write a simple parser if we
-instead limit the number of digits to a reasonable amount.
+This creates unnecessary complexity in the parser because we need to consider
+what happens if the result is greater than 32 bits, significantly larger than
+unicode's current `10FFFF` limit. One way to do this would be to store the
+result in a 32-bit integer and keep parsing until the value goes above `10FFFF`,
+then error as invalid if that's exceeded.
+
+It should make it easier to write a simple parser if we instead limit the number
+of digits to a reasonable amount.
 
 ### Limiting to 6 digits versus 8
 


### PR DESCRIPTION
The `\u{HHHH...}` can be an arbitrary length, potentially including `\u{}`.
Restrict to 1 to 8 characters.
