### PR TITLE
README.md: add a section with past talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,13 @@ Learn more about the Carbon project:
 -   [Carbon Explorer](/explorer)
 -   [FAQ](/docs/project/faq.md)
 
+## Conference talks
+
+Past Carbon focused talks from the community:
+
+-   [Carbon Language: An experimental successor to C++](https://www.youtube.com/watch?v=omrY53kbVoA), CppNorth 2022
+-   [Carbon Language: Syntax and trade-offs](https://www.youtube.com/watch?v=9Y2ivB8VaIs), Core C++ 2022
+
 ## Join us
 
 Carbon is committed to a welcoming and inclusive environment where everyone can

--- a/README.md
+++ b/README.md
@@ -304,8 +304,10 @@ Learn more about the Carbon project:
 
 Past Carbon focused talks from the community:
 
--   [Carbon Language: An experimental successor to C++](https://www.youtube.com/watch?v=omrY53kbVoA), CppNorth 2022
--   [Carbon Language: Syntax and trade-offs](https://www.youtube.com/watch?v=9Y2ivB8VaIs), Core C++ 2022
+-   [Carbon Language: An experimental successor to C++](https://www.youtube.com/watch?v=omrY53kbVoA),
+    CppNorth 2022
+-   [Carbon Language: Syntax and trade-offs](https://www.youtube.com/watch?v=9Y2ivB8VaIs),
+    Core C++ 2022
 
 ## Join us
 


### PR DESCRIPTION
Suggesting to add a section with past conference talks, to include content that has been created around carbon. This feel to me like an accessible type of content to have in the main README for those wanting to dig a bit deeper without going into /docs.

This does not show the speaker name to keep it "Carbon/community" oriented, vs naming, but there's an argument both ways I think.