### PR TITLE
Fix .carbon file formatting of tests data with clang-format

### DIFF
--- a/explorer/testdata/addr/fail_method_let.carbon
+++ b/explorer/testdata/addr/fail_method_let.carbon
@@ -11,10 +11,7 @@
 package ExplorerTest api;
 
 class Point {
-
-  fn Origin() -> Point {
-    return {.x = 0, .y = 0};
-  }
+  fn Origin() -> Point { return {.x = 0, .y = 0}; }
 
   fn GetSetX[addr me: Point*](x: i32) -> i32 {
     var old: auto = (*me).x;

--- a/explorer/testdata/addr/fail_method_me_type.carbon
+++ b/explorer/testdata/addr/fail_method_me_type.carbon
@@ -15,10 +15,7 @@ class Shape {
 }
 
 class Point {
-
-  fn Origin() -> Point {
-    return {.x = 0, .y = 0};
-  }
+  fn Origin() -> Point { return {.x = 0, .y = 0}; }
 
   fn GetSetX[addr me: Shape*](x: i32) -> i32 {
     var old: auto = (*me).x;

--- a/explorer/testdata/addr/method.carbon
+++ b/explorer/testdata/addr/method.carbon
@@ -12,10 +12,7 @@
 package ExplorerTest api;
 
 class Point {
-
-  fn Origin() -> Point {
-    return {.x = 0, .y = 0};
-  }
+  fn Origin() -> Point { return {.x = 0, .y = 0}; }
 
   fn GetSetX[addr me: Point*](x: i32) -> i32 {
     var old: auto = (*me).x;

--- a/explorer/testdata/alias/class_alias.carbon
+++ b/explorer/testdata/alias/class_alias.carbon
@@ -21,7 +21,9 @@ impl i32 as Addable {
   fn Add[me: Self](k: i32) -> Self { return me + k; }
 }
 
-class Class { var n: i32; }
+class Class {
+  var n: i32;
+}
 class GenericClass(T:! Addable) {
   var m: T;
   fn Get[me: Self](n: i32) -> T { return me.m.Add(n); }

--- a/explorer/testdata/alias/fail_self_alias.carbon
+++ b/explorer/testdata/alias/fail_self_alias.carbon
@@ -13,6 +13,4 @@ package ExplorerTest api;
 // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/alias/fail_self_alias.carbon:[[@LINE+1]]: 'a' is not usable until after it has been completely declared
 alias a = a;
 
-fn Main() -> i32 {
-  return 0;
-}
+fn Main() -> i32 { return 0; }

--- a/explorer/testdata/alias/function_alias.carbon
+++ b/explorer/testdata/alias/function_alias.carbon
@@ -19,6 +19,4 @@ fn GenericFunction[T:! Type](x: T) -> T { return x; }
 alias FunctionAlias = Function;
 alias GenericFunctionAlias = GenericFunction;
 
-fn Main() -> i32 {
-  return FunctionAlias(1, 2) + GenericFunctionAlias(4);
-}
+fn Main() -> i32 { return FunctionAlias(1, 2) + GenericFunctionAlias(4); }

--- a/explorer/testdata/alias/interface_alias.carbon
+++ b/explorer/testdata/alias/interface_alias.carbon
@@ -11,10 +11,18 @@
 
 package ExplorerTest api;
 
-class Class { var a: i32; }
-class GenericClass(T:! Type) { var a: T; }
-interface Interface { fn Make() -> Self; }
-interface GenericInterface(T:! Type) { fn Make() -> (Self, T); }
+class Class {
+  var a: i32;
+}
+class GenericClass(T:! Type) {
+  var a: T;
+}
+interface Interface {
+  fn Make() -> Self;
+}
+interface GenericInterface(T:! Type) {
+  fn Make() -> (Self, T);
+}
 
 alias ClassAlias = Class;
 alias GenericClassAlias = GenericClass;
@@ -34,15 +42,13 @@ impl GenericClassAlias(S) as GenericInterfaceAlias(S) {
   fn Make() -> (Self, {.a: i32}) { return ({.a = {.a = 4}}, {.a = 5}); }
 }
 
-fn CheckImplementsInterface[T:! Interface](x: T) -> T {
+fn CheckImplementsInterface[T:! Interface](x: T) -> T { return T.Make(); }
+fn CheckImplementsGenericInterface_i32[T:! GenericInterface(i32)](x: T)
+    -> (T, i32) {
   return T.Make();
 }
-fn CheckImplementsGenericInterface_i32
-    [T:! GenericInterface(i32)](x: T) -> (T, i32) {
-  return T.Make();
-}
-fn CheckImplementsGenericInterface_struct
-    [T:! GenericInterface(S)](x: T) -> (T, S) {
+fn CheckImplementsGenericInterface_struct[T:! GenericInterface(S)](x: T)
+    -> (T, S) {
   return T.Make();
 }
 
@@ -51,12 +57,11 @@ fn Main() -> i32 {
   a = CheckImplementsInterface(a);
 
   var b: GenericClass(i32) = {.a = 0};
-  var (b2: GenericClass(i32), n: i32) =
-    CheckImplementsGenericInterface_i32(b);
+  var (b2: GenericClass(i32), n: i32) = CheckImplementsGenericInterface_i32(b);
 
   var c: GenericClass({.a: i32}) = {.a = {.a = 0}};
   var (c2: GenericClass({.a: i32}), s: S) =
-    CheckImplementsGenericInterface_struct(c);
+      CheckImplementsGenericInterface_struct(c);
 
   return 10000 * a.a + 1000 * b2.a + 100 * n + 10 * c2.a.a + s.a;
 }

--- a/explorer/testdata/alias/member_name_alias.carbon
+++ b/explorer/testdata/alias/member_name_alias.carbon
@@ -39,43 +39,43 @@ alias i32IM = i32.(IM);
 fn Main() -> i32 {
   var a: A = {.n = 0};
   // TODO: Use != once we support it.
-  if (not (A.(IF)() == 1)) {
+  if (not(A.(IF)() == 1)) {
     return 1;
   }
-  if (not (a.(IF)() == 1)) {
+  if (not(a.(IF)() == 1)) {
     return 2;
   }
-  if (not (a.(IM)() == 2)) {
+  if (not(a.(IM)() == 2)) {
     return 3;
   }
-  if (not (a.(A.(IM))() == 2)) {
+  if (not(a.(A.(IM))() == 2)) {
     return 4;
   }
-  if (not (AIF() == 1)) {
+  if (not(AIF() == 1)) {
     return 5;
   }
-  if (not (a.(AIM)() == 2)) {
+  if (not(a.(AIM)() == 2)) {
     return 6;
   }
-  if (not (a.(AG)() == 3)) {
+  if (not(a.(AG)() == 3)) {
     return 7;
   }
-  if (not (i32.(IF)() == 4)) {
+  if (not(i32.(IF)() == 4)) {
     return 8;
   }
-  if (not (0.(IF)() == 4)) {
+  if (not(0.(IF)() == 4)) {
     return 9;
   }
-  if (not (0.(IM)() == 5)) {
+  if (not(0.(IM)() == 5)) {
     return 10;
   }
-  if (not (0.(i32.(IM))() == 5)) {
+  if (not(0.(i32.(IM))() == 5)) {
     return 11;
   }
-  if (not (i32IF() == 4)) {
+  if (not(i32IF() == 4)) {
     return 12;
   }
-  if (not (0.(i32IM)() == 5)) {
+  if (not(0.(i32IM)() == 5)) {
     return 13;
   }
   return 0;

--- a/explorer/testdata/basic_syntax/addition.carbon
+++ b/explorer/testdata/basic_syntax/addition.carbon
@@ -11,6 +11,4 @@
 
 package ExplorerTest api;
 
-fn Main() -> i32 {
-  return (1 + 2) + 4;
-}
+fn Main() -> i32 { return (1 + 2) + 4; }

--- a/explorer/testdata/basic_syntax/fail_var_named_self.carbon
+++ b/explorer/testdata/basic_syntax/fail_var_named_self.carbon
@@ -15,6 +15,6 @@ fn Main() -> i32 {
   // TODO: Current error message is unclear, better would be to say
   // something like: unexpected `Self`, expecting identifier
   // CHECK: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_var_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting SLASH or binary *
-  var Self : i32 = 0;
+  var Self: i32 = 0;
   return Self;
 }

--- a/explorer/testdata/basic_syntax/next.carbon
+++ b/explorer/testdata/basic_syntax/next.carbon
@@ -11,8 +11,7 @@
 
 package ExplorerTest api;
 
-fn Main () -> i32
-{
+fn Main() -> i32 {
   var x: i32 = 0;
   return x;
 }

--- a/explorer/testdata/basic_syntax/star.carbon
+++ b/explorer/testdata/basic_syntax/star.carbon
@@ -14,12 +14,10 @@ package ExplorerTest api;
 // Never actually called, so this only tests typechecking and semantic analysis.
 fn F(n: i32, p: i32*, q: i32***) -> i32* {
   var a: i32 = n * *p;
-  var b: i32 = a*n;
-  *p = b*(*p);
+  var b: i32 = a * n;
+  *p = b * (*p);
   **q = p;
   return **q;
 }
 
-fn Main() -> i32 {
-  return 0;
-}
+fn Main() -> i32 { return 0; }

--- a/explorer/testdata/basic_syntax/trace.carbon
+++ b/explorer/testdata/basic_syntax/trace.carbon
@@ -24,6 +24,4 @@
 
 package ExplorerTest api;
 
-fn Main() -> i32 {
-  return 0;
-}
+fn Main() -> i32 { return 0; }

--- a/explorer/testdata/basic_syntax/zero.carbon
+++ b/explorer/testdata/basic_syntax/zero.carbon
@@ -11,6 +11,4 @@
 
 package ExplorerTest api;
 
-fn Main() -> i32 {
-  return 0;
-}
+fn Main() -> i32 { return 0; }


### PR DESCRIPTION
Format the  .carbon test data with experimental clang-format with Carbon Language support

NOTE: This is my first pull request here and likely the first of a number of commits as we look at modifying clang-format to treat Carbon as a first class citizen (https://reviews.llvm.org/D134652). I am using the explorer/test_data directories as a test bed for ensuring we can correctly format Carbon code. These changes mainly bring the .carbon file in line with Google style which is to `AllowShortFunctionsOnASingeLine`. By correcting these simple changes in the suite we can focus on the more challenging things.