### PR TITLE
Rename PointerType::type to pointee_type.

### DIFF
--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -450,7 +450,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       out << "Continuation";
       break;
     case Value::Kind::PointerType:
-      out << cast<PointerType>(*this).type() << "*";
+      out << cast<PointerType>(*this).pointee_type() << "*";
       break;
     case Value::Kind::FunctionType: {
       const auto& fn_type = cast<FunctionType>(*this);
@@ -722,8 +722,8 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
   }
   switch (t1->kind()) {
     case Value::Kind::PointerType:
-      return TypeEqual(&cast<PointerType>(*t1).type(),
-                       &cast<PointerType>(*t2).type(), equality_ctx);
+      return TypeEqual(&cast<PointerType>(*t1).pointee_type(),
+                       &cast<PointerType>(*t2).pointee_type(), equality_ctx);
     case Value::Kind::FunctionType: {
       const auto& fn1 = cast<FunctionType>(*t1);
       const auto& fn2 = cast<FunctionType>(*t2);

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -602,17 +602,19 @@ class FunctionType : public Value {
 // A pointer type.
 class PointerType : public Value {
  public:
-  explicit PointerType(Nonnull<const Value*> type)
-      : Value(Kind::PointerType), type_(type) {}
+  // Constructs a pointer type with the given pointee type.
+  explicit PointerType(Nonnull<const Value*> pointee_type)
+      : Value(Kind::PointerType), pointee_type_(pointee_type) {}
 
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::PointerType;
   }
 
-  auto type() const -> const Value& { return *type_; }
+  // Returns the pointee type.
+  auto pointee_type() const -> const Value& { return *pointee_type_; }
 
  private:
-  Nonnull<const Value*> type_;
+  Nonnull<const Value*> pointee_type_;
 };
 
 // The `auto` type.


### PR DESCRIPTION
This avoids the confusion that can arise from the natural assumption that `foo->type()` returns the type of the value `foo`.