### PR TITLE
Fix sorted output flakiness by using stable_sort

### DIFF
--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -26,7 +26,8 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
 
   // Sorts and flushes buffered diagnostics.
   void Flush() override {
-    llvm::sort(diagnostics_, [](const Diagnostic& lhs, const Diagnostic& rhs) {
+    llvm::stable_sort(diagnostics_, [](const Diagnostic& lhs,
+                                       const Diagnostic& rhs) {
       return std::tie(lhs.location.line_number, lhs.location.column_number) <
              std::tie(rhs.location.line_number, rhs.location.column_number);
     });

--- a/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
@@ -37,6 +37,7 @@ TEST(SortedDiagnosticEmitterTest, SortErrors) {
   emitter.Emit({"f", 1, 3}, TestDiagnostic, "M3");
   emitter.Emit({"f", 3, 4}, TestDiagnostic, "M4");
   emitter.Emit({"f", 3, 2}, TestDiagnostic, "M5");
+  emitter.Emit({"f", 3, 2}, TestDiagnostic, "M6");
 
   InSequence s;
   EXPECT_CALL(consumer, HandleDiagnostic(
@@ -51,6 +52,9 @@ TEST(SortedDiagnosticEmitterTest, SortErrors) {
   EXPECT_CALL(consumer, HandleDiagnostic(
                             IsDiagnostic(DiagnosticKind::TestDiagnostic,
                                          DiagnosticLevel::Error, 3, 2, "M5")));
+  EXPECT_CALL(consumer, HandleDiagnostic(
+                            IsDiagnostic(DiagnosticKind::TestDiagnostic,
+                                         DiagnosticLevel::Error, 3, 2, "M6")));
   EXPECT_CALL(consumer, HandleDiagnostic(
                             IsDiagnostic(DiagnosticKind::TestDiagnostic,
                                          DiagnosticLevel::Error, 3, 4, "M4")));


### PR DESCRIPTION
Visible with bazel test //toolchain/parser/testdata:if/fail_errors.carbon.test --runs_per_test=20 (produces 2 errors on the same line)