### PR TITLE
Rephrased all "you" instances into a communal "we"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,7 @@ that we ask all community members to adhere to:
 -   be friendly and patient,
 -   be considerate,
 -   be kind,
--   be careful in the words that you choose,
+-   be careful in the words that we choose,
 -   when we disagree, try to understand why, and
 -   recognize when progress has stopped, and take a step back.
 
@@ -43,14 +43,14 @@ This list isn't exhaustive. Rather, take it in the spirit in which it’s intend
 This code of conduct applies to all spaces managed by the Carbon project. This
 includes chat systems, forums, emails (on lists or between members), issue
 trackers, events, and any other spaces that the community uses for
-communication. It applies to all of your communication and conduct in these
-spaces, including emails, chats, things you say, slides, videos, posters, signs,
-or even t-shirts you display in these spaces.
+communication. It applies to all of our communication and conduct in these
+spaces, including emails, chats, things we say, slides, videos, posters, signs,
+or even t-shirts we display in these spaces.
 
 All community members should help support our standards of acceptable behavior.
 Everyone is encouraged to speak up in response to any behavior that they deem
-inappropriate, threatening, offensive, or harmful. If you believe someone is
-violating the code of conduct, please report it to the
+inappropriate, threatening, offensive, or harmful. If we believe someone is
+violating the code of conduct, we can report it to the
 [conduct team](#conduct-team).
 
 More detailed guidance on how to participate effectively in our community
@@ -68,14 +68,14 @@ spaces:
     our community in a constructive manner, so we can keep a friendly
     atmosphere. This is especially important because many of our communication
     tools on the Internet are low-fidelity and make it difficult to understand
-    each other. Be patient, acknowledge that we are all on a learning journey,
+    each other. Let's be patient, acknowledge that we are all on a learning journey,
     and stay supportive so that we can learn how to collaborate effectively as a
     group.
 
--   **Be considerate.** Your work will be used by other people, and you in turn
-    will depend on the work of others. Any decision you make will affect users
-    and colleagues, and you should take those consequences into account.
-    Remember that we’re a world-wide community, so you might not be
+-   **Be considerate.** Our work will be used by other people, and we in turn
+    will depend on the work of others. Any decision we make will affect users
+    and colleagues, and we should take those consequences into account.
+    Let's remember that we’re a world-wide community, so we might not be
     communicating in someone else’s primary language.
 
 -   **Be kind.** Not all of us will agree all the time, but disagreement is no
@@ -86,7 +86,7 @@ spaces:
     kind when dealing with other members as well as with people outside the
     Carbon community.
 
--   **Be careful in the words that you choose and be kind to others.** Do not
+-   **Be careful in the words that we choose and be kind to others.** We do not
     insult or put down other participants. Harassment and other exclusionary
     behaviors aren’t acceptable. This includes, but is not limited to:
 
@@ -98,26 +98,26 @@ spaces:
     -   Personal insults, especially those using racist or sexist terms.
     -   Unwelcome sexual attention.
     -   Advocating for, or encouraging, any of the above behavior.
-    -   In general, if someone asks you to stop, then stop. Persisting after
+    -   In general, if someone asks us to stop, we should stop. Persisting after
         being asked to stop is considered harassment.
 
--   **When we disagree, try to understand why.** Disagreements, both social and
+-   **When we disagree, we try to understand why.** Disagreements, both social and
     technical, happen all the time, and Carbon is no exception. It is important
     that we resolve disagreements and differing views constructively. Remember
     that we’re different. The strength of the project comes from its varied
     community: people from a wide range of backgrounds. Different people have
     different perspectives on issues. Being unable to understand why someone
-    holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is
-    human to err and blaming each other doesn’t get us anywhere. Instead, focus
+    holds a viewpoint doesn’t mean that they’re wrong. Let's not forget that it is
+    human to err and blaming each other doesn’t get us anywhere. Instead, we focus
     on helping to resolve issues and learning from mistakes.
 
 -   **Recognize when progress has stopped, and take a step back.** Regardless of
-    whether you're trying to resolve a disagreement or anything else, think
-    about whether you're making progress. Sometimes messaging doesn't give time
+    whether we're trying to resolve a disagreement or anything else, we think
+    about whether we're making progress. Sometimes messaging doesn't give time
     to think about a situation fully, and repeating positions can make people
-    defensive. Step back for a few minutes or hours to think through the issue
-    before responding again. Consider pulling in another community member to
-    give a fresh perspective. Maybe meet over VC instead. Switching approaches
+    defensive. We can step back for a few minutes or hours to think through the issue
+    before responding again. We consider pulling in another community member to
+    give a fresh perspective. We may meet over VC instead. Switching approaches
     can help resume progress.
 
 No weapons are allowed at Carbon events. Weapons include, but are not limited
@@ -139,7 +139,7 @@ issue could impact the community's safety, well-being, and inclusivity. It is
 our priority to remain a welcoming community to victims as well as groups
 subjected to systemic marginalization or underrepresentation.
 
-If you have questions, please feel free to ask on Discord,
+In case of questions, we can ask the community on Discord,
 [GitHub](https://github.com/carbon-language/carbon-lang/discussions), or contact
 any member of the conduct team directly.
 
@@ -164,33 +164,33 @@ shared with new members without the permission of the reporter.
 
 ### Reporting conduct
 
-If you believe someone is violating the code of conduct, you can report it
+Whenever we believe someone is violating the code of conduct, we can report it
 several ways, including:
 
 -   Asking for help on
     [#community-help](https://discord.com/channels/655572317891461132/996113200464543804).
     An available moderator will respond privately.
-    -   If you want to privately ask for moderator assistance, direct message a
-        moderator on Discord. Look under the Moderator list for logged in
-        moderators, and click on a moderator's name to send a message.
+    -   If we want to privately, we can ask for moderator assistance, and direct message a
+        moderator on Discord. The Moderator list for logged in
+        moderators is displayed, so we can click on a moderator's name to send a message.
 -   Emailing the [conduct team](#conduct-team) directly at
-    carbon-lang-conduct@googlegroups.com. Bear in mind that
+    carbon-lang-conduct@googlegroups.com. Let's bear in mind that
     [responses may take time](#what-happens-after-contacting-the-conduct-team).
 
 **All reports will be kept confidential.**
 
-Please send reports concerning a member of the conduct team directly to other
+Reports concerning a member of the conduct team should be sent directly to other
 members of the conduct team. This allows discussion of the complaint to more
 easily exclude the concerned member as a [special case](#special-cases).
 
-If you believe anyone is in **physical danger**, please notify appropriate law
-enforcement first. If you are unsure what law enforcement agency is appropriate,
-please include this in your report and we will attempt to notify them.
+Whenever we believe anyone is in **physical danger**, we notify appropriate law
+enforcement first. When we are unsure what law enforcement agency is appropriate,
+we include this in our report and the team will attempt to notify them.
 
-If the violation occurs at an event and requires immediate attention, you can
+If the violation occurs at an event and requires immediate attention, we can
 also reach out to any of the event organizers or staff. Event organizers and
-staff will be prepared to handle the incident and be able to help. If you cannot
-find one of the organizers, the venue staff can locate one for you. Specific
+staff will be prepared to handle the incident and be able to help. When we cannot
+find one of the organizers, the venue staff can locate one for us. Specific
 event information will include detailed contact information for that event. In
 person reports will still be kept confidential exactly as above, but also feel
 free to email the conduct team, anonymously if needed.
@@ -198,23 +198,23 @@ free to email the conduct team, anonymously if needed.
 ### Filing a report
 
 Reports can be as formal or informal as needed for the situation at hand. If
-possible, please include as much information as you can. If you feel
-comfortable, please consider including:
+possible, we include as much information as we can. If we feel
+comfortable, let's consider including:
 
--   Your contact info, so we can get in touch with you if we need to follow up.
+-   Our contact info, so the team can get in touch with us if they need to follow up.
 -   Names -- real, nicknames, or pseudonyms -- of any individuals involved. If
-    there were other witnesses besides you, please try to include them as well.
--   When and where the incident occurred. Please be as specific as possible.
--   Your account of what occurred, including any private chat logs or email.
+    there were other witnesses besides ourselves, we try to include them as well.
+-   When and where the incident occurred. Let's be as specific as possible.
+-   Our account of what occurred, including any private chat logs or email.
 -   Links for any public records, including community discussions.
 -   Any extra context for the incident.
--   If you believe this incident is ongoing.
--   Any other information you believe we should have.
+-   If we believe this incident is ongoing.
+-   Any other information we believe the team should have.
 
 ### What happens after contacting the conduct team?
 
-You will receive a reply from the conduct team acknowledging receipt within 1
-business day, and we will aim to respond much quicker than that.
+We will receive a reply from the conduct team acknowledging receipt within 1
+business day, and the team will aim to respond much quicker than that.
 
 The conduct team will review the incident as soon as possible and try to
 determine:
@@ -241,13 +241,13 @@ decision as to how to respond. Responses may include:
 -   One or more [enforcement actions](#enforcement-action-guidelines).
 -   Involvement of relevant law enforcement if appropriate.
 
-If the situation is not resolved within one week, we’ll respond to the original
+If the situation is not resolved within one week, the team will respond to the original
 reporter with an update and explanation.
 
-Once we’ve determined our response, we will separately contact the original
-reporter and other individuals to let them know what actions, if any, we’ll be
-taking. We will take into account feedback from the individuals involved on the
-appropriateness of our response, but we don’t guarantee we’ll act on it.
+Once the team has determined their response, they will separately contact the original
+reporter and other individuals to let them know what actions, if any, will be
+taken. The conduct team will take into account feedback from the individuals involved on the
+appropriateness of the response, but they don’t guarantee they will act on it.
 
 After any incident, the conduct team will make a report on the situation to the
 Carbon leads. The Carbon leads may choose to make a public statement about the
@@ -261,8 +261,8 @@ have a dedicated conduct team that's separate from the Carbon leads.
 
 Only permanent resolutions, such as bans, or requests for public actions may be
 appealed. To appeal a decision of the conduct team, contact the
-[Carbon leads](docs/project/evolution.md#carbon-leads-1) with your appeal and
-they will review the case.
+[Carbon leads](docs/project/evolution.md#carbon-leads-1) with said appeal and
+the team will review the case.
 
 In general, it is **not** appropriate to appeal a particular decision in public
 areas of GitHub or Discord. Doing so would involve disclosure of information


### PR DESCRIPTION
A higher sense of community, belonging and accountability is achieved when using "we" to talk about us as a community, including when addressing issues. So I suggest to use that phrasing throughout the CoC.  Then, the "we" used in the previous version for the conduct team needed to also be explicited into "conduct team" or "team". So I updated these instances as well.

**Replace this paragraph with a description of what this PR is changing or
adding, and why.**

Closes #ISSUE
