### PR TITLE
Bring in the LLVM CommandLine API

### DIFF
--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -37,7 +37,7 @@ class Driver {
   // Returns true if the operation succeeds. If the operation fails, returns
   // false and any information about the failure is printed to the registered
   // error stream (stderr by default).
-  auto RunFullCommand(llvm::ArrayRef<llvm::StringRef> args) -> bool;
+  auto RunFullCommand(int argc, char **argv) -> bool;
 
   // Subcommand that prints available help text to the error stream.
   //

--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -14,8 +14,7 @@ auto main(int argc, char** argv) -> int {
     return EXIT_FAILURE;
   }
 
-  llvm::SmallVector<llvm::StringRef, 16> args(argv + 1, argv + argc);
   Carbon::Driver driver;
-  bool success = driver.RunFullCommand(args);
+  bool success = driver.RunFullCommand(argc, argv);
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
The change in args of `RunFullCommand` is due to `ParseCommandLineOptions`. Otherwise, `args` should be re-converted back to argv to use the function.

In `RunFullCommand`, `subcommand_args` is almost a stub for RunXSubcommands, because there are two same patterns in two RunXXSubcommands, that should be factored out and taken care possibly before the switch returns.

Use `dummycat` as a workaround for clean up and hide default Categories. I left `Unknown` in the enum, even if LLVM CommandLine handles the case.