### PR TITLE
Add llvm to PATH instead of CC

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,7 +31,9 @@ RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
 RUN ./llvm.sh 15 all
 RUN rm llvm.sh
-ENV CC="/usr/bin/clang-15"
+# Add the lib dir to the PATH. This helps Bazel find clang, and VS Code find
+# clangd.
+ENV PATH="/usr/lib/llvm-15/bin:${PATH}"
 
 # Update pip and install black and pre-commit.
 RUN pip3 install -U pip

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,8 +31,8 @@ RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
 RUN ./llvm.sh 15 all
 RUN rm llvm.sh
-# Add the lib dir to the PATH. This helps Bazel find clang, and VS Code find
-# clangd.
+# Add the lib dir to the PATH. This helps Bazel find clang and VS Code find
+# clangd, without version suffixes.
 ENV PATH="/usr/lib/llvm-15/bin:${PATH}"
 
 # Update pip and install black and pre-commit.


### PR DESCRIPTION
This helps VS Code find clangd (instead of needing to pass in clangd-15 somehow), and seems like it'll work in general.