### PR TITLE
Bring constraints for an associated constant into scope within the interface

### DIFF
--- a/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
+++ b/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:result: 5
+
+package ExplorerTest api;
+
+interface A(T:! Type) { let AResult:! Type; }
+interface B(T:! Type) { let BResult:! A(T); }
+interface I(T:! Type) {
+  let X:! B(T);
+  // The constraints introduced by X should be in scope here.
+  let Y:! X.BResult.AResult;
+}
+
+class CA {
+  impl as A(i32) where .AResult = i32 {}
+}
+class CB {
+  impl as B(i32) where .BResult = CA {}
+}
+class CI {
+  impl as I(i32) where .X = CB and .Y = 5 {}
+}
+
+fn Main() -> i32 {
+  var v: CI = {};
+  return v.(I(i32).Y);
+}


### PR DESCRIPTION
This allows us to write code within an interface that assumes its associated types satisfy their constriants.