### PR TITLE
Change result_id to use is_valid instead of an optional.

### DIFF
--- a/toolchain/common/index_base.h
+++ b/toolchain/common/index_base.h
@@ -29,7 +29,7 @@ struct IndexBase {
 
   auto Print(llvm::raw_ostream& output) const -> void { output << index; }
 
-  auto is_valid() -> bool { return index != InvalidIndex; }
+  auto is_valid() const -> bool { return index != InvalidIndex; }
 
   int32_t index;
 };

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -23,12 +23,16 @@ struct SemanticsNodeId : public IndexBase {
   static auto MakeCrossReference(int32_t index) -> SemanticsNodeId {
     return SemanticsNodeId(index | CrossReferenceBit);
   }
+
   // Constructs a cross-reference node ID for a builtin. This relies on
   // SemanticsIR guarantees for builtin cross-reference placement.
   static auto MakeBuiltinReference(SemanticsBuiltinKind kind)
       -> SemanticsNodeId {
     return MakeCrossReference(kind.AsInt());
   }
+
+  // Constructs an explicitly invalid instance.
+  static auto MakeInvalid() -> SemanticsNodeId { return SemanticsNodeId(); }
 
   using IndexBase::IndexBase;
 

--- a/toolchain/semantics/semantics_parse_tree_handler.cpp
+++ b/toolchain/semantics/semantics_parse_tree_handler.cpp
@@ -130,7 +130,7 @@ auto SemanticsParseTreeHandler::Push(ParseTree::Node parse_node) -> void {
                 << parse_tree_->node_kind(parse_node) << "\n";
   CARBON_CHECK(node_stack_.size() < (1 << 20))
       << "Excessive stack size: likely infinite loop";
-  node_stack_.push_back({parse_node, SemanticsNodeId()});
+  node_stack_.push_back({parse_node, SemanticsNodeId::MakeInvalid()});
 }
 
 auto SemanticsParseTreeHandler::Push(ParseTree::Node parse_node,

--- a/toolchain/semantics/semantics_parse_tree_handler.cpp
+++ b/toolchain/semantics/semantics_parse_tree_handler.cpp
@@ -152,7 +152,8 @@ auto SemanticsParseTreeHandler::Pop(ParseNodeKind pop_parse_kind) -> void {
   CARBON_CHECK(parse_kind == pop_parse_kind)
       << "Expected " << pop_parse_kind << ", found " << parse_kind;
   CARBON_CHECK(!back.result_id.is_valid())
-      << "Expected no result ID on " << parse_kind;
+      << "Expected no result ID on " << parse_kind << ", was "
+      << back.result_id;
 }
 
 auto SemanticsParseTreeHandler::PopWithResult() -> SemanticsNodeId {

--- a/toolchain/semantics/semantics_parse_tree_handler.h
+++ b/toolchain/semantics/semantics_parse_tree_handler.h
@@ -37,8 +37,11 @@ class SemanticsParseTreeHandler {
 
   struct TraversalStackEntry {
     ParseTree::Node parse_node;
-    std::optional<SemanticsNodeId> result_id;
+    // The result_id may be invalid if there's no result.
+    SemanticsNodeId result_id;
   };
+  static_assert(sizeof(TraversalStackEntry) == 8,
+                "Unexpected TraversalStackEntry size");
 
   // Adds an identifier for a DeclaredName node, returning its reference.
   auto AddIdentifier(ParseTree::Node decl_node) -> SemanticsIdentifierId;


### PR DESCRIPTION
Incrementally shrinks size, but should also make the errors a bit clearer with better context.