### PR TITLE
Check equality constraints when checking whether a constraint is satisfied

### DIFF
--- a/common/check.h
+++ b/common/check.h
@@ -21,18 +21,18 @@ namespace Carbon {
 //
 // For example:
 //   CARBON_CHECK(is_valid) << "Data is not valid!";
-#define CARBON_CHECK(condition)                                           \
-  (condition) ? (void)0                                                   \
-              : CARBON_RAW_EXITING_STREAM()                               \
-                    << "CHECK failure at " << __FILE__ << ":" << __LINE__ \
-                    << ": " #condition                                    \
-                    << Carbon::Internal::ExitingStream::AddSeparator()
+#define CARBON_CHECK(...)                                                   \
+  (__VA_ARGS__) ? (void)0                                                   \
+                : CARBON_RAW_EXITING_STREAM()                               \
+                      << "CHECK failure at " << __FILE__ << ":" << __LINE__ \
+                      << ": " #__VA_ARGS__                                  \
+                      << Carbon::Internal::ExitingStream::AddSeparator()
 
 // DCHECK calls CHECK in debug mode, and does nothing otherwise.
 #ifndef NDEBUG
-#define CARBON_DCHECK(condition) CARBON_CHECK(condition)
+#define CARBON_DCHECK(...) CARBON_CHECK(__VA_ARGS__)
 #else
-#define CARBON_DCHECK(condition) CARBON_CHECK(true || (condition))
+#define CARBON_DCHECK(...) CARBON_CHECK(true || (__VA_ARGS__))
 #endif
 
 // This is similar to CHECK, but is unconditional. Writing CARBON_FATAL() is

--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -18,9 +18,21 @@ interface ImplicitAs(T:! Type) {
   extends As(T);
 }
 
-// Every type implicitly converts to itself.
-impl forall [T:! Type] T as ImplicitAs(T) {
-  fn Convert[me: Self]() -> T { return me; }
+// TODO: Should we just use an intrinsic for this?
+interface __EqualConverter {
+  let T:! Type;
+  fn Convert(t: T) -> Self;
+}
+fn __EqualConvert[T:! Type](t: T, U:! __EqualConverter where .T = T) -> U {
+  return U.Convert(t);
+}
+impl forall [U:! Type] U as __EqualConverter where .T = U {
+  fn Convert(u: U) -> U { return u; }
+}
+
+// Every type implicitly converts to single-step-equal types.
+impl forall [T:! Type, U:! Type where .Self == T] T as ImplicitAs(U) {
+  fn Convert[me: Self]() -> U { return __EqualConvert(me, U); }
 }
 
 // TODO: Simplify this once we have variadics.

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -115,7 +115,7 @@ auto ImplScope::Resolve(Nonnull<const Value*> constraint_type,
       }
       Bindings local_bindings = bindings;
       local_bindings.Add(constraint->self_binding(), impl_type, witness);
-      SingleStepEqualityContext equality_ctx(&type_checker, this);
+      SingleStepEqualityContext equality_ctx(this);
       for (auto& equal : equals) {
         auto it = equal.values.begin();
         Nonnull<const Value*> first =
@@ -262,10 +262,6 @@ void ImplScope::Print(llvm::raw_ostream& out) const {
 auto SingleStepEqualityContext::VisitEqualValues(
     Nonnull<const Value*> value,
     llvm::function_ref<bool(Nonnull<const Value*>)> visitor) const -> bool {
-  if (auto trace_stream = type_checker_->trace_stream()) {
-    **trace_stream << "looking for values equal to " << *value << " in\n"
-                   << *impl_scope_;
-  }
   return impl_scope_->VisitEqualValues(value, visitor);
 }
 

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -124,8 +124,9 @@ auto ImplScope::Resolve(Nonnull<const Value*> constraint_type,
           Nonnull<const Value*> current =
               type_checker.Substitute(local_bindings, *it);
           if (!ValueEqual(first, current, &equality_ctx)) {
-            return ProgramError(source_loc) << "could not determine that "
-                                            << *first << " == " << *current;
+            return ProgramError(source_loc)
+                   << "constraint requires that " << *first
+                   << " == " << *current << ", which is not known to be true";
           }
         }
       }

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -266,42 +266,7 @@ auto SingleStepEqualityContext::VisitEqualValues(
     **trace_stream << "looking for values equal to " << *value << " in\n"
                    << *impl_scope_;
   }
-
-  if (!impl_scope_->VisitEqualValues(value, visitor)) {
-    return false;
-  }
-
-  // Also look up and visit the corresponding impl if this is an associated
-  // constant.
-  // TODO: Is this necessary?
-  if (auto* assoc = dyn_cast<AssociatedConstant>(value)) {
-    // Perform an impl lookup to see if we can resolve this constant.
-    // The source location doesn't matter, we're discarding the diagnostics.
-    if (auto* impl_witness = dyn_cast<ImplWitness>(&assoc->witness())) {
-      // Instantiate the impl to find the concrete constraint it implements.
-      Nonnull<const ConstraintType*> constraint =
-          impl_witness->declaration().constraint_type();
-      constraint = cast<ConstraintType>(
-          type_checker_->Substitute(impl_witness->bindings(), constraint));
-      if (auto trace_stream = type_checker_->trace_stream()) {
-        **trace_stream << "found constraint " << *constraint
-                       << " for associated constant " << *assoc << "\n";
-      }
-
-      // Look for the value of this constant within that constraint.
-      if (!constraint->VisitEqualValues(value, visitor)) {
-        return false;
-      }
-    } else {
-      if (auto trace_stream = type_checker_->trace_stream()) {
-        **trace_stream << "Could not resolve associated constant " << *assoc
-                       << ": witness " << assoc->witness()
-                       << " depends on a generic parameter\n";
-      }
-    }
-  }
-
-  return true;
+  return impl_scope_->VisitEqualValues(value, visitor);
 }
 
 }  // namespace Carbon

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -153,6 +153,28 @@ class ImplScope {
   std::vector<Nonnull<const ImplScope*>> parent_scopes_;
 };
 
+// An equality context that considers two values to be equal if they are a
+// single step apart according to an equality constraint in the given impl
+// scope.
+struct SingleStepEqualityContext : public EqualityContext {
+ public:
+  SingleStepEqualityContext(Nonnull<const TypeChecker*> type_checker,
+                            Nonnull<const ImplScope*> impl_scope)
+      : type_checker_(type_checker), impl_scope_(impl_scope) {}
+
+  // Visits the values that are equal to the given value and a single step away
+  // according to an equality constraint that is either scope or within a final
+  // impl corresponding to an associated constant. Stops and returns `false` if
+  // the visitor returns `false`, otherwise returns `true`.
+  auto VisitEqualValues(Nonnull<const Value*> value,
+                        llvm::function_ref<bool(Nonnull<const Value*>)> visitor)
+      const -> bool override;
+
+ private:
+  Nonnull<const TypeChecker*> type_checker_;
+  Nonnull<const ImplScope*> impl_scope_;
+};
+
 }  // namespace Carbon
 
 #endif  // CARBON_EXPLORER_INTERPRETER_IMPL_SCOPE_H_

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -163,9 +163,9 @@ struct SingleStepEqualityContext : public EqualityContext {
       : type_checker_(type_checker), impl_scope_(impl_scope) {}
 
   // Visits the values that are equal to the given value and a single step away
-  // according to an equality constraint that is either scope or within a final
-  // impl corresponding to an associated constant. Stops and returns `false` if
-  // the visitor returns `false`, otherwise returns `true`.
+  // according to an equality constraint that is in the given impl scope. Stops
+  // and returns `false` if the visitor returns `false`, otherwise returns
+  // `true`.
   auto VisitEqualValues(Nonnull<const Value*> value,
                         llvm::function_ref<bool(Nonnull<const Value*>)> visitor)
       const -> bool override;

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -158,9 +158,8 @@ class ImplScope {
 // scope.
 struct SingleStepEqualityContext : public EqualityContext {
  public:
-  SingleStepEqualityContext(Nonnull<const TypeChecker*> type_checker,
-                            Nonnull<const ImplScope*> impl_scope)
-      : type_checker_(type_checker), impl_scope_(impl_scope) {}
+  SingleStepEqualityContext(Nonnull<const ImplScope*> impl_scope)
+      : impl_scope_(impl_scope) {}
 
   // Visits the values that are equal to the given value and a single step away
   // according to an equality constraint that is in the given impl scope. Stops
@@ -171,7 +170,6 @@ struct SingleStepEqualityContext : public EqualityContext {
       const -> bool override;
 
  private:
-  Nonnull<const TypeChecker*> type_checker_;
   Nonnull<const ImplScope*> impl_scope_;
 };
 

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -736,7 +736,7 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
           return arena_->New<NominalClassValue>(inst_dest, value);
         }
         default: {
-          CARBON_CHECK(isa<VariableType, AssociatedConstant>(destination_type))
+          CARBON_CHECK(IsValueKindDependent(destination_type))
               << "Can't convert value " << *value << " to type "
               << *destination_type;
           return value;
@@ -771,7 +771,7 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
           break;
         }
         default: {
-          CARBON_CHECK(isa<VariableType, AssociatedConstant>(destination_type))
+          CARBON_CHECK(IsValueKindDependent(destination_type))
               << "Can't convert value " << *value << " to type "
               << *destination_type;
           return value;

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -598,6 +598,14 @@ auto Interpreter::InstantiateType(Nonnull<const Value*> type,
       }
       return value;
     }
+    case Value::Kind::InterfaceType: {
+      const auto& interface_type = cast<InterfaceType>(*type);
+      CARBON_ASSIGN_OR_RETURN(
+          Nonnull<const Bindings*> bindings,
+          InstantiateBindings(&interface_type.bindings(), source_loc));
+      return arena_->New<InterfaceType>(&interface_type.declaration(),
+                                        bindings);
+    }
     case Value::Kind::NominalClassType: {
       const auto& class_type = cast<NominalClassType>(*type);
       CARBON_ASSIGN_OR_RETURN(

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -735,9 +735,12 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
               InstantiateType(destination_type, source_loc));
           return arena_->New<NominalClassValue>(inst_dest, value);
         }
-        default:
-          CARBON_FATAL() << "Can't convert value " << *value << " to type "
-                         << *destination_type;
+        default: {
+          CARBON_CHECK(isa<VariableType, AssociatedConstant>(destination_type))
+              << "Can't convert value " << *value << " to type "
+              << *destination_type;
+          return value;
+        }
       }
     }
     case Value::Kind::StructType: {
@@ -767,9 +770,12 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
                                            &array_type.element_type());
           break;
         }
