### PR TITLE
Fix some broken regexes for files in pre-commit configs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,11 +60,11 @@ repos:
         args: ['-r', '.']
         language: python
         files: |
-          '(?x)^(
+          (?x)^(
             .*BUILD.*|
             .*WORKSPACE.*|
             .*\.bzl
-          )$'
+          )$
       - id: clang-format
         name: clang-format
         entry: clang-format
@@ -87,7 +87,7 @@ repos:
         name: Check header guards
         entry: scripts/check_header_guards.py
         language: python
-        files: '^.*\.h$'
+        files: ^.*\.h$
       - id: check-sha-filenames
         # This may rename files, so it's deliberately between formatters and
         # linters.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,11 +10,11 @@ skylib_version = "1.3.0"
 
 http_archive(
     name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(skylib_version),
         "https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(skylib_version),
     ],
-    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
 )
 
 ###############################################################################

--- a/bazel/cc_toolchains/BUILD
+++ b/bazel/cc_toolchains/BUILD
@@ -8,7 +8,10 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 # Matches when asan is enabled on a macOS platform.
 selects.config_setting_group(
     name = "macos_asan",
-    match_all = [":is_macos", ":macos_asan_build_modes"],
+    match_all = [
+        ":is_macos",
+        ":macos_asan_build_modes",
+    ],
 )
 
 # For use by rules.bzl.
@@ -22,7 +25,10 @@ config_setting(
 # Matches build modes where asan is enabled.
 selects.config_setting_group(
     name = "macos_asan_build_modes",
-    match_any = [":dbg", ":fastbuild"],
+    match_any = [
+        ":dbg",
+        ":fastbuild",
+    ],
 )
 
 # For use by rules.bzl.

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -20,10 +20,10 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     ":clang_detected_variables.bzl",
     "clang_bindir",
-    "clang_version",
-    "clang_version_for_cache",
     "clang_include_dirs_list",
     "clang_resource_dir",
+    "clang_version",
+    "clang_version_for_cache",
     "llvm_bindir",
     "sysroot_dir",
 )
@@ -100,6 +100,7 @@ def _impl(ctx):
     ]
 
     std_compile_flags = ["-std=c++17"]
+
     # libc++ is only used on non-Windows platforms.
     if ctx.attr.target_cpu != "x64_windows":
         std_compile_flags.append("-stdlib=libc++")

--- a/bazel/testing/BUILD
+++ b/bazel/testing/BUILD
@@ -2,11 +2,14 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(default_visibility=["//visibility:public"])
+package(default_visibility = ["//visibility:public"])
 
-exports_files(["lit_test.py", "merge_output.py"])
+exports_files([
+    "lit_test.py",
+    "merge_output.py",
+])
 
 py_binary(
-  name = "merge_output",
-  srcs = ["merge_output.py"],
+    name = "merge_output",
+    srcs = ["merge_output.py"],
 )

--- a/migrate_cpp/BUILD
+++ b/migrate_cpp/BUILD
@@ -25,6 +25,10 @@ cc_library(
     name = "rewriter",
     srcs = ["rewriter.cpp"],
     hdrs = ["rewriter.h"],
+    visibility = [
+        # For dependency checking. Remove once it has a binary using it.
+        "//bazel/check_deps:__pkg__",
+    ],
     deps = [
         ":output_segment",
         "//common:check",
@@ -35,10 +39,6 @@ cc_library(
         "@llvm-project//clang:tooling",
         "@llvm-project//clang:tooling_core",
         "@llvm-project//llvm:Support",
-    ],
-    visibility = [
-      # For dependency checking. Remove once it has a binary using it.
-      "//bazel/check_deps:__pkg__",
     ],
 )
 


### PR DESCRIPTION
The result was we weren't actually running buildifier on files for example, so this also runs it on a bunch of files to clean things up.