### PR TITLE
Remove copyright from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,4 @@
-<!--
-Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-Exceptions. See /LICENSE for license information.
-SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
--->
-
-_Replace this paragraph with a description of what this PR is changing or
-adding, and why._
+**Replace this paragraph with a description of what this PR is changing or
+adding, and why.**
 
 Closes #ISSUE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,6 +177,7 @@ repos:
         exclude: |
           (?x)^(
               .bazelversion|
+              .github/pull_request_template.md|
               compile_flags.txt|
               third_party/.*|
               bazel/llvm_patches/.*\.patch|

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <p align="center">
   <a href="#why-build-carbon">Why?</a> |
-  <a href="#language-goals">Goals</a> |
-  <a href="#project-status">Status</a> |
-  <a href="#getting-started">Getting started</a> |
-  <a href="#join-us">Join us</a>
+
+<a href="#language-goals">Goals</a> | <a href="#project-status">Status</a> |
+<a href="#getting-started">Getting started</a> | <a href="#join-us">Join us</a>
+
 </p>
 
 **See our [announcement video](https://youtu.be/omrY53kbVoA) from

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <p align="center">
   <a href="#why-build-carbon">Why?</a> |
-
-<a href="#language-goals">Goals</a> | <a href="#project-status">Status</a> |
-<a href="#getting-started">Getting started</a> | <a href="#join-us">Join us</a>
-
+  <a href="#language-goals">Goals</a> |
+  <a href="#project-status">Status</a> |
+  <a href="#getting-started">Getting started</a> |
+  <a href="#join-us">Join us</a>
 </p>
 
 **See our [announcement video](https://youtu.be/omrY53kbVoA) from


### PR DESCRIPTION
The template gets inserted into the PR description verbatim, copyright included, which wasn't my intent.