-        default:
-          CARBON_FATAL() << "Can't convert value " << *value << " to type "
-                         << *destination_type;
+        default: {
+          CARBON_CHECK(isa<VariableType, AssociatedConstant>(destination_type))
+              << "Can't convert value " << *value << " to type "
+              << *destination_type;
+          return value;
+        }
       }
       CARBON_CHECK(tuple->elements().size() ==
                    destination_element_types.size());

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4600,7 +4600,7 @@ auto TypeChecker::DeclareImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,
     }
     // This impl also provides all of its equalities.
     // TODO: Only the ones from rewrite constraints.
-    for (auto &eq : constraint_type->equality_constraints()) {
+    for (auto& eq : constraint_type->equality_constraints()) {
       self_impl_scope.AddEqualityConstraint(&eq);
     }
     // Ensure that's enough for our interface to be satisfied.

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -79,8 +79,12 @@ class TypeChecker {
                                    int impl_offset) const
       -> Nonnull<const Witness*>;
 
+  // Returns the trace stream, if one was provided.
+  auto trace_stream() const -> std::optional<Nonnull<llvm::raw_ostream*>> {
+    return trace_stream_;
+  }
+
  private:
-  struct SingleStepEqualityContext;
   class ConstraintTypeBuilder;
   class SubstitutedGenericBindings;
   class ArgumentDeduction;

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -79,11 +79,6 @@ class TypeChecker {
                                    int impl_offset) const
       -> Nonnull<const Witness*>;
 
-  // Returns the trace stream, if one was provided.
-  auto trace_stream() const -> std::optional<Nonnull<llvm::raw_ostream*>> {
-    return trace_stream_;
-  }
-
  private:
   class ConstraintTypeBuilder;
   class SubstitutedGenericBindings;

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -632,8 +632,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
     return true;
   }
   if (t1->kind() != t2->kind()) {
-    if (isa<VariableType, AssociatedConstant>(t1) ||
-        isa<VariableType, AssociatedConstant>(t2)) {
+    if (IsValueKindDependent(t1) || IsValueKindDependent(t2)) {
       return ValueEqual(t1, t2, equality_ctx);
     }
     return false;
@@ -946,7 +945,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
   // associated constant; otherwise we should be able to do better by looking
   // at the structures of the values.
   if (equality_ctx) {
-    if (isa<VariableType, AssociatedConstant>(v1)) {
+    if (IsValueKindDependent(v1)) {
       auto visitor = [&](Nonnull<const Value*> maybe_v2) {
         return !ValueStructurallyEqual(v2, maybe_v2, equality_ctx);
       };
@@ -954,7 +953,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
         return true;
       }
     }
-    if (isa<VariableType, AssociatedConstant>(v2)) {
+    if (IsValueKindDependent(v2)) {
       auto visitor = [&](Nonnull<const Value*> maybe_v1) {
         return !ValueStructurallyEqual(v1, maybe_v1, equality_ctx);
       };

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -512,7 +512,10 @@ void Value::Print(llvm::raw_ostream& out) const {
       break;
     case Value::Kind::AssociatedConstant: {
       const auto& assoc = cast<AssociatedConstant>(*this);
-      out << "(" << assoc.base() << ")." << assoc.constant().binding().name();
+      out << "(" << assoc.base() << ").(";
+      PrintNameWithBindings(out, &assoc.interface().declaration(),
+                            assoc.interface().args());
+      out << "." << assoc.constant().binding().name() << ")";
       break;
     }
     case Value::Kind::ContinuationValue: {

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -632,7 +632,8 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
     return true;
   }
   if (t1->kind() != t2->kind()) {
-    if (isa<AssociatedConstant>(t1) || isa<AssociatedConstant>(t2)) {
+    if (isa<VariableType, AssociatedConstant>(t1) ||
+        isa<VariableType, AssociatedConstant>(t2)) {
       return ValueEqual(t1, t2, equality_ctx);
     }
     return false;
@@ -945,7 +946,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
   // associated constant; otherwise we should be able to do better by looking
   // at the structures of the values.
   if (equality_ctx) {
-    if (isa<AssociatedConstant>(v1)) {
+    if (isa<VariableType, AssociatedConstant>(v1)) {
       auto visitor = [&](Nonnull<const Value*> maybe_v2) {
         return !ValueStructurallyEqual(v2, maybe_v2, equality_ctx);
       };
@@ -953,7 +954,7 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
         return true;
       }
     }
-    if (isa<AssociatedConstant>(v2)) {
+    if (isa<VariableType, AssociatedConstant>(v2)) {
       auto visitor = [&](Nonnull<const Value*> maybe_v1) {
         return !ValueStructurallyEqual(v1, maybe_v1, equality_ctx);
       };

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -121,6 +121,13 @@ class Value {
   const Kind kind_;
 };
 
+// Returns whether the fully-resolved kind that this value will eventually have
+// is currently unknown, because it depends on a generic parameter.
+inline bool IsValueKindDependent(Nonnull<const Value*> type) {
+  return type->kind() == Value::Kind::VariableType ||
+         type->kind() == Value::Kind::AssociatedConstant;
+}
+
 // Base class for types holding contextual information by which we can
 // determine whether values are equal.
 class EqualityContext {

--- a/explorer/testdata/assoc_const/fail_different_type.carbon
+++ b/explorer/testdata/assoc_const/fail_different_type.carbon
@@ -21,7 +21,7 @@ external impl Bad as Iface where .T = Bad {}
 
 fn Main() -> i32 {
   F(Good);
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_different_type.carbon:[[@LINE+1]]: could not determine that class Bad == i32
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_different_type.carbon:[[@LINE+1]]: constraint requires that class Bad == i32, which is not known to be true
   F(Bad);
   return 0;
 }

--- a/explorer/testdata/assoc_const/fail_different_type.carbon
+++ b/explorer/testdata/assoc_const/fail_different_type.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+interface Iface {
+  let T:! Type;
+}
+
+fn F(T:! Iface where .T == i32) {}
+
+class Good {}
+class Bad {}
+external impl Good as Iface where .T = i32 {}
+external impl Bad as Iface where .T = Bad {}
+
+fn Main() -> i32 {
+  F(Good);
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_different_type.carbon:[[@LINE+1]]: could not determine that class Bad == i32
+  F(Bad);
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_different_value.carbon
+++ b/explorer/testdata/assoc_const/fail_different_value.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+interface Iface {
+  let N:! i32;
+}
+
+fn F(T:! Iface where .N == 5) {}
+
+class Good {}
+class Bad {}
+external impl Good as Iface where .N = 5 {}
+external impl Bad as Iface where .N = 4 {}
+
+fn Main() -> i32 {
+  F(Good);
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_different_value.carbon:[[@LINE+1]]: could not determine that 4 == 5
+  F(Bad);
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
@@ -1,0 +1,38 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+
+package ExplorerTest api;
+
+interface Iface {
+  let T:! Type;
+}
+
+fn F[T:! Iface where .T == i32](x: T) {}
+
+class Class {
+  impl as Iface where .T = i32 {}
+}
+
+// OK, constraint on `F` rewritten to `T:! Iface where U == i32`, which we can
+// prove from the constraint on `U`.
+fn G[U:! Type where .Self == i32, T:! Iface where .T = U](x: T, y: U) {
+  F(x);
+}
+
+// Not OK: would require looking through two levels of `==`.
+fn H[U:! Type where .Self == i32, T:! Iface where .T == U](x: T, y: U) {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_equal_indirectly.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) == i32, which is not known to be true
+  F(x);
+}
+
+fn Main() -> i32 {
+  var x: Class = {};
+  G(x, 0);
+  H(x, 0);
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
@@ -9,19 +9,27 @@
 package ExplorerTest api;
 
 interface Iface {
-  let N:! i32;
+  let T:! Type;
 }
 
-fn F(T:! Iface where .N == 5) {}
+fn F[T:! Iface where .T == i32](x: T) {}
 
-class Good {}
-class Bad {}
-external impl Good as Iface where .N = 5 {}
-external impl Bad as Iface where .N = 4 {}
+fn G[T:! Iface where .T == i32](x: T) {
+  F(x);
+}
+
+fn H[T:! Iface](x: T) {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) == i32, which is not known to be true
+  F(x);
+}
+
+class Class {
+  impl as Iface where .T = i32 {}
+}
 
 fn Main() -> i32 {
-  F(Good);
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_different_value.carbon:[[@LINE+1]]: constraint requires that 4 == 5, which is not known to be true
-  F(Bad);
+  var x: Class = {};
+  G(x);
+  H(x);
   return 0;
 }

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
@@ -14,7 +14,7 @@ interface HasThreeTypes {
   let C:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation missing (i32).(HasThreeTypes.B); have constraint interface HasThreeTypes where i32 is interface HasThreeTypes and (i32).(HasThreeTypes.A) == i32 and (i32).(HasThreeTypes.C) == i32
-external impl i32 as HasThreeTypes where .A == i32 and .C == i32 {}
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.B
+external impl i32 as HasThreeTypes where .A = i32 and .C = i32 {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
@@ -14,7 +14,7 @@ interface HasThreeTypes {
   let C:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation missing (i32).B; have constraint interface HasThreeTypes where i32 is interface HasThreeTypes and (i32).A == i32 and (i32).C == i32
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation missing (i32).(HasThreeTypes.B); have constraint interface HasThreeTypes where i32 is interface HasThreeTypes and (i32).(HasThreeTypes.A) == i32 and (i32).(HasThreeTypes.C) == i32
 external impl i32 as HasThreeTypes where .A == i32 and .C == i32 {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
@@ -14,7 +14,7 @@ interface HasThreeTypes {
   let C:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for (i32).(HasThreeTypes.B)
-external impl i32 as HasThreeTypes where .A == i32 and .B == .C {}
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.C
+external impl i32 as HasThreeTypes where .A = i32 and .B = .C {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
@@ -14,7 +14,7 @@ interface HasThreeTypes {
   let C:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for (i32).B
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for (i32).(HasThreeTypes.B)
 external impl i32 as HasThreeTypes where .A == i32 and .B == .C {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
+++ b/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
@@ -23,7 +23,7 @@ fn F2[U:! A where .T == i32](x: i32) -> U.T {
 }
 
 fn F3[T:! A where .T == i32, U:! A where .T == i32](x: T.T) -> U.T {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_indirectly_equal.carbon:[[@LINE+1]]: type error in return value: '(T).T' is not implicitly convertible to '(U).T'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_indirectly_equal.carbon:[[@LINE+1]]: type error in return value: '(T).(A.T)' is not implicitly convertible to '(U).(A.T)'
   return x;
 }
 

--- a/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
@@ -13,7 +13,7 @@ package ExplorerTest api;
 interface Vector {
   let Dim:! i32;
 }
-external impl (i32, i32, i32) as Vector where .Dim == 3 {}
+external impl (i32, i32, i32) as Vector where .Dim = 3 {}
 
 class Point(Scalar:! Type, Dim:! i32) {}
 

--- a/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
@@ -22,7 +22,7 @@ fn F[Scalar:! Type, V:! Vector where .Dim == 3](p: Point(Scalar, V.Dim), v: V) {
 fn G[Scalar:! Type](p: Point(Scalar, 3)) {}
 fn H[V:! Vector where .Dim == 3](v: V) {
   var p: Point(i32, V.Dim) = {};
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_match_in_deduction.carbon:[[@LINE+1]]: mismatch in non-type values, `(V).Dim` != `3`
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_match_in_deduction.carbon:[[@LINE+1]]: mismatch in non-type values, `(V).(Vector.Dim)` != `3`
   G(p);
 }
 

--- a/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
+++ b/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
@@ -18,7 +18,7 @@ interface B {
 }
 
 class C(T:! Type) {
-  impl as A & B where .TA == i32 and .TB == i32 {
+  impl as A & B where .TA = i32 and .TB = i32 {
     fn FA() -> i32 {
       // OK, know that TA is i32 here.
       let v: Self.(A.TA) = 1;
@@ -29,10 +29,8 @@ class C(T:! Type) {
       // OK, know that TB is i32 here.
       let v: Self.(B.TB) = 2;
       // Don't know that TA is i32; it could be specialized.
+      // TODO: We should not accept this.
       let w: Self.(A.TA) = 3;
-      // TODO: This error is confusing. We should be diagnosing the previous
-      // line because we don't know that `3` can be converted to `Self.(A.TA)`.
-      // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon:[[@LINE+1]]: type error in return value: '((class C(T = T)).(B.TB)).(AddWith(U = (class C(T = T)).(A.TA)).Result)' is not implicitly convertible to 'i32'
       return v + w;
     }
   }
@@ -40,6 +38,7 @@ class C(T:! Type) {
 
 external impl C(i32) as B where .TB == () {
   fn FB() -> () { return (); }
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon:[[@LINE+1]]: ambiguous implementations of interface B for class C(T = i32)
 }
 
 fn Main() -> i32 { return C(i32).FB(); }

--- a/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
+++ b/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon
@@ -32,7 +32,7 @@ class C(T:! Type) {
       let w: Self.(A.TA) = 3;
       // TODO: This error is confusing. We should be diagnosing the previous
       // line because we don't know that `3` can be converted to `Self.(A.TA)`.
-      // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon:[[@LINE+1]]: type error in return value: '((class C(T = T)).TB).Result' is not implicitly convertible to 'i32'
+      // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_multi_impl_scoping.carbon:[[@LINE+1]]: type error in return value: '((class C(T = T)).(B.TB)).(AddWith(U = (class C(T = T)).(A.TA)).Result)' is not implicitly convertible to 'i32'
       return v + w;
     }
   }

--- a/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
@@ -17,8 +17,8 @@ interface HasThreeTypes {
 fn F[T:! Type](x: (T, T, T));
 fn G[X:! HasThreeTypes where .A == .B and .B == .C and .C == .A](x: X) {
   // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_multiple_deduction.carbon:[[@LINE+3]]: deduced multiple different values for T:! Type:
-  // CHECK:STDERR:   (X).A
-  // CHECK:STDERR:   (X).B
+  // CHECK:STDERR:   (X).(HasThreeTypes.A)
+  // CHECK:STDERR:   (X).(HasThreeTypes.B)
   F(x.Make());
 }
 

--- a/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
+++ b/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
@@ -12,7 +12,7 @@ interface HasType {
   let T:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_overspecified_impl.carbon:[[@LINE+1]]: implementation provides multiple values for (i32).T: i32 and {.a: i32}
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_overspecified_impl.carbon:[[@LINE+1]]: implementation provides multiple values for (i32).(HasType.T): i32 and {.a: i32}
 external impl i32 as HasType where .T == i32 and .T == {.a: i32} {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
+++ b/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
@@ -12,7 +12,9 @@ interface HasType {
   let T:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_overspecified_impl.carbon:[[@LINE+1]]: implementation provides multiple values for (i32).(HasType.T): i32 and {.a: i32}
-external impl i32 as HasType where .T == i32 and .T == {.a: i32} {}
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_overspecified_impl.carbon:[[@LINE+3]]: multiple different rewrites for `.(interface HasType.T)`:
+// CHECK:STDERR:   i32
+// CHECK:STDERR:   {.a: i32}
+external impl i32 as HasType where .T = i32 and .T = {.a: i32} {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_unknown_value.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value.carbon
@@ -13,7 +13,7 @@ interface Iface { let N:! i32; }
 fn PickType(N: i32) -> Type { return i32; }
 
 fn F[T:! Iface](x: T) -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_unknown_value.carbon:[[@LINE+1]]: value of associated constant (T).N is not known
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_unknown_value.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
   var x: PickType(T.N) = 0;
   return x;
 }

--- a/explorer/testdata/assoc_const/fail_unknown_value.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value.carbon
@@ -18,7 +18,7 @@ fn F[T:! Iface](x: T) -> i32 {
   return x;
 }
 
-impl i32 as Iface where .N == 5 {}
+impl i32 as Iface where .N = 5 {}
 
 fn Main() -> i32 {
   return F(0);

--- a/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
@@ -14,7 +14,7 @@ fn PickType(N: i32) -> Type { return i32; }
 
 fn F[T:! Iface where .N == 5](x: T) -> i32 {
   // TODO: This should be valid: the value of T.N is known to be 5 here.
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon:[[@LINE+1]]: value of associated constant (T).N is not known
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
   var x: PickType(T.N) = 0;
   return x;
 }

--- a/explorer/testdata/assoc_const/impl_lookup.carbon
+++ b/explorer/testdata/assoc_const/impl_lookup.carbon
@@ -26,7 +26,7 @@ class AlmostI32 {
   }
 }
 
-impl i32 as Frob where .Result == AlmostI32 {
+impl i32 as Frob where .Result = AlmostI32 {
   fn F[me: Self]() -> AlmostI32 { return {.val = me}; }
 }
 

--- a/explorer/testdata/assoc_const/implement.carbon
+++ b/explorer/testdata/assoc_const/implement.carbon
@@ -16,7 +16,7 @@ interface Vector {
 class Point {
   var x: i32;
   var y: i32;
-  impl as Vector where .Dim == 2 {}
+  impl as Vector where .Dim = 2 {}
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/member_of_value.carbon
+++ b/explorer/testdata/assoc_const/member_of_value.carbon
@@ -16,7 +16,7 @@ interface Vector {
 class Point {
   var x: i32;
   var y: i32;
-  impl as Vector where .Dim == 2 {}
+  impl as Vector where .Dim = 2 {}
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/pass_equal_to_rewrite.carbon
+++ b/explorer/testdata/assoc_const/pass_equal_to_rewrite.carbon
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface Container {
+  let Element:! Type;
+  fn Front[me: Self]() -> Element;
+}
+
+fn A[T:! Container where .Element = i32](x: T) -> T.Element {
+  return x.Front();
+}
+
+fn B[T:! Container where .Element == i32](x: T) -> T.Element {
+  return A(x);
+}
+
+external impl (i32, i32) as Container where .Element = i32 {
+  fn Front[me: Self]() -> i32 {
+    let (a: i32, b: i32) = me;
+    return a;
+  }
+}
+
+fn Main() -> i32 {
+  return B((1, 2));
+}

--- a/explorer/testdata/assoc_const/pass_rewrite_to_equal.carbon
+++ b/explorer/testdata/assoc_const/pass_rewrite_to_equal.carbon
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface Container {
+  let Element:! Type;
+  fn Front[me: Self]() -> Element;
+}
+
+fn A[T:! Container where .Element == i32](x: T) -> T.Element {
+  return x.Front();
+}
+
+fn B[T:! Container where .Element = i32](x: T) -> T.Element {
+  return A(x);
+}
+
+external impl (i32, i32) as Container where .Element = i32 {
+  fn Front[me: Self]() -> i32 {
+    let (a: i32, b: i32) = me;
+    return a;
+  }
+}
+
+fn Main() -> i32 {
+  return B((1, 2));
+}

--- a/explorer/testdata/assoc_const/simple_constraint.carbon
+++ b/explorer/testdata/assoc_const/simple_constraint.carbon
@@ -14,12 +14,12 @@ interface Frob {
   fn F[me: Self]() -> Result;
 }
 
-fn Use[T:! Frob where .Result == .Self](x: T) -> T {
+fn Use[T:! Frob where .Result = .Self](x: T) -> T {
   var v: T = x.F();
   return v;
 }
 
-impl i32 as Frob where .Result == i32 {
+impl i32 as Frob where .Result = i32 {
   fn F[me: Self]() -> i32 { return me + 1; }
 }
 

--- a/explorer/testdata/assoc_const/simple_equality.carbon
+++ b/explorer/testdata/assoc_const/simple_equality.carbon
@@ -19,7 +19,7 @@ fn Use[T:! Frob](x: T) -> T.Result {
   return v;
 }
 
-impl i32 as Frob where .Result == i32 {
+impl i32 as Frob where .Result = i32 {
   fn F[me: Self]() -> i32 { return 0; }
 }
 

--- a/explorer/testdata/constraint/binding_dot_self_in_constraint.carbon
+++ b/explorer/testdata/constraint/binding_dot_self_in_constraint.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s | %{FileCheck-strict} %s
+// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK:STDOUT: result: 6
+
+package ExplorerTest api;
+
+// The constraint here resolves to:
+//
+//   MulWith(T) where <ConstraintSelf>.(MulWith(T).Result) == <ConstraintSelf>
+//
+// Note in particular that this involves a member of `MulWith(T)`, so we need
+// `T` to have a symbolic identity when checking its own type.
+fn DoMul[T:! MulWith(.Self) where .Result == .Self](x: T, y: T) -> T {
+  return x * y;
+}
+
+fn Main() -> i32 {
+  return DoMul(2, 3);
+}

--- a/explorer/testdata/operators/add.carbon
+++ b/explorer/testdata/operators/add.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as AddWith(i32) where .Result == A {
+external impl A as AddWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n + rhs}; }
 }
 

--- a/explorer/testdata/operators/bit_and.carbon
+++ b/explorer/testdata/operators/bit_and.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as BitAndWith(i32) where .Result == A {
+external impl A as BitAndWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n & rhs}; }
 }
 

--- a/explorer/testdata/operators/bit_complement.carbon
+++ b/explorer/testdata/operators/bit_complement.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as BitComplement where .Result == A {
+external impl A as BitComplement where .Result = A {
   fn Op[me: Self]() -> A { return {.n = ^me.n}; }
 }
 

--- a/explorer/testdata/operators/bit_or.carbon
+++ b/explorer/testdata/operators/bit_or.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as BitOrWith(i32) where .Result == A {
+external impl A as BitOrWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n | rhs}; }
 }
 

--- a/explorer/testdata/operators/bit_xor.carbon
+++ b/explorer/testdata/operators/bit_xor.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as BitXorWith(i32) where .Result == A {
+external impl A as BitXorWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n ^ rhs}; }
 }
 

--- a/explorer/testdata/operators/div.carbon
+++ b/explorer/testdata/operators/div.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as DivWith(i32) where .Result == A {
+external impl A as DivWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n / rhs}; }
 }
 

--- a/explorer/testdata/operators/left_shift.carbon
+++ b/explorer/testdata/operators/left_shift.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as LeftShiftWith(i32) where .Result == A {
+external impl A as LeftShiftWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n << rhs}; }
 }
 

--- a/explorer/testdata/operators/mod.carbon
+++ b/explorer/testdata/operators/mod.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as ModWith(i32) where .Result == A {
+external impl A as ModWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n % rhs}; }
 }
 

--- a/explorer/testdata/operators/mul.carbon
+++ b/explorer/testdata/operators/mul.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as MulWith(i32) where .Result == A {
+external impl A as MulWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n * rhs}; }
 }
 

--- a/explorer/testdata/operators/negate.carbon
+++ b/explorer/testdata/operators/negate.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as Negate where .Result == A {
+external impl A as Negate where .Result = A {
   fn Op[me: Self]() -> A { return {.n = -me.n}; }
 }
 

--- a/explorer/testdata/operators/right_shift.carbon
+++ b/explorer/testdata/operators/right_shift.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as RightShiftWith(i32) where .Result == A {
+external impl A as RightShiftWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n >> rhs}; }
 }
 

--- a/explorer/testdata/operators/sub.carbon
+++ b/explorer/testdata/operators/sub.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 
 class A { var n: i32; }
 
-external impl A as SubWith(i32) where .Result == A {
+external impl A as SubWith(i32) where .Result = A {
   fn Op[me: Self](rhs: i32) -> A { return {.n = me.n - rhs}; }
 }
 

--- a/explorer/testdata/print/associated_constant.carbon
+++ b/explorer/testdata/print/associated_constant.carbon
@@ -15,8 +15,8 @@ interface HasName {
     let Name:! String;
 }
 
-external impl i32 as HasName where .Name == "i32" {}
-external impl String as HasName where .Name == "String" {}
+external impl i32 as HasName where .Name = "i32" {}
+external impl String as HasName where .Name = "String" {}
 
 fn Main() -> i32 {
     Print(i32.(HasName.Name));


### PR DESCRIPTION
Add checking that a type only satisfies a constraint if it satisfies all of that constraint's equality and rewrite constraints.

Enforce the rule that `=` must be used in impls when specifying associated constant values rather than `==`.

Turn off the pre-#2173 single-step equality behavior. This is getting somewhat ahead of the approved design, but it's a one-line change to restore the old behavior.

Fix `CARBON_CHECK` to handle top-level `,`s in its argument, such as may happen in template argument lists, as this change introduces such a check.