### PR TITLE
Remove pattern evaluation from the interpreter. 

### DIFF
--- a/explorer/ast/pattern.h
+++ b/explorer/ast/pattern.h
@@ -71,7 +71,10 @@ class Pattern : public AstNode {
 
   // Sets the value of this pattern. Can only be called once, during
   // typechecking.
-  void set_value(Nonnull<const Value*> value) { value_ = value; }
+  void set_value(Nonnull<const Value*> value) {
+    CARBON_CHECK(!value_) << "set_value called more than once";
+    value_ = value;
+  }
 
   // Returns whether the value has been set. Should only be called
   // during typechecking: before typechecking it's guaranteed to be false,

--- a/explorer/interpreter/action.cpp
+++ b/explorer/interpreter/action.cpp
@@ -124,9 +124,6 @@ void Action::Print(llvm::raw_ostream& out) const {
     case Action::Kind::WitnessAction:
       out << *cast<WitnessAction>(*this).witness() << " ";
       break;
-    case Action::Kind::PatternAction:
-      out << cast<PatternAction>(*this).pattern() << " ";
-      break;
     case Action::Kind::StatementAction:
       cast<StatementAction>(*this).statement().PrintDepth(1, out);
       out << " ";

--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -96,7 +96,6 @@ class Action {
     LValAction,
     ExpressionAction,
     WitnessAction,
-    PatternAction,
     StatementAction,
     DeclarationAction,
     ScopeAction,
@@ -218,24 +217,6 @@ class WitnessAction : public Action {
 
  private:
   Nonnull<const Witness*> witness_;
-};
-
-// An Action which implements evaluation of a Pattern. The result is expressed
-// as a Value.
-class PatternAction : public Action {
- public:
-  explicit PatternAction(Nonnull<const Pattern*> pattern)
-      : Action(Kind::PatternAction), pattern_(pattern) {}
-
-  static auto classof(const Action* action) -> bool {
-    return action->kind() == Kind::PatternAction;
-  }
-
-  // The Pattern this Action evaluates.
-  auto pattern() const -> const Pattern& { return *pattern_; }
-
- private:
-  Nonnull<const Pattern*> pattern_;
 };
 
 // An Action which implements execution of a Statement. Does not produce a

--- a/explorer/interpreter/action_stack.cpp
+++ b/explorer/interpreter/action_stack.cpp
@@ -144,7 +144,6 @@ static auto FinishActionKindFor(Action::Kind kind) -> FinishActionKind {
     case Action::Kind::ExpressionAction:
     case Action::Kind::WitnessAction:
     case Action::Kind::LValAction:
-    case Action::Kind::PatternAction:
       return FinishActionKind::Value;
     case Action::Kind::StatementAction:
     case Action::Kind::DeclarationAction:

--- a/explorer/interpreter/interpreter.h
+++ b/explorer/interpreter/interpreter.h
@@ -34,13 +34,6 @@ auto InterpExp(Nonnull<const Expression*> e, Nonnull<Arena*> arena,
                std::optional<Nonnull<llvm::raw_ostream*>> trace_stream)
     -> ErrorOr<Nonnull<const Value*>>;
 
-// Interprets `p` at compile-time, allocating values on `arena` and
-// printing traces if `trace` is true. The caller must ensure that all the
-// code this evaluates has been typechecked.
-auto InterpPattern(Nonnull<const Pattern*> p, Nonnull<Arena*> arena,
-                   std::optional<Nonnull<llvm::raw_ostream*>> trace_stream)
-    -> ErrorOr<Nonnull<const Value*>>;
-
 // Attempts to match `v` against the pattern `p`, returning whether matching
 // is successful. If it is, populates **bindings with the variables bound by
 // the match; `bindings` should only be nullopt in contexts where `p`

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -3822,6 +3822,7 @@ auto TypeChecker::TypeCheckPattern(
   switch (p->kind()) {
     case PatternKind::AutoPattern: {
       p->set_static_type(arena_->New<TypeType>());
+      SetValue(p, arena_->New<AutoType>());
       return Success();
     }
     case PatternKind::BindingPattern: {
@@ -3834,9 +3835,7 @@ auto TypeChecker::TypeCheckPattern(
       }
       CARBON_RETURN_IF_ERROR(TypeCheckPattern(
           &binding.type(), std::nullopt, impl_scope, enclosing_value_category));
-      CARBON_ASSIGN_OR_RETURN(
-          Nonnull<const Value*> type,
-          InterpPattern(&binding.type(), arena_, trace_stream_));
+      Nonnull<const Value*> type = &binding.type().value();
       // Convert to a type.
       // TODO: Convert the pattern before interpreting it rather than doing
       // this as a separate step.
@@ -3878,9 +3877,9 @@ auto TypeChecker::TypeCheckPattern(
       CARBON_CHECK(!IsPlaceholderType(type))
           << "should be no way to write a placeholder type";
       binding.set_static_type(type);
-      CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> binding_value,
-                              InterpPattern(&binding, arena_, trace_stream_));
-      SetValue(&binding, binding_value);
+      SetValue(&binding, binding.name() != AnonymousName
+                             ? arena_->New<BindingPlaceholderValue>(&binding)
+                             : arena_->New<BindingPlaceholderValue>());
 
       if (!binding.has_value_category()) {
         binding.set_value_category(enclosing_value_category);
@@ -3901,6 +3900,7 @@ auto TypeChecker::TypeCheckPattern(
     case PatternKind::TuplePattern: {
       auto& tuple = cast<TuplePattern>(*p);
       std::vector<Nonnull<const Value*>> field_types;
+      std::vector<Nonnull<const Value*>> field_patterns;
       if (expected && (*expected)->kind() != Value::Kind::TupleType) {
         return ProgramError(p->source_loc()) << "didn't expect a tuple";
       }
@@ -3921,11 +3921,10 @@ auto TypeChecker::TypeCheckPattern(
                           << "\n";
         }
         field_types.push_back(&field->static_type());
+        field_patterns.push_back(&field->value());
       }
       tuple.set_static_type(arena_->New<TupleType>(std::move(field_types)));
-      CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> tuple_value,
-                              InterpPattern(&tuple, arena_, trace_stream_));
-      SetValue(&tuple, tuple_value);
+      SetValue(&tuple, arena_->New<TupleValue>(std::move(field_patterns)));
       return Success();
     }
     case PatternKind::AlternativePattern: {
@@ -3962,10 +3961,10 @@ auto TypeChecker::TypeCheckPattern(
           TypeCheckPattern(&alternative.arguments(), substituted_parameter_type,
                            impl_scope, enclosing_value_category));
       alternative.set_static_type(&choice_type);
-      CARBON_ASSIGN_OR_RETURN(
-          Nonnull<const Value*> alternative_value,
-          InterpPattern(&alternative, arena_, trace_stream_));
-      SetValue(&alternative, alternative_value);
+      SetValue(&alternative,
+               arena_->New<AlternativeValue>(
+                   alternative.alternative_name(), choice_type.name(),
+                   &alternative.arguments().value()));
       return Success();
     }
     case PatternKind::ExpressionPattern: {
@@ -3973,7 +3972,7 @@ auto TypeChecker::TypeCheckPattern(
       CARBON_RETURN_IF_ERROR(TypeCheckExp(&expression, impl_scope));
       p->set_static_type(&expression.static_type());
       CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> expr_value,
-                              InterpPattern(p, arena_, trace_stream_));
+                              InterpExp(&expression, arena_, trace_stream_));
       SetValue(p, expr_value);
       return Success();
     }
@@ -3984,13 +3983,10 @@ auto TypeChecker::TypeCheckPattern(
                                               impl_scope,
                                               var_pattern.value_category()));
       var_pattern.set_static_type(&var_pattern.pattern().static_type());
-      CARBON_ASSIGN_OR_RETURN(
-          Nonnull<const Value*> pattern_value,
-          InterpPattern(&var_pattern, arena_, trace_stream_));
-      SetValue(&var_pattern, pattern_value);
+      SetValue(&var_pattern, &var_pattern.pattern().value());
       return Success();
     }
-    case PatternKind::AddrPattern:
+    case PatternKind::AddrPattern: {
       std::optional<Nonnull<const Value*>> expected_ptr;
       auto& addr_pattern = cast<AddrPattern>(*p);
       if (expected) {
@@ -4007,11 +4003,10 @@ auto TypeChecker::TypeCheckPattern(
         return ProgramError(addr_pattern.source_loc())
                << "Type associated with addr must be a pointer type.";
       }
-      CARBON_ASSIGN_OR_RETURN(
-          Nonnull<const Value*> pattern_value,
-          InterpPattern(&addr_pattern, arena_, trace_stream_));
-      SetValue(&addr_pattern, pattern_value);
+      SetValue(&addr_pattern,
+               arena_->New<AddrValue>(&addr_pattern.binding().value()));
       return Success();
+    }
   }
 }
 


### PR DESCRIPTION
Patterns all compute their values when type-checked, so we never
actually need to do any multi-step evaluation to compute the value of a
pattern. Doing so was leading to quadratic runtime and excess noise in
the trace file.