### PR TITLE
Explorer: basic `abstract` class support

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4504,11 +4504,6 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
   ImplScope class_scope;
   class_scope.AddParent(scope_info.innermost_scope);
 
-  if (class_decl->extensibility() == ClassExtensibility::Abstract) {
-    return ProgramError(class_decl->source_loc())
-           << "Class prefix `abstract` is not supported yet";
-  }
-
   std::optional<Nonnull<const NominalClassType*>> base_class;
   if (class_decl->base_expr().has_value()) {
     Nonnull<Expression*> base_class_expr = *class_decl->base_expr();

--- a/explorer/testdata/class/abstract_class.carbon
+++ b/explorer/testdata/class/abstract_class.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: d.a=1
+// CHECK:STDOUT: d.b=2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+abstract class C {
+  var a: i32;
+}
+
+class D extends C {
+  var b: i32;
+}
+
+fn Main() -> i32 {
+  var d: D = { .base = {.a = 1}, .b = 2 };
+  Print("d.a={0}", d.a);
+  Print("d.b={0}", d.b);
+  return 0;
+}

--- a/explorer/testdata/class/fail_abstract_class_subtyping.carbon
+++ b/explorer/testdata/class/fail_abstract_class_subtyping.carbon
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class C {
+  var a: i32;
+}
+
+class D extends C {
+  var b: i32;
+}
+
+fn Main() -> i32 {
+  var d: D = { .base = {.a = 1}, .b = 2 };
+  // XFAIL: Not supported yet.
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_class_subtyping.carbon:[[@LINE+1]]: type error in name binding: 'class D*' is not implicitly convertible to 'class C*'
+  var c: C* = &d;
+  return 0;
+}

--- a/explorer/testdata/class/fail_abstract_class_subtyping.carbon
+++ b/explorer/testdata/class/fail_abstract_class_subtyping.carbon
@@ -18,7 +18,7 @@ class D extends C {
 
 fn Main() -> i32 {
   var d: D = { .base = {.a = 1}, .b = 2 };
-  // XFAIL: Not supported yet.
+  // Not supported yet.
   // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_class_subtyping.carbon:[[@LINE+1]]: type error in name binding: 'class D*' is not implicitly convertible to 'class C*'
   var c: C* = &d;
   return 0;

--- a/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
@@ -9,6 +9,7 @@
 package ExplorerTest api;
 
 abstract class C {
+  // TODO: Returning `Self` for an abstract class should error: `partial Self` should be used instead. This should be updated when `partial` is implemented.
   fn Create() -> Self {
     return { .a = 1 };
   }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class C {
+  fn Create() -> Self {
+    return { .a = 1 };
+  }
+  var a: i32;
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  var c: C = C.Create();
+  return 0;
+}

--- a/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
@@ -13,7 +13,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_assign.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C;
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
@@ -9,10 +9,11 @@
 package ExplorerTest api;
 
 abstract class C {
-  fn F() {}
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_class.carbon:[[@LINE+1]]: Class prefix `abstract` is not supported yet
+  var a: i32;
 }
 
 fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_assign.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  var c: C;
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class C {
+  var a: i32;
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  var c: C = { .a = 1 };
+  return 0;
+}

--- a/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
@@ -13,7 +13,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C = { .a = 1 };
   return 0;
 }


### PR DESCRIPTION
Relates to #1881 

Features:
* Add basic support for `abstract` class
    * Allow extending an abstract class
    * Prevent direct instantiation of an abstract class

Changes:
* Check that class extensibility for `VariableDefinition` is not `Abstract`
* Add corresponding set of lit tests