### PR TITLE
Remove equality on enum types

### DIFF
--- a/toolchain/lexer/token_kind.h
+++ b/toolchain/lexer/token_kind.h
@@ -35,13 +35,6 @@ class TokenKind {
   // constructed using the above factory functions for each unique kind.
   TokenKind() = delete;
 
-  friend auto operator==(TokenKind lhs, TokenKind rhs) -> bool {
-    return lhs.kind_value_ == rhs.kind_value_;
-  }
-  friend auto operator!=(TokenKind lhs, TokenKind rhs) -> bool {
-    return lhs.kind_value_ != rhs.kind_value_;
-  }
-
   // Get a friendly name for the token for logging or debugging.
   [[nodiscard]] auto Name() const -> llvm::StringRef;
 

--- a/toolchain/parser/parse_node_kind.h
+++ b/toolchain/parser/parse_node_kind.h
@@ -46,13 +46,6 @@ class ParseNodeKind {
   // kind.
   ParseNodeKind() = delete;
 
-  friend auto operator==(ParseNodeKind lhs, ParseNodeKind rhs) -> bool {
-    return lhs.kind_ == rhs.kind_;
-  }
-  friend auto operator!=(ParseNodeKind lhs, ParseNodeKind rhs) -> bool {
-    return lhs.kind_ != rhs.kind_;
-  }
-
   // Gets a friendly name for the token for logging or debugging.
   [[nodiscard]] auto name() const -> llvm::StringRef;
 

--- a/toolchain/parser/parser_state.h
+++ b/toolchain/parser/parser_state.h
@@ -35,13 +35,6 @@ class ParserState {
   // kind.
   ParserState() = delete;
 
-  friend auto operator==(ParserState lhs, ParserState rhs) -> bool {
-    return lhs.state_ == rhs.state_;
-  }
-  friend auto operator!=(ParserState lhs, ParserState rhs) -> bool {
-    return lhs.state_ != rhs.state_;
-  }
-
   // Gets a friendly name for the token for logging or debugging.
   [[nodiscard]] auto name() const -> llvm::StringRef;
 

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -37,15 +37,6 @@ class SemanticsBuiltinKind {
   // kind.
   SemanticsBuiltinKind() = delete;
 
-  friend auto operator==(SemanticsBuiltinKind lhs, SemanticsBuiltinKind rhs)
-      -> bool {
-    return lhs.kind_ == rhs.kind_;
-  }
-  friend auto operator!=(SemanticsBuiltinKind lhs, SemanticsBuiltinKind rhs)
-      -> bool {
-    return lhs.kind_ != rhs.kind_;
-  }
-
   // Gets a friendly name for the token for logging or debugging.
   [[nodiscard]] auto name() const -> llvm::StringRef;
 

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -34,13 +34,6 @@ class SemanticsNodeKind {
   // kind.
   SemanticsNodeKind() = delete;
 
-  friend auto operator==(SemanticsNodeKind lhs, SemanticsNodeKind rhs) -> bool {
-    return lhs.kind_ == rhs.kind_;
-  }
-  friend auto operator!=(SemanticsNodeKind lhs, SemanticsNodeKind rhs) -> bool {
-    return lhs.kind_ != rhs.kind_;
-  }
-
   // Gets a friendly name for the token for logging or debugging.
   [[nodiscard]] auto name() const -> llvm::StringRef;
 


### PR DESCRIPTION
A quick check suggests this isn't necessary -- probably because the implicit enum cast is used for comparisons. I think this adds a lot to the boilerplate feel of these types, so if we can remove it there's a lot less sharing to do.