### PR TITLE
Fix typo in extended final class error message

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4487,7 +4487,7 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
         ClassExtensibility::None) {
       return ProgramError(class_decl->source_loc())
              << "Base class `" << base_class.value()->declaration().name()
-             << "` is `final` and cannot inherited. Add the `base` or "
+             << "` is `final` and cannot be inherited. Add the `base` or "
                 "`abstract` class prefix to `"
              << base_class.value()->declaration().name()
              << "` to allow it to be inherited";

--- a/explorer/testdata/class/fail_extends_final_class.carbon
+++ b/explorer/testdata/class/fail_extends_final_class.carbon
@@ -14,7 +14,7 @@ class C {
 
 class D extends C {
   fn G() {}
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_extends_final_class.carbon:[[@LINE+1]]: Base class `C` is `final` and cannot inherited. Add the `base` or `abstract` class prefix to `C` to allow it to be inherited
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_extends_final_class.carbon:[[@LINE+1]]: Base class `C` is `final` and cannot be inherited. Add the `base` or `abstract` class prefix to `C` to allow it to be inherited
 }
 
 fn Main() -> i32 {


### PR DESCRIPTION
added the word "be" and updated test result.