### PR TITLE
Switch proposal link text from pNNNN to #NN for consistency

### DIFF
--- a/proposals/p0157.md
+++ b/proposals/p0157.md
@@ -229,8 +229,8 @@ supply the missing functionality identified above. These features are largely
 separable, although there are some dependencies between them, so their detailed
 design will be addressed in future proposals, and the details discussed here
 should be considered provisional. This proposal merely establishes the overall
-design direction for sum types, in the same way that [p0083](p0083.md)
-established the overall design direction for the language as a whole.
+design direction for sum types, in the same way that [#83](p0083.md) established
+the overall design direction for the language as a whole.
 
 To support manual lifetime control and storage sharing, I propose introducing at
 least one and preferably both of the following:


### PR DESCRIPTION
This is the only occurrence of using pNNNN in text to refer to a Carbon proposal in the repo. This gets us closer to following https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/design_style_guide.md.