### PR TITLE
Implement support for rewrite constraints

### DIFF
--- a/common/fuzzing/carbon.proto
+++ b/common/fuzzing/carbon.proto
@@ -139,10 +139,16 @@ message EqualsWhereClause {
   optional Expression rhs = 2;
 }
 
+message RewriteWhereClause {
+  optional string member_name = 1;
+  optional Expression replacement = 2;
+}
+
 message WhereClause {
   oneof kind {
     IsWhereClause is = 1;
     EqualsWhereClause equals = 2;
+    RewriteWhereClause rewrite = 3;
   }
 }
 

--- a/common/fuzzing/proto_to_carbon.cpp
+++ b/common/fuzzing/proto_to_carbon.cpp
@@ -409,6 +409,10 @@ static auto ExpressionToCarbon(const Fuzzing::Expression& expression,
             out << " == ";
             ExpressionToCarbon(clause.equals().rhs(), out);
             break;
+          case Fuzzing::WhereClause::kRewrite:
+            out << "." << clause.rewrite().member_name() << " = ";
+            ExpressionToCarbon(clause.rewrite().replacement(), out);
+            break;
           case Fuzzing::WhereClause::KIND_NOT_SET:
             // Arbitrary default to avoid invalid syntax.
             out << ".Self == .Self";

--- a/explorer/ast/ast_rtti.txt
+++ b/explorer/ast/ast_rtti.txt
@@ -75,3 +75,4 @@ abstract class Expression : AstNode;
 abstract class WhereClause : AstNode;
   class IsWhereClause : WhereClause;
   class EqualsWhereClause : WhereClause;
+  class RewriteWhereClause : WhereClause;

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -585,6 +585,8 @@ class ImplDeclaration : public Declaration {
   auto constraint_type() const -> Nonnull<const ConstraintType*> {
     return *constraint_type_;
   }
+  // Returns the deduced parameters specified on the impl declaration. This
+  // does not include any generic parameters from enclosing scopes.
   auto deduced_parameters() const
       -> llvm::ArrayRef<Nonnull<const GenericBinding*>> {
     return deduced_parameters_;

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -500,12 +500,27 @@ class InterfaceDeclaration : public Declaration {
 
   auto value_category() const -> ValueCategory { return ValueCategory::Let; }
 
+  // Get the constraint type corresponding to this interface, or nullopt if
+  // this interface is incomplete.
+  auto constraint_type() const
+      -> std::optional<Nonnull<const ConstraintType*>> {
+    return constraint_type_;
+  }
+
+  // Set the constraint type corresponding to this interface. Can only be set
+  // once, by type-checking.
+  void set_constraint_type(Nonnull<const ConstraintType*> constraint_type) {
+    CARBON_CHECK(!constraint_type_);
+    constraint_type_ = constraint_type;
+  }
+
  private:
   std::string name_;
   std::optional<Nonnull<TuplePattern*>> params_;
   Nonnull<SelfDeclaration*> self_type_;
   Nonnull<GenericBinding*> self_;
   std::vector<Nonnull<Declaration*>> members_;
+  std::optional<Nonnull<const ConstraintType*>> constraint_type_;
 };
 
 class AssociatedConstantDeclaration : public Declaration {

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -360,6 +360,11 @@ void WhereClause::Print(llvm::raw_ostream& out) const {
       out << clause.lhs() << " == " << clause.rhs();
       break;
     }
+    case WhereClauseKind::RewriteWhereClause: {
+      auto& clause = cast<RewriteWhereClause>(*this);
+      out << "." << clause.member_name() << " = " << clause.replacement();
+      break;
+    }
   }
 }
 

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -93,6 +93,33 @@ class Expression : public AstNode {
   std::optional<ValueCategory> value_category_;
 };
 
+// A mixin for expressions that can be rewritten to a different expression by
+// type-checking.
+template<typename Base>
+class RewritableMixin : public Base {
+ public:
+  using Base::Base;
+
+  // Set the rewritten form of this expression. Can only be called during type
+  // checking.
+  auto set_rewritten_form(const Expression* rewritten_form) -> void {
+    CARBON_CHECK(!rewritten_form_.has_value()) << "rewritten form set twice";
+    rewritten_form_ = rewritten_form;
+    this->set_static_type(&rewritten_form->static_type());
+    this->set_value_category(rewritten_form->value_category());
+  }
+
+  // Get the rewritten form of this expression. A rewritten form is used when
+  // the expression is rewritten as a function call on an interface. A
+  // rewritten form is not used when providing built-in operator semantics.
+  auto rewritten_form() const -> std::optional<Nonnull<const Expression*>> {
+    return rewritten_form_;
+  }
+
+ private:
+  std::optional<Nonnull<const Expression*>> rewritten_form_;
+};
+
 // A FieldInitializer represents the initialization of a single struct field.
 class FieldInitializer {
  public:
@@ -246,10 +273,26 @@ class MemberAccessExpression : public Expression {
     impl_ = impl;
   }
 
+  // Returns the constant value of this expression, if one has been set. This
+  // value will be used instead of accessing a member. Even if this is present,
+  // the operand of the member access expression must still be evaluated, in
+  // case it has side effects.
+  auto constant_value() const -> std::optional<Nonnull<const Value*>> {
+    return constant_value_;
+  }
+
+  // Sets the value returned by constant_value(). Can only be called once,
+  // during typechecking.
+  void set_constant_value(Nonnull<const Value*> value) {
+    CARBON_CHECK(!constant_value_.has_value());
+    constant_value_ = value;
+  }
+
  private:
   Nonnull<Expression*> object_;
   bool is_type_access_ = false;
   std::optional<Nonnull<const Witness*>> impl_;
+  std::optional<Nonnull<const Value*>> constant_value_;
 };
 
 class SimpleMemberAccessExpression : public MemberAccessExpression {
@@ -511,11 +554,11 @@ class StructTypeLiteral : public Expression {
   std::vector<FieldInitializer> fields_;
 };
 
-class OperatorExpression : public Expression {
+class OperatorExpression : public RewritableMixin<Expression> {
  public:
   explicit OperatorExpression(SourceLocation source_loc, Operator op,
                               std::vector<Nonnull<Expression*>> arguments)
-      : Expression(AstNodeKind::OperatorExpression, source_loc),
+      : RewritableMixin(AstNodeKind::OperatorExpression, source_loc),
         op_(op),
         arguments_(std::move(arguments)) {}
 
@@ -531,25 +574,9 @@ class OperatorExpression : public Expression {
     return arguments_;
   }
 
-  // Set the rewritten form of this expression. Can only be called during type
-  // checking.
-  auto set_rewritten_form(const Expression* rewritten_form) -> void {
-    CARBON_CHECK(!rewritten_form_.has_value()) << "rewritten form set twice";
-    rewritten_form_ = rewritten_form;
-    set_static_type(&rewritten_form->static_type());
-    set_value_category(rewritten_form->value_category());
-  }
-  // Get the rewritten form of this expression. A rewritten form is used when
-  // the expression is rewritten as a function call on an interface. A
-  // rewritten form is not used when providing built-in operator semantics.
-  auto rewritten_form() const -> std::optional<Nonnull<const Expression*>> {
-    return rewritten_form_;
-  }
-
  private:
   Operator op_;
   std::vector<Nonnull<Expression*>> arguments_;
-  std::optional<Nonnull<const Expression*>> rewritten_form_;
 };
 
 class CallExpression : public Expression {
@@ -837,6 +864,33 @@ class EqualsWhereClause : public WhereClause {
  private:
   Nonnull<Expression*> lhs_;
   Nonnull<Expression*> rhs_;
+};
+
+// An `=` where clause.
+//
+// For example, `Constraint where .Type = i32` specifies that the associated
+// type `.Type` is rewritten to `i32` whenever used.
+class RewriteWhereClause : public WhereClause {
+ public:
+  explicit RewriteWhereClause(SourceLocation source_loc,
+                              std::string member_name,
+                              Nonnull<Expression*> replacement)
+      : WhereClause(WhereClauseKind::RewriteWhereClause, source_loc),
+        member_name_(member_name),
+        replacement_(replacement) {}
+
+  static auto classof(const AstNode* node) {
+    return InheritsFromRewriteWhereClause(node->kind());
+  }
+
+  auto member_name() const -> std::string_view { return member_name_; }
+
+  auto replacement() const -> const Expression& { return *replacement_; }
+  auto replacement() -> Expression& { return *replacement_; }
+
+ private:
+  std::string member_name_;
+  Nonnull<Expression*> replacement_;
 };
 
 // A `where` expression: `AddableWith(i32) where .Result == i32`.

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -95,7 +95,7 @@ class Expression : public AstNode {
 
 // A mixin for expressions that can be rewritten to a different expression by
 // type-checking.
-template<typename Base>
+template <typename Base>
 class RewritableMixin : public Base {
  public:
   using Base::Base;

--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -332,22 +332,22 @@ interface ModWith(U:! Type) {
 // TODO: constraint Mod { ... }
 
 // Note, these impls use the builtin addition for i32.
-external impl i32 as Negate where .Result == i32 {
+external impl i32 as Negate where .Result = i32 {
   fn Op[me: i32]() -> i32 { return -me; }
 }
-external impl i32 as AddWith(i32) where .Result == i32 {
+external impl i32 as AddWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 { return me + other; }
 }
-external impl i32 as SubWith(i32) where .Result == i32 {
+external impl i32 as SubWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 { return me - other; }
 }
-external impl i32 as MulWith(i32) where .Result == i32 {
+external impl i32 as MulWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 { return me * other; }
 }
-external impl i32 as DivWith(i32) where .Result == i32 {
+external impl i32 as DivWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 { return me / other; }
 }
-external impl i32 as ModWith(i32) where .Result == i32 {
+external impl i32 as ModWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 { return me % other; }
 }
 
@@ -370,7 +370,7 @@ interface BitAndWith(U:! Type) {
 }
 // TODO:
 // constraint BitAnd {
-//   extends BitAndWith(Self) where .Result == Self;
+//   extends BitAndWith(Self) where .Result = Self;
 // }
 
 // Binary `|`.
@@ -381,7 +381,7 @@ interface BitOrWith(U:! Type) {
 }
 // TODO:
 // constraint BitOr {
-//   extends BitOrWith(Self) where .Result == Self;
+//   extends BitOrWith(Self) where .Result = Self;
 // }
 
 // Binary `^`.
@@ -392,7 +392,7 @@ interface BitXorWith(U:! Type) {
 }
 // TODO:
 // constraint BitXor {
-//   extends BitXorWith(Self) where .Result == Self;
+//   extends BitXorWith(Self) where .Result = Self;
 // }
 
 // Binary `<<`.
@@ -403,7 +403,7 @@ interface LeftShiftWith(U:! Type) {
 }
 // TODO:
 // constraint LeftShift {
-//   extends LeftShiftWith(Self) where .Result == Self;
+//   extends LeftShiftWith(Self) where .Result = Self;
 // }
 
 // Binary `>>`.
@@ -414,35 +414,35 @@ interface RightShiftWith(U:! Type) {
 }
 // TODO:
 // constraint RightShift {
-//   extends RightShiftWith(Self) where .Result == Self;
+//   extends RightShiftWith(Self) where .Result = Self;
 // }
 
-external impl i32 as BitComplement where .Result == i32 {
+external impl i32 as BitComplement where .Result = i32 {
   fn Op[me: i32]() -> i32 {
     return __intrinsic_int_bit_complement(me);
   }
 }
-external impl i32 as BitAndWith(i32) where .Result == i32 {
+external impl i32 as BitAndWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 {
     return __intrinsic_int_bit_and(me, other);
   }
 }
-external impl i32 as BitOrWith(i32) where .Result == i32 {
+external impl i32 as BitOrWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 {
     return __intrinsic_int_bit_or(me, other);
   }
 }
-external impl i32 as BitXorWith(i32) where .Result == i32 {
+external impl i32 as BitXorWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 {
     return __intrinsic_int_bit_xor(me, other);
   }
 }
-external impl i32 as LeftShiftWith(i32) where .Result == i32 {
+external impl i32 as LeftShiftWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 {
     return __intrinsic_int_left_shift(me, other);
   }
 }
-external impl i32 as RightShiftWith(i32) where .Result == i32 {
+external impl i32 as RightShiftWith(i32) where .Result = i32 {
   fn Op[me: i32](other: i32) -> i32 {
     return __intrinsic_int_right_shift(me, other);
   }

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -237,6 +237,14 @@ static auto ExpressionToProto(const Expression& expression)
                 ExpressionToProto(cast<EqualsWhereClause>(where)->rhs());
             break;
           }
+          case WhereClauseKind::RewriteWhereClause: {
+            auto* rewrite = clause_proto.mutable_rewrite();
+            rewrite->set_member_name(
+                std::string(cast<RewriteWhereClause>(where)->member_name()));
+            *rewrite->mutable_replacement() = ExpressionToProto(
+                cast<RewriteWhereClause>(where)->replacement());
+            break;
+          }
         }
         *where_proto->add_clauses() = clause_proto;
       }

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -11,6 +11,7 @@
 
 using llvm::cast;
 using llvm::dyn_cast;
+using llvm::isa;
 
 namespace Carbon {
 
@@ -137,6 +138,41 @@ auto ImplScope::ResolveInterface(Nonnull<const InterfaceType*> iface_type,
   return *result;
 }
 
+// Combines the results of two impl lookups.
+static auto CombineResults(Nonnull<const InterfaceType*> iface_type,
+                           Nonnull<const Value*> type,
+                           SourceLocation source_loc,
+                           std::optional<Nonnull<const Witness*>> a,
+                           std::optional<Nonnull<const Witness*>> b)
+    -> ErrorOr<std::optional<Nonnull<const Witness*>>> {
+  // If only one lookup succeeded, return that.
+  if (!a) {
+    return b;
+  }
+  if (!b) {
+    return a;
+  }
+  // If either of them was a symbolic result, then they'll end up being
+  // equivalent. Pick whichever we found first.
+  if (!isa<ImplWitness>(*b)) {
+    return a;
+  }
+  if (!isa<ImplWitness>(*a)) {
+    return b;
+  }
+  // If they refer to the same `impl` declaration, it doesn't matter which one
+  // we pick.
+  auto* impl_a = cast<ImplWitness>(*a);
+  auto* impl_b = cast<ImplWitness>(*b);
+  // TODO: Compare the identities of the `impl`s, not the declarations.
+  if (&impl_a->declaration() == &impl_b->declaration()) {
+    return a;
+  }
+  // TODO: Order the `impl`s based on type structure.
+  return ProgramError(source_loc) << "ambiguous implementations of "
+                                  << *iface_type << " for " << *type;
+}
+
 auto ImplScope::TryResolve(Nonnull<const InterfaceType*> iface_type,
                            Nonnull<const Value*> type,
                            SourceLocation source_loc,
@@ -151,14 +187,8 @@ auto ImplScope::TryResolve(Nonnull<const InterfaceType*> iface_type,
         std::optional<Nonnull<const Witness*>> parent_result,
         parent->TryResolve(iface_type, type, source_loc, original_scope,
                            type_checker));
-    if (parent_result.has_value()) {
-      if (result.has_value()) {
-        return ProgramError(source_loc) << "ambiguous implementations of "
-                                        << *iface_type << " for " << *type;
-      } else {
-        result = *parent_result;
-      }
-    }
+    CARBON_ASSIGN_OR_RETURN(result, CombineResults(iface_type, type, source_loc,
+                                                   result, parent_result));
   }
   return result;
 }
@@ -173,14 +203,8 @@ auto ImplScope::ResolveHere(Nonnull<const InterfaceType*> iface_type,
   for (const Impl& impl : impls_) {
     std::optional<Nonnull<const Witness*>> m = type_checker.MatchImpl(
         *iface_type, impl_type, impl, original_scope, source_loc);
-    if (m.has_value()) {
-      if (result.has_value()) {
-        return ProgramError(source_loc) << "ambiguous implementations of "
-                                        << *iface_type << " for " << *impl_type;
-      } else {
-        result = *m;
-      }
-    }
+    CARBON_ASSIGN_OR_RETURN(
+        result, CombineResults(iface_type, impl_type, source_loc, result, m));
   }
   return result;
 }

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -169,8 +169,8 @@ static auto CombineResults(Nonnull<const InterfaceType*> iface_type,
     return a;
   }
   // TODO: Order the `impl`s based on type structure.
-  return ProgramError(source_loc) << "ambiguous implementations of "
-                                  << *iface_type << " for " << *type;
+  return ProgramError(source_loc)
+         << "ambiguous implementations of " << *iface_type << " for " << *type;
 }
 
 auto ImplScope::TryResolve(Nonnull<const InterfaceType*> iface_type,

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -76,8 +76,15 @@ class ImplScope {
   // Returns the associated impl for the given `constraint` and `type` in
   // the ancestor graph of this scope, or reports a compilation error
   // at `source_loc` there isn't exactly one matching impl.
+  //
+  // If any substitutions should be made into the constraint before resolving
+  // it, those should be passed in `bindings`. The witness returned will be for
+  // `constraint`, not for the result of substituting the bindings into the
+  // constraint. The substituted type might in general have a different shape
+  // of witness due to deduplication.
   auto Resolve(Nonnull<const Value*> constraint, Nonnull<const Value*> type,
-               SourceLocation source_loc, const TypeChecker& type_checker) const
+               SourceLocation source_loc, const TypeChecker& type_checker,
+               const Bindings& bindings = {}) const
       -> ErrorOr<Nonnull<const Witness*>>;
 
   // Visits the values that are a single step away from `value` according to an

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -292,6 +292,12 @@ static auto ResolveNames(WhereClause& clause,
           ResolveNames(equals_clause.rhs(), enclosing_scope));
       break;
     }
+    case WhereClauseKind::RewriteWhereClause: {
+      auto& rewrite_clause = cast<RewriteWhereClause>(clause);
+      CARBON_RETURN_IF_ERROR(
+          ResolveNames(rewrite_clause.replacement(), enclosing_scope));
+      break;
+    }
   }
   return Success();
 }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -1521,13 +1521,10 @@ auto TypeChecker::Substitute(const Bindings& bindings,
           builder.AddAndSubstitute(*this, &constraint, builder.GetSelfType(),
                                    builder.GetSelfWitness(), bindings,
                                    /*add_lookup_contexts=*/true);
-      if (!result.ok()) {
-        // TODO: Handle this better!
-        if (trace_stream_) {
-          **trace_stream_ << "substitution of " << constraint
-                          << " failed: " << result.error() << "\n";
-        }
-      }
+      // TODO: This appears to theoretically be possible, and should be handled
+      // better.
+      CARBON_CHECK(result.ok()) << "substitution into " << constraint
+                                << " failed: " << result.error();
       Nonnull<const ConstraintType*> new_constraint =
           std::move(builder).Build(arena_);
       if (trace_stream_) {

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -708,8 +708,8 @@ auto TypeChecker::ArgumentDeduction::Deduce(Nonnull<const Value*> param,
       // same kind of type.
       // TODO: This seems like something we should be able to accept.
       return ProgramError(source_loc_) << "type error in " << context_ << "\n"
-                                      << "expected: " << *param << "\n"
-                                      << "actual: " << *arg;
+                                       << "expected: " << *param << "\n"
+                                       << "actual: " << *arg;
     }
 
     if (ValueEqual(param, arg, std::nullopt)) {
@@ -728,7 +728,8 @@ auto TypeChecker::ArgumentDeduction::Deduce(Nonnull<const Value*> param,
   switch (param->kind()) {
     case Value::Kind::VariableType: {
       const auto& binding = cast<VariableType>(*param).binding();
-      if (auto it = deduced_values_.find(&binding); it != deduced_values_.end()) {
+      if (auto it = deduced_values_.find(&binding);
+          it != deduced_values_.end()) {
         it->second.push_back(arg);
       } else {
         return handle_non_deduced_type();
@@ -1105,8 +1106,9 @@ class TypeChecker::ConstraintTypeBuilder {
           return Success();
         }
         return ProgramError(source_loc)
-               << "multiple different rewrites for `.(" << *rewrite.interface
-               << "." << *GetName(*rewrite.constant) << ")`:\n"
+               << "multiple different rewrites for `.("
+               << *rewrite.interface << "." << *GetName(*rewrite.constant)
+               << ")`:\n"
                << "  " << *existing.replacement << "\n"
                << "  " << *rewrite.replacement;
       }
@@ -1225,7 +1227,8 @@ class TypeChecker::ConstraintTypeBuilder {
           if (ValueEqual(&assoc->base(), GetSelfType(), std::nullopt)) {
             for (const auto& rewrite : rewrite_constraints_) {
               if (&assoc->constant() == rewrite.constant &&
-                  ValueEqual(&assoc->interface(), rewrite.interface, std::nullopt)) {
+                  ValueEqual(&assoc->interface(), rewrite.interface,
+                             std::nullopt)) {
                 impl_constraint.type = &rewrite.replacement->value();
                 performed_rewrite = true;
               }
@@ -1305,8 +1308,9 @@ class TypeChecker::SubstitutedGenericBindings {
       return std::nullopt;
     }
     Nonnull<ImplBinding*> impl_binding =
-        type_checker_->arena_->New<ImplBinding>(
-            new_binding->source_loc(), new_binding, &new_binding->static_type());
+        type_checker_->arena_->New<ImplBinding>(new_binding->source_loc(),
+                                                new_binding,
+                                                &new_binding->static_type());
     impl_binding->set_original(old_binding->impl_binding().value());
     auto* witness = type_checker_->arena_->New<BindingWitness>(impl_binding);
     impl_binding->set_symbolic_identity(witness);
@@ -1491,8 +1495,8 @@ auto TypeChecker::Substitute(const Bindings& bindings,
       if (!result.ok()) {
         // TODO: Handle this better!
         if (trace_stream_) {
-          **trace_stream_ << "substitution of " << constraint << " failed: "
-                          << result.error() << "\n";
+          **trace_stream_ << "substitution of " << constraint
+                          << " failed: " << result.error() << "\n";
         }
       }
       Nonnull<const ConstraintType*> new_constraint =
@@ -4451,7 +4455,7 @@ auto TypeChecker::DeclareImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,
   if (auto* iface_type = dyn_cast<InterfaceType>(implemented_type)) {
     CARBON_ASSIGN_OR_RETURN(
         implemented_type, MakeConstraintForInterface(
-                             impl_decl->interface().source_loc(), iface_type));
+                              impl_decl->interface().source_loc(), iface_type));
   }
   if (!isa<ConstraintType>(implemented_type)) {
     return ProgramError(impl_decl->interface().source_loc())

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -210,11 +210,12 @@ class TypeChecker {
 
   // Check that an `impl` declaration satisfies its constraints and add the
   // corresponding `ImplBinding`s to the impl scope.
-  auto CheckAndAddImplBindings(Nonnull<const ImplDeclaration*> impl_decl,
-                               Nonnull<const Value*> impl_type,
-                               Nonnull<const Witness*> self_witness,
-                               Nonnull<const Witness*> impl_witness,
-                               const ScopeInfo& scope_info) -> ErrorOr<Success>;
+  auto CheckAndAddImplBindings(
+      Nonnull<const ImplDeclaration*> impl_decl,
+      Nonnull<const Value*> impl_type, Nonnull<const Witness*> self_witness,
+      Nonnull<const Witness*> impl_witness,
+      llvm::ArrayRef<Nonnull<const GenericBinding*>> deduced_bindings,
+      const ScopeInfo& scope_info) -> ErrorOr<Success>;
 
   auto DeclareImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,
                               const ScopeInfo& scope_info) -> ErrorOr<Success>;

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -434,6 +434,10 @@ class TypeChecker {
       llvm::ArrayRef<Nonnull<const ConstraintType*>> constraints)
       -> ErrorOr<Nonnull<const ConstraintType*>>;
 
+  // Gets the type for the given associated constant.
+  auto GetTypeForAssociatedConstant(
+      Nonnull<const AssociatedConstant*> assoc) const -> Nonnull<const Value*>;
+
   // Given `type.(interface.member)`, look for a rewrite in the declared type
   // of `type`.
   auto LookupRewriteInTypeOf(Nonnull<const Value*> type,

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -98,6 +98,7 @@ class TypeChecker {
 
  private:
   struct SingleStepEqualityContext;
+  class ConstraintTypeBuilder;
   class SubstitutedGenericBindings;
 
   // Information about the currently enclosing scopes.
@@ -431,7 +432,21 @@ class TypeChecker {
   auto CombineConstraints(
       SourceLocation source_loc,
       llvm::ArrayRef<Nonnull<const ConstraintType*>> constraints)
-      -> Nonnull<const ConstraintType*>;
+      -> ErrorOr<Nonnull<const ConstraintType*>>;
+
+  // Given `type.(interface.member)`, look for a rewrite in the declared type
+  // of `type`.
+  auto LookupRewriteInTypeOf(Nonnull<const Value*> type,
+                             Nonnull<const InterfaceType*> interface,
+                             Nonnull<const Declaration*> member) const
+      -> std::optional<const ValueLiteral*>;
+
+  // Given a witness value, look for a rewrite for the given associated
+  // constant.
+  auto LookupRewriteInWitness(Nonnull<const Witness*> witness,
+                              Nonnull<const InterfaceType*> interface,
+                              Nonnull<const Declaration*> member) const
+      -> std::optional<const ValueLiteral*>;
 
   /*
   ** Adds a member of a declaration to collected_members_

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -423,10 +423,11 @@ class TypeChecker {
                     const BindingMap& deduced_type_args,
                     ImplWitnessMap& impls) const -> ErrorOr<Success>;
 
-  // Given an interface type, form a corresponding constraint type.
+  // Given an interface type, form a corresponding constraint type. The
+  // interface must be a complete type.
   auto MakeConstraintForInterface(SourceLocation source_loc,
                                   Nonnull<const InterfaceType*> iface_type)
-      -> Nonnull<const ConstraintType*>;
+      -> ErrorOr<Nonnull<const ConstraintType*>>;
 
   // Given a list of constraint types, form the combined constraint.
   auto CombineConstraints(

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -222,6 +222,7 @@ class TypeChecker {
                            Nonnull<const ImplDeclaration*> impl_decl,
                            Nonnull<const Value*> self_type,
                            Nonnull<const Witness*> self_witness,
+                           Nonnull<const Witness*> iface_witness,
                            const ImplScope& impl_scope) -> ErrorOr<Success>;
 
   // Check that an `impl` declaration satisfies its constraints and add the
@@ -229,6 +230,7 @@ class TypeChecker {
   auto CheckAndAddImplBindings(Nonnull<const ImplDeclaration*> impl_decl,
                                Nonnull<const Value*> impl_type,
                                Nonnull<const Witness*> self_witness,
+                               Nonnull<const Witness*> impl_witness,
                                const ScopeInfo& scope_info) -> ErrorOr<Success>;
 
   auto DeclareImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -346,8 +346,7 @@ class TypeChecker {
 
   // Attempt to implicitly convert type-checked expression `source` to the type
   // `destination`.
-  auto ImplicitlyConvert(const std::string& context,
-                         const ImplScope& impl_scope,
+  auto ImplicitlyConvert(std::string_view context, const ImplScope& impl_scope,
                          Nonnull<Expression*> source,
                          Nonnull<const Value*> destination)
       -> ErrorOr<Nonnull<Expression*>>;

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -431,6 +431,12 @@ void Value::Print(llvm::raw_ostream& out) const {
       }
       out << " where ";
       llvm::ListSeparator sep(" and ");
+      for (const ConstraintType::RewriteConstraint& rewrite :
+           constraint.rewrite_constraints()) {
+        out << sep << ".(" << *rewrite.interface << "."
+            << *GetName(*rewrite.constant)
+            << ") = " << rewrite.replacement->value();
+      }
       for (const ConstraintType::ImplConstraint& impl :
            constraint.impl_constraints()) {
         // TODO: Skip cases where `impl.type` is `.Self` and the interface is
@@ -439,6 +445,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       }
       for (const ConstraintType::EqualityConstraint& equality :
            constraint.equality_constraints()) {
+        // TODO: Skip cases matching something in `rewrite_constraints()`.
         out << sep;
         llvm::ListSeparator equal(" == ");
         for (Nonnull<const Value*> value : equality.values) {

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -45,6 +45,7 @@ static auto GetMember(Nonnull<Arena*> arena, Nonnull<const Value*> v,
     if (auto* assoc_const = dyn_cast_or_null<AssociatedConstantDeclaration>(
             field.member().declaration().value_or(nullptr))) {
       CARBON_CHECK(field.interface()) << "have witness but no interface";
+      // TODO: Use witness to find the value of the constant.
       return arena->New<AssociatedConstant>(v, *field.interface(), assoc_const,
                                             witness);
     }

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -625,6 +625,9 @@ static auto BindingMapEqual(
 auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
                std::optional<Nonnull<const EqualityContext*>> equality_ctx)
     -> bool {
+  if (t1 == t2) {
+    return true;
+  }
   if (t1->kind() != t2->kind()) {
     if (isa<AssociatedConstant>(t1) || isa<AssociatedConstant>(t2)) {
       return ValueEqual(t1, t2, equality_ctx);
@@ -801,6 +804,9 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
 auto ValueStructurallyEqual(
     Nonnull<const Value*> v1, Nonnull<const Value*> v2,
     std::optional<Nonnull<const EqualityContext*>> equality_ctx) -> bool {
+  if (v1 == v2) {
+    return true;
+  }
   if (v1->kind() != v2->kind()) {
     return false;
   }
@@ -927,6 +933,10 @@ auto ValueStructurallyEqual(
 auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
                 std::optional<Nonnull<const EqualityContext*>> equality_ctx)
     -> bool {
+  if (v1 == v2) {
+    return true;
+  }
+
   // If we're given an equality context, check to see if it knows these values
   // are equal. Only perform the check if one or the other value is an
   // associated constant; otherwise we should be able to do better by looking

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -775,6 +775,14 @@ class ConstraintType : public Value {
 
   using EqualityConstraint = Carbon::EqualityConstraint;
 
+  // A constraint indicating that access to an associated constant should be
+  // replaced by another value.
+  struct RewriteConstraint {
+    Nonnull<const InterfaceType*> interface;
+    Nonnull<const AssociatedConstantDeclaration*> constant;
+    Nonnull<const ValueLiteral*> replacement;
+  };
+
   // A context in which we might look up a name.
   struct LookupContext {
     Nonnull<const Value*> context;
@@ -784,11 +792,13 @@ class ConstraintType : public Value {
   explicit ConstraintType(Nonnull<const GenericBinding*> self_binding,
                           std::vector<ImplConstraint> impl_constraints,
                           std::vector<EqualityConstraint> equality_constraints,
+                          std::vector<RewriteConstraint> rewrite_constraints,
                           std::vector<LookupContext> lookup_contexts)
       : Value(Kind::ConstraintType),
         self_binding_(self_binding),
         impl_constraints_(std::move(impl_constraints)),
         equality_constraints_(std::move(equality_constraints)),
+        rewrite_constraints_(std::move(rewrite_constraints)),
         lookup_contexts_(std::move(lookup_contexts)) {}
 
   static auto classof(const Value* value) -> bool {
@@ -805,6 +815,10 @@ class ConstraintType : public Value {
 
   auto equality_constraints() const -> llvm::ArrayRef<EqualityConstraint> {
     return equality_constraints_;
+  }
+
+  auto rewrite_constraints() const -> llvm::ArrayRef<RewriteConstraint> {
+    return rewrite_constraints_;
   }
 
   auto lookup_contexts() const -> llvm::ArrayRef<LookupContext> {
@@ -826,6 +840,7 @@ class ConstraintType : public Value {
   Nonnull<const GenericBinding*> self_binding_;
   std::vector<ImplConstraint> impl_constraints_;
   std::vector<EqualityConstraint> equality_constraints_;
+  std::vector<RewriteConstraint> rewrite_constraints_;
   std::vector<LookupContext> lookup_contexts_;
 };
 

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -931,6 +931,8 @@ class ConstraintImplWitness : public Witness {
   // element.
   static auto Make(Nonnull<Arena*> arena, Nonnull<const Witness*> witness,
                    int index) -> Nonnull<const Witness*> {
+    CARBON_CHECK(!llvm::isa<ImplWitness>(witness))
+        << "impl witness has no components to access";
     if (auto* constraint_witness = llvm::dyn_cast<ConstraintWitness>(witness)) {
       return constraint_witness->witnesses()[index];
     }

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -683,6 +683,9 @@ where_clause:
     { $$ = arena->New<IsWhereClause>(context.source_loc(), $1, $3); }
 | comparison_operand EQUAL_EQUAL comparison_operand
     { $$ = arena->New<EqualsWhereClause>(context.source_loc(), $1, $3); }
+// TODO: .(expression) = expression
+| designator EQUAL comparison_operand
+    { $$ = arena->New<RewriteWhereClause>(context.source_loc(), $1, $3); }
 ;
 where_clause_list:
   where_clause

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -1,0 +1,72 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:result: 2
+
+package ExplorerTest api;
+
+interface Hashable {
+  fn Hash[me: Self]() -> i32;
+}
+
+class Potato {
+  external impl as Hashable {
+    fn Hash[me: Self]() -> i32 {
+      Print("Potato.(Hashable.Hash)");
+      return 1;
+    }
+  }
+
+  fn Hash[me: Self]() -> i32 {
+    Print("Potato.Hash");
+    return 2;
+  }
+}
+
+interface Maker {
+  let Result:! Hashable;
+  fn Make() -> Result;
+}
+
+fn F[T:! Maker where .Result = i32](x: T) -> i32 {
+  // OK, can treat T.Make() as an i32.
+  return T.Make() + 1;
+}
+
+fn G[T:! Maker](x: T) -> i32 {
+  // OK, Potato.(Hashable.Hash), not Potato.Hash.
+  return T.Make().Hash();
+}
+
+fn H[T:! Maker where .Result = Potato](x: T) -> i32 {
+  // OK, Potato.Hash, not Potato.(Hashable.Hash).
+  return T.Make().Hash();
+}
+
+fn I[T:! Maker where .Result = Potato](x: T) -> i32 {
+  var p: Potato = {};
+  // OK, Potato.Hash, not Potato.(Hashable.Hash), even though we know Potato is
+  // Hashable here.
+  return p.Hash();
+}
+
+class PotatoFactory {
+  impl as Maker where .Result = Potato {
+    fn Make() -> Potato { return {}; }
+  }
+}
+
+fn Main() -> i32 {
+  var f: PotatoFactory = {};
+  Print("{0}", F(f));
+  Print("{0}", G(f));
+  Print("{0}", H(f));
+  Print("{0}", I(f));
+  return 0;
+}

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -34,6 +34,13 @@ interface Maker {
   fn Make() -> Result;
 }
 
+external impl i32 as Hashable {
+  fn Hash[me: Self]() -> i32 {
+    Print("i32.Hash");
+    return me;
+  }
+}
+
 fn F[T:! Maker where .Result = i32](x: T) -> i32 {
   // OK, can treat T.Make() as an i32.
   return T.Make() + 1;

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -7,7 +7,16 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK:result: 2
+// CHECK:1
+// CHECK:i32.Hash
+// CHECK:0
+// CHECK:Potato.(Hashable.Hash)
+// CHECK:1
+// CHECK:Potato.Hash
+// CHECK:2
+// CHECK:Potato.Hash
+// CHECK:2
+// CHECK:result: 0
 
 package ExplorerTest api;
 
@@ -63,6 +72,12 @@ fn I[T:! Maker where .Result = Potato](x: T) -> i32 {
   return p.Hash();
 }
 
+class IntFactory {
+  impl as Maker where .Result = i32 {
+    fn Make() -> i32 { return 0; }
+  }
+}
+
 class PotatoFactory {
   impl as Maker where .Result = Potato {
     fn Make() -> Potato { return {}; }
@@ -70,10 +85,12 @@ class PotatoFactory {
 }
 
 fn Main() -> i32 {
-  var f: PotatoFactory = {};
+  var f: IntFactory = {};
+  var g: PotatoFactory = {};
   Print("{0}", F(f));
   Print("{0}", G(f));
-  Print("{0}", H(f));
-  Print("{0}", I(f));
+  Print("{0}", G(g));
+  Print("{0}", H(g));
+  Print("{0}", I(g));
   return 0;
 }

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:1
 // CHECK:i32.Hash

--- a/explorer/testdata/comparison/builtin_equality.carbon
+++ b/explorer/testdata/comparison/builtin_equality.carbon
@@ -38,12 +38,12 @@ fn CompareEqualValues[T:! EqWith(.Self)](format: String, a: T, b: T) {
   Print(format, if a != b then 0 else 1);
 }
 
-fn CompareDifferentValues[T:! EqWith(.Self)](format: String, a: T, b: T) {
+fn CompareDifferentValues[U:! EqWith(.Self)](format: String, a: U, b: U) {
   Print(format, if a == b then 0 else 1);
   Print(format, if a != b then 1 else 0);
 }
 
-fn CompareAll[T:! EqWith(.Self)](format: String, a: T, b: T) {
+fn CompareAll[V:! EqWith(.Self)](format: String, a: V, b: V) {
   CompareEqualValues(format, a, a);
   CompareEqualValues(format, b, b);
   CompareDifferentValues(format, a, b);

--- a/explorer/testdata/comparison/fail_empty_struct.carbon
+++ b/explorer/testdata/comparison/fail_empty_struct.carbon
@@ -9,7 +9,7 @@
 package ExplorerTest api;
 
 // TODO: This should work
-// CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/comparison/fail_empty_struct.carbon:[[@LINE+1]]: type error in call: '{}' is not implicitly convertible to 'Type'
+// CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/comparison/fail_empty_struct.carbon:[[@LINE+1]]: type error in call: '({})' is not implicitly convertible to '(Type)'
 external impl {} as EqWith({}) {
   fn Equal[me: Self](other: Self) -> bool {
     return true;

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -14,8 +14,7 @@ interface HasAssoc {
   let AssocVal:! i32;
 }
 class X {
-  // TODO: Replace `==` with `=`.
-  external impl as HasAssoc where .Assoc == i32 and .AssocVal == 2 {}
+  external impl as HasAssoc where .Assoc = i32 and .AssocVal = 2 {}
 }
 
 fn F[T:! HasAssoc where .Assoc = i32](x: T) -> i32 {

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 12
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! Type;
+  let AssocVal:! i32;
+}
+class X {
+  // TODO: Replace `==` with `=`.
+  external impl as HasAssoc where .Assoc == i32 and .AssocVal == 2 {}
+}
+
+fn F[T:! HasAssoc where .Assoc = i32](x: T) -> i32 {
+  var a: T.Assoc = 1;
+  return a;
+}
+
+fn G[T:! HasAssoc where .AssocVal = 2](x: T) -> i32 {
+  return x.AssocVal;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  return F(x) * 10 + G(x);
+}

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 12
+// CHECK:result: 12
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:result: 12
 

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:result: 1
 

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! Type;
+}
+class X {
+  // TODO: Replace `==` with `=`.
+  external impl as HasAssoc where .Assoc == i32 {}
+}
+
+alias WithoutRewrite = HasAssoc where .Assoc == i32;
+alias WithRewrite = HasAssoc where .Assoc = i32;
+
+fn F[T:! WithRewrite](x: T) -> i32 {
+  var a: T.(WithoutRewrite.Assoc) = 1;
+  return a;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  return F(x);
+}

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 1
+// CHECK:result: 1
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -13,8 +13,7 @@ interface HasAssoc {
   let Assoc:! Type;
 }
 class X {
-  // TODO: Replace `==` with `=`.
-  external impl as HasAssoc where .Assoc == i32 {}
+  external impl as HasAssoc where .Assoc = i32 {}
 }
 
 alias WithoutRewrite = HasAssoc where .Assoc == i32;

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 1
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! i32;
+}
+class X {
+  // TODO: Replace `==` with `=`.
+  external impl as HasAssoc where .Assoc == 1 {}
+}
+
+alias WithoutRewrite = HasAssoc where .Assoc == 1;
+alias WithRewrite = HasAssoc where .Assoc = 1;
+
+fn F[T:! WithRewrite](x: T) -> i32 {
+  return x.(WithoutRewrite.Assoc);
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  return F(x);
+}

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -13,8 +13,7 @@ interface HasAssoc {
   let Assoc:! i32;
 }
 class X {
-  // TODO: Replace `==` with `=`.
-  external impl as HasAssoc where .Assoc == 1 {}
+  external impl as HasAssoc where .Assoc = 1 {}
 }
 
 alias WithoutRewrite = HasAssoc where .Assoc == 1;

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:result: 1
 

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 1
+// CHECK:result: 1
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:result: 2
 

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 2
+// CHECK:result: 2
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 2
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! Type;
+}
+class X {
+  // TODO: Replace `==` with `=`.
+  external impl as HasAssoc where .Assoc == i32 {}
+}
+
+alias WithoutRewrite = HasAssoc where .Assoc == i32;
+alias WithRewrite = HasAssoc where .Assoc = i32;
+
+fn G[T:! WithoutRewrite](x: T) -> i32 {
+  // TODO: We should reject this once `==` isn't applied automatically.
+  var a: T.(WithRewrite.Assoc) = 2;
+  return a;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  return G(x);
+}

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -13,8 +13,7 @@ interface HasAssoc {
   let Assoc:! Type;
 }
 class X {
-  // TODO: Replace `==` with `=`.
-  external impl as HasAssoc where .Assoc == i32 {}
+  external impl as HasAssoc where .Assoc = i32 {}
 }
 
 alias WithoutRewrite = HasAssoc where .Assoc == i32;

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 3
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! Type;
+}
+class X {
+  // TODO: Replace `==` with `=`.
+  external impl as HasAssoc where .Assoc == i32 {}
+}
+
+fn H[T:! HasAssoc where .Assoc = i32, U:! Type where .Self == i32](a: T, b: U) -> i32 {
+  var a: T.((HasAssoc where .Assoc = U).Assoc) = 3;
+  return a;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  var y: i32 = 0;
+  return H(x, y);
+}

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -7,7 +7,7 @@
 // RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
 // RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
 // AUTOUPDATE: %{explorer} %s
-// CHECK: result: 3
+// CHECK:result: 3
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -13,8 +13,7 @@ interface HasAssoc {
   let Assoc:! Type;
 }
 class X {
-  // TODO: Replace `==` with `=`.
-  external impl as HasAssoc where .Assoc == i32 {}
+  external impl as HasAssoc where .Assoc = i32 {}
 }
 
 fn H[T:! HasAssoc where .Assoc = i32, U:! Type where .Self == i32](a: T, b: U) -> i32 {

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -2,10 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
-// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
-// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
 // CHECK:result: 3
 

--- a/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
+++ b/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
@@ -22,7 +22,7 @@ class Point(T:! i32) {
 }
 
 fn Main() -> i32 {
-  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_class/fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in call: 'Type' is not implicitly convertible to 'i32'
+  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_class/fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in call: '(Type)' is not implicitly convertible to '(i32)'
   var p: Point(i32) = Point(i32).Origin(0);
   return p.GetX();
 }

--- a/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
+++ b/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
@@ -22,7 +22,7 @@ class Point(T:! i32) {
 }
 
 fn Main() -> i32 {
-  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_class/fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in call: '(Type)' is not implicitly convertible to '(i32)'
+  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_class/fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in call: 'Type' is not implicitly convertible to 'i32'
   var p: Point(i32) = Point(i32).Origin(0);
   return p.GetX();
 }

--- a/explorer/testdata/generic_class/parameter_type_conversion.carbon
+++ b/explorer/testdata/generic_class/parameter_type_conversion.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:result: 4
+
+package ExplorerTest api;
+
+class Holder(N:! i32) {
+  fn Get() -> i32 {
+    return N;
+  }
+}
+
+class IntLike {
+  impl as ImplicitAs(i32) {
+    fn Convert[me: Self]() -> i32 { return 4; }
+  }
+  fn Make() -> IntLike { return {}; }
+}
+
+fn Main() -> i32 {
+  return Holder(IntLike.Make()).Get();
+}

--- a/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -13,7 +13,6 @@ fn id[T:! Type](x: i32) -> i32 {
 }
 
 fn Main() -> i32 {
-  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_function/fail_type_deduction_unused.carbon:[[@LINE+2]]: could not deduce type argument for type parameter T
-  // CHECK:in id(0)
+  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/generic_function/fail_type_deduction_unused.carbon:[[@LINE+1]]: could not deduce type argument for type parameter T in call
   return id(0);
 }

--- a/explorer/testdata/interface/fail_interface_missing_member.carbon
+++ b/explorer/testdata/interface/fail_interface_missing_member.carbon
@@ -13,7 +13,7 @@ interface Vector {
 }
 
 fn ScaleGeneric[T:! Vector](a: T, s: i32) -> T {
-  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_interface_missing_member.carbon:[[@LINE+1]]: member access, Scale not in interface Vector
+  // CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_interface_missing_member.carbon:[[@LINE+1]]: member access, Scale not in constraint interface Vector where T is interface Vector
   return a.Scale(s);
 }
 

--- a/explorer/testdata/interface/fail_use_symbolic_member.carbon
+++ b/explorer/testdata/interface/fail_use_symbolic_member.carbon
@@ -12,7 +12,7 @@ interface X {
   fn F() -> Type;
 }
 
-// CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_use_symbolic_member.carbon:[[@LINE+1]]: member lookup for F in symbolic witness for T:! X
+// CHECK:COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_use_symbolic_member.carbon:[[@LINE+1]]: member lookup for F in symbolic witness 0 of witness for T:! X
 fn G[T:! X]() -> T.F() {
   return {};
 }


### PR DESCRIPTION
Implements basic support for rewrite constraints as proposed in #2173.

Support for associated constants and complex constraints in general is also made more robust: argument deduction now properly computes and substitutes witnesses, and interface declarations track a more correct description of the constraint that they introduce than the one we previously built.