### PR TITLE
Explorer: add one missing `Nonnull<>`

### DIFF
--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -103,7 +103,7 @@ class RewritableMixin : public Base {
 
   // Set the rewritten form of this expression. Can only be called during type
   // checking.
-  auto set_rewritten_form(const Expression* rewritten_form) -> void {
+  auto set_rewritten_form(Nonnull<const Expression*> rewritten_form) -> void {
     CARBON_CHECK(!rewritten_form_.has_value()) << "rewritten form set twice";
     rewritten_form_ = rewritten_form;
     this->set_static_type(&rewritten_form->static_type());


### PR DESCRIPTION
Trivial change adding a missing `Nonnull<>` to `RewritableMixin`.