### PR TITLE
Remove the use of `-fast-isel` with LLVM.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -268,19 +268,6 @@ def _impl(ctx):
                     "-O1",
                 ])],
             ),
-            # Use a conditional flag set for enabling the fast instruction
-            # selector to work around an LLVM bug:
-            # https://github.com/llvm/llvm-project/issues/56133
-            flag_set(
-                actions = codegen_compile_actions,
-                flag_groups = [flag_group(flags = [
-                    "-mllvm",
-                    "-fast-isel",
-                ])],
-                with_features = [
-                    with_feature_set(not_features = ["fuzzer"]),
-                ],
-            ),
         ],
     )
     default_optimization_flags = feature(


### PR DESCRIPTION
This had already hit one bug in LLVM, and now I've hit another: https://github.com/llvm/llvm-project/issues/58385

Since this isn't specific to a config, and it seems to be a clear sign that this isn't the best tested path, let's just drop to the more fully tested flags. Probably should have done this rather than the more targeted workaround last time...