### PR TITLE
Disable readability-identifier-length in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,8 +18,8 @@ Checks:
   -modernize-use-nodiscard, performance-*, -performance-unnecessary-value-param,
   readability-*, -readability-convert-member-functions-to-static,
   -readability-function-cognitive-complexity, -readability-else-after-return,
-  -readability-implicit-bool-conversion, -readability-magic-numbers,
-  -readability-make-member-function-const,
+  -readability-identifier-length, -readability-implicit-bool-conversion,
+  -readability-magic-numbers, -readability-make-member-function-const,
   -readability-qualified-auto,  -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument, -readability-use-anyofallof
 WarningsAsErrors: true


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-length.html

This complains about `id` which I'm using a lot and feels like a reasonable name, and honestly single-letter variable names seem reasonable in certain contexts. Trying to make this work better doesn't seem like it'll be worth the time cost.