### PR TITLE
Checked and template generic terminology

### DIFF
--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -73,7 +73,8 @@ Advantages:
 
 -   The terms "generic" and "template" are more concise than "checked generic"
     and "template generic".
--   More familiar to people coming from C++.
+-   The term "template" is more familiar than "template generic" to people
+    coming from C++.
 
 Disadvantages:
 
@@ -92,14 +93,14 @@ and "generic" when we mean both.
 
 Advantages:
 
--   Shorter term than in this proposal.
+-   More concise term than in this proposal.
 -   More familiar to people coming from C++.
 -   People will likely use this term anyway rather than saying "template
     generics".
 
 Disadvantages:
 
--   Does not parallel the term "unchecked generics".
+-   Does not parallel the term "checked generics".
 -   Loses the implication that a template generic is a kind of generic.
 -   Carbon's template generics aren't exactly the same as C++'s templates, so
     this may give the wrong intuition for people coming from C++ in some cases.
@@ -122,3 +123,8 @@ Disadvantages:
 -   Unfamiliar to people coming from C++.
 -   Would either need to rename the `template` keyword or pick new non-keyword
     syntax for it, or have a mismatch between keywords and terminology.
+-   Template generics still involve checking, it just can't complete until later
+    when the argument values are known.
+
+This was suggested in
+[#1443](https://github.com/carbon-language/carbon-lang/pull/1443).

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -42,6 +42,11 @@ Change terminology from "generics" and "templates" to "checked generics" and
 "template generics". Afterwards, "generics" will be an umbrella term that
 include templates.
 
+Similarly, for parameters, use "checked generic parameter" and "template generic
+parameter", with the umbrella term "generic parameter" describing both kinds. The
+word "generic" can be omitted from these terms if it's clear from context, which
+will usually be the case for template parameters.
+
 Some existing design docs give examples of the difference before and after this
 proposal:
 

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -12,53 +12,40 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
+-   [Abstract](#abstract)
 -   [Problem](#problem)
--   [Background](#background)
 -   [Proposal](#proposal)
--   [Details](#details)
 -   [Rationale](#rationale)
--   [Alternatives considered](#alternatives-considered)
 
 <!-- tocstop -->
 
+## Abstract
+
+Change terminology from "generics" and "templates" to "checked generics" and
+"template generics", so the term "generics" will now include templates refers to
+both.
+
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
-
-## Background
-
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+The C++ community does "generic programming" using templates in C++, and so
+thinks of templates as a mechanism for implementing generics. In Carbon,
+templates and other generic features are more similar than they are different,
+so it is worthwhile to have an easy way to talk about things that apply to both.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Change terminology from "generics" and "templates" to "checked generics" and
+"template generics", so the term "generics" will now include templates refers to
+both.
 
-## Details
-
-TODO: Fully explain the details of the proposed solution.
+The [generics overview](/docs/design/generics/overview.md), for example,
+currently demonstrates the current approach of using "generics" and "templates".
+The [generics section of the design overview](/docs/design/README.md#generics)
+demonstrates the use of the proposed new terminology.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
+Using the terminology expected by the community supports these goals:
 
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
-
-## Alternatives considered
-
-TODO: What alternative solutions have you considered?

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -1,0 +1,64 @@
+# Checked and template generic terminology
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2138)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -38,14 +38,22 @@ Change terminology from "generics" and "templates" to "checked generics" and
 "template generics". Afterwards, "generics" will be an umbrella term that
 include templates.
 
-The [generics overview](/docs/design/generics/overview.md), for example,
-currently demonstrates the current approach of using "generics" and "templates".
-The [generics section of the design overview](/docs/design/README.md#generics)
-demonstrates the use of the proposed new terminology.
+Some existing design docs give examples of the difference before and after this
+proposal:
+
+-   The [generics overview](/docs/design/generics/overview.md), for example,
+    currently demonstrates the current approach of using "generics" and
+    "templates".
+-   The
+    [generics section of the design overview](/docs/design/README.md#generics)
+    demonstrates the use of the proposed new terminology.
 
 ## Rationale
 
 Using the terminology expected by the community supports these goals:
 
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+    since our documentation governing the interpretation of that code will be
+    more easily understood and with greater accuracy.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+    since there will be a smaller terminology gap between Carbon and C++.

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -43,9 +43,9 @@ Change terminology from "generics" and "templates" to "checked generics" and
 include templates.
 
 Similarly, for parameters, use "checked generic parameter" and "template generic
-parameter", with the umbrella term "generic parameter" describing both kinds. The
-word "generic" can be omitted from these terms if it's clear from context, which
-will usually be the case for template parameters.
+parameter", with the umbrella term "generic parameter" describing both kinds.
+The word "generic" can be omitted from these terms if it's clear from context,
+which will usually be the case for template parameters.
 
 Some existing design docs give examples of the difference before and after this
 proposal:

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -22,8 +22,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Abstract
 
 Change terminology from "generics" and "templates" to "checked generics" and
-"template generics", so the term "generics" will now include templates refers to
-both.
+"template generics". Afterwards, "generics" will be an umbrella term that
+include templates.
 
 ## Problem
 
@@ -35,8 +35,8 @@ so it is worthwhile to have an easy way to talk about things that apply to both.
 ## Proposal
 
 Change terminology from "generics" and "templates" to "checked generics" and
-"template generics", so the term "generics" will now include templates refers to
-both.
+"template generics". Afterwards, "generics" will be an umbrella term that
+include templates.
 
 The [generics overview](/docs/design/generics/overview.md), for example,
 currently demonstrates the current approach of using "generics" and "templates".

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -57,3 +57,50 @@ Using the terminology expected by the community supports these goals:
     more easily understood and with greater accuracy.
 -   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
     since there will be a smaller terminology gap between Carbon and C++.
+
+## Alternatives considered
+
+### Status quo: "generic" means "checked"
+
+Use "generic" for checked generics, "template" for template generics, and "template or generic" when we mean both.
+
+Advantages:
+
+-   The terms "generic" and "template" are more concise than "checked generic" and "template generic".
+-   More familiar to people coming from C++.
+
+Disadvantages:
+
+-   Does not provide a unifying term for templates and generics, leading to our needing to talk about both in various places, given that they are very similar concepts in Carbon.
+-   Does not acknowledge that templates are used for generic programming and as such are a kind of generic.
+-   Carbon's template generics aren't exactly the same as C++'s templates, so this may give the wrong intuition for people coming from C++ in some cases.
+
+### Use the name "templates" instead of "template generics"
+
+Use "checked generic" for checked generics, "template" for template generics, and "generic" when we mean both.
+
+Advantages:
+
+-   Shorter term than in this proposal.
+-   More familiar to people coming from C++.
+-   People will likely use this term anyway rather than saying "template generics".
+
+Disadvantages:
+
+-   Does not parallel the term "unchecked generics".
+-   Loses the implication that a template generic is a kind of generic.
+-   Carbon's template generics aren't exactly the same as C++'s templates, so this may give the wrong intuition for people coming from C++ in some cases.
+
+### Use the name "unchecked generics" instead of "template generics"
+
+Use "checked generic" for checked generics, "unchecked generic" for template generics, and "generic" when we mean both.
+
+Advantages:
+
+-   Creates a better parallel between "checked generics" and "unchecked generics".
+-   Describes the semantics rather than the implementation strategy, especially given that templating / monomorphization is also the implementation strategy we intend to use for unchecked generics.
+
+Disadvantages:
+
+-   Unfamiliar to people coming from C++.
+-   Would either need to rename the `template` keyword or pick new non-keyword syntax for it, or have a mismatch between keywords and terminology.

--- a/proposals/p2138.md
+++ b/proposals/p2138.md
@@ -16,6 +16,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Problem](#problem)
 -   [Proposal](#proposal)
 -   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Status quo: "generic" means "checked"](#status-quo-generic-means-checked)
+    -   [Use the name "templates" instead of "template generics"](#use-the-name-templates-instead-of-template-generics)
+    -   [Use the name "unchecked generics" instead of "template generics"](#use-the-name-unchecked-generics-instead-of-template-generics)
 
 <!-- tocstop -->
 
@@ -62,45 +66,59 @@ Using the terminology expected by the community supports these goals:
 
 ### Status quo: "generic" means "checked"
 
-Use "generic" for checked generics, "template" for template generics, and "template or generic" when we mean both.
+Use "generic" for checked generics, "template" for template generics, and
+"template or generic" when we mean both.
 
 Advantages:
 
--   The terms "generic" and "template" are more concise than "checked generic" and "template generic".
+-   The terms "generic" and "template" are more concise than "checked generic"
+    and "template generic".
 -   More familiar to people coming from C++.
 
 Disadvantages:
 
--   Does not provide a unifying term for templates and generics, leading to our needing to talk about both in various places, given that they are very similar concepts in Carbon.
--   Does not acknowledge that templates are used for generic programming and as such are a kind of generic.
--   Carbon's template generics aren't exactly the same as C++'s templates, so this may give the wrong intuition for people coming from C++ in some cases.
+-   Does not provide a unifying term for templates and generics, leading to our
+    needing to talk about both in various places, given that they are very
+    similar concepts in Carbon.
+-   Does not acknowledge that templates are used for generic programming and as
+    such are a kind of generic.
+-   Carbon's template generics aren't exactly the same as C++'s templates, so
+    this may give the wrong intuition for people coming from C++ in some cases.
 
 ### Use the name "templates" instead of "template generics"
 
-Use "checked generic" for checked generics, "template" for template generics, and "generic" when we mean both.
+Use "checked generic" for checked generics, "template" for template generics,
+and "generic" when we mean both.
 
 Advantages:
 
 -   Shorter term than in this proposal.
 -   More familiar to people coming from C++.
--   People will likely use this term anyway rather than saying "template generics".
+-   People will likely use this term anyway rather than saying "template
+    generics".
 
 Disadvantages:
 
 -   Does not parallel the term "unchecked generics".
 -   Loses the implication that a template generic is a kind of generic.
--   Carbon's template generics aren't exactly the same as C++'s templates, so this may give the wrong intuition for people coming from C++ in some cases.
+-   Carbon's template generics aren't exactly the same as C++'s templates, so
+    this may give the wrong intuition for people coming from C++ in some cases.
 
 ### Use the name "unchecked generics" instead of "template generics"
 
-Use "checked generic" for checked generics, "unchecked generic" for template generics, and "generic" when we mean both.
+Use "checked generic" for checked generics, "unchecked generic" for template
+generics, and "generic" when we mean both.
 
 Advantages:
 
--   Creates a better parallel between "checked generics" and "unchecked generics".
--   Describes the semantics rather than the implementation strategy, especially given that templating / monomorphization is also the implementation strategy we intend to use for unchecked generics.
+-   Creates a better parallel between "checked generics" and "unchecked
+    generics".
+-   Describes the semantics rather than the implementation strategy, especially
+    given that templating / monomorphization is also the implementation strategy
+    we intend to use for unchecked generics.
 
 Disadvantages:
 
 -   Unfamiliar to people coming from C++.
--   Would either need to rename the `template` keyword or pick new non-keyword syntax for it, or have a mismatch between keywords and terminology.
+-   Would either need to rename the `template` keyword or pick new non-keyword
+    syntax for it, or have a mismatch between keywords and terminology.


### PR DESCRIPTION
Change terminology from "generics" and "templates" to "checked generics" and "template generics". Afterwards, "generics" will be an umbrella term that include templates.