### PR TITLE
Improve driver debugability

### DIFF
--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -7,7 +7,7 @@
 #include "common/bazel_working_dir.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/InitLLVM.h"
 #include "toolchain/driver/driver.h"
 
 auto main(int argc, char** argv) -> int {
@@ -16,6 +16,16 @@ auto main(int argc, char** argv) -> int {
   }
 
   Carbon::SetWorkingDirForBazel();
+
+  llvm::setBugReportMsg(
+      "Please report issues to "
+      "https://github.com/carbon-language/carbon-lang/issues and include the "
+      "crash backtrace.\n");
+  llvm::InitLLVM init_llvm(argc, argv);
+
+  // Printing to stderr should flush stdout. This is most noticeable when stderr
+  // is piped to stdout.
+  llvm::errs().tie(&llvm::outs());
 
   llvm::SmallVector<llvm::StringRef, 16> args(argv + 1, argv + argc);
   Carbon::Driver driver;


### PR DESCRIPTION
llvm::InitLLVM starts getting stacks on assertion errors. Tieing errs to outs causes outs to be flushed when errs is used (avoiding munging out incompletely flushed output).