### PR TITLE
Set HOMEBREW_NO_INSTALL_CLEANUP due to llvm reinstall errors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,6 +70,8 @@ jobs:
       # toolchain. We also take some care to be as resilient as possible to
       # issues fetching and installing the toolchain.
       - name: Setup LLVM and Clang
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
           brew update
           brew install --force-bottle --only-dependencies llvm


### PR DESCRIPTION
Trying to address issues like:
https://github.com/carbon-language/carbon-lang/runs/8252863868?check_suite_focus=true

```
==> Reinstalling 2 dependents with broken linkage from source:
llvm, mpdecimal
```

But llvm doesn't get reinstalled (but we also probably don't need/want this, particularly building from source).