### PR TITLE
Switch to PrettyStackTrace for CHECK/FATAL

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -14,7 +14,10 @@ cc_library(
 
 cc_library(
     name = "check",
-    srcs = ["check_internal.h"],
+    srcs = [
+        "check_internal.cpp",
+        "check_internal.h",
+    ],
     hdrs = ["check.h"],
     deps = [
         "@llvm-project//llvm:Support",

--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/check_internal.h"
+
+namespace Carbon::Internal {
+
+// Prints the buffered message.
+auto PrintAfterStackTrace(void* str) -> void {
+  llvm::errs() << reinterpret_cast<char*>(str);
+}
+
+ExitingStream::~ExitingStream() {
+  llvm_unreachable(
+      "Exiting streams should only be constructed by check.h macros that "
+      "ensure the special operator| exits the program prior to their "
+      "destruction!");
+}
+
+auto ExitingStream::Done() -> void {
+  buffer_ << "\n";
+  // Register another signal handler to print the buffered message. This is
+  // because we want it at the bottom of output, after LLVM's builtin stack
+  // output, rather than the top.
+  llvm::sys::AddSignalHandler(PrintAfterStackTrace,
+                              const_cast<char*>(buffer_str_.c_str()));
+  // It's useful to exit the program with `std::abort()` for integration with
+  // debuggers and other tools. We also assume LLVM's exit handling is
+  // installed, which will stack trace on `std::abort()`.
+  std::abort();
+}
+
+}  // namespace Carbon::Internal

--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -25,7 +25,7 @@ class ExitingStream {
   // Internal type used in macros to dispatch to the `operator|` overload.
   struct Helper {};
 
-  ExitingStream() : buffer(buffer_str) {}
+  ExitingStream() : buffer_(buffer_str_) {}
 
   [[noreturn]] ~ExitingStream() {
     llvm_unreachable(
@@ -42,10 +42,10 @@ class ExitingStream {
   template <typename T>
   auto operator<<(const T& message) -> ExitingStream& {
     if (separator_) {
-      buffer << ": ";
+      buffer_ << ": ";
       separator_ = false;
     }
-    buffer << message;
+    buffer_ << message;
     return *this;
   }
 
@@ -58,7 +58,7 @@ class ExitingStream {
   // output and exit the program. We do this in a binary operator rather than
   // the destructor to ensure good debug info and backtraces for errors.
   [[noreturn]] friend auto operator|(Helper /*helper*/, ExitingStream& stream) {
-    llvm::PrettyStackTraceString str(stream.buffer_str.c_str());
+    llvm::PrettyStackTraceString str(stream.buffer_str_.c_str());
     // It's useful to exit the program with `std::abort()` for integration with
     // debuggers and other tools. We also assume LLVM's exit handling is
     // installed, which will stack trace on `std::abort()`.
@@ -69,8 +69,8 @@ class ExitingStream {
   // Whether a separator should be printed if << is used again.
   bool separator_ = false;
 
-  std::string buffer_str;
-  llvm::raw_string_ostream buffer;
+  std::string buffer_str_;
+  llvm::raw_string_ostream buffer_;
 };
 
 }  // namespace Carbon::Internal

--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -13,9 +13,11 @@ TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 
 TEST(CheckTest, CheckFalse) {
   ASSERT_DEATH({ CARBON_CHECK(false); },
-               "Stack trace:\n"
-               "(.|\n)+\n"
-               "CHECK failure at common/check_test.cpp:\\d+: false\n");
+               "\\d+\\.\tCHECK failure at common/check_test.cpp:\\d+: false\n");
+}
+
+TEST(CheckTest, CheckFalseHasStackDump) {
+  ASSERT_DEATH({ CARBON_CHECK(false); }, "\nStack dump:\n");
 }
 
 TEST(CheckTest, CheckTrueCallbackNotUsed) {
@@ -29,8 +31,9 @@ TEST(CheckTest, CheckTrueCallbackNotUsed) {
 }
 
 TEST(CheckTest, CheckFalseMessage) {
-  ASSERT_DEATH({ CARBON_CHECK(false) << "msg"; },
-               "CHECK failure at common/check_test.cpp:.+: false: msg\n");
+  ASSERT_DEATH(
+      { CARBON_CHECK(false) << "msg"; },
+      "\\d+\\.\tCHECK failure at common/check_test.cpp:.+: false: msg\n");
 }
 
 TEST(CheckTest, CheckOutputForms) {
@@ -42,14 +45,18 @@ TEST(CheckTest, CheckOutputForms) {
 
 TEST(CheckTest, Fatal) {
   ASSERT_DEATH({ CARBON_FATAL() << "msg"; },
-               "FATAL failure at common/check_test.cpp:.+: msg\n");
+               "\\d+\\.\tFATAL failure at common/check_test.cpp:.+: msg\n");
+}
+
+TEST(CheckTest, FatalHasStackDump) {
+  ASSERT_DEATH({ CARBON_FATAL() << "msg"; }, "\nStack dump:\n");
 }
 
 auto FatalNoReturnRequired() -> int { CARBON_FATAL() << "msg"; }
 
 TEST(ErrorTest, FatalNoReturnRequired) {
   ASSERT_DEATH({ FatalNoReturnRequired(); },
-               "FATAL failure at common/check_test.cpp:.+: msg\n");
+               "\\d+\\.\tFATAL failure at common/check_test.cpp:.+: msg\n");
 }
 
 }  // namespace

--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -13,7 +13,7 @@ TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
 
 TEST(CheckTest, CheckFalse) {
   ASSERT_DEATH({ CARBON_CHECK(false); },
-               "\\d+\\.\tCHECK failure at common/check_test.cpp:\\d+: false\n");
+               "\nCHECK failure at common/check_test.cpp:\\d+: false\n");
 }
 
 TEST(CheckTest, CheckFalseHasStackDump) {
@@ -31,9 +31,8 @@ TEST(CheckTest, CheckTrueCallbackNotUsed) {
 }
 
 TEST(CheckTest, CheckFalseMessage) {
-  ASSERT_DEATH(
-      { CARBON_CHECK(false) << "msg"; },
-      "\\d+\\.\tCHECK failure at common/check_test.cpp:.+: false: msg\n");
+  ASSERT_DEATH({ CARBON_CHECK(false) << "msg"; },
+               "\nCHECK failure at common/check_test.cpp:.+: false: msg\n");
 }
 
 TEST(CheckTest, CheckOutputForms) {
@@ -45,7 +44,7 @@ TEST(CheckTest, CheckOutputForms) {
 
 TEST(CheckTest, Fatal) {
   ASSERT_DEATH({ CARBON_FATAL() << "msg"; },
-               "\\d+\\.\tFATAL failure at common/check_test.cpp:.+: msg\n");
+               "\nFATAL failure at common/check_test.cpp:.+: msg\n");
 }
 
 TEST(CheckTest, FatalHasStackDump) {
@@ -56,7 +55,7 @@ auto FatalNoReturnRequired() -> int { CARBON_FATAL() << "msg"; }
 
 TEST(ErrorTest, FatalNoReturnRequired) {
   ASSERT_DEATH({ FatalNoReturnRequired(); },
-               "\\d+\\.\tFATAL failure at common/check_test.cpp:.+: msg\n");
+               "\nFATAL failure at common/check_test.cpp:.+: msg\n");
 }
 
 }  // namespace

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -68,6 +68,8 @@ class TokenizedBufferToken {
     return lhs.index_ >= rhs.index_;
   }
 
+  auto Print(llvm::raw_ostream& output) const -> void { output << index_; }
+
  private:
   friend TokenizedBuffer;
 

--- a/toolchain/parser/parser2.cpp
+++ b/toolchain/parser/parser2.cpp
@@ -25,7 +25,7 @@ class Parser2::PrettyStackTraceParseState : public llvm::PrettyStackTraceEntry {
 
   auto print(llvm::raw_ostream& output) const -> void override {
     output << "Parser stack:\n";
-    for (int i = parser_->state_stack_.size() - 1; i >= 0; --i) {
+    for (int i = 0; i < static_cast<int>(parser_->state_stack_.size()); ++i) {
       const auto& entry = parser_->state_stack_[i];
       output << "\t" << i << ".\t" << entry.state << " @ " << entry.start_token
              << ":" << parser_->tokens_.GetKind(entry.start_token).Name()

--- a/toolchain/parser/parser2.cpp
+++ b/toolchain/parser/parser2.cpp
@@ -9,12 +9,33 @@
 
 #include "common/check.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "toolchain/lexer/token_kind.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/parser/parse_node_kind.h"
 #include "toolchain/parser/parse_tree.h"
 
 namespace Carbon {
+
+class Parser2::PrettyStackTraceParseState : public llvm::PrettyStackTraceEntry {
+ public:
+  explicit PrettyStackTraceParseState(const Parser2* parser)
+      : parser_(parser) {}
+  ~PrettyStackTraceParseState() override = default;
+
+  auto print(llvm::raw_ostream& output) const -> void override {
+    output << "Parser stack:\n";
+    for (int i = parser_->state_stack_.size() - 1; i >= 0; --i) {
+      const auto& entry = parser_->state_stack_[i];
+      output << "\t" << i << ".\t" << entry.state << " @ " << entry.start_token
+             << ":" << parser_->tokens_.GetKind(entry.start_token).Name()
+             << "\n";
+    }
+  }
+
+ private:
+  const Parser2* parser_;
+};
 
 Parser2::Parser2(ParseTree& tree_arg, TokenizedBuffer& tokens_arg,
                  TokenDiagnosticEmitter& emitter)
@@ -71,6 +92,10 @@ auto Parser2::ConsumeIf(TokenKind kind)
 }
 
 auto Parser2::Parse() -> void {
+#ifndef NDEBUG
+  PrettyStackTraceParseState pretty_stack(this);
+#endif
+
   PushState(ParserState::Declaration());
   while (!state_stack_.empty()) {
     switch (state_stack_.back().state) {

--- a/toolchain/parser/parser2.h
+++ b/toolchain/parser/parser2.h
@@ -28,6 +28,8 @@ class Parser2 {
   }
 
  private:
+  class PrettyStackTraceParseState;
+
   // Used to track state on state_stack_.
   struct StateStackEntry {
     // The state.

--- a/toolchain/parser/parser_impl.cpp
+++ b/toolchain/parser/parser_impl.cpp
@@ -797,7 +797,6 @@ auto ParseTree::Parser::ParseBraceExpression() -> llvm::Optional<Node> {
 }
 
 auto ParseTree::Parser::ParsePrimaryExpression() -> llvm::Optional<Node> {
-  CARBON_FATAL() << "x";
   CARBON_RETURN_IF_STACK_LIMITED(llvm::None);
   llvm::Optional<ParseNodeKind> kind;
   switch (NextTokenKind()) {

--- a/toolchain/parser/parser_impl.cpp
+++ b/toolchain/parser/parser_impl.cpp
@@ -797,6 +797,7 @@ auto ParseTree::Parser::ParseBraceExpression() -> llvm::Optional<Node> {
 }
 
 auto ParseTree::Parser::ParsePrimaryExpression() -> llvm::Optional<Node> {
+  CARBON_FATAL() << "x";
   CARBON_RETURN_IF_STACK_LIMITED(llvm::None);
   llvm::Optional<ParseNodeKind> kind;
   switch (NextTokenKind()) {


### PR DESCRIPTION
At present, CHECK/FATAL print their own stack trace. This switches to just using std::abort for the stack trace, as well as the CHECK printing more completely.

This has a few consequences:

1) I'm now buffering the FATAL strings in order to print it later.
2) We now print the bug report message and program arguments on failure. This is part of pretty printing and was elided before.
3) We can now have pretty printing on FATAL, e.g. to show the stacks we're building in the parser.