### PR TITLE
Always `==` not `=` in `where` clauses

### DIFF
--- a/docs/design/expressions/arithmetic.md
+++ b/docs/design/expressions/arithmetic.md
@@ -205,7 +205,7 @@ interface AddWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint Add {
-  extends AddWith(Self) where .Result = Self;
+  extends AddWith(Self) where .Result == Self;
 }
 ```
 
@@ -216,7 +216,7 @@ interface SubWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint Sub {
-  extends SubWith(Self) where .Result = Self;
+  extends SubWith(Self) where .Result == Self;
 }
 ```
 
@@ -227,7 +227,7 @@ interface MulWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint Mul {
-  extends MulWith(Self) where .Result = Self;
+  extends MulWith(Self) where .Result == Self;
 }
 ```
 
@@ -238,7 +238,7 @@ interface DivWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint Div {
-  extends DivWith(Self) where .Result = Self;
+  extends DivWith(Self) where .Result == Self;
 }
 ```
 
@@ -249,7 +249,7 @@ interface ModWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint Mod {
-  extends ModWith(Self) where .Result = Self;
+  extends ModWith(Self) where .Result == Self;
 }
 ```
 

--- a/docs/design/expressions/bitwise.md
+++ b/docs/design/expressions/bitwise.md
@@ -209,7 +209,7 @@ interface BitAndWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint BitAnd {
-  extends BitAndWith(Self) where .Result = Self;
+  extends BitAndWith(Self) where .Result == Self;
 }
 ```
 
@@ -220,7 +220,7 @@ interface BitOrWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint BitOr {
-  extends BitOrWith(Self) where .Result = Self;
+  extends BitOrWith(Self) where .Result == Self;
 }
 ```
 
@@ -231,7 +231,7 @@ interface BitXorWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint BitXor {
-  extends BitXorWith(Self) where .Result = Self;
+  extends BitXorWith(Self) where .Result == Self;
 }
 ```
 
@@ -242,7 +242,7 @@ interface LeftShiftWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint LeftShift {
-  extends LeftShiftWith(Self) where .Result = Self;
+  extends LeftShiftWith(Self) where .Result == Self;
 }
 ```
 
@@ -253,7 +253,7 @@ interface RightShiftWith(U:! Type) {
   fn Op[me: Self](other: U) -> Result;
 }
 constraint RightShift {
-  extends RightShiftWith(Self) where .Result = Self;
+  extends RightShiftWith(Self) where .Result == Self;
 }
 ```
 

