### PR TITLE
Switch testing to pre-installed versions of clang-14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [brew]
+    branches: [brew ]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,10 +31,11 @@ jobs:
   test:
     strategy:
       matrix:
+        # At present, these images are newer than "latest". We use them to test
+        # against more recent tooling versions.
         # https://github.com/actions/runner-images
         # TODO
-        #os: [ubuntu-22.04, macos-12]
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
         # TODO
         #build_mode: [fastbuild, opt]
         build_mode: [opt]
@@ -66,20 +67,18 @@ jobs:
           go get github.com/bazelbuild/bazelisk
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      # Use 14 following:
+      # Use LLVM 14 following:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
       - name: Setup LLVM and Clang (macOS)
         if: matrix.os == 'macos-12'
         run: |
-          echo '*** Updating PATH'
           echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
 
-      # Use v14 following:
+      # Use LLVM 14 following:
       # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
       - name: Setup LLVM and Clang (Linux)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          sudo apt install libc++-dev
           echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH
 
       # Print the various tool paths and versions to help in debugging.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,15 +59,6 @@ jobs:
           # Match the min version listed in docs/project/contribution_tools.md
           python-version: '3.9'
 
-      # On macOS we need Go and to use it to install Bazelisk.
-      - uses: actions/setup-go@v3
-        if: matrix.os == 'macos-12'
-      - name: Install bazelisk
-        if: matrix.os == 'macos-12'
-        run: |
-          go get github.com/bazelbuild/bazelisk
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
       # Use LLVM 14 following:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
       - name: Setup LLVM and Clang (macOS)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,9 +59,9 @@ jobs:
 
       # On macOS we need Go and to use it to install Bazelisk.
       - uses: actions/setup-go@v3
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
       - name: Install bazelisk
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: |
           go get github.com/bazelbuild/bazelisk
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -69,7 +69,7 @@ jobs:
       # Use 14 following:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
       - name: Setup LLVM and Clang (macOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: |
           echo '*** Updating PATH'
           echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
@@ -77,7 +77,7 @@ jobs:
       # Use v14 following:
       # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
       - name: Setup LLVM and Clang (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt install libc++-dev
           echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,6 @@ name: test
 
 on:
   push:
-    # TODO
-    #branches: [trunk]
     branches: [brew]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
@@ -27,6 +25,12 @@ on:
       - '!CODEOWNERS'
       - '!.git*'
 
+# Cancel previous workflows on the PR when there are multiple fast commits.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:
@@ -34,11 +38,8 @@ jobs:
         # At present, these images are newer than "latest". We use them to test
         # against more recent tooling versions.
         # https://github.com/actions/runner-images
-        # TODO
         os: [ubuntu-22.04, macos-12]
-        # TODO
-        #build_mode: [fastbuild, opt]
-        build_mode: [opt]
+        build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,6 +70,11 @@ jobs:
           echo '*** Updating PATH'
           echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
 
+      - name: Setup LLVM and Clang (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH
+
       # Print the various tool paths and versions to help in debugging.
       - name: Print tool debugging info
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [brew]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # https://github.com/actions/runner-images
+        os: [macos-12]
         # TODO
         #build_mode: [fastbuild, opt]
         build_mode: [opt]
@@ -63,13 +64,16 @@ jobs:
           go get github.com/bazelbuild/bazelisk
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      # On macOS, use Homebrew to install a recent LLVM and Clang.
+      # Use 14 following:
+      # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
       - name: Setup LLVM and Clang (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           echo '*** Updating PATH'
           echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
 
+      # Use v14 following:
+      # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
       - name: Setup LLVM and Clang (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [brew]
+    branches: [trunk]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.
@@ -108,6 +108,16 @@ jobs:
           echo "$GCP_BUILDS_SERVICE_ACCOUNT" \
             | base64 -d > $HOME/gcp-builds-service-account.json
 
+      # We need to replace the `.` with a `_` for the build cache.
+      - name: Setup LLVM and Clang (macOS)
+        if: matrix.os == 'macos-12'
+        run: |
+          echo "os_for_cache=macos-12" >> $GITHUB_ENV
+      - name: Setup LLVM and Clang (Linux)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          echo "os_for_cache=ubuntu-22_04" >> $GITHUB_ENV
+
       # Add our bazel configuration and print basic info to ease debugging.
       - name: Configure Bazel and print info
         env:
@@ -117,7 +127,7 @@ jobs:
         run: |
           cat >user.bazelrc <<EOF
           # Enable remote cache for our CI.
-          build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ matrix.os }}
+          build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ env.os_for_cache }}
           build --google_credentials=$HOME/gcp-builds-service-account.json
 
           # General build options.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,9 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    # TODO
+    #branches: [trunk]
+    branches: [brew]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.
@@ -30,7 +32,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        build_mode: [fastbuild, opt]
+        # TODO
+        #build_mode: [fastbuild, opt]
+        build_mode: [opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.
@@ -62,37 +66,9 @@ jobs:
       # On macOS, use Homebrew to install a recent LLVM and Clang.
       - name: Setup LLVM and Clang (macOS)
         if: matrix.os == 'macos-latest'
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          echo '*** Updating brew'
-          brew update
-          echo '*** Installing Python'
-          # Explicitly use --overwrite because of file conflicts in
-          # /usr/local/bin with GitHub's installed version. If this stops being
-          # required, great!
-          brew install --force-bottle --overwrite python@3.11
-          echo '*** Installing LLVM deps'
-          brew install --force-bottle --only-dependencies llvm
-          echo '*** Installing LLVM itself'
-          brew install --force-bottle --force --verbose llvm
-          echo '*** brew info llvm'
-          brew info llvm
-          echo '*** brew config'
-          brew config
           echo '*** Updating PATH'
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-
-      # On Ubuntu, use apt.llvm.org to install a recent LLVM and Clang.
-      - name: Setup LLVM and Clang (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 15 all
-          rm llvm.sh
-          echo "/usr/lib/llvm-15/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
 
       # Print the various tool paths and versions to help in debugging.
       - name: Print tool debugging info

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [brew ]
+    branches: [trunk]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,9 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/runner-images
-        os: [macos-12]
+        # TODO
+        #os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04]
         # TODO
         #build_mode: [fastbuild, opt]
         build_mode: [opt]
@@ -77,6 +79,7 @@ jobs:
       - name: Setup LLVM and Clang (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo apt install libc++-dev
           echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH
 
       # Print the various tool paths and versions to help in debugging.


### PR DESCRIPTION
We keep seeing fragility installing software, with both brew (e.g., the recent python issues) and apt.llvm.org (currently flaky).

At this point, images for both ubuntu and macos have versions of llvm-14 that seem to successfully compile:
https://github.com/carbon-language/carbon-lang/actions/runs/3474670746/jobs/5808098087

Although we may want to figure out a way to resume running llvm-15 so that we can see compatibility issues, this seems preferable for baseline testing in order to reduce maintenance churn.

In addition to the above changes, this also configures cancellation more precisely, and stops installing bazel/bazelisk (it should already be preinstalled).