### PR TITLE
Fix the Digit Expression in a death test

### DIFF
--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -12,10 +12,9 @@ namespace {
 TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 
 TEST(CheckTest, CheckFalse) {
-  // TODO: figure out why we can't use \\d+ instead of .+ in these patterns.
   ASSERT_DEATH({ CARBON_CHECK(false); },
                "Stack trace:\n"
-               ".+\n"
+               "[[:digit:]]+\n"
                "CHECK failure at common/check_test.cpp:.+: false\n");
 }
 

--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -14,8 +14,8 @@ TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 TEST(CheckTest, CheckFalse) {
   ASSERT_DEATH({ CARBON_CHECK(false); },
                "Stack trace:\n"
-               "[[:digit:]]+\n"
-               "CHECK failure at common/check_test.cpp:.+: false\n");
+               ".+\n"
+               "CHECK failure at common/check_test.cpp:[[:digit:]]+: false\n");
 }
 
 TEST(CheckTest, CheckTrueCallbackNotUsed) {


### PR DESCRIPTION
This is a behavior of RE2 that is used by Googletest.
However, this may not be supported on Windows since
Windows is not POSIX-compliant. Therefore, we should revisit
here once we consider supporting Windows.