### PR TITLE
Switch gtest to re2, adjust related tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,15 +55,29 @@ http_archive(
 )
 
 ###############################################################################
+# RE2 libraries
+###############################################################################
+
+# Head as of 2022-09-14.
+re2_version = "cc1c9db8bf5155d89d10d65998cdb226f676492c"
+
+http_archive(
+    name = "com_googlesource_code_re2",
+    sha256 = "8ef976c79a300f8c5e880535665bd4ba146fb09fb6d2342f8f1a02d9af29f365",
+    strip_prefix = "re2-%s" % re2_version,
+    urls = ["https://github.com/google/re2/archive/%s.tar.gz" % re2_version],
+)
+
+###############################################################################
 # GoogleTest libraries
 ###############################################################################
 
-# Version as of 2021-12-07. Not a major release, but gets a clang-tidy fix.
-googletest_version = "4c5650f68866e3c2e60361d5c4c95c6f335fb64b"
+# Head as of 2022-09-14.
+googletest_version = "1336c4b6d1a6f4bc6beebccb920e5ff858889292"
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "770e61fa13d51320736c2881ff6279212e4eab8a9100709fff8c44759f61d126",
+    sha256 = "d701aaeb9a258afba27210d746d971042be96c371ddc5a49f1e8914d9ea17e3c",
     strip_prefix = "googletest-%s" % googletest_version,
     urls = ["https://github.com/google/googletest/archive/%s.tar.gz" % googletest_version],
 )

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -58,6 +58,14 @@ def _compute_mac_os_sysroot(repository_ctx):
     output = _run(repository_ctx, [xcrun, "--show-sdk-path"]).stdout
     return output.splitlines()[0]
 
+def _transform_include_path(repository_ctx, path):
+    """Transforms an include path from Clang into one for Bazel."""
+    path = path.lstrip(" ")
+    framework_suffix = " (framework directory)"
+    if path.endswith(framework_suffix):
+      path = path[:len(path) - len(framework_suffix)]
+    return repository_ctx.path(path)
+
 def _compute_clang_cpp_include_search_paths(repository_ctx, clang, sysroot):
     """Runs the `clang` binary and extracts the include search paths.
 
@@ -113,7 +121,7 @@ def _compute_clang_cpp_include_search_paths(repository_ctx, clang, sysroot):
     include_end = output.index("End of search list.", include_begin)
 
     return [
-        repository_ctx.path(s.lstrip(" "))
+        _transform_include_path(repository_ctx, s)
         for s in output[include_begin:include_end]
     ]
 

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -112,6 +112,7 @@ def _compute_clang_cpp_include_search_paths(repository_ctx, clang, sysroot):
     include_begin = output.index("#include <...> search starts here:") + 1
     include_end = output.index("End of search list.", include_begin)
 
+    # Suffix present on framework paths.
     framework_suffix = " (framework directory)"
     return [
         repository_ctx.path(s.lstrip(" ").removesuffix(framework_suffix))

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -58,14 +58,6 @@ def _compute_mac_os_sysroot(repository_ctx):
     output = _run(repository_ctx, [xcrun, "--show-sdk-path"]).stdout
     return output.splitlines()[0]
 
-def _transform_include_path(repository_ctx, path):
-    """Transforms an include path from Clang into one for Bazel."""
-    path = path.lstrip(" ")
-    framework_suffix = " (framework directory)"
-    if path.endswith(framework_suffix):
-      path = path[:len(path) - len(framework_suffix)]
-    return repository_ctx.path(path)
-
 def _compute_clang_cpp_include_search_paths(repository_ctx, clang, sysroot):
     """Runs the `clang` binary and extracts the include search paths.
 
@@ -120,8 +112,9 @@ def _compute_clang_cpp_include_search_paths(repository_ctx, clang, sysroot):
     include_begin = output.index("#include <...> search starts here:") + 1
     include_end = output.index("End of search list.", include_begin)
 
+    framework_suffix = " (framework directory)"
     return [
-        _transform_include_path(repository_ctx, s)
+        repository_ctx.path(s.lstrip(" ").removesuffix(framework_suffix))
         for s in output[include_begin:include_end]
     ]
 

--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -12,11 +12,10 @@ namespace {
 TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 
 TEST(CheckTest, CheckFalse) {
-  // TODO: figure out why we can't use \\d+ instead of .+ in these patterns.
   ASSERT_DEATH({ CARBON_CHECK(false); },
                "Stack trace:\n"
-               ".+\n"
-               "CHECK failure at common/check_test.cpp:.+: false\n");
+               "(.|\n)+\n"
+               "CHECK failure at common/check_test.cpp:\\d+: false\n");
 }
 
 TEST(CheckTest, CheckTrueCallbackNotUsed) {

--- a/toolchain/lexer/token_kind_test.cpp
+++ b/toolchain/lexer/token_kind_test.cpp
@@ -18,7 +18,8 @@ using ::testing::MatchesRegex;
 
 // We restrict symbols to punctuation characters that are expected to be widely
 // available on modern keyboards used for programming.
-constexpr llvm::StringLiteral SymbolRegex = "[][{}!@#%^&*()/?\\|;:.,<>=+~-]+";
+constexpr llvm::StringLiteral SymbolRegex =
+    "[\\[\\]{}!@#%^&*()/?\\\\|;:.,<>=+~-]+";
 
 // We restrict keywords to be lowercase ASCII letters and underscores.
 constexpr llvm::StringLiteral KeywordRegex = "[a-z_]+";


### PR DESCRIPTION
See https://github.com/google/googletest/blob/main/docs/advanced.md#regular-expression-syntax for gtest regex notes.

Add framework suffix handling for includes because of a dep being triggered on macos.

@micttyl FYI