### PR TITLE
Refactor common main logic

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -5,6 +5,14 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "bazel_working_dir",
+    hdrs = ["bazel_working_dir.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "check",
     srcs = ["check_internal.h"],
     hdrs = ["check.h"],

--- a/common/bazel_working_dir.h
+++ b/common/bazel_working_dir.h
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_BAZEL_WORKING_DIR_H_
+#define CARBON_COMMON_BAZEL_WORKING_DIR_H_
+
+#include "llvm/Support/FileSystem.h"
+
+namespace Carbon {
+
+// Behave as if the working directory is where `bazel run` was invoked.
+inline auto SetWorkingDirForBazel() -> bool {
+  char* build_working_dir = getenv("BUILD_WORKING_DIRECTORY");
+  if (build_working_dir == nullptr) {
+    return true;
+  }
+
+  if (std::error_code err =
+          llvm::sys::fs::set_current_path(build_working_dir)) {
+    llvm::errs() << "Failed to set working directory: " << err.message();
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace Carbon
+
+#endif  // CARBON_COMMON_BAZEL_WORKING_DIR_H_

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -33,11 +33,12 @@ cc_library(
 cc_binary(
     name = "explorer",
     srcs = ["main_bin.cpp"],
+    env = macos_malloc_env(),
     deps = [
         ":main",
+        "//common:bazel_working_dir",
         "@llvm-project//llvm:Support",
     ],
-    env = macos_malloc_env(),
 )
 
 py_binary(

--- a/explorer/main.h
+++ b/explorer/main.h
@@ -9,9 +9,10 @@
 
 namespace Carbon {
 
-// Runs explorer.
-auto ExplorerMain(llvm::StringRef default_prelude_file, int argc, char** argv)
-    -> int;
+// Runs explorer. relative_prelude_path must be POSIX-style, not native, and
+// will be translated to native.
+auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
+                  llvm::StringRef relative_prelude_path) -> int;
 
 }  // namespace Carbon
 

--- a/explorer/main_bin.cpp
+++ b/explorer/main_bin.cpp
@@ -2,31 +2,16 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "common/bazel_working_dir.h"
 #include "explorer/main.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
 
 auto main(int argc, char** argv) -> int {
-  // This assumes execution from `bazel-bin/explorer`, either directly or with
-  // `bazel run`.
+  Carbon::SetWorkingDirForBazel();
+
   static int static_for_main_addr;
-  std::string exe = llvm::sys::fs::getMainExecutable(
-      argv[0], static_cast<void*>(&static_for_main_addr));
-  llvm::SmallString<256> prelude_path = llvm::sys::path::parent_path(exe);
-  llvm::sys::path::append(prelude_path, "explorer.runfiles", "carbon",
-                          "explorer", "data");
-  llvm::sys::path::append(prelude_path, "prelude.carbon");
-
-  // Behave as if the working directory is where `bazel run` was invoked.
-  char* build_working_dir = getenv("BUILD_WORKING_DIRECTORY");
-  if (build_working_dir != nullptr) {
-    if (std::error_code err =
-            llvm::sys::fs::set_current_path(build_working_dir)) {
-      llvm::errs() << "Failed to set working directory: " << err.message();
-      return 1;
-    }
-  }
-
-  return Carbon::ExplorerMain(prelude_path, argc, argv);
+  return Carbon::ExplorerMain(
+      argc, argv, static_cast<void*>(&static_for_main_addr),
+      // This assumes execution from `bazel-bin/explorer`, either directly or
+      // with `bazel run`.
+      "explorer.runfiles/carbon/explorer/data/prelude.carbon");
 }

--- a/installers/local/carbon.cpp
+++ b/installers/local/carbon.cpp
@@ -3,23 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "explorer/main.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
-namespace fs = llvm::sys::fs;
-namespace path = llvm::sys::path;
-
 auto main(int argc, char** argv) -> int {
-  llvm::StringRef bin = path::filename(argv[0]);
+  llvm::StringRef bin = llvm::sys::path::filename(argv[0]);
   if (bin == "carbon-explorer") {
     static int static_for_main_addr;
-    std::string exe = fs::getMainExecutable(
-        argv[0], static_cast<void*>(&static_for_main_addr));
-    llvm::StringRef install_path = path::parent_path(exe);
-    llvm::SmallString<256> prelude_file(install_path);
-    path::append(prelude_file, "data", "prelude.carbon");
-    return Carbon::ExplorerMain(prelude_file, argc, argv);
+    return Carbon::ExplorerMain(argc, argv,
+                                static_cast<void*>(&static_for_main_addr),
+                                "data/prelude.carbon");
   } else {
     fprintf(stderr, "Unrecognized Carbon binary requested: %s", argv[0]);
     return 1;

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -55,6 +55,7 @@ cc_binary(
     srcs = ["driver_main.cpp"],
     deps = [
         ":driver",
+        "//common:bazel_working_dir",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdlib>
 
+#include "common/bazel_working_dir.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
@@ -14,15 +15,7 @@ auto main(int argc, char** argv) -> int {
     return EXIT_FAILURE;
   }
 
-  // Behave as if the working directory is where `bazel run` was invoked.
-  char* build_working_dir = getenv("BUILD_WORKING_DIRECTORY");
-  if (build_working_dir != nullptr) {
-    if (std::error_code err =
-            llvm::sys::fs::set_current_path(build_working_dir)) {
-      llvm::errs() << "Failed to set working directory: " << err.message();
-      return EXIT_FAILURE;
-    }
-  }
+  Carbon::SetWorkingDirForBazel();
 
   llvm::SmallVector<llvm::StringRef, 16> args(argv + 1, argv + argc);
   Carbon::Driver driver;


### PR DESCRIPTION
1) toolchain and explorer use the same working dir logic, share it
2) explorer's carbon.cpp and main_bin.cpp use the same relative path logic, share it
3) You can append a longer path in one call with the right kind of iterator
4) Fix what's maybe a bug in passing `relative_prelude_path.str()` to `cl::init`
5) Collapse Main and ExplorerMain to avoid passing more parameters between