### PR TITLE
Finish making clang-tidy (mostly) work and run -fix

### DIFF
--- a/common/indirect_value_test.cpp
+++ b/common/indirect_value_test.cpp
@@ -58,7 +58,7 @@ struct TestValue {
   TestValue(TestValue&& other) noexcept : state("move constructed") {
     other.state = "move constructed from";
   }
-  auto operator=(const TestValue&) noexcept -> TestValue& {
+  auto operator=(const TestValue& /*unused*/) noexcept -> TestValue& {
     state = "copy assigned";
     return *this;
   }

--- a/common/string_helpers_test.cpp
+++ b/common/string_helpers_test.cpp
@@ -11,7 +11,6 @@
 
 #include "llvm/Support/Error.h"
 
-using ::llvm::toString;
 using ::testing::Eq;
 using ::testing::Optional;
 

--- a/explorer/ast/bindings.h
+++ b/explorer/ast/bindings.h
@@ -6,6 +6,7 @@
 #define CARBON_EXPLORER_AST_BINDINGS_H_
 
 #include <map>
+#include <utility>
 
 #include "explorer/common/nonnull.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -40,18 +41,19 @@ class Bindings {
       -> Nonnull<const Bindings*>;
 
   // Create an empty set of bindings.
-  Bindings() {}
+  Bindings() = default;
 
   // Create an instantiated set of bindings for use during evaluation,
   // containing both arguments and witnesses.
   Bindings(BindingMap args, ImplWitnessMap witnesses)
-      : args_(args), witnesses_(witnesses) {}
+      : args_(std::move(args)), witnesses_(std::move(witnesses)) {}
 
   enum NoWitnessesTag { NoWitnesses };
 
   // Create a set of bindings for use during type-checking, containing only the
   // arguments but not the corresponding witnesses.
-  Bindings(BindingMap args, NoWitnessesTag) : args_(args), witnesses_() {}
+  Bindings(BindingMap args, NoWitnessesTag /*unused*/)
+      : args_(std::move(args)) {}
 
   // Add a value, and perhaps a witness, for a generic binding.
   void Add(Nonnull<const GenericBinding*> binding, Nonnull<const Value*> value,

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -316,7 +316,7 @@ class MixinDeclaration : public Declaration {
                    std::vector<Nonnull<Declaration*>> members)
       : Declaration(AstNodeKind::MixinDeclaration, source_loc),
         name_(std::move(name)),
-        params_(std::move(params)),
+        params_(params),
         self_(self),
         members_(std::move(members)) {}
 
@@ -489,7 +489,7 @@ class InterfaceDeclaration : public Declaration {
                        std::vector<Nonnull<Declaration*>> members)
       : Declaration(AstNodeKind::InterfaceDeclaration, source_loc),
         name_(std::move(name)),
-        params_(std::move(params)),
+        params_(params),
         self_type_(arena->New<SelfDeclaration>(source_loc)),
         members_(std::move(members)) {
     // `interface X` has `Self:! X`.
@@ -688,10 +688,10 @@ class AliasDeclaration : public Declaration {
  public:
   using ImplementsCarbonValueNode = void;
 
-  explicit AliasDeclaration(SourceLocation source_loc, const std::string& name,
+  explicit AliasDeclaration(SourceLocation source_loc, std::string name,
                             Nonnull<Expression*> target)
       : Declaration(AstNodeKind::AliasDeclaration, source_loc),
-        name_(name),
+        name_(std::move(name)),
         target_(target) {}
 
   static auto classof(const AstNode* node) -> bool {

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -876,7 +877,7 @@ class RewriteWhereClause : public WhereClause {
                               std::string member_name,
                               Nonnull<Expression*> replacement)
       : WhereClause(WhereClauseKind::RewriteWhereClause, source_loc),
-        member_name_(member_name),
+        member_name_(std::move(member_name)),
         replacement_(replacement) {}
 
   static auto classof(const AstNode* node) {

--- a/explorer/ast/impl_binding.h
+++ b/explorer/ast/impl_binding.h
@@ -80,10 +80,11 @@ class ImplBinding : public AstNode {
 
   // Return the original impl binding.
   auto original() const -> Nonnull<const ImplBinding*> {
-    if (original_.has_value())
+    if (original_.has_value()) {
       return *original_;
-    else
+    } else {
       return this;
+    }
   }
 
   // Set the original impl binding.

--- a/explorer/ast/member.cpp
+++ b/explorer/ast/member.cpp
@@ -15,7 +15,7 @@ Member::Member(Nonnull<const NamedValue*> struct_member)
     : member_(struct_member) {}
 
 auto Member::name() const -> std::string_view {
-  if (const Declaration* decl = member_.dyn_cast<const Declaration*>()) {
+  if (const auto* decl = member_.dyn_cast<const Declaration*>()) {
     return GetName(*decl).value();
   } else {
     return member_.get<const NamedValue*>()->name;
@@ -23,7 +23,7 @@ auto Member::name() const -> std::string_view {
 }
 
 auto Member::type() const -> const Value& {
-  if (const Declaration* decl = member_.dyn_cast<const Declaration*>()) {
+  if (const auto* decl = member_.dyn_cast<const Declaration*>()) {
     return decl->static_type();
   } else {
     return *member_.get<const NamedValue*>()->value;
@@ -31,7 +31,7 @@ auto Member::type() const -> const Value& {
 }
 
 auto Member::declaration() const -> std::optional<Nonnull<const Declaration*>> {
-  if (const Declaration* decl = member_.dyn_cast<const Declaration*>()) {
+  if (const auto* decl = member_.dyn_cast<const Declaration*>()) {
     return decl;
   }
   return std::nullopt;

--- a/explorer/ast/pattern.h
+++ b/explorer/ast/pattern.h
@@ -275,10 +275,11 @@ class GenericBinding : public Pattern {
 
   // Return the original generic binding.
   auto original() const -> Nonnull<const GenericBinding*> {
-    if (original_.has_value())
+    if (original_.has_value()) {
       return *original_;
-    else
+    } else {
       return this;
+    }
   }
   // Set the original generic binding.
   void set_original(Nonnull<const GenericBinding*> orig) { original_ = orig; }

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -772,7 +772,7 @@ static auto DeclarationToProto(const Declaration& declaration)
   return declaration_proto;
 }
 
-Fuzzing::CompilationUnit AstToProto(const AST& ast) {
+auto AstToProto(const AST& ast) -> Fuzzing::CompilationUnit {
   Fuzzing::CompilationUnit compilation_unit;
   *compilation_unit.mutable_package_statement() =
       LibraryNameToProto(ast.package);

--- a/explorer/interpreter/action_stack.h
+++ b/explorer/interpreter/action_stack.h
@@ -90,7 +90,7 @@ class ActionStack {
       -> ErrorOr<Success>;
   // Replace the current action with another action that produces the same kind
   // of result and run it next.
-  auto ReplaceWith(std::unique_ptr<Action> child) -> ErrorOr<Success>;
+  auto ReplaceWith(std::unique_ptr<Action> replacement) -> ErrorOr<Success>;
 
   // Start a new recursive action.
   auto BeginRecursiveAction() {

--- a/explorer/interpreter/builtins.h
+++ b/explorer/interpreter/builtins.h
@@ -20,7 +20,7 @@ namespace Carbon {
 
 class Builtins {
  public:
-  explicit Builtins() {}
+  explicit Builtins() = default;
 
   enum class Builtin {
     // Conversions.

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -11,7 +11,6 @@
 
 using llvm::cast;
 using llvm::dyn_cast;
-using llvm::isa;
 
 namespace Carbon {
 

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -158,7 +158,7 @@ class ImplScope {
 // scope.
 struct SingleStepEqualityContext : public EqualityContext {
  public:
-  SingleStepEqualityContext(Nonnull<const ImplScope*> impl_scope)
+  explicit SingleStepEqualityContext(Nonnull<const ImplScope*> impl_scope)
       : impl_scope_(impl_scope) {}
 
   // Visits the values that are equal to the given value and a single step away

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1299,7 +1299,8 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
           CARBON_ASSIGN_OR_RETURN(
               Nonnull<const Value*> string_value,
               Convert(args[1], arena_->New<StringType>(), exp.source_loc()));
-          if (!cast<BoolValue>(condition)->value()) {
+          bool condition_value = cast<BoolValue>(condition)->value();
+          if (!condition_value) {
             return ProgramError(exp.source_loc()) << *string_value;
           }
           return todo_.FinishAction(TupleValue::Empty());

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1699,10 +1699,10 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
             &cast<For>(stmt).variable_declaration()));
       }
       if (act.pos() == 2) {
-        auto loop_var = cast<const BindingPlaceholderValue>(
+        const auto* loop_var = cast<BindingPlaceholderValue>(
             act.results()[LoopVarPosInResult]);
-        auto source_array =
-            cast<const TupleValue>(act.results()[TargetVarPosInResult]);
+        const auto* source_array =
+            cast<TupleValue>(act.results()[TargetVarPosInResult]);
 
         auto start_index =
             cast<IntValue>(act.results()[CurrentIndexPosInResult])->value();

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1686,8 +1686,8 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
             std::make_unique<ExpressionAction>(&cast<For>(stmt).loop_target()));
       }
       if (act.pos() == 1) {
-        auto source_array =
-            cast<const TupleValue>(act.results()[TargetVarPosInResult]);
+        const auto* source_array =
+            cast<TupleValue>(act.results()[TargetVarPosInResult]);
 
         auto end_index = static_cast<int>(source_array->elements().size());
         if (end_index == 0) {

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -160,7 +160,7 @@ class Interpreter {
 
   void PrintState(llvm::raw_ostream& out);
 
-  Phase phase() const { return phase_; }
+  auto phase() const -> Phase { return phase_; }
 
   Nonnull<Arena*> arena_;
 
@@ -836,7 +836,7 @@ auto Interpreter::CallFunction(const CallExpression& call,
           alt.alt_name(), alt.choice_name(), arg));
     }
     case Value::Kind::FunctionValue: {
-      const FunctionValue& fun_val = cast<FunctionValue>(*fun);
+      const auto& fun_val = cast<FunctionValue>(*fun);
       const FunctionDeclaration& function = fun_val.declaration();
       if (!function.body().has_value()) {
         return ProgramError(call.source_loc())
@@ -1219,7 +1219,7 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
       }
     }
     case ExpressionKind::CallExpression: {
-      const CallExpression& call = cast<CallExpression>(exp);
+      const auto& call = cast<CallExpression>(exp);
       unsigned int num_impls = call.impls().size();
       if (act.pos() == 0) {
         //    { {e1(e2) :: C, E, F} :: S, H}
@@ -1231,12 +1231,12 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
         // -> { { e :: v([]) :: C, E, F} :: S, H}
         return todo_.Spawn(
             std::make_unique<ExpressionAction>(&call.argument()));
-      } else if (num_impls > 0 && act.pos() < 2 + int(num_impls)) {
+      } else if (num_impls > 0 && act.pos() < 2 + static_cast<int>(num_impls)) {
         auto iter = call.impls().begin();
         std::advance(iter, act.pos() - 2);
         return todo_.Spawn(
             std::make_unique<WitnessAction>(cast<Witness>(iter->second)));
-      } else if (act.pos() == 2 + int(num_impls)) {
+      } else if (act.pos() == 2 + static_cast<int>(num_impls)) {
         //    { { v2 :: v1([]) :: C, E, F} :: S, H}
         // -> { {C',E',F'} :: {C, E, F} :: S, H}
         ImplWitnessMap witnesses;
@@ -1249,12 +1249,13 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
         }
         return CallFunction(call, act.results()[0], act.results()[1],
                             std::move(witnesses));
-      } else if (act.pos() == 3 + int(num_impls)) {
+      } else if (act.pos() == 3 + static_cast<int>(num_impls)) {
         if (act.results().size() < 3 + num_impls) {
           // Control fell through without explicit return.
           return todo_.FinishAction(TupleValue::Empty());
         } else {
-          return todo_.FinishAction(act.results()[2 + int(num_impls)]);
+          return todo_.FinishAction(
+              act.results()[2 + static_cast<int>(num_impls)]);
         }
       } else {
         CARBON_FATAL() << "in StepExp with Call pos " << act.pos();
@@ -1298,7 +1299,7 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
           CARBON_ASSIGN_OR_RETURN(
               Nonnull<const Value*> string_value,
               Convert(args[1], arena_->New<StringType>(), exp.source_loc()));
-          if (cast<BoolValue>(condition)->value() == false) {
+          if (!cast<BoolValue>(condition)->value()) {
             return ProgramError(exp.source_loc()) << *string_value;
           }
           return todo_.FinishAction(TupleValue::Empty());
@@ -1684,7 +1685,7 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
             std::make_unique<ExpressionAction>(&cast<For>(stmt).loop_target()));
       }
       if (act.pos() == 1) {
-        Nonnull<const TupleValue*> source_array =
+        auto source_array =
             cast<const TupleValue>(act.results()[TargetVarPosInResult]);
 
         auto end_index = static_cast<int>(source_array->elements().size());
@@ -1697,10 +1698,9 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
             &cast<For>(stmt).variable_declaration()));
       }
       if (act.pos() == 2) {
-        Nonnull<const BindingPlaceholderValue*> loop_var =
-            cast<const BindingPlaceholderValue>(
-                act.results()[LoopVarPosInResult]);
-        Nonnull<const TupleValue*> source_array =
+        auto loop_var = cast<const BindingPlaceholderValue>(
+            act.results()[LoopVarPosInResult]);
+        auto source_array =
             cast<const TupleValue>(act.results()[TargetVarPosInResult]);
 
         auto start_index =
@@ -1719,11 +1719,10 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
             cast<IntValue>(act.results()[EndIndexPosInResult])->value();
 
         if (current_index < end_index) {
-          Nonnull<const TupleValue*> source_array =
+          auto source_array =
               cast<const TupleValue>(act.results()[TargetVarPosInResult]);
-          Nonnull<const BindingPlaceholderValue*> loop_var =
-              cast<const BindingPlaceholderValue>(
-                  act.results()[LoopVarPosInResult]);
+          auto loop_var = cast<const BindingPlaceholderValue>(
+              act.results()[LoopVarPosInResult]);
 
           CARBON_ASSIGN_OR_RETURN(
               Nonnull<const Value*> assigned_array_element,
@@ -2008,7 +2007,7 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
 
 auto Interpreter::StepCleanUp() -> ErrorOr<Success> {
   Action& act = todo_.CurrentAction();
-  CleanupAction& cleanup = cast<CleanupAction>(act);
+  auto& cleanup = cast<CleanupAction>(act);
   if (act.pos() < cleanup.locals_count()) {
     auto lvalue = act.scope()->locals()[cleanup.locals_count() - act.pos() - 1];
     SourceLocation source_loc("destructor", 1);

--- a/explorer/interpreter/pattern_analysis.h
+++ b/explorer/interpreter/pattern_analysis.h
@@ -65,7 +65,7 @@ class AbstractPattern {
  private:
   // This is aligned so that we can use it in the `PointerUnion` below.
   struct alignas(8) WildcardTag {};
-  AbstractPattern(WildcardTag)
+  explicit AbstractPattern(WildcardTag /*unused*/)
       : value_(static_cast<const WildcardTag*>(nullptr)), type_(nullptr) {}
 
   void Set(Nonnull<const Pattern*> pattern);

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -27,7 +27,6 @@
 
 using llvm::cast;
 using llvm::dyn_cast;
-using llvm::dyn_cast_or_null;
 using llvm::isa;
 
 namespace Carbon {
@@ -44,7 +43,7 @@ static void SetValue(Nonnull<Pattern*> pattern, Nonnull<const Value*> value) {
 
 auto TypeChecker::IsSameType(Nonnull<const Value*> type1,
                              Nonnull<const Value*> type2,
-                             const ImplScope& impl_scope) const -> bool {
+                             const ImplScope& /*impl_scope*/) const -> bool {
   return TypeEqual(type1, type2, std::nullopt);
 }
 
@@ -1097,7 +1096,7 @@ class TypeChecker::ConstraintTypeBuilder {
                         Nonnull<GenericBinding*> self_binding)
       : self_binding_(PrepareSelfBinding(arena, self_binding)),
         impl_binding_(AddImplBinding(arena, self_binding_)) {}
-  ConstraintTypeBuilder(Nonnull<Arena*> arena,
+  ConstraintTypeBuilder(Nonnull<Arena*> /*arena*/,
                         Nonnull<GenericBinding*> self_binding,
                         Nonnull<ImplBinding*> impl_binding)
       : self_binding_(self_binding), impl_binding_(impl_binding) {}
@@ -1350,7 +1349,6 @@ class TypeChecker::ConstraintTypeBuilder {
     return impl_binding;
   }
 
- private:
   Nonnull<GenericBinding*> self_binding_;
   Nonnull<ImplBinding*> impl_binding_;
   std::vector<ConstraintType::ImplConstraint> impl_constraints_;
@@ -1427,7 +1425,7 @@ auto TypeChecker::Substitute(const Bindings& bindings,
     return type;
   }
 
-  auto SubstituteIntoBindings =
+  auto substitute_into_bindings =
       [&](Nonnull<const Bindings*> inner_bindings) -> Nonnull<const Bindings*> {
     BindingMap values;
     for (const auto& [name, value] : inner_bindings->args()) {
@@ -1529,14 +1527,14 @@ auto TypeChecker::Substitute(const Bindings& bindings,
       Nonnull<const NominalClassType*> new_class_type =
           arena_->New<NominalClassType>(
               &class_type.declaration(),
-              SubstituteIntoBindings(&class_type.bindings()));
+              substitute_into_bindings(&class_type.bindings()));
       return new_class_type;
     }
     case Value::Kind::InterfaceType: {
       const auto& iface_type = cast<InterfaceType>(*type);
       Nonnull<const InterfaceType*> new_iface_type = arena_->New<InterfaceType>(
           &iface_type.declaration(),
-          SubstituteIntoBindings(&iface_type.bindings()));
+          substitute_into_bindings(&iface_type.bindings()));
       return new_iface_type;
     }
     case Value::Kind::ConstraintType: {
@@ -1585,7 +1583,8 @@ auto TypeChecker::Substitute(const Bindings& bindings,
     case Value::Kind::ImplWitness: {
       const auto& witness = cast<ImplWitness>(*type);
       return arena_->New<ImplWitness>(
-          &witness.declaration(), SubstituteIntoBindings(&witness.bindings()));
+          &witness.declaration(),
+          substitute_into_bindings(&witness.bindings()));
     }
     case Value::Kind::BindingWitness: {
       auto it =
@@ -1720,9 +1719,9 @@ auto TypeChecker::MatchImpl(const InterfaceType& iface,
 }
 
 auto TypeChecker::MakeConstraintWitness(
-    const ConstraintType& constraint,
+    const ConstraintType& /*constraint*/,
     std::vector<Nonnull<const Witness*>> impl_constraint_witnesses,
-    SourceLocation source_loc) const -> Nonnull<const Witness*> {
+    SourceLocation /*source_loc*/) const -> Nonnull<const Witness*> {
   return arena_->New<ConstraintWitness>(std::move(impl_constraint_witnesses));
 }
 
@@ -1794,7 +1793,7 @@ auto TypeChecker::DeduceCallBindings(
     CallExpression& call, Nonnull<const Value*> params_type,
     llvm::ArrayRef<FunctionType::GenericParameter> generic_params,
     llvm::ArrayRef<Nonnull<const GenericBinding*>> deduced_bindings,
-    llvm::ArrayRef<Nonnull<const ImplBinding*>> impl_bindings,
+    llvm::ArrayRef<Nonnull<const ImplBinding*>> /*impl_bindings*/,
     const ImplScope& impl_scope) -> ErrorOr<Success> {
   llvm::ArrayRef<Nonnull<const Value*>> params =
       cast<TupleValue>(*params_type).elements();
@@ -1863,7 +1862,7 @@ auto TypeChecker::LookupInConstraint(SourceLocation source_loc,
       // constraints.
       continue;
     }
-    const InterfaceType& iface_type = cast<InterfaceType>(*lookup.context);
+    const auto& iface_type = cast<InterfaceType>(*lookup.context);
     if (std::optional<Nonnull<const Declaration*>> member =
             FindMember(member_name, iface_type.declaration().members());
         member.has_value()) {
@@ -2313,7 +2312,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                      << " does not have a field named " << access.member_name();
             }
             case Value::Kind::ChoiceType: {
-              const ChoiceType& choice = cast<ChoiceType>(*type);
+              const auto& choice = cast<ChoiceType>(*type);
               std::optional<Nonnull<const Value*>> parameter_types =
                   choice.FindAlternative(access.member_name());
               if (!parameter_types.has_value()) {
@@ -2339,8 +2338,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
               return Success();
             }
             case Value::Kind::NominalClassType: {
-              const NominalClassType& class_type =
-                  cast<NominalClassType>(*type);
+              const auto& class_type = cast<NominalClassType>(*type);
               CARBON_ASSIGN_OR_RETURN(
                   auto type_member,
                   FindMixedMemberAndType(
@@ -2474,7 +2472,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
         access.set_impl(impl);
       }
 
-      auto SubstituteIntoMemberType = [&]() {
+      auto substitute_into_member_type = [&]() {
         Nonnull<const Value*> member_type = &member_name.member().type();
         if (member_name.interface()) {
           Nonnull<const InterfaceType*> iface_type = *member_name.interface();
@@ -2494,7 +2492,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                    : DeclarationKind::VariableDeclaration) {
         case DeclarationKind::VariableDeclaration:
           if (has_instance) {
-            access.set_static_type(SubstituteIntoMemberType());
+            access.set_static_type(substitute_into_member_type());
             access.set_value_category(access.object().value_category());
             return Success();
           }
@@ -2506,14 +2504,14 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
             CARBON_CHECK(!has_instance || is_instance_member ||
                          !member_name.base_type().has_value())
                 << "vacuous compound member access";
-            access.set_static_type(SubstituteIntoMemberType());
+            access.set_static_type(substitute_into_member_type());
             access.set_value_category(ValueCategory::Let);
             return Success();
           }
           break;
         }
         case DeclarationKind::AssociatedConstantDeclaration:
-          access.set_static_type(SubstituteIntoMemberType());
+          access.set_static_type(substitute_into_member_type());
           access.set_value_category(access.object().value_category());
           return Success();
         default:
@@ -2899,7 +2897,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
           // TODO: Remove Print special casing once we have variadics or
           // overloads. Here, that's the name Print instead of __intrinsic_print
           // in errors.
-          if (args.size() < 1 || args.size() > 2) {
+          if (args.empty() || args.size() > 2) {
             return ProgramError(e->source_loc())
                    << "Print takes 1 or 2 arguments, received " << args.size();
           }
@@ -3472,9 +3470,10 @@ auto TypeChecker::TypeCheckPattern(
         }
         CARBON_RETURN_IF_ERROR(TypeCheckPattern(
             field, expected_field_type, impl_scope, enclosing_value_category));
-        if (trace_stream_)
+        if (trace_stream_) {
           **trace_stream_ << "finished checking tuple pattern field " << *field
                           << "\n";
+        }
         field_types.push_back(&field->static_type());
       }
       tuple.set_static_type(arena_->New<TupleValue>(std::move(field_types)));
@@ -3494,7 +3493,7 @@ auto TypeChecker::TypeCheckPattern(
         return ProgramError(alternative.source_loc())
                << "alternative pattern does not name a choice type.";
       }
-      const ChoiceType& choice_type = cast<ChoiceType>(*type);
+      const auto& choice_type = cast<ChoiceType>(*type);
       if (expected) {
         CARBON_RETURN_IF_ERROR(ExpectType(alternative.source_loc(),
                                           "alternative pattern", &choice_type,
@@ -3987,8 +3986,9 @@ auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
     function_scope.AddParent(&impl_scope);
     BringImplsIntoScope(cast<FunctionType>(f->static_type()).impl_bindings(),
                         function_scope);
-    if (trace_stream_)
+    if (trace_stream_) {
       **trace_stream_ << function_scope;
+    }
     CARBON_RETURN_IF_ERROR(TypeCheckStmt(*f->body(), function_scope));
     if (!f->return_term().is_omitted()) {
       CARBON_RETURN_IF_ERROR(
@@ -4395,7 +4395,7 @@ auto TypeChecker::CheckImplIsDeducible(
     SourceLocation source_loc, Nonnull<const Value*> impl_type,
     Nonnull<const InterfaceType*> impl_iface,
     llvm::ArrayRef<Nonnull<const GenericBinding*>> deduced_bindings,
-    const ImplScope& impl_scope) -> ErrorOr<Success> {
+    const ImplScope& /*impl_scope*/) -> ErrorOr<Success> {
   ArgumentDeduction deduction(source_loc, "impl", deduced_bindings,
                               trace_stream_);
   CARBON_RETURN_IF_ERROR(deduction.Deduce(impl_type, impl_type,
@@ -4413,7 +4413,7 @@ auto TypeChecker::CheckImplIsDeducible(
 auto TypeChecker::CheckImplIsComplete(Nonnull<const InterfaceType*> iface_type,
                                       Nonnull<const ImplDeclaration*> impl_decl,
                                       Nonnull<const Value*> self_type,
-                                      Nonnull<const Witness*> self_witness,
+                                      Nonnull<const Witness*> /*self_witness*/,
                                       Nonnull<const Witness*> iface_witness,
                                       const ImplScope& impl_scope)
     -> ErrorOr<Success> {
@@ -4728,7 +4728,7 @@ auto TypeChecker::TypeCheckChoiceDeclaration(
   return Success();
 }
 
-static bool IsValidTypeForAliasTarget(Nonnull<const Value*> type) {
+static auto IsValidTypeForAliasTarget(Nonnull<const Value*> type) -> bool {
   switch (type->kind()) {
     case Value::Kind::IntValue:
     case Value::Kind::FunctionValue:

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -40,7 +40,7 @@ class TypeChecker {
   // Construct a type that is the same as `type` except that occurrences
   // of type variables (aka. `GenericBinding` and references to `ImplBinding`)
   // are replaced by their corresponding type or witness in `dict`.
-  auto Substitute(const Bindings& dict, Nonnull<const Value*> type) const
+  auto Substitute(const Bindings& bindings, Nonnull<const Value*> type) const
       -> Nonnull<const Value*>;
 
   // If `impl` can be an implementation of interface `iface` for the given
@@ -62,7 +62,7 @@ class TypeChecker {
   auto FindMixedMemberAndType(SourceLocation source_loc,
                               const std::string_view& name,
                               llvm::ArrayRef<Nonnull<Declaration*>> members,
-                              const Nonnull<const Value*> enclosing_type)
+                              Nonnull<const Value*> enclosing_type)
       -> ErrorOr<std::optional<
           std::pair<Nonnull<const Value*>, Nonnull<const Declaration*>>>>;
 
@@ -302,7 +302,7 @@ class TypeChecker {
 
   // Type check all the members of the implementation.
   auto TypeCheckImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,
-                                const ImplScope& impl_scope)
+                                const ImplScope& enclosing_scope)
       -> ErrorOr<Success>;
 
   // This currently does nothing, but perhaps that will change in the future.

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -123,7 +123,7 @@ class Value {
 
 // Returns whether the fully-resolved kind that this value will eventually have
 // is currently unknown, because it depends on a generic parameter.
-inline bool IsValueKindDependent(Nonnull<const Value*> type) {
+inline auto IsValueKindDependent(Nonnull<const Value*> type) -> bool {
   return type->kind() == Value::Kind::VariableType ||
          type->kind() == Value::Kind::AssociatedConstant;
 }
@@ -356,8 +356,8 @@ class AlternativeConstructorValue : public Value {
   AlternativeConstructorValue(std::string_view alt_name,
                               std::string_view choice_name)
       : Value(Kind::AlternativeConstructorValue),
-        alt_name_(std::move(alt_name)),
-        choice_name_(std::move(choice_name)) {}
+        alt_name_(alt_name),
+        choice_name_(choice_name) {}
 
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::AlternativeConstructorValue;
@@ -377,8 +377,8 @@ class AlternativeValue : public Value {
   AlternativeValue(std::string_view alt_name, std::string_view choice_name,
                    Nonnull<const Value*> argument)
       : Value(Kind::AlternativeValue),
-        alt_name_(std::move(alt_name)),
-        choice_name_(std::move(choice_name)),
+        alt_name_(alt_name),
+        choice_name_(choice_name),
         argument_(argument) {}
 
   static auto classof(const Value* value) -> bool {
@@ -402,7 +402,7 @@ class TupleValue : public Value {
   static auto Empty() -> Nonnull<const TupleValue*> {
     static const TupleValue empty =
         TupleValue(std::vector<Nonnull<const Value*>>());
-    return Nonnull<const TupleValue*>(&empty);
+    return static_cast<Nonnull<const TupleValue*>>(&empty);
   }
 
   explicit TupleValue(std::vector<Nonnull<const Value*>> elements)
@@ -795,7 +795,6 @@ class ConstraintType : public Value {
     Nonnull<const Value*> context;
   };
 
- public:
   explicit ConstraintType(Nonnull<const GenericBinding*> self_binding,
                           std::vector<ImplConstraint> impl_constraints,
                           std::vector<EqualityConstraint> equality_constraints,

--- a/toolchain/lexer/token_kind_test.cpp
+++ b/toolchain/lexer/token_kind_test.cpp
@@ -19,7 +19,7 @@ using ::testing::MatchesRegex;
 // We restrict symbols to punctuation characters that are expected to be widely
 // available on modern keyboards used for programming.
 constexpr llvm::StringLiteral SymbolRegex =
-    "[\\[\\]{}!@#%^&*()/?\\\\|;:.,<>=+~-]+";
+    R"([\[\]{}!@#%^&*()/?\\|;:.,<>=+~-]+)";
 
 // We restrict keywords to be lowercase ASCII letters and underscores.
 constexpr llvm::StringLiteral KeywordRegex = "[a-z_]+";

--- a/toolchain/semantics/node_ref.h
+++ b/toolchain/semantics/node_ref.h
@@ -16,7 +16,7 @@ namespace Carbon::Semantics {
 struct NodeStoreIndex {
   explicit NodeStoreIndex(int32_t index) : index(index) {}
 
-  operator int32_t() const { return index; }
+  explicit operator int32_t() const { return index; }
 
   int32_t index;
 };


### PR DESCRIPTION
This does some more work to the run_clang_tidy.py wrapper script, and runs an example pass.

"mostly" because there's still an issue within the proto fuzzer that it can't find "port/protobuf.h", i.e. https://github.com/google/libprotobuf-mutator/tree/master/port, but I'm still hesitant to add an include path there.