### PR TITLE
Automate the addition of RUN and simplify RUN lines

### DIFF
--- a/bazel/testing/lit.cfg.py
+++ b/bazel/testing/lit.cfg.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import lit.formats
 import os
+from pathlib import Path
 
 
 # This is a provided variable, ignore the undefined name warning.
@@ -13,47 +14,63 @@ config = config  # noqa: F821
 
 
 def fullpath(relative_path):
-    return os.path.join(os.environ["TEST_SRCDIR"], relative_path)
+    return Path(os.environ["TEST_SRCDIR"]).joinpath(relative_path)
+
+
+def add_substitution(before, after):
+    """Adds a substitution to the config. Wraps before as `%{before}`."""
+    config.substitutions.append((f"%{{{before}}}", after))
+
+
+def add_substitutions():
+    """Adds required substitutions to the config."""
+    tools = {
+        "carbon": fullpath("carbon/toolchain/driver/carbon"),
+        "explorer": fullpath("carbon/explorer/explorer"),
+        "explorer_prelude": fullpath("carbon/explorer/data/prelude.carbon"),
+        "filecheck": fullpath("llvm-project/llvm/FileCheck"),
+        "not": fullpath("llvm-project/llvm/not"),
+        "merge_output": fullpath("carbon/bazel/testing/merge_output"),
+    }
+
+    run_carbon = f"{tools['merge_output']} {tools['carbon']}"
+    run_explorer = (
+        f"{tools['merge_output']} {tools['explorer']} %s "
+        f"--prelude={tools['explorer_prelude']}"
+    )
+    filecheck_allow_unmatched = (
+        f"{tools['filecheck']} %s --match-full-lines --strict-whitespace"
+    )
+    filecheck_strict = (
+        f"{filecheck_allow_unmatched} --implicit-check-not={{{{.}}}}"
+    )
+
+    add_substitution("carbon", f"{tools['merge_output']} {tools['carbon']}")
+    add_substitution(
+        "carbon-run-parser",
+        f"{run_carbon} dump parse-tree %s | {filecheck_strict}",
+    )
+    add_substitution(
+        "carbon-run-semantics",
+        f"{run_carbon} dump semantics-ir %s | {filecheck_strict}",
+    )
+    add_substitution(
+        "carbon-run-tokens", f"{run_carbon} dump tokens %s | {filecheck_strict}"
+    )
+    add_substitution(
+        "explorer-run",
+        f"{run_explorer} | {filecheck_strict}",
+    )
+    add_substitution(
+        "explorer-run-trace",
+        f"{run_explorer} --parser_debug --trace_file=- | "
+        f"{filecheck_allow_unmatched}",
+    )
+    add_substitution("FileCheck-strict", filecheck_strict)
+    add_substitution("not", tools["not"])
 
 
 config.name = "lit"
 config.suffixes = [".carbon"]
 config.test_format = lit.formats.ShTest()
-
-_MERGE_OUTPUT = fullpath("carbon/bazel/testing/merge_output")
-
-config.substitutions.append(
-    (
-        "%{carbon}",
-        "%s %s" % (_MERGE_OUTPUT, fullpath("carbon/toolchain/driver/carbon")),
-    )
-)
-_EXPLORER = "%s %s --prelude=%s" % (
-    _MERGE_OUTPUT,
-    fullpath("carbon/explorer/explorer"),
-    fullpath("carbon/explorer/data/prelude.carbon"),
-)
-config.substitutions.append(("%{explorer}", _EXPLORER))
-config.substitutions.append(
-    ("%{explorer-trace}", _EXPLORER + " --parser_debug --trace_file=-")
-)
-
-config.substitutions.append(("%{not}", fullpath("llvm-project/llvm/not")))
-
-_FILE_CHECK = "%s --dump-input-filter=all" % fullpath(
-    "llvm-project/llvm/FileCheck"
-)
-config.substitutions.append(("%{FileCheck}", _FILE_CHECK))
-config.substitutions.append(
-    (
-        "%{FileCheck-allow-unmatched}",
-        _FILE_CHECK + " --match-full-lines --strict-whitespace",
-    )
-)
-config.substitutions.append(
-    (
-        "%{FileCheck-strict}",
-        _FILE_CHECK
-        + " --implicit-check-not={{.}} --match-full-lines --strict-whitespace",
-    )
-)
+add_substitutions()

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from abc import ABC, abstractmethod
 import argparse
 from concurrent import futures
-import logging
 import os
 from pathlib import Path
 import re
@@ -19,27 +18,42 @@ import subprocess
 from typing import Any, Dict, List, NamedTuple, Optional, Pattern, Set, Tuple
 
 # A prefix followed by a command to run for autoupdating checked output.
-AUTOUPDATE_MARKER = "// AUTOUPDATE: "
+AUTOUPDATE_MARKER = "// AUTOUPDATE"
 
 # Indicates no autoupdate is requested.
 NOAUTOUPDATE_MARKER = "// NOAUTOUPDATE"
 
 # Standard replacements normally done in lit.cfg.py.
 MERGE_OUTPUT = "./bazel-bin/bazel/testing/merge_output"
-LIT_REPLACEMENTS = [
-    ("%{carbon}", f"{MERGE_OUTPUT} ./bazel-bin/toolchain/driver/carbon"),
-    ("%{explorer}", f"{MERGE_OUTPUT} ./bazel-bin/explorer/explorer"),
-]
+
+
+class Tool(NamedTuple):
+    build_target: str
+    autoupdate_cmd: List[str]
+
+
+tools = {
+    "carbon": Tool(
+        "//toolchain/driver:carbon",
+        [MERGE_OUTPUT, "./bazel-bin/toolchain/driver/carbon"],
+    ),
+    "explorer": Tool(
+        "//explorer",
+        [MERGE_OUTPUT, "./bazel-bin/explorer/explorer"],
+    ),
+}
 
 
 class ParsedArgs(NamedTuple):
+    autoupdate_args: List[str]
     build_mode: str
-    build_target: str
     extra_check_replacements: List[Tuple[Pattern, Pattern, str]]
     line_number_format: str
     line_number_pattern: Pattern
+    lit_run: List[str]
     testdata: str
     tests: List[Path]
+    tool: str
 
 
 def parse_args() -> ParsedArgs:
@@ -47,16 +61,17 @@ def parse_args() -> ParsedArgs:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("tests", nargs="*")
     parser.add_argument(
+        "--autoupdate_arg",
+        metavar="COMMAND",
+        default=[],
+        action="append",
+        help="Optional arguments to pass to the autoupdate command.",
+    )
+    parser.add_argument(
         "--build_mode",
         metavar="MODE",
         default="opt",
         help="The build mode to use. Defaults to opt for faster execution.",
-    )
-    parser.add_argument(
-        "--build_target",
-        metavar="TARGET",
-        required=True,
-        help="The target to build.",
     )
     parser.add_argument(
         "--extra_check_replacement",
@@ -81,11 +96,25 @@ def parse_args() -> ParsedArgs:
         "only group.",
     )
     parser.add_argument(
+        "--lit_run",
+        metavar="COMMAND",
+        required=True,
+        action="append",
+        help="RUN lines to set.",
+    )
+    parser.add_argument(
         "--testdata",
         metavar="PATH",
         required=True,
         help="The path to the testdata to update, relative to the workspace "
         "root.",
+    )
+    parser.add_argument(
+        "--tool",
+        metavar="TOOL",
+        required=True,
+        choices=tools.keys(),
+        help="The tool being tested.",
     )
     parsed_args = parser.parse_args()
     extra_check_replacements = [
@@ -93,13 +122,15 @@ def parse_args() -> ParsedArgs:
         for line_matcher, before, after in parsed_args.extra_check_replacement
     ]
     return ParsedArgs(
+        autoupdate_args=parsed_args.autoupdate_arg,
         build_mode=parsed_args.build_mode,
-        build_target=parsed_args.build_target,
         extra_check_replacements=extra_check_replacements,
         line_number_format=parsed_args.line_number_format,
         line_number_pattern=re.compile(parsed_args.line_number_pattern),
+        lit_run=parsed_args.lit_run,
         testdata=parsed_args.testdata,
         tests=[Path(test).resolve() for test in parsed_args.tests],
+        tool=parsed_args.tool,
     )
 
 
@@ -133,6 +164,16 @@ class OriginalLine(Line):
 
     def __init__(self, line_number: int, text: str) -> None:
         self.line_number = line_number
+        self.text = text
+
+    def format(self, **kwargs: Any) -> str:
+        return self.text
+
+
+class RunLine(Line):
+    """A RUN line."""
+
+    def __init__(self, text: str) -> None:
         self.text = text
 
     def format(self, **kwargs: Any) -> str:
@@ -179,23 +220,17 @@ class CheckLine(Line):
         return f"{self.indent}// CHECK:{result}\n"
 
 
-class Autoupdate(NamedTuple):
-    line_number: int
-    cmd: str
-
-
-def find_autoupdate(test: str, orig_lines: List[str]) -> Optional[Autoupdate]:
+def find_autoupdate(test: str, orig_lines: List[str]) -> Optional[int]:
     """Figures out whether autoupdate should occur.
 
-    For AUTOUPDATE, returns the line and command. For NOAUTOUPDATE, returns
-    None.
+    For AUTOUPDATE, returns the line. For NOAUTOUPDATE, returns None.
     """
     found = 0
     result = None
     for line_number, line in enumerate(orig_lines):
         if line.startswith(AUTOUPDATE_MARKER):
             found += 1
-            result = Autoupdate(line_number, line[len(AUTOUPDATE_MARKER) :])
+            result = line_number
         elif line.startswith(NOAUTOUPDATE_MARKER):
             found += 1
     if found == 0:
@@ -219,23 +254,16 @@ def replace_all(s: str, replacements: List[Tuple[str, str]]) -> str:
 
 
 def get_matchable_test_output(
-    parsed_args: ParsedArgs,
-    test: str,
-    autoupdate_cmd: str,
+    autoupdate_args: List[str],
     extra_check_replacements: List[Tuple[Pattern, Pattern, str]],
+    tool: str,
+    test: str,
 ) -> List[str]:
     """Runs the autoupdate command and returns the output lines."""
