### PR TITLE
Cleanup: since explorer_fuzzer is now a standard cc_fuzz_test, and runs on all files in the corpus, there's no need for fuzzer_util_test to do the same manually

### DIFF
--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -90,6 +90,7 @@ cc_test(
     ],
     deps = [
         ":fuzzer_util",
+        "//common:gtest_main",
         "@com_google_googletest//:gtest",
         "@com_google_protobuf//:protobuf_headers",
         "@llvm-project//llvm:Support",
@@ -125,6 +126,7 @@ cc_fuzz_test(
     corpus = glob(["fuzzer_corpus/*"]),
     deps = [
         ":fuzzer_util",
+        "//common:error",
         "@com_google_libprotobuf_mutator//:libprotobuf_mutator",
         "@llvm-project//llvm:Support",
     ],

--- a/explorer/fuzzing/explorer_fuzzer.cpp
+++ b/explorer/fuzzing/explorer_fuzzer.cpp
@@ -4,8 +4,15 @@
 
 #include <libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h>
 
+#include "common/error.h"
 #include "explorer/fuzzing/fuzzer_util.h"
+#include "llvm/Support/raw_ostream.h"
 
 DEFINE_TEXT_PROTO_FUZZER(const Carbon::Fuzzing::Carbon& input) {
-  Carbon::ParseAndExecute(input.compilation_unit());
+  const auto result = Carbon::ParseAndExecute(input.compilation_unit());
+  if (result.ok()) {
+    llvm::outs() << "Executed OK: " << *result << "\n";
+  } else {
+    llvm::errs() << "Execution failed: " << result.error() << "\n";
+  }
 }

--- a/explorer/fuzzing/fuzzer_util.cpp
+++ b/explorer/fuzzing/fuzzer_util.cpp
@@ -80,7 +80,7 @@ auto ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit)
   const ErrorOr<std::string> prelude_path =
       Internal::GetRunfilesFile("carbon/explorer/data/prelude.carbon");
   // Can't do anything without a prelude, so it's a fatal error.
-  CARBON_CHECK(prelude_path.ok()) << prelude_path.error().message();
+  CARBON_CHECK(prelude_path.ok()) << prelude_path.error();
 
   AddPrelude(*prelude_path, &arena, &ast.declarations);
   return ExecProgram(&arena, ast, /*trace_stream=*/std::nullopt);

--- a/explorer/fuzzing/fuzzer_util.cpp
+++ b/explorer/fuzzing/fuzzer_util.cpp
@@ -7,13 +7,13 @@
 #include <google/protobuf/text_format.h>
 
 #include "common/check.h"
+#include "common/error.h"
 #include "common/fuzzing/proto_to_carbon.h"
 #include "explorer/interpreter/exec_program.h"
 #include "explorer/syntax/parse.h"
 #include "explorer/syntax/prelude.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/raw_ostream.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
 namespace Carbon {
@@ -69,27 +69,21 @@ auto ProtoToCarbonWithMain(const Fuzzing::CompilationUnit& compilation_unit)
   return Carbon::ProtoToCarbon(compilation_unit) + (has_main ? "" : EmptyMain);
 }
 
-void ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit) {
+auto ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit)
+    -> ErrorOr<int> {
   const std::string source = ProtoToCarbonWithMain(compilation_unit);
 
   Arena arena;
-  ErrorOr<AST> ast = ParseFromString(&arena, "Fuzzer.carbon", source,
-                                     /*parser_debug=*/false);
-  if (!ast.ok()) {
-    llvm::errs() << "Parsing failed: " << ast.error().message() << "\n";
-    return;
-  }
+  CARBON_ASSIGN_OR_RETURN(AST ast,
+                          ParseFromString(&arena, "Fuzzer.carbon", source,
+                                          /*parser_debug=*/false));
   const ErrorOr<std::string> prelude_path =
       Internal::GetRunfilesFile("carbon/explorer/data/prelude.carbon");
+  // Can't do anything without a prelude, so it's a fatal error.
   CARBON_CHECK(prelude_path.ok()) << prelude_path.error().message();
-  AddPrelude(*prelude_path, &arena, &ast->declarations);
-  const ErrorOr<int> result =
-      ExecProgram(&arena, *ast, /*trace_stream=*/std::nullopt);
-  if (!result.ok()) {
-    llvm::errs() << "Execution failed: " << result.error().message() << "\n";
-    return;
-  }
-  llvm::outs() << "Executed OK: " << *result << "\n";
+
+  AddPrelude(*prelude_path, &arena, &ast.declarations);
+  return ExecProgram(&arena, ast, /*trace_stream=*/std::nullopt);
 }
 
 }  // namespace Carbon

--- a/explorer/fuzzing/fuzzer_util.h
+++ b/explorer/fuzzing/fuzzer_util.h
@@ -21,7 +21,9 @@ auto ProtoToCarbonWithMain(const Fuzzing::CompilationUnit& compilation_unit)
     -> std::string;
 
 // Parses and executes a fuzzer-generated program.
-void ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit);
+// Returns program result if execution was successful.
+auto ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit)
+    -> ErrorOr<int>;
 
 namespace Internal {
 


### PR DESCRIPTION
Before:
```
//explorer/fuzzing:fuzzer_util_test                                      PASSED in 18.5s
```

After:
```
//explorer/fuzzing:fuzzer_util_test                                      PASSED in 0.3s
```