### PR TITLE
Clean up Bison grammar

### DIFF
--- a/explorer/ast/pattern.h
+++ b/explorer/ast/pattern.h
@@ -17,7 +17,8 @@
 #include "explorer/ast/value_category.h"
 #include "explorer/common/source_location.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
+//the include bellow doesn't seem to be used and doesn't exists on clang13
+//#include "llvm/ADT/STLFunctionalExtras.h"
 
 namespace Carbon {
 

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -40,7 +40,7 @@
 // "inout" parameters passed to both the parser and the lexer.
 %param {Nonnull<Arena*> arena}
 %param {yyscan_t yyscanner}
-%param {ParseAndLexContext& context}
+%param {ParseAndLexContext& pl_context}
 
 // "out" parameter passed to the parser, where the AST is written.
 %parse-param {std::optional<AST>* ast}
@@ -87,7 +87,7 @@
 
 %code {
   void Carbon::Parser::error(const location_type&, const std::string& message) {
-    context.RecordSyntaxError(message);
+    pl_context.RecordSyntaxError(message);
   }
 }  // %code
 
@@ -300,148 +300,148 @@
 %%
 input: package_directive import_directives declaration_list
     {
-      *ast = AST({.package = $1.first,
-                  .is_api = $1.second,
-                  .imports = std::move($2),
-                  .declarations = std::move($3)});
+      *ast = AST({.package = $package_directive.first,
+                  .is_api = $package_directive.second,
+                  .imports = std::move($import_directives),
+                  .declarations = std::move($declaration_list)});
     }
 ;
 package_directive:
   PACKAGE identifier optional_library_path api_or_impl SEMICOLON
-    { $$ = {LibraryName({.package = $2, .path = $3}), $4}; }
+    { $package_directive = {LibraryName({.package = $identifier, .path = $optional_library_path}), $api_or_impl}; }
 ;
 import_directive:
   IMPORT identifier optional_library_path SEMICOLON
-    { $$ = LibraryName({.package = $2, .path = $3}); }
+    { $import_directive = LibraryName({.package = $identifier, .path = $optional_library_path}); }
 ;
 import_directives:
   // Empty
     { $$ = std::vector<LibraryName>(); }
-| import_directives import_directive
+| import_directives[idlist] import_directive
     {
-      $$ = std::move($1);
-      $$.push_back($2);
+      $$ = std::move($idlist);
+      $$.push_back($import_directive);
     }
 ;
 optional_library_path:
   // Empty
-    { $$ = ""; }
+    { $optional_library_path = ""; }
 | LIBRARY string_literal
-    { $$ = $2; }
+    { $optional_library_path = $string_literal; }
 ;
 api_or_impl:
   API
-    { $$ = true; }
+    { $api_or_impl = true; }
 | IMPL
-    { $$ = false; }
+    { $api_or_impl = false; }
 ;
 primary_expression:
   identifier
-    { $$ = arena->New<IdentifierExpression>(context.source_loc(), $1); }
+    { $primary_expression = arena->New<IdentifierExpression>(pl_context.source_loc(), $identifier); }
 | designator
     {
       // `.Foo` is rewritten to `.Self.Foo`.
-      $$ = arena->New<SimpleMemberAccessExpression>(
-          context.source_loc(),
-          arena->New<DotSelfExpression>(context.source_loc()), $1);
+      $primary_expression = arena->New<SimpleMemberAccessExpression>(
+          pl_context.source_loc(),
+          arena->New<DotSelfExpression>(pl_context.source_loc()), $designator);
     }
 | PERIOD SELF
-    { $$ = arena->New<DotSelfExpression>(context.source_loc()); }
+    { $primary_expression = arena->New<DotSelfExpression>(pl_context.source_loc()); }
 | integer_literal
-    { $$ = arena->New<IntLiteral>(context.source_loc(), $1); }
+    { $primary_expression = arena->New<IntLiteral>(pl_context.source_loc(), $integer_literal); }
 | string_literal
-    { $$ = arena->New<StringLiteral>(context.source_loc(), $1); }
+    { $primary_expression = arena->New<StringLiteral>(pl_context.source_loc(), $string_literal); }
 | TRUE
-    { $$ = arena->New<BoolLiteral>(context.source_loc(), true); }
+    { $primary_expression = arena->New<BoolLiteral>(pl_context.source_loc(), true); }
 | FALSE
-    { $$ = arena->New<BoolLiteral>(context.source_loc(), false); }
+    { $primary_expression = arena->New<BoolLiteral>(pl_context.source_loc(), false); }
 | sized_type_literal
     {
       int val = 0;
-      if (!llvm::to_integer(llvm::StringRef($1).substr(1), val)) {
-        context.RecordSyntaxError(
-            llvm::formatv("Invalid type literal: {0}", $1));
+      if (!llvm::to_integer(llvm::StringRef($sized_type_literal).substr(1), val)) {
+        pl_context.RecordSyntaxError(
+            llvm::formatv("Invalid type literal: {0}", $sized_type_literal));
         YYERROR;
-      } else if ($1[0] != 'i' || val != 32) {
-        context.RecordSyntaxError(
-            llvm::formatv("Only i32 is supported for now: {0}", $1));
+      } else if ($sized_type_literal[0] != 'i' || val != 32) {
+        pl_context.RecordSyntaxError(
+            llvm::formatv("Only i32 is supported for now: {0}", $sized_type_literal));
         YYERROR;
       } else {
-        $$ = arena->New<IntTypeLiteral>(context.source_loc());
+        $primary_expression = arena->New<IntTypeLiteral>(pl_context.source_loc());
       }
     }
 | SELF
     // TODO: Should we create a new TypeLiteral for `Self`?
-    { $$ = arena->New<IdentifierExpression>(context.source_loc(), "Self"); }
+    { $primary_expression = arena->New<IdentifierExpression>(pl_context.source_loc(), "Self"); }
 | STRING
-    { $$ = arena->New<StringTypeLiteral>(context.source_loc()); }
+    { $primary_expression = arena->New<StringTypeLiteral>(pl_context.source_loc()); }
 | BOOL
-    { $$ = arena->New<BoolTypeLiteral>(context.source_loc()); }
+    { $primary_expression = arena->New<BoolTypeLiteral>(pl_context.source_loc()); }
 | TYPE
-    { $$ = arena->New<TypeTypeLiteral>(context.source_loc()); }
+    { $primary_expression = arena->New<TypeTypeLiteral>(pl_context.source_loc()); }
 | CONTINUATION_TYPE
-    { $$ = arena->New<ContinuationTypeLiteral>(context.source_loc()); }
-| paren_expression { $$ = $1; }
-| struct_literal { $$ = $1; }
-| struct_type_literal { $$ = $1; }
-| LEFT_SQUARE_BRACKET expression SEMICOLON expression RIGHT_SQUARE_BRACKET
-    { $$ = arena->New<ArrayTypeLiteral>(context.source_loc(), $2, $4); }
+    { $primary_expression = arena->New<ContinuationTypeLiteral>(pl_context.source_loc()); }
+| paren_expression { $primary_expression = $paren_expression; }
+| struct_literal { $primary_expression = $struct_literal; }
+| struct_type_literal { $primary_expression = $struct_type_literal; }
+| LEFT_SQUARE_BRACKET expression[exp1] SEMICOLON expression[exp2] RIGHT_SQUARE_BRACKET
+    { $primary_expression = arena->New<ArrayTypeLiteral>(pl_context.source_loc(), $exp1, $exp2); }
 ;
 postfix_expression:
   primary_expression
-| postfix_expression designator
+| postfix_expression[lhs] designator
     {
-      $$ = arena->New<SimpleMemberAccessExpression>(context.source_loc(), $1,
-                                                    $2);
+      $$ = arena->New<SimpleMemberAccessExpression>(pl_context.source_loc(), $lhs,
+                                                    $designator);
     }
-| postfix_expression PERIOD LEFT_PARENTHESIS expression RIGHT_PARENTHESIS
+| postfix_expression[lhs] PERIOD LEFT_PARENTHESIS expression RIGHT_PARENTHESIS
     {
-      $$ = arena->New<CompoundMemberAccessExpression>(context.source_loc(), $1,
-                                                      $4);
+      $$ = arena->New<CompoundMemberAccessExpression>(pl_context.source_loc(), $lhs,
+                                                      $expression);
     }
-| postfix_expression LEFT_SQUARE_BRACKET expression RIGHT_SQUARE_BRACKET
-    { $$ = arena->New<IndexExpression>(context.source_loc(), $1, $3); }
+| postfix_expression[lhs] LEFT_SQUARE_BRACKET expression RIGHT_SQUARE_BRACKET
+    { $$ = arena->New<IndexExpression>(pl_context.source_loc(), $lhs, $expression); }
 | intrinsic_identifier tuple
-    { $$ = arena->New<IntrinsicExpression>($1, $2, context.source_loc()); }
-| postfix_expression tuple
-    { $$ = arena->New<CallExpression>(context.source_loc(), $1, $2); }
-| postfix_expression POSTFIX_STAR
+    { $postfix_expression = arena->New<IntrinsicExpression>($intrinsic_identifier, $tuple, pl_context.source_loc()); }
+| postfix_expression[lhs] tuple
+    { $$ = arena->New<CallExpression>(pl_context.source_loc(), $lhs, $tuple); }
+| postfix_expression[lhs] POSTFIX_STAR
     {
       $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Ptr,
-          std::vector<Nonnull<Expression*>>({$1}));
+          pl_context.source_loc(), Operator::Ptr,
+          std::vector<Nonnull<Expression*>>({$lhs}));
     }
