### PR TITLE
The typed_linked_list test trace output is too slow, so stop testing it.

### DIFF
--- a/explorer/testdata/linked_list/typed_linked_list.carbon
+++ b/explorer/testdata/linked_list/typed_linked_list.carbon
@@ -2,9 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// AUTOUPDATE
+// This doesn't test trace ouptut because it's too slow.
+// NOAUTOUPDATE
 // RUN: %{explorer-run}
-// RUN: %{explorer-run-trace}
 // CHECK:STDOUT: String list length is: 7
 // CHECK:STDOUT: This is a String Entry 4
 // CHECK:STDOUT: Value 1337


### PR DESCRIPTION
Another case of flakiness from trace output performance:
https://github.com/carbon-language/carbon-lang/actions/runs/3760820974/jobs/6391950894