### PR TITLE
Fix for Minor Style Issue: a non-auto method to auto

### DIFF
--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -400,8 +400,8 @@ class TokenizedBuffer {
 
     int index;
     int kind;
-    int column;
     int line;
+    int column;
     int indent;
   };
 

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -227,7 +227,7 @@ class TokenizedBuffer {
     // If true, the value is mantissa * 10^exponent.
     [[nodiscard]] auto IsDecimal() const -> bool { return is_decimal_; }
 
-    void Print(llvm::raw_ostream& output_stream) const {
+    auto Print(llvm::raw_ostream& output_stream) const -> void {
       output_stream << Mantissa() << "*" << (is_decimal_ ? "10" : "2") << "^"
                     << Exponent();
     }
@@ -351,7 +351,7 @@ class TokenizedBuffer {
   // line-oriented shell tools from `grep` to `awk`.
   auto Print(llvm::raw_ostream& output_stream) const -> void;
 
-  // Prints a description of a single token.  See `print` for details on the
+  // Prints a description of a single token.  See `Print` for details on the
   // format.
   auto PrintToken(llvm::raw_ostream& output_stream, Token token) const -> void;
 

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -440,7 +440,7 @@ class TokenizedBuffer {
     int64_t start;
 
     // The byte length of the line. Does not include the newline character (or a
-    // null terminator or EOF).
+    // nul-terminator or EOF).
     int32_t length;
 
     // The byte offset from the start of the line of the first non-whitespace

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <limits>
 #include <system_error>
+#include <utility>
 #include <variant>
 
 #include "common/check.h"

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -48,7 +48,7 @@ static auto ErrnoToError(int errno_value) -> llvm::Error {
 
 auto SourceBuffer::CreateFromFile(llvm::StringRef filename)
     -> llvm::Expected<SourceBuffer> {
-  // Add storage to ensure there's a nul-terminator for open().
+  // Add storage to ensure there's a null-terminator for open().
   std::string filename_str = filename.str();
 
   errno = 0;

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -53,7 +53,7 @@ auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
 
 auto SourceBuffer::CreateFromFile(llvm::StringRef filename)
     -> llvm::Expected<SourceBuffer> {
-  // Add storage to ensure there's a null-terminator for open().
+  // Add storage to ensure there's a nul-terminator for open().
   std::string filename_str = filename.str();
 
   errno = 0;

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -23,23 +23,14 @@
 
 namespace Carbon {
 
-namespace {
-
 // Verifies that the content size is within limits.
-auto CheckContentSize(int64_t size) -> llvm::Error {
+static auto CheckContentSize(int64_t size) -> llvm::Error {
   if (size < std::numeric_limits<int32_t>::max()) {
     return llvm::Error::success();
   }
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "Input too large!");
 }
-
-auto ErrnoToError(int errno_value) -> llvm::Error {
-  return llvm::errorCodeToError(
-      std::error_code(errno_value, std::generic_category()));
-}
-
-}  // namespace
 
 auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
     -> llvm::Expected<SourceBuffer> {
@@ -49,6 +40,11 @@ auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
     return std::move(size_check);
   }
   return SourceBuffer(filename.str(), std::move(buffer));
+}
+
+static auto ErrnoToError(int errno_value) -> llvm::Error {
+  return llvm::errorCodeToError(
+      std::error_code(errno_value, std::generic_category()));
 }
 
 auto SourceBuffer::CreateFromFile(llvm::StringRef filename)

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -23,14 +23,23 @@
 
 namespace Carbon {
 
+namespace {
+
 // Verifies that the content size is within limits.
-static auto CheckContentSize(int64_t size) -> llvm::Error {
+auto CheckContentSize(int64_t size) -> llvm::Error {
   if (size < std::numeric_limits<int32_t>::max()) {
     return llvm::Error::success();
   }
   return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                  "Input too large!");
 }
+
+auto ErrnoToError(int errno_value) -> llvm::Error {
+  return llvm::errorCodeToError(
+      std::error_code(errno_value, std::generic_category()));
+}
+
+}  // namespace
 
 auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
     -> llvm::Expected<SourceBuffer> {
@@ -40,11 +49,6 @@ auto SourceBuffer::CreateFromText(llvm::Twine text, llvm::StringRef filename)
     return std::move(size_check);
   }
   return SourceBuffer(filename.str(), std::move(buffer));
-}
-
-static auto ErrnoToError(int errno_value) -> llvm::Error {
-  return llvm::errorCodeToError(
-      std::error_code(errno_value, std::generic_category()));
 }
 
 auto SourceBuffer::CreateFromFile(llvm::StringRef filename)


### PR DESCRIPTION
Minor Style Change: a non-auto method to auto

Change the comment to address the correct function name

Sort the Members of `TokenizedBuffer` according to the YAML format

Fix to have the preferred term, `nul` over `null`

Include the library of the added function in carbon-language#2030