### PR TITLE
Clarify a macro-defined header

### DIFF
--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <vector>
 
+#include "common/check.h"
 #include "common/ostream.h"
 #include "explorer/ast/expression.h"
 #include "explorer/ast/pattern.h"


### PR DESCRIPTION
In the current build flow, Bazel takes `common/check` for the macro and this is
not done by the file per se.
1. This may lead to a problem later when it comes to different build system.
2. This may be a problem now for indexing.