### PR TITLE
Modify `package` in the README.md to mark unreviewed ideas as provisional.

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2154,7 +2154,7 @@ default package.
 
 > **Note:** This is provisional, designs for making the package name optional
 > have not been through the proposal process yet. See
-> [#2323](https://github.com/carbon-language/carbon-lang/issues/2323).
+> [#2001](https://github.com/carbon-language/carbon-lang/issues/2001).
 
 After the package declaration, files may include `import` declarations. These
 include the package name and optionally `library` followed by the library name.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2122,15 +2122,15 @@ package Geometry library "Shapes" api;
 
 Parts of this declaration may be omitted:
 
--   If the library keyword is not specified, as in `package Geometry api;`, this
-    file contributes to the default library.
+-   If the package name is omitted, as in `package library "Main" api;`, the
+    file contributes to the default package. No other package may import from
+    the default package.
 
     -   **Note:** This is provisional, no design has been through the proposal
         process yet.
 
--   If the package name is omitted, as in `package library "Main" api;`, the
-    file contributes to the default package. No other package may import from
-    the default package.
+-   If the library keyword is not specified, as in `package Geometry api;`, this
+    file contributes to the default library.
 
 A program need not use the default package, but if it does, it should contain
 the entry-point function. By default, the entry-point function is `Run` from the

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2103,6 +2103,11 @@ to coordinate to avoid name conflicts, but not across packages.
 
 ### Package declaration
 
+> **Note:** This is provisional, designs for a default package, making the
+> package name optional, and omitting the `package` declaration have not been
+> through the proposal process yet. See
+> [#2323](https://github.com/carbon-language/carbon-lang/issues/2323).
+
 Files start with an optional package declaration, consisting of:
 
 -   the `package` keyword introducer,
@@ -2129,17 +2134,11 @@ Parts of this declaration may be omitted:
 -   If the library keyword is not specified, as in `package Geometry api;`, this
     file contributes to the default library.
 
-    -   **Note:** This is provisional, no design has been through the proposal
-        process yet.
-
 -   If a file has no package declaration at all, it is the `api` file belonging
     to the default package and default library. This is particularly for tests
     and smaller examples. No other library can import this library even from
     within the default package. It can be split across multiple `impl` files
     using a `package impl;` package declaration.
-
-    -   **Note:** This is provisional, no design has been through the proposal
-        process yet.
 
 A program need not use the default package, but if it does, it should contain
 the entry-point function. By default, the entry-point function is `Run` from the
@@ -2152,6 +2151,10 @@ default package.
 >     [#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107)
 
 ### Imports
+
+> **Note:** This is provisional, designs for making the package name optional
+> have not been through the proposal process yet. See
+> [#2323](https://github.com/carbon-language/carbon-lang/issues/2323).
 
 After the package declaration, files may include `import` declarations. These
 include the package name and optionally `library` followed by the library name.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2122,16 +2122,15 @@ package Geometry library "Shapes" api;
 
 Parts of this declaration may be omitted:
 
+-   If the library keyword is not specified, as in `package Geometry api;`, this
+    file contributes to the default library.
+
+    -   **Note:** This is provisional, no design has been through the proposal
+        process yet.
+
 -   If the package name is omitted, as in `package library "Main" api;`, the
     file contributes to the default package. No other package may import from
     the default package.
--   If the library keyword is not specified, as in `package Geometry api;`, this
-    file contributes to the default library.
--   If a file has no package declaration at all, it is the `api` file belonging
-    to the default package and default library. This is particularly for tests
-    and smaller examples. No other library can import this library even from
-    within the default package. It can be split across multiple `impl` files
-    using a `package impl;` package declaration.
 
 A program need not use the default package, but if it does, it should contain
 the entry-point function. By default, the entry-point function is `Run` from the

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2126,11 +2126,20 @@ Parts of this declaration may be omitted:
     file contributes to the default package. No other package may import from
     the default package.
 
+-   If the library keyword is not specified, as in `package Geometry api;`, this
+    file contributes to the default library.
+
     -   **Note:** This is provisional, no design has been through the proposal
         process yet.
 
--   If the library keyword is not specified, as in `package Geometry api;`, this
-    file contributes to the default library.
+-   If a file has no package declaration at all, it is the `api` file belonging
+    to the default package and default library. This is particularly for tests
+    and smaller examples. No other library can import this library even from
+    within the default package. It can be split across multiple `impl` files
+    using a `package impl;` package declaration.
+
+    -   **Note:** This is provisional, no design has been through the proposal
+        process yet.
 
 A program need not use the default package, but if it does, it should contain
 the entry-point function. By default, the entry-point function is `Run` from the


### PR DESCRIPTION
I've filed #2323 to track the design idea for `package`, and #2001 already tracked `import`, but these should be explicitly marked as provisional.