### PR TITLE
Build value representations for all kinds of witness

### DIFF
--- a/explorer/ast/ast_rtti.txt
+++ b/explorer/ast/ast_rtti.txt
@@ -71,7 +71,6 @@ abstract class Expression : AstNode;
   class WhereExpression : Expression;
   class UnimplementedExpression : Expression;
   class ArrayTypeLiteral : Expression;
-  class InstantiateImpl : Expression;
 abstract class WhereClause : AstNode;
   class IsWhereClause : WhereClause;
   class EqualsWhereClause : WhereClause;

--- a/explorer/ast/bindings.h
+++ b/explorer/ast/bindings.h
@@ -47,6 +47,11 @@ class Bindings {
   // An empty set of bindings.
   static auto None() -> Nonnull<const Bindings*>;
 
+  // Determine whether this is an empty set of bindings.
+  [[nodiscard]] auto empty() const -> bool {
+    return args_.empty() && witnesses_.empty();
+  }
+
  private:
   BindingMap args_;
   ImplWitnessMap witnesses_;

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -257,12 +257,6 @@ void Expression::Print(llvm::raw_ostream& out) const {
       }
       break;
     }
-    case ExpressionKind::InstantiateImpl: {
-      // TODO: For layering reasons, we can't print out the witness and
-      // argument values from here.
-      out << "instantiate impl";
-      break;
-    }
     case ExpressionKind::UnimplementedExpression: {
       const auto& unimplemented = cast<UnimplementedExpression>(*this);
       out << "UnimplementedExpression<" << unimplemented.label() << ">(";
@@ -347,7 +341,6 @@ void Expression::PrintID(llvm::raw_ostream& out) const {
     case ExpressionKind::UnimplementedExpression:
     case ExpressionKind::FunctionTypeLiteral:
     case ExpressionKind::ArrayTypeLiteral:
-    case ExpressionKind::InstantiateImpl:
       out << "...";
       break;
   }

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -853,33 +853,6 @@ class WhereExpression : public Expression {
   std::vector<Nonnull<WhereClause*>> clauses_;
 };
 
-// Instantiate a generic impl.
-class InstantiateImpl : public Expression {
- public:
-  using ImplementsCarbonValueNode = void;
-
-  explicit InstantiateImpl(SourceLocation source_loc,
-                           Nonnull<const Witness*> generic_impl,
-                           Bindings bindings)
-      : Expression(AstNodeKind::InstantiateImpl, source_loc),
-        generic_impl_(generic_impl),
-        bindings_(std::move(bindings)) {}
-
-  static auto classof(const AstNode* node) -> bool {
-    return InheritsFromInstantiateImpl(node->kind());
-  }
-  auto generic_impl() const -> Nonnull<const Witness*> { return generic_impl_; }
-  auto type_args() const -> const BindingMap& { return bindings_.args(); }
-
-  // Maps each of the impl bindings to an expression that constructs
-  // the witness table for that impl.
-  auto impls() const -> const ImplWitnessMap& { return bindings_.witnesses(); }
-
- private:
-  Nonnull<const Witness*> generic_impl_;
-  Bindings bindings_;
-};
-
 // An expression whose semantics have not been implemented. This can be used
 // as a placeholder during development, in order to implement and test parsing
 // of a new expression syntax without having to implement its semantics.

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -110,9 +110,11 @@ static auto ExpressionToProto(const Expression& expression)
     -> Fuzzing::Expression {
   Fuzzing::Expression expression_proto;
   switch (expression.kind()) {
-    case ExpressionKind::ValueLiteral:
+    case ExpressionKind::ValueLiteral: {
       // This does not correspond to source syntax.
       break;
+    }
+
     case ExpressionKind::CallExpression: {
       const auto& call = cast<CallExpression>(expression);
       auto* call_proto = expression_proto.mutable_call();

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -110,11 +110,9 @@ static auto ExpressionToProto(const Expression& expression)
     -> Fuzzing::Expression {
   Fuzzing::Expression expression_proto;
   switch (expression.kind()) {
-    case ExpressionKind::InstantiateImpl:
-    case ExpressionKind::ValueLiteral: {
-      // These do not correspond to source syntax.
+    case ExpressionKind::ValueLiteral:
+      // This does not correspond to source syntax.
       break;
-    }
     case ExpressionKind::CallExpression: {
       const auto& call = cast<CallExpression>(expression);
       auto* call_proto = expression_proto.mutable_call();

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1449,7 +1449,7 @@ auto Interpreter::StepWitness() -> ErrorOr<Success> {
       }
       std::vector<Nonnull<const Witness*>> new_witnesses;
       new_witnesses.reserve(witnesses.size());
-      for (auto* witness: act.results()) {
+      for (auto* witness : act.results()) {
         new_witnesses.push_back(cast<Witness>(witness));
       }
       return todo_.FinishAction(

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -655,7 +655,6 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::ChoiceType:
     case Value::Kind::ContinuationType:
@@ -914,9 +913,6 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
         return todo_.Spawn(std::make_unique<ExpressionAction>(
             &cast<IndexExpression>(exp).object()));
       } else if (act.pos() == 1) {
-        if (!isa<TupleValue>(act.results()[0])) {
-          return todo_.FinishAction(arena_->New<SymbolicWitness>(&exp));
-        }
         return todo_.Spawn(std::make_unique<ExpressionAction>(
             &cast<IndexExpression>(exp).offset()));
       } else {
@@ -1430,10 +1426,6 @@ auto Interpreter::StepWitness() -> ErrorOr<Success> {
                     << ". --->\n";
   }
   switch (witness->kind()) {
-    case Value::Kind::SymbolicWitness:
-      return todo_.ReplaceWith(std::make_unique<ExpressionAction>(
-          &cast<SymbolicWitness>(witness)->impl_expression()));
-
     case Value::Kind::BindingWitness: {
       const ImplBinding* binding = cast<BindingWitness>(witness)->binding();
       CARBON_ASSIGN_OR_RETURN(

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -512,6 +512,8 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
         CARBON_RETURN_IF_ERROR(ResolveNames(**iface.params(), iface_scope));
       }
       enclosing_scope.MarkUsable(iface.name());
+      // Don't resolve names in the type of the self binding. The
+      // InterfaceDeclaration constructor already did that.
       CARBON_RETURN_IF_ERROR(iface_scope.Add("Self", iface.self()));
       CARBON_RETURN_IF_ERROR(
           ResolveMemberNames(iface.members(), iface_scope, bodies));

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -267,7 +267,6 @@ static auto ResolveNames(Expression& expression,
     case ExpressionKind::TypeTypeLiteral:
     case ExpressionKind::ValueLiteral:
       break;
-    case ExpressionKind::InstantiateImpl:  // created after name resolution
     case ExpressionKind::UnimplementedExpression:
       return CompilationError(expression.source_loc()) << "Unimplemented";
   }

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -140,7 +140,6 @@ static auto ResolveUnformed(Nonnull<const Expression*> expression,
     case ExpressionKind::UnimplementedExpression:
     case ExpressionKind::FunctionTypeLiteral:
     case ExpressionKind::ArrayTypeLiteral:
-    case ExpressionKind::InstantiateImpl:
       break;
   }
   return Success();

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -183,7 +183,6 @@ static auto IsTypeOfType(Nonnull<const Value*> value) -> bool {
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
     case Value::Kind::TypeOfParameterizedEntityName:
@@ -247,7 +246,6 @@ static auto IsType(Nonnull<const Value*> value, bool concrete = false) -> bool {
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
       return false;
@@ -873,7 +871,6 @@ auto TypeChecker::ArgumentDeduction(
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
     case Value::Kind::IntValue:
@@ -1186,7 +1183,6 @@ auto TypeChecker::Substitute(
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
     case Value::Kind::IntValue:
@@ -4041,7 +4037,6 @@ static bool IsValidTypeForAliasTarget(Nonnull<const Value*> type) {
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ParameterizedEntityName:
     case Value::Kind::MemberName:
     case Value::Kind::BindingPlaceholderValue:

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -467,7 +467,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       const auto& witness = cast<ConstraintWitness>(*this);
       out << "(";
       llvm::ListSeparator sep;
-      for (auto *elem : witness.witnesses()) {
+      for (auto* elem : witness.witnesses()) {
         out << sep << *elem;
       }
       out << ")";

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -71,6 +71,7 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
                  << "member " << f << " not in " << *witness;
         }
       }
+      case Value::Kind::BindingWitness:
       case Value::Kind::SymbolicWitness: {
         return RuntimeError(source_loc)
                << "member lookup for " << f << " in symbolic " << *witness
@@ -459,6 +460,11 @@ void Value::Print(llvm::raw_ostream& out) const {
           << witness.declaration().interface();
       break;
     }
+    case Value::Kind::BindingWitness: {
+      const auto& witness = cast<BindingWitness>(*this);
+      out << "witness " << *witness.binding()->type_var();
+      break;
+    }
     case Value::Kind::SymbolicWitness: {
       const auto& witness = cast<SymbolicWitness>(*this);
       out << "witness " << witness.impl_expression();
@@ -767,6 +773,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
                      << *t1 << "\n"
                      << *t2;
     case Value::Kind::ImplWitness:
+    case Value::Kind::BindingWitness:
     case Value::Kind::SymbolicWitness:
       CARBON_FATAL() << "TypeEqual: unexpected Witness";
       break;
@@ -868,6 +875,7 @@ auto ValueStructurallyEqual(
     case Value::Kind::InterfaceType:
     case Value::Kind::ConstraintType:
     case Value::Kind::ImplWitness:
+    case Value::Kind::BindingWitness:
     case Value::Kind::SymbolicWitness:
     case Value::Kind::ChoiceType:
     case Value::Kind::ContinuationType:

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -479,11 +479,6 @@ void Value::Print(llvm::raw_ostream& out) const {
           << *witness.constraint_witness();
       break;
     }
-    case Value::Kind::SymbolicWitness: {
-      const auto& witness = cast<SymbolicWitness>(*this);
-      out << "witness " << witness.impl_expression();
-      break;
-    }
     case Value::Kind::ParameterizedEntityName:
       out << *GetName(cast<ParameterizedEntityName>(*this).declaration());
       break;
@@ -790,7 +785,6 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
       CARBON_FATAL() << "TypeEqual: unexpected Witness";
       break;
     case Value::Kind::AutoType:
@@ -894,7 +888,6 @@ auto ValueStructurallyEqual(
     case Value::Kind::BindingWitness:
     case Value::Kind::ConstraintWitness:
     case Value::Kind::ConstraintImplWitness:
-    case Value::Kind::SymbolicWitness:
     case Value::Kind::ChoiceType:
     case Value::Kind::ContinuationType:
     case Value::Kind::VariableType:

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -71,14 +71,12 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
                  << "member " << f << " not in " << *witness;
         }
       }
-      case Value::Kind::BindingWitness:
-      case Value::Kind::SymbolicWitness: {
+      default:
+        CARBON_CHECK(isa<Witness>(witness))
+            << "expected Witness, not " << *witness;
         return RuntimeError(source_loc)
                << "member lookup for " << f << " in symbolic " << *witness
                << " not implemented yet";
-      }
-      default:
-        CARBON_FATAL() << "expected Witness, not " << *witness;
     }
   }
   switch (v->kind()) {
@@ -456,13 +454,29 @@ void Value::Print(llvm::raw_ostream& out) const {
     }
     case Value::Kind::ImplWitness: {
       const auto& witness = cast<ImplWitness>(*this);
-      out << "witness " << *witness.declaration().impl_type() << " as "
+      out << "witness for impl " << *witness.declaration().impl_type() << " as "
           << witness.declaration().interface();
       break;
     }
     case Value::Kind::BindingWitness: {
       const auto& witness = cast<BindingWitness>(*this);
-      out << "witness " << *witness.binding()->type_var();
+      out << "witness for " << *witness.binding()->type_var();
+      break;
+    }
+    case Value::Kind::ConstraintWitness: {
+      const auto& witness = cast<ConstraintWitness>(*this);
+      out << "(";
+      llvm::ListSeparator sep;
+      for (auto *elem : witness.witnesses()) {
+        out << sep << *elem;
+      }
+      out << ")";
+      break;
+    }
+    case Value::Kind::ConstraintImplWitness: {
+      const auto& witness = cast<ConstraintImplWitness>(*this);
+      out << "witness " << witness.index() << " of "
+          << *witness.constraint_witness();
       break;
     }
     case Value::Kind::SymbolicWitness: {
@@ -774,6 +788,8 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
                      << *t2;
     case Value::Kind::ImplWitness:
     case Value::Kind::BindingWitness:
+    case Value::Kind::ConstraintWitness:
+    case Value::Kind::ConstraintImplWitness:
     case Value::Kind::SymbolicWitness:
       CARBON_FATAL() << "TypeEqual: unexpected Witness";
       break;
@@ -876,6 +892,8 @@ auto ValueStructurallyEqual(
     case Value::Kind::ConstraintType:
     case Value::Kind::ImplWitness:
     case Value::Kind::BindingWitness:
+    case Value::Kind::ConstraintWitness:
+    case Value::Kind::ConstraintImplWitness:
     case Value::Kind::SymbolicWitness:
     case Value::Kind::ChoiceType:
     case Value::Kind::ContinuationType:

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -913,15 +913,6 @@ class ConstraintWitness : public Witness {
 // a symbolic witness for the constraint type.
 class ConstraintImplWitness : public Witness {
  public:
-  explicit ConstraintImplWitness(Nonnull<const Witness*> constraint_witness,
-                                 int index)
-      : Witness(Kind::ConstraintImplWitness),
-        constraint_witness_(constraint_witness),
-        index_(index) {
-    CARBON_CHECK(!llvm::isa<ConstraintWitness>(constraint_witness))
-        << "should have resolved element from constraint witness";
-  }
-
   // Make a witness for the given impl_constraint of the given `ConstraintType`
   // witness. If we're indexing into a known tuple of witnesses, pull out the
   // element.
@@ -931,6 +922,15 @@ class ConstraintImplWitness : public Witness {
       return constraint_witness->witnesses()[index];
     }
     return arena->New<ConstraintImplWitness>(witness, index);
+  }
+
+  explicit ConstraintImplWitness(Nonnull<const Witness*> constraint_witness,
+                                 int index)
+      : Witness(Kind::ConstraintImplWitness),
+        constraint_witness_(constraint_witness),
+        index_(index) {
+    CARBON_CHECK(!llvm::isa<ConstraintWitness>(constraint_witness))
+        << "should have resolved element from constraint witness";
   }
 
   static auto classof(const Value* value) -> bool {

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -925,9 +925,8 @@ class ConstraintImplWitness : public Witness {
   // Make a witness for the given impl_constraint of the given `ConstraintType`
   // witness. If we're indexing into a known tuple of witnesses, pull out the
   // element.
-  static auto Make(Nonnull<Arena*> arena,
-                   Nonnull<const Witness*> witness, int index)
-      -> Nonnull<const Witness*> {
+  static auto Make(Nonnull<Arena*> arena, Nonnull<const Witness*> witness,
+                   int index) -> Nonnull<const Witness*> {
     if (auto* constraint_witness = llvm::dyn_cast<ConstraintWitness>(witness)) {
       return constraint_witness->witnesses()[index];
     }

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -51,6 +51,8 @@ class Value {
     UninitializedValue,
     ImplWitness,
     BindingWitness,
+    ConstraintWitness,
+    ConstraintImplWitness,
     SymbolicWitness,
     IntType,
     BoolType,
@@ -833,6 +835,8 @@ class Witness : public Value {
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::ImplWitness ||
            value->kind() == Kind::BindingWitness ||
+           value->kind() == Kind::ConstraintWitness ||
+           value->kind() == Kind::ConstraintImplWitness ||
            value->kind() == Kind::SymbolicWitness;
   }
 };
@@ -871,7 +875,7 @@ class ImplWitness : public Witness {
   Nonnull<const Bindings*> bindings_ = Bindings::None();
 };
 
-// The witness table for an impl binding.
+// The symbolic witness corresponding to an unresolved impl binding.
 class BindingWitness : public Witness {
  public:
   // Construct a witness for an impl binding.
@@ -886,6 +890,67 @@ class BindingWitness : public Witness {
 
  private:
   Nonnull<const ImplBinding*> binding_;
+};
+
+// A witness for a constraint type, expressed as a tuple of witnesses for the
+// individual impl constraints in the constraint type.
+class ConstraintWitness : public Witness {
+ public:
+  explicit ConstraintWitness(std::vector<Nonnull<const Witness*>> witnesses)
+      : Witness(Kind::ConstraintWitness), witnesses_(std::move(witnesses)) {}
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::ConstraintWitness;
+  }
+
+  auto witnesses() const -> llvm::ArrayRef<Nonnull<const Witness*>> {
+    return witnesses_;
+  }
+
+ private:
+  std::vector<Nonnull<const Witness*>> witnesses_;
+};
+
+// A witness for an impl constraint in a constraint type, expressed in terms of
+// a symbolic witness for the constraint type.
+class ConstraintImplWitness : public Witness {
+ public:
+  explicit ConstraintImplWitness(Nonnull<const Witness*> constraint_witness,
+                                 int index)
+      : Witness(Kind::ConstraintImplWitness),
+        constraint_witness_(constraint_witness),
+        index_(index) {
+    CARBON_CHECK(!llvm::isa<ConstraintWitness>(constraint_witness))
+        << "should have resolved element from constraint witness";
+  }
+
+  // Make a witness for the given impl_constraint of the given `ConstraintType`
+  // witness. If we're indexing into a known tuple of witnesses, pull out the
+  // element.
+  static auto Make(Nonnull<Arena*> arena,
+                   Nonnull<const Witness*> witness, int index)
+      -> Nonnull<const Witness*> {
+    if (auto* constraint_witness = llvm::dyn_cast<ConstraintWitness>(witness)) {
+      return constraint_witness->witnesses()[index];
+    }
+    return arena->New<ConstraintImplWitness>(witness, index);
+  }
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::ConstraintImplWitness;
+  }
+
+  // Get the witness for the complete `ConstraintType`.
+  auto constraint_witness() const -> Nonnull<const Witness*> {
+    return constraint_witness_;
+  }
+
+  // Get the index of the impl constraint within the constraint type.
+  auto index() const -> int { return index_; }
+
+ private:
+  Nonnull<const Witness*> constraint_witness_;
+  int index_;
 };
 
 // A witness table whose concrete value cannot be determined yet.

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -50,6 +50,7 @@ class Value {
     TupleValue,
     UninitializedValue,
     ImplWitness,
+    BindingWitness,
     SymbolicWitness,
     IntType,
     BoolType,
@@ -831,6 +832,7 @@ class Witness : public Value {
  public:
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::ImplWitness ||
+           value->kind() == Kind::BindingWitness ||
            value->kind() == Kind::SymbolicWitness;
   }
 };
@@ -867,6 +869,23 @@ class ImplWitness : public Witness {
  private:
   Nonnull<const ImplDeclaration*> declaration_;
   Nonnull<const Bindings*> bindings_ = Bindings::None();
+};
+
+// The witness table for an impl binding.
+class BindingWitness : public Witness {
+ public:
+  // Construct a witness for an impl binding.
+  explicit BindingWitness(Nonnull<const ImplBinding*> binding)
+      : Witness(Kind::BindingWitness), binding_(binding) {}
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::BindingWitness;
+  }
+
+  auto binding() const -> Nonnull<const ImplBinding*> { return binding_; }
+
+ private:
+  Nonnull<const ImplBinding*> binding_;
 };
 
 // A witness table whose concrete value cannot be determined yet.

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -53,7 +53,6 @@ class Value {
     BindingWitness,
     ConstraintWitness,
     ConstraintImplWitness,
-    SymbolicWitness,
     IntType,
     BoolType,
     TypeType,
@@ -836,8 +835,7 @@ class Witness : public Value {
     return value->kind() == Kind::ImplWitness ||
            value->kind() == Kind::BindingWitness ||
            value->kind() == Kind::ConstraintWitness ||
-           value->kind() == Kind::ConstraintImplWitness ||
-           value->kind() == Kind::SymbolicWitness;
+           value->kind() == Kind::ConstraintImplWitness;
   }
 };
 
@@ -951,25 +949,6 @@ class ConstraintImplWitness : public Witness {
  private:
   Nonnull<const Witness*> constraint_witness_;
   int index_;
-};
-
-// A witness table whose concrete value cannot be determined yet.
-//
-// These are used to represent symbolic witness values which can be computed at
-// runtime but whose values are not known statically.
-class SymbolicWitness : public Witness {
- public:
-  explicit SymbolicWitness(Nonnull<const Expression*> impl_expr)
-      : Witness(Kind::SymbolicWitness), impl_expr_(impl_expr) {}
-
-  static auto classof(const Value* value) -> bool {
-    return value->kind() == Kind::SymbolicWitness;
-  }
-
-  auto impl_expression() const -> const Expression& { return *impl_expr_; }
-
- private:
-  Nonnull<const Expression*> impl_expr_;
 };
 
 // A choice type.

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -1172,14 +1172,7 @@ declaration:
     }
 | INTERFACE identifier type_params LEFT_CURLY_BRACE interface_body RIGHT_CURLY_BRACE
     {
-      // TODO: Type of `Self` should be the interface being declared, not
-      // `Type`.
-      auto ty_ty = arena -> New<TypeTypeLiteral>(context.source_loc());
-      // TODO: Should this be switched to use a `SelfDeclaration` instead?
-      auto self =
-          arena -> New<GenericBinding>(context.source_loc(), "Self", ty_ty);
-      $$ = arena->New<InterfaceDeclaration>(context.source_loc(), $2, $3, self,
-                                            $5);
+      $$ = arena->New<InterfaceDeclaration>(arena, context.source_loc(), $2, $3, $5);
     }
 | impl_kind IMPL impl_deduced_params impl_type AS type_or_where_expression LEFT_CURLY_BRACE impl_body RIGHT_CURLY_BRACE
     {

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -1172,7 +1172,8 @@ declaration:
     }
 | INTERFACE identifier type_params LEFT_CURLY_BRACE interface_body RIGHT_CURLY_BRACE
     {
-      $$ = arena->New<InterfaceDeclaration>(arena, context.source_loc(), $2, $3, $5);
+      $$ = arena->New<InterfaceDeclaration>(arena, context.source_loc(), $2, $3,
+                                            $5);
     }
 | impl_kind IMPL impl_deduced_params impl_type AS type_or_where_expression LEFT_CURLY_BRACE impl_body RIGHT_CURLY_BRACE
     {


### PR DESCRIPTION
Instead of forming a `SymbolicWitness` that contains an `Expression` when we can't directly resolve a witness to an `impl`, form different kinds of `Witness` values for the various situations:

- A `BindingWitness` witnesses that a type implements a constraint by reference to an `ImplBinding`.
- A `ConstraintWitness` witnesses that a type implements a constraint by reference to witnesses for each of the impl constraints within the constraint.
- A `ConstraintImplWitness` witnesses that a type implements a constraint by reference to a larger constraint which contains that constraint as an impl constraint.

Remove `SymbolicWitness` values and `InstantiateImpl` expressions, which are now unused. In order to remove the final usage of `SymbolicWitness`, I fixed a TODO to give `Self` the proper type within an interface declaration. I don't think this is an observable change.

No functional change intended.