### PR TITLE
Specify specific source for pulling homebrew container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ARG TAG=3.5.6
-FROM homebrew/brew:${TAG}
+FROM docker.io/homebrew/brew:${TAG}
 
 # Install libxcrypt using Homebrew.
 RUN brew install libxcrypt --overwrite


### PR DESCRIPTION
## Description

- Since VS Code Dev container extention has a non-interactive shell, user
cannot select a specific image if there are multiple images under same
named authors.
- This fix ensures that images are only pulled from Docker Hub and no
interactive menu is presented.
- References: #1816, #1817
- Fixes #2043

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>
