### PR TITLE
Automate labeling of explorer and toolchain PRs

### DIFF
--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: 'Auto Assign'
+name: 'Auto label PRs'
 on:
   pull_request_target:
     types: [opened, ready_for_review]

--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -1,0 +1,37 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: 'Auto Assign'
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            explorer:
+              - 'explorer/**'
+            toolchain:
+              - 'toolchain/**'
+
+      - id: explorer
+        if: steps.filter.outputs.explorer == 'true'
+        run: |
+          gh pr edit "${PR}" --add-label "explorer"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+
+      - id: assign-toolchain
+        if: steps.filter.outputs.toolchain == 'true'
+        run: |
+          gh pr edit "${PR}" --add-label "toolchain"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Pixep has been doing this by hand, so offering up some automation.

This is derivative of other workflows for [path-filter](https://github.com/carbon-language/carbon-lang/blob/trunk/.github/workflows/assign_prs.yaml) and [using gh for labels](https://github.com/carbon-language/carbon-lang/blob/trunk/.github/workflows/proposal_labeled.yaml). It felt best to stick it in its own workflow rather than merging with assign_prs.yaml, just to make the boundary clearer (I believe the separate workflow is cheap).