### PR TITLE
Add support for 'auto' in global var declarations

### DIFF
--- a/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon
@@ -8,7 +8,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon:[[@LINE+1]]: Expected expression for variable type
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_invalid_var_expression.carbon:[[@LINE+1]]: Expected initializer for auto type
 var a: auto;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/global_variable/global_auto.carbon
+++ b/explorer/testdata/global_variable/global_auto.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test global variable initialization and read.
+
+var zero: auto = 0;
+
+fn Main() -> i32 {
+  return zero;
+}
+


### PR DESCRIPTION
Only ExpressionPattern was allowed as a binding up to this point. 

This PR adds support for AutoPattern to global variable declarations.

Closes #1093
