### PR TITLE
Include Missing Libraries

### DIFF
--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -30,6 +30,7 @@ cc_library(
     deps = [
         "//common:check",
         "//toolchain/parser:parse_tree",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/toolchain/semantics/parse_subtree_consumer.h
+++ b/toolchain/semantics/parse_subtree_consumer.h
@@ -5,6 +5,9 @@
 #ifndef CARBON_TOOLCHAIN_SEMANTICS_PARSE_SUBTREE_CONSUMER_H_
 #define CARBON_TOOLCHAIN_SEMANTICS_PARSE_SUBTREE_CONSUMER_H_
 
+#include <iterator>
+
+#include "llvm/ADT/Optional.h"
 #include "toolchain/parser/parse_tree.h"
 
 namespace Carbon {


### PR DESCRIPTION
For better:
	`<iterator>` for `std::reverse_iterator`
	`Optional.h` for `llvm::Optional`