### PR TITLE
Manual clang-tidy fixes

### DIFF
--- a/common/string_helpers.cpp
+++ b/common/string_helpers.cpp
@@ -197,7 +197,7 @@ auto ParseBlockStringLiteral(llvm::StringRef source, const int hashtag_num)
 }
 
 auto StringRefContainsPointer(llvm::StringRef ref, const char* ptr) -> bool {
-  auto le = std::less_equal<const char*>();
+  auto le = std::less_equal<>();
   return le(ref.begin(), ptr) && le(ptr, ref.end());
 }
 

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -227,7 +227,7 @@ auto GetName(const Declaration& declaration)
     case DeclarationKind::ImplDeclaration:
       return std::nullopt;
     case DeclarationKind::SelfDeclaration:
-      return cast<SelfDeclaration>(declaration).name();
+      return SelfDeclaration::name();
     case DeclarationKind::AliasDeclaration: {
       return cast<AliasDeclaration>(declaration).name();
     }

--- a/explorer/fuzzing/ast_to_proto_test.cpp
+++ b/explorer/fuzzing/ast_to_proto_test.cpp
@@ -102,7 +102,7 @@ TEST(AstToProtoTest, SetsAllProtoFields) {
   Carbon::Fuzzing::CompilationUnit merged_proto;
   for (const llvm::StringRef f : *carbon_files) {
     Carbon::Arena arena;
-    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*trace=*/false);
+    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*parser_debug=*/false);
     if (ast.ok()) {
       merged_proto.MergeFrom(AstToProto(*ast));
     }

--- a/explorer/fuzzing/fuzzverter.cpp
+++ b/explorer/fuzzing/fuzzverter.cpp
@@ -71,7 +71,7 @@ static auto CarbonToTextProto(std::string_view input_file_name,
     -> ErrorOr<Success> {
   Carbon::Arena arena;
   const ErrorOr<AST> ast = Carbon::Parse(&arena, input_file_name,
-                                         /*trace=*/false);
+                                         /*parser_debug=*/false);
   if (!ast.ok()) {
     return ErrorBuilder() << "Parsing failed: " << ast.error().message();
   }

--- a/explorer/fuzzing/proto_to_carbon_test.cpp
+++ b/explorer/fuzzing/proto_to_carbon_test.cpp
@@ -31,7 +31,7 @@ TEST(ProtoToCarbonTest, Roundtrip) {
   int parsed_ok_count = 0;
   for (const llvm::StringRef f : *carbon_files) {
     Carbon::Arena arena;
-    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*trace=*/false);
+    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*parser_debug=*/false);
     if (ast.ok()) {
       ++parsed_ok_count;
       const std::string source_from_proto = ProtoToCarbon(AstToProto(*ast));
@@ -39,7 +39,7 @@ TEST(ProtoToCarbonTest, Roundtrip) {
                    << "Carbon file: " << f << ", source from proto:\n"
                    << source_from_proto);
       const ErrorOr<AST> ast_from_proto = Carbon::ParseFromString(
-          &arena, f, source_from_proto, /*trace=*/false);
+          &arena, f, source_from_proto, /*parser_debug=*/false);
 
       if (ast_from_proto.ok()) {
         EXPECT_EQ(AstToString(*ast), AstToString(*ast_from_proto));

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -1101,7 +1101,7 @@ class TypeChecker::ConstraintTypeBuilder {
         return i;
       }
     }
-    impl_constraints_.push_back(std::move(impl));
+    impl_constraints_.push_back(impl);
     return impl_constraints_.size() - 1;
   }
 
@@ -1142,7 +1142,7 @@ class TypeChecker::ConstraintTypeBuilder {
                << "  " << rewrite.replacement->value();
       }
     }
-    rewrite_constraints_.push_back(std::move(rewrite));
+    rewrite_constraints_.push_back(rewrite);
     return Success();
   }
 
@@ -1153,7 +1153,7 @@ class TypeChecker::ConstraintTypeBuilder {
         return;
       }
     }
-    lookup_contexts_.push_back(std::move(context));
+    lookup_contexts_.push_back(context);
   }
 
   // Adds all the constraints from another constraint type. The given value

