### PR TITLE
Fix missing include in element.h

### DIFF
--- a/explorer/ast/element.h
+++ b/explorer/ast/element.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include "common/ostream.h"
 #include "explorer/ast/ast_rtti.h"
 #include "explorer/common/nonnull.h"
 #include "llvm/ADT/PointerUnion.h"


### PR DESCRIPTION
Without this, some compile setups can get a missing symbol for llvm::raw_ostream; this is relying on ostream.h through other code paths at present, so should be explicit about it.