### PR TITLE
Begin publishing CoC and moderation transparency reports.

### DIFF
--- a/docs/project/transparency_reports.md
+++ b/docs/project/transparency_reports.md
@@ -1,0 +1,79 @@
+# Conduct and moderation transparency reports
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+## Overview
+
+Carbon regularly publishes transparency reports that cover conduct issues that
+have come up in our spaces as well as the moderation and other actions taken in
+response. We prioritize keeping the Carbon community [welcoming and inclusive]()
+and believe this kind of transparency is essential to sustaining that.
+
+## Cadence and publishing
+
+We publish a report every N months in a GitHub discussion thread in the
+[transparency reports](https://github.com/carbon-language/carbon-lang/discussions/categories/transparency-reports)
+topic. We use the following template for each of these reports.
+
+## Template
+
+The Carbon community works to be welcoming and kind among itself and to others,
+with a deep commitment to psychological safety, and we want to ensure that
+doesn’t change as we grow and evolve. To that end, we have a few ground rules
+that we ask all community members to adhere to:
+
+-   be welcoming,
+-   be friendly and patient,
+-   be considerate,
+-   be kind,
+-   be careful in the words that we choose, when we disagree, we try to
+    understand why, and recognize when progress has stopped, and take a step
+    back.
+
+The following summary is intended to help the community understand what kinds of
+Code of Conduct (CoC) incidents were brought to our attention lately, and how we
+dealt with them.
+
+Publishing such transparency reports in the future will help us track progress
+and hold ourselves accountable to high standards of community culture.
+
+### Summary
+
+_[overview with overall number of interventions and mention of major community
+related events during that period]_
+
+Please note that some incidents may have escaped our attention. Please help us
+keep our spaces welcoming and fostering a spirit of collaboration, and report
+any situation that may require our intervention:
+https://github.com/carbon-language/carbon-lang/blob/trunk/CODE_OF_CONDUCT.md
+
+### Our interventions from _[YYYY-MM-DD (start date)]_ through _[YYYY-MM-DD (end date)]_
+
+_[mention of preventive measures if applicable]_
+
+These are the conduct incidents that were brought to our attention during the
+last documentation period with the relevant sections of the Carbon community
+Code of Conduct when this report was published:
+
+-   > _[Quote1 from the Code of Conduct related to the following interventions]_
+
+    _[Number of related incidents, and corresponding moderation interventions]_
+
+-   > _[Quote2 from the Code of Conduct related to the following interventions]_
+
+    _[Number of related incidents, and corresponding moderation interventions]_
+
+-   > _[Quote3 from the Code of Conduct related to the following interventions]_
+
+    _[Number of related incidents, and corresponding moderation interventions]_
+
+_[Final observations]_
+
+Thank you all for helping us keep such a fantastic Carbon community,
+
+-- The Carbon Language community moderation team, together with the Carbon
+leads.

--- a/docs/project/transparency_reports.md
+++ b/docs/project/transparency_reports.md
@@ -15,9 +15,11 @@ and believe this kind of transparency is essential to sustaining that.
 
 ## Cadence and publishing
 
-We publish a report every N months in a GitHub discussion thread in the
+We publish a report quarterly in a GitHub discussion thread in the
 [transparency reports](https://github.com/carbon-language/carbon-lang/discussions/categories/transparency-reports)
 topic. We use the following template for each of these reports.
+
+We may publish outside of the quarterly cycle if needed for an urgent response.
 
 ## Template
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -53,8 +53,6 @@ We will create a template for Carbon's transparency reports and maintain that as
 part of the project. Our Code of Conduct team will then create and publish
 regular reports in the GitHub discussion forum based on that template.
 
-Open question: With what frequency should Carbon publish these reports?
-
 ## Details
 
 Some examples of transparency reports in which conduct incidents had been
@@ -101,7 +99,13 @@ Such a dashboard could be an attractive alternative for the future.
 
 ### Different cadence
 
-TODO: when we have a cadence, discuss why we picked this one.
+Publishing quarterly may result in some quarters with very little or even
+nothing to publish. That seems fine. We considered a slower cadence of annually,
+but we worry that would be too slow for folks in the community to hold the
+conduct team and leadership accountable as things start to be forgotten.
+
+We also thought about how to respond rapidly when needed but would prefer to
+publish out-of-band when needed rather than run an even more rapid cadence.
 
 ### Different publishing options
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -94,8 +94,8 @@ conduct of our community and how we respond to it.
 
 An automated dashboard (for example “X days since AutoMod detected a “guys” in
 our Discord”, “Y incidents of harmful language”) would be great, but we are
-still to figure out the basics and principles together because we can automate
-more now.
+still figuring out the basics and principles together before we can automate
+more.
 
 Such a dashboard could be an attractive alternative for the future.
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -19,6 +19,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Details](#details)
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
+    -   [Automated dashboards](#automated-dashboards)
+    -   [Different cadence](#different-cadence)
+    -   [Different publishing options](#different-publishing-options)
 
 <!-- tocstop -->
 
@@ -89,9 +92,10 @@ conduct of our community and how we respond to it.
 
 ### Automated dashboards
 
-An automated dashboard (e.g. “X days since AutoMod detected a “guys” in our
-Discord”, “Y incidents of harmful language”) would be great, but we are still to
-figure out the basics and principles together because we can automate more now.
+An automated dashboard (for example “X days since AutoMod detected a “guys” in
+our Discord”, “Y incidents of harmful language”) would be great, but we are
+still to figure out the basics and principles together because we can automate
+more now.
 
 Such a dashboard could be an attractive alternative for the future.
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -27,8 +27,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+Proposes a documented cadence, publishing target, and template for Code of Conduct and moderation transparency reports.
 
 ## Problem
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -1,4 +1,4 @@
-# Begin publishing CoC and moderation transparency reports.
+# Begin publishing CoC and moderation transparency reports
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -29,42 +29,89 @@ paragraph should be reproduced verbatim in the PR summary.
 
 ## Problem
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
+The Carbon community wants to be an example in terms of diversity, equity and
+inclusion. One of the best practices that supports such ambition is publishing
+transparency reports about misconduct within the community and actions taken in
+response. There is no previous experience with reporting back to the community
+about this so far.
 
 ## Background
 
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+Transparency reports are not very common practice, but already around. So there
+are some ideas to grab from other communities, with their permission.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+We will benchmark relevant transparency reports to find inspiration to create
+our own. We will look at their scope, their format, their regularity and
+possibly community feedback we have access to.
+
+We will create a template for Carbon's transparency reports and maintain that as
+part of the project. Our Code of Conduct team will then create and publish
+regular reports in the GitHub discussion forum based on that template.
+
+Open question: With what frequency should Carbon publish these reports?
 
 ## Details
 
-TODO: Fully explain the details of the proposed solution.
+Some examples of transparency reports in which conduct incidents had been
+reported:
+
+Conferences:
+
+-   PyCon US 2022:
+    https://pycon.blogspot.com/2022/06/pycon-us-2022-transparency-report.html
+-   CppCon 2021: https://cppcon.org/cppcon-2021-transparency-report/
+-   PyConDE 2019:
+    https://2019.pycon.de/blog/code-of-conduct-transparency-report/
+
+Other:
+
+-   LLVM CoC July 15, 2022: https://llvm.org/coc-reports/2022-07-15-report.html
+-   Linux Foundation 2021:
+    https://www.linuxfoundation.org/blog/blog/linux-foundation-events-code-of-conduct-transparency-report-2021-event-summary
+
+We propose a [template](/docs/project/transparency_reports.md#template) for our
+own CoC transparency report, which has been greatly inspired by transparency
+reports issued by the Python community worldwide. Thank you, Pythonistas!
+
+We also document there the
+[cadence and target of publishing](/docs/project/transparency_reports.md#cadence-and-publishing).
 
 ## Rationale
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
-
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+Transparent moderation and handling of conduct issues is essential to sustaining
+a healthy [community and culture](/docs/project/goals.md#community-and-culture),
+one of Carbon's primary goals. We need to clearly and transparently surface the
+conduct of our community and how we respond to it.
 
 ## Alternatives considered
 
-TODO: What alternative solutions have you considered?
+### Automated dashboards
+
+An automated dashboard (e.g. “X days since AutoMod detected a “guys” in our
+Discord”, “Y incidents of harmful language”) would be great, but we are still to
+figure out the basics and principles together because we can automate more now.
+
+Such a dashboard could be an attractive alternative for the future.
+
+### Different cadence
+
+TODO: when we have a cadence, discuss why we picked this one.
+
+### Different publishing options
+
+We considered different places to publish the individual transparency reports.
+
+They don't seem to belong as part of our version controlled repository as they
+aren't something that should be persistent -- they reflect a report at a moment
+in time. And while we hope to never need it, we should retain the ability to
+easily redact information or make permanent edits to them if necessary. GitHub
+discussions seem like a good fit overall compared to alternatives like the main
+repository, the wiki, etc.
+
+Using GitHub discussions also allows comments and discussion where folks could
+for example ask questions or get more information about how and why we are
+taking our moderation approaches. While there is some risk of these discussions
+being unproductive, we hope to be able to moderate them as well and still
+provide a place where productive and on-topic discussion can still take place.

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -27,7 +27,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-Proposes a documented cadence, publishing target, and template for Code of Conduct and moderation transparency reports.
+Proposes a documented cadence, publishing target, and template for Code of
+Conduct and moderation transparency reports.
 
 ## Problem
 

--- a/proposals/p2295.md
+++ b/proposals/p2295.md
@@ -1,0 +1,70 @@
+# Begin publishing CoC and moderation transparency reports.
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2295)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?


### PR DESCRIPTION
Proposes a documented cadence, publishing target, and template for Code of Conduct and moderation transparency reports.

Based on the initial proposal draft from @CelineausBerlin.