### PR TITLE
Support `p->member`, rewriting it to `(*p).member` in the parser.

### DIFF
--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -395,10 +395,26 @@ postfix_expression:
       $$ = arena->New<SimpleMemberAccessExpression>(context.source_loc(), $1,
                                                     $2);
     }
+| postfix_expression ARROW identifier
+    {
+      auto deref = arena->New<OperatorExpression>(
+          context.source_loc(), Operator::Deref,
+          std::vector<Nonnull<Expression*>>({$1}));
+      $$ = arena->New<SimpleMemberAccessExpression>(context.source_loc(), deref,
+                                                    $3);
+    }
 | postfix_expression PERIOD LEFT_PARENTHESIS expression RIGHT_PARENTHESIS
     {
       $$ = arena->New<CompoundMemberAccessExpression>(context.source_loc(), $1,
                                                       $4);
+    }
+| postfix_expression ARROW LEFT_PARENTHESIS expression RIGHT_PARENTHESIS
+    {
+      auto deref = arena->New<OperatorExpression>(
+          context.source_loc(), Operator::Deref,
+          std::vector<Nonnull<Expression*>>({$1}));
+      $$ = arena->New<CompoundMemberAccessExpression>(context.source_loc(),
+                                                      deref, $4);
     }
 | postfix_expression LEFT_SQUARE_BRACKET expression RIGHT_SQUARE_BRACKET
     { $$ = arena->New<IndexExpression>(context.source_loc(), $1, $3); }

--- a/explorer/testdata/member_access/arrow.carbon
+++ b/explorer/testdata/member_access/arrow.carbon
@@ -5,7 +5,11 @@
 // AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
-// CHECK:STDOUT: result: 4
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: result: 0
 
 package Foo api;
 class X {
@@ -15,5 +19,9 @@ class X {
 fn Main() -> i32 {
   var v: X = {.n = 1};
   let p: X* = &v;
-  return p->n + p->(X.n) + p->F() + p->(X.F)();
+  Print("{0}", p->n);
+  Print("{0}", p->(X.n));
+  Print("{0}", p->F());
+  Print("{0}", p->(X.F)());
+  return 0;
 }

--- a/explorer/testdata/member_access/arrow.carbon
+++ b/explorer/testdata/member_access/arrow.carbon
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDERR: Please report issues to https://github.com/carbon-language/carbon-lang/issues and include the crash backtrace.
+// CHECK:STDERR: Stack dump:
+// CHECK:STDERR: 0.	Program arguments: ./bazel-bin/explorer/explorer {{.*}}/explorer/testdata/member_access/arrow.carbon
+// CHECK:STDERR: #0 0x000055ca03f3d9c3 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (./bazel-bin/explorer/explorer+0x1c09c3)
+// CHECK:STDERR: #1 0x000055ca03f3b81e llvm::sys::RunSignalHandlers() (./bazel-bin/explorer/explorer+0x1be81e)
+// CHECK:STDERR: #2 0x000055ca03f3ddba SignalHandler(int) Signals.cpp:0:0
+// CHECK:STDERR: #3 0x00007fca9243daa0 (/lib/x86_64-linux-gnu/libc.so.6+0x3daa0)
+// CHECK:STDERR: #4 0x00007fca9248957c __pthread_kill_implementation ./nptl/./nptl/pthread_kill.c:44:76
+// CHECK:STDERR: #5 0x00007fca9243da02 gsignal ./signal/../sysdeps/posix/raise.c:27:6
+// CHECK:STDERR: #6 0x00007fca92428469 abort ./stdlib/./stdlib/abort.c:81:7
+// CHECK:STDERR: #7 0x000055ca03f043b2 Carbon::Internal::ExitingStream::Done() (./bazel-bin/explorer/explorer+0x1873b2)
+// CHECK:STDERR: FATAL failure at explorer/interpreter/value.cpp:172: field access not allowed for value lval<Allocation(1)>
+
+package Foo api;
+class X {
+  fn F[addr self: Self*]() -> i32 { return self->n; }
+  var n: i32;
+}
+fn Main() -> i32 {
+  var v: X = {.n = 1};
+  let p: X* = &v;
+  return p->n + p->(X.n) + p->F() + p->(X.F)();
+}

--- a/explorer/testdata/member_access/arrow.carbon
+++ b/explorer/testdata/member_access/arrow.carbon
@@ -5,22 +5,11 @@
 // AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
-// CHECK:STDERR: Please report issues to https://github.com/carbon-language/carbon-lang/issues and include the crash backtrace.
-// CHECK:STDERR: Stack dump:
-// CHECK:STDERR: 0.	Program arguments: ./bazel-bin/explorer/explorer {{.*}}/explorer/testdata/member_access/arrow.carbon
-// CHECK:STDERR: #0 0x000055ca03f3d9c3 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (./bazel-bin/explorer/explorer+0x1c09c3)
-// CHECK:STDERR: #1 0x000055ca03f3b81e llvm::sys::RunSignalHandlers() (./bazel-bin/explorer/explorer+0x1be81e)
-// CHECK:STDERR: #2 0x000055ca03f3ddba SignalHandler(int) Signals.cpp:0:0
-// CHECK:STDERR: #3 0x00007fca9243daa0 (/lib/x86_64-linux-gnu/libc.so.6+0x3daa0)
-// CHECK:STDERR: #4 0x00007fca9248957c __pthread_kill_implementation ./nptl/./nptl/pthread_kill.c:44:76
-// CHECK:STDERR: #5 0x00007fca9243da02 gsignal ./signal/../sysdeps/posix/raise.c:27:6
-// CHECK:STDERR: #6 0x00007fca92428469 abort ./stdlib/./stdlib/abort.c:81:7
-// CHECK:STDERR: #7 0x000055ca03f043b2 Carbon::Internal::ExitingStream::Done() (./bazel-bin/explorer/explorer+0x1873b2)
-// CHECK:STDERR: FATAL failure at explorer/interpreter/value.cpp:172: field access not allowed for value lval<Allocation(1)>
+// CHECK:STDOUT: result: 4
 
 package Foo api;
 class X {
-  fn F[addr self: Self*]() -> i32 { return self->n; }
+  fn F[self: Self]() -> i32 { return self.n; }
   var n: i32;
 }
 fn Main() -> i32 {


### PR DESCRIPTION
This behavior is as described in
https://github.com/carbon-language/carbon-lang/tree/trunk/docs/design#pointer-types:

> `p->m` is syntactic sugar for `(*p).m`.