### PR TITLE
Adjust how invalid declarations pass errors.

### DIFF
--- a/toolchain/parser/parser.cpp
+++ b/toolchain/parser/parser.cpp
@@ -706,14 +706,11 @@ auto Parser::HandleDeclarationLoopState() -> void {
                         "Unrecognized declaration introducer.");
       emitter_->Emit(*position_, UnrecognizedDeclaration);
       auto cursor = *position_;
-      if (auto semi = SkipPastLikelyEnd(cursor)) {
-        AddLeafNode(ParseNodeKind::EmptyDeclaration(), *semi,
-                    /*has_error=*/true);
-      } else {
-        // Use the cursor prior to the skip to produce a local error.
-        AddLeafNode(ParseNodeKind::EmptyDeclaration(), cursor,
-                    /*has_error=*/true);
-      }
+      auto semi = SkipPastLikelyEnd(cursor);
+      // Locate the EmptyDeclaration at the semi when found, but use the
+      // original cursor location for an error when not.
+      AddLeafNode(ParseNodeKind::EmptyDeclaration(), semi ? *semi : cursor,
+                  /*has_error=*/true);
       break;
     }
   }

--- a/toolchain/parser/parser.cpp
+++ b/toolchain/parser/parser.cpp
@@ -705,9 +705,13 @@ auto Parser::HandleDeclarationLoopState() -> void {
       CARBON_DIAGNOSTIC(UnrecognizedDeclaration, Error,
                         "Unrecognized declaration introducer.");
       emitter_->Emit(*position_, UnrecognizedDeclaration);
-      tree_->has_errors_ = true;
-      if (auto semi = SkipPastLikelyEnd(*position_)) {
+      auto cursor = *position_;
+      if (auto semi = SkipPastLikelyEnd(cursor)) {
         AddLeafNode(ParseNodeKind::EmptyDeclaration(), *semi,
+                    /*has_error=*/true);
+      } else {
+        // Use the cursor prior to the skip to produce a local error.
+        AddLeafNode(ParseNodeKind::EmptyDeclaration(), cursor,
                     /*has_error=*/true);
       }
       break;

--- a/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
@@ -5,6 +5,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
+// CHECK:STDOUT: {kind: 'EmptyDeclaration', text: 'foo', has_error: yes},
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 

--- a/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
@@ -5,6 +5,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-parser}
 // CHECK:STDOUT: [
+// CHECK:STDOUT: {kind: 'EmptyDeclaration', text: 'struct', has_error: yes},
 // CHECK:STDOUT:   {kind: 'FunctionIntroducer', text: 'fn'},
 // CHECK:STDOUT:   {kind: 'DeclaredName', text: 'F'},
 // CHECK:STDOUT:     {kind: 'ParameterListStart', text: '('},


### PR DESCRIPTION
When there's no semicolon for an invalid EmptyDeclaration, rather than producing nothing, produce an EmptyDeclaration with the original location that led to the error.

Note this removes a direct edit (the only one) of the parse tree's error state. Elsewhere it's an indirection from adding an error node.