### PR TITLE
Include the Library of the added function in carbon-language#1341

### DIFF
--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_COMMON_CHECK_INTERNAL_H_
 #define CARBON_COMMON_CHECK_INTERNAL_H_
 
-#include <unistd.h>
+#include <cstdlib>
 
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Signals.h"


### PR DESCRIPTION
`cstdlib` is added for `abort()` in carbon-language#1341

`unistd.h` was not removed with `exit()` in carbon-language#1175