### PR TITLE
Make Compiler Explorer easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,8 @@ semantics onto C++ such as Rust-inspired
 
 ## Getting started
 
-As there is no compiler yet, to try out Carbon, you can use the
-Carbon explorer to interpret Carbon code and print
-its output. You can try it out immediately at
+As there is no compiler yet, to try out Carbon, you can use the Carbon explorer
+to interpret Carbon code and print its output. You can try it out immediately at
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
 To build the Carbon explorer yourself, follow these instructions:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,12 @@ semantics onto C++ such as Rust-inspired
 
 ## Getting started
 
-You can get started playing with Carbon by checking out the codebase and using
-the Carbon explorer:
+As there is no compiler yet, to try out Carbon, you can use the
+Carbon explorer to interpret Carbon code and print
+its output. You can try it out immediately at
+[compiler-explorer.com](http://carbon.compiler-explorer.com/).
+
+To build the Carbon explorer yourself, follow these instructions:
 
 ```shell
 # Install bazelisk using Homebrew.


### PR DESCRIPTION
Our "Getting Started" section doesn't mention the Compiler Explorer as a first step.  Compiler Explorer already has the Carbon explorer installed, so it would save interested folks a lot of time if they just want to try code out before installing a lot of tools to build from scratch.

This is a repeat link of the status section, but given the title of this section ("Getting Started") it's quite possible visitors end up here before they read the status section.