### PR TITLE
Mark some other issue categories as not-stale.

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -39,7 +39,8 @@ jobs:
             activity in the 14 days since the `inactive` label was added.
           stale-issue-label: 'inactive'
           stale-pr-label: 'inactive'
-          exempt-issue-labels: 'long term'
+          exempt-issue-labels:
+            'long term,design idea,design update,good first issue'
           days-before-stale: 90
           days-before-close: 14
           days-before-issue-close: -1


### PR DESCRIPTION
While we have a generic 'long term' label, it seems redundant for some issues that are already labeled with something that clearly is open-ended and not something we should expect to have a bounded timeline. For example, we want to actively curate a backlog of design ideas and good first issues for folks to browse and pick up, so we shouldn't be marking them as inactive after any fixed time frame.