### PR TITLE
[Toolchain][Lexer] Try to fix closing token recovery algorithm.

### DIFF
--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -428,9 +428,8 @@ class TokenizedBuffer::Lexer {
         return;
       }
 
-      TokenInfo& opening_token_info = buffer_.GetTokenInfo(opening_token);
       LineInfo& opening_token_line_info =
-          buffer_.GetLineInfo(opening_token_info.token_line);
+          buffer_.GetLineInfo(buffer_.GetTokenInfo(opening_token).token_line);
 
       auto is_current_line_shallower_than_opening_token = [&]() {
         return opening_token_line_info.start != current_line_info_->start &&
@@ -483,6 +482,8 @@ class TokenizedBuffer::Lexer {
              .is_recovery = true,
              .token_line = current_line_,
              .column = current_column_});
+
+        TokenInfo& opening_token_info = buffer_.GetTokenInfo(opening_token);
         TokenInfo& closing_token_info = buffer_.GetTokenInfo(closing_token);
         opening_token_info.closing_token = closing_token;
         closing_token_info.opening_token = opening_token;

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -1213,7 +1213,7 @@ TEST_F(LexerTest, ClosingTokenRecovery_1) {
                                                {"spelling", "["},
                                                {"closing_token", "1"},
                                                {"has_trailing_space", "true"}}},
-                  // A `]` recovery token is added since the following`{` opens
+                  // A `]` recovery token is added since the following `{` opens
                   // a new scope on the same nesting level as the opening `[`.
                   {"token", Yaml::MappingValue{{"index", "1"},
                                                {"kind", "CloseSquareBracket"},
@@ -1273,7 +1273,7 @@ TEST_F(LexerTest, ClosingTokenRecovery_2) {
                                        {"spelling", "["},
                                        {"closing_token", "1"},
                                        {"has_trailing_space", "true"}}},
-          // A `]` recovery token is added since the following`{` opens
+          // A `]` recovery token is added since the following `{` opens
           // a new scope on a shallower nesting level as the opening `[`.
           {"token", Yaml::MappingValue{{"index", "1"},
                                        {"kind", "CloseSquareBracket"},
@@ -1349,8 +1349,8 @@ TEST_F(LexerTest, ClosingTokenRecovery_3) {
                                        {"spelling", "}"},
                                        {"opening_token", "1"},
                                        {"has_trailing_space", "true"}}},
-          // A `]` recovery token is not added until here since the following`{`
-          // opens a new scope on a deeper nesting level as the opening `[`.
+          // A `]` recovery token is not added until here since the following
+          // `{` opens a new scope on a deeper nesting level as the opening `[`.
           {"token", Yaml::MappingValue{{"index", "3"},
                                        {"kind", "CloseSquareBracket"},
                                        {"line", "3"},


### PR DESCRIPTION
Summary:

Extends the current recovery strategy for missing closing tokens. This commit focuses on taking indentation into account. In particular, it makes sure that we close open unmatched opening tokens if we lex an opening token on a shallowers indentation.
