### PR TITLE
Hack `clang-format` config to format our macros better.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,6 @@ DerivePointerAlignment: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 FixNamespaceComments: 'true'
 PointerAlignment: Left
+# We abuse control macros for formatting other kinds of macros.
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+IfMacros: ['CARBON_DEFINE_RAW_ENUM_CLASS']

--- a/toolchain/common/enum_base.h
+++ b/toolchain/common/enum_base.h
@@ -30,7 +30,7 @@ namespace Carbon::Internal {
 //
 // In `my_kind.h`:
 //   ```
-//   CARBON_DEFINE_RAW_ENUM_CLASS(MyKind, uint8_t){
+//   CARBON_DEFINE_RAW_ENUM_CLASS(MyKind, uint8_t) {
 //   #define CARBON_MY_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 //   #include "toolchain/.../my_kind.def"
 //   };

--- a/toolchain/common/enum_base_test.cpp
+++ b/toolchain/common/enum_base_test.cpp
@@ -8,7 +8,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(TestKind, uint8_t){
+CARBON_DEFINE_RAW_ENUM_CLASS(TestKind, uint8_t) {
 #define CARBON_ENUM_BASE_TEST_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/common/enum_base_test.def"
 };

--- a/toolchain/parser/parser_state.h
+++ b/toolchain/parser/parser_state.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(ParserState, uint8_t){
+CARBON_DEFINE_RAW_ENUM_CLASS(ParserState, uint8_t) {
 #define CARBON_PARSER_STATE(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/parser/parser_state.def"
 };

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsBuiltinKind, uint8_t){
+CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsBuiltinKind, uint8_t) {
 #define CARBON_SEMANTICS_BUILTIN_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/semantics/semantics_builtin_kind.def"
 };

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -9,7 +9,7 @@
 
 namespace Carbon {
 
-CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsNodeKind, uint8_t){
+CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsNodeKind, uint8_t) {
 #define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/semantics/semantics_node_kind.def"
 };


### PR DESCRIPTION
This somewhat abuses control-flow macro handling in `clang-format` to get the behavior we want. Fortunately, I don't think we're ever likely to want this for its intended purpose so it seems harmless to co-opt it like this. If we really wanted, we can narrow it to `if`-macros, but I picked the simpler option to start.

FWIW, I tried all the other macro formatting special cases to see if one would work but it didn't. Might be worth filing a feature request to get a `TypeDefinitionMacros` setting to compliment `TypenameMacros` and format like this does, but it seems (very) low priority.