### PR TITLE
Fix a small typo in the driver help message.

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -119,8 +119,8 @@ auto Driver::RunDumpSubcommand(DiagnosticConsumer& consumer,
                        .Case("semantics-ir", DumpMode::SemanticsIR)
                        .Default(DumpMode::Unknown);
   if (dump_mode == DumpMode::Unknown) {
-    error_stream_ << "ERROR: Dump mode should be one of tokens, parse_tree, or "
-                     "semantics_ir.\n";
+    error_stream_ << "ERROR: Dump mode should be one of tokens, parse-tree, or "
+                     "semantics-ir.\n";
     return false;
   }
   args = args.drop_front();


### PR DESCRIPTION
The help message was using `_`s while the actual sub-commands use `-`.