### PR TITLE
Name of application entry point

### DIFF
--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -16,7 +16,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Problem](#problem)
 -   [Background](#background)
 -   [Proposal](#proposal)
--   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
 
@@ -24,47 +23,45 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+This proposal evaluates some possible reasoning which may contribute to a
+decision about naming the application entry point.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+While it isn't a pressing need, a standardization on the name of the entry point
+will be necessary as execution starts from a consistent and known place.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+Within Carbon community based discussions, the two names that have merrited
+discussion so far have been `Main` and `Run`.
+
+Overwhelmingly, the majority of mainstream programming languages use a version
+of `Main` as their entry point (although capitalization varies based on the
+language's standards). Some of the most prominent examples are C, C++, D, Zig,
+Rust, Kotlin, Java, C#, Go, and Haskell.
+
+Meanwhile, `Run` seems to be far less common as an application entry point,
+although it does see more use as a framework entry point, likely aided by its
+place in the English language as a "command" word. Notably it is also used by
+Docker to begin running a container process.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
-
-## Details
-
-TODO: Fully explain the details of the proposed solution.
+Carbon officially adopts the name `Main` for its application entry point.
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+By going with `Main` the entry point both
+[adheres to the principle of least surprise](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+and provides
+[familiarity for experienced C++ developers with a gentle learning curve](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code).
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+Options for alternatives are limitless although few others are as standardized
+or likely to receive support due to familiarity and convention.
+
+Additionally, options representing a more dramatic paradigm shift such as (a)
+user defined entry point(s) or similar structural changes have not been
+discussed as they are outside of the scope of this proposal.

--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -35,7 +35,7 @@ will be necessary as execution starts from a consistent and known place.
 
 ## Background
 
-Within Carbon community based discussions, the two names that have merrited
+Within Carbon community based discussions, the two names that have merited
 discussion so far have been `Main` and `Run`.
 
 Overwhelmingly, the majority of mainstream programming languages use a version

--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -67,3 +67,15 @@ or likely to receive support due to familiarity and convention.
 Additionally, options representing a more dramatic paradigm shift such as (a)
 user defined entry point(s) or similar structural changes have not been
 discussed as they are outside of the scope of this proposal.
+
+### Use the name `Run`
+
+We considered using the name `Run` instead of `Main`. One motivation for this is
+that we typically want function names to be verb phrases rather than noun
+phrases. Another is that the entry point function is seldom the main, or most
+important, function in the program, so the name `Main` is an anachronism from a
+time when programs were much smaller.
+
+However, the benefits of selecting a new name are minor, and the benefits of
+following established conventions are more significant, especially given our
+goal of familiarity for experienced C++ developers.

--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -1,0 +1,70 @@
+# Name of application entry point
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2265)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -23,8 +23,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-This proposal evaluates some possible reasoning which may contribute to a
-decision about naming the application entry point.
+This proposal presents a bit of background information on entry point names from
+other languages and draws the conclusion that Carbon should adopt `Main` as its
+entry point name from the little objective information and trends that can be
+deduced.
 
 ## Problem
 

--- a/proposals/p2265.md
+++ b/proposals/p2265.md
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Proposal](#proposal)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Use the name `Run`](#use-the-name-run)
 
 <!-- tocstop -->
 


### PR DESCRIPTION
This proposal presents a bit of background information on entry point names from
 other languages and draws the conclusion that Carbon should adopt `Main` as its
 entry point name from the little objective information and trends that can be
 deduced.

Fixes #2004.