### PR TITLE
Add a ForIn node for a colon, move the error

### DIFF
--- a/toolchain/parser/parser.cpp
+++ b/toolchain/parser/parser.cpp
@@ -1457,9 +1457,7 @@ auto Parser::HandleStatementForHeaderInState() -> void {
     if (auto colon = ConsumeIf(TokenKind::Colon())) {
       CARBON_DIAGNOSTIC(ExpectedIn, Error, "`:` should be replaced by `in`.");
       emitter_.Emit(*colon, ExpectedIn);
-      // TODO: Should probably add a ForIn node for consistency in ParseTree
-      // structure, but doesn't for consistency with the old implementation.
-      state.has_error = true;
+      AddLeafNode(ParseNodeKind::ForIn(), *colon, /*has_error=*/true);
     } else {
       CARBON_DIAGNOSTIC(ExpectedIn, Error,
                         "Expected `in` after loop `var` declaration.");

--- a/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
+++ b/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
@@ -14,9 +14,10 @@
 // CHECK:STDOUT:           {kind: 'Literal', text: 'i32'},
 // CHECK:STDOUT:         {kind: 'PatternBinding', text: ':', subtree_size: 3},
 // CHECK:STDOUT:       {kind: 'VariableDeclaration', text: 'var', subtree_size: 4},
+// CHECK:STDOUT:       {kind: 'ForIn', text: ':', has_error: yes},
 // CHECK:STDOUT:       {kind: 'NameReference', text: 'y'},
 // CHECK:STDOUT:       {kind: 'ForHeaderEnd', text: ')'},
-// CHECK:STDOUT:     {kind: 'ForHeader', text: '(', has_error: yes, subtree_size: 7},
+// CHECK:STDOUT:     {kind: 'ForHeader', text: '(', subtree_size: 8},
 // CHECK:STDOUT:       {kind: 'CodeBlockStart', text: '{'},
 // CHECK:STDOUT:           {kind: 'NameReference', text: 'Print'},
 // CHECK:STDOUT:           {kind: 'NameReference', text: 'x'},
@@ -24,8 +25,8 @@
 // CHECK:STDOUT:         {kind: 'CallExpression', text: '(', subtree_size: 4},
 // CHECK:STDOUT:       {kind: 'ExpressionStatement', text: ';', subtree_size: 5},
 // CHECK:STDOUT:     {kind: 'CodeBlock', text: '}', subtree_size: 7},
-// CHECK:STDOUT:   {kind: 'ForStatement', text: 'for', subtree_size: 15},
-// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 21},
+// CHECK:STDOUT:   {kind: 'ForStatement', text: 'for', subtree_size: 16},
+// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 22},
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 


### PR DESCRIPTION
This is to keep the tree consistent with the error-free state. It also more precisely locates the error.