-    # Mirror lit.cfg.py substitutions; bazel runs don't need --prelude.
-    # Also replaces `%s` with the test file.
-    autoupdate_cmd = replace_all(
-        autoupdate_cmd, [("%s", test)] + LIT_REPLACEMENTS
-    )
-
     # Run the autoupdate command to generate output.
     # (`bazel run` would serialize)
     p = subprocess.run(
-        autoupdate_cmd,
-        shell=True,
+        tools[tool].autoupdate_cmd + autoupdate_args + [test],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -263,9 +291,17 @@ def get_matchable_test_output(
     return out_lines
 
 
+def is_replaced(line: str) -> bool:
+    """Returns true if autoupdate should replace the line."""
+    line = line.lstrip()
+    return line.startswith("// CHECK") or line.startswith("// RUN:")
+
+
 def merge_lines(
     line_number_format: str,
     line_number_pattern: Pattern,
+    lit_run: List[str],
+    test: str,
     autoupdate_line_number: int,
     raw_orig_lines: List[str],
     out_lines: List[str],
@@ -274,8 +310,7 @@ def merge_lines(
     orig_lines = [
         OriginalLine(i, line)
         for i, line in enumerate(raw_orig_lines)
-        # Remove CHECK lines in the original output.
-        if not line.lstrip().startswith("// CHECK")
+        if not is_replaced(line)
     ]
     check_lines = [
         CheckLine(out_line, line_number_format, line_number_pattern)
@@ -286,6 +321,11 @@ def merge_lines(
     # CHECK lines must go after AUTOUPDATE.
     while orig_lines and orig_lines[0].line_number <= autoupdate_line_number:
         result_lines.append(orig_lines.pop(0))
+    for line in lit_run:
+        run_not = ""
+        if Path(test).name.startswith("fail_"):
+            run_not = "%{not} "
+        result_lines.append(RunLine(f"// RUN: {run_not}{line}\n"))
     # Interleave the original lines and the CHECK: lines.
     while orig_lines and check_lines:
         # Original lines go first when the CHECK line is known and later.
@@ -315,21 +355,23 @@ def update_check(parsed_args: ParsedArgs, test: Path) -> bool:
         orig_lines = f.readlines()
 
     # Make sure we're supposed to autoupdate.
-    autoupdate = find_autoupdate(str(test), orig_lines)
-    if autoupdate is None:
+    autoupdate_line = find_autoupdate(str(test), orig_lines)
+    if autoupdate_line is None:
         return False
 
     # Determine the merged output lines.
     out_lines = get_matchable_test_output(
-        parsed_args,
-        str(test),
-        autoupdate.cmd,
+        parsed_args.autoupdate_args,
         parsed_args.extra_check_replacements,
+        parsed_args.tool,
+        str(test),
     )
     result_lines = merge_lines(
         parsed_args.line_number_format,
         parsed_args.line_number_pattern,
-        autoupdate.line_number,
+        parsed_args.lit_run,
+        str(test),
+        autoupdate_line,
         orig_lines,
         out_lines,
     )
@@ -369,8 +411,8 @@ def update_checks(parsed_args: ParsedArgs, tests: Set[Path]) -> None:
     def map_helper(test: Path) -> bool:
         try:
             updated = update_check(parsed_args, test)
-        except Exception:
-            logging.exception(f"Failed to update {test}")
+        except Exception as e:
+            raise ValueError(f"Failed to update {test}") from e
         print(".", end="", flush=True)
         return updated
 
@@ -406,7 +448,7 @@ def main() -> None:
             "-c",
             parsed_args.build_mode,
             "//bazel/testing:merge_output",
-            parsed_args.build_target,
+            tools[parsed_args.tool].build_target,
         ]
     )
 

--- a/explorer/README.md
+++ b/explorer/README.md
@@ -72,7 +72,7 @@ boilerplate at the top:
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:result: 0

--- a/explorer/README.md
+++ b/explorer/README.md
@@ -72,9 +72,9 @@ boilerplate at the top:
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:result: 0
 
 package ExplorerTest api;
@@ -83,23 +83,16 @@ package ExplorerTest api;
 To explain this boilerplate:
 
 -   The standard copyright is expected.
+-   The `AUTOUPDATE` line indicates that `RUN` and `CHECK` lines will be
+    automatically inserted immediately below by the `./lit_autoupdate.py`
+    script.
 -   The `RUN` lines indicate two commands for `lit` to execute using the file:
     one without trace and debug output, one with.
-    -   Output is piped to `FileCheck` for verification.
-    -   Setting `-allow-unused-prefixes` to false when processing the ordinary
-        output, and true when handling the trace output, allows us to omit the
-        tracing output from the `CHECK` lines, while ensuring they cover all
-        non-tracing output.
-    -   Setting `-match-full-lines` in both cases indicates that each `CHECK`
-        line must match a complete output line, with no extra characters before
-        or after the `CHECK` pattern.
     -   `RUN:` will be followed by the `not` command when failure is expected.
         In particular, `RUN: not explorer ...`.
-    -   `%s` is a
-        [`lit` substitution](https://llvm.org/docs/CommandGuide/lit.html#substitutions)
-        for the path to the given test file.
--   The `AUTOUPDATE` line indicates that `CHECK` lines will be automatically
-    inserted immediately below by the `./lit_autoupdate.py` script.
+    -   The full command is in `lit.cfg.py`; it will run explorer and pass
+        results to
+        [`FileCheck`](https://llvm.org/docs/CommandGuide/FileCheck.html).
 -   The `CHECK` lines indicate expected output, verified by `FileCheck`.
     -   Where a `CHECK` line contains text like `{{.*}}`, the double curly
         braces indicate a contained regular expression.

--- a/explorer/lit_autoupdate.py
+++ b/explorer/lit_autoupdate.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 
 def main() -> None:
-    # Calls the main script with explorer settings. This uses execv in order to
-    # avoid Python import behaviors.
+    # Calls the main script using execv in order to avoid Python import
+    # behaviors.
     this_py = Path(__file__).resolve()
     actual_py = this_py.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
@@ -23,12 +23,11 @@ def main() -> None:
     args = [
         sys.argv[0],
         # Flags to configure for explorer testing.
-        "--build_target",
-        "//explorer",
-        "--testdata",
-        "explorer/testdata",
-        "--line_number_pattern",
-        r"(?<=\.carbon:)(\d+)(?=(?:\D|$))",
+        "--tool=explorer",
+        "--testdata=explorer/testdata",
+        r"--line_number_pattern=(?<=\.carbon:)(\d+)(?=(?:\D|$))",
+        "--lit_run=%{explorer-run}",
+        "--lit_run=%{explorer-run-trace}",
     ] + sys.argv[1:]
     os.execv(actual_py, args)
 

--- a/explorer/testdata/addr/fail_method_let.carbon
+++ b/explorer/testdata/addr/fail_method_let.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/addr/fail_method_let.carbon
+++ b/explorer/testdata/addr/fail_method_let.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/addr/fail_method_me_misspelled.carbon
+++ b/explorer/testdata/addr/fail_method_me_misspelled.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/addr/fail_method_me_misspelled.carbon
+++ b/explorer/testdata/addr/fail_method_me_misspelled.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/addr/fail_method_me_type.carbon
+++ b/explorer/testdata/addr/fail_method_me_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/addr/fail_method_me_type.carbon
+++ b/explorer/testdata/addr/fail_method_me_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/addr/method.carbon
+++ b/explorer/testdata/addr/method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/addr/method.carbon
+++ b/explorer/testdata/addr/method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/addr/nested_method.carbon
+++ b/explorer/testdata/addr/nested_method.carbon
@@ -3,7 +3,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/addr/nested_method.carbon
+++ b/explorer/testdata/addr/nested_method.carbon
@@ -3,9 +3,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/alias/class_alias.carbon
+++ b/explorer/testdata/alias/class_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: b.n: 1

--- a/explorer/testdata/alias/class_alias.carbon
+++ b/explorer/testdata/alias/class_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: b.n: 1
 // CHECK:STDOUT: d.Get(0): 2
 // CHECK:STDOUT: e.Get(1): 3

--- a/explorer/testdata/alias/fail_alias_expression.carbon
+++ b/explorer/testdata/alias/fail_alias_expression.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/alias/fail_alias_expression.carbon
+++ b/explorer/testdata/alias/fail_alias_expression.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/alias/fail_alias_var.carbon
+++ b/explorer/testdata/alias/fail_alias_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/alias/fail_alias_var.carbon
+++ b/explorer/testdata/alias/fail_alias_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/alias/fail_self_alias.carbon
+++ b/explorer/testdata/alias/fail_self_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/alias/fail_self_alias.carbon
+++ b/explorer/testdata/alias/fail_self_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/alias/function_alias.carbon
+++ b/explorer/testdata/alias/function_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 7
 
 package ExplorerTest api;

--- a/explorer/testdata/alias/function_alias.carbon
+++ b/explorer/testdata/alias/function_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 7

--- a/explorer/testdata/alias/interface_alias.carbon
+++ b/explorer/testdata/alias/interface_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12345
 
 package ExplorerTest api;

--- a/explorer/testdata/alias/interface_alias.carbon
+++ b/explorer/testdata/alias/interface_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12345

--- a/explorer/testdata/alias/member_name_alias.carbon
+++ b/explorer/testdata/alias/member_name_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/alias/member_name_alias.carbon
+++ b/explorer/testdata/alias/member_name_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/alias/struct_alias.carbon
+++ b/explorer/testdata/alias/struct_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: ab.a: 2

--- a/explorer/testdata/alias/struct_alias.carbon
+++ b/explorer/testdata/alias/struct_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: ab.a: 2
 // CHECK:STDOUT: ab.b: 1
 // CHECK:STDOUT: ba.a: 2

--- a/explorer/testdata/alias/type_alias.carbon
+++ b/explorer/testdata/alias/type_alias.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4

--- a/explorer/testdata/alias/type_alias.carbon
+++ b/explorer/testdata/alias/type_alias.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4
 
 package ExplorerTest api;

--- a/explorer/testdata/array/fail_index.carbon
+++ b/explorer/testdata/array/fail_index.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/array/fail_index.carbon
+++ b/explorer/testdata/array/fail_index.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/array/fail_negative_size.carbon
+++ b/explorer/testdata/array/fail_negative_size.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/array/fail_negative_size.carbon
+++ b/explorer/testdata/array/fail_negative_size.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/array/fail_size_mismatch.carbon
+++ b/explorer/testdata/array/fail_size_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/array/fail_size_mismatch.carbon
+++ b/explorer/testdata/array/fail_size_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/array/index.carbon
+++ b/explorer/testdata/array/index.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/array/index.carbon
+++ b/explorer/testdata/array/index.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/array/nested.carbon
+++ b/explorer/testdata/array/nested.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/array/nested.carbon
+++ b/explorer/testdata/array/nested.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/as/as_same_type.carbon
+++ b/explorer/testdata/as/as_same_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/as/as_same_type.carbon
+++ b/explorer/testdata/as/as_same_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/as/convert.carbon
+++ b/explorer/testdata/as/convert.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/as/convert.carbon
+++ b/explorer/testdata/as/convert.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/as/fail_destination_not_type.carbon
+++ b/explorer/testdata/as/fail_destination_not_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/as/fail_destination_not_type.carbon
+++ b/explorer/testdata/as/fail_destination_not_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/as/fail_no_conversion.carbon
+++ b/explorer/testdata/as/fail_no_conversion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/as/fail_no_conversion.carbon
+++ b/explorer/testdata/as/fail_no_conversion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/as/implicit_as.carbon
+++ b/explorer/testdata/as/implicit_as.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/as/implicit_as.carbon
+++ b/explorer/testdata/as/implicit_as.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -5,9 +5,10 @@
 // This won't auto-update because it uses a regex for the prelude line number,
 // so that it doesn't need to be updated on every prelude change.
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// This can't be autoupdated because the error line comes form a different file.
 // NOAUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
 
 package ExplorerTest api;

--- a/explorer/testdata/assign/convert_rhs.carbon
+++ b/explorer/testdata/assign/convert_rhs.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/assign/convert_rhs.carbon
+++ b/explorer/testdata/assign/convert_rhs.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/assign/destruct_original.carbon
+++ b/explorer/testdata/assign/destruct_original.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/assign/destruct_original.carbon
+++ b/explorer/testdata/assign/destruct_original.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/assign/reassign_original.carbon
+++ b/explorer/testdata/assign/reassign_original.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/assign/reassign_original.carbon
+++ b/explorer/testdata/assign/reassign_original.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/assoc_const/fail_anonymous.carbon
+++ b/explorer/testdata/assoc_const/fail_anonymous.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_anonymous.carbon
+++ b/explorer/testdata/assoc_const/fail_anonymous.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
+++ b/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
+++ b/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 // TODO: Should this work?
 

--- a/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
+++ b/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
+++ b/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
+++ b/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
+++ b/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_redefined.carbon
+++ b/explorer/testdata/assoc_const/fail_redefined.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_redefined.carbon
+++ b/explorer/testdata/assoc_const/fail_redefined.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_unknown_value.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_unknown_value.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/impl_lookup.carbon
+++ b/explorer/testdata/assoc_const/impl_lookup.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/impl_lookup.carbon
+++ b/explorer/testdata/assoc_const/impl_lookup.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/assoc_const/implement.carbon
+++ b/explorer/testdata/assoc_const/implement.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/assoc_const/implement.carbon
+++ b/explorer/testdata/assoc_const/implement.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: 1
 // CHECK:STDOUT: i32.Hash
 // CHECK:STDOUT: 0

--- a/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
+++ b/explorer/testdata/assoc_const/lookup_in_rewrite.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: 1

--- a/explorer/testdata/assoc_const/member_of_value.carbon
+++ b/explorer/testdata/assoc_const/member_of_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/assoc_const/member_of_value.carbon
+++ b/explorer/testdata/assoc_const/member_of_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/simple_constraint.carbon
+++ b/explorer/testdata/assoc_const/simple_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/simple_constraint.carbon
+++ b/explorer/testdata/assoc_const/simple_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/assoc_const/simple_equality.carbon
+++ b/explorer/testdata/assoc_const/simple_equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/simple_equality.carbon
+++ b/explorer/testdata/assoc_const/simple_equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/auto/fail_use_in_init.carbon
+++ b/explorer/testdata/auto/fail_use_in_init.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/auto/fail_use_in_init.carbon
+++ b/explorer/testdata/auto/fail_use_in_init.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/addition.carbon
+++ b/explorer/testdata/basic_syntax/addition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 7
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/addition.carbon
+++ b/explorer/testdata/basic_syntax/addition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 7

--- a/explorer/testdata/basic_syntax/choice.carbon
+++ b/explorer/testdata/basic_syntax/choice.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/choice.carbon
+++ b/explorer/testdata/basic_syntax/choice.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_block.carbon
+++ b/explorer/testdata/basic_syntax/fail_block.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_block.carbon
+++ b/explorer/testdata/basic_syntax/fail_block.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
+++ b/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 
 fn CompareBools(a: bool, b: bool) -> bool {
-  // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/basic_syntax/not_compare_precedence.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
+  // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_compare_precedence.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
   return not a == b;
 }

--- a/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
+++ b/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_invalid_char.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_char.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_invalid_char.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_char.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_invalid_char.carbon:[[@LINE+1]]: invalid character '\xEF' in source file.
 �

--- a/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_missing_var.carbon
+++ b/explorer/testdata/basic_syntax/fail_missing_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_missing_var.carbon
+++ b/explorer/testdata/basic_syntax/fail_missing_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_nested_binding.carbon
+++ b/explorer/testdata/basic_syntax/fail_nested_binding.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_nested_binding.carbon
+++ b/explorer/testdata/basic_syntax/fail_nested_binding.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
+++ b/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
+++ b/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
+++ b/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
+++ b/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_var_named_self.carbon
+++ b/explorer/testdata/basic_syntax/fail_var_named_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_var_named_self.carbon
+++ b/explorer/testdata/basic_syntax/fail_var_named_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/fail_var_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_var_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/basic_syntax/fail_var_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_var_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/basic_syntax/next.carbon
+++ b/explorer/testdata/basic_syntax/next.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/next.carbon
+++ b/explorer/testdata/basic_syntax/next.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/placeholder_variable.carbon
+++ b/explorer/testdata/basic_syntax/placeholder_variable.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/placeholder_variable.carbon
+++ b/explorer/testdata/basic_syntax/placeholder_variable.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/record.carbon
+++ b/explorer/testdata/basic_syntax/record.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/record.carbon
+++ b/explorer/testdata/basic_syntax/record.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/star.carbon
+++ b/explorer/testdata/basic_syntax/star.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/star.carbon
+++ b/explorer/testdata/basic_syntax/star.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/trace.carbon
+++ b/explorer/testdata/basic_syntax/trace.carbon
@@ -2,12 +2,11 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
-//
 // A lot of output is elided: this is only checking for a few things for simple
 // sanity checking on --parser_debug --trace_file=- output.
 //
 // NOAUTOUPDATE
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: ********** source program **********
 // CHECK:STDOUT: interface ImplicitAs {
 // CHECK:STDOUT: ********** type checking **********

--- a/explorer/testdata/basic_syntax/var_tuple.carbon
+++ b/explorer/testdata/basic_syntax/var_tuple.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/var_tuple.carbon
+++ b/explorer/testdata/basic_syntax/var_tuple.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/basic_syntax/zero.carbon
+++ b/explorer/testdata/basic_syntax/zero.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/basic_syntax/zero.carbon
+++ b/explorer/testdata/basic_syntax/zero.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/block/empty.carbon
+++ b/explorer/testdata/block/empty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/block/empty.carbon
+++ b/explorer/testdata/block/empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/block/shadowing.carbon
+++ b/explorer/testdata/block/shadowing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/block/shadowing.carbon
+++ b/explorer/testdata/block/shadowing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/choice/fail_recursive_use.carbon
+++ b/explorer/testdata/choice/fail_recursive_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/choice/fail_recursive_use.carbon
+++ b/explorer/testdata/choice/fail_recursive_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/choice/generic_choice_multiple_template_arguments.carbon
+++ b/explorer/testdata/choice/generic_choice_multiple_template_arguments.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 22

--- a/explorer/testdata/choice/generic_choice_multiple_template_arguments.carbon
+++ b/explorer/testdata/choice/generic_choice_multiple_template_arguments.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 22
 
 package ExplorerTest api;

--- a/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
+++ b/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: H 22

--- a/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
+++ b/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: H 22
 // CHECK:STDOUT: result: 0
 

--- a/explorer/testdata/choice/generic_choice_simple_assignment.carbon
+++ b/explorer/testdata/choice/generic_choice_simple_assignment.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 22

--- a/explorer/testdata/choice/generic_choice_simple_assignment.carbon
+++ b/explorer/testdata/choice/generic_choice_simple_assignment.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 22
 
 package ExplorerTest api;

--- a/explorer/testdata/class/assign.carbon
+++ b/explorer/testdata/class/assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/assign.carbon
+++ b/explorer/testdata/class/assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/assign_member.carbon
+++ b/explorer/testdata/class/assign_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/assign_member.carbon
+++ b/explorer/testdata/class/assign_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/bound_method.carbon
+++ b/explorer/testdata/class/bound_method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/bound_method.carbon
+++ b/explorer/testdata/class/bound_method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/class_function.carbon
+++ b/explorer/testdata/class/class_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/class_function.carbon
+++ b/explorer/testdata/class/class_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/class_function_from_instance.carbon
+++ b/explorer/testdata/class/class_function_from_instance.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/class_function_from_instance.carbon
+++ b/explorer/testdata/class/class_function_from_instance.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/class_function_self.carbon
+++ b/explorer/testdata/class/class_function_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/class_function_self.carbon
+++ b/explorer/testdata/class/class_function_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/class_function_value.carbon
+++ b/explorer/testdata/class/class_function_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/class_function_value.carbon
+++ b/explorer/testdata/class/class_function_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/empty_class.carbon
+++ b/explorer/testdata/class/empty_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/empty_class.carbon
+++ b/explorer/testdata/class/empty_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/fail_abstract_class.carbon
+++ b/explorer/testdata/class/fail_abstract_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_abstract_class.carbon
+++ b/explorer/testdata/class/fail_abstract_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_base_class.carbon
+++ b/explorer/testdata/class/fail_base_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_base_class.carbon
+++ b/explorer/testdata/class/fail_base_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_class_extends.carbon
+++ b/explorer/testdata/class/fail_class_extends.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_class_extends.carbon
+++ b/explorer/testdata/class/fail_class_extends.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_class_named_self.carbon
+++ b/explorer/testdata/class/fail_class_named_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_class_named_self.carbon
+++ b/explorer/testdata/class/fail_class_named_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_access_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_access_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_field_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_field_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_field_missing.carbon
+++ b/explorer/testdata/class/fail_field_missing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_field_missing.carbon
+++ b/explorer/testdata/class/fail_field_missing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_member_call_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_member_call_before_typecheck.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_member_call_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_member_call_before_typecheck.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_member_of_self.carbon
+++ b/explorer/testdata/class/fail_member_of_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_member_of_self.carbon
+++ b/explorer/testdata/class/fail_member_of_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_method_deduced.carbon
+++ b/explorer/testdata/class/fail_method_deduced.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_method_deduced.carbon
+++ b/explorer/testdata/class/fail_method_deduced.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_method_from_class.carbon
+++ b/explorer/testdata/class/fail_method_from_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_method_from_class.carbon
+++ b/explorer/testdata/class/fail_method_from_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_method_in_var.carbon
+++ b/explorer/testdata/class/fail_method_in_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_method_in_var.carbon
+++ b/explorer/testdata/class/fail_method_in_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_return_method.carbon
+++ b/explorer/testdata/class/fail_return_method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/fail_return_method.carbon
+++ b/explorer/testdata/class/fail_return_method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_use_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_use_before_typecheck.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/class/fail_use_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_use_before_typecheck.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/class/function_param.carbon
+++ b/explorer/testdata/class/function_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/function_param.carbon
+++ b/explorer/testdata/class/function_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/global_var.carbon
+++ b/explorer/testdata/class/global_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/global_var.carbon
+++ b/explorer/testdata/class/global_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/method.carbon
+++ b/explorer/testdata/class/method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/method.carbon
+++ b/explorer/testdata/class/method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/method_call_method.carbon
+++ b/explorer/testdata/class/method_call_method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/method_call_method.carbon
+++ b/explorer/testdata/class/method_call_method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/method_self.carbon
+++ b/explorer/testdata/class/method_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/method_self.carbon
+++ b/explorer/testdata/class/method_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/temp.carbon
+++ b/explorer/testdata/class/temp.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/temp.carbon
+++ b/explorer/testdata/class/temp.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/class/var.carbon
+++ b/explorer/testdata/class/var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/class/var.carbon
+++ b/explorer/testdata/class/var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/comparison/builtin_comparsion.carbon
+++ b/explorer/testdata/comparison/builtin_comparsion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: strings less: 1

--- a/explorer/testdata/comparison/builtin_comparsion.carbon
+++ b/explorer/testdata/comparison/builtin_comparsion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: strings less: 1
 // CHECK:STDOUT: ints less: 0
 // CHECK:STDOUT: strings less eq: 1

--- a/explorer/testdata/comparison/builtin_equality.carbon
+++ b/explorer/testdata/comparison/builtin_equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: bool: 1
 // CHECK:STDOUT: bool: 1
 // CHECK:STDOUT: bool: 1

--- a/explorer/testdata/comparison/builtin_equality.carbon
+++ b/explorer/testdata/comparison/builtin_equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: bool: 1

--- a/explorer/testdata/comparison/custom_equality.carbon
+++ b/explorer/testdata/comparison/custom_equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: structs equal: 0
 // CHECK:STDOUT: structs not equal: 1
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/comparison/custom_equality.carbon
+++ b/explorer/testdata/comparison/custom_equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: structs equal: 0

--- a/explorer/testdata/comparison/fail_empty_struct.carbon
+++ b/explorer/testdata/comparison/fail_empty_struct.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/comparison/fail_empty_struct.carbon
+++ b/explorer/testdata/comparison/fail_empty_struct.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/comparison/fail_no_impl.carbon
+++ b/explorer/testdata/comparison/fail_no_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/comparison/fail_no_impl.carbon
+++ b/explorer/testdata/comparison/fail_no_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/binding_self.carbon
+++ b/explorer/testdata/constraint/binding_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/binding_self.carbon
+++ b/explorer/testdata/constraint/binding_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/constraint/combined_interfaces.carbon
+++ b/explorer/testdata/constraint/combined_interfaces.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 526
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/combined_interfaces.carbon
+++ b/explorer/testdata/constraint/combined_interfaces.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 526

--- a/explorer/testdata/constraint/dot_self_is_other.carbon
+++ b/explorer/testdata/constraint/dot_self_is_other.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/dot_self_is_other.carbon
+++ b/explorer/testdata/constraint/dot_self_is_other.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/constraint/fail_ambiguous_member.carbon
+++ b/explorer/testdata/constraint/fail_ambiguous_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_ambiguous_member.carbon
+++ b/explorer/testdata/constraint/fail_ambiguous_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_combine_equality.carbon
+++ b/explorer/testdata/constraint/fail_combine_equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 
@@ -13,7 +13,7 @@ impl i32 as I {}
 
 fn F(A:! i32, B:! i32, C:! i32, D:! i32, E:! i32,
      T:! I where A == B and C == D and C == E and B == D) {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/no_combine_equality.carbon:[[@LINE+1]]: member access, F not in constraint interface I where T is interface I and A == B and C == D and C == E and B == D
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/fail_combine_equality.carbon:[[@LINE+1]]: member access, F not in constraint interface I where T is interface I and A == B and C == D and C == E and B == D
   T.F();
 }
 

--- a/explorer/testdata/constraint/fail_combine_equality.carbon
+++ b/explorer/testdata/constraint/fail_combine_equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_infinite_self.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_infinite_self.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_missing_member.carbon
+++ b/explorer/testdata/constraint/fail_missing_member.carbon
@@ -2,16 +2,16 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 
 interface A { fn F() -> i32; }
 interface B { fn G() -> i32; }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/missing_member.carbon:[[@LINE+1]]: member access, H not in constraint interface A & interface B where T is interface A and T is interface B
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/fail_missing_member.carbon:[[@LINE+1]]: member access, H not in constraint interface A & interface B where T is interface A and T is interface B
 fn Get[T:! A & B](n: T) -> i32 { return n.H(); }
 
 impl i32 as A {

--- a/explorer/testdata/constraint/fail_missing_member.carbon
+++ b/explorer/testdata/constraint/fail_missing_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_non_type_self.carbon
+++ b/explorer/testdata/constraint/fail_non_type_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_non_type_self.carbon
+++ b/explorer/testdata/constraint/fail_non_type_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_where_equals_different_types.carbon
+++ b/explorer/testdata/constraint/fail_where_equals_different_types.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_where_equals_different_types.carbon
+++ b/explorer/testdata/constraint/fail_where_equals_different_types.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
+++ b/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
+++ b/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_where_is_non_type.carbon
+++ b/explorer/testdata/constraint/fail_where_is_non_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_where_is_non_type.carbon
+++ b/explorer/testdata/constraint/fail_where_is_non_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/fail_where_non_type_is.carbon
+++ b/explorer/testdata/constraint/fail_where_non_type_is.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/constraint/fail_where_non_type_is.carbon
+++ b/explorer/testdata/constraint/fail_where_non_type_is.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/constraint/nondependent_where.carbon
+++ b/explorer/testdata/constraint/nondependent_where.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/nondependent_where.carbon
+++ b/explorer/testdata/constraint/nondependent_where.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/constraint/qualified_lookup_in_where.carbon
+++ b/explorer/testdata/constraint/qualified_lookup_in_where.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 122
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/qualified_lookup_in_where.carbon
+++ b/explorer/testdata/constraint/qualified_lookup_in_where.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 122

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/rewrite.carbon
+++ b/explorer/testdata/constraint/rewrite.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/rewrite_compound.carbon
+++ b/explorer/testdata/constraint/rewrite_compound.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/rewrite_compound_2.carbon
+++ b/explorer/testdata/constraint/rewrite_compound_2.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/constraint/rewrite_in_qualifier.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
+++ b/explorer/testdata/constraint/rewrite_in_qualifier_and_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/constraint/where_self.carbon
+++ b/explorer/testdata/constraint/where_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/where_self.carbon
+++ b/explorer/testdata/constraint/where_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/destructor/call_destructor_from_destructor.carbon
+++ b/explorer/testdata/destructor/call_destructor_from_destructor.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1
 // CHECK:STDOUT: DESTRUCTOR B 2
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/call_destructor_from_destructor.carbon
+++ b/explorer/testdata/destructor/call_destructor_from_destructor.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1

--- a/explorer/testdata/destructor/destructor_with_return.carbon
+++ b/explorer/testdata/destructor/destructor_with_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/destructor_with_return.carbon
+++ b/explorer/testdata/destructor/destructor_with_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 3
 // CHECK:STDOUT: result: 1
 

--- a/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
+++ b/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
+++ b/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/destructor/function_with_return.carbon
+++ b/explorer/testdata/destructor/function_with_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR C 1
 // CHECK:STDOUT: DESTRUCTOR B 2
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/function_with_return.carbon
+++ b/explorer/testdata/destructor/function_with_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR C 1

--- a/explorer/testdata/destructor/loop_block.carbon
+++ b/explorer/testdata/destructor/loop_block.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1
 // CHECK:STDOUT: DESTRUCTOR A 2
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/loop_block.carbon
+++ b/explorer/testdata/destructor/loop_block.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1

--- a/explorer/testdata/destructor/loop_break_continue.carbon
+++ b/explorer/testdata/destructor/loop_break_continue.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1
 // CHECK:STDOUT: DESTRUCTOR A 2
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/loop_break_continue.carbon
+++ b/explorer/testdata/destructor/loop_break_continue.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1

--- a/explorer/testdata/destructor/nested_block_with_return.carbon
+++ b/explorer/testdata/destructor/nested_block_with_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1
 // CHECK:STDOUT: DESTRUCTOR A 2
 // CHECK:STDOUT: DESTRUCTOR A 3

--- a/explorer/testdata/destructor/nested_block_with_return.carbon
+++ b/explorer/testdata/destructor/nested_block_with_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: DESTRUCTOR A 1

--- a/explorer/testdata/experimental_continuation/await_maintains_scope.carbon
+++ b/explorer/testdata/experimental_continuation/await_maintains_scope.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/await_maintains_scope.carbon
+++ b/explorer/testdata/experimental_continuation/await_maintains_scope.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/experimental_continuation/convert_run.carbon
+++ b/explorer/testdata/experimental_continuation/convert_run.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/convert_run.carbon
+++ b/explorer/testdata/experimental_continuation/convert_run.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/experimental_continuation/creation_is_noop.carbon
+++ b/explorer/testdata/experimental_continuation/creation_is_noop.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/creation_is_noop.carbon
+++ b/explorer/testdata/experimental_continuation/creation_is_noop.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
+++ b/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
+++ b/explorer/testdata/experimental_continuation/fail_auto_return_await.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/experimental_continuation/fail_continuation_syntax.carbon
+++ b/explorer/testdata/experimental_continuation/fail_continuation_syntax.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/experimental_continuation/fail_continuation_syntax.carbon
+++ b/explorer/testdata/experimental_continuation/fail_continuation_syntax.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/experimental_continuation/fail_lifetime.carbon
+++ b/explorer/testdata/experimental_continuation/fail_lifetime.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/experimental_continuation/fail_lifetime.carbon
+++ b/explorer/testdata/experimental_continuation/fail_lifetime.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
+++ b/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
+++ b/explorer/testdata/experimental_continuation/fail_recursive_continuation.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/experimental_continuation/fail_return_in_continuation.carbon
+++ b/explorer/testdata/experimental_continuation/fail_return_in_continuation.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/experimental_continuation/fail_return_in_continuation.carbon
+++ b/explorer/testdata/experimental_continuation/fail_return_in_continuation.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/experimental_continuation/recursive.carbon
+++ b/explorer/testdata/experimental_continuation/recursive.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/recursive.carbon
+++ b/explorer/testdata/experimental_continuation/recursive.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10

--- a/explorer/testdata/experimental_continuation/run.carbon
+++ b/explorer/testdata/experimental_continuation/run.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/run.carbon
+++ b/explorer/testdata/experimental_continuation/run.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/experimental_continuation/run_with_await.carbon
+++ b/explorer/testdata/experimental_continuation/run_with_await.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/run_with_await.carbon
+++ b/explorer/testdata/experimental_continuation/run_with_await.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/experimental_continuation/shallow_copy.carbon
+++ b/explorer/testdata/experimental_continuation/shallow_copy.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/experimental_continuation/shallow_copy.carbon
+++ b/explorer/testdata/experimental_continuation/shallow_copy.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/for/for_loop.carbon
+++ b/explorer/testdata/for/for_loop.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: HALLO WELT 0

--- a/explorer/testdata/for/for_loop.carbon
+++ b/explorer/testdata/for/for_loop.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: HALLO WELT 0
 // CHECK:STDOUT: HALLO WELT 1
 // CHECK:STDOUT: HALLO WELT 2

--- a/explorer/testdata/for/for_loop_auto.carbon
+++ b/explorer/testdata/for/for_loop_auto.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: HALLO WELT 0

--- a/explorer/testdata/for/for_loop_auto.carbon
+++ b/explorer/testdata/for/for_loop_auto.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: HALLO WELT 0
 // CHECK:STDOUT: HALLO WELT 1
 // CHECK:STDOUT: HALLO WELT 2

--- a/explorer/testdata/for/for_loop_break.carbon
+++ b/explorer/testdata/for/for_loop_break.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/for/for_loop_break.carbon
+++ b/explorer/testdata/for/for_loop_break.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/for/for_loop_continue.carbon
+++ b/explorer/testdata/for/for_loop_continue.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4

--- a/explorer/testdata/for/for_loop_continue.carbon
+++ b/explorer/testdata/for/for_loop_continue.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4
 
 package ExplorerTest api;

--- a/explorer/testdata/for/for_loop_empty.carbon
+++ b/explorer/testdata/for/for_loop_empty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/for/for_loop_empty.carbon
+++ b/explorer/testdata/for/for_loop_empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/for/for_loop_nested.carbon
+++ b/explorer/testdata/for/for_loop_nested.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 20

--- a/explorer/testdata/for/for_loop_nested.carbon
+++ b/explorer/testdata/for/for_loop_nested.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 20
 
 package ExplorerTest api;

--- a/explorer/testdata/function/auto_return/add.carbon
+++ b/explorer/testdata/function/auto_return/add.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/auto_return/add.carbon
+++ b/explorer/testdata/function/auto_return/add.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
+++ b/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
+++ b/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
+++ b/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
+++ b/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/auto_return/fail_no_return.carbon
+++ b/explorer/testdata/function/auto_return/fail_no_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/auto_return/fail_no_return.carbon
+++ b/explorer/testdata/function/auto_return/fail_no_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/auto_return/fail_separate_decl.carbon
+++ b/explorer/testdata/function/auto_return/fail_separate_decl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/auto_return/fail_separate_decl.carbon
+++ b/explorer/testdata/function/auto_return/fail_separate_decl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/auto_return/modify_arg_type.carbon
+++ b/explorer/testdata/function/auto_return/modify_arg_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/auto_return/modify_arg_type.carbon
+++ b/explorer/testdata/function/auto_return/modify_arg_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/auto_return/modify_return_type.carbon
+++ b/explorer/testdata/function/auto_return/modify_return_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/auto_return/modify_return_type.carbon
+++ b/explorer/testdata/function/auto_return/modify_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/auto_return/type.carbon
+++ b/explorer/testdata/function/auto_return/type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/auto_return/type.carbon
+++ b/explorer/testdata/function/auto_return/type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/convert_args.carbon
+++ b/explorer/testdata/function/convert_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 123
 
 package ExplorerTest api;

--- a/explorer/testdata/function/convert_args.carbon
+++ b/explorer/testdata/function/convert_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 123

--- a/explorer/testdata/function/empty_params.carbon
+++ b/explorer/testdata/function/empty_params.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/empty_params.carbon
+++ b/explorer/testdata/function/empty_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/fail_call_undefined.carbon
+++ b/explorer/testdata/function/fail_call_undefined.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_call_undefined.carbon
+++ b/explorer/testdata/function/fail_call_undefined.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_call_undefined_main.carbon
+++ b/explorer/testdata/function/fail_call_undefined_main.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 // CHECK:STDERR: RUNTIME ERROR: <Main()>:0: attempt to call function `Main` that has not been defined
 
 package ExplorerTest api;

--- a/explorer/testdata/function/fail_call_undefined_main.carbon
+++ b/explorer/testdata/function/fail_call_undefined_main.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 // CHECK:STDERR: RUNTIME ERROR: <Main()>:0: attempt to call function `Main` that has not been defined

--- a/explorer/testdata/function/fail_call_with_tuple.carbon
+++ b/explorer/testdata/function/fail_call_with_tuple.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_call_with_tuple.carbon
+++ b/explorer/testdata/function/fail_call_with_tuple.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_invalid_fnty.carbon
+++ b/explorer/testdata/function/fail_invalid_fnty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_invalid_fnty.carbon
+++ b/explorer/testdata/function/fail_invalid_fnty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_match_no_return.carbon
+++ b/explorer/testdata/function/fail_match_no_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_match_no_return.carbon
+++ b/explorer/testdata/function/fail_match_no_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_match_partial_return.carbon
+++ b/explorer/testdata/function/fail_match_partial_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_match_partial_return.carbon
+++ b/explorer/testdata/function/fail_match_partial_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_non_exhaustive_match.carbon
+++ b/explorer/testdata/function/fail_non_exhaustive_match.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_non_exhaustive_match.carbon
+++ b/explorer/testdata/function/fail_non_exhaustive_match.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_parameter_type.carbon
+++ b/explorer/testdata/function/fail_parameter_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_parameter_type.carbon
+++ b/explorer/testdata/function/fail_parameter_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_recurse_before_typecheck.carbon
+++ b/explorer/testdata/function/fail_recurse_before_typecheck.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_recurse_before_typecheck.carbon
+++ b/explorer/testdata/function/fail_recurse_before_typecheck.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_recurse_in_return_type.carbon
+++ b/explorer/testdata/function/fail_recurse_in_return_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/function/fail_recurse_in_return_type.carbon
+++ b/explorer/testdata/function/fail_recurse_in_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
+++ b/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
@@ -2,8 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 2>&1 | %{FileCheck} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package EmptyIdentifier impl;
 

--- a/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
+++ b/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fail_var_type_is_call.carbon
+++ b/explorer/testdata/function/fail_var_type_is_call.carbon
@@ -2,8 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 2>&1 | %{FileCheck} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package EmptyIdentifier impl;
 

--- a/explorer/testdata/function/fail_var_type_is_call.carbon
+++ b/explorer/testdata/function/fail_var_type_is_call.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/function/fnty.carbon
+++ b/explorer/testdata/function/fnty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/fnty.carbon
+++ b/explorer/testdata/function/fnty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/ignored_parameter.carbon
+++ b/explorer/testdata/function/ignored_parameter.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/ignored_parameter.carbon
+++ b/explorer/testdata/function/ignored_parameter.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/multiple_args.carbon
+++ b/explorer/testdata/function/multiple_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/multiple_args.carbon
+++ b/explorer/testdata/function/multiple_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/non_exhaustive_match_no_return_type.carbon
+++ b/explorer/testdata/function/non_exhaustive_match_no_return_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/non_exhaustive_match_no_return_type.carbon
+++ b/explorer/testdata/function/non_exhaustive_match_no_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/non_exhaustive_match_return.carbon
+++ b/explorer/testdata/function/non_exhaustive_match_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/function/non_exhaustive_match_return.carbon
+++ b/explorer/testdata/function/non_exhaustive_match_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/function/param_lifetime.carbon
+++ b/explorer/testdata/function/param_lifetime.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/param_lifetime.carbon
+++ b/explorer/testdata/function/param_lifetime.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/recursive.carbon
+++ b/explorer/testdata/function/recursive.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/recursive.carbon
+++ b/explorer/testdata/function/recursive.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/return.carbon
+++ b/explorer/testdata/function/return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/return.carbon
+++ b/explorer/testdata/function/return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/function/return_exhaustive_match.carbon
+++ b/explorer/testdata/function/return_exhaustive_match.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/function/return_exhaustive_match.carbon
+++ b/explorer/testdata/function/return_exhaustive_match.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/function/type_match.carbon
+++ b/explorer/testdata/function/type_match.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/function/type_match.carbon
+++ b/explorer/testdata/function/type_match.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/class_function.carbon
+++ b/explorer/testdata/generic_class/class_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/class_function.carbon
+++ b/explorer/testdata/generic_class/class_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/convert_from_struct.carbon
+++ b/explorer/testdata/generic_class/convert_from_struct.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/generic_class/convert_from_struct.carbon
+++ b/explorer/testdata/generic_class/convert_from_struct.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/fail_args_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_args_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_args_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_args_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_argument_deduction.carbon
+++ b/explorer/testdata/generic_class/fail_argument_deduction.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_argument_deduction.carbon
+++ b/explorer/testdata/generic_class/fail_argument_deduction.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
+++ b/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
+++ b/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
+++ b/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
+++ b/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_generic_class_arg.carbon
+++ b/explorer/testdata/generic_class/fail_generic_class_arg.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_generic_class_arg.carbon
+++ b/explorer/testdata/generic_class/fail_generic_class_arg.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
+++ b/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
+++ b/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
+++ b/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
+++ b/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_no_args.carbon
+++ b/explorer/testdata/generic_class/fail_no_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_no_args.carbon
+++ b/explorer/testdata/generic_class/fail_no_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_point_equal.carbon
+++ b/explorer/testdata/generic_class/fail_point_equal.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_point_equal.carbon
+++ b/explorer/testdata/generic_class/fail_point_equal.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_return_type_is_type.carbon
+++ b/explorer/testdata/generic_class/fail_return_type_is_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_return_type_is_type.carbon
+++ b/explorer/testdata/generic_class/fail_return_type_is_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_self_with_arg.carbon
+++ b/explorer/testdata/generic_class/fail_self_with_arg.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_self_with_arg.carbon
+++ b/explorer/testdata/generic_class/fail_self_with_arg.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_two_arg_lists.carbon
+++ b/explorer/testdata/generic_class/fail_two_arg_lists.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_two_arg_lists.carbon
+++ b/explorer/testdata/generic_class/fail_two_arg_lists.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_class/generic_class_substitution.carbon
+++ b/explorer/testdata/generic_class/generic_class_substitution.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/generic_class_substitution.carbon
+++ b/explorer/testdata/generic_class/generic_class_substitution.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/generic_fun_and_class.carbon
+++ b/explorer/testdata/generic_class/generic_fun_and_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/generic_fun_and_class.carbon
+++ b/explorer/testdata/generic_class/generic_fun_and_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/generic_point.carbon
+++ b/explorer/testdata/generic_class/generic_point.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/generic_point.carbon
+++ b/explorer/testdata/generic_class/generic_point.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/impl_with_argument.carbon
+++ b/explorer/testdata/generic_class/impl_with_argument.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/impl_with_argument.carbon
+++ b/explorer/testdata/generic_class/impl_with_argument.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/impl_with_self.carbon
+++ b/explorer/testdata/generic_class/impl_with_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/impl_with_self.carbon
+++ b/explorer/testdata/generic_class/impl_with_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/instantiation_at_compile_time.carbon
+++ b/explorer/testdata/generic_class/instantiation_at_compile_time.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/instantiation_at_compile_time.carbon
+++ b/explorer/testdata/generic_class/instantiation_at_compile_time.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/param_with_dependent_type.carbon
+++ b/explorer/testdata/generic_class/param_with_dependent_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/param_with_dependent_type.carbon
+++ b/explorer/testdata/generic_class/param_with_dependent_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/generic_class/parameter_type_conversion.carbon
+++ b/explorer/testdata/generic_class/parameter_type_conversion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4

--- a/explorer/testdata/generic_class/parameter_type_conversion.carbon
+++ b/explorer/testdata/generic_class/parameter_type_conversion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/point_with_interface.carbon
+++ b/explorer/testdata/generic_class/point_with_interface.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/point_with_interface.carbon
+++ b/explorer/testdata/generic_class/point_with_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/use_at_compile_time.carbon
+++ b/explorer/testdata/generic_class/use_at_compile_time.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/use_at_compile_time.carbon
+++ b/explorer/testdata/generic_class/use_at_compile_time.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_class/use_self.carbon
+++ b/explorer/testdata/generic_class/use_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_class/use_self.carbon
+++ b/explorer/testdata/generic_class/use_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_function/apply.carbon
+++ b/explorer/testdata/generic_function/apply.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -2

--- a/explorer/testdata/generic_function/apply.carbon
+++ b/explorer/testdata/generic_function/apply.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -2
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/call_at_compile_time.carbon
+++ b/explorer/testdata/generic_function/call_at_compile_time.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/call_at_compile_time.carbon
+++ b/explorer/testdata/generic_function/call_at_compile_time.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_missing_exclam.carbon
+++ b/explorer/testdata/generic_function/fail_missing_exclam.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_missing_exclam.carbon
+++ b/explorer/testdata/generic_function/fail_missing_exclam.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_not_addable.carbon
+++ b/explorer/testdata/generic_function/fail_not_addable.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_not_addable.carbon
+++ b/explorer/testdata/generic_function/fail_not_addable.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_not_type.carbon
+++ b/explorer/testdata/generic_function/fail_not_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_not_type.carbon
+++ b/explorer/testdata/generic_function/fail_not_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
+++ b/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package Foo api;
 

--- a/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
+++ b/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/generic_function/generic_method.carbon
+++ b/explorer/testdata/generic_function/generic_method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/generic_method.carbon
+++ b/explorer/testdata/generic_function/generic_method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_function/implicit_conversion.carbon
+++ b/explorer/testdata/generic_function/implicit_conversion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4213
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/implicit_conversion.carbon
+++ b/explorer/testdata/generic_function/implicit_conversion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4213

--- a/explorer/testdata/generic_function/non_generic_param.carbon
+++ b/explorer/testdata/generic_function/non_generic_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/non_generic_param.carbon
+++ b/explorer/testdata/generic_function/non_generic_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/generic_function/nondeduced_generic_param.carbon
+++ b/explorer/testdata/generic_function/nondeduced_generic_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/nondeduced_generic_param.carbon
+++ b/explorer/testdata/generic_function/nondeduced_generic_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/generic_function/return_val.carbon
+++ b/explorer/testdata/generic_function/return_val.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/return_val.carbon
+++ b/explorer/testdata/generic_function/return_val.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_function/swap.carbon
+++ b/explorer/testdata/generic_function/swap.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/swap.carbon
+++ b/explorer/testdata/generic_function/swap.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/generic_function/tuple_map.carbon
+++ b/explorer/testdata/generic_function/tuple_map.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/tuple_map.carbon
+++ b/explorer/testdata/generic_function/tuple_map.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/generic_function/type_matching.carbon
+++ b/explorer/testdata/generic_function/type_matching.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/generic_function/type_matching.carbon
+++ b/explorer/testdata/generic_function/type_matching.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/fail_init_type_mismatch.carbon
+++ b/explorer/testdata/global_variable/fail_init_type_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/global_variable/fail_init_type_mismatch.carbon
+++ b/explorer/testdata/global_variable/fail_init_type_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/global_variable/fail_modify_in_constant_expr.carbon
+++ b/explorer/testdata/global_variable/fail_modify_in_constant_expr.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/global_variable/fail_modify_in_constant_expr.carbon
+++ b/explorer/testdata/global_variable/fail_modify_in_constant_expr.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/global_variable/fail_named_self.carbon
+++ b/explorer/testdata/global_variable/fail_named_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/global_variable/fail_named_self.carbon
+++ b/explorer/testdata/global_variable/fail_named_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/global_variable/implicit_conversion.carbon
+++ b/explorer/testdata/global_variable/implicit_conversion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/global_variable/implicit_conversion.carbon
+++ b/explorer/testdata/global_variable/implicit_conversion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/init_and_read.carbon
+++ b/explorer/testdata/global_variable/init_and_read.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/init_and_read.carbon
+++ b/explorer/testdata/global_variable/init_and_read.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/init_from_function.carbon
+++ b/explorer/testdata/global_variable/init_from_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/init_from_function.carbon
+++ b/explorer/testdata/global_variable/init_from_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/init_order.carbon
+++ b/explorer/testdata/global_variable/init_order.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/init_order.carbon
+++ b/explorer/testdata/global_variable/init_order.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/shadowing.carbon
+++ b/explorer/testdata/global_variable/shadowing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/shadowing.carbon
+++ b/explorer/testdata/global_variable/shadowing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/write.carbon
+++ b/explorer/testdata/global_variable/write.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/write.carbon
+++ b/explorer/testdata/global_variable/write.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/global_variable/write_from_function.carbon
+++ b/explorer/testdata/global_variable/write_from_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/global_variable/write_from_function.carbon
+++ b/explorer/testdata/global_variable/write_from_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/convert_condition.carbon
+++ b/explorer/testdata/if_else/convert_condition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/convert_condition.carbon
+++ b/explorer/testdata/if_else/convert_condition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/if_else/if_else.carbon
+++ b/explorer/testdata/if_else/if_else.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_else.carbon
+++ b/explorer/testdata/if_else/if_else.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/if_else_if.carbon
+++ b/explorer/testdata/if_else/if_else_if.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_else_if.carbon
+++ b/explorer/testdata/if_else/if_else_if.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/if_else_if_else.carbon
+++ b/explorer/testdata/if_else/if_else_if_else.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_else_if_else.carbon
+++ b/explorer/testdata/if_else/if_else_if_else.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/if_false.carbon
+++ b/explorer/testdata/if_else/if_false.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_false.carbon
+++ b/explorer/testdata/if_else/if_false.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/if_nesting.carbon
+++ b/explorer/testdata/if_else/if_nesting.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_nesting.carbon
+++ b/explorer/testdata/if_else/if_nesting.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_else/if_true.carbon
+++ b/explorer/testdata/if_else/if_true.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/if_else/if_true.carbon
+++ b/explorer/testdata/if_else/if_true.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/if_expression/convert_condition.carbon
+++ b/explorer/testdata/if_expression/convert_condition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/if_expression/convert_condition.carbon
+++ b/explorer/testdata/if_expression/convert_condition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/if_expression/if_then_else.carbon
+++ b/explorer/testdata/if_expression/if_then_else.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package ExplorerTest api;

--- a/explorer/testdata/if_expression/if_then_else.carbon
+++ b/explorer/testdata/if_expression/if_then_else.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/impl/deducible_parameter.carbon
+++ b/explorer/testdata/impl/deducible_parameter.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/deducible_parameter.carbon
+++ b/explorer/testdata/impl/deducible_parameter.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/impl/fail_ambiguous_impl.carbon
+++ b/explorer/testdata/impl/fail_ambiguous_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/fail_ambiguous_impl.carbon
+++ b/explorer/testdata/impl/fail_ambiguous_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_ambiguous_impl_generic.carbon
+++ b/explorer/testdata/impl/fail_ambiguous_impl_generic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_ambiguous_impl_generic.carbon
+++ b/explorer/testdata/impl/fail_ambiguous_impl_generic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_bad_member_kind.carbon
+++ b/explorer/testdata/impl/fail_bad_member_kind.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_bad_member_kind.carbon
+++ b/explorer/testdata/impl/fail_bad_member_kind.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_impl_as.carbon
+++ b/explorer/testdata/impl/fail_impl_as.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_impl_as.carbon
+++ b/explorer/testdata/impl/fail_impl_as.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_impl_as_non_interface.carbon
+++ b/explorer/testdata/impl/fail_impl_as_non_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_impl_as_non_interface.carbon
+++ b/explorer/testdata/impl/fail_impl_as_non_interface.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_impl_as_parameterized.carbon
+++ b/explorer/testdata/impl/fail_impl_as_parameterized.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_impl_as_parameterized.carbon
+++ b/explorer/testdata/impl/fail_impl_as_parameterized.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_nondeducible_parameter.carbon
+++ b/explorer/testdata/impl/fail_nondeducible_parameter.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_nondeducible_parameter.carbon
+++ b/explorer/testdata/impl/fail_nondeducible_parameter.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_param_interface_in_impl.carbon
+++ b/explorer/testdata/impl/fail_param_interface_in_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_param_interface_in_impl.carbon
+++ b/explorer/testdata/impl/fail_param_interface_in_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_unambiguous_impl_generic.carbon
+++ b/explorer/testdata/impl/fail_unambiguous_impl_generic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_unambiguous_impl_generic.carbon
+++ b/explorer/testdata/impl/fail_unambiguous_impl_generic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/fail_unmet_impl_constraint.carbon
+++ b/explorer/testdata/impl/fail_unmet_impl_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/impl/fail_unmet_impl_constraint.carbon
+++ b/explorer/testdata/impl/fail_unmet_impl_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/impl/generic_method_impl.carbon
+++ b/explorer/testdata/impl/generic_method_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/generic_method_impl.carbon
+++ b/explorer/testdata/impl/generic_method_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/impl/impl_constraint.carbon
+++ b/explorer/testdata/impl/impl_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1234

--- a/explorer/testdata/impl/impl_constraint.carbon
+++ b/explorer/testdata/impl/impl_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1234
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/impl_in_generic_class.carbon
+++ b/explorer/testdata/impl/impl_in_generic_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1133

--- a/explorer/testdata/impl/impl_in_generic_class.carbon
+++ b/explorer/testdata/impl/impl_in_generic_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1133
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/param_impl.carbon
+++ b/explorer/testdata/impl/param_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/param_impl.carbon
+++ b/explorer/testdata/impl/param_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/impl/param_impl2.carbon
+++ b/explorer/testdata/impl/param_impl2.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/param_impl2.carbon
+++ b/explorer/testdata/impl/param_impl2.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/impl/param_impl_with_self.carbon
+++ b/explorer/testdata/impl/param_impl_with_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/param_impl_with_self.carbon
+++ b/explorer/testdata/impl/param_impl_with_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/impl/param_interface_in_impl.carbon
+++ b/explorer/testdata/impl/param_interface_in_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/impl/param_interface_in_impl.carbon
+++ b/explorer/testdata/impl/param_interface_in_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/import/fail_order.carbon
+++ b/explorer/testdata/import/fail_order.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/import/fail_order.carbon
+++ b/explorer/testdata/import/fail_order.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/import/nonexistent_library.carbon
+++ b/explorer/testdata/import/nonexistent_library.carbon
@@ -4,14 +4,14 @@
 //
 // TODO: This SHOULD fail but doesn't presently.
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
-import ExplorerTest library "Nonexistent";
+import Nonexistent;
 
 fn Main() -> i32 {
   return 0;

--- a/explorer/testdata/import/nonexistent_library.carbon
+++ b/explorer/testdata/import/nonexistent_library.carbon
@@ -4,7 +4,7 @@
 //
 // TODO: This SHOULD fail but doesn't presently.
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/import/nonexistent_package.carbon
+++ b/explorer/testdata/import/nonexistent_package.carbon
@@ -4,14 +4,14 @@
 //
 // TODO: This SHOULD fail but doesn't presently.
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
-import Nonexistent;
+import ExplorerTest library "Nonexistent";
 
 fn Main() -> i32 {
   return 0;

--- a/explorer/testdata/import/nonexistent_package.carbon
+++ b/explorer/testdata/import/nonexistent_package.carbon
@@ -4,7 +4,7 @@
 //
 // TODO: This SHOULD fail but doesn't presently.
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
+++ b/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
+++ b/explorer/testdata/interface/assoc_constant_constraints_in_scope.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/class_function.carbon
+++ b/explorer/testdata/interface/class_function.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/class_function.carbon
+++ b/explorer/testdata/interface/class_function.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/constrained_parameter.carbon
+++ b/explorer/testdata/interface/constrained_parameter.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/constrained_parameter.carbon
+++ b/explorer/testdata/interface/constrained_parameter.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/extends.carbon
+++ b/explorer/testdata/interface/extends.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Carrot.G

--- a/explorer/testdata/interface/extends.carbon
+++ b/explorer/testdata/interface/extends.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Carrot.G
 // CHECK:STDOUT: result: 5
 

--- a/explorer/testdata/interface/external_impl_point_vector.carbon
+++ b/explorer/testdata/interface/external_impl_point_vector.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/external_impl_point_vector.carbon
+++ b/explorer/testdata/interface/external_impl_point_vector.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/external_impl_use_self.carbon
+++ b/explorer/testdata/interface/external_impl_use_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/external_impl_use_self.carbon
+++ b/explorer/testdata/interface/external_impl_use_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/fail_bad_member_kind.carbon
+++ b/explorer/testdata/interface/fail_bad_member_kind.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_bad_member_kind.carbon
+++ b/explorer/testdata/interface/fail_bad_member_kind.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_extends_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_extends_not_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_extends_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_extends_not_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_external_impl_omit_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_omit_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_external_impl_omit_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_omit_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_external_impl_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_external_impl_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_impl_as_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_impl_as_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_impl_bad_member.carbon
+++ b/explorer/testdata/interface/fail_impl_bad_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_impl_bad_member.carbon
+++ b/explorer/testdata/interface/fail_impl_bad_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_impl_missing_member.carbon
+++ b/explorer/testdata/interface/fail_impl_missing_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_impl_missing_member.carbon
+++ b/explorer/testdata/interface/fail_impl_missing_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_impl_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_not_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_impl_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_not_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_interface_missing_member.carbon
+++ b/explorer/testdata/interface/fail_interface_missing_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_interface_missing_member.carbon
+++ b/explorer/testdata/interface/fail_interface_missing_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_no_impl.carbon
+++ b/explorer/testdata/interface/fail_no_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_no_impl.carbon
+++ b/explorer/testdata/interface/fail_no_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s 2>&1 | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s 2>&1 | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_use_symbolic_member.carbon
+++ b/explorer/testdata/interface/fail_use_symbolic_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/interface/fail_use_symbolic_member.carbon
+++ b/explorer/testdata/interface/fail_use_symbolic_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/interface/generic_call_generic.carbon
+++ b/explorer/testdata/interface/generic_call_generic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/generic_call_generic.carbon
+++ b/explorer/testdata/interface/generic_call_generic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/generic_with_two_params.carbon
+++ b/explorer/testdata/interface/generic_with_two_params.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/generic_with_two_params.carbon
+++ b/explorer/testdata/interface/generic_with_two_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/impl_as.carbon
+++ b/explorer/testdata/interface/impl_as.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Carrot.G

--- a/explorer/testdata/interface/impl_as.carbon
+++ b/explorer/testdata/interface/impl_as.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Carrot.G
 // CHECK:STDOUT: result: 5
 

--- a/explorer/testdata/interface/impl_as_not_self.carbon
+++ b/explorer/testdata/interface/impl_as_not_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/interface/impl_as_not_self.carbon
+++ b/explorer/testdata/interface/impl_as_not_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/impl_self_interface_parameter.carbon
+++ b/explorer/testdata/interface/impl_self_interface_parameter.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/impl_self_interface_parameter.carbon
+++ b/explorer/testdata/interface/impl_self_interface_parameter.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/omit_self.carbon
+++ b/explorer/testdata/interface/omit_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/omit_self.carbon
+++ b/explorer/testdata/interface/omit_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/param_with_dependent_type.carbon
+++ b/explorer/testdata/interface/param_with_dependent_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42

--- a/explorer/testdata/interface/param_with_dependent_type.carbon
+++ b/explorer/testdata/interface/param_with_dependent_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/parameterized.carbon
+++ b/explorer/testdata/interface/parameterized.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/parameterized.carbon
+++ b/explorer/testdata/interface/parameterized.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/tuple_vector_add_scale.carbon
+++ b/explorer/testdata/interface/tuple_vector_add_scale.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/tuple_vector_add_scale.carbon
+++ b/explorer/testdata/interface/tuple_vector_add_scale.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/vector_point_add_scale.carbon
+++ b/explorer/testdata/interface/vector_point_add_scale.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/vector_point_add_scale.carbon
+++ b/explorer/testdata/interface/vector_point_add_scale.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/interface/with_self.carbon
+++ b/explorer/testdata/interface/with_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/interface/with_self.carbon
+++ b/explorer/testdata/interface/with_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/let/fail_function_args.carbon
+++ b/explorer/testdata/let/fail_function_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_function_args.carbon
+++ b/explorer/testdata/let/fail_function_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_global_assign.carbon
+++ b/explorer/testdata/let/fail_global_assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_global_assign.carbon
+++ b/explorer/testdata/let/fail_global_assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_global_named_self.carbon
+++ b/explorer/testdata/let/fail_global_named_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_global_named_self.carbon
+++ b/explorer/testdata/let/fail_global_named_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_local_assign.carbon
+++ b/explorer/testdata/let/fail_local_assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_local_assign.carbon
+++ b/explorer/testdata/let/fail_local_assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_local_named_self.carbon
+++ b/explorer/testdata/let/fail_local_named_self.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_local_named_self.carbon
+++ b/explorer/testdata/let/fail_local_named_self.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_match_choice.carbon
+++ b/explorer/testdata/let/fail_match_choice.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_match_choice.carbon
+++ b/explorer/testdata/let/fail_match_choice.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_method_args.carbon
+++ b/explorer/testdata/let/fail_method_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_method_args.carbon
+++ b/explorer/testdata/let/fail_method_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/let/implicit_conversion.carbon
+++ b/explorer/testdata/let/implicit_conversion.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/let/implicit_conversion.carbon
+++ b/explorer/testdata/let/implicit_conversion.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/let/implicit_conversion_choice.carbon
+++ b/explorer/testdata/let/implicit_conversion_choice.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/let/implicit_conversion_choice.carbon
+++ b/explorer/testdata/let/implicit_conversion_choice.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/let/nested_tuple_pattern.carbon
+++ b/explorer/testdata/let/nested_tuple_pattern.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/let/nested_tuple_pattern.carbon
+++ b/explorer/testdata/let/nested_tuple_pattern.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/linked_list/linked_list.carbon
+++ b/explorer/testdata/linked_list/linked_list.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: 1

--- a/explorer/testdata/linked_list/linked_list.carbon
+++ b/explorer/testdata/linked_list/linked_list.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: 1
 // CHECK:STDOUT: 2
 // CHECK:STDOUT: 3

--- a/explorer/testdata/match/any_int.carbon
+++ b/explorer/testdata/match/any_int.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/any_int.carbon
+++ b/explorer/testdata/match/any_int.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/convert.carbon
+++ b/explorer/testdata/match/convert.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/convert.carbon
+++ b/explorer/testdata/match/convert.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/exhaustive.carbon
+++ b/explorer/testdata/match/exhaustive.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/match/exhaustive.carbon
+++ b/explorer/testdata/match/exhaustive.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/match/exhaustive_bool.carbon
+++ b/explorer/testdata/match/exhaustive_bool.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/match/exhaustive_bool.carbon
+++ b/explorer/testdata/match/exhaustive_bool.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/match/exhaustive_exponential_8x.carbon
+++ b/explorer/testdata/match/exhaustive_exponential_8x.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/exhaustive_exponential_8x.carbon
+++ b/explorer/testdata/match/exhaustive_exponential_8x.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/exhaustive_exponential_series_t.carbon
+++ b/explorer/testdata/match/exhaustive_exponential_series_t.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/exhaustive_exponential_series_t.carbon
+++ b/explorer/testdata/match/exhaustive_exponential_series_t.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_exhaustive_int.carbon
+++ b/explorer/testdata/match/fail_exhaustive_int.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_exhaustive_int.carbon
+++ b/explorer/testdata/match/fail_exhaustive_int.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_not_alternative.carbon
+++ b/explorer/testdata/match/fail_not_alternative.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_not_alternative.carbon
+++ b/explorer/testdata/match/fail_not_alternative.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_not_exhaustive.carbon
+++ b/explorer/testdata/match/fail_not_exhaustive.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_not_exhaustive.carbon
+++ b/explorer/testdata/match/fail_not_exhaustive.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_not_reachable.carbon
+++ b/explorer/testdata/match/fail_not_reachable.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_not_reachable.carbon
+++ b/explorer/testdata/match/fail_not_reachable.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_not_reachable_default.carbon
+++ b/explorer/testdata/match/fail_not_reachable_default.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_not_reachable_default.carbon
+++ b/explorer/testdata/match/fail_not_reachable_default.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_pattern_type_mismatch.carbon
+++ b/explorer/testdata/match/fail_pattern_type_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_pattern_type_mismatch.carbon
+++ b/explorer/testdata/match/fail_pattern_type_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/fail_redundant_int.carbon
+++ b/explorer/testdata/match/fail_redundant_int.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/match/fail_redundant_int.carbon
+++ b/explorer/testdata/match/fail_redundant_int.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/match/int.carbon
+++ b/explorer/testdata/match/int.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/int.carbon
+++ b/explorer/testdata/match/int.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/int_default.carbon
+++ b/explorer/testdata/match/int_default.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/int_default.carbon
+++ b/explorer/testdata/match/int_default.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/no_match.carbon
+++ b/explorer/testdata/match/no_match.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/no_match.carbon
+++ b/explorer/testdata/match/no_match.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/match/placeholder.carbon
+++ b/explorer/testdata/match/placeholder.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/match/placeholder.carbon
+++ b/explorer/testdata/match/placeholder.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/member_access/convert_lhs_class.carbon
+++ b/explorer/testdata/member_access/convert_lhs_class.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/convert_lhs_class.carbon
+++ b/explorer/testdata/member_access/convert_lhs_class.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/convert_lhs_interface.carbon
+++ b/explorer/testdata/member_access/convert_lhs_interface.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/convert_lhs_interface.carbon
+++ b/explorer/testdata/member_access/convert_lhs_interface.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/evaluate_type_before_dot.carbon
+++ b/explorer/testdata/member_access/evaluate_type_before_dot.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Struct OK

--- a/explorer/testdata/member_access/evaluate_type_before_dot.carbon
+++ b/explorer/testdata/member_access/evaluate_type_before_dot.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Struct OK
 // CHECK:STDOUT: Choice OK
 // CHECK:STDOUT: Class OK

--- a/explorer/testdata/member_access/fail_qualified_non_member.carbon
+++ b/explorer/testdata/member_access/fail_qualified_non_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package Foo api;
 fn F[me: i32]() {}

--- a/explorer/testdata/member_access/fail_qualified_non_member.carbon
+++ b/explorer/testdata/member_access/fail_qualified_non_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/member_access/fail_vacuous_access.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/member_access/fail_vacuous_access.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package Foo api;
 interface A { fn F() -> i32; }

--- a/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package Foo api;
 interface A { fn F() -> i32; }

--- a/explorer/testdata/member_access/nearly_vacuous_access_with_impl_lookup.carbon
+++ b/explorer/testdata/member_access/nearly_vacuous_access_with_impl_lookup.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package Foo api;

--- a/explorer/testdata/member_access/nearly_vacuous_access_with_impl_lookup.carbon
+++ b/explorer/testdata/member_access/nearly_vacuous_access_with_impl_lookup.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/member_access/nearly_vacuous_access_with_instance_binding.carbon
+++ b/explorer/testdata/member_access/nearly_vacuous_access_with_instance_binding.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package Foo api;

--- a/explorer/testdata/member_access/nearly_vacuous_access_with_instance_binding.carbon
+++ b/explorer/testdata/member_access/nearly_vacuous_access_with_instance_binding.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/member_access/param_qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/param_qualified_interface_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/param_qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/param_qualified_interface_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/qualified_class_member.carbon
+++ b/explorer/testdata/member_access/qualified_class_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/qualified_class_member.carbon
+++ b/explorer/testdata/member_access/qualified_class_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/qualified_constraint_member.carbon
+++ b/explorer/testdata/member_access/qualified_constraint_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12
 
 package Foo api;

--- a/explorer/testdata/member_access/qualified_constraint_member.carbon
+++ b/explorer/testdata/member_access/qualified_constraint_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 12

--- a/explorer/testdata/member_access/qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/qualified_interface_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/qualified_interface_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/qualified_param_member.carbon
+++ b/explorer/testdata/member_access/qualified_param_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package Foo api;

--- a/explorer/testdata/member_access/qualified_param_member.carbon
+++ b/explorer/testdata/member_access/qualified_param_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/member_access/qualified_struct_member.carbon
+++ b/explorer/testdata/member_access/qualified_struct_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/member_access/qualified_struct_member.carbon
+++ b/explorer/testdata/member_access/qualified_struct_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package Foo api;

--- a/explorer/testdata/member_access/type_qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/type_qualified_interface_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42
 
 package Foo api;

--- a/explorer/testdata/member_access/type_qualified_interface_member.carbon
+++ b/explorer/testdata/member_access/type_qualified_interface_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42

--- a/explorer/testdata/mixin/fail_circular_mixing.carbon
+++ b/explorer/testdata/mixin/fail_circular_mixing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;
 
 __mixin M1 {

--- a/explorer/testdata/mixin/fail_circular_mixing.carbon
+++ b/explorer/testdata/mixin/fail_circular_mixing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;

--- a/explorer/testdata/mixin/fail_field_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_field_member_name_clash.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_field_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_field_member_name_clash.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/fail_method_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_method_member_name_clash.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_method_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_method_member_name_clash.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
+++ b/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
+++ b/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;
 
 __mixin M1 {

--- a/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;

--- a/explorer/testdata/mixin/fail_mix_in_global.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_global.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_mix_in_global.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_global.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/fail_mix_in_impl.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_impl.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_mix_in_impl.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_impl.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/fail_mix_members_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_members_clash.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;
 
 __mixin M1 {

--- a/explorer/testdata/mixin/fail_mix_members_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_members_clash.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;

--- a/explorer/testdata/mixin/fail_recursive_mixing.carbon
+++ b/explorer/testdata/mixin/fail_recursive_mixing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;
 
 __mixin M1 {

--- a/explorer/testdata/mixin/fail_recursive_mixing.carbon
+++ b/explorer/testdata/mixin/fail_recursive_mixing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 package ExplorerTest api;

--- a/explorer/testdata/mixin/fail_self_substitution.carbon
+++ b/explorer/testdata/mixin/fail_self_substitution.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/mixin/fail_self_substitution.carbon
+++ b/explorer/testdata/mixin/fail_self_substitution.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/mixin/self_substitution.carbon
+++ b/explorer/testdata/mixin/self_substitution.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/mixin/self_substitution.carbon
+++ b/explorer/testdata/mixin/self_substitution.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/mixin/simple_mix_in_mixin.carbon
+++ b/explorer/testdata/mixin/simple_mix_in_mixin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/mixin/simple_mix_in_mixin.carbon
+++ b/explorer/testdata/mixin/simple_mix_in_mixin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/mixin/simple_reuse.carbon
+++ b/explorer/testdata/mixin/simple_reuse.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/mixin/simple_reuse.carbon
+++ b/explorer/testdata/mixin/simple_reuse.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/mixin/use_mixin_method_in_class_method.carbon
+++ b/explorer/testdata/mixin/use_mixin_method_in_class_method.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/mixin/use_mixin_method_in_class_method.carbon
+++ b/explorer/testdata/mixin/use_mixin_method_in_class_method.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/name_lookup/class_fn_body_reorder.carbon
+++ b/explorer/testdata/name_lookup/class_fn_body_reorder.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/name_lookup/class_fn_body_reorder.carbon
+++ b/explorer/testdata/name_lookup/class_fn_body_reorder.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/name_lookup/fail_block_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_block_duplicate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_block_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_block_duplicate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_class_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_class_duplicate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_class_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_class_duplicate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
+++ b/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
+++ b/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_global_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_global_duplicate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_global_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_global_duplicate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_use_before_declare.carbon
+++ b/explorer/testdata/name_lookup/fail_use_before_declare.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_use_before_declare.carbon
+++ b/explorer/testdata/name_lookup/fail_use_before_declare.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/name_lookup/global_shadow.carbon
+++ b/explorer/testdata/name_lookup/global_shadow.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/name_lookup/global_shadow.carbon
+++ b/explorer/testdata/name_lookup/global_shadow.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/name_lookup/match_shadow.carbon
+++ b/explorer/testdata/name_lookup/match_shadow.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/name_lookup/match_shadow.carbon
+++ b/explorer/testdata/name_lookup/match_shadow.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/operators/add.carbon
+++ b/explorer/testdata/operators/add.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 6

--- a/explorer/testdata/operators/add.carbon
+++ b/explorer/testdata/operators/add.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 6
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/add_builtin.carbon
+++ b/explorer/testdata/operators/add_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 5
 // CHECK:STDOUT: Op: 5
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/add_builtin.carbon
+++ b/explorer/testdata/operators/add_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 5

--- a/explorer/testdata/operators/bit_and.carbon
+++ b/explorer/testdata/operators/bit_and.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/bit_and.carbon
+++ b/explorer/testdata/operators/bit_and.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/operators/bit_complement.carbon
+++ b/explorer/testdata/operators/bit_complement.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -6
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/bit_complement.carbon
+++ b/explorer/testdata/operators/bit_complement.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -6

--- a/explorer/testdata/operators/bit_or.carbon
+++ b/explorer/testdata/operators/bit_or.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5

--- a/explorer/testdata/operators/bit_or.carbon
+++ b/explorer/testdata/operators/bit_or.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 5
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/bit_xor.carbon
+++ b/explorer/testdata/operators/bit_xor.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4

--- a/explorer/testdata/operators/bit_xor.carbon
+++ b/explorer/testdata/operators/bit_xor.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/bitwise.carbon
+++ b/explorer/testdata/operators/bitwise.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/bitwise.carbon
+++ b/explorer/testdata/operators/bitwise.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/div.carbon
+++ b/explorer/testdata/operators/div.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/operators/div.carbon
+++ b/explorer/testdata/operators/div.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/div_builtin.carbon
+++ b/explorer/testdata/operators/div_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 2

--- a/explorer/testdata/operators/div_builtin.carbon
+++ b/explorer/testdata/operators/div_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 2
 // CHECK:STDOUT: Op: 2
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/fail_no_add.carbon
+++ b/explorer/testdata/operators/fail_no_add.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/operators/fail_no_add.carbon
+++ b/explorer/testdata/operators/fail_no_add.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_no_mul.carbon
+++ b/explorer/testdata/operators/fail_no_mul.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/operators/fail_no_mul.carbon
+++ b/explorer/testdata/operators/fail_no_mul.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_no_negate.carbon
+++ b/explorer/testdata/operators/fail_no_negate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/operators/fail_no_negate.carbon
+++ b/explorer/testdata/operators/fail_no_negate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_no_sub.carbon
+++ b/explorer/testdata/operators/fail_no_sub.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/operators/fail_no_sub.carbon
+++ b/explorer/testdata/operators/fail_no_sub.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/left_shift.carbon
+++ b/explorer/testdata/operators/left_shift.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/left_shift.carbon
+++ b/explorer/testdata/operators/left_shift.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10

--- a/explorer/testdata/operators/mod.carbon
+++ b/explorer/testdata/operators/mod.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/mod.carbon
+++ b/explorer/testdata/operators/mod.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/operators/mod_builtin.carbon
+++ b/explorer/testdata/operators/mod_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 2

--- a/explorer/testdata/operators/mod_builtin.carbon
+++ b/explorer/testdata/operators/mod_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 2
 // CHECK:STDOUT: Op: 2
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/mod_edges.carbon
+++ b/explorer/testdata/operators/mod_edges.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/mod_edges.carbon
+++ b/explorer/testdata/operators/mod_edges.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/mul.carbon
+++ b/explorer/testdata/operators/mul.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/mul.carbon
+++ b/explorer/testdata/operators/mul.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 10

--- a/explorer/testdata/operators/mul_builtin.carbon
+++ b/explorer/testdata/operators/mul_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 6
 // CHECK:STDOUT: Op: 6
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/mul_builtin.carbon
+++ b/explorer/testdata/operators/mul_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 6

--- a/explorer/testdata/operators/negate.carbon
+++ b/explorer/testdata/operators/negate.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -5
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/negate.carbon
+++ b/explorer/testdata/operators/negate.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: -5

--- a/explorer/testdata/operators/negate_builtin.carbon
+++ b/explorer/testdata/operators/negate_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: -3

--- a/explorer/testdata/operators/negate_builtin.carbon
+++ b/explorer/testdata/operators/negate_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: -3
 // CHECK:STDOUT: Op: -3
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/right_shift.carbon
+++ b/explorer/testdata/operators/right_shift.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/operators/right_shift.carbon
+++ b/explorer/testdata/operators/right_shift.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/shift.carbon
+++ b/explorer/testdata/operators/shift.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/shift.carbon
+++ b/explorer/testdata/operators/shift.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/shortcircuit_and.carbon
+++ b/explorer/testdata/operators/shortcircuit_and.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/shortcircuit_and.carbon
+++ b/explorer/testdata/operators/shortcircuit_and.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/operators/shortcircuit_and_no_shortcircuit.carbon
+++ b/explorer/testdata/operators/shortcircuit_and_no_shortcircuit.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/operators/shortcircuit_and_no_shortcircuit.carbon
+++ b/explorer/testdata/operators/shortcircuit_and_no_shortcircuit.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/shortcircuit_or.carbon
+++ b/explorer/testdata/operators/shortcircuit_or.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/shortcircuit_or.carbon
+++ b/explorer/testdata/operators/shortcircuit_or.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/operators/shortcircuit_or_no_shortcircuit.carbon
+++ b/explorer/testdata/operators/shortcircuit_or_no_shortcircuit.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2

--- a/explorer/testdata/operators/shortcircuit_or_no_shortcircuit.carbon
+++ b/explorer/testdata/operators/shortcircuit_or_no_shortcircuit.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 2
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/sub.carbon
+++ b/explorer/testdata/operators/sub.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4

--- a/explorer/testdata/operators/sub.carbon
+++ b/explorer/testdata/operators/sub.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 4
 
 package ExplorerTest api;

--- a/explorer/testdata/operators/sub_builtin.carbon
+++ b/explorer/testdata/operators/sub_builtin.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 5
 // CHECK:STDOUT: Op: 5
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/operators/sub_builtin.carbon
+++ b/explorer/testdata/operators/sub_builtin.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Interface: 5

--- a/explorer/testdata/optional/init_optional_with_non_value.carbon
+++ b/explorer/testdata/optional/init_optional_with_non_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/optional/init_optional_with_non_value.carbon
+++ b/explorer/testdata/optional/init_optional_with_non_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/optional/init_optional_with_value.carbon
+++ b/explorer/testdata/optional/init_optional_with_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Hallo Welt
 // CHECK:STDOUT: result: 0
 

--- a/explorer/testdata/optional/init_optional_with_value.carbon
+++ b/explorer/testdata/optional/init_optional_with_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Hallo Welt

--- a/explorer/testdata/package/fail_missing.carbon
+++ b/explorer/testdata/package/fail_missing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/package/fail_missing.carbon:[[@LINE+1]]: syntax error, unexpected FN, expecting PACKAGE
 fn Main() -> i32 {

--- a/explorer/testdata/package/fail_missing.carbon
+++ b/explorer/testdata/package/fail_missing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/package/with_library.carbon
+++ b/explorer/testdata/package/with_library.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest library "Foo" api;

--- a/explorer/testdata/package/with_library.carbon
+++ b/explorer/testdata/package/with_library.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/aliasing.carbon
+++ b/explorer/testdata/pointer/aliasing.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/aliasing.carbon
+++ b/explorer/testdata/pointer/aliasing.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/basic.carbon
+++ b/explorer/testdata/pointer/basic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/basic.carbon
+++ b/explorer/testdata/pointer/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/fail_rvalue_addressof.carbon
+++ b/explorer/testdata/pointer/fail_rvalue_addressof.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/pointer/fail_rvalue_addressof.carbon
+++ b/explorer/testdata/pointer/fail_rvalue_addressof.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/pointer/fail_use_after_free.carbon
+++ b/explorer/testdata/pointer/fail_use_after_free.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/pointer/fail_use_after_free.carbon
+++ b/explorer/testdata/pointer/fail_use_after_free.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/pointer/heap_alloc_lifetime.carbon
+++ b/explorer/testdata/pointer/heap_alloc_lifetime.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/heap_alloc_lifetime.carbon
+++ b/explorer/testdata/pointer/heap_alloc_lifetime.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/intrinsic_new.carbon
+++ b/explorer/testdata/pointer/intrinsic_new.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/intrinsic_new.carbon
+++ b/explorer/testdata/pointer/intrinsic_new.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/new_and_delete.carbon
+++ b/explorer/testdata/pointer/new_and_delete.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/new_and_delete.carbon
+++ b/explorer/testdata/pointer/new_and_delete.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/pointer/struct_pointer.carbon
+++ b/explorer/testdata/pointer/struct_pointer.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/pointer/struct_pointer.carbon
+++ b/explorer/testdata/pointer/struct_pointer.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/print/associated_constant.carbon
+++ b/explorer/testdata/print/associated_constant.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: i32
 // CHECK:STDOUT: String
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/print/associated_constant.carbon
+++ b/explorer/testdata/print/associated_constant.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: i32

--- a/explorer/testdata/print/fail_no_args.carbon
+++ b/explorer/testdata/print/fail_no_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/print/fail_no_args.carbon
+++ b/explorer/testdata/print/fail_no_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/print/fail_not_str.carbon
+++ b/explorer/testdata/print/fail_not_str.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/print/fail_not_str.carbon
+++ b/explorer/testdata/print/fail_not_str.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/print/fail_too_many_args.carbon
+++ b/explorer/testdata/print/fail_too_many_args.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/print/fail_too_many_args.carbon
+++ b/explorer/testdata/print/fail_too_many_args.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/print/fail_type.carbon
+++ b/explorer/testdata/print/fail_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/print/fail_type.carbon
+++ b/explorer/testdata/print/fail_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/print/format_only.carbon
+++ b/explorer/testdata/print/format_only.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Hello world!
 // CHECK:STDOUT: result: 0
 

--- a/explorer/testdata/print/format_only.carbon
+++ b/explorer/testdata/print/format_only.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Hello world!

--- a/explorer/testdata/print/i32.carbon
+++ b/explorer/testdata/print/i32.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Printing 1
 // CHECK:STDOUT: result: 0
 

--- a/explorer/testdata/print/i32.carbon
+++ b/explorer/testdata/print/i32.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Printing 1

--- a/explorer/testdata/random/random.carbon
+++ b/explorer/testdata/random/random.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Nice!
 // CHECK:STDOUT: result: 0
 

--- a/explorer/testdata/random/random.carbon
+++ b/explorer/testdata/random/random.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: Nice!

--- a/explorer/testdata/return/convert_return_value.carbon
+++ b/explorer/testdata/return/convert_return_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42

--- a/explorer/testdata/return/convert_return_value.carbon
+++ b/explorer/testdata/return/convert_return_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42
 
 package ExplorerTest api;

--- a/explorer/testdata/return/explicit_empty.carbon
+++ b/explorer/testdata/return/explicit_empty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/return/explicit_empty.carbon
+++ b/explorer/testdata/return/explicit_empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/return/fail_explicit_with_no_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_no_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/return/fail_explicit_with_no_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_no_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/return/fail_explicit_with_plain_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_plain_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/return/fail_explicit_with_plain_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_plain_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
+++ b/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
+++ b/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/return/implicit_with_no_return.carbon
+++ b/explorer/testdata/return/implicit_with_no_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/return/implicit_with_no_return.carbon
+++ b/explorer/testdata/return/implicit_with_no_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/return/implicit_with_plain_return.carbon
+++ b/explorer/testdata/return/implicit_with_plain_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/return/implicit_with_plain_return.carbon
+++ b/explorer/testdata/return/implicit_with_plain_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/returned_var/fail_duplicate_return_var.carbon
+++ b/explorer/testdata/returned_var/fail_duplicate_return_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_duplicate_return_var.carbon
+++ b/explorer/testdata/returned_var/fail_duplicate_return_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/fail_missing_declaration.carbon
+++ b/explorer/testdata/returned_var/fail_missing_declaration.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_missing_declaration.carbon
+++ b/explorer/testdata/returned_var/fail_missing_declaration.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/fail_missing_return.carbon
+++ b/explorer/testdata/returned_var/fail_missing_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_missing_return.carbon
+++ b/explorer/testdata/returned_var/fail_missing_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/fail_returned_var_mismatch_signature.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_mismatch_signature.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_returned_var_mismatch_signature.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_mismatch_signature.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/fail_returned_var_multi_auto.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_multi_auto.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_returned_var_multi_auto.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_multi_auto.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/fail_returned_var_type_mismatch.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_type_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/returned_var/fail_returned_var_type_mismatch.carbon
+++ b/explorer/testdata/returned_var/fail_returned_var_type_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/returned_var/multiple_returned_var_control_flow.carbon
+++ b/explorer/testdata/returned_var/multiple_returned_var_control_flow.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/multiple_returned_var_control_flow.carbon
+++ b/explorer/testdata/returned_var/multiple_returned_var_control_flow.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/returned_var/normal_return_control_flow.carbon
+++ b/explorer/testdata/returned_var/normal_return_control_flow.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/normal_return_control_flow.carbon
+++ b/explorer/testdata/returned_var/normal_return_control_flow.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/returned_var/returned_var_auto.carbon
+++ b/explorer/testdata/returned_var/returned_var_auto.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/returned_var_auto.carbon
+++ b/explorer/testdata/returned_var/returned_var_auto.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/returned_var/returned_var_basic.carbon
+++ b/explorer/testdata/returned_var/returned_var_basic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/returned_var_basic.carbon
+++ b/explorer/testdata/returned_var/returned_var_basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/returned_var/returned_var_name_lookup.carbon
+++ b/explorer/testdata/returned_var/returned_var_name_lookup.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/returned_var_name_lookup.carbon
+++ b/explorer/testdata/returned_var/returned_var_name_lookup.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/returned_var/returned_var_omitted_expression.carbon
+++ b/explorer/testdata/returned_var/returned_var_omitted_expression.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/returned_var/returned_var_omitted_expression.carbon
+++ b/explorer/testdata/returned_var/returned_var_omitted_expression.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/basic.carbon
+++ b/explorer/testdata/string/basic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/basic.carbon
+++ b/explorer/testdata/string/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/block.carbon
+++ b/explorer/testdata/string/block.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/block.carbon
+++ b/explorer/testdata/string/block.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/block_escaped_triple_quotes.carbon
+++ b/explorer/testdata/string/block_escaped_triple_quotes.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/block_escaped_triple_quotes.carbon
+++ b/explorer/testdata/string/block_escaped_triple_quotes.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/block_file_type_indicator.carbon
+++ b/explorer/testdata/string/block_file_type_indicator.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/block_file_type_indicator.carbon
+++ b/explorer/testdata/string/block_file_type_indicator.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_hex_lower.carbon
+++ b/explorer/testdata/string/fail_hex_lower.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_hex_lower.carbon
+++ b/explorer/testdata/string/fail_hex_lower.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_hex_truncated.carbon
+++ b/explorer/testdata/string/fail_hex_truncated.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_hex_truncated.carbon
+++ b/explorer/testdata/string/fail_hex_truncated.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_invalid_escape.carbon
+++ b/explorer/testdata/string/fail_invalid_escape.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_invalid_escape.carbon
+++ b/explorer/testdata/string/fail_invalid_escape.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_newline.carbon
+++ b/explorer/testdata/string/fail_newline.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_newline.carbon
+++ b/explorer/testdata/string/fail_newline.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_octal.carbon
+++ b/explorer/testdata/string/fail_octal.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_octal.carbon
+++ b/explorer/testdata/string/fail_octal.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_block_single_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_single_line.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_block_single_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_single_line.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/fail_tab.carbon
+++ b/explorer/testdata/string/fail_tab.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/string/fail_tab.carbon
+++ b/explorer/testdata/string/fail_tab.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/string/hex.carbon
+++ b/explorer/testdata/string/hex.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/hex.carbon
+++ b/explorer/testdata/string/hex.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/newline.carbon
+++ b/explorer/testdata/string/newline.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/newline.carbon
+++ b/explorer/testdata/string/newline.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_basic.carbon
+++ b/explorer/testdata/string/raw_basic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_basic.carbon
+++ b/explorer/testdata/string/raw_basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_basic_multi_hashtag.carbon
+++ b/explorer/testdata/string/raw_basic_multi_hashtag.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_basic_multi_hashtag.carbon
+++ b/explorer/testdata/string/raw_basic_multi_hashtag.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_block.carbon
+++ b/explorer/testdata/string/raw_block.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_block.carbon
+++ b/explorer/testdata/string/raw_block.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_block_escaped_back_slash.carbon
+++ b/explorer/testdata/string/raw_block_escaped_back_slash.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_block_escaped_back_slash.carbon
+++ b/explorer/testdata/string/raw_block_escaped_back_slash.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_block_escaped_triple_quotes.carbon
+++ b/explorer/testdata/string/raw_block_escaped_triple_quotes.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_block_escaped_triple_quotes.carbon
+++ b/explorer/testdata/string/raw_block_escaped_triple_quotes.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/raw_nesting.carbon
+++ b/explorer/testdata/string/raw_nesting.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/raw_nesting.carbon
+++ b/explorer/testdata/string/raw_nesting.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/string/unicode.carbon
+++ b/explorer/testdata/string/unicode.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/string/unicode.carbon
+++ b/explorer/testdata/string/unicode.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/assign.carbon
+++ b/explorer/testdata/struct/assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/assign.carbon
+++ b/explorer/testdata/struct/assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/assign_member.carbon
+++ b/explorer/testdata/struct/assign_member.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/assign_member.carbon
+++ b/explorer/testdata/struct/assign_member.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/empty.carbon
+++ b/explorer/testdata/struct/empty.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/empty.carbon
+++ b/explorer/testdata/struct/empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/ending_comma.carbon
+++ b/explorer/testdata/struct/ending_comma.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/ending_comma.carbon
+++ b/explorer/testdata/struct/ending_comma.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/equality.carbon
+++ b/explorer/testdata/struct/equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: t1 == t2: 1

--- a/explorer/testdata/struct/equality.carbon
+++ b/explorer/testdata/struct/equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: t1 == t2: 1
 // CHECK:STDOUT: t1 != t2: 0
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/equality_false.carbon
+++ b/explorer/testdata/struct/equality_false.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/equality_false.carbon
+++ b/explorer/testdata/struct/equality_false.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/fail_equality_type.carbon
+++ b/explorer/testdata/struct/fail_equality_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/struct/fail_equality_type.carbon
+++ b/explorer/testdata/struct/fail_equality_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/struct/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/struct/fail_field_access_mismatch.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/struct/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/struct/fail_field_access_mismatch.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/struct/name_order.carbon
+++ b/explorer/testdata/struct/name_order.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/name_order.carbon
+++ b/explorer/testdata/struct/name_order.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/temp.carbon
+++ b/explorer/testdata/struct/temp.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/temp.carbon
+++ b/explorer/testdata/struct/temp.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/struct/var.carbon
+++ b/explorer/testdata/struct/var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/struct/var.carbon
+++ b/explorer/testdata/struct/var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/ending_comma.carbon
+++ b/explorer/testdata/tuple/ending_comma.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/ending_comma.carbon
+++ b/explorer/testdata/tuple/ending_comma.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/equality.carbon
+++ b/explorer/testdata/tuple/equality.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/equality.carbon
+++ b/explorer/testdata/tuple/equality.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/equality_false.carbon
+++ b/explorer/testdata/tuple/equality_false.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/equality_false.carbon
+++ b/explorer/testdata/tuple/equality_false.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/fail_equality_type.carbon
+++ b/explorer/testdata/tuple/fail_equality_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/tuple/fail_equality_type.carbon
+++ b/explorer/testdata/tuple/fail_equality_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/tuple/fail_index.carbon
+++ b/explorer/testdata/tuple/fail_index.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/tuple/fail_index.carbon
+++ b/explorer/testdata/tuple/fail_index.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/tuple/fail_index_var.carbon
+++ b/explorer/testdata/tuple/fail_index_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/tuple/fail_index_var.carbon
+++ b/explorer/testdata/tuple/fail_index_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/tuple/fail_to_array.carbon
+++ b/explorer/testdata/tuple/fail_to_array.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/tuple/fail_to_array.carbon
+++ b/explorer/testdata/tuple/fail_to_array.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/tuple/index.carbon
+++ b/explorer/testdata/tuple/index.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/index.carbon
+++ b/explorer/testdata/tuple/index.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/match.carbon
+++ b/explorer/testdata/tuple/match.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/match.carbon
+++ b/explorer/testdata/tuple/match.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/match_nested.carbon
+++ b/explorer/testdata/tuple/match_nested.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/match_nested.carbon
+++ b/explorer/testdata/tuple/match_nested.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/no_ending_comma.carbon
+++ b/explorer/testdata/tuple/no_ending_comma.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/no_ending_comma.carbon
+++ b/explorer/testdata/tuple/no_ending_comma.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/tuple/to_array.carbon
+++ b/explorer/testdata/tuple/to_array.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3
 
 package ExplorerTest api;

--- a/explorer/testdata/tuple/to_array.carbon
+++ b/explorer/testdata/tuple/to_array.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 3

--- a/explorer/testdata/unformed/control_flow_defer_to_dynamic.carbon
+++ b/explorer/testdata/unformed/control_flow_defer_to_dynamic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/control_flow_defer_to_dynamic.carbon
+++ b/explorer/testdata/unformed/control_flow_defer_to_dynamic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/unformed/dynamic/fail_global.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_global.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_global.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_global.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/dynamic/fail_param.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_param.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/dynamic/fail_return.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_return.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/global_assign_before_use.carbon
+++ b/explorer/testdata/unformed/global_assign_before_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/global_assign_before_use.carbon
+++ b/explorer/testdata/unformed/global_assign_before_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/global_escape.carbon
+++ b/explorer/testdata/unformed/global_escape.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42

--- a/explorer/testdata/unformed/global_escape.carbon
+++ b/explorer/testdata/unformed/global_escape.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/global_unformed_without_use.carbon
+++ b/explorer/testdata/unformed/global_unformed_without_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/global_unformed_without_use.carbon
+++ b/explorer/testdata/unformed/global_unformed_without_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/local_assign_before_use.carbon
+++ b/explorer/testdata/unformed/local_assign_before_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/local_assign_before_use.carbon
+++ b/explorer/testdata/unformed/local_assign_before_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/local_escape.carbon
+++ b/explorer/testdata/unformed/local_escape.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42

--- a/explorer/testdata/unformed/local_escape.carbon
+++ b/explorer/testdata/unformed/local_escape.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 42
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/local_unformed_without_use.carbon
+++ b/explorer/testdata/unformed/local_unformed_without_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/local_unformed_without_use.carbon
+++ b/explorer/testdata/unformed/local_unformed_without_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/pattern_declare.carbon
+++ b/explorer/testdata/unformed/pattern_declare.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/pattern_declare.carbon
+++ b/explorer/testdata/unformed/pattern_declare.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/returned_var_assign_before_use.carbon
+++ b/explorer/testdata/unformed/returned_var_assign_before_use.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/unformed/returned_var_assign_before_use.carbon
+++ b/explorer/testdata/unformed/returned_var_assign_before_use.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1

--- a/explorer/testdata/unformed/static/fail_field_value.carbon
+++ b/explorer/testdata/unformed/static/fail_field_value.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_field_value.carbon
+++ b/explorer/testdata/unformed/static/fail_field_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_if_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_if_cond.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_if_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_if_cond.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_if_else.carbon
+++ b/explorer/testdata/unformed/static/fail_if_else.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_if_else.carbon
+++ b/explorer/testdata/unformed/static/fail_if_else.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_if_then.carbon
+++ b/explorer/testdata/unformed/static/fail_if_then.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_if_then.carbon
+++ b/explorer/testdata/unformed/static/fail_if_then.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
+++ b/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
+++ b/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
+++ b/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
+++ b/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_match_clause.carbon
+++ b/explorer/testdata/unformed/static/fail_match_clause.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_match_clause.carbon
+++ b/explorer/testdata/unformed/static/fail_match_clause.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_match_expression.carbon
+++ b/explorer/testdata/unformed/static/fail_match_expression.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_match_expression.carbon
+++ b/explorer/testdata/unformed/static/fail_match_expression.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_param.carbon
+++ b/explorer/testdata/unformed/static/fail_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_param.carbon
+++ b/explorer/testdata/unformed/static/fail_param.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_return.carbon
+++ b/explorer/testdata/unformed/static/fail_return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_return.carbon
+++ b/explorer/testdata/unformed/static/fail_return.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/static/fail_returned_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/static/fail_returned_var.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_rhs_def.carbon
+++ b/explorer/testdata/unformed/static/fail_rhs_def.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_rhs_def.carbon
+++ b/explorer/testdata/unformed/static/fail_rhs_def.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_struct_member_access.carbon
+++ b/explorer/testdata/unformed/static/fail_struct_member_access.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_struct_member_access.carbon
+++ b/explorer/testdata/unformed/static/fail_struct_member_access.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_while_body.carbon
+++ b/explorer/testdata/unformed/static/fail_while_body.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_while_body.carbon
+++ b/explorer/testdata/unformed/static/fail_while_body.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/unformed/static/fail_while_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_while_cond.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
 

--- a/explorer/testdata/unformed/static/fail_while_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_while_cond.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/while/basic.carbon
+++ b/explorer/testdata/while/basic.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/while/basic.carbon
+++ b/explorer/testdata/while/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/while/break.carbon
+++ b/explorer/testdata/while/break.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/while/break.carbon
+++ b/explorer/testdata/while/break.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/while/continue.carbon
+++ b/explorer/testdata/while/continue.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/while/continue.carbon
+++ b/explorer/testdata/while/continue.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/while/convert_condition.carbon
+++ b/explorer/testdata/while/convert_condition.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/explorer/testdata/while/convert_condition.carbon
+++ b/explorer/testdata/while/convert_condition.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{explorer} %s
+// AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 0

--- a/toolchain/driver/testdata/errors_sorted_test.carbon
+++ b/toolchain/driver/testdata/errors_sorted_test.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump tokens %s | %{FileCheck-strict} %s
+// RUN: %{not} %{carbon-run-tokens}
 // CHECK-COUNT-17:STDOUT: token: {{.*}}
 
 // CHECK:STDERR: {{.*}}/errors_sorted_test.carbon:[[@LINE+1]]:24: Closing symbol does not match most recent opening symbol.

--- a/toolchain/driver/testdata/errors_streamed_test.carbon
+++ b/toolchain/driver/testdata/errors_streamed_test.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // RUN: %{not} %{carbon} --print-errors=streamed dump tokens %s | \
-// RUN:   %{FileCheck-strict} %s
+// RUN:   %{FileCheck-strict}
 // CHECK-COUNT-17:STDOUT: token: {{.*}}
 
 fn run(String program) {

--- a/toolchain/lexer/lit_autoupdate.py
+++ b/toolchain/lexer/lit_autoupdate.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 
 def main() -> None:
-    # Calls the main script with lexer settings. This uses execv in order to
-    # avoid Python import behaviors.
+    # Calls the main script using execv in order to avoid Python import
+    # behaviors.
     this_py = Path(__file__).resolve()
     actual_py = this_py.parent.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
@@ -23,8 +23,9 @@ def main() -> None:
     args = [
         sys.argv[0],
         # Flags to configure for lexer testing.
-        "--build_target",
-        "//toolchain/driver:carbon",
+        "--tool=carbon",
+        "--autoupdate_arg=dump",
+        "--autoupdate_arg=tokens",
         # Ignore the resulting column of EndOfFile because it's typically the
         # end of the CHECK comment.
         "--extra_check_replacement",
@@ -32,12 +33,10 @@ def main() -> None:
         r"column: (?:\d+)",
         "column: {{[0-9]+}}",
         # Ignore spaces that are used to columnize lines.
-        "--line_number_format",
-        "{{ *}}[[@LINE%(delta)s]]",
-        "--line_number_pattern",
-        r"(?<= line: )( *\d+)(?=,)",
-        "--testdata",
-        "toolchain/lexer/testdata",
+        "--line_number_format={{ *}}[[@LINE%(delta)s]]",
+        r"--line_number_pattern=(?<= line: )( *\d+)(?=,)",
+        "--lit_run=%{carbon-run-tokens}",
+        "--testdata=toolchain/lexer/testdata",
     ] + sys.argv[1:]
     os.execv(actual_py, args)
 

--- a/toolchain/lexer/testdata/carbon_test.carbon
+++ b/toolchain/lexer/testdata/carbon_test.carbon
@@ -2,21 +2,21 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump tokens %s | %{FileCheck-strict} %s
-// AUTOUPDATE: %{carbon} dump tokens %s
+// AUTOUPDATE
+// RUN: %{carbon-run-tokens}
 
-// CHECK:STDOUT: token: { index:  0, kind:              'Fn', line: {{ *}}[[@LINE+7]], column:   1, indent: 1, spelling: 'fn', has_trailing_space: true }
-// CHECK:STDOUT: token: { index:  1, kind:      'Identifier', line: {{ *}}[[@LINE+6]], column:   4, indent: 1, spelling: 'run', identifier: 0 }
-// CHECK:STDOUT: token: { index:  2, kind:       'OpenParen', line: {{ *}}[[@LINE+5]], column:   7, indent: 1, spelling: '(', closing_token: 5 }
-// CHECK:STDOUT: token: { index:  3, kind:      'Identifier', line: {{ *}}[[@LINE+4]], column:   8, indent: 1, spelling: 'String', identifier: 1, has_trailing_space: true }
-// CHECK:STDOUT: token: { index:  4, kind:      'Identifier', line: {{ *}}[[@LINE+3]], column:  15, indent: 1, spelling: 'program', identifier: 2 }
-// CHECK:STDOUT: token: { index:  5, kind:      'CloseParen', line: {{ *}}[[@LINE+2]], column:  22, indent: 1, spelling: ')', opening_token: 2, has_trailing_space: true }
-// CHECK:STDOUT: token: { index:  6, kind:  'OpenCurlyBrace', line: {{ *}}[[@LINE+1]], column:  24, indent: 1, spelling: '{', closing_token: 10, has_trailing_space: true }
+// CHECK:STDOUT: token: { index:  0, kind:              'Fn', line: {{ *}}[[@LINE+7]], column:  1, indent: 1, spelling: 'fn', has_trailing_space: true }
+// CHECK:STDOUT: token: { index:  1, kind:      'Identifier', line: {{ *}}[[@LINE+6]], column:  4, indent: 1, spelling: 'run', identifier: 0 }
+// CHECK:STDOUT: token: { index:  2, kind:       'OpenParen', line: {{ *}}[[@LINE+5]], column:  7, indent: 1, spelling: '(', closing_token: 5 }
+// CHECK:STDOUT: token: { index:  3, kind:      'Identifier', line: {{ *}}[[@LINE+4]], column:  8, indent: 1, spelling: 'String', identifier: 1, has_trailing_space: true }
+// CHECK:STDOUT: token: { index:  4, kind:      'Identifier', line: {{ *}}[[@LINE+3]], column: 15, indent: 1, spelling: 'program', identifier: 2 }
+// CHECK:STDOUT: token: { index:  5, kind:      'CloseParen', line: {{ *}}[[@LINE+2]], column: 22, indent: 1, spelling: ')', opening_token: 2, has_trailing_space: true }
+// CHECK:STDOUT: token: { index:  6, kind:  'OpenCurlyBrace', line: {{ *}}[[@LINE+1]], column: 24, indent: 1, spelling: '{', closing_token: 10, has_trailing_space: true }
 fn run(String program) {
-  // CHECK:STDOUT: token: { index:  7, kind:          'Return', line: {{ *}}[[@LINE+3]], column:   3, indent: 3, spelling: 'return', has_trailing_space: true }
-  // CHECK:STDOUT: token: { index:  8, kind:      'Identifier', line: {{ *}}[[@LINE+2]], column:  10, indent: 3, spelling: 'True', identifier: 3 }
-  // CHECK:STDOUT: token: { index:  9, kind:            'Semi', line: {{ *}}[[@LINE+1]], column:  14, indent: 3, spelling: ';', has_trailing_space: true }
+  // CHECK:STDOUT: token: { index:  7, kind:          'Return', line: {{ *}}[[@LINE+3]], column:  3, indent: 3, spelling: 'return', has_trailing_space: true }
+  // CHECK:STDOUT: token: { index:  8, kind:      'Identifier', line: {{ *}}[[@LINE+2]], column: 10, indent: 3, spelling: 'True', identifier: 3 }
+  // CHECK:STDOUT: token: { index:  9, kind:            'Semi', line: {{ *}}[[@LINE+1]], column: 14, indent: 3, spelling: ';', has_trailing_space: true }
   return True;
-// CHECK:STDOUT: token: { index: 10, kind: 'CloseCurlyBrace', line: {{ *}}[[@LINE+1]], column:   1, indent: 1, spelling: '}', opening_token: 6, has_trailing_space: true }
+// CHECK:STDOUT: token: { index: 10, kind: 'CloseCurlyBrace', line: {{ *}}[[@LINE+2]], column:  1, indent: 1, spelling: '}', opening_token: 6, has_trailing_space: true }
+// CHECK:STDOUT: token: { index: 11, kind:       'EndOfFile', line: {{ *}}[[@LINE+1]], column:  2, indent: 1, spelling: '' }
 }
-// CHECK:STDOUT: token: { index: 11, kind:       'EndOfFile', line: {{ *}}[[@LINE+0]], column: {{[0-9]+}}, indent: 1, spelling: '' }

--- a/toolchain/parser/lit_autoupdate.py
+++ b/toolchain/parser/lit_autoupdate.py
@@ -14,21 +14,21 @@ from pathlib import Path
 
 
 def main() -> None:
-    # Calls the main script with explorer settings. This uses execv in order to
-    # avoid Python import behaviors.
+    # Calls the main script using execv in order to avoid Python import
+    # behaviors.
     this_py = Path(__file__).resolve()
     actual_py = this_py.parent.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
     )
     args = [
         sys.argv[0],
-        # Flags to configure for explorer testing.
-        "--build_target",
-        "//toolchain/driver:carbon",
-        "--line_number_pattern",
-        r"(?<=\.carbon:)(\d+)(?=(?:\D|$))",
-        "--testdata",
-        "toolchain/parser/testdata",
+        # Flags to configure for parser testing.
+        "--tool=carbon",
+        "--autoupdate_arg=dump",
+        "--autoupdate_arg=parse-tree",
+        r"--line_number_pattern=(?<=\.carbon:)(\d+)(?=(?:\D|$))",
+        "--lit_run=%{carbon-run-parser}",
+        "--testdata=toolchain/parser/testdata",
     ] + sys.argv[1:]
     os.execv(actual_py, args)
 

--- a/toolchain/parser/testdata/basics/empty.carbon
+++ b/toolchain/parser/testdata/basics/empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FileEnd', text: ''},

--- a/toolchain/parser/testdata/basics/empty.carbon
+++ b/toolchain/parser/testdata/basics/empty.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]

--- a/toolchain/parser/testdata/basics/empty_declaration.carbon
+++ b/toolchain/parser/testdata/basics/empty_declaration.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'EmptyDeclaration', text: ';'},
 // CHECK:STDOUT: {node_index: 1, kind: 'FileEnd', text: ''},

--- a/toolchain/parser/testdata/basics/empty_declaration.carbon
+++ b/toolchain/parser/testdata/basics/empty_declaration.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'EmptyDeclaration', text: ';'},

--- a/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
+++ b/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 15, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 16, children: [

--- a/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
+++ b/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 15, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 16, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -26,10 +26,10 @@
 
 // NOTE: Move to its own directory when more tests are added.
 fn F() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.;
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.fn;
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.42;
 }

--- a/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
@@ -2,12 +2,12 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'EmptyDeclaration', text: ';', has_error: yes},
 // CHECK:STDOUT: {node_index: 1, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/no_intro_with_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 foo;

--- a/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'EmptyDeclaration', text: ';', has_error: yes},

--- a/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
@@ -2,11 +2,11 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/no_intro_without_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 foo bar baz

--- a/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FileEnd', text: ''},

--- a/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
+++ b/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'VariableDeclaration', text: 'var', has_error: yes, subtree_size: 5, children: [

--- a/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
+++ b/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'VariableDeclaration', text: 'var', has_error: yes, subtree_size: 5, children: [
 // CHECK:STDOUT:   {node_index: 3, kind: 'VariableInitializer', text: '=', subtree_size: 4, children: [
@@ -13,7 +13,7 @@
 // CHECK:STDOUT: {node_index: 5, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/paren_match_regression.carbon:[[@LINE+3]]:5: Expected pattern in `var` declaration.
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/paren_match_regression.carbon:[[@LINE+2]]:12: Expected `,` or `)`.
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/paren_match_regression.carbon:[[@LINE+1]]:15: Expected `;` after expression.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+3]]:5: Expected pattern in `var` declaration.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+2]]:12: Expected `,` or `)`.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+1]]:15: Expected `;` after expression.
 var = (foo {})

--- a/toolchain/parser/testdata/basics/function_call.carbon
+++ b/toolchain/parser/testdata/basics/function_call.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 24, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 25, children: [

--- a/toolchain/parser/testdata/basics/function_call.carbon
+++ b/toolchain/parser/testdata/basics/function_call.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 24, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 25, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/basics/package.carbon
+++ b/toolchain/parser/testdata/basics/package.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 3, kind: 'PackageDirective', text: 'package', subtree_size: 4, children: [

--- a/toolchain/parser/testdata/basics/package.carbon
+++ b/toolchain/parser/testdata/basics/package.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 3, kind: 'PackageDirective', text: 'package', subtree_size: 4, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'Geometry'},

--- a/toolchain/parser/testdata/basics/return.carbon
+++ b/toolchain/parser/testdata/basics/return.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 13, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 14, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/basics/return.carbon
+++ b/toolchain/parser/testdata/basics/return.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 13, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 14, children: [

--- a/toolchain/parser/testdata/basics/structs.carbon
+++ b/toolchain/parser/testdata/basics/structs.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 26, kind: 'VariableDeclaration', text: 'var', subtree_size: 27, children: [

--- a/toolchain/parser/testdata/basics/structs.carbon
+++ b/toolchain/parser/testdata/basics/structs.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 26, kind: 'VariableDeclaration', text: 'var', subtree_size: 27, children: [
 // CHECK:STDOUT:   {node_index: 12, kind: 'PatternBinding', text: ':', subtree_size: 13, children: [

--- a/toolchain/parser/testdata/basics/tuples.carbon
+++ b/toolchain/parser/testdata/basics/tuples.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 14, kind: 'VariableDeclaration', text: 'var', subtree_size: 15, children: [

--- a/toolchain/parser/testdata/basics/tuples.carbon
+++ b/toolchain/parser/testdata/basics/tuples.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 14, kind: 'VariableDeclaration', text: 'var', subtree_size: 15, children: [
 // CHECK:STDOUT:   {node_index: 6, kind: 'PatternBinding', text: ':', subtree_size: 7, children: [

--- a/toolchain/parser/testdata/basics/var.carbon
+++ b/toolchain/parser/testdata/basics/var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'VariableDeclaration', text: 'var', subtree_size: 7, children: [

--- a/toolchain/parser/testdata/basics/var.carbon
+++ b/toolchain/parser/testdata/basics/var.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'VariableDeclaration', text: 'var', subtree_size: 7, children: [
 // CHECK:STDOUT:   {node_index: 2, kind: 'PatternBinding', text: ':', subtree_size: 3, children: [

--- a/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
+++ b/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 20, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 21, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
@@ -30,7 +30,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/colon_instead_of_in.carbon:[[@LINE+1]]:19: `:` should be replaced by `in`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon:[[@LINE+1]]:19: `:` should be replaced by `in`.
   for (var x: i32 : y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
+++ b/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 20, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 21, children: [

--- a/toolchain/parser/testdata/for/fail_missing_in.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_in.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 19, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 20, children: [

--- a/toolchain/parser/testdata/for/fail_missing_in.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_in.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 19, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 20, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
@@ -29,7 +29,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/missing_in.carbon:[[@LINE+1]]:19: Expected `in` after loop `var` declaration.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/fail_missing_in.carbon:[[@LINE+1]]:19: Expected `in` after loop `var` declaration.
   for (var x: i32 y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/for/fail_missing_var.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_var.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 17, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 18, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
@@ -27,7 +27,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/missing_var.carbon:[[@LINE+1]]:8: Expected `var` declaration.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/for/fail_missing_var.carbon:[[@LINE+1]]:8: Expected `var` declaration.
   for (x: i32 in y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/for/fail_missing_var.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_var.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 17, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 18, children: [

--- a/toolchain/parser/testdata/for/nested.carbon
+++ b/toolchain/parser/testdata/for/nested.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 32, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 33, children: [

--- a/toolchain/parser/testdata/for/nested.carbon
+++ b/toolchain/parser/testdata/for/nested.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 32, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 33, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/for/simple.carbon
+++ b/toolchain/parser/testdata/for/simple.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 21, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 22, children: [

--- a/toolchain/parser/testdata/for/simple.carbon
+++ b/toolchain/parser/testdata/for/simple.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 21, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 22, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/function/declaration/basic.carbon
+++ b/toolchain/parser/testdata/function/declaration/basic.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/function/declaration/basic.carbon
+++ b/toolchain/parser/testdata/function/declaration/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 2, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 3, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 2, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 3, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
@@ -11,5 +11,5 @@
 // CHECK:STDOUT: {node_index: 3, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/identifier_instead_of_sig.carbon:[[@LINE+1]]:8: Expected `(` after function name.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon:[[@LINE+1]]:8: Expected `(` after function name.
 fn foo bar;

--- a/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 2, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/repeated_fn_and_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
-fn fn;
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+fn ();

--- a/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
-// CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
+// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'}]},
 // CHECK:STDOUT: {node_index: 2, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/missing_name.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
-fn ();
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon:[[@LINE+1]]:7: Expected `(` after function name.
+fn foo

--- a/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 2, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/only_fn_and_semi.carbon:[[@LINE+1]]:3: Expected function name after `fn` keyword.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon:[[@LINE+1]]:3: Expected function name after `fn` keyword.
 fn;

--- a/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 2, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/without_name_and_many_tokens_in_params.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
-fn (a tokens c d e f g h i j k l m n o p q r s t u v w x y z);
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+fn fn;

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},
 // CHECK:STDOUT: {node_index: 5, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
@@ -14,7 +14,7 @@
 // CHECK:STDOUT: {node_index: 6, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/skip_indented_newline_until_outdent.carbon:[[@LINE+1]]:6: Expected function name after `fn` keyword.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon:[[@LINE+1]]:6: Expected function name after `fn` keyword.
   fn (x,
       y,
       z)

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
@@ -15,7 +15,7 @@
 // CHECK:STDOUT: {node_index: 7, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/skip_indented_newline_with_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
 fn (x,
     y,
     z);

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},
 // CHECK:STDOUT: {node_index: 5, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
@@ -14,7 +14,7 @@
 // CHECK:STDOUT: {node_index: 6, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/skip_indented_newline_without_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
 fn (x,
     y,
     z)

--- a/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},

--- a/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 0, kind: 'FunctionDeclaration', text: 'fn', has_error: yes},
 // CHECK:STDOUT: {node_index: 5, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
@@ -14,6 +14,6 @@
 // CHECK:STDOUT: {node_index: 6, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/skip_to_newline_without_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
 fn ()
 fn F();

--- a/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
@@ -2,16 +2,17 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
-// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
-// CHECK:STDOUT:   {node_index: 2, kind: 'ParameterList', text: '(', has_error: yes, subtree_size: 2, children: [
+// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
+// CHECK:STDOUT:   {node_index: 2, kind: 'ParameterList', text: '(', subtree_size: 2, children: [
 // CHECK:STDOUT:     {node_index: 1, kind: 'ParameterListEnd', text: ')'}]},
 // CHECK:STDOUT:   {node_index: 3, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 5, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/with_identifier_as_param.carbon:[[@LINE+1]]:8: Expected parameter declaration.
-fn foo(bar);
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+struct X { fn () }
+fn F();

--- a/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
@@ -2,17 +2,16 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 4, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 5, children: [
-// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
-// CHECK:STDOUT:   {node_index: 2, kind: 'ParameterList', text: '(', subtree_size: 2, children: [
+// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},
+// CHECK:STDOUT:   {node_index: 2, kind: 'ParameterList', text: '(', has_error: yes, subtree_size: 2, children: [
 // CHECK:STDOUT:     {node_index: 1, kind: 'ParameterListEnd', text: ')'}]},
 // CHECK:STDOUT:   {node_index: 3, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 5, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/skip_without_semi_to_curly.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
-struct X { fn () }
-fn F();
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon:[[@LINE+1]]:8: Expected parameter declaration.
+fn foo(bar);

--- a/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [

--- a/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
@@ -2,13 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 1, kind: 'FunctionDeclaration', text: 'fn', has_error: yes, subtree_size: 2, children: [
-// CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'}]},
+// CHECK:STDOUT:   {node_index: 0, kind: 'DeclarationEnd', text: ';'}]},
 // CHECK:STDOUT: {node_index: 2, kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/no_sig_or_semi.carbon:[[@LINE+1]]:7: Expected `(` after function name.
-fn foo
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon:[[@LINE+1]]:4: Expected function name after `fn` keyword.
+fn (a tokens c d e f g h i j k l m n o p q r s t u v w x y z);

--- a/toolchain/parser/testdata/function/declaration/with_params.carbon
+++ b/toolchain/parser/testdata/function/declaration/with_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [

--- a/toolchain/parser/testdata/function/declaration/with_params.carbon
+++ b/toolchain/parser/testdata/function/declaration/with_params.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/function/declaration/with_return_type.carbon
+++ b/toolchain/parser/testdata/function/declaration/with_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 7, children: [

--- a/toolchain/parser/testdata/function/declaration/with_return_type.carbon
+++ b/toolchain/parser/testdata/function/declaration/with_return_type.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 7, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/function/definition/basic.carbon
+++ b/toolchain/parser/testdata/function/definition/basic.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 5, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 6, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/function/definition/basic.carbon
+++ b/toolchain/parser/testdata/function/definition/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 5, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 6, children: [

--- a/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
+++ b/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 7, children: [

--- a/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
+++ b/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 6, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 7, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -19,5 +19,5 @@ fn F() {
   // Note: this might become valid depending on the expression syntax. This test
   // shouldn't be taken as a sign it should remain invalid.
   bar
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/definition/identifier_in_statements.carbon:[[@LINE+1]]:1: Expected `;` after expression.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon:[[@LINE+1]]:1: Expected `;` after expression.
 }

--- a/toolchain/parser/testdata/function/definition/with_params.carbon
+++ b/toolchain/parser/testdata/function/definition/with_params.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 21, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 22, children: [

--- a/toolchain/parser/testdata/function/definition/with_params.carbon
+++ b/toolchain/parser/testdata/function/definition/with_params.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 21, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 22, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/function/definition/with_return_type.carbon
+++ b/toolchain/parser/testdata/function/definition/with_return_type.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 10, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 11, children: [

--- a/toolchain/parser/testdata/function/definition/with_return_type.carbon
+++ b/toolchain/parser/testdata/function/definition/with_return_type.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 10, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 11, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'foo'},

--- a/toolchain/parser/testdata/if/basic.carbon
+++ b/toolchain/parser/testdata/if/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 25, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 26, children: [

--- a/toolchain/parser/testdata/if/basic.carbon
+++ b/toolchain/parser/testdata/if/basic.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 25, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 26, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/if/else.carbon
+++ b/toolchain/parser/testdata/if/else.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 60, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 61, children: [

--- a/toolchain/parser/testdata/if/else.carbon
+++ b/toolchain/parser/testdata/if/else.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 60, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 61, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/if/else_unbraced.carbon
+++ b/toolchain/parser/testdata/if/else_unbraced.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 52, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 53, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/if/else_unbraced.carbon
+++ b/toolchain/parser/testdata/if/else_unbraced.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 52, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 53, children: [

--- a/toolchain/parser/testdata/if/fail_errors.carbon
+++ b/toolchain/parser/testdata/if/fail_errors.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 24, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 25, children: [

--- a/toolchain/parser/testdata/if/fail_errors.carbon
+++ b/toolchain/parser/testdata/if/fail_errors.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 24, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 25, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -34,13 +34,13 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/errors.carbon:[[@LINE+1]]:6: Expected `(` after `if`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:6: Expected `(` after `if`.
   if a {}
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/errors.carbon:[[@LINE+1]]:7: Expected expression.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:7: Expected expression.
   if () {}
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/errors.carbon:[[@LINE+1]]:9: Unexpected tokens before `)`.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:9: Unexpected tokens before `)`.
   if (b c) {}
   if (d)
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/errors.carbon:[[@LINE+2]]:1: Expected braced code block.
-// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/errors.carbon:[[@LINE+1]]:1: Expected expression.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+2]]:1: Expected braced code block.
+// CHECK:STDERR: {{.*}}/toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:1: Expected expression.
 }

--- a/toolchain/parser/testdata/if/unbraced.carbon
+++ b/toolchain/parser/testdata/if/unbraced.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // TODO: This should have an error.
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 19, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 20, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/if/unbraced.carbon
+++ b/toolchain/parser/testdata/if/unbraced.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // TODO: This should have an error.
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 19, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 20, children: [

--- a/toolchain/parser/testdata/operators/associative.carbon
+++ b/toolchain/parser/testdata/operators/associative.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/operators/associative.carbon
+++ b/toolchain/parser/testdata/operators/associative.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [

--- a/toolchain/parser/testdata/operators/fail_missing_precedence_and_or.carbon
+++ b/toolchain/parser/testdata/operators/fail_missing_precedence_and_or.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -21,6 +21,6 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/missing_precedence_and_or.carbon:[[@LINE+1]]:11: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_missing_precedence_and_or.carbon:[[@LINE+1]]:11: Parentheses are required to disambiguate operator precedence.
   a and b or c;
 }

--- a/toolchain/parser/testdata/operators/fail_missing_precedence_and_or.carbon
+++ b/toolchain/parser/testdata/operators/fail_missing_precedence_and_or.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [

--- a/toolchain/parser/testdata/operators/fail_missing_precedence_or_and.carbon
+++ b/toolchain/parser/testdata/operators/fail_missing_precedence_or_and.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -21,6 +21,6 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/missing_precedence_or_and.carbon:[[@LINE+1]]:10: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_missing_precedence_or_and.carbon:[[@LINE+1]]:10: Parentheses are required to disambiguate operator precedence.
   a or b and c;
 }

--- a/toolchain/parser/testdata/operators/fail_missing_precedence_or_and.carbon
+++ b/toolchain/parser/testdata/operators/fail_missing_precedence_or_and.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [

--- a/toolchain/parser/testdata/operators/fail_variety.carbon
+++ b/toolchain/parser/testdata/operators/fail_variety.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 26, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 27, children: [

--- a/toolchain/parser/testdata/operators/fail_variety.carbon
+++ b/toolchain/parser/testdata/operators/fail_variety.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 26, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 27, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},
@@ -36,9 +36,9 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/variety.carbon:[[@LINE+4]]:29: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/variety.carbon:[[@LINE+3]]:34: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/variety.carbon:[[@LINE+2]]:38: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/variety.carbon:[[@LINE+1]]:40: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+4]]:29: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+3]]:34: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+2]]:38: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+1]]:40: Parentheses are required to disambiguate operator precedence.
   n = a * b + c * d = d * d << e & f - not g;
 }

--- a/toolchain/parser/testdata/operators/fixity.carbon
+++ b/toolchain/parser/testdata/operators/fixity.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 64, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 65, children: [

--- a/toolchain/parser/testdata/operators/fixity.carbon
+++ b/toolchain/parser/testdata/operators/fixity.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 64, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 65, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/operators/missing_precedence_not.carbon
+++ b/toolchain/parser/testdata/operators/missing_precedence_not.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 14, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 15, children: [

--- a/toolchain/parser/testdata/operators/missing_precedence_not.carbon
+++ b/toolchain/parser/testdata/operators/missing_precedence_not.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 14, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 15, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/operators/postfix_unary.carbon
+++ b/toolchain/parser/testdata/operators/postfix_unary.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 9, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 10, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/operators/postfix_unary.carbon
+++ b/toolchain/parser/testdata/operators/postfix_unary.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 9, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 10, children: [

--- a/toolchain/parser/testdata/operators/prefix_unary.carbon
+++ b/toolchain/parser/testdata/operators/prefix_unary.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 9, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 10, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/operators/prefix_unary.carbon
+++ b/toolchain/parser/testdata/operators/prefix_unary.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 9, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 10, children: [

--- a/toolchain/parser/testdata/while/basic.carbon
+++ b/toolchain/parser/testdata/while/basic.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 27, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 28, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/while/basic.carbon
+++ b/toolchain/parser/testdata/while/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 27, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 28, children: [

--- a/toolchain/parser/testdata/while/unbraced.carbon
+++ b/toolchain/parser/testdata/while/unbraced.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // TODO: This should have an error.
-// RUN: %{carbon} dump parse-tree %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump parse-tree %s
+// RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [
 // CHECK:STDOUT:   {node_index: 0, kind: 'DeclaredName', text: 'F'},

--- a/toolchain/parser/testdata/while/unbraced.carbon
+++ b/toolchain/parser/testdata/while/unbraced.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // TODO: This should have an error.
-// AUTOUPDATE: %{carbon} dump parse-tree %s
+// AUTOUPDATE
 // RUN: %{carbon-run-parser}
 // CHECK:STDOUT: [
 // CHECK:STDOUT: {node_index: 11, kind: 'FunctionDeclaration', text: 'fn', subtree_size: 12, children: [

--- a/toolchain/semantics/lit_autoupdate.py
+++ b/toolchain/semantics/lit_autoupdate.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 
 def main() -> None:
-    # Calls the main script with explorer settings. This uses execv in order to
-    # avoid Python import behaviors.
+    # Calls the main script using execv in order to avoid Python import
+    # behaviors.
     this_py = Path(__file__).resolve()
     actual_py = this_py.parent.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
@@ -23,14 +23,14 @@ def main() -> None:
     args = [
         sys.argv[0],
         # Flags to configure for explorer testing.
-        "--build_target",
-        "//toolchain/driver:carbon",
+        "--tool=carbon",
+        "--autoupdate_arg=dump",
+        "--autoupdate_arg=semantics-ir",
         # TODO: This should eventually have lines in output, but it doesn't
         # right now.
-        "--line_number_pattern",
-        "UNUSED",
-        "--testdata",
-        "toolchain/semantics/testdata",
+        "--line_number_pattern=UNUSED",
+        "--lit_run=%{carbon-run-semantics}",
+        "--testdata=toolchain/semantics/testdata",
     ] + sys.argv[1:]
     os.execv(actual_py, args)
 

--- a/toolchain/semantics/testdata/empty.carbon
+++ b/toolchain/semantics/testdata/empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT: }

--- a/toolchain/semantics/testdata/empty.carbon
+++ b/toolchain/semantics/testdata/empty.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT: }

--- a/toolchain/semantics/testdata/function/basic.carbon
+++ b/toolchain/semantics/testdata/function/basic.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(

--- a/toolchain/semantics/testdata/function/basic.carbon
+++ b/toolchain/semantics/testdata/function/basic.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(
 // CHECK:STDOUT:       %0,

--- a/toolchain/semantics/testdata/function/order.carbon
+++ b/toolchain/semantics/testdata/function/order.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(
 // CHECK:STDOUT:       %2,

--- a/toolchain/semantics/testdata/function/order.carbon
+++ b/toolchain/semantics/testdata/function/order.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(

--- a/toolchain/semantics/testdata/return/binary_op.carbon
+++ b/toolchain/semantics/testdata/return/binary_op.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(

--- a/toolchain/semantics/testdata/return/binary_op.carbon
+++ b/toolchain/semantics/testdata/return/binary_op.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(
 // CHECK:STDOUT:       %0,

--- a/toolchain/semantics/testdata/return/literal.carbon
+++ b/toolchain/semantics/testdata/return/literal.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(

--- a/toolchain/semantics/testdata/return/literal.carbon
+++ b/toolchain/semantics/testdata/return/literal.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(
 // CHECK:STDOUT:       %0,

--- a/toolchain/semantics/testdata/return/trivial.carbon
+++ b/toolchain/semantics/testdata/return/trivial.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE: %{carbon} dump semantics-ir %s
+// AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(

--- a/toolchain/semantics/testdata/return/trivial.carbon
+++ b/toolchain/semantics/testdata/return/trivial.carbon
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump semantics-ir %s | %{FileCheck-strict} %s
 // AUTOUPDATE: %{carbon} dump semantics-ir %s
+// RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: {
 // CHECK:STDOUT:   Function(
 // CHECK:STDOUT:       %0,


### PR DESCRIPTION
This was an offshoot of the discussion about how much boilerplate we could remove. lit requires RUN lines be there, everything else is optional.