### PR TITLE
Move member types of ConstraintType out to namespace Carbon.

### DIFF
--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -49,13 +49,13 @@ void ImplScope::Add(Nonnull<const Value*> iface,
                     .witness = witness});
 }
 
-void ImplScope::Add(llvm::ArrayRef<ConstraintType::ImplConstraint> impls,
+void ImplScope::Add(llvm::ArrayRef<ImplConstraint> impls,
                     llvm::ArrayRef<Nonnull<const GenericBinding*>> deduced,
                     llvm::ArrayRef<Nonnull<const ImplBinding*>> impl_bindings,
                     Nonnull<const Witness*> witness,
                     const TypeChecker& type_checker) {
   for (size_t i = 0; i != impls.size(); ++i) {
-    ConstraintType::ImplConstraint impl = impls[i];
+    ImplConstraint impl = impls[i];
     Add(impl.interface, deduced, impl.type, impl_bindings,
         type_checker.MakeConstraintWitnessAccess(witness, i), type_checker);
   }
@@ -172,7 +172,7 @@ auto ImplScope::Resolve(Nonnull<const Value*> constraint_type,
 auto ImplScope::VisitEqualValues(
     Nonnull<const Value*> value,
     llvm::function_ref<bool(Nonnull<const Value*>)> visitor) const -> bool {
-  for (Nonnull<const ConstraintType::EqualityConstraint*> eq : equalities_) {
+  for (Nonnull<const EqualityConstraint*> eq : equalities_) {
     if (!eq->VisitEqualValues(value, visitor)) {
       return false;
     }
@@ -279,7 +279,7 @@ void ImplScope::Print(llvm::raw_ostream& out) const {
   for (const Impl& impl : impls_) {
     out << sep << *(impl.type) << " as " << *(impl.interface);
   }
-  for (Nonnull<const ConstraintType::EqualityConstraint*> eq : equalities_) {
+  for (Nonnull<const EqualityConstraint*> eq : equalities_) {
     out << sep;
     llvm::ListSeparator equal(" == ");
     for (Nonnull<const Value*> value : eq->values) {

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -59,7 +59,7 @@ class ImplScope {
   // Adds a list of impl constraints from a constraint type into scope. Any
   // references to `.Self` are expected to have already been substituted for
   // the type implementing the constraint.
-  void Add(llvm::ArrayRef<ConstraintType::ImplConstraint> impls,
+  void Add(llvm::ArrayRef<ImplConstraint> impls,
            llvm::ArrayRef<Nonnull<const GenericBinding*>> deduced,
            llvm::ArrayRef<Nonnull<const ImplBinding*>> impl_bindings,
            Nonnull<const Witness*> witness, const TypeChecker& type_checker);

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -426,13 +426,12 @@ void Value::Print(llvm::raw_ostream& out) const {
       const auto& constraint = cast<ConstraintType>(*this);
       out << "constraint ";
       llvm::ListSeparator combine(" & ");
-      for (const ConstraintType::LookupContext& ctx :
-           constraint.lookup_contexts()) {
+      for (const LookupContext& ctx : constraint.lookup_contexts()) {
         out << combine << *ctx.context;
       }
       out << " where ";
       llvm::ListSeparator sep(" and ");
-      for (const ConstraintType::RewriteConstraint& rewrite :
+      for (const RewriteConstraint& rewrite :
            constraint.rewrite_constraints()) {
         out << sep << ".(";
         PrintNameWithBindings(out, &rewrite.constant->interface().declaration(),
@@ -440,13 +439,12 @@ void Value::Print(llvm::raw_ostream& out) const {
         out << "." << *GetName(rewrite.constant->constant())
             << ") = " << *rewrite.unconverted_replacement;
       }
-      for (const ConstraintType::ImplConstraint& impl :
-           constraint.impl_constraints()) {
+      for (const ImplConstraint& impl : constraint.impl_constraints()) {
         // TODO: Skip cases where `impl.type` is `.Self` and the interface is
         // in `lookup_contexts()`.
         out << sep << *impl.type << " is " << *impl.interface;
       }
-      for (const ConstraintType::EqualityConstraint& equality :
+      for (const EqualityConstraint& equality :
            constraint.equality_constraints()) {
         // TODO: Skip cases matching something in `rewrite_constraints()`.
         out << sep;

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -732,7 +732,15 @@ class InterfaceType : public Value {
   Nonnull<const Bindings*> bindings_ = Bindings::None();
 };
 
-// A collection of values that are known to be the same.
+// A constraint that requires implementation of an interface.
+struct ImplConstraint {
+  // The type that is required to implement the interface.
+  Nonnull<const Value*> type;
+  // The interface that is required to be implemented.
+  Nonnull<const InterfaceType*> interface;
+};
+
+// A constraint that a collection of values are known to be the same.
 struct EqualityConstraint {
   // Visit the values in this equality constraint that are a single step away
   // from the given value according to this equality constraint. That is: if
@@ -762,6 +770,11 @@ struct RewriteConstraint {
   Nonnull<const Value*> converted_replacement;
 };
 
+// A context in which we might look up a name.
+struct LookupContext {
+  Nonnull<const Value*> context;
+};
+
 // A type-of-type for an unknown constrained type.
 //
 // These types are formed by the `&` operator that combines constraints and by
@@ -780,21 +793,6 @@ struct RewriteConstraint {
 // `VariableType` naming the `self_binding`.
 class ConstraintType : public Value {
  public:
-  // A required implementation of an interface.
-  struct ImplConstraint {
-    Nonnull<const Value*> type;
-    Nonnull<const InterfaceType*> interface;
-  };
-
-  using RewriteConstraint = Carbon::RewriteConstraint;
-
-  using EqualityConstraint = Carbon::EqualityConstraint;
-
-  // A context in which we might look up a name.
-  struct LookupContext {
-    Nonnull<const Value*> context;
-  };
-
   explicit ConstraintType(Nonnull<const GenericBinding*> self_binding,
                           std::vector<ImplConstraint> impl_constraints,
                           std::vector<EqualityConstraint> equality_constraints,


### PR DESCRIPTION
We had already moved two of these out because they're more generally applicable. Move the other two out for consistency and remove the member names.

As requested in review of #2321.