--- a/explorer/syntax/parse_test.cpp
+++ b/explorer/syntax/parse_test.cpp
@@ -23,8 +23,8 @@ fn Foo() {}
 
 TEST(ParseTest, ParseFromString) {
   Arena arena;
-  ErrorOr<AST> parse_result =
-      ParseFromString(&arena, "file.carbon", FileContents, /*trace=*/false);
+  ErrorOr<AST> parse_result = ParseFromString(
+      &arena, "file.carbon", FileContents, /*parser_debug=*/false);
   ASSERT_TRUE(parse_result.ok());
   EXPECT_EQ(parse_result->declarations.size(), 1);
 }

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -98,6 +98,7 @@ cc_library(
         ":matcher",
         "@llvm-project//clang:ast_matchers",
         "@llvm-project//clang:type_nodes_gen",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/migrate_cpp/cpp_refactoring/var_decl.cpp
+++ b/migrate_cpp/cpp_refactoring/var_decl.cpp
@@ -5,6 +5,7 @@
 #include "migrate_cpp/cpp_refactoring/var_decl.h"
 
 #include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/Support/FormatVariadic.h"
 
 namespace cam = ::clang::ast_matchers;
 
@@ -54,7 +55,8 @@ auto VarDecl::GetTypeStr(const clang::VarDecl& decl) -> std::string {
     } else if (range_str.empty()) {
       segments.push_back({type_loc_class, qual_str});
     } else {
-      segments.push_back({type_loc_class, qual_str + " " + range_str});
+      segments.push_back(
+          {type_loc_class, llvm::formatv("{0} {1}", qual_str, range_str)});
     }
 
     type_loc = type_loc.getNextTypeLoc();

--- a/toolchain/semantics/nodes/function.h
+++ b/toolchain/semantics/nodes/function.h
@@ -20,7 +20,7 @@ class Function {
   static constexpr NodeKind Kind = NodeKind::Function;
 
   Function(ParseTree::Node node, NodeId id, llvm::SmallVector<NodeRef> body)
-      : node_(node), id_(id), body_(body) {}
+      : node_(node), id_(id), body_(std::move(body)) {}
 
   void Print(
       llvm::raw_ostream& out, int indent,


### PR DESCRIPTION
Note, not trying to address every last error, just some obvious/easy ones.

```
/usr/local/google/home/jperkins/dev/carbon-lang/common/string_helpers.cpp:200:13: warning: prefer transparent functors 'less_equal<>' [modernize-use-transparent-functors]
  auto le = std::less_equal<const char*>();
            ^
/usr/local/google/home/jperkins/dev/carbon-lang/toolchain/semantics/nodes/function.h:22:45: warning: pass by value and use std::move [modernize-pass-by-value]
  Function(ParseTree::Node node, NodeId id, llvm::SmallVector<NodeRef> body)
                                            ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/ast/declaration.cpp:230:14: warning: static member accessed through instance [readability-static-accessed-through-instance]
      return cast<SelfDeclaration>(declaration).name();
             ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/interpreter/type_checker.cpp:1104:33: warning: std::move of the variable 'impl' of the trivially-copyable type 'ConstraintType::ImplConstraint' has no effect [performance-move-const-arg]
    impl_constraints_.push_back(std::move(impl));
                                ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/interpreter/type_checker.cpp:1145:36: warning: std::move of the variable 'rewrite' of the trivially-copyable type 'ConstraintType::RewriteConstraint' has no effect [performance-move-const-arg]
    rewrite_constraints_.push_back(std::move(rewrite));
                                   ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/interpreter/type_checker.cpp:1156:32: warning: std::move of the variable 'context' of the trivially-copyable type 'ConstraintType::LookupContext' has no effect [performance-move-const-arg]
    lookup_contexts_.push_back(std::move(context));
                               ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/fuzzing/fuzzverter.cpp:74:42: warning: argument name 'trace' in comment does not match parameter name 'parser_debug' [bugprone-argument-comment]
                                         /*trace=*/false);
                                         ^
./explorer/syntax/parse.h:19:17: note: 'parser_debug' declared here
           bool parser_debug) -> ErrorOr<Carbon::AST>;
                ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/fuzzing/proto_to_carbon_test.cpp:34:55: warning: argument name 'trace' in comment does not match parameter name 'parser_debug' [bugprone-argument-comment]
    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*trace=*/false);
                                                      ^
./explorer/syntax/parse.h:19:17: note: 'parser_debug' declared here
           bool parser_debug) -> ErrorOr<Carbon::AST>;
                ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/fuzzing/proto_to_carbon_test.cpp:42:41: warning: argument name 'trace' in comment does not match parameter name 'parser_debug' [bugprone-argument-comment]
          &arena, f, source_from_proto, /*trace=*/false);
                                        ^
./explorer/syntax/parse.h:25:59: note: 'parser_debug' declared here
                     std::string_view file_contents, bool parser_debug)
                                                          ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/syntax/parse_test.cpp:27:60: warning: argument name 'trace' in comment does not match parameter name 'parser_debug' [bugprone-argument-comment]
      ParseFromString(&arena, "file.carbon", FileContents, /*trace=*/false);
                                                           ^
./explorer/syntax/parse.h:25:59: note: 'parser_debug' declared here
                     std::string_view file_contents, bool parser_debug)
                                                          ^
/usr/local/google/home/jperkins/dev/carbon-lang/migrate_cpp/cpp_refactoring/var_decl.cpp:57:58: warning: string concatenation results in allocation of unnecessary temporary strings; consider using 'operator+=' or 'string::append()' instead [performance-inefficient-string-concatenation]
      segments.push_back({type_loc_class, qual_str + " " + range_str});
                                                         ^
/usr/local/google/home/jperkins/dev/carbon-lang/explorer/fuzzing/ast_to_proto_test.cpp:105:55: warning: argument name 'trace' in comment does not match parameter name 'parser_debug' [bugprone-argument-comment]
    const ErrorOr<AST> ast = Carbon::Parse(&arena, f, /*trace=*/false);
                                                      ^
./explorer/syntax/parse.h:19:17: note: 'parser_debug' declared here
           bool parser_debug) -> ErrorOr<Carbon::AST>;
                ^
```