### PR TITLE
Switch Diagnostic structure to use DiagnosticMessage to avoid pointers

### DIFF
--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -9,6 +9,7 @@ cc_library(
     hdrs = ["diagnostic_emitter.h"],
     deps = [
         ":diagnostic_kind",
+        "//common:check",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -23,7 +23,7 @@ from typing import Dict, List, NamedTuple, Set
 
 
 # Example or test diagnostics, ignored because they're expected to not pass.
-IGNORED = set(["MyDiagnostic", "TestDiagnostic"])
+IGNORED = set(["MyDiagnostic", "TestDiagnostic", "TestDiagnosticNote"])
 
 
 class Location(NamedTuple):

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -113,7 +113,7 @@ class DiagnosticConsumer {
   // Handle a diagnostic.
   //
   // This relies on moves of the Diagnostic. At present, diagnostics are
-  // allocated on the stack, so there lifetime is that of HandleDiagnostic.
+  // allocated on the stack, so their lifetime is that of HandleDiagnostic.
   // However, SortingDiagnosticConsumer needs a longer lifetime, until all
   // diagnostics have been produced. As a consequence, it needs to either copy
   // or move the Diagnostic, and right now we're moving due to the overhead of

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -120,10 +120,10 @@ class DiagnosticConsumer {
   // notes.
   //
   // At present, there is no persistent storage of diagnostics because IDEs
-  // would be fine with diagnostics being printed immediately and discarded, without
-  // SortingDiagnosticConsumer. If this becomes a performance issue, we may want
-  // to investigate alternative ownership models that address both IDE and CLI
-  // user needs.
+  // would be fine with diagnostics being printed immediately and discarded,
+  // without SortingDiagnosticConsumer. If this becomes a performance issue, we
+  // may want to investigate alternative ownership models that address both IDE
+  // and CLI user needs.
   virtual auto HandleDiagnostic(Diagnostic diagnostic) -> void = 0;
 
   // Flushes any buffered input.

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -169,10 +169,10 @@ struct DiagnosticBase {
  private:
   // Handles the cast of llvm::Any to Args types for formatv.
   template <std::size_t... N>
-  inline auto FormatFnImpl(const DiagnosticMessage& diagnostic,
+  inline auto FormatFnImpl(const DiagnosticMessage& message,
                            std::index_sequence<N...> /*indices*/) const
       -> std::string {
-    assert(diagnostic.format_args.size() == sizeof...(Args));
+    assert(message.format_args.size() == sizeof...(Args));
     return llvm::formatv(diagnostic.format.data(),
                          llvm::any_cast<Args>(diagnostic.format_args[N])...);
   }

--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -119,8 +119,8 @@ class DiagnosticConsumer {
   // or move the Diagnostic, and right now we're moving due to the overhead of
   // notes.
   //
-  // At present, there is no single ownership of diagnostics partly because IDEs
-  // would be fine with diagnostics being printed immediately, without
+  // At present, there is no persistent storage of diagnostics because IDEs
+  // would be fine with diagnostics being printed immediately and discarded, without
   // SortingDiagnosticConsumer. If this becomes a performance issue, we may want
   // to investigate alternative ownership models that address both IDE and CLI
   // user needs.

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -60,11 +60,12 @@ TEST_F(DiagnosticEmitterTest, EmitOneArgDiagnostic) {
 
 TEST_F(DiagnosticEmitterTest, EmitNote) {
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnosticNote, Note, "note");
   EXPECT_CALL(consumer_,
               HandleDiagnostic(IsDiagnostic(DiagnosticKind::TestDiagnostic,
                                             DiagnosticLevel::Warning, 1, 1,
                                             "simple warning")));
-  emitter_.Build(1, TestDiagnostic).Note(2, TestDiagnostic).Emit();
+  emitter_.Build(1, TestDiagnostic).Note(2, TestDiagnosticNote).Emit();
 }
 
 }  // namespace

--- a/toolchain/diagnostics/diagnostic_registry.def
+++ b/toolchain/diagnostics/diagnostic_registry.def
@@ -100,5 +100,6 @@ CARBON_DIAGNOSTIC_KIND(PreviousDefinition)
 
 // TestDiagnostic is only for unit tests.
 CARBON_DIAGNOSTIC_KIND(TestDiagnostic)
+CARBON_DIAGNOSTIC_KIND(TestDiagnosticNote)
 
 #undef CARBON_DIAGNOSTIC_KIND

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -7,16 +7,26 @@
 namespace Carbon {
 
 void PrintTo(const Diagnostic& diagnostic, std::ostream* os) {
-  *os << "Diagnostic{" << diagnostic.kind << ", ";
+  *os << "Diagnostic{" << diagnostic.main.kind << ", ";
   PrintTo(diagnostic.level, os);
-  *os << ", " << diagnostic.location.file_name << ":"
-      << diagnostic.location.line_number << ":"
-      << diagnostic.location.column_number << ", \""
-      << diagnostic.format_fn(diagnostic) << "\"}";
+  *os << ", " << diagnostic.main.location.file_name << ":"
+      << diagnostic.main.location.line_number << ":"
+      << diagnostic.main.location.column_number << ", \""
+      << diagnostic.main.format_fn(diagnostic.main) << "\"}";
 }
 
 void PrintTo(DiagnosticLevel level, std::ostream* os) {
-  *os << (level == DiagnosticLevel::Error ? "Error" : "Warning");
+  switch (level) {
+    case DiagnosticLevel::Note:
+      *os << "Note";
+      break;
+    case DiagnosticLevel::Warning:
+      *os << "Warning";
+      break;
+    case DiagnosticLevel::Error:
+      *os << "Error";
+      break;
+  }
 }
 
 }  // namespace Carbon

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -7,12 +7,12 @@
 namespace Carbon {
 
 void PrintTo(const Diagnostic& diagnostic, std::ostream* os) {
-  *os << "Diagnostic{" << diagnostic.main.kind << ", ";
+  *os << "Diagnostic{" << diagnostic.message.kind << ", ";
   PrintTo(diagnostic.level, os);
-  *os << ", " << diagnostic.main.location.file_name << ":"
-      << diagnostic.main.location.line_number << ":"
-      << diagnostic.main.location.column_number << ", \""
-      << diagnostic.main.format_fn(diagnostic.main) << "\"}";
+  *os << ", " << diagnostic.message.location.file_name << ":"
+      << diagnostic.message.location.line_number << ":"
+      << diagnostic.message.location.column_number << ", \""
+      << diagnostic.message.format_fn(diagnostic.message) << "\"}";
 }
 
 void PrintTo(DiagnosticLevel level, std::ostream* os) {

--- a/toolchain/diagnostics/mocks.h
+++ b/toolchain/diagnostics/mocks.h
@@ -18,7 +18,7 @@ class MockDiagnosticConsumer : public DiagnosticConsumer {
 
 MATCHER_P(IsDiagnosticMessage, matcher, "") {
   const Diagnostic& diag = arg;
-  return testing::ExplainMatchResult(matcher, diag.format_fn(diag),
+  return testing::ExplainMatchResult(matcher, diag.main.format_fn(diag.main),
                                      result_listener);
 }
 
@@ -28,16 +28,20 @@ inline auto IsDiagnostic(testing::Matcher<DiagnosticKind> kind,
                          testing::Matcher<int> column_number,
                          testing::Matcher<std::string> message) {
   return testing::AllOf(
-      testing::Field("kind", &Diagnostic::kind, kind),
       testing::Field("level", &Diagnostic::level, level),
       testing::Field(
-          &Diagnostic::location,
+          "main", &Diagnostic::main,
           testing::AllOf(
-              testing::Field("line_number", &DiagnosticLocation::line_number,
-                             line_number),
-              testing::Field("column_number",
-                             &DiagnosticLocation::column_number,
-                             column_number))),
+              testing::Field("kind", &DiagnosticMessage::kind, kind),
+              testing::Field(
+                  &DiagnosticMessage::location,
+                  testing::AllOf(
+                      testing::Field("line_number",
+                                     &DiagnosticLocation::line_number,
+                                     line_number),
+                      testing::Field("column_number",
+                                     &DiagnosticLocation::column_number,
+                                     column_number))))),
       IsDiagnosticMessage(message));
 }
 

--- a/toolchain/diagnostics/mocks.h
+++ b/toolchain/diagnostics/mocks.h
@@ -18,8 +18,8 @@ class MockDiagnosticConsumer : public DiagnosticConsumer {
 
 MATCHER_P(IsDiagnosticMessage, matcher, "") {
   const Diagnostic& diag = arg;
-  return testing::ExplainMatchResult(matcher, diag.main.format_fn(diag.main),
-                                     result_listener);
+  return testing::ExplainMatchResult(
+      matcher, diag.message.format_fn(diag.message), result_listener);
 }
 
 inline auto IsDiagnostic(testing::Matcher<DiagnosticKind> kind,
@@ -30,7 +30,7 @@ inline auto IsDiagnostic(testing::Matcher<DiagnosticKind> kind,
   return testing::AllOf(
       testing::Field("level", &Diagnostic::level, level),
       testing::Field(
-          "main", &Diagnostic::main,
+          "message", &Diagnostic::message,
           testing::AllOf(
               testing::Field("kind", &DiagnosticMessage::kind, kind),
               testing::Field(

--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -28,10 +28,10 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
   void Flush() override {
     llvm::stable_sort(diagnostics_,
                       [](const Diagnostic& lhs, const Diagnostic& rhs) {
-                        return std::tie(lhs.main.location.line_number,
-                                        lhs.main.location.column_number) <
-                               std::tie(rhs.main.location.line_number,
-                                        rhs.main.location.column_number);
+                        return std::tie(lhs.message.location.line_number,
+                                        lhs.message.location.column_number) <
+                               std::tie(rhs.message.location.line_number,
+                                        rhs.message.location.column_number);
                       });
     for (auto& diag : diagnostics_) {
       next_consumer_->HandleDiagnostic(std::move(diag));

--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -26,11 +26,13 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
 
   // Sorts and flushes buffered diagnostics.
   void Flush() override {
-    llvm::stable_sort(diagnostics_, [](const Diagnostic& lhs,
-                                       const Diagnostic& rhs) {
-      return std::tie(lhs.location.line_number, lhs.location.column_number) <
-             std::tie(rhs.location.line_number, rhs.location.column_number);
-    });
+    llvm::stable_sort(diagnostics_,
+                      [](const Diagnostic& lhs, const Diagnostic& rhs) {
+                        return std::tie(lhs.main.location.line_number,
+                                        lhs.main.location.column_number) <
+                               std::tie(rhs.main.location.line_number,
+                                        rhs.main.location.column_number);
+                      });
     for (auto& diag : diagnostics_) {
       next_consumer_->HandleDiagnostic(std::move(diag));
     }


### PR DESCRIPTION
Followup for #2490 

The switch of DiagnosticMessage to have DiagnosticMessage means we don't need to use unique_ptr. This means that copy constructors are implicit again and don't need to be avoided, but per discussion still keeping with moves. Comments on HandleDiagnostic try to capture the use of moves there.

I'm keeping DiagnosticLevel at the top-level, and adding some checking that notes are actually Notes.

Also, adding MakeMessage to unify some of the logic (this has particularly been bugging me around format_fn, and I ran into it here because of the Diagnostic -> DiagnosticMessage change). The addition of NoTypeDeduction is intended to avoid some duplicative comments that'd been piling up.