### PR TITLE
Explicitly install python with --overwrite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
           echo '*** Installing LLVM deps'
           brew keg_only --force-bottle --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew keg_only --force-bottle --force --verbose llvm
+          brew keg_only  --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
           echo '*** Installing LLVM deps'
           brew keg_only --force-bottle --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew keg_only  --force-bottle --force --verbose llvm
+          brew keg_only --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,9 +71,9 @@ jobs:
           echo '*** Installing LLVM deps'
           # We overwrite any existing links to address non-homebrew conflicts
           # (python3 in particular).
-          brew --force-bottle --overwrite --only-dependencies llvm
+          brew install --force-bottle --overwrite --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew --force-bottle --force --verbose llvm
+          brew install --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,8 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 15 all
+          # Retry once in case of apt.llvm.org flakiness.
+          sudo ./llvm.sh 15 all || sleep 10 && sudo ./llvm.sh 15 all
           rm llvm.sh
           echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
           echo '*** Updating brew'
           brew update
           echo '*** Installing LLVM itself'
-          brew install --force-bottle --force --verbose llvm
+          brew install --force-bottle --force --overwrite --verbose llvm python
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [brew]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.
@@ -71,7 +71,7 @@ jobs:
           echo '*** Installing LLVM deps'
           brew keg_only --force-bottle --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew keg_only  --force-bottle --force --verbose llvm
+          brew keg_only --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,10 +68,6 @@ jobs:
         run: |
           echo '*** Updating brew'
           brew update
-          echo '*** Installing LLVM deps'
-          # We overwrite any existing links to address non-homebrew conflicts
-          # (python3 in particular).
-          brew install --force-bottle --overwrite --only-dependencies llvm
           echo '*** Installing LLVM itself'
           brew install --force-bottle --force --verbose llvm
           echo '*** brew info llvm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        build_mode: [fastbuild, opt]
+        build_mode: [opt]
+        #build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.
@@ -85,7 +86,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80-retries
+          sudo bash -c "echo 'Acquire::Retries \"10\";' > /etc/apt/apt.conf.d/80-retries"
           sudo ./llvm.sh 15 all
           rm llvm.sh
           echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,9 @@ jobs:
           echo '*** Updating brew'
           brew update
           echo '*** Installing LLVM deps'
-          brew --force-bottle --only-dependencies llvm || true
+          # We overwrite any existing links to address non-homebrew conflicts
+          # (python3 in particular).
+          brew --force-bottle --overwrite --only-dependencies llvm
           echo '*** Installing LLVM itself'
           brew --force-bottle --force --verbose llvm
           echo '*** brew info llvm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,8 +68,10 @@ jobs:
         run: |
           echo '*** Updating brew'
           brew update
+          echo '*** Installing Python'
+          brew install --force-bottle --force --overwrite --verbose python@3.11
           echo '*** Installing LLVM itself'
-          brew install --force-bottle --force --overwrite --verbose llvm python
+          brew install --force-bottle --force --overwrite --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'
@@ -83,8 +85,8 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          # Retry once in case of apt.llvm.org flakiness.
-          sudo ./llvm.sh 15 all || sleep 10 && sudo ./llvm.sh 15 all
+          echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80-retries
+          sudo ./llvm.sh 15 all
           rm llvm.sh
           echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,9 +69,9 @@ jobs:
           echo '*** Updating brew'
           brew update
           echo '*** Installing LLVM deps'
-          brew install --force-bottle --only-dependencies llvm
+          brew keg_only --force-bottle --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew install --force-bottle --force --verbose llvm
+          brew keg_only --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,9 +69,9 @@ jobs:
           echo '*** Updating brew'
           brew update
           echo '*** Installing LLVM deps'
-          brew keg_only --force-bottle --only-dependencies llvm
+          brew --force-bottle --only-dependencies llvm || true
           echo '*** Installing LLVM itself'
-          brew keg_only --force-bottle --force --verbose llvm
+          brew --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         build_mode: [fastbuild, opt]
-        #build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,9 +70,14 @@ jobs:
           echo '*** Updating brew'
           brew update
           echo '*** Installing Python'
-          brew install --force-bottle --force --overwrite --verbose python@3.11
+          # Explicitly use --overwrite because of file conflicts in
+          # /usr/local/bin with GitHub's installed version. If this stops being
+          # required, great!
+          brew install --force-bottle --overwrite python@3.11
+          echo '*** Installing LLVM deps'
+          brew install --force-bottle --only-dependencies llvm
           echo '*** Installing LLVM itself'
-          brew install --force-bottle --force --overwrite --verbose llvm
+          brew install --force-bottle --force --verbose llvm
           echo '*** brew info llvm'
           brew info llvm
           echo '*** brew config'
@@ -86,7 +91,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 15 all || sudo ./llvm.sh 15 all
+          sudo ./llvm.sh 15 all
           rm llvm.sh
           echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        build_mode: [opt]
+        build_mode: [fastbuild, opt]
         #build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [brew]
+    branches: [trunk]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,8 +86,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo bash -c "echo 'Acquire::Retries \"10\";' > /etc/apt/apt.conf.d/80-retries"
-          sudo ./llvm.sh 15 all
+          sudo ./llvm.sh 15 all || sudo ./llvm.sh 15 all
           rm llvm.sh
           echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
```
==> Pouring python@3.11--3.11.0.monterey.bottle.tar.gz
Error: The brew link step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.11
Target /usr/local/bin/2to3-3.11
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.11'
```

Installing llvm with --overwrite didn't seem to pass it on dependencies, particularly python (https://github.com/carbon-language/carbon-lang/actions/runs/3464174572/jobs/5785378508). So this instead installs python separately, and then --overwrite works.

See https://github.com/carbon-language/carbon-lang/actions/runs/3464364789/jobs/5785802783 for the example passing run. The actions on this PR will probably still use the trunk version.