### PR TITLE
Fix things up to make running clang-tidy easier.

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -70,6 +70,10 @@ bazel-execroot/external/com_google_googletest
 -iquote
 bazel-bin/external/com_google_googletest
 -iquote
+bazel-execroot/external/com_googlesource_code_re2
+-iquote
+bazel-bin/external/com_googlesource_code_re2
+-iquote
 bazel-execroot/external/bazel_tools
 -iquote
 bazel-bin/external/bazel_tools

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -106,6 +106,8 @@ generated_file_labels = subprocess.run(
         (
             'filter(".*\\.(h|cpp|cc|c|cxx|def|inc)$",'
             'kind("generated file", deps(//...)))'
+            " union "
+            'kind("cc_proto_library", deps(//...))'
         ),
     ],
     check=True,
@@ -113,6 +115,8 @@ generated_file_labels = subprocess.run(
     stderr=subprocess.DEVNULL,
     universal_newlines=True,
 ).stdout.splitlines()
+for f in generated_file_labels:
+    print(f)
 print("Found %d generated files..." % (len(generated_file_labels),))
 
 # Directly build these labels so that indexing can find them. Allow this to
@@ -132,6 +136,7 @@ subprocess.run(
         "@llvm-project//llvm:LICENSE.TXT",
         "@com_google_absl//:LICENSE",
         "@com_google_googletest//:LICENSE",
+        "@com_googlesource_code_re2//:LICENSE",
         "@com_github_google_benchmark//:benchmark",
     ]
 )

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -115,8 +115,6 @@ generated_file_labels = subprocess.run(
     stderr=subprocess.DEVNULL,
     universal_newlines=True,
 ).stdout.splitlines()
-for f in generated_file_labels:
-    print(f)
 print("Found %d generated files..." % (len(generated_file_labels),))
 
 # Directly build these labels so that indexing can find them. Allow this to

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -97,6 +97,7 @@ print(
 )
 
 # Now collect the generated file labels.
+# cc_proto_library generates files, but they aren't seen with "generated file".
 generated_file_labels = subprocess.run(
     [
         bazel,

--- a/scripts/run_clang_tidy.py
+++ b/scripts/run_clang_tidy.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+"""Runs clang-tidy over all Carbon files.
+"""
+
+__copyright__ = """
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import os
+import subprocess
+
+from pathlib import Path
+
+
+def main() -> None:
+    # Set the repo root as the working directory.
+    os.chdir(Path(__file__).parent.parent)
+    # Ensure create_compdb has been run.
+    subprocess.check_call(["./scripts/create_compdb.py"])
+    # Run clang-tidy from clang-tools-extra.
+    exit(
+        subprocess.call(
+            [
+                "./bazel-execroot/external/llvm-project/clang-tools-extra/"
+                "clang-tidy/tool/run-clang-tidy.py",
+                "^(?!.*/(bazel-|third_party)).*$",
+            ]
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_clang_tidy.py
+++ b/scripts/run_clang_tidy.py
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
 import subprocess
+import sys
 
 from pathlib import Path
 
@@ -20,14 +21,19 @@ def main() -> None:
     os.chdir(Path(__file__).parent.parent)
     # Ensure create_compdb has been run.
     subprocess.check_call(["./scripts/create_compdb.py"])
+
+    args = sys.argv[1:]
+    if not args or args[0] == "--fix":
+        args.append("^(?!.*/(bazel-|third_party)).*$")
+
     # Run clang-tidy from clang-tools-extra.
     exit(
         subprocess.call(
             [
                 "./bazel-execroot/external/llvm-project/clang-tools-extra/"
                 "clang-tidy/tool/run-clang-tidy.py",
-                "^(?!.*/(bazel-|third_party)).*$",
             ]
+            + args
         )
     )
 


### PR DESCRIPTION
run_clang_tidy.py (the clang-tools-extras version) is parallel so should be feasible to work with. I'm trying to codify this mainly because finding out the right invocation can be difficult.

This fixes some loading of re2 and proto that's started to become an issue.

It's hard to see actual issues because of the identifier length warning being turned off in #2244, and just general issue creep. There may be more fixes to do but this should still be an improvement.