### PR TITLE
Explorer: add class qualified initialization

### DIFF
--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -124,10 +124,14 @@ class RewritableMixin : public Base {
 // A FieldInitializer represents the initialization of a single struct field.
 class FieldInitializer {
  public:
-  FieldInitializer(std::string name, Nonnull<Expression*> expression)
-      : name_(std::move(name)), expression_(expression) {}
+  FieldInitializer(std::string name, Nonnull<Expression*> expression,
+                   std::optional<std::string> qualifier = {})
+      : name_(std::move(name)),
+        qualifier_(std::move(qualifier)),
+        expression_(expression) {}
 
   auto name() const -> const std::string& { return name_; }
+  auto qualifier() const -> std::optional<std::string> { return qualifier_; }
 
   auto expression() const -> const Expression& { return *expression_; }
   auto expression() -> Expression& { return *expression_; }
@@ -135,6 +139,9 @@ class FieldInitializer {
  private:
   // The field name. Cannot be empty.
   std::string name_;
+
+  // The field qualifier.
+  std::optional<std::string> qualifier_;
 
   // The expression that initializes the field.
   Nonnull<Expression*> expression_;

--- a/explorer/ast/member.h
+++ b/explorer/ast/member.h
@@ -23,6 +23,9 @@ struct NamedValue {
 
   // The field's value.
   Nonnull<const Value*> value;
+
+  // The field's qualifier.
+  std::optional<std::string> qualifier = {};
 };
 
 // A member of a type.

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -703,10 +703,10 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
           const auto& destination_struct_type =
               cast<StructType>(*destination_type);
           std::vector<NamedValue> new_elements;
-          for (const auto& [field_name, field_type] :
+          for (const auto& [field_name, field_type, field_qualifier] :
                destination_struct_type.fields()) {
             std::optional<Nonnull<const Value*>> old_value =
-                struct_val.FindField(field_name);
+                struct_val.FindField(field_name, field_qualifier);
             CARBON_ASSIGN_OR_RETURN(
                 Nonnull<const Value*> val,
                 Convert(*old_value, field_type, source_loc));

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -335,6 +335,10 @@ class TypeChecker {
   auto FieldTypes(const NominalClassType& class_type) const
       -> std::vector<NamedValue>;
 
+  // Returns the field names and types of the class and its parents.
+  auto FieldTypesWithParents(const NominalClassType& class_type) const
+      -> std::vector<NamedValue>;
+
   // Returns true if source_fields and destination_fields contain the same set
   // of names, and each value in source_fields is implicitly convertible to
   // the corresponding value in destination_fields. All values in both arguments

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -321,7 +321,8 @@ class StructValue : public Value {
 
   // Returns the value of the field named `name` in this struct, or
   // nullopt if there is no such field.
-  auto FindField(std::string_view name) const
+  auto FindField(std::string_view name,
+                 std::optional<std::string> qualifier = {}) const
       -> std::optional<Nonnull<const Value*>>;
 
  private:

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -97,6 +97,7 @@
 %token <std::string> sized_type_literal
 %token <std::string> string_literal
 %type <std::string> designator
+%type <std::pair<std::string, std::string>> qualified_designator
 %type <ImplKind> impl_kind
 %type <Nonnull<Expression*>> impl_type
 %type <std::pair<LibraryName, bool>> package_directive
@@ -723,7 +724,13 @@ if_expression:
 expression:
   if_expression
 ;
-designator: PERIOD identifier { $$ = $2; }
+designator:
+  PERIOD identifier
+    { $$ = $2; }
+;
+qualified_designator:
+  PERIOD LEFT_PARENTHESIS identifier PERIOD identifier RIGHT_PARENTHESIS
+    { $$ = std::make_pair($3, $5); }
 ;
 paren_expression: paren_expression_base
     { $$ = ExpressionFromParenContents(arena, context.source_loc(), $1); }
@@ -761,10 +768,17 @@ struct_literal:
 struct_literal_contents:
   designator EQUAL expression
     { $$ = {FieldInitializer($1, $3)}; }
+|  qualified_designator EQUAL expression
+    { $$ = {FieldInitializer($1.second, $3, $1.first)}; }
 | struct_literal_contents COMMA designator EQUAL expression
     {
       $$ = std::move($1);
       $$.push_back(FieldInitializer($3, $5));
+    }
+| struct_literal_contents COMMA qualified_designator EQUAL expression
+    {
+      $$ = std::move($1);
+      $$.push_back(FieldInitializer($3.second, $5, $3.first));
     }
 ;
 

--- a/explorer/testdata/class/fail_incorrect_qualification.carbon
+++ b/explorer/testdata/class/fail_incorrect_qualification.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+base class A {
+  var var_a: i32;
+}
+
+base class B extends A {
+  var var_b: i32;
+}
+
+fn Main() -> i32 {
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_incorrect_qualification.carbon:[[@LINE+1]]: type error in name binding: '{.var_a: i32, .A.var_b: i32}' is not implicitly convertible to 'class B'
+  var b: B = {.var_a=1, .(A.var_b)=2};
+  return 0;
+}

--- a/explorer/testdata/class/qualified_initialization.carbon
+++ b/explorer/testdata/class/qualified_initialization.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: var_a=1
+// CHECK:STDOUT: var_b=2
+// CHECK:STDOUT: var_a=3
+// CHECK:STDOUT: var_b=4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class A {
+  var var_a: i32;
+}
+
+base class B extends A {
+  var var_b: i32;
+}
+
+fn Main() -> i32 {
+  var b: B = {.(A.var_a)=1, .(B.var_b)=2};
+  Print("var_a={0}", b.var_a);
+  Print("var_b={0}", b.var_b);
+
+  b = {.(A.var_a)=3, .(B.var_b)=4};
+  Print("var_a={0}", b.var_a);
+  Print("var_b={0}", b.var_b);
+  return 0;
+}


### PR DESCRIPTION
Add support for qualified initialization using the form `= {.(C.attr) = 1}` to allow for disambiguation

This aims at implementing a way to:
* address ambiguity in class initialization when members from parent(s) have identical names
* make assignments more expressive

Relates to https://github.com/carbon-language/carbon-lang/pull/1946#discussion_r997595116
Looking at the design again, it seems we haven't defined how this would work, except if I missed it.