### PR TITLE
Avoid unnecessary vector copies when parsing lists.

### DIFF
--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -747,7 +747,7 @@ paren_expression_contents:
     { $$ = {.elements = {$1}, .has_trailing_comma = false}; }
 | paren_expression_contents COMMA expression
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.elements.push_back($3);
     }
 ;
@@ -763,7 +763,7 @@ struct_literal_contents:
     { $$ = {FieldInitializer($1, $3)}; }
 | struct_literal_contents COMMA designator EQUAL expression
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(FieldInitializer($3, $5));
     }
 ;
@@ -781,7 +781,7 @@ struct_type_literal_contents:
     { $$ = {FieldInitializer($1, $3)}; }
 | struct_type_literal_contents COMMA designator COLON expression
   {
-    $$ = $1;
+    $$ = std::move($1);
     $$.push_back(FieldInitializer($3, $5));
   }
 ;
@@ -855,12 +855,12 @@ paren_pattern_contents:
     }
 | paren_pattern_contents COMMA expression
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.elements.push_back(arena->New<ExpressionPattern>($3));
     }
 | paren_pattern_contents COMMA non_expression_pattern
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.elements.push_back($3);
     }
 ;
@@ -897,7 +897,7 @@ clause_list:
     { $$ = {}; }
 | clause_list clause
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back($2);
     }
 ;
@@ -1027,7 +1027,7 @@ deduced_param_list:
     { $$ = {$1}; }
 | deduced_param_list COMMA deduced_param
     {
-      $$ = $1;  // TODO: can we std::move here?
+      $$ = std::move($1);
       $$.push_back($3);
     }
 ;
@@ -1094,16 +1094,16 @@ alternative_list:
   // Empty
     { $$ = {}; }
 | alternative_list_contents
-    { $$ = $1; }
+    { $$ = std::move($1); }
 | alternative_list_contents COMMA
-    { $$ = $1; }
+    { $$ = std::move($1); }
 ;
 alternative_list_contents:
   alternative
     { $$ = {std::move($1)}; }
 | alternative_list_contents COMMA alternative
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(std::move($3));
     }
 ;
@@ -1224,7 +1224,7 @@ declaration_list:
     { $$ = {}; }
 | declaration_list declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(Nonnull<Declaration*>($2));
     }
 ;
@@ -1233,12 +1233,12 @@ class_body:
     { $$ = {}; }
 | class_body declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(Nonnull<Declaration*>($2));
     }
 | class_body mix_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(Nonnull<Declaration*>($2));
     }
 ;
@@ -1248,12 +1248,12 @@ mixin_body:
     { $$ = {}; }
 | mixin_body function_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(Nonnull<Declaration*>($2));
     }
 | mixin_body mix_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(Nonnull<Declaration*>($2));
     }
 ;
@@ -1262,24 +1262,24 @@ interface_body:
     { $$ = {}; }
 | interface_body function_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back($2);
     }
 | interface_body LET generic_binding SEMICOLON
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(
           arena->New<AssociatedConstantDeclaration>(context.source_loc(), $3));
     }
 | interface_body EXTENDS expression SEMICOLON
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(arena->New<InterfaceExtendsDeclaration>(context.source_loc(),
                                                            $3));
     }
 | interface_body IMPL impl_type AS type_or_where_expression SEMICOLON
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back(arena->New<InterfaceImplDeclaration>(context.source_loc(),
                                                         $3, $5));
     }
@@ -1289,12 +1289,12 @@ impl_body:
     { $$ = {}; }
 | impl_body function_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back($2);
     }
 | impl_body alias_declaration
     {
-      $$ = $1;
+      $$ = std::move($1);
       $$.push_back($2);
     }
 ;


### PR DESCRIPTION
No functional change intended, but these parsing actions should now be linear-time instead of quadratic-time.

As requested in review of #2279.