--- a/docs/design/expressions/member_access.md
+++ b/docs/design/expressions/member_access.md
@@ -305,7 +305,7 @@ interface Addable {
   // #1
   fn Add[me: Self](other: Self) -> Self;
   // #2
-  default fn Sum[Seq:! Iterable where .ValueType = Self](seq: Seq) -> Self {
+  default fn Sum[Seq:! Iterable where .ValueType == Self](seq: Seq) -> Self {
     // ...
   }
 }
@@ -372,7 +372,7 @@ interface I {
   let N:! i32;
 }
 class C {
-  impl as I where .N = 5 {
+  impl as I where .N == 5 {
     // #2
     fn F[me: C]() {}
   }

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -2607,7 +2607,8 @@ fn Contains
 ```
 
 A constraint setting an associated type to a concrete type, like
-`where .ElementType == String`, gives `.ElementType` the complete `String` API.
+`where .ElementType == String`, gives `.ElementType` the complete `String` API,
+in addition to any API from the type of `ElementType`.
 
 #### Type bound for associated type
 

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -2440,8 +2440,8 @@ naming some classes of constraints.
 #### Set an associated constant to a specific value
 
 We might need to write a function that only works with a specific value of an
-[associated constant](#associated-constants) `N`. In this case, the name of the
-associated constant is written first, followed by an `==`, and then the value:
+[associated constant](#associated-constants) `N`. Write the name of the
+associated constant and the value with an `==` between them:
 
 ```
 fn PrintPoint2D[PointT:! NSpacePoint where .N == 2](p: PointT) {
@@ -2456,6 +2456,9 @@ interface Has2DPoint {
   let PointT:! NSpacePoint where .N == 2;
 }
 ```
+
+There must exist an implicit conversion from the constant value to the type of
+the associated constant.
 
 To name such a constraint, you may use a `let` or a `constraint` declaration:
 
@@ -2483,6 +2486,7 @@ interface PointCloud {
 ```
 
 In this case, the types of the two associated constants must be compatible.
+Either they most both be associated types or have the same type.
 
 ```
 interface C { let A:! Type; }
@@ -2491,11 +2495,6 @@ interface D { let B:! i32; }
 //           with type of U.B == i32.
 fn F[U:! D, T:! C where .A == U.B]();
 ```
-
-FIXME: What is the definition of compatible? Could be having an implicit
-conversion from one to the other, use the same unification rules as
-`if`...`then`...`else` uses, or having a defined `==` operator overload between
-the two types.
 
 #### Same type constraints
 

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -5638,3 +5638,4 @@ parameter, as opposed to an associated type, as in `N:! u32 where ___ >= 2`.
 -   [#1144: Generic details 11: operator overloading](https://github.com/carbon-language/carbon-lang/pull/1144)
 -   [#1146: Generic details 12: parameterized types](https://github.com/carbon-language/carbon-lang/pull/1146)
 -   [#1327: Generics: `impl forall`](https://github.com/carbon-language/carbon-lang/pull/1327)
+-   [#2070: Always `==` not `=` in `where` clauses](https://github.com/carbon-language/carbon-lang/pull/2070)

--- a/docs/design/generics/overview.md
+++ b/docs/design/generics/overview.md
@@ -610,7 +610,7 @@ of associated types (and other associated constants).
 
 ```
 class Vector(T:! Movable) {
-  impl as Stack where .ElementType = T { ... }
+  impl as Stack where .ElementType == T { ... }
 }
 ```
 

--- a/docs/design/generics/terminology.md
+++ b/docs/design/generics/terminology.md
@@ -705,9 +705,9 @@ interface AddWith(T:! Type) {
 An `i32` value might support addition with `i32`, `u16`, and `f64` values.
 
 ```
-impl i32 as AddWith(i32) where .ResultType = i32 { ... }
-impl i32 as AddWith(u16) where .ResultType = i32 { ... }
-impl i32 as AddWith(f64) where .ResultType = f64 { ... }
+impl i32 as AddWith(i32) where .ResultType == i32 { ... }
+impl i32 as AddWith(u16) where .ResultType == i32 { ... }
+impl i32 as AddWith(f64) where .ResultType == f64 { ... }
 ```
 
 To write a generic function requiring a parameter to be `AddWith`, there needs

--- a/proposals/p2070.md
+++ b/proposals/p2070.md
@@ -135,3 +135,8 @@ interface Has2DPoint {
   let PointT:! NSpacePoint where .N = 2;
 }
 ```
+
+Using `=` in a `where` clause to specify the values of associated types in an
+`impl` declaration would be a bit less surprising. For now we are going to try
+always using `==`, but that is one situation where we might later switch to use
+`=`.

--- a/proposals/p2070.md
+++ b/proposals/p2070.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [`=` instead of `==`](#-instead-of-)
 
 <!-- tocstop -->
 
@@ -112,12 +113,25 @@ develop
 ## Alternatives considered
 
 Mainly this proposal is being evaluated against the status quo of the existing
-design. However, we did consider which of `=` and `==` to use. The main
-advantages of `=` were:
+design.
+
+### `=` instead of `==`
+
+We did consider which of `=` and `==` to use. The main advantages of `=` were:
 
 -   it is shorter,
 -   it is arguably more natural when defining an implementation, and
 -   we found ourselves reaching for `=` more often in examples.
 
 Instead, `==` was chosen for consistency since it looked like a constraint,
-since it resulted in a boolean expression like other `where` clauses.
+since it resulted in a boolean expression like other `where` clauses. `==`
+avoids confusion with an initializer after a type expression in `var` or `let`
+statement. It also arises with an associated constants that could have a default
+value, as in:
+
+```
+interface Has2DPoint {
+  // Is 2 a default value or part of the `where` constraint?
+  let PointT:! NSpacePoint where .N = 2;
+}
+```

--- a/proposals/p2070.md
+++ b/proposals/p2070.md
@@ -58,6 +58,8 @@ That was not chosen because the `=` and `==` cases were given different (but
 similar) semantics.
 
 After #818 was accepted, proposal
+[#950](https://github.com/carbon-language/carbon-lang/pull/950) removed some of
+the semantic differences. Further, proposal
 [#989: Member access expressions](https://github.com/carbon-language/carbon-lang/pull/989)
 established how member name lookup was performed in a number of situations,
 including for template parameters. Generally speaking, the rule can be
@@ -66,6 +68,13 @@ summarized as:
 > Look up the given name in all the relevant types and interfaces. If a unique
 > name name is found, use it. If more than one name is found, require the user
 > to add qualification to disambiguate.
+
+Applying this rule to `where` constraints to remove the semantic difference
+between the two forms was discussed:
+
+-   [in the #syntax on Discord](https://discord.com/channels/655572317891461132/709488742942900284/979811441852960808),
+    and
+-   [during the 2022-06-01 weekly sync meeting](https://docs.google.com/document/d/1dwS2sJ8tsN3LwxqmZSv9OvqutYhP71dK9Dmr1IXQFTs/edit?resourcekey=0-NxBWgL9h05yD2GOR3wUisg#heading=h.qarzfirrcrgf).
 
 ## Proposal
 
@@ -102,5 +111,13 @@ develop
 
 ## Alternatives considered
 
-No new alternatives were considered as part of this proposal. It is being
-evaluated against the status quo of the existing design.
+Mainly this proposal is being evaluated against the status quo of the existing
+design. However, we did consider which of `=` and `==` to use. The main
+advantages of `=` were:
+
+-   it is shorter,
+-   it is arguably more natural when defining an implementation, and
+-   we found ourselves reaching for `=` more often in examples.
+
+Instead, `==` was chosen for consistency since it looked like a constraint,
+since it resulted in a boolean expression like other `where` clauses.

--- a/proposals/p2070.md
+++ b/proposals/p2070.md
@@ -1,0 +1,64 @@
+# Always `==` not `=` in `where` clauses
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2070)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2070.md
+++ b/proposals/p2070.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
+-   [Abstract](#abstract)
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
@@ -21,44 +22,85 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <!-- tocstop -->
 
+## Abstract
+
+Instead of having two different operators and semantics when constraining an
+associated type to be equal to another type variable versus a concrete type,
+unify the semantics and consistently use just the `==` operator in `where`
+clauses.
+
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+Having two ways to say two things are constrained to be equal in `where` clauses
+had some downsides:
+
+-   Much more likely for users to use the wrong operator, adding a round trip
+    through the compiler.
+-   Users would have to remember the difference in semantics between the two
+    cases.
+-   The `=` operator didn't follow the pattern of other `where` constraints,
+    which look like boolean expressions returning `true` when the constraint is
+    satisfied.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+A `where` clause may used in two situations:
+
+-   to constrain an associated type, see accepted proposal
+    [#818: Constraints for generics (generics details 3)](https://github.com/carbon-language/carbon-lang/pull/818),
+    and
+-   to set the values of associated types in an `impl`, see accepted proposal
+    [#1013: Generics: Set associated constants using `where` constraints](https://github.com/carbon-language/carbon-lang/pull/1013).
+
+Proposal #818 considered the alternative of
+[using only `==` instead of also `=`](/proposals/p0818.md#using-only--instead-of-also-).
+That was not chosen because the `=` and `==` cases were given different (but
+similar) semantics.
+
+After #818 was accepted, proposal
+[#989: Member access expressions](https://github.com/carbon-language/carbon-lang/pull/989)
+established how member name lookup was performed in a number of situations,
+including for template parameters. Generally speaking, the rule can be
+summarized as:
+
+> Look up the given name in all the relevant types and interfaces. If a unique
+> name name is found, use it. If more than one name is found, require the user
+> to add qualification to disambiguate.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+The proposal is to use the single `==` syntax, which is more consistent with
+other `where` constraint clauses. This syntax would consistently use the same
+semantics whether the constraint uses a concrete type or not. In both cases,
+when looking up a name in a constrained type variable, the nae will be looked up
+using the information from both sides of the `==`. As usual, name conflicts are
+resolved by explicit disambiguation.
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+The new semantics are described in the
+["Satisfying both type-of-types" section](/docs/design/generics/details.md#satisfying-both-type-of-types)
+of the
+[Generics: Details document at `docs/design/generics/details.md`](/docs/design/generics/details.md).
+In addition, references to the old syntax have been updated in:
+
+-   [`docs/design/expressions/arithmetic.md`](/docs/design/expressions/arithmetic.md)
+-   [`docs/design/expressions/bitwise.md`](/docs/design/expressions/bitwise.md)
+-   [`docs/design/expressions/member_access.md`](/docs/design/expressions/member_access.md)
+-   [`docs/design/generics/details.md`](/docs/design/generics/details.md)
+-   [`docs/design/generics/overview.md`](/docs/design/generics/overview.md)
+-   [`docs/design/generics/terminology.md`](/docs/design/generics/terminology.md)
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+The new semantics are more consistent with the rest of Carbon, and is simpler.
+This directly helps the
+["code that is easy to read, understand, and write"](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+goal. In addition, fewer syntactic and semantics constructs, making it easier to
+develop
+[language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem).
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+No new alternatives were considered as part of this proposal. It is being
+evaluated against the status quo of the existing design.


### PR DESCRIPTION
Instead of having two different operators and semantics when constraining an associated type to be equal to another type variable versus a concrete type, unify the semantics and consistently use just the `==` operator in `where` clauses.