-| postfix_expression UNARY_STAR
+| postfix_expression[lhs] UNARY_STAR
     {
       $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Ptr,
-          std::vector<Nonnull<Expression*>>({$1}));
+          pl_context.source_loc(), Operator::Ptr,
+          std::vector<Nonnull<Expression*>>({$lhs}));
     }
 ;
 ref_deref_expression:
   postfix_expression
-| PREFIX_STAR ref_deref_expression
+| PREFIX_STAR ref_deref_expression[rdexpr]
     {
       $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Deref,
-          std::vector<Nonnull<Expression*>>({$2}));
+          pl_context.source_loc(), Operator::Deref,
+          std::vector<Nonnull<Expression*>>({$rdexpr}));
     }
-| UNARY_STAR ref_deref_expression
+| UNARY_STAR ref_deref_expression[rdexpr]
     {
       $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Deref,
-          std::vector<Nonnull<Expression*>>({$2}));
+          pl_context.source_loc(), Operator::Deref,
+          std::vector<Nonnull<Expression*>>({$rdexpr}));
     }
-| AMPERSAND ref_deref_expression
+| AMPERSAND ref_deref_expression[rdexpr]
     {
       $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::AddressOf,
-          std::vector<Nonnull<Expression*>>({$2}));
+          pl_context.source_loc(), Operator::AddressOf,
+          std::vector<Nonnull<Expression*>>({$rdexpr}));
     }
 ;
 fn_type_expression:
   FN_TYPE tuple ARROW type_expression
-    { $$ = arena->New<FunctionTypeLiteral>(context.source_loc(), $2, $4); }
+    { $fn_type_expression = arena->New<FunctionTypeLiteral>(pl_context.source_loc(), $tuple, $type_expression); }
 ;
 type_expression:
   ref_deref_expression
@@ -452,18 +452,18 @@ minus_expression:
   // ref_deref_expression excluded due to precedence diamond.
   MINUS ref_deref_expression
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Neg,
-          std::vector<Nonnull<Expression*>>({$2}));
+      $minus_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Neg,
+          std::vector<Nonnull<Expression*>>({$ref_deref_expression}));
     }
 ;
 complement_expression:
   // ref_deref_expression excluded due to precedence diamond.
   CARET ref_deref_expression
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Complement,
-          std::vector<Nonnull<Expression*>>({$2}));
+      $complement_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Complement,
+          std::vector<Nonnull<Expression*>>({$ref_deref_expression}));
     }
 ;
 unary_expression:
@@ -484,15 +484,15 @@ multiplicative_lhs:
 multiplicative_expression:
   multiplicative_lhs BINARY_STAR simple_binary_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Mul,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $multiplicative_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Mul,
+          std::vector<Nonnull<Expression*>>({$multiplicative_lhs, $simple_binary_operand}));
     }
 | multiplicative_lhs SLASH simple_binary_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Div,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $multiplicative_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Div,
+          std::vector<Nonnull<Expression*>>({$multiplicative_lhs, $simple_binary_operand}));
     }
 ;
 additive_operand:
@@ -507,23 +507,23 @@ additive_expression:
   multiplicative_expression
 | additive_lhs PLUS additive_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Add,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $additive_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Add,
+          std::vector<Nonnull<Expression*>>({$additive_lhs, $additive_operand}));
     }
 | additive_lhs MINUS additive_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Sub,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $additive_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Sub,
+          std::vector<Nonnull<Expression*>>({$additive_lhs, $additive_operand}));
     }
 ;
 modulo_expression:
-  simple_binary_operand PERCENT simple_binary_operand
+  simple_binary_operand[lhs] PERCENT simple_binary_operand[rhs]
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Mod,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $modulo_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Mod,
+          std::vector<Nonnull<Expression*>>({$lhs, $rhs}));
     }
 ;
 bitwise_and_lhs:
@@ -533,9 +533,9 @@ bitwise_and_lhs:
 bitwise_and_expression:
   bitwise_and_lhs AMPERSAND simple_binary_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::BitwiseAnd,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $bitwise_and_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::BitwiseAnd,
+          std::vector<Nonnull<Expression*>>({$bitwise_and_lhs, $simple_binary_operand}));
     }
 ;
 bitwise_or_lhs:
