### PR TITLE
Refactor the internal enum for formatting

### DIFF
--- a/toolchain/common/enum_base.h
+++ b/toolchain/common/enum_base.h
@@ -30,7 +30,7 @@ namespace Carbon::Internal {
 //
 // In `my_kind.h`:
 //   ```
-//   CARBON_DEFINE_RAW_ENUM_CLASS(MyKind, uint8_t){
+//   enum class CARBON_RAW_ENUM_NAME(MyKind) : uint8_t {
 //   #define CARBON_MY_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 //   #include "toolchain/.../my_kind.def"
 //   };
@@ -123,12 +123,7 @@ class EnumBase {
 // Use this before defining a class that derives from `EnumBase` to begin the
 // definition of the raw `enum class`. It should be followed by the body of that
 // raw enum class.
-#define CARBON_DEFINE_RAW_ENUM_CLASS(EnumClassName, UnderlyingType) \
-  namespace Internal {                                              \
-  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                  \
-  enum class EnumClassName##RawEnum : UnderlyingType;               \
-  }                                                                 \
-  enum class ::Carbon::Internal::EnumClassName##RawEnum : UnderlyingType
+#define CARBON_RAW_ENUM_NAME(EnumClassName) Internal##EnumClassName##RawEnum
 
 // In CARBON_DEFINE_RAW_ENUM_CLASS block, use this to generate each enumerator.
 #define CARBON_RAW_ENUM_ENUMERATOR(Name) Name,
@@ -138,7 +133,7 @@ class EnumBase {
 // namespaces are correct.
 #define CARBON_ENUM_BASE(EnumClassName)       \
   ::Carbon::Internal::EnumBase<EnumClassName, \
-                               ::Carbon::Internal::EnumClassName##RawEnum>
+                               CARBON_RAW_ENUM_NAME(EnumClassName)>
 
 // Use this within the Carbon enum class body to generate named constant
 // declarations for each value.
@@ -161,13 +156,13 @@ class EnumBase {
    * reference it from an explicit function specialization. */                \
   template <>                                                                 \
   llvm::StringLiteral Internal::EnumBase<                                     \
-      EnumClassName, Internal::EnumClassName##RawEnum>::names[];              \
+      EnumClassName, CARBON_RAW_ENUM_NAME(EnumClassName)>::names[];           \
                                                                               \
   /* Now define an explicit function specialization for the `name` method, as \
    * it can now reference our specialized array. */                           \
   template <>                                                                 \
-  auto                                                                        \
-  Internal::EnumBase<EnumClassName, Internal::EnumClassName##RawEnum>::name() \
+  auto Internal::EnumBase<EnumClassName,                                      \
+                          CARBON_RAW_ENUM_NAME(EnumClassName)>::name()        \
       const->llvm::StringRef {                                                \
     return names[static_cast<int>(value_)];                                   \
   }                                                                           \
@@ -176,7 +171,7 @@ class EnumBase {
    * populate using the x-macro include. */                                   \
   template <>                                                                 \
   llvm::StringLiteral Internal::EnumBase<                                     \
-      EnumClassName, Internal::EnumClassName##RawEnum>::names[]
+      EnumClassName, CARBON_RAW_ENUM_NAME(EnumClassName)>::names[]
 
 // Use this within the names array initializer to generate a string for each
 // name.

--- a/toolchain/common/enum_base_test.cpp
+++ b/toolchain/common/enum_base_test.cpp
@@ -8,7 +8,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(TestKind, uint8_t){
+enum class CARBON_RAW_ENUM_NAME(TestKind) : uint8_t {
 #define CARBON_ENUM_BASE_TEST_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/common/enum_base_test.def"
 };

--- a/toolchain/parser/parser_state.h
+++ b/toolchain/parser/parser_state.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(ParserState, uint8_t){
+enum class CARBON_RAW_ENUM_NAME(ParserState) : uint8_t {
 #define CARBON_PARSER_STATE(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/parser/parser_state.def"
 };

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsBuiltinKind, uint8_t){
+enum class CARBON_RAW_ENUM_NAME(SemanticsBuiltinKind) : uint8_t {
 #define CARBON_SEMANTICS_BUILTIN_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/semantics/semantics_builtin_kind.def"
 };

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsNodeKind, uint8_t){
+enum class CARBON_RAW_ENUM_NAME(SemanticsNodeKind) : uint8_t {
 #define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/semantics/semantics_node_kind.def"
 };


### PR DESCRIPTION
A small edit on #2504 mainly addressing clang-format.

This replaces `CARBON_DEFINE_RAW_ENUM_CLASS(enum_name, type) { ... };` with `enum class CARBON_RAW_ENUM_NAME(enum_name) : type { ... };`

With the former, clang-format decides that due to the `;` after the `}` in particular, there shouldn't be a space between `){`, which looks a little weird. By changing this to look like more traditional C++, we can avoid that.

The flipside is that before it would generate a name in the `Internal` namespace, whereas now it generates an `Internal`-prefixed name in the `Carbon` namespace. I think this is slightly dubious, but maybe a reasonable trade-off?