### PR TITLE
Small cleanups in toolchain code

### DIFF
--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -130,6 +130,12 @@ CARBON_PARSER_STATE(CodeBlockFinish)
 //   1. DeclarationLoop
 CARBON_PARSER_STATE(DeclarationLoop)
 
+// To handle parsing deduced parameter list at the end.
+//
+// Always:
+//   (state done)
+CARBON_PARSER_STATE(DeducedParameterListFinish)
+
 // Handles a designator expression, such as `.z` in `x.(y.z)`.
 //
 // Always:
@@ -369,11 +375,26 @@ CARBON_PARSER_STATE(ParenExpressionFinishAsTuple)
 CARBON_PARSER_STATE(PatternAsFunctionParameter)
 CARBON_PARSER_STATE(PatternAsVariable)
 
+// Handles `addr` in a pattern.
+//
+// Always:
+//   (state done)
+CARBON_PARSER_STATE(PatternAddress)
+
 // Finishes pattern processing.
 //
 // Always:
 //   (state done)
 CARBON_PARSER_STATE(PatternFinish)
+
+// To start parsing `self` deduced parameter.
+//
+// If valid:
+//   1. Expression
+//   2. PatternFinish
+// Else:
+//   1. PatternFinish
+CARBON_PARSER_STATE(SelfPattern)
 
 // Handles a single statement. While typically within a statement block, this
 // can also be used for error recovery where we expect a statement block and
@@ -570,22 +591,5 @@ CARBON_PARSER_STATE(VarFinishAsFor)
 //   1. FunctionParameterListFinish
 //   2. FunctionAfterParameterList
 CARBON_PARSER_STATE(FunctionAfterDeducedParameterList)
-
-// To handle parsing deduced parameter list at the end.
-//
-// Always:
-//   (state done)
-CARBON_PARSER_STATE(DeducedParameterListFinish)
-
-// To start parsing `self` deduced parameter.
-//
-// If valid:
-//   1. Expression
-//   2. PatternFinish
-// Else:
-//   1. PatternFinish
-CARBON_PARSER_STATE(SelfPattern)
-
-CARBON_PARSER_STATE(PatternAddress)
 
 #undef CARBON_PARSER_STATE

--- a/toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon
+++ b/toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon
@@ -66,7 +66,7 @@ interface foo {
   // CHECK:STDERR: {{.*}}/toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon:[[@LINE+1]]:10: Deduced parameters must be of the form: `<name>: <Type>` or `addr <name>: <Type>`.
   fn Mul[Self](b: Self) -> Self;
 
-  // TODO The recovery token is currently inserted after the `;`:
+  // TODO: The recovery token is currently inserted after the `;`:
   // ```
   // fn Div[me: Self(b: Self) -> Self;]
   // ```

--- a/toolchain/semantics/semantics_parse_tree_handler.cpp
+++ b/toolchain/semantics/semantics_parse_tree_handler.cpp
@@ -198,6 +198,11 @@ auto SemanticsParseTreeHandler::AddIdentifier(ParseTree::Node decl_node)
   return semantics_->AddIdentifier(text);
 }
 
+auto SemanticsParseTreeHandler::HandleAddress(ParseTree::Node /*parse_node*/)
+    -> void {
+  CARBON_FATAL() << "TODO";
+}
+
 auto SemanticsParseTreeHandler::HandleBreakStatement(
     ParseTree::Node /*parse_node*/) -> void {
   CARBON_FATAL() << "TODO";
@@ -247,6 +252,16 @@ auto SemanticsParseTreeHandler::HandleDeclaredName(ParseTree::Node parse_node)
     -> void {
   // The parent is responsible for binding the name.
   Push(parse_node);
+}
+
+auto SemanticsParseTreeHandler::HandleDeducedParameterList(
+    ParseTree::Node /*parse_node*/) -> void {
+  CARBON_FATAL() << "TODO";
+}
+
+auto SemanticsParseTreeHandler::HandleDeducedParameterListStart(
+    ParseTree::Node /*parse_node*/) -> void {
+  CARBON_FATAL() << "TODO";
 }
 
 auto SemanticsParseTreeHandler::HandleDesignatedName(
@@ -535,6 +550,16 @@ auto SemanticsParseTreeHandler::HandleReturnType(ParseTree::Node /*parse_node*/)
   CARBON_FATAL() << "TODO";
 }
 
+auto SemanticsParseTreeHandler::HandleSelfDeducedParameter(
+    ParseTree::Node /*parse_node*/) -> void {
+  CARBON_FATAL() << "TODO";
+}
+
+auto SemanticsParseTreeHandler::HandleSelfType(ParseTree::Node /*parse_node*/)
+    -> void {
+  CARBON_FATAL() << "TODO";
+}
+
 auto SemanticsParseTreeHandler::HandleStructComma(
     ParseTree::Node /*parse_node*/) -> void {
   CARBON_FATAL() << "TODO";
@@ -626,28 +651,4 @@ auto SemanticsParseTreeHandler::HandleWhileStatement(
   CARBON_FATAL() << "TODO";
 }
 
-auto SemanticsParseTreeHandler::HandleAddress(ParseTree::Node /*parse_node*/)
-    -> void {
-  CARBON_FATAL() << "TODO";
-}
-
-auto SemanticsParseTreeHandler::HandleSelfType(ParseTree::Node /*parse_node*/)
-    -> void {
-  CARBON_FATAL() << "TODO";
-}
-
-auto SemanticsParseTreeHandler::HandleDeducedParameterList(
-    ParseTree::Node /*parse_node*/) -> void {
-  CARBON_FATAL() << "TODO";
-}
-
-auto SemanticsParseTreeHandler::HandleSelfDeducedParameter(
-    ParseTree::Node /*parse_node*/) -> void {
-  CARBON_FATAL() << "TODO";
-}
-
-auto SemanticsParseTreeHandler::HandleDeducedParameterListStart(
-    ParseTree::Node /*parse_node*/) -> void {
-  CARBON_FATAL() << "TODO";
-}
 }  // namespace Carbon


### PR DESCRIPTION
Doing some sorting of functions / enums (generally speaking, I've been trying to keep these loosely lexically sorted for lack of a better ordering).

Also removes some code that seems to be dead, and a minor TODO comment fix.