@@ -545,9 +545,9 @@ bitwise_or_lhs:
 bitwise_or_expression:
   bitwise_or_lhs PIPE simple_binary_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::BitwiseOr,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $bitwise_or_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::BitwiseOr,
+          std::vector<Nonnull<Expression*>>({$bitwise_or_lhs, $simple_binary_operand}));
     }
 ;
 bitwise_xor_lhs:
@@ -557,9 +557,9 @@ bitwise_xor_lhs:
 bitwise_xor_expression:
   bitwise_xor_lhs CARET simple_binary_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::BitwiseXor,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $bitwise_xor_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::BitwiseXor,
+          std::vector<Nonnull<Expression*>>({$bitwise_xor_lhs, $simple_binary_operand}));
     }
 ;
 bitwise_expression:
@@ -568,33 +568,33 @@ bitwise_expression:
 | bitwise_xor_expression
 ;
 bit_shift_expression:
-  simple_binary_operand LESS_LESS simple_binary_operand
+  simple_binary_operand[lhs] LESS_LESS simple_binary_operand[rhs]
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::BitShiftLeft,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $bit_shift_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::BitShiftLeft,
+          std::vector<Nonnull<Expression*>>({$lhs, $rhs}));
     }
-| simple_binary_operand GREATER_GREATER simple_binary_operand
+| simple_binary_operand[lhs] GREATER_GREATER simple_binary_operand[rhs]
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::BitShiftRight,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $bit_shift_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::BitShiftRight,
+          std::vector<Nonnull<Expression*>>({$lhs, $rhs}));
     }
 ;
 as_expression:
-  simple_binary_operand AS simple_binary_operand
+  simple_binary_operand[lhs] AS simple_binary_operand[rhs]
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::As,
-          std::vector<Nonnull<Expression*>>{$1, $3});
+      $as_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::As,
+          std::vector<Nonnull<Expression*>>{$lhs, $rhs});
     }
 ;
 unimpl_expression:
   // ref_deref_expression excluded due to precedence diamond.
-  ref_deref_expression UNIMPL_EXAMPLE ref_deref_expression
+  ref_deref_expression[lhs] UNIMPL_EXAMPLE ref_deref_expression[rhs]
     {
-      $$ = arena->New<UnimplementedExpression>(context.source_loc(),
-                                               "ExampleInfix", $1, $3);
+      $unimpl_expression = arena->New<UnimplementedExpression>(pl_context.source_loc(),
+                                               "ExampleInfix", $lhs, $rhs);
     }
 ;
 value_expression:
@@ -614,33 +614,33 @@ comparison_operand:
 ;
 comparison_operator:
   EQUAL_EQUAL
-    { $$ = Operator::Eq; }
+    { $comparison_operator = Operator::Eq; }
 | LESS
-    { $$ = Operator::Less; }
+    { $comparison_operator = Operator::Less; }
 | LESS_EQUAL
-    { $$ = Operator::LessEq; }
+    { $comparison_operator = Operator::LessEq; }
 |  GREATER
-    { $$ = Operator::Greater; }
+    { $comparison_operator = Operator::Greater; }
 | GREATER_EQUAL
-    { $$ = Operator::GreaterEq; }
+    { $comparison_operator = Operator::GreaterEq; }
 | NOT_EQUAL
-    { $$ = Operator::NotEq; }
+    { $comparison_operator = Operator::NotEq; }
 ;
 comparison_expression:
   value_expression
-| comparison_operand comparison_operator comparison_operand
+| comparison_operand[lhs] comparison_operator comparison_operand[rhs]
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), $2,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $comparison_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), $comparison_operator,
+          std::vector<Nonnull<Expression*>>({$lhs, $rhs}));
     }
 ;
 not_expression:
   NOT ref_deref_expression
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Not,
-          std::vector<Nonnull<Expression*>>({$2}));
+      $not_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Not,
+          std::vector<Nonnull<Expression*>>({$ref_deref_expression}));
     }
 ;
 predicate_expression:
@@ -660,9 +660,9 @@ and_expression:
   // predicate_expression excluded due to precedence diamond.
   and_lhs AND and_or_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::And,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $and_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::And,
+          std::vector<Nonnull<Expression*>>({$and_lhs, $and_or_operand}));
     }
 ;
 or_lhs:
@@ -673,32 +673,32 @@ or_expression:
   // predicate_expression excluded due to precedence diamond.
   or_lhs OR and_or_operand
     {
-      $$ = arena->New<OperatorExpression>(
-          context.source_loc(), Operator::Or,
-          std::vector<Nonnull<Expression*>>({$1, $3}));
+      $or_expression = arena->New<OperatorExpression>(
+          pl_context.source_loc(), Operator::Or,
+          std::vector<Nonnull<Expression*>>({$or_lhs, $and_or_operand}));
     }
 ;
 where_clause:
-  comparison_operand IS comparison_operand
-    { $$ = arena->New<IsWhereClause>(context.source_loc(), $1, $3); }
-| comparison_operand EQUAL_EQUAL comparison_operand
-    { $$ = arena->New<EqualsWhereClause>(context.source_loc(), $1, $3); }
+  comparison_operand[lhs] IS comparison_operand[rhs]
+    { $where_clause = arena->New<IsWhereClause>(pl_context.source_loc(), $lhs, $rhs); }
+| comparison_operand[lhs] EQUAL_EQUAL comparison_operand[rhs]
+    { $where_clause = arena->New<EqualsWhereClause>(pl_context.source_loc(), $lhs, $rhs); }
 ;
 where_clause_list:
   where_clause
-    { $$ = {$1}; }
-| where_clause_list AND where_clause
+    { $where_clause_list = {$where_clause}; }
+| where_clause_list[wclist] AND where_clause
     {
-      $$ = std::move($1);
-      $$.push_back($3);
+      $$ = std::move($wclist);
+      $$.push_back($where_clause);
     }
 ;
 where_expression:
   type_expression WHERE where_clause_list
     {
       auto* self =
-          arena -> New<GenericBinding>(context.source_loc(), ".Self", $1);
-      $$ = arena->New<WhereExpression>(context.source_loc(), self, $3);
+          arena -> New<GenericBinding>(pl_context.source_loc(), ".Self", $type_expression);
+      $where_expression = arena->New<WhereExpression>(pl_context.source_loc(), self, $where_clause_list);
     }
 ;
 type_or_where_expression:
@@ -714,72 +714,72 @@ statement_expression:
 ;
 if_expression:
   statement_expression
-| IF expression THEN if_expression ELSE if_expression
-    { $$ = arena->New<IfExpression>(context.source_loc(), $2, $4, $6); }
+| IF expression THEN if_expression[if_true] ELSE if_expression[if_else]
+    { $$ = arena->New<IfExpression>(pl_context.source_loc(), $expression, $if_true, $if_else); }
 ;
 expression:
   if_expression
 ;
-designator: PERIOD identifier { $$ = $2; }
+designator: PERIOD identifier { $designator = $identifier; }
 ;
 paren_expression: paren_expression_base
-    { $$ = ExpressionFromParenContents(arena, context.source_loc(), $1); }
+    { $paren_expression = ExpressionFromParenContents(arena, pl_context.source_loc(), $paren_expression_base); }
 ;
 tuple: paren_expression_base
-    { $$ = TupleExpressionFromParenContents(arena, context.source_loc(), $1); }
+    { $tuple = TupleExpressionFromParenContents(arena, pl_context.source_loc(), $paren_expression_base); }
 ;
 paren_expression_base:
   LEFT_PARENTHESIS RIGHT_PARENTHESIS
-    { $$ = {.elements = {}, .has_trailing_comma = false}; }
+    { $paren_expression_base = {.elements = {}, .has_trailing_comma = false}; }
 | LEFT_PARENTHESIS paren_expression_contents RIGHT_PARENTHESIS
-    { $$ = $2; }
+    { $paren_expression_base = $paren_expression_contents; }
 | LEFT_PARENTHESIS paren_expression_contents COMMA RIGHT_PARENTHESIS
     {
-      $$ = $2;
-      $$.has_trailing_comma = true;
+      $paren_expression_base = $paren_expression_contents;
+      $paren_expression_base.has_trailing_comma = true;
     }
 ;
 paren_expression_contents:
   expression
-    { $$ = {.elements = {$1}, .has_trailing_comma = false}; }
-| paren_expression_contents COMMA expression
+    { $paren_expression_contents = {.elements = {$expression}, .has_trailing_comma = false}; }
+| paren_expression_contents[peclist] COMMA expression
     {
-      $$ = $1;
-      $$.elements.push_back($3);
+      $$ = $peclist;
+      $$.elements.push_back($expression);
     }
 ;
 
 struct_literal:
   LEFT_CURLY_BRACE struct_literal_contents RIGHT_CURLY_BRACE
-    { $$ = arena->New<StructLiteral>(context.source_loc(), $2); }
+    { $struct_literal = arena->New<StructLiteral>(pl_context.source_loc(), $struct_literal_contents); }
 | LEFT_CURLY_BRACE struct_literal_contents COMMA RIGHT_CURLY_BRACE
-    { $$ = arena->New<StructLiteral>(context.source_loc(), $2); }
+    { $struct_literal = arena->New<StructLiteral>(pl_context.source_loc(), $struct_literal_contents); }
 ;
 struct_literal_contents:
   designator EQUAL expression
-    { $$ = {FieldInitializer($1, $3)}; }
-| struct_literal_contents COMMA designator EQUAL expression
+    { $struct_literal_contents = {FieldInitializer($designator, $expression)}; }
+| struct_literal_contents[slclist] COMMA designator EQUAL expression
     {
-      $$ = $1;
-      $$.push_back(FieldInitializer($3, $5));
+      $$ = std::move($slclist);
+      $$.push_back(FieldInitializer($designator, $expression));
     }
 ;
 
 struct_type_literal:
   LEFT_CURLY_BRACE RIGHT_CURLY_BRACE
-    { $$ = arena->New<StructTypeLiteral>(context.source_loc()); }
+    { $struct_type_literal = arena->New<StructTypeLiteral>(pl_context.source_loc()); }
 | LEFT_CURLY_BRACE struct_type_literal_contents RIGHT_CURLY_BRACE
-    { $$ = arena->New<StructTypeLiteral>(context.source_loc(), $2); }
+    { $struct_type_literal = arena->New<StructTypeLiteral>(pl_context.source_loc(), $struct_type_literal_contents); }
 | LEFT_CURLY_BRACE struct_type_literal_contents COMMA RIGHT_CURLY_BRACE
-    { $$ = arena->New<StructTypeLiteral>(context.source_loc(), $2); }
+    { $struct_type_literal = arena->New<StructTypeLiteral>(pl_context.source_loc(), $struct_type_literal_contents); }
 ;
 struct_type_literal_contents:
   designator COLON expression
-    { $$ = {FieldInitializer($1, $3)}; }
-| struct_type_literal_contents COMMA designator COLON expression
+    { $struct_type_literal_contents = {FieldInitializer($designator, $expression)}; }
+| struct_type_literal_contents[stlclist] COMMA designator COLON expression
   {
-    $$ = $1;
-    $$.push_back(FieldInitializer($3, $5));
+    $$ = std::move($stlclist);
+    $$.push_back(FieldInitializer($designator, $expression));
   }
 ;
 
@@ -791,50 +791,50 @@ struct_type_literal_contents:
 // specified.
 pattern:
   non_expression_pattern
-    { $$ = $1; }
+    { $pattern = $non_expression_pattern; }
 | expression
-    { $$ = arena->New<ExpressionPattern>($1); }
+    { $pattern = arena->New<ExpressionPattern>($expression); }
 ;
 non_expression_pattern:
   AUTO
-    { $$ = arena->New<AutoPattern>(context.source_loc()); }
+    { $non_expression_pattern = arena->New<AutoPattern>(pl_context.source_loc()); }
 | binding_lhs COLON pattern
     {
-      $$ = arena->New<BindingPattern>(context.source_loc(), $1, $3,
+      $non_expression_pattern = arena->New<BindingPattern>(pl_context.source_loc(), $binding_lhs, $pattern,
                                       std::nullopt);
     }
 | binding_lhs COLON_BANG expression
-    { $$ = arena->New<GenericBinding>(context.source_loc(), $1, $3); }
+    { $non_expression_pattern = arena->New<GenericBinding>(pl_context.source_loc(), $binding_lhs, $expression); }
 | paren_pattern
-    { $$ = $1; }
+    { $non_expression_pattern = $paren_pattern; }
 | postfix_expression tuple_pattern
     {
       ErrorOr<Nonnull<AlternativePattern*>> alternative_pattern =
-          AlternativePattern::Create(arena, context.source_loc(), $1, $2);
+          AlternativePattern::Create(arena, pl_context.source_loc(), $postfix_expression, $tuple_pattern);
       if (alternative_pattern.ok()) {
-        $$ = *alternative_pattern;
+        $non_expression_pattern = *alternative_pattern;
       } else {
-        context.RecordSyntaxError(std::move(alternative_pattern).error());
+        pl_context.RecordSyntaxError(std::move(alternative_pattern).error());
         YYERROR;
       }
     }
-| VAR non_expression_pattern
-    { $$ = arena->New<VarPattern>(context.source_loc(), $2); }
+| VAR non_expression_pattern[rhs]
+    { $$ = arena->New<VarPattern>(pl_context.source_loc(), $rhs); }
 ;
 binding_lhs:
-  identifier { $$ = $1; }
-| UNDERSCORE { $$ = AnonymousName; }
+  identifier { $binding_lhs = $identifier; }
+| UNDERSCORE { $binding_lhs = AnonymousName; }
 ;
 paren_pattern: paren_pattern_base
-    { $$ = PatternFromParenContents(arena, context.source_loc(), $1); }
+    { $paren_pattern = PatternFromParenContents(arena, pl_context.source_loc(), $paren_pattern_base); }
 ;
 paren_pattern_base:
   LEFT_PARENTHESIS paren_pattern_contents RIGHT_PARENTHESIS
-    { $$ = $2; }
+    { $paren_pattern_base = $paren_pattern_contents; }
 | LEFT_PARENTHESIS paren_pattern_contents COMMA RIGHT_PARENTHESIS
     {
-      $$ = $2;
-      $$.has_trailing_comma = true;
+      $paren_pattern_base = $paren_pattern_contents;
+      $paren_pattern_base.has_trailing_comma = true;
     }
 ;
 // paren_pattern is analogous to paren_expression, but in order to avoid
@@ -844,25 +844,25 @@ paren_pattern_base:
 // enforce that requirement.
 paren_pattern_contents:
   non_expression_pattern
-    { $$ = {.elements = {$1}, .has_trailing_comma = false}; }
+    { $paren_pattern_contents = {.elements = {$non_expression_pattern}, .has_trailing_comma = false}; }
 | paren_expression_contents COMMA non_expression_pattern
     {
-      $$ = ParenExpressionToParenPattern(arena, $1);
-      $$.elements.push_back($3);
+      $paren_pattern_contents = ParenExpressionToParenPattern(arena, $paren_expression_contents);
+      $paren_pattern_contents.elements.push_back($non_expression_pattern);
     }
-| paren_pattern_contents COMMA expression
+| paren_pattern_contents[ppclist] COMMA expression
     {
-      $$ = $1;
-      $$.elements.push_back(arena->New<ExpressionPattern>($3));
+      $$ = $ppclist;
+      $$.elements.push_back(arena->New<ExpressionPattern>($expression));
     }
-| paren_pattern_contents COMMA non_expression_pattern
+| paren_pattern_contents[ppclist] COMMA non_expression_pattern
     {
-      $$ = $1;
-      $$.elements.push_back($3);
+      $$ = $ppclist;
+      $$.elements.push_back($non_expression_pattern);
     }
 ;
 tuple_pattern: paren_pattern_base
-    { $$ = TuplePatternFromParenContents(arena, context.source_loc(), $1); }
+    { $tuple_pattern = TuplePatternFromParenContents(arena, pl_context.source_loc(), $paren_pattern_base); }
 ;
 // Unlike most `pattern` nonterminals, this one overlaps with `expression`,
 // so it should be used only when prior context (such as an introducer)
@@ -870,334 +870,343 @@ tuple_pattern: paren_pattern_base
 maybe_empty_tuple_pattern:
   LEFT_PARENTHESIS RIGHT_PARENTHESIS
     {
-      $$ = arena->New<TuplePattern>(context.source_loc(),
+      $maybe_empty_tuple_pattern = arena->New<TuplePattern>(pl_context.source_loc(),
                                     std::vector<Nonnull<Pattern*>>());
     }
 | tuple_pattern
-    { $$ = $1; }
+    { $maybe_empty_tuple_pattern = $tuple_pattern; }
 ;
 
 clause:
   CASE pattern DOUBLE_ARROW block
-    { $$ = Match::Clause($2, $4); }
+    { $clause = Match::Clause($pattern, $block); }
 | DEFAULT DOUBLE_ARROW block
     {
-      $$ = Match::Clause(arena->New<BindingPattern>(
-                             context.source_loc(), std::string(AnonymousName),
-                             arena->New<AutoPattern>(context.source_loc()),
+      $clause = Match::Clause(arena->New<BindingPattern>(
+                             pl_context.source_loc(), std::string(AnonymousName),
+                             arena->New<AutoPattern>(pl_context.source_loc()),
                              ValueCategory::Let),
-                         $3);
+                         $block);
     }
 ;
+
 clause_list:
   // Empty
-    { $$ = {}; }
-| clause_list clause
+    { $clause_list = {}; }
+| clause_list[clist] clause
     {
-      $$ = $1;
-      $$.push_back($2);
+      $$ = std::move($clist);
+      $$.push_back($clause);
     }
 ;
+
 statement:
   statement_expression EQUAL expression SEMICOLON
-    { $$ = arena->New<Assign>(context.source_loc(), $1, $3); }
+    { $statement = arena->New<Assign>(pl_context.source_loc(), $statement_expression, $expression); }
 | VAR pattern SEMICOLON
     {
-      $$ = arena->New<VariableDefinition>(
-          context.source_loc(), $2, std::nullopt, ValueCategory::Var,
+      $statement = arena->New<VariableDefinition>(
+          pl_context.source_loc(), $pattern, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }
 | VAR pattern EQUAL expression SEMICOLON
     {
-      $$ = arena->New<VariableDefinition>(
-          context.source_loc(), $2, $4, ValueCategory::Var,
+      $statement = arena->New<VariableDefinition>(
+          pl_context.source_loc(), $pattern, $expression, ValueCategory::Var,
           VariableDefinition::DefinitionType::Var);
     }
 | RETURNED VAR variable_declaration SEMICOLON
     {
-      $$ = arena->New<VariableDefinition>(
-          context.source_loc(), $3, std::nullopt, ValueCategory::Var,
+      $statement = arena->New<VariableDefinition>(
+          pl_context.source_loc(), $variable_declaration, std::nullopt, ValueCategory::Var,
           VariableDefinition::DefinitionType::Returned);
     }
 | RETURNED VAR variable_declaration EQUAL expression SEMICOLON
     {
-      $$ = arena->New<VariableDefinition>(
-          context.source_loc(), $3, $5, ValueCategory::Var,
+      $statement = arena->New<VariableDefinition>(
+          pl_context.source_loc(), $variable_declaration, $expression, ValueCategory::Var,
           VariableDefinition::DefinitionType::Returned);
     }
 | LET pattern EQUAL expression SEMICOLON
     {
-      $$ = arena->New<VariableDefinition>(
-          context.source_loc(), $2, $4, ValueCategory::Let,
+      $statement = arena->New<VariableDefinition>(
+          pl_context.source_loc(), $pattern, $expression, ValueCategory::Let,
           VariableDefinition::DefinitionType::Var);
     }
 | statement_expression SEMICOLON
-    { $$ = arena->New<ExpressionStatement>(context.source_loc(), $1); }
+    { $statement = arena->New<ExpressionStatement>(pl_context.source_loc(), $statement_expression); }
 | if_statement
-    { $$ = $1; }
+    { $statement = $if_statement; }
 | WHILE LEFT_PARENTHESIS expression RIGHT_PARENTHESIS block
-    { $$ = arena->New<While>(context.source_loc(), $3, $5); }
+    { $statement = arena->New<While>(pl_context.source_loc(), $expression, $block); }
 | BREAK SEMICOLON
-    { $$ = arena->New<Break>(context.source_loc()); }
+    { $statement = arena->New<Break>(pl_context.source_loc()); }
 | CONTINUE SEMICOLON
-    { $$ = arena->New<Continue>(context.source_loc()); }
+    { $statement = arena->New<Continue>(pl_context.source_loc()); }
 | RETURN return_expression SEMICOLON
     {
-      auto [return_exp, is_omitted_exp] = $2;
-      $$ = arena->New<ReturnExpression>(context.source_loc(), return_exp,
+      auto [return_exp, is_omitted_exp] = $return_expression;
+      $statement = arena->New<ReturnExpression>(pl_context.source_loc(), return_exp,
                                         is_omitted_exp);
     }
 | RETURN VAR SEMICOLON
-    { $$ = arena->New<ReturnVar>(context.source_loc()); }
+    { $statement = arena->New<ReturnVar>(pl_context.source_loc()); }
 | MATCH LEFT_PARENTHESIS expression RIGHT_PARENTHESIS LEFT_CURLY_BRACE
   clause_list RIGHT_CURLY_BRACE
-    { $$ = arena->New<Match>(context.source_loc(), $3, $6); }
+    { $statement = arena->New<Match>(pl_context.source_loc(), $expression, $clause_list); }
 | CONTINUATION identifier block
-    { $$ = arena->New<Continuation>(context.source_loc(), $2, $3); }
+    { $statement = arena->New<Continuation>(pl_context.source_loc(), $identifier, $block); }
 | RUN expression SEMICOLON
-    { $$ = arena->New<Run>(context.source_loc(), $2); }
+    { $statement = arena->New<Run>(pl_context.source_loc(), $expression); }
 | AWAIT SEMICOLON
-    { $$ = arena->New<Await>(context.source_loc()); }
+    { $statement = arena->New<Await>(pl_context.source_loc()); }
 | FOR LEFT_PARENTHESIS variable_declaration IN type_expression RIGHT_PARENTHESIS block
-    { $$ = arena->New<For>(context.source_loc(), $3, $5, $7); }
+    { $statement = arena->New<For>(pl_context.source_loc(), $variable_declaration, $type_expression, $block); }
 ;
 if_statement:
   IF LEFT_PARENTHESIS expression RIGHT_PARENTHESIS block optional_else
-    { $$ = arena->New<If>(context.source_loc(), $3, $5, $6); }
+    { $if_statement = arena->New<If>(pl_context.source_loc(), $expression, $block, $optional_else); }
 ;
 optional_else:
   // Empty
-    { $$ = std::nullopt; }
+    { $optional_else = std::nullopt; }
 | ELSE if_statement
     {
-      $$ = arena->New<Block>(context.source_loc(),
-                             std::vector<Nonnull<Statement*>>({$2}));
+      $optional_else = arena->New<Block>(pl_context.source_loc(),
+                             std::vector<Nonnull<Statement*>>({$if_statement}));
     }
 | ELSE block
-    { $$ = $2; }
+    { $optional_else = $block; }
 ;
 return_expression:
   // Empty
-    { $$ = {arena->New<TupleLiteral>(context.source_loc()), true}; }
+    { $return_expression = {arena->New<TupleLiteral>(pl_context.source_loc()), true}; }
 | expression
-    { $$ = {$1, false}; }
+    { $return_expression = {$expression, false}; }
 ;
 statement_list:
   // Empty
-    { $$ = {}; }
-| statement_list statement
+    { $statement_list = {}; }
+| statement_list[slist] statement
     {
-      $$ = std::move($1);
-      $$.push_back($2);
+      $$ = std::move($slist);
+      $$.push_back($statement);
     }
 ;
 block:
   LEFT_CURLY_BRACE statement_list RIGHT_CURLY_BRACE
-    { $$ = arena->New<Block>(context.source_loc(), std::move($2)); }
+    { $block = arena->New<Block>(pl_context.source_loc(), std::move($statement_list)); }
 ;
+
 return_term:
   // Empty
-    { $$ = ReturnTerm::Omitted(context.source_loc()); }
+    { $return_term = ReturnTerm::Omitted(pl_context.source_loc()); }
 | ARROW AUTO
-    { $$ = ReturnTerm::Auto(context.source_loc()); }
+    { $return_term = ReturnTerm::Auto(pl_context.source_loc()); }
 | ARROW expression
-    { $$ = ReturnTerm::Explicit($2); }
+    { $return_term = ReturnTerm::Explicit($expression); }
 ;
+
 generic_binding:
   identifier COLON_BANG expression
     {
-      $$ = arena->New<GenericBinding>(context.source_loc(), std::move($1), $3);
+      $generic_binding = arena->New<GenericBinding>(pl_context.source_loc(), std::move($identifier), $expression);
     }
 ;
+
 deduced_param:
   generic_binding
-    { $$ = $1; }
+    { $deduced_param = $generic_binding; }
 | variable_declaration
-    { $$ = $1; }
+    { $deduced_param = $variable_declaration; }
 | ADDR variable_declaration
-    { $$ = arena->New<AddrPattern>(context.source_loc(), $2); }
+    { $deduced_param = arena->New<AddrPattern>(pl_context.source_loc(), $variable_declaration); }
 ;
+
 deduced_param_list:
   // Empty
-    { $$ = {}; }
+    { $deduced_param_list = {}; }
 | deduced_param
-    { $$ = {$1}; }
-| deduced_param_list COMMA deduced_param
+    { $deduced_param_list = {$deduced_param}; }
+| deduced_param_list[dplist] COMMA deduced_param
     {
-      $$ = $1;  // TODO: can we std::move here?
-      $$.push_back($3);
+      $$ = std::move($dplist);
+      $$.push_back($deduced_param);
     }
 ;
+
 deduced_params:
   // Empty
-    { $$ = std::vector<Nonnull<AstNode*>>(); }
+    { $deduced_params = std::vector<Nonnull<AstNode*>>(); }
 | LEFT_SQUARE_BRACKET deduced_param_list RIGHT_SQUARE_BRACKET
-    { $$ = $2; }
+    { $deduced_params = $deduced_param_list; }
 ;
+
 impl_deduced_params:
   // Empty
-    { $$ = std::vector<Nonnull<AstNode*>>(); }
+    { $impl_deduced_params = std::vector<Nonnull<AstNode*>>(); }
 | FORALL LEFT_SQUARE_BRACKET deduced_param_list RIGHT_SQUARE_BRACKET
-    { $$ = $3; }
+    { $impl_deduced_params = $deduced_param_list; }
 ;
+
 function_declaration:
   FN identifier deduced_params maybe_empty_tuple_pattern return_term block
     {
       ErrorOr<FunctionDeclaration*> fn = FunctionDeclaration::Create(
-          arena, context.source_loc(), $2, $3, $4, $5, $6);
+          arena, pl_context.source_loc(), $identifier, $deduced_params, $maybe_empty_tuple_pattern, $return_term, $block);
       if (fn.ok()) {
-        $$ = *fn;
+        $function_declaration = *fn;
       } else {
-        context.RecordSyntaxError(std::move(fn).error());
+        pl_context.RecordSyntaxError(std::move(fn).error());
         YYERROR;
       }
     }
 | FN identifier deduced_params maybe_empty_tuple_pattern return_term SEMICOLON
     {
       ErrorOr<FunctionDeclaration*> fn = FunctionDeclaration::Create(
-          arena, context.source_loc(), $2, $3, $4, $5, std::nullopt);
+          arena, pl_context.source_loc(), $identifier, $deduced_params, $maybe_empty_tuple_pattern, $return_term, std::nullopt);
       if (fn.ok()) {
-        $$ = *fn;
+        $function_declaration = *fn;
       } else {
-        context.RecordSyntaxError(std::move(fn).error());
+        pl_context.RecordSyntaxError(std::move(fn).error());
         YYERROR;
       }
     }
 ;
 variable_declaration: identifier COLON pattern
     {
-      $$ = arena->New<BindingPattern>(context.source_loc(), $1, $3,
+      $variable_declaration = arena->New<BindingPattern>(pl_context.source_loc(), $identifier, $pattern,
                                       std::nullopt);
     }
 ;
 alias_declaration: ALIAS identifier EQUAL expression SEMICOLON
-    { $$ = arena->New<AliasDeclaration>(context.source_loc(), $2, $4); }
+    { $alias_declaration = arena->New<AliasDeclaration>(pl_context.source_loc(), $identifier, $expression); }
 ;
 // EXPERIMENTAL MIXIN FEATURE
 mix_declaration: MIX expression SEMICOLON
-    { $$ = arena->New<MixDeclaration>(context.source_loc(), $2); }
+    { $mix_declaration = arena->New<MixDeclaration>(pl_context.source_loc(), $expression); }
 ;
 alternative:
   identifier tuple
-    { $$ = arena->New<AlternativeSignature>(context.source_loc(), $1, $2); }
+    { $alternative = arena->New<AlternativeSignature>(pl_context.source_loc(), $identifier, $tuple); }
 | identifier
     {
-      $$ = arena->New<AlternativeSignature>(
-          context.source_loc(), $1,
-          arena->New<TupleLiteral>(context.source_loc()));
+      $alternative = arena->New<AlternativeSignature>(
+          pl_context.source_loc(), $identifier,
+          arena->New<TupleLiteral>(pl_context.source_loc()));
     }
 ;
 alternative_list:
   // Empty
-    { $$ = {}; }
+    { $alternative_list = {}; }
 | alternative_list_contents
-    { $$ = $1; }
+    { $alternative_list = $alternative_list_contents; }
 | alternative_list_contents COMMA
-    { $$ = $1; }
+    { $alternative_list = $alternative_list_contents; }
 ;
 alternative_list_contents:
   alternative
-    { $$ = {std::move($1)}; }
-| alternative_list_contents COMMA alternative
+    { $alternative_list_contents = {std::move($alternative)}; }
+| alternative_list_contents[alclist] COMMA alternative
     {
-      $$ = $1;
-      $$.push_back(std::move($3));
+      $$ = std::move($alclist);
+      $$.push_back(std::move($alternative));
     }
 ;
 type_params:
   // Empty
-    { $$ = std::nullopt; }
+    { $type_params = std::nullopt; }
 | tuple_pattern
-    { $$ = $1; }
+    { $type_params = $tuple_pattern; }
 ;
 // EXPERIMENTAL MIXIN FEATURE
 mixin_import:
   // Empty
-    { $$ = arena->New<TypeTypeLiteral>(context.source_loc()); }
+    { $mixin_import = arena->New<TypeTypeLiteral>(pl_context.source_loc()); }
 | FOR expression
     {
-      context.RecordSyntaxError("'for' not supported currently");
+      pl_context.RecordSyntaxError("'for' not supported currently");
       YYERROR;
-      // $$ = $2;
+      // $mixin_import = $expression;
     }
 ;
 class_declaration_extensibility:
   // Empty
-    { $$ = Carbon::ClassExtensibility::None; }
+    { $class_declaration_extensibility = Carbon::ClassExtensibility::None; }
 | ABSTRACT
-    { $$ = Carbon::ClassExtensibility::Abstract; }
+    { $class_declaration_extensibility = Carbon::ClassExtensibility::Abstract; }
 | BASE
-    { $$ = Carbon::ClassExtensibility::Base; }
+    { $class_declaration_extensibility = Carbon::ClassExtensibility::Base; }
 ;
 class_declaration_extends:
   // Empty
-    { $$ = std::nullopt; }
+    { $class_declaration_extends = std::nullopt; }
 | EXTENDS expression
-    { $$ = $2; }
+    { $class_declaration_extends = $expression; }
 ;
 declaration:
   function_declaration
-    { $$ = $1; }
+    { $declaration = $function_declaration; }
 | destructor_declaration
-    { $$ = $1; }
+    { $declaration = $destructor_declaration; }
 | class_declaration_extensibility CLASS identifier type_params class_declaration_extends LEFT_CURLY_BRACE class_body RIGHT_CURLY_BRACE
     {
-      $$ = arena->New<ClassDeclaration>(
-          context.source_loc(), $3,
-          arena->New<SelfDeclaration>(context.source_loc()), $1, $4, $5, $7);
+      $declaration = arena->New<ClassDeclaration>(
+          pl_context.source_loc(), $identifier,
+          arena->New<SelfDeclaration>(pl_context.source_loc()), $class_declaration_extensibility, $type_params, $class_declaration_extends, $class_body);
     }
 | MIXIN identifier type_params mixin_import LEFT_CURLY_BRACE mixin_body RIGHT_CURLY_BRACE
     {
       // EXPERIMENTAL MIXN FEATURE
       auto self =
-          arena -> New<GenericBinding>(context.source_loc(), "Self", $4);
-      $$ = arena->New<MixinDeclaration>(context.source_loc(), $2, $3, self, $6);
+          arena -> New<GenericBinding>(pl_context.source_loc(), "Self", $mixin_import);
+      $declaration = arena->New<MixinDeclaration>(pl_context.source_loc(), $identifier, $type_params, self, $mixin_body);
     }
 | CHOICE identifier type_params LEFT_CURLY_BRACE alternative_list RIGHT_CURLY_BRACE
-    { $$ = arena->New<ChoiceDeclaration>(context.source_loc(), $2, $3, $5); }
+    { $declaration = arena->New<ChoiceDeclaration>(pl_context.source_loc(), $identifier, $type_params, $alternative_list); }
 | VAR variable_declaration SEMICOLON
     {
-      $$ = arena->New<VariableDeclaration>(context.source_loc(), $2,
+      $declaration = arena->New<VariableDeclaration>(pl_context.source_loc(), $variable_declaration,
                                            std::nullopt, ValueCategory::Var);
     }
 | VAR variable_declaration EQUAL expression SEMICOLON
     {
-      $$ = arena->New<VariableDeclaration>(context.source_loc(), $2, $4,
+      $declaration = arena->New<VariableDeclaration>(pl_context.source_loc(), $variable_declaration, $expression,
                                            ValueCategory::Var);
     }
 | LET variable_declaration EQUAL expression SEMICOLON
     {
-      $$ = arena->New<VariableDeclaration>(context.source_loc(), $2, $4,
+      $declaration = arena->New<VariableDeclaration>(pl_context.source_loc(), $variable_declaration, $expression,
                                            ValueCategory::Let);
     }
 | INTERFACE identifier type_params LEFT_CURLY_BRACE interface_body RIGHT_CURLY_BRACE
     {
-      $$ = arena->New<InterfaceDeclaration>(arena, context.source_loc(), $2, $3,
-                                            $5);
+      $declaration = arena->New<InterfaceDeclaration>(arena, pl_context.source_loc(), $identifier, $type_params,
+                                            $interface_body);
     }
 | impl_kind IMPL impl_deduced_params impl_type AS type_or_where_expression LEFT_CURLY_BRACE impl_body RIGHT_CURLY_BRACE
     {
       ErrorOr<ImplDeclaration*> impl = ImplDeclaration::Create(
-          arena, context.source_loc(), $1, $4, $6, $3, $8);
+          arena, pl_context.source_loc(), $impl_kind, $impl_type, $type_or_where_expression, $impl_deduced_params, $impl_body);
       if (impl.ok()) {
-        $$ = *impl;
+        $declaration = *impl;
       } else {
-        context.RecordSyntaxError(std::move(impl).error());
+        pl_context.RecordSyntaxError(std::move(impl).error());
         YYERROR;
       }
     }
 | alias_declaration
-    { $$ = $1; }
+    { $declaration = $alias_declaration; }
 ;
 impl_kind:
   // Internal
-    { $$ = Carbon::ImplKind::InternalImpl; }
+    { $impl_kind = Carbon::ImplKind::InternalImpl; }
 | EXTERNAL
-    { $$ = Carbon::ImplKind::ExternalImpl; }
+    { $impl_kind = Carbon::ImplKind::ExternalImpl; }
 ;
 impl_type:
   // Self
-    { $$ = arena->New<IdentifierExpression>(context.source_loc(), "Self"); }
+    { $impl_type = arena->New<IdentifierExpression>(pl_context.source_loc(), "Self"); }
 | type_expression
 ;
 destructor_declaration:
@@ -1205,83 +1214,83 @@ destructor_declaration:
   {
     ErrorOr<DestructorDeclaration*> fn =
         DestructorDeclaration::CreateDestructor(
-            arena, context.source_loc(), $2,
-            arena->New<TuplePattern>(context.source_loc(),
+            arena, pl_context.source_loc(), $deduced_params,
+            arena->New<TuplePattern>(pl_context.source_loc(),
                                      std::vector<Nonnull<Pattern*>>()),
-            ReturnTerm::Omitted(context.source_loc()), $3);
+            ReturnTerm::Omitted(pl_context.source_loc()), $block);
     if (fn.ok()) {
-      $$ = *fn;
+      $destructor_declaration = *fn;
     } else {
-      context.RecordSyntaxError(std::move(fn).error());
+      pl_context.RecordSyntaxError(std::move(fn).error());
       YYERROR;
     }
   }
 ;
 declaration_list:
   // Empty
-    { $$ = {}; }
-| declaration_list declaration
+    { $declaration_list = {}; }
+| declaration_list[dlist] declaration
     {
-      $$ = $1;
-      $$.push_back(Nonnull<Declaration*>($2));
+      $$ = std::move($dlist);
+      $$.push_back(Nonnull<Declaration*>($declaration));
     }
 ;
 class_body:
   // Empty
-    { $$ = {}; }
-| class_body declaration
+    { $class_body = {}; }
+| class_body[cblist] declaration
     {
-      $$ = $1;
-      $$.push_back(Nonnull<Declaration*>($2));
+      $$ = std::move($cblist);
+      $$.push_back(Nonnull<Declaration*>($declaration));
     }
-| class_body mix_declaration
+| class_body[cblist] mix_declaration
     {
-      $$ = $1;
-      $$.push_back(Nonnull<Declaration*>($2));
+      $$ = std::move($cblist);
+      $$.push_back(Nonnull<Declaration*>($mix_declaration));
     }
 ;
 // EXPERIMENTAL MIXIN FEATURE
 mixin_body:
   // Empty
-    { $$ = {}; }
-| mixin_body function_declaration
+    { $mixin_body = {}; }
+| mixin_body[mblist] function_declaration
     {
-      $$ = $1;
-      $$.push_back(Nonnull<Declaration*>($2));
+      $$ = std::move($mblist);
+      $$.push_back(Nonnull<Declaration*>($function_declaration));
     }
-| mixin_body mix_declaration
+| mixin_body[mblist] mix_declaration
     {
-      $$ = $1;
-      $$.push_back(Nonnull<Declaration*>($2));
+      $$ = std::move($mblist);
+      $$.push_back(Nonnull<Declaration*>($mix_declaration));
     }
 ;
 interface_body:
   // Empty
-    { $$ = {}; }
-| interface_body function_declaration
+    { $interface_body = {}; }
+| interface_body[iblist] function_declaration
     {
-      $$ = $1;
-      $$.push_back($2);
+      $$ = std::move($iblist);
+      $$.push_back($function_declaration);
     }
-| interface_body LET generic_binding SEMICOLON
+| interface_body[iblist] LET generic_binding SEMICOLON
     {
-      $$ = $1;
+      $$ = std::move($iblist);
       $$.push_back(
-          arena->New<AssociatedConstantDeclaration>(context.source_loc(), $3));
+          arena->New<AssociatedConstantDeclaration>(pl_context.source_loc(), $generic_binding));
     }
 ;
 impl_body:
   // Empty
-    { $$ = {}; }
-| impl_body function_declaration
+    { $impl_body = {}; }
+| impl_body[iblist] function_declaration
     {
-      $$ = $1;
-      $$.push_back($2);
+      $$ = std::move($iblist);
+      $$.push_back($function_declaration);
     }
-| impl_body alias_declaration
+| impl_body[iblist] alias_declaration
     {
-      $$ = $1;
-      $$.push_back($2);
+      $$ = std::move($iblist);
+      $$.push_back($alias_declaration);
     }
 ;
 %%


### PR DESCRIPTION
- Replace positional references with named references
- Rename `context` to be able to use bison 3.2.8 (there is a name clash with 'context')
- Add `std::move' to several std::vector lists