### PR TITLE
Make the toolchain binary work better with `bazel run`.

### DIFF
--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -4,14 +4,24 @@
 
 #include <cstdlib>
 
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
 #include "toolchain/driver/driver.h"
 
 auto main(int argc, char** argv) -> int {
   if (argc < 1) {
     return EXIT_FAILURE;
+  }
+
+  // Behave as if the working directory is where `bazel run` was invoked.
+  char* build_working_dir = getenv("BUILD_WORKING_DIRECTORY");
+  if (build_working_dir != nullptr) {
+    if (std::error_code err =
+            llvm::sys::fs::set_current_path(build_working_dir)) {
+      llvm::errs() << "Failed to set working directory: " << err.message();
+      return EXIT_FAILURE;
+    }
   }
 
   llvm::SmallVector<llvm::StringRef, 16> args(argv + 1, argv + argc);


### PR DESCRIPTION
Makes the toolchain binary work with `bazel run` and relative paths, such as:

bazel run //toolchain/driver:carbon -- dump semantics-ir empty.carbon