### PR TITLE
Properly check that a constraint appears after `is`.

### DIFF
--- a/explorer/testdata/assoc_const/fail_different_type.carbon
+++ b/explorer/testdata/assoc_const/fail_different_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_different_value.carbon
+++ b/explorer/testdata/assoc_const/fail_different_value.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{not} %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assoc_const/pass_equal_to_rewrite.carbon
+++ b/explorer/testdata/assoc_const/pass_equal_to_rewrite.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/assoc_const/pass_rewrite_to_equal.carbon
+++ b/explorer/testdata/assoc_const/pass_rewrite_to_equal.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 1
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/binding_dot_self_in_constraint.carbon
+++ b/explorer/testdata/constraint/binding_dot_self_in_constraint.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{explorer} %s | %{FileCheck-strict} %s
-// RUN: %{explorer-trace} %s | %{FileCheck-allow-unmatched} %s
 // AUTOUPDATE: %{explorer} %s
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: result: 6
 
 package ExplorerTest api;

--- a/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
+++ b/explorer/testdata/constraint/fail_where_is_non_constraint.carbon
@@ -10,7 +10,7 @@ package ExplorerTest api;
 
 interface A {}
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/fail_where_is_non_constraint.carbon:[[@LINE+1]]: expression after `is` does not resolve to a constraint, found value i32 of type Type
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/constraint/fail_where_is_non_constraint.carbon:[[@LINE+1]]: expected a constraint in expression after `is`, found i32
 alias B = A where i32 is i32;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/where_is.carbon
+++ b/explorer/testdata/constraint/where_is.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: i32.F
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Base {
+  fn F();
+}
+
+interface Extension {
+  extends Base;
+}
+
+fn F[T:! Type where .Self is Extension](x: T) {
+  x.(Extension.F)();
+}
+
+impl i32 as Extension {
+  fn F() { Print("i32.F"); }
+}
+
+fn Main() -> i32 {
+  var n: i32 = 0;
+  F(n);
+  return 0;
+}


### PR DESCRIPTION
In particular, if we find the name of an interface after `is`, it should be exapnded to a constraint, including any implied constraints such as extended interfaces, rather than forming a constraint requiring only that interface in isolation.