### PR TITLE
Can't override virtual methods in an adapter

### DIFF
--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -1561,7 +1561,9 @@ This allows developers to provide implementations of new interfaces (as in
 -   You can add any declaration that you could add to a class except for
     declarations that would change the representation of the type. This means
     you can add methods, functions, interface implementations, and aliases, but
-    not fields, base classes, or virtual functions.
+    not fields, base classes, or virtual functions. The specific implementations
+    of virtual functions are part of the type representation, and so no virtual
+    functions may be overridden in an adapter either.
 -   The adapted type is compatible with the original type, and that relationship
     is an equivalence class, so all of `Song`, `SongByTitle`, `FormattedSong`,
     and `FormattedSongByTitle` end up compatible with each other.


### PR DESCRIPTION
This is just a consequence of casting to an adapter type doesn't change the data, including the vtable pointer.
