### PR TITLE
Compute a fixed point of rewrite constraints.

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -723,7 +723,8 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
           return arena_->New<NominalClassValue>(inst_dest, value);
         }
         default: {
-          CARBON_CHECK(IsValueKindDependent(destination_type))
+          CARBON_CHECK(IsValueKindDependent(destination_type) ||
+                       isa<TypeType, ConstraintType>(destination_type))
               << "Can't convert value " << *value << " to type "
               << *destination_type;
           return value;
@@ -758,7 +759,8 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
           break;
         }
         default: {
-          CARBON_CHECK(IsValueKindDependent(destination_type))
+          CARBON_CHECK(IsValueKindDependent(destination_type) ||
+                       isa<TypeType, ConstraintType>(destination_type))
               << "Can't convert value " << *value << " to type "
               << *destination_type;
           return value;

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -393,6 +393,12 @@ class TypeChecker {
                        Nonnull<const Value*> actual,
                        const ImplScope& impl_scope) const -> ErrorOr<Success>;
 
+  // Implementation of Substitute. Does not check that bindings are nonempty,
+  // nor does it trace its progress.
+  auto SubstituteImpl(const Bindings& bindings,
+                      Nonnull<const Value*> type) const
+      -> Nonnull<const Value*>;
+
   // The name of a builtin interface, with any arguments.
   struct BuiltinInterfaceName {
     Builtins::Builtin builtin;

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -393,8 +393,13 @@ class TypeChecker {
                        Nonnull<const Value*> actual,
                        const ImplScope& impl_scope) const -> ErrorOr<Success>;
 
-  // Implementation of Substitute. Does not check that bindings are nonempty,
-  // nor does it trace its progress.
+  // Rebuild a value in the current type-checking context. Applies any rewrites
+  // that are in scope and attempts to resolve associated constants using impls
+  // that have been declared since the value was formed.
+  auto RebuildValue(Nonnull<const Value*> value) const -> Nonnull<const Value*>;
+
+  // Implementation of Substitute and RebuildValue. Does not check that
+  // bindings are nonempty, nor does it trace its progress.
   auto SubstituteImpl(const Bindings& bindings,
                       Nonnull<const Value*> type) const
       -> Nonnull<const Value*>;

--- a/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface HasType {
+  let T:! Type;
+}
+
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon:[[@LINE+1]]: 0rewrite of (H).(HasType.T) applies within its own resolved expansion of (H).(HasType.T)*
+fn F[H:! HasType where .T = .T*]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
@@ -12,7 +12,7 @@ interface HasType {
   let T:! Type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon:[[@LINE+1]]: 0rewrite of (H).(HasType.T) applies within its own resolved expansion of (H).(HasType.T)*
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon:[[@LINE+1]]: rewrite of (H).(HasType.T) applies within its own resolved expansion of (H).(HasType.T)*
 fn F[H:! HasType where .T = .T*]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
@@ -32,7 +32,7 @@ fn F[
     .T6 = .T7 and
     .T7 = .T8 and
     .T8 = .T9 and
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T9) applies within its own resolved expansion of (M).(ManyTypes.T9)
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T4) applies within its own resolved expansion of (M).(ManyTypes.T4)
     .T9 = .T0]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
@@ -32,7 +32,7 @@ fn F[
     .T6 = .T7 and
     .T7 = .T8 and
     .T8 = .T9 and
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: 9rewrite of (M).(ManyTypes.T9) applies within its own resolved expansion of (M).(ManyTypes.T9)
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T9) applies within its own resolved expansion of (M).(ManyTypes.T9)
     .T9 = .T0]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! Type;
+  let T1:! Type;
+  let T2:! Type;
+  let T3:! Type;
+  let T4:! Type;
+  let T5:! Type;
+  let T6:! Type;
+  let T7:! Type;
+  let T8:! Type;
+  let T9:! Type;
+}
+
+fn F[
+  M:! ManyTypes where
+    .T0 = .T1 and
+    .T1 = .T2 and
+    .T2 = .T3 and
+    .T3 = .T4 and
+    .T4 = .T5 and
+    .T5 = .T6 and
+    .T6 = .T7 and
+    .T7 = .T8 and
+    .T8 = .T9 and
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: 9rewrite of (M).(ManyTypes.T9) applies within its own resolved expansion of (M).(ManyTypes.T9)
+    .T9 = .T0]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon
+++ b/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface TwoTypes {
+  let T:! Type;
+  let U:! Type;
+}
+
+// Attempting to fully resolve the replacement for `.T` would never create a
+// situation where `.T`'s expansion involves `.T`. Ensure we catch this anyway.
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
+fn F[X:! TwoTypes where .T = .U and .U = .U*]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon
+++ b/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface TwoTypes {
+  let T:! Type;
+  let U:! Type;
+}
+
+// Attempting to fully resolve the replacement for `.T` would never create a
+// situation where `.T`'s expansion involves `.T`. Ensure we catch this anyway.
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
+fn F[X:! TwoTypes where .U = .U* and .T = .U]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/assoc_const/resolve_rewrites.carbon
+++ b/explorer/testdata/assoc_const/resolve_rewrites.carbon
@@ -1,0 +1,58 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! Type;
+  let T1:! Type;
+  let T2:! Type;
+  let T3:! Type;
+  let T4:! Type;
+  let T5:! Type;
+  let T6:! Type;
+  let T7:! Type;
+  let T8:! Type;
+  let T9:! Type;
+}
+
+fn F[
+  M:! ManyTypes where
+    .T0 = .T1 and
+    .T1 = .T2 and
+    .T2 = .T3 and
+    .T3 = .T4 and
+    .T4 = .T5 and
+    .T5 = .T6 and
+    .T6 = .T7 and
+    .T7 = .T8 and
+    .T8 = .T9 and
+    .T9 = i32](m: M) -> i32 {
+  var v: M.T0 = 1;
+  return v;
+}
+
+class C {
+  impl as ManyTypes where
+    .T0 = i32 and
+    .T1 = .T0 and
+    .T2 = .T1 and
+    .T3 = .T2 and
+    .T4 = .T3 and
+    .T5 = .T4 and
+    .T6 = .T5 and
+    .T7 = .T6 and
+    .T8 = .T7 and
+    .T9 = .T8 {}
+}
+
+fn Main() -> i32 {
+  var c: C = {};
+  return F(c);
+}

--- a/explorer/testdata/assoc_const/rewrite_interface_params.carbon
+++ b/explorer/testdata/assoc_const/rewrite_interface_params.carbon
@@ -1,0 +1,46 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface HasTypes {
+  let A:! Type;
+  let B:! Type;
+  let C:! Type;
+  let D:! Type;
+  let E:! Type;
+  let F:! Type;
+}
+
+interface HasParams(A:! Type, B:! Type, C:! Type, D:! Type) {
+  let V:! HasTypes;
+}
+
+// Here we discover that there is a rewrite for `HasParams(...).V` only after
+// substitution converts each one to `HasParam(X, X, X, X).V`.
+fn F[X:! (HasTypes & HasParams(.Self, .Self, .Self, .Self)) where
+       .Self is HasParams(.A, .A, .A, .A) and
+       .Self is HasParams(.B, .B, .B, .B) and
+       .Self is HasParams(.C, .C, .C, .C) and
+       .Self is HasParams(.D, .D, .D, .D) and
+       .Self is HasParams(.E, .E, .E, .E) and
+       .F = .Self.(HasParams(.E, .E, .E, .E).V).A and
+       .E = .Self.(HasParams(.D, .D, .D, .D).V).A and
+       .D = .Self.(HasParams(.C, .C, .C, .C).V).A and
+       .C = .Self.(HasParams(.B, .B, .B, .B).V).A and
+       .B = .Self.(HasParams(.A, .A, .A, .A).V).A and
+       .A = .Self and .V = .Self](x: X) -> X.F { return x; }
+
+impl i32 as HasTypes
+  where .A = .B and .B = .C and .C = .D and .D = .E and .E = .F and .F = i32 {}
+impl i32 as HasParams(i32, i32, i32, i32) where .V = i32 {}
+
+fn Main() -> i32 {
+  return F(0);
+}

--- a/explorer/testdata/assoc_const/rewrite_large_type.carbon
+++ b/explorer/testdata/assoc_const/rewrite_large_type.carbon
@@ -1,0 +1,89 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! Type;
+  let T1:! Type;
+  let T2:! Type;
+  let T3:! Type;
+  let T4:! Type;
+  let T5:! Type;
+  let T6:! Type;
+  let T7:! Type;
+}
+
+interface Splat { fn Op(n: i32) -> Self; }
+impl i32 as Splat {
+  fn Op(n: i32) -> Self { return n; }
+}
+impl forall [T:! Splat] (T, T, T) as Splat {
+  fn Op(n: i32) -> Self {
+    let v: T = T.Op(n);
+    return (v, v, v);
+  }
+}
+
+fn CallSplat(T:! Splat, n: i32) -> T { return T.Op(n); }
+
+fn DoSplat(
+    M:! ManyTypes where
+      .T0 = (.T1, .T1, .T1) and
+      .T1 = (.T2, .T2, .T2) and
+      .T2 = (.T3, .T3, .T3) and
+      .T3 = (.T4, .T4, .T4) and
+      .T4 = (.T5, .T5, .T5) and
+      .T5 = (.T6, .T6, .T6) and
+      .T6 = (.T7, .T7, .T7) and
+      .T7 = i32,
+    n: M.T7) -> M.T0 {
+  return CallSplat(M.T0, n);
+}
+
+interface First { fn Op[me: Self]() -> i32; }
+impl i32 as First {
+  fn Op[me: Self]() -> i32 { return me; }
+}
+impl forall [T:! First] (T, T, T) as First {
+  fn Op[me: Self]() -> i32 {
+    let (a: T, b: T, c: T) = me;
+    return a.Op();
+  }
+}
+
+fn DoFirst(
+    M:! ManyTypes where
+      .T7 = i32 and
+      .T6 = (.T7, .T7, .T7) and
+      .T5 = (.T6, .T6, .T6) and
+      .T4 = (.T5, .T5, .T5) and
+      .T3 = (.T4, .T4, .T4) and
+      .T2 = (.T3, .T3, .T3) and
+      .T1 = (.T2, .T2, .T2) and
+      .T0 = (.T1, .T1, .T1),
+    v: M.T0) -> M.T7 {
+  return v.(First.Op)();
+}
+
+class C {
+  impl as ManyTypes where
+      .T3 = (.T4, .T4, .T4) and
+      .T1 = (.T2, .T2, .T2) and
+      .T4 = (.T5, .T5, .T5) and
+      .T6 = (.T7, .T7, .T7) and
+      .T2 = (.T3, .T3, .T3) and
+      .T7 = i32 and
+      .T5 = (.T6, .T6, .T6) and
+      .T0 = (.T1, .T1, .T1) {}
+}
+
+fn Main() -> i32 {
+  return DoFirst(C, DoSplat(C, 1));
+}


### PR DESCRIPTION
When resolving a constraint type, compute the fixed point of the specified rewrite constraints, as requested by @josh11b in review of #2173 and tentatively agreed as our direction. If no such fixed point exists, detect that situation and diagnose the problem.

The algorithm used here is to iteratively apply all rewrites to each rewrite constraint until either one of them refers to itself, which indicates there's a cycle in the rewrite graph, or the set of rewrites converges.

This algorithm has some pathological inputs in which the runtime can grow exponentially in the size of the input (indeed, the fully-rewritten set of rewrites can grow exponentially in the size of the input, so this is unavoidable), so an iteration limit is also provided.