### PR TITLE
explorer: number support for 8bit and 16bit integers

### DIFF
--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -295,6 +295,29 @@ void Expression::Print(llvm::raw_ostream& out) const {
   }
 }
 
+void IntTypeLiteral::PrintType(const SizedTypesType type, llvm::raw_ostream& out) {
+  switch(type) {
+    case SizedTypesType::I32:
+      out << "i32";
+      break;
+    case SizedTypesType::U8:
+      out << "u8";
+      break;
+    case SizedTypesType::I8:
+      out << "i8";
+      break;
+    case SizedTypesType::U16:
+      out << "u16";
+      break;
+    case SizedTypesType::I16:
+      out << "i16";
+      break;
+    default:
+      out << "<unknown sized type>";
+      break;
+  }
+}
+
 void Expression::PrintID(llvm::raw_ostream& out) const {
   switch (kind()) {
     case ExpressionKind::IdentifierExpression:
@@ -313,7 +336,7 @@ void Expression::PrintID(llvm::raw_ostream& out) const {
       out << "bool";
       break;
     case ExpressionKind::IntTypeLiteral:
-      out << "i32";
+      IntTypeLiteral::PrintType(cast<IntTypeLiteral>(*this).type(), out);
       break;
     case ExpressionKind::StringLiteral:
       out << "\"";

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -295,8 +295,9 @@ void Expression::Print(llvm::raw_ostream& out) const {
   }
 }
 
-void IntTypeLiteral::PrintType(const SizedTypesType type, llvm::raw_ostream& out) {
-  switch(type) {
+void IntTypeLiteral::PrintType(const SizedTypesType type,
+                               llvm::raw_ostream& out) {
+  switch (type) {
     case SizedTypesType::I32:
       out << "i32";
       break;

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -140,6 +140,14 @@ class FieldInitializer {
   Nonnull<Expression*> expression_;
 };
 
+enum class SizedTypesType {
+  I32,
+  U8,
+  I8,
+  U16,
+  I16
+};
+
 enum class Operator {
   Add,
   AddressOf,
@@ -682,12 +690,16 @@ class BoolTypeLiteral : public Expression {
 
 class IntTypeLiteral : public Expression {
  public:
-  explicit IntTypeLiteral(SourceLocation source_loc)
-      : Expression(AstNodeKind::IntTypeLiteral, source_loc) {}
+  explicit IntTypeLiteral(SourceLocation source_loc, SizedTypesType type)
+      : Expression(AstNodeKind::IntTypeLiteral, source_loc), type_(type) {}
 
   static auto classof(const AstNode* node) -> bool {
     return InheritsFromIntTypeLiteral(node->kind());
   }
+  static void PrintType(const SizedTypesType type, llvm::raw_ostream& out);
+  auto type() const -> SizedTypesType { return type_; }
+ private:
+  SizedTypesType type_;
 };
 
 class ContinuationTypeLiteral : public Expression {

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -140,13 +140,7 @@ class FieldInitializer {
   Nonnull<Expression*> expression_;
 };
 
-enum class SizedTypesType {
-  I32,
-  U8,
-  I8,
-  U16,
-  I16
-};
+enum class SizedTypesType { I32, U8, I8, U16, I16 };
 
 enum class Operator {
   Add,
@@ -698,6 +692,7 @@ class IntTypeLiteral : public Expression {
   }
   static void PrintType(const SizedTypesType type, llvm::raw_ostream& out);
   auto type() const -> SizedTypesType { return type_; }
+
  private:
   SizedTypesType type_;
 };

--- a/explorer/interpreter/action.cpp
+++ b/explorer/interpreter/action.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Casting.h"
 
 namespace Carbon {
+
 using llvm::cast;
 
 RuntimeScope::RuntimeScope(RuntimeScope&& other) noexcept

--- a/explorer/interpreter/action.cpp
+++ b/explorer/interpreter/action.cpp
@@ -18,7 +18,6 @@
 #include "llvm/Support/Casting.h"
 
 namespace Carbon {
-
 using llvm::cast;
 
 RuntimeScope::RuntimeScope(RuntimeScope&& other) noexcept

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -658,10 +658,14 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
     -> ErrorOr<Nonnull<const Value*>> {
   switch (value->kind()) {
     case Value::Kind::IntValue: {
-      const auto& type = cast<IntType>(*destination_type);
-      const int int_value = cast<IntValue>(*value).value();
-      return arena_->New<IntValue>(int_value, type.type());
-     }
+      if(destination_type->kind() == Value::Kind::IntType) {
+        const auto& type = cast<IntType>(*destination_type);
+        const int int_value = cast<IntValue>(*value).value();
+        return arena_->New<IntValue>(int_value, type.type());
+      } else {
+        return value;
+      }
+    }
     case Value::Kind::FunctionValue:
     case Value::Kind::DestructorValue:
     case Value::Kind::BoundMethodValue:

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -658,7 +658,7 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
     -> ErrorOr<Nonnull<const Value*>> {
   switch (value->kind()) {
     case Value::Kind::IntValue: {
-      if(destination_type->kind() == Value::Kind::IntType) {
+      if (destination_type->kind() == Value::Kind::IntType) {
         const auto& type = cast<IntType>(*destination_type);
         const int int_value = cast<IntValue>(*value).value();
         return arena_->New<IntValue>(int_value, type.type());

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -657,7 +657,11 @@ auto Interpreter::Convert(Nonnull<const Value*> value,
                           SourceLocation source_loc)
     -> ErrorOr<Nonnull<const Value*>> {
   switch (value->kind()) {
-    case Value::Kind::IntValue:
+    case Value::Kind::IntValue: {
+      const auto& type = cast<IntType>(*destination_type);
+      const int int_value = cast<IntValue>(*value).value();
+      return arena_->New<IntValue>(int_value, type.type());
+     }
     case Value::Kind::FunctionValue:
     case Value::Kind::DestructorValue:
     case Value::Kind::BoundMethodValue:
@@ -1404,7 +1408,8 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
     }
     case ExpressionKind::IntTypeLiteral: {
       CARBON_CHECK(act.pos() == 0);
-      return todo_.FinishAction(arena_->New<IntType>());
+      SizedTypesType size_type = (cast<IntTypeLiteral>(exp).type());
+      return todo_.FinishAction(arena_->New<IntType>(size_type));
     }
     case ExpressionKind::BoolTypeLiteral: {
       CARBON_CHECK(act.pos() == 0);

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -229,7 +229,7 @@ static auto PrintNameWithBindings(llvm::raw_ostream& out,
   }
 }
 void IntType::PrintType(const SizedTypesType type, llvm::raw_ostream& out) {
-  switch(type) {
+  switch (type) {
     case SizedTypesType::I32:
       out << "i32";
       break;

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -228,7 +228,28 @@ static auto PrintNameWithBindings(llvm::raw_ostream& out,
     out << ")";
   }
 }
-
+void IntType::PrintType(const SizedTypesType type, llvm::raw_ostream& out) {
+  switch(type) {
+    case SizedTypesType::I32:
+      out << "i32";
+      break;
+    case SizedTypesType::U8:
+      out << "u8";
+      break;
+    case SizedTypesType::I8:
+      out << "i8";
+      break;
+    case SizedTypesType::U16:
+      out << "u16";
+      break;
+    case SizedTypesType::I16:
+      out << "i16";
+      break;
+    default:
+      out << "<unknown sized type>";
+      break;
+  }
+}
 void Value::Print(llvm::raw_ostream& out) const {
   switch (kind()) {
     case Value::Kind::AlternativeConstructorValue: {
@@ -349,7 +370,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       out << "bool";
       break;
     case Value::Kind::IntType:
-      out << "i32";
+      IntType::PrintType(cast<IntType>(*this).type(), out);
       break;
     case Value::Kind::TypeType:
       out << "Type";

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -146,117 +146,112 @@ auto ValueEqual(Nonnull<const Value*> v1, Nonnull<const Value*> v2,
     -> bool;
 
 class SizedInteger {
-  public:
-    explicit SizedInteger(SizedTypesType type, int intValue) : type_(type) {}
-    explicit SizedInteger() {}
-    auto type() const -> SizedTypesType { return type_; };
-    virtual int value() const = 0;
-    virtual ~SizedInteger() = default;
-  private:
-    SizedTypesType type_;
+ public:
+  explicit SizedInteger(SizedTypesType type, int intValue) : type_(type) {}
+  explicit SizedInteger() {}
+  auto type() const -> SizedTypesType { return type_; };
+  virtual int value() const = 0;
+  virtual ~SizedInteger() = default;
+
+ private:
+  SizedTypesType type_;
 };
 
 class SizedIntegerU8 : public SizedInteger {
-  public:
-    SizedIntegerU8(int value) : SizedInteger(SizedTypesType::U8, value) {
-     sized_value_ = static_cast<uint8_t>(value); 
-    }
-    int value() const override {
-      return static_cast<int>(sized_value_);
-    }
-private:
+ public:
+  SizedIntegerU8(int value) : SizedInteger(SizedTypesType::U8, value) {
+    sized_value_ = static_cast<uint8_t>(value);
+  }
+  int value() const override { return static_cast<int>(sized_value_); }
+
+ private:
   uint8_t sized_value_;
 };
 
 class SizedIntegerI8 : public SizedInteger {
-  public:
-    SizedIntegerI8(int value) : SizedInteger(SizedTypesType::I8, value) {
-     sized_value_ = static_cast<int8_t>(value); 
-    }
-    int value() const override {
-      return static_cast<int>(sized_value_);
-    }
-private:
+ public:
+  SizedIntegerI8(int value) : SizedInteger(SizedTypesType::I8, value) {
+    sized_value_ = static_cast<int8_t>(value);
+  }
+  int value() const override { return static_cast<int>(sized_value_); }
+
+ private:
   int8_t sized_value_;
 };
 
 class SizedIntegerI16 : public SizedInteger {
-  public:
-    SizedIntegerI16(int value) : SizedInteger(SizedTypesType::I16, value) {
-     sized_value_ = static_cast<int16_t>(value); 
-    }
-    int value() const override {
-      return static_cast<int>(sized_value_);
-    }
-private:
+ public:
+  SizedIntegerI16(int value) : SizedInteger(SizedTypesType::I16, value) {
+    sized_value_ = static_cast<int16_t>(value);
+  }
+  int value() const override { return static_cast<int>(sized_value_); }
+
+ private:
   int16_t sized_value_;
 };
 
 class SizedIntegerU16 : public SizedInteger {
-  public:
-    SizedIntegerU16(int value) : SizedInteger(SizedTypesType::U16, value) {
-     sized_value_ = static_cast<uint16_t>(value); 
-    }
-    int value() const override {
-      return static_cast<int>(sized_value_);
-    }
-private:
+ public:
+  SizedIntegerU16(int value) : SizedInteger(SizedTypesType::U16, value) {
+    sized_value_ = static_cast<uint16_t>(value);
+  }
+  int value() const override { return static_cast<int>(sized_value_); }
+
+ private:
   uint16_t sized_value_;
 };
 
 class SizedIntegerI32 : public SizedInteger {
-  public:
-    SizedIntegerI32(int value) : SizedInteger(SizedTypesType::I32, value) {
-     sized_value_ = static_cast<int32_t>(value); 
-    }
-    int value() const override {
-      return static_cast<int>(sized_value_);
-    }
-private:
-  int32_t sized_value_;
+ public:
+  SizedIntegerI32(int value) : SizedInteger(SizedTypesType::I32, value) {
+    sized_value_ = static_cast<int32_t>(value);
+  }
+  int value() const override { return static_cast<int>(sized_value_); }
 
+ private:
+  int32_t sized_value_;
 };
 // An integer value.
 class IntValue : public Value {
-  public:
-    explicit IntValue(int value) : Value(Kind::IntValue){
-      set_type(value, SizedTypesType::I32);
+ public:
+  explicit IntValue(int value) : Value(Kind::IntValue) {
+    set_type(value, SizedTypesType::I32);
+  }
 
-    }
+  explicit IntValue(int value, SizedTypesType type) : Value(Kind::IntValue) {
+    set_type(value, type);
+  }
 
-    explicit IntValue(int value, SizedTypesType type) : Value(Kind::IntValue) {
-      set_type(value, type);
+  void set_type(int value, SizedTypesType type) {
+    switch (type) {
+      case SizedTypesType::I32:
+        container_ = std::make_shared<SizedIntegerI32>(SizedIntegerI32(value));
+        break;
+      case SizedTypesType::U8:
+        container_ = std::make_shared<SizedIntegerU8>(SizedIntegerU8(value));
+        break;
+      case SizedTypesType::I8:
+        container_ = std::make_shared<SizedIntegerI8>(SizedIntegerI8(value));
+        break;
+      case SizedTypesType::U16:
+        container_ = std::make_shared<SizedIntegerU16>(SizedIntegerU16(value));
+        break;
+      case SizedTypesType::I16:
+        container_ = std::make_shared<SizedIntegerI16>(SizedIntegerI16(value));
+        break;
+      default:
+        container_ = std::make_shared<SizedIntegerI32>(SizedIntegerI32(value));
     }
+  }
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::IntValue;
+  }
 
-    void set_type(int value, SizedTypesType type) {
-      switch(type) {
-        case SizedTypesType::I32:
-          container_ = std::make_shared<SizedIntegerI32>(SizedIntegerI32(value));
-          break;
-        case SizedTypesType::U8:
-          container_ = std::make_shared<SizedIntegerU8>(SizedIntegerU8(value));
-          break;
-        case SizedTypesType::I8:
-          container_ = std::make_shared<SizedIntegerI8>(SizedIntegerI8(value));
-          break;
-        case SizedTypesType::U16:
-          container_ = std::make_shared<SizedIntegerU16>(SizedIntegerU16(value));
-          break;
-        case SizedTypesType::I16:
-          container_ = std::make_shared<SizedIntegerI16>(SizedIntegerI16(value));
-          break;
-        default:
-          container_ = std::make_shared<SizedIntegerI32>(SizedIntegerI32(value));
-      }
-    }
-    static auto classof(const Value* value) -> bool {
-      return value->kind() == Kind::IntValue;
-    }
+  auto value() const -> int { return container_->value(); }
+  auto type() const -> SizedTypesType { return container_->type(); }
 
-    auto value() const -> int { return container_->value(); }
-    auto type() const -> SizedTypesType { return container_->type(); }
-  private:
-    std::shared_ptr<SizedInteger> container_;
+ private:
+  std::shared_ptr<SizedInteger> container_;
 };
 
 // A function value.
@@ -604,11 +599,12 @@ class IntType : public Value {
   IntType() : Value(Kind::IntType), type_(SizedTypesType::I32) {}
 
   IntType(SizedTypesType type) : Value(Kind::IntType), type_(type) {}
-  auto type() const -> SizedTypesType {return type_; }
+  auto type() const -> SizedTypesType { return type_; }
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::IntType;
   }
   static void PrintType(const SizedTypesType type, llvm::raw_ostream& out);
+
  private:
   SizedTypesType type_;
 };

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -150,8 +150,7 @@ class SizedInteger {
     explicit SizedInteger(SizedTypesType type, int intValue) : type_(type) {}
     explicit SizedInteger() {}
     auto type() const -> SizedTypesType { return type_; };
-    virtual void set_int_value(int value) = 0;
-    virtual int integer_value() const = 0;
+    virtual int value() const = 0;
     virtual ~SizedInteger() = default;
   private:
     SizedTypesType type_;
@@ -162,10 +161,7 @@ class SizedIntegerU8 : public SizedInteger {
     SizedIntegerU8(int value) : SizedInteger(SizedTypesType::U8, value) {
      sized_value_ = static_cast<uint8_t>(value); 
     }
-    void set_int_value(int value) override {
-      sized_value_ = static_cast<uint8_t>(value);
-    }
-    int integer_value() const override {
+    int value() const override {
       return static_cast<int>(sized_value_);
     }
 private:
@@ -177,10 +173,7 @@ class SizedIntegerI8 : public SizedInteger {
     SizedIntegerI8(int value) : SizedInteger(SizedTypesType::I8, value) {
      sized_value_ = static_cast<int8_t>(value); 
     }
-    void set_int_value(int value) override {
-      sized_value_ = static_cast<int8_t>(value);
-    }
-    int integer_value() const override {
+    int value() const override {
       return static_cast<int>(sized_value_);
     }
 private:
@@ -192,10 +185,7 @@ class SizedIntegerI16 : public SizedInteger {
     SizedIntegerI16(int value) : SizedInteger(SizedTypesType::I16, value) {
      sized_value_ = static_cast<int16_t>(value); 
     }
-    void set_int_value(int value) override {
-      sized_value_ = static_cast<int16_t>(value);
-    }
-    int integer_value() const override {
+    int value() const override {
       return static_cast<int>(sized_value_);
     }
 private:
@@ -207,10 +197,7 @@ class SizedIntegerU16 : public SizedInteger {
     SizedIntegerU16(int value) : SizedInteger(SizedTypesType::U16, value) {
      sized_value_ = static_cast<uint16_t>(value); 
     }
-    void set_int_value(int value) override {
-      sized_value_ = static_cast<uint16_t>(value);
-    }
-    int integer_value() const override {
+    int value() const override {
       return static_cast<int>(sized_value_);
     }
 private:
@@ -222,10 +209,7 @@ class SizedIntegerI32 : public SizedInteger {
     SizedIntegerI32(int value) : SizedInteger(SizedTypesType::I32, value) {
      sized_value_ = static_cast<int32_t>(value); 
     }
-    void set_int_value(int value) override {
-      sized_value_ = static_cast<int32_t>(value);
-    }
-    int integer_value() const override {
+    int value() const override {
       return static_cast<int>(sized_value_);
     }
 private:
@@ -242,10 +226,6 @@ class IntValue : public Value {
 
     explicit IntValue(int value, SizedTypesType type) : Value(Kind::IntValue) {
       set_type(value, type);
-    }
-
-    void set_type(SizedTypesType type) {
-      set_type(container_->integer_value(), type);
     }
 
     void set_type(int value, SizedTypesType type) {
@@ -273,7 +253,7 @@ class IntValue : public Value {
       return value->kind() == Kind::IntValue;
     }
 
-    auto value() const -> int { return container_->integer_value(); }
+    auto value() const -> int { return container_->value(); }
     auto type() const -> SizedTypesType { return container_->type(); }
   private:
     std::shared_ptr<SizedInteger> container_;

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -362,12 +362,46 @@ primary_expression:
         context.RecordSyntaxError(
             llvm::formatv("Invalid type literal: {0}", $1));
         YYERROR;
-      } else if ($1[0] != 'i' || val != 32) {
-        context.RecordSyntaxError(
-            llvm::formatv("Only i32 is supported for now: {0}", $1));
-        YYERROR;
       } else {
-        $$ = arena->New<IntTypeLiteral>(context.source_loc());
+        char typeChar = $1[0];
+        SizedTypesType type;
+        if(typeChar == 'u') {
+          switch(val) {
+            case 8:
+              type = SizedTypesType::U8;
+              break;
+            case 16:
+              type = SizedTypesType::U16;
+              break;
+            default: 
+              context.RecordSyntaxError(
+                  llvm::formatv("Unsupported Number Type: {0}", $1));
+              YYERROR;
+              break;
+          }
+        } else if (typeChar == 'i') {
+          switch(val) {
+            case 8:
+              type = SizedTypesType::I8;
+              break;
+            case 16:
+              type = SizedTypesType::I16;
+              break;
+            case 32:
+              type = SizedTypesType::I32;
+              break;
+            default: 
+              context.RecordSyntaxError(
+                  llvm::formatv("Unsupported Number Type: {0}", $1));
+              YYERROR;
+              break;
+          }
+        } else {
+          context.RecordSyntaxError(
+              llvm::formatv("Unsupported Number Type: {0}", $1));
+          YYERROR;
+        }
+        $$ = arena->New<IntTypeLiteral>(context.source_loc(), type);
       }
     }
 | SELF

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -365,22 +365,22 @@ primary_expression:
       } else {
         char typeChar = $1[0];
         SizedTypesType type;
-        if(typeChar == 'u') {
-          switch(val) {
+        if (typeChar == 'u') {
+          switch (val) {
             case 8:
               type = SizedTypesType::U8;
               break;
             case 16:
               type = SizedTypesType::U16;
               break;
-            default: 
+            default:
               context.RecordSyntaxError(
                   llvm::formatv("Unsupported Number Type: {0}", $1));
               YYERROR;
               break;
           }
         } else if (typeChar == 'i') {
-          switch(val) {
+          switch (val) {
             case 8:
               type = SizedTypesType::I8;
               break;
@@ -390,7 +390,7 @@ primary_expression:
             case 32:
               type = SizedTypesType::I32;
               break;
-            default: 
+            default:
               context.RecordSyntaxError(
                   llvm::formatv("Unsupported Number Type: {0}", $1));
               YYERROR;

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -9,7 +9,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 is supported for now: i64
+  // CHECK:STDERR: SYNTAX ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon:[[@LINE+1]]: Unsupported Number Type: i64
   var x: i64 = 1;
   return 0;
 }


### PR DESCRIPTION
This is a primitive implementation idea i had for supporting smaller number types then signed 32bit, i.e
this pr is not a final solution but a possible partial implementation for integer types.
## The problem
Currently carbon explorer only supports 32bit signed integers, which work for a lot of cases but for some others it can be useful to have other smaller types.

## What is this trying to solve
Im would assume this is not the optimal way to implement other number types, but it does implement them in a pretty easy way, basically integers within the parser/interpreter are still signed 32bit values, but when stored in a `IntValue` the value is passed to the defined type, which can also loose information.
I spend two days looking and trying to start understanding the code structure and how the various apis interact with each other. I do not **expect** this to be merged necessarily as i pointed out this is probably not a optimal way of implementing them.

### Where are unsigned 32 and 64 bit values?
Well...i was/am playing around with them but this poses the problem of a more major refactor. especially since with these all operations need to be aware whether they are operating on signed or unsigned values. The current way keeps the implementation simple and does not introduce issues with signed/unsigned values since the largest type did not change.
I will probably play around with that exact issue more as i learn more about the codebase and how this would be able to be done without adding if else everywhere to handle signed/unsigned cases. Maybe there its better to create entirely seperate types, but that would mean more implementation debt for operations on these types...