### PR TITLE
Add support for silencing nano zone warnings that arise from asan+macOS

### DIFF
--- a/bazel/macos_malloc/BUILD
+++ b/bazel/macos_malloc/BUILD
@@ -1,0 +1,10 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+exports_files(["env.bzl"])
+
+config_setting(
+    name = "opt",
+    values = {"compilation_mode": "opt"},
+)

--- a/bazel/macos_malloc/BUILD
+++ b/bazel/macos_malloc/BUILD
@@ -2,9 +2,31 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 exports_files(["env.bzl"])
 
+selects.config_setting_group(
+    name = "macos_asan",
+    match_all = [":is_macos", ":macos_asan_build_modes"],
+)
+
 config_setting(
-    name = "opt",
-    values = {"compilation_mode": "opt"},
+    name = "is_macos",
+    constraint_values = ["@platforms//os:osx"],
+)
+
+selects.config_setting_group(
+    name = "macos_asan_build_modes",
+    match_any = [":dbg", ":fastbuild"],
+)
+
+config_setting(
+    name = "dbg",
+    values = {"compilation_mode": "dbg"},
+)
+
+config_setting(
+    name = "fastbuild",
+    values = {"compilation_mode": "fastbuild"},
 )

--- a/bazel/macos_malloc/env.bzl
+++ b/bazel/macos_malloc/env.bzl
@@ -2,12 +2,12 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Provides support for macos-specific malloc issues."""
+"""Provides support for macOS-specific malloc issues."""
 
 def macos_malloc_env():
     """Disable nano malloc when running asan.
 
-    On MacOS, there's a nano zone allocation warning due to asan (arises
+    On macOS, there's a nano zone allocation warning due to asan (arises
     in fastbuild/dbg). This suppresses the warning in `bazel run`.
     """
     return select({

--- a/bazel/macos_malloc/env.bzl
+++ b/bazel/macos_malloc/env.bzl
@@ -1,0 +1,17 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Provides support for macos-specific malloc issues."""
+
+def macos_malloc_env():
+    """Disable nano malloc when running asan.
+
+    On MacOS, there's a nano zone allocation warning due to asan (arises
+    in fastbuild/dbg). This suppresses the warning in `bazel run`.
+    """
+    return select({
+        "//bazel/macos_malloc:opt": {},
+        "@platforms//os:osx": {"MallocNanoZone": "0"},
+        "//conditions:default": {},
+    })

--- a/bazel/macos_malloc/env.bzl
+++ b/bazel/macos_malloc/env.bzl
@@ -11,7 +11,6 @@ def macos_malloc_env():
     in fastbuild/dbg). This suppresses the warning in `bazel run`.
     """
     return select({
-        "//bazel/macos_malloc:opt": {},
-        "@platforms//os:osx": {"MallocNanoZone": "0"},
+        "//bazel/macos_malloc:macos_asan": {"MallocNanoZone": "0"},
         "//conditions:default": {},
     })

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//bazel/macos_malloc:env.bzl", "macos_malloc_env")
+
 package(default_visibility = [
     "//bazel/check_deps:__pkg__",
     "//explorer:__subpackages__",
@@ -35,6 +37,7 @@ cc_binary(
         ":main",
         "@llvm-project//llvm:Support",
     ],
+    env = macos_malloc_env(),
 )
 
 py_binary(


### PR DESCRIPTION
Note this will need to be set per-cc_binary, but I don't think there's a good way to avoid that.

I didn't try hijacking the `cc_binary` rule name because that felt a bit excessive. We probably will have a few binaries we want to run directly, but I don't think it needs to be addressed on every last one.

This is part of addressing #1404 