### PR TITLE
Add the languages' successors shown in Chandler's talk to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ along existing investments, codebases, and developer populations. There are a
 few languages that have followed this model for other ecosystems, and Carbon
 aims to fill an analogous role for C++:
 
+-   C → C++
 -   JavaScript → TypeScript
+-   Objective-C → Swift
 -   Java → Kotlin
 -   C++ → **_Carbon_**
 


### PR DESCRIPTION
Add `C → C++` and `Objective-C → Swift` to main README as shown in [Chandler's talk](https://www.youtube.com/watch?v=omrY53kbVoA).