### PR TITLE
Replace a tricky conversion between equal types with an intrinsic.

### DIFF
--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -31,6 +31,7 @@ auto IntrinsicExpression::FindIntrinsic(std::string_view name,
        {"new", Intrinsic::Alloc},
        {"delete", Intrinsic::Dealloc},
        {"rand", Intrinsic::Rand},
+       {"as_equal_type", Intrinsic::AsEqualType},
        {"int_eq", Intrinsic::IntEq},
        {"int_compare", Intrinsic::IntCompare},
        {"int_bit_complement", Intrinsic::IntBitComplement},
@@ -61,6 +62,8 @@ auto IntrinsicExpression::name() const -> std::string_view {
       return "__intrinsic_delete";
     case IntrinsicExpression::Intrinsic::Rand:
       return "__intrinsic_rand";
+    case IntrinsicExpression::Intrinsic::AsEqualType:
+      return "__intrinsic_as_equal_type";
     case IntrinsicExpression::Intrinsic::IntEq:
       return "__intrinsic_int_eq";
     case IntrinsicExpression::Intrinsic::IntCompare:

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -715,6 +715,7 @@ class IntrinsicExpression : public Expression {
     Alloc,
     Dealloc,
     Rand,
+    AsEqualType,
     IntEq,
     StrEq,
     StrCompare,

--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -18,21 +18,9 @@ interface ImplicitAs(T:! Type) {
   extends As(T);
 }
 
-// TODO: Should we just use an intrinsic for this?
-interface __EqualConverter {
-  let T:! Type;
-  fn Convert(t: T) -> Self;
-}
-fn __EqualConvert[T:! Type](t: T, U:! __EqualConverter where .T = T) -> U {
-  return U.Convert(t);
-}
-impl forall [U:! Type] U as __EqualConverter where .T = U {
-  fn Convert(u: U) -> U { return u; }
-}
-
 // Every type implicitly converts to single-step-equal types.
 impl forall [T:! Type, U:! Type where .Self == T] T as ImplicitAs(U) {
-  fn Convert[me: Self]() -> U { return __EqualConvert(me, U); }
+  fn Convert[me: Self]() -> U { return __intrinsic_as_equal_type(me, U); }
 }
 
 // TODO: Simplify this once we have variadics.

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1323,6 +1323,13 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
           int r = (generator() % (high - low)) + low;
           return todo_.FinishAction(arena_->New<IntValue>(r));
         }
+        case IntrinsicExpression::Intrinsic::AsEqualType: {
+          CARBON_CHECK(args.size() == 2);
+          CARBON_ASSIGN_OR_RETURN(
+              Nonnull<const Value*> val,
+              Convert(args[0], args[1], intrinsic.source_loc()));
+          return todo_.FinishAction(val);
+        }
         case IntrinsicExpression::Intrinsic::IntEq: {
           CARBON_CHECK(args.size() == 2);
           auto lhs = cast<IntValue>(*args[0]).value();

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2968,6 +2968,27 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
 
           return Success();
         }
+        case IntrinsicExpression::Intrinsic::AsEqualType: {
+          if (args.size() != 2) {
+            return ProgramError(e->source_loc())
+                   << "__intrinsic_as_equal_type takes 2 arguments";
+          }
+          if (!IsTypeOfType(&args[1]->static_type())) {
+            return ProgramError(e->source_loc())
+                   << "second argument should be a type";
+          }
+          CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> type,
+                                  InterpExp(args[1], arena_, trace_stream_));
+          SingleStepEqualityContext equality_ctx(&impl_scope);
+          if (!TypeEqual(&args[0]->static_type(), type, &equality_ctx)) {
+            return ProgramError(e->source_loc())
+                   << "type " << args[0]->static_type()
+                   << " of first argument is not known to be equal to value "
+                   << *type << " of second argument";
+          }
+          e->set_static_type(type);
+          return Success();
+        }
         case IntrinsicExpression::Intrinsic::IntEq: {
           if (args.size() != 2) {
             return ProgramError(e->source_loc())

--- a/explorer/testdata/assoc_const/convert_equal.carbon
+++ b/explorer/testdata/assoc_const/convert_equal.carbon
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+interface EqualConverter {
+  let T:! Type;
+  fn Convert(t: T) -> Self;
+}
+
+fn DoEqualConvert[T:! Type](t: T, U:! EqualConverter where .T = T) -> U {
+  return U.Convert(t);
+}
+
+impl forall [U:! Type] U as EqualConverter where .T = U {
+  fn Convert(u: U) -> U { return u; }
+}
+
+// Converts from T to U given only that T == U. Implemented without
+// __intrinsic_as_equal_type, as proof that this is possible.
+fn EqualConvert[T:! Type](t: T, U:! Type where .Self == T) -> U {
+  return DoEqualConvert(t, U);
+}
+
+interface HasTwoTypes {
+  let T:! Type;
+  let U:! Type;
+}
+
+fn TestConvert(X:! HasTwoTypes where .T == .U, t: X.T) -> X.U {
+  return EqualConvert(t, X.U);
+}
+
+impl i32 as HasTwoTypes where .T = i32 and .U = i32 {}
+
+fn Main() -> i32 {
+  return TestConvert(i32, 5);
+}


### PR DESCRIPTION
We previously used a tricky implementation of `T as ImplicitAs(U)` in the prelude for types `T` and `U` that are constrained to be equal. Replace that with an intrinsic function to make the prelude easier to understand.

Turn the old tricky conversion method into a test.