### PR TITLE
Add notes to comment on #access-requests as a notification substitute.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,10 +172,16 @@ access. All requests require a
     [join group](https://groups.google.com/a/carbon-lang.dev/g/commenters/about)
     -   Grants commenter access to Carbon Language documents, as well as the
         ability to view Calendar events.
+    -   After you apply to join, please let us know on
+        [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
+        we don't get notifications otherwise.
 -   Google Docs/Calendar contributor access:
     [join group](https://groups.google.com/a/carbon-lang.dev/g/contributors/about)
     -   Grants edit access to Carbon Language documents, as well as the ability
         to edit Calendar events.
+    -   After you apply to join, please let us know on
+        [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
+        we don't get notifications otherwise.
 -   GitHub Label/project contributor access:
     [ask on #access-requests](https://discord.com/channels/655572317891461132/1006221387574292540)
     -   Don't forget to mention your GitHub username.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ access. All requests require a
         -   [Google Calendar](https://calendar.google.com/calendar/embed?src=c_07td7k4qjq0ssb4gdl6bmbnkik%40group.calendar.google.com):
             View and edit event details.
     -   After you apply to join, please let us know on
-        [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
+        [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540);
         we don't get notifications otherwise.
 -   GitHub Label/project contributor access:
     [ask on #access-requests](https://discord.com/channels/655572317891461132/1006221387574292540)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ access. All requests require a
 -   Google Docs/Calendar access groups:
     -   **Commenter** access:
         [join group](https://groups.google.com/a/carbon-lang.dev/g/commenters/about)
-        -   Google Docs: Comments on files.
+        -   Google Docs: Comment on files.
         -   Google Calendar: View event details.
     -   **Contributor** access:
         [join group](https://groups.google.com/a/carbon-lang.dev/g/contributors/about)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,12 +171,16 @@ access. All requests require a
 -   Google Docs/Calendar access groups:
     -   **Commenter** access:
         [join group](https://groups.google.com/a/carbon-lang.dev/g/commenters/about)
-        -   Google Docs: Comment on files.
-        -   Google Calendar: View event details.
+        -   [Google Docs](https://drive.google.com/drive/folders/1aC5JJ5EcI8B7cgVDrLvO7WNw97F0LpS2):
+            Comment on files.
+        -   [Google Calendar](https://calendar.google.com/calendar/embed?src=c_07td7k4qjq0ssb4gdl6bmbnkik%40group.calendar.google.com):
+            View event details.
     -   **Contributor** access:
         [join group](https://groups.google.com/a/carbon-lang.dev/g/contributors/about)
-        -   Google Docs: Add, edit, and comment on files.
-        -   Google Calendar: View and edit event details.
+        -   [Google Docs](https://drive.google.com/drive/folders/1aC5JJ5EcI8B7cgVDrLvO7WNw97F0LpS2):
+            Add, edit, and comment on files.
+        -   [Google Calendar](https://calendar.google.com/calendar/embed?src=c_07td7k4qjq0ssb4gdl6bmbnkik%40group.calendar.google.com):
+            View and edit event details.
     -   After you apply to join, please let us know on
         [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
         we don't get notifications otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,17 +168,15 @@ When requesting any of the following access, please provide a reason for the
 access. All requests require a
 [signed CLA](#contributor-license-agreements-clas).
 
--   Google Docs/Calendar commenter access:
-    [join group](https://groups.google.com/a/carbon-lang.dev/g/commenters/about)
-    -   Grants commenter access to Carbon Language documents, as well as the
-        ability to view Calendar events.
-    -   After you apply to join, please let us know on
-        [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
-        we don't get notifications otherwise.
--   Google Docs/Calendar contributor access:
-    [join group](https://groups.google.com/a/carbon-lang.dev/g/contributors/about)
-    -   Grants edit access to Carbon Language documents, as well as the ability
-        to edit Calendar events.
+-   Google Docs/Calendar access groups:
+    -   **Commenter** access:
+        [join group](https://groups.google.com/a/carbon-lang.dev/g/commenters/about)
+        -   Google Docs: Comments on files.
+        -   Google Calendar: View event details.
+    -   **Contributor** access:
+        [join group](https://groups.google.com/a/carbon-lang.dev/g/contributors/about)
+        -   Google Docs: Add, edit, and comment on files.
+        -   Google Calendar: View and edit event details.
     -   After you apply to join, please let us know on
         [#access-requests](https://discord.com/channels/655572317891461132/1006221387574292540):
         we don't get notifications otherwise.


### PR DESCRIPTION
I've been meaning to do this -- just a couple days ago I processed some that we'd missed for a few weeks...