### PR TITLE
Switch to clang-format 14.0.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,14 +71,14 @@ repos:
         types_or: [c++, proto]
         language: python
         args: ['-i']
-        additional_dependencies: ['clang-format==13.0.1']
+        additional_dependencies: ['clang-format==14.0.6']
       - id: explorer-format-grammar
         name: Format the explorer grammar file
         entry: explorer/syntax/format_grammar.py
         language: python
         files: ^explorer/syntax/(lexer.lpp|parser.ypp)$
         pass_filenames: false
-        additional_dependencies: ['clang-format==13.0.1']
+        additional_dependencies: ['clang-format==14.0.6']
 
   - repo: local
     hooks:

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -697,7 +697,7 @@ where_expression:
   type_expression WHERE where_clause_list
     {
       auto* self =
-          arena -> New<GenericBinding>(context.source_loc(), ".Self", $1);
+          arena->New<GenericBinding>(context.source_loc(), ".Self", $1);
       $$ = arena->New<WhereExpression>(context.source_loc(), self, $3);
     }
 ;
@@ -1149,8 +1149,7 @@ declaration:
 | MIXIN identifier type_params mixin_import LEFT_CURLY_BRACE mixin_body RIGHT_CURLY_BRACE
     {
       // EXPERIMENTAL MIXN FEATURE
-      auto self =
-          arena -> New<GenericBinding>(context.source_loc(), "Self", $4);
+      auto self = arena->New<GenericBinding>(context.source_loc(), "Self", $4);
       $$ = arena->New<MixinDeclaration>(context.source_loc(), $2, $3, self, $6);
     }
 | CHOICE identifier type_params LEFT_CURLY_BRACE alternative_list RIGHT_CURLY_BRACE
@@ -1174,10 +1173,10 @@ declaration:
     {
       // TODO: Type of `Self` should be the interface being declared, not
       // `Type`.
-      auto ty_ty = arena -> New<TypeTypeLiteral>(context.source_loc());
+      auto ty_ty = arena->New<TypeTypeLiteral>(context.source_loc());
       // TODO: Should this be switched to use a `SelfDeclaration` instead?
       auto self =
-          arena -> New<GenericBinding>(context.source_loc(), "Self", ty_ty);
+          arena->New<GenericBinding>(context.source_loc(), "Self", ty_ty);
       $$ = arena->New<InterfaceDeclaration>(context.source_loc(), $2, $3, self,
                                             $5);
     }


### PR DESCRIPTION
14.0.6 is the latest release at https://pypi.org/project/clang-format/#history, hopefully 15.0.0 will be out soon. Looks like https://github.com/ssciwr/clang-format-wheel/issues/49 is noting issues for this particular release process though.