### PR TITLE
hasValue -> has_value

### DIFF
--- a/toolchain/lexer/string_literal_test.cpp
+++ b/toolchain/lexer/string_literal_test.cpp
@@ -93,7 +93,7 @@ TEST_F(StringLiteralTest, StringLiteralBounds) {
   for (llvm::StringLiteral test : valid) {
     SCOPED_TRACE(test);
     llvm::Optional<LexedStringLiteral> result = LexedStringLiteral::Lex(test);
-    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(result.has_value());
     if (result) {
       EXPECT_EQ(result->text(), test);
     }
@@ -118,7 +118,7 @@ TEST_F(StringLiteralTest, StringLiteralBounds) {
   for (llvm::StringLiteral test : invalid) {
     SCOPED_TRACE(test);
     llvm::Optional<LexedStringLiteral> result = LexedStringLiteral::Lex(test);
-    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(result.has_value());
     if (result) {
       EXPECT_FALSE(result->is_terminated());
     }

--- a/toolchain/parser/precedence_test.cpp
+++ b/toolchain/parser/precedence_test.cpp
@@ -15,19 +15,20 @@ namespace {
 using ::testing::Eq;
 
 TEST(PrecedenceTest, OperatorsAreRecognized) {
-  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Minus()).hasValue());
-  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Tilde()).hasValue());
-  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Slash()).hasValue());
-  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Identifier()).hasValue());
+  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Minus()).has_value());
+  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Tilde()).has_value());
+  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Slash()).has_value());
+  EXPECT_FALSE(
+      PrecedenceGroup::ForLeading(TokenKind::Identifier()).has_value());
 
   EXPECT_TRUE(
-      PrecedenceGroup::ForTrailing(TokenKind::Minus(), false).hasValue());
+      PrecedenceGroup::ForTrailing(TokenKind::Minus(), false).has_value());
   EXPECT_FALSE(
-      PrecedenceGroup::ForTrailing(TokenKind::Tilde(), false).hasValue());
+      PrecedenceGroup::ForTrailing(TokenKind::Tilde(), false).has_value());
   EXPECT_TRUE(
-      PrecedenceGroup::ForTrailing(TokenKind::Slash(), true).hasValue());
+      PrecedenceGroup::ForTrailing(TokenKind::Slash(), true).has_value());
   EXPECT_FALSE(
-      PrecedenceGroup::ForTrailing(TokenKind::Identifier(), false).hasValue());
+      PrecedenceGroup::ForTrailing(TokenKind::Identifier(), false).has_value());
 
   EXPECT_TRUE(
       PrecedenceGroup::ForTrailing(TokenKind::Minus(), true)->is_binary);


### PR DESCRIPTION
For consistency and due to LLVM migrating Optional in this direction.

See also #2424, this is just breaking out a trivial piece from it.