### PR TITLE
Switch SemanticsIR dumps to produce YAML

### DIFF
--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -75,3 +75,18 @@ cc_library(
         "@llvm-project//llvm:Support",
     ],
 )
+
+cc_test(
+    name = "semantics_ir_test",
+    size = "small",
+    srcs = ["semantics_ir_test.cpp"],
+    deps = [
+        ":semantics_ir",
+        "//common:gtest_main",
+        "//toolchain/common:yaml_test_helpers",
+        "//toolchain/diagnostics:diagnostic_emitter",
+        "//toolchain/lexer:tokenized_buffer",
+        "@com_google_googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -80,7 +80,7 @@ auto SemanticsIR::Print(llvm::raw_ostream& out) const -> void {
   out << "integer_literals:\n";
   for (int32_t i = 0; i < static_cast<int32_t>(integer_literals_.size()); ++i) {
     out.indent(Indent);
-    out << "- \"" << integer_literals_[i] << "\"\n";
+    out << "- " << integer_literals_[i] << "\n";
   }
 
   out << "strings:\n";

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -77,35 +77,41 @@ auto SemanticsIR::Print(llvm::raw_ostream& out) const -> void {
 
   out << "cross_reference_irs_size: " << cross_reference_irs_.size() << "\n";
 
-  out << "integer_literals:\n";
+  out << "integer_literals: [\n";
   for (int32_t i = 0; i < static_cast<int32_t>(integer_literals_.size()); ++i) {
     out.indent(Indent);
-    out << "- " << integer_literals_[i] << "\n";
+    out << integer_literals_[i] << ",\n";
   }
+  out << "]\n";
 
-  out << "strings:\n";
+  out << "strings: [\n";
   for (int32_t i = 0; i < static_cast<int32_t>(strings_.size()); ++i) {
     out.indent(Indent);
-    out << "- " << strings_[i] << "\n";
+    out << strings_[i] << ",\n";
   }
+  out << "]\n";
 
-  out << "nodes:\n";
+  out << "nodes: [\n";
   for (int32_t i = 0; i < static_cast<int32_t>(nodes_.size()); ++i) {
     out.indent(Indent);
-    out << "- " << nodes_[i] << "\n";
+    out << nodes_[i] << ",\n";
   }
+  out << "]\n";
 
-  out << "node_blocks:\n";
+  out << "node_blocks: [\n";
   for (int32_t i = 0; i < static_cast<int32_t>(node_blocks_.size()); ++i) {
     out.indent(Indent);
-    out << "-\n";
+    out << "[\n";
 
     const auto& node_block = node_blocks_[i];
     for (int32_t i = 0; i < static_cast<int32_t>(node_block.size()); ++i) {
       out.indent(2 * Indent);
-      out << "- " << node_block[i] << "\n";
+      out << node_block[i] << ",\n";
     }
+    out.indent(Indent);
+    out << "],\n";
   }
+  out << "]\n";
 }
 
 }  // namespace Carbon

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -75,45 +75,37 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
 auto SemanticsIR::Print(llvm::raw_ostream& out) const -> void {
   constexpr int Indent = 2;
 
-  out << "cross_reference_irs.size == " << cross_reference_irs_.size() << ",\n";
+  out << "cross_reference_irs_size: " << cross_reference_irs_.size() << "\n";
 
-  out << "integer_literals = {\n";
+  out << "integer_literals:\n";
   for (int32_t i = 0; i < static_cast<int32_t>(integer_literals_.size()); ++i) {
     out.indent(Indent);
-    out << SemanticsIntegerLiteralId(i) << " = " << integer_literals_[i]
-        << ";\n";
+    out << "- \"" << integer_literals_[i] << "\"\n";
   }
-  out << "},\n";
 
-  out << "strings = {\n";
+  out << "strings:\n";
   for (int32_t i = 0; i < static_cast<int32_t>(strings_.size()); ++i) {
     out.indent(Indent);
-    out << SemanticsStringId(i) << " = \"" << strings_[i] << "\";\n";
+    out << "- " << strings_[i] << "\n";
   }
-  out << "},\n";
 
-  out << "nodes = {\n";
+  out << "nodes:\n";
   for (int32_t i = 0; i < static_cast<int32_t>(nodes_.size()); ++i) {
     out.indent(Indent);
-    out << SemanticsNodeId(i) << " = " << nodes_[i] << ";\n";
+    out << "- " << nodes_[i] << "\n";
   }
-  out << "},\n";
 
-  out << "node_blocks = {\n";
+  out << "node_blocks:\n";
   for (int32_t i = 0; i < static_cast<int32_t>(node_blocks_.size()); ++i) {
     out.indent(Indent);
-    out << SemanticsNodeBlockId(i) << " = {\n";
+    out << "-\n";
 
     const auto& node_block = node_blocks_[i];
     for (int32_t i = 0; i < static_cast<int32_t>(node_block.size()); ++i) {
       out.indent(2 * Indent);
-      out << node_block[i] << ";\n";
+      out << "- " << node_block[i] << "\n";
     }
-
-    out.indent(Indent);
-    out << "},\n";
   }
-  out << "}\n";
 }
 
 }  // namespace Carbon

--- a/toolchain/semantics/semantics_ir_test.cpp
+++ b/toolchain/semantics/semantics_ir_test.cpp
@@ -1,0 +1,76 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/semantics/semantics_ir.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <forward_list>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "toolchain/common/yaml_test_helpers.h"
+#include "toolchain/diagnostics/diagnostic_emitter.h"
+#include "toolchain/lexer/tokenized_buffer.h"
+
+namespace Carbon::Testing {
+namespace {
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::Each;
+using ::testing::ElementsAre;
+using ::testing::MatchesRegex;
+using ::testing::Pair;
+
+TEST(SemanticsIRTest, YAML) {
+  DiagnosticConsumer& consumer = ConsoleDiagnosticConsumer();
+  llvm::Expected<SourceBuffer> source =
+      SourceBuffer::CreateFromText("var x: i32 = 0;");
+  TokenizedBuffer tokens = TokenizedBuffer::Lex(*source, consumer);
+  ParseTree parse_tree =
+      ParseTree::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
+  SemanticsIR builtin_ir = SemanticsIR::MakeBuiltinIR();
+  SemanticsIR semantics_ir = SemanticsIR::MakeFromParseTree(
+      builtin_ir, tokens, parse_tree, consumer, /*vlog_stream=*/nullptr);
+
+  std::string print_output;
+  llvm::raw_string_ostream print_stream(print_output);
+  semantics_ir.Print(print_stream);
+  print_stream.flush();
+
+  // Matches the ID of a node. The numbers may change because of builtin
+  // cross-references, so this code is only doing loose structural checks.
+  auto node_id = Yaml::Scalar(MatchesRegex("node\\d+"));
+
+  EXPECT_THAT(
+      Yaml::Value::FromText(print_output),
+      ElementsAre(Yaml::Mapping(ElementsAre(
+          Pair("cross_reference_irs_size", "1"),
+          Pair("integer_literals", Yaml::Sequence(ElementsAre("0"))),
+          Pair("strings", Yaml::Sequence(ElementsAre("x"))),
+          Pair("nodes",
+               Yaml::Sequence(AllOf(
+                   // kind is required, other parts are optional.
+                   Each(Yaml::Mapping(Contains(Pair("kind", _)))),
+                   // A 0-arg node.
+                   Contains(Yaml::Mapping(ElementsAre(
+                       Pair("kind", "VarStorage"), Pair("type", node_id)))),
+                   // A 1-arg node.
+                   Contains(Yaml::Mapping(ElementsAre(
+                       Pair("kind", "IntegerLiteral"), Pair("arg0", "int0"),
+                       Pair("type", node_id)))),
+                   // A 2-arg node.
+                   Contains(Yaml::Mapping(ElementsAre(
+                       Pair("kind", "BindName"), Pair("arg0", "str0"),
+                       Pair("arg1", node_id), Pair("type", node_id))))))),
+          // This production has only one node block.
+          Pair("node_blocks",
+               Yaml::Sequence(ElementsAre(Yaml::Sequence(Each(node_id)))))))));
+}
+
+}  // namespace
+}  // namespace Carbon::Testing

--- a/toolchain/semantics/semantics_node.cpp
+++ b/toolchain/semantics/semantics_node.cpp
@@ -9,20 +9,21 @@
 namespace Carbon {
 
 static auto PrintArgs(llvm::raw_ostream& /*out*/,
-                      const SemanticsNode::NoArgs /*no_args*/) {}
+                      const SemanticsNode::NoArgs /*no_args*/) -> void {}
 
 template <typename T>
-static auto PrintArgs(llvm::raw_ostream& out, T arg) {
-  out << arg;
+static auto PrintArgs(llvm::raw_ostream& out, T arg) -> void {
+  out << ", arg0: " << arg;
 }
 
 template <typename T0, typename T1>
-static auto PrintArgs(llvm::raw_ostream& out, std::pair<T0, T1> args) {
-  out << args.first << ", " << args.second;
+static auto PrintArgs(llvm::raw_ostream& out, std::pair<T0, T1> args) -> void {
+  PrintArgs(out, args.first);
+  out << ", arg1: " << args.second;
 }
 
 void SemanticsNode::Print(llvm::raw_ostream& out) const {
-  out << kind_ << "(";
+  out << "{kind: " << kind_;
   switch (kind_) {
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
   case SemanticsNodeKind::Name:          \
@@ -30,10 +31,10 @@ void SemanticsNode::Print(llvm::raw_ostream& out) const {
     break;
 #include "toolchain/semantics/semantics_node_kind.def"
   }
-  out << ")";
-  if (type_.index != -1) {
-    out << ": " << type_;
+  if (type_.is_valid()) {
+    out << ", type: " << type_;
   }
+  out << "}";
 }
 
 }  // namespace Carbon

--- a/toolchain/semantics/testdata/basics/empty.carbon
+++ b/toolchain/semantics/testdata/basics/empty.carbon
@@ -5,12 +5,17 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]

--- a/toolchain/semantics/testdata/basics/empty.carbon
+++ b/toolchain/semantics/testdata/basics/empty.carbon
@@ -4,18 +4,13 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -

--- a/toolchain/semantics/testdata/basics/empty_decl.carbon
+++ b/toolchain/semantics/testdata/basics/empty_decl.carbon
@@ -5,14 +5,19 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 ;

--- a/toolchain/semantics/testdata/basics/empty_decl.carbon
+++ b/toolchain/semantics/testdata/basics/empty_decl.carbon
@@ -4,20 +4,15 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
 
 ;

--- a/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
@@ -4,30 +4,24 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/basics/fail_name_lookup.carbon:[[@LINE+1]]:3: Name x not found

--- a/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
@@ -5,23 +5,29 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/basics/fail_name_lookup.carbon:[[@LINE+1]]:3: Name x not found

--- a/toolchain/semantics/testdata/basics/verbose.carbon
+++ b/toolchain/semantics/testdata/basics/verbose.carbon
@@ -7,7 +7,7 @@
 //
 // Only checks a couple statements in order to minimize manual update churn.
 // CHECK:STDERR: Push 0: FunctionIntroducer -> node<invalid>
-// CHECK:STDERR: AddNode block0: BindName(str0, node{{[0-9]+}})
+// CHECK:STDERR: AddNode block0: {kind: BindName, arg0: str0, arg1: node4}
 
 fn Foo() {
   return;

--- a/toolchain/semantics/testdata/function/basic.carbon
+++ b/toolchain/semantics/testdata/function/basic.carbon
@@ -4,29 +4,23 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Foo";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Foo
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
 
 fn Foo() {}

--- a/toolchain/semantics/testdata/function/basic.carbon
+++ b/toolchain/semantics/testdata/function/basic.carbon
@@ -5,22 +5,28 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Foo
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Foo,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Foo() {}

--- a/toolchain/semantics/testdata/function/order.carbon
+++ b/toolchain/semantics/testdata/function/order.carbon
@@ -4,48 +4,40 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Foo";
-// CHECK:STDOUT:   str1 = "Bar";
-// CHECK:STDOUT:   str2 = "Baz";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = FunctionDeclaration();
-// CHECK:STDOUT:   node8 = BindName(str1, node7);
-// CHECK:STDOUT:   node9 = FunctionDefinition(node7, block2);
-// CHECK:STDOUT:   node10 = FunctionDeclaration();
-// CHECK:STDOUT:   node11 = BindName(str2, node10);
-// CHECK:STDOUT:   node12 = FunctionDefinition(node10, block3);
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:     node11;
-// CHECK:STDOUT:     node12;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block2 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block3 = {
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Foo
+// CHECK:STDOUT:   - Bar
+// CHECK:STDOUT:   - Baz
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node7, arg1: block2}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node10}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node10, arg1: block3}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
+// CHECK:STDOUT:     - node11
+// CHECK:STDOUT:     - node12
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:   -
 
 fn Foo() {}
 fn Bar() {}

--- a/toolchain/semantics/testdata/function/order.carbon
+++ b/toolchain/semantics/testdata/function/order.carbon
@@ -5,39 +5,47 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Foo
-// CHECK:STDOUT:   - Bar
-// CHECK:STDOUT:   - Baz
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node7, arg1: block2}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node10}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node10, arg1: block3}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
-// CHECK:STDOUT:     - node11
-// CHECK:STDOUT:     - node12
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:   -
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Foo,
+// CHECK:STDOUT:   Bar,
+// CHECK:STDOUT:   Baz,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node7, arg1: block2},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str2, arg1: node10},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node10, arg1: block3},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:     node11,
+// CHECK:STDOUT:     node12,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Foo() {}
 fn Bar() {}

--- a/toolchain/semantics/testdata/operators/binary_op.carbon
+++ b/toolchain/semantics/testdata/operators/binary_op.carbon
@@ -4,40 +4,34 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 12;
-// CHECK:STDOUT:   int1 = 34;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node8 = IntegerLiteral(int1): node2;
-// CHECK:STDOUT:   node9 = BinaryOperatorAdd(node7, node8): node2;
-// CHECK:STDOUT:   node10 = ReturnExpression(node9): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT:   - "34"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
+// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node2}
+// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node9, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 fn Main() {
   return 12 + 34;

--- a/toolchain/semantics/testdata/operators/binary_op.carbon
+++ b/toolchain/semantics/testdata/operators/binary_op.carbon
@@ -5,33 +5,39 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 12
-// CHECK:STDOUT:   - 34
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
-// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node2}
-// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node9, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   12,
+// CHECK:STDOUT:   34,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int1, type: node2},
+// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node2},
+// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node9, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   return 12 + 34;

--- a/toolchain/semantics/testdata/operators/binary_op.carbon
+++ b/toolchain/semantics/testdata/operators/binary_op.carbon
@@ -6,8 +6,8 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "12"
-// CHECK:STDOUT:   - "34"
+// CHECK:STDOUT:   - 12
+// CHECK:STDOUT:   - 34
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT: nodes:

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
@@ -6,7 +6,7 @@
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT:   - 12
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT: nodes:

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
@@ -5,32 +5,38 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 12
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
-// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1}
-// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node9, type: node1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   12,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: RealLiteral, type: node3},
+// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1},
+// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node9, type: node1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon:[[@LINE+1]]:13: Type mismatch: lhs is node2, rhs is node3

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
@@ -4,39 +4,33 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 12;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node8 = RealLiteral(): node3;
-// CHECK:STDOUT:   node9 = BinaryOperatorAdd(node7, node8): node1;
-// CHECK:STDOUT:   node10 = ReturnExpression(node9): node1;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
+// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1}
+// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node9, type: node1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon:[[@LINE+1]]:13: Type mismatch: lhs is node2, rhs is node3

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
@@ -5,37 +5,43 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 12
-// CHECK:STDOUT:   - 12
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
-// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
-// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node9, arg1: node10, type: node1}
-// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node11, type: node1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
-// CHECK:STDOUT:     - node11
-// CHECK:STDOUT:     - node12
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   12,
+// CHECK:STDOUT:   12,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: RealLiteral, type: node3},
+// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int1, type: node2},
+// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node9, arg1: node10, type: node1},
+// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node11, type: node1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:     node11,
+// CHECK:STDOUT:     node12,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   // The following line has two mismatches, but after the first, it shouldn't

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
@@ -6,8 +6,8 @@
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "12"
-// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT:   - 12
+// CHECK:STDOUT:   - 12
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT: nodes:

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
@@ -4,44 +4,38 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 12;
-// CHECK:STDOUT:   int1 = 12;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node8 = RealLiteral(): node3;
-// CHECK:STDOUT:   node9 = BinaryOperatorAdd(node7, node8): node1;
-// CHECK:STDOUT:   node10 = IntegerLiteral(int1): node2;
-// CHECK:STDOUT:   node11 = BinaryOperatorAdd(node9, node10): node1;
-// CHECK:STDOUT:   node12 = ReturnExpression(node11): node1;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:     node11;
-// CHECK:STDOUT:     node12;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT:   - "12"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
+// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node7, arg1: node8, type: node1}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
+// CHECK:STDOUT:   - {kind: BinaryOperatorAdd, arg0: node9, arg1: node10, type: node1}
+// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node11, type: node1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
+// CHECK:STDOUT:     - node11
+// CHECK:STDOUT:     - node12
 
 fn Main() {
   // The following line has two mismatches, but after the first, it shouldn't

--- a/toolchain/semantics/testdata/return/literal.carbon
+++ b/toolchain/semantics/testdata/return/literal.carbon
@@ -4,35 +4,29 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node8 = ReturnExpression(node7): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node7, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
 
 fn Main() {
   return 0;

--- a/toolchain/semantics/testdata/return/literal.carbon
+++ b/toolchain/semantics/testdata/return/literal.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT: nodes:

--- a/toolchain/semantics/testdata/return/literal.carbon
+++ b/toolchain/semantics/testdata/return/literal.carbon
@@ -5,28 +5,34 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: ReturnExpression, arg0: node7, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node7, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   return 0;

--- a/toolchain/semantics/testdata/return/trivial.carbon
+++ b/toolchain/semantics/testdata/return/trivial.carbon
@@ -5,25 +5,31 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: Return}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: Return},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   return;

--- a/toolchain/semantics/testdata/return/trivial.carbon
+++ b/toolchain/semantics/testdata/return/trivial.carbon
@@ -4,32 +4,26 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = Return();
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: Return}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
 
 fn Main() {
   return;

--- a/toolchain/semantics/testdata/var/decl.carbon
+++ b/toolchain/semantics/testdata/var/decl.carbon
@@ -4,35 +4,29 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
 
 fn Main() {
   var x: i32;

--- a/toolchain/semantics/testdata/var/decl.carbon
+++ b/toolchain/semantics/testdata/var/decl.carbon
@@ -5,28 +5,34 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   var x: i32;

--- a/toolchain/semantics/testdata/var/decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/decl_with_init.carbon
@@ -5,33 +5,39 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node9, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   var x: i32 = 0;

--- a/toolchain/semantics/testdata/var/decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/decl_with_init.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT:   - x

--- a/toolchain/semantics/testdata/var/decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/decl_with_init.carbon
@@ -4,40 +4,34 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node10 = Assign(node7, node9): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 fn Main() {
   var x: i32 = 0;

--- a/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
@@ -5,42 +5,48 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node11, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node13, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
-// CHECK:STDOUT:     - node11
-// CHECK:STDOUT:     - node12
-// CHECK:STDOUT:     - node13
-// CHECK:STDOUT:     - node14
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node9, type: node2},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node11, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int1, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node13, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:     node11,
+// CHECK:STDOUT:     node12,
+// CHECK:STDOUT:     node13,
+// CHECK:STDOUT:     node14,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 
 fn Main() {

--- a/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
@@ -6,8 +6,8 @@
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT:   - x

--- a/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
@@ -4,49 +4,43 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT:   int1 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node10 = Assign(node7, node9): node2;
-// CHECK:STDOUT:   node11 = VarStorage(): node2;
-// CHECK:STDOUT:   node12 = BindName(str1, node11): node2;
-// CHECK:STDOUT:   node13 = IntegerLiteral(int1): node2;
-// CHECK:STDOUT:   node14 = Assign(node7, node13): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:     node11;
-// CHECK:STDOUT:     node12;
-// CHECK:STDOUT:     node13;
-// CHECK:STDOUT:     node14;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node11, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int1, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node13, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
+// CHECK:STDOUT:     - node11
+// CHECK:STDOUT:     - node12
+// CHECK:STDOUT:     - node13
+// CHECK:STDOUT:     - node14
 
 
 fn Main() {

--- a/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
@@ -4,39 +4,33 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = RealLiteral(): node3;
-// CHECK:STDOUT:   node10 = Assign(node7, node9): node1;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon:[[@LINE+1]]:19: Type mismatch: lhs is node2, rhs is node3

--- a/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
@@ -5,32 +5,38 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: RealLiteral, type: node3}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: RealLiteral, type: node3},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node9, type: node1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon:[[@LINE+1]]:19: Type mismatch: lhs is node2, rhs is node3

--- a/toolchain/semantics/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_with_self.carbon
@@ -4,37 +4,31 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = Assign(node7, node1): node1;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node1, type: node1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/var/fail_init_with_self.carbon:[[@LINE+1]]:16: Name x not found

--- a/toolchain/semantics/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_with_self.carbon
@@ -5,30 +5,36 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node1, type: node1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node1, type: node1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   // CHECK:STDERR: {{.*}}/toolchain/semantics/testdata/var/fail_init_with_self.carbon:[[@LINE+1]]:16: Name x not found

--- a/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
@@ -5,35 +5,41 @@
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT:   - y
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node9, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node9, arg1: node1, type: node1}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
-// CHECK:STDOUT:     - node11
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT:   y,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str2, arg1: node9, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node9, arg1: node1, type: node1},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:     node11,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   var x: i32;

--- a/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
@@ -4,42 +4,36 @@
 //
 // AUTOUPDATE
 // RUN: %{not} %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT:   str2 = "y";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = VarStorage(): node2;
-// CHECK:STDOUT:   node10 = BindName(str2, node9): node2;
-// CHECK:STDOUT:   node11 = Assign(node9, node1): node1;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:     node11;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT:   - y
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node9, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node9, arg1: node1, type: node1}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
+// CHECK:STDOUT:     - node11
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
 
 fn Main() {
   var x: i32;

--- a/toolchain/semantics/testdata/var/global_decl.carbon
+++ b/toolchain/semantics/testdata/var/global_decl.carbon
@@ -5,19 +5,24 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 var x: i32;

--- a/toolchain/semantics/testdata/var/global_decl.carbon
+++ b/toolchain/semantics/testdata/var/global_decl.carbon
@@ -4,25 +4,20 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = VarStorage(): node2;
-// CHECK:STDOUT:   node5 = BindName(str0, node4): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
 
 var x: i32;

--- a/toolchain/semantics/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/global_decl_with_init.carbon
@@ -5,24 +5,29 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:     - node7
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node4, arg1: node6, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 var x: i32 = 0;

--- a/toolchain/semantics/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/global_decl_with_init.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - x
 // CHECK:STDOUT: nodes:

--- a/toolchain/semantics/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/global_decl_with_init.carbon
@@ -4,30 +4,25 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = VarStorage(): node2;
-// CHECK:STDOUT:   node5 = BindName(str0, node4): node2;
-// CHECK:STDOUT:   node6 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node7 = Assign(node4, node6): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:     - node7
 
 var x: i32 = 0;

--- a/toolchain/semantics/testdata/var/global_lookup.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup.carbon
@@ -4,38 +4,33 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "x";
-// CHECK:STDOUT:   str1 = "y";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = VarStorage(): node2;
-// CHECK:STDOUT:   node5 = BindName(str0, node4): node2;
-// CHECK:STDOUT:   node6 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node7 = Assign(node4, node6): node2;
-// CHECK:STDOUT:   node8 = VarStorage(): node2;
-// CHECK:STDOUT:   node9 = BindName(str1, node8): node2;
-// CHECK:STDOUT:   node10 = Assign(node8, node4): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT:   - y
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node8, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node8, arg1: node4, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 var x: i32 = 0;
 var y: i32 = x;

--- a/toolchain/semantics/testdata/var/global_lookup.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup.carbon
@@ -5,32 +5,37 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT:   - y
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node8, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node8, arg1: node4, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT:   y,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node4, arg1: node6, type: node2},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node8, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node8, arg1: node4, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 var x: i32 = 0;
 var y: i32 = x;

--- a/toolchain/semantics/testdata/var/global_lookup.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - x
 // CHECK:STDOUT:   - y

--- a/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
@@ -4,47 +4,41 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "x";
-// CHECK:STDOUT:   str1 = "Main";
-// CHECK:STDOUT:   str2 = "y";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = VarStorage(): node2;
-// CHECK:STDOUT:   node5 = BindName(str0, node4): node2;
-// CHECK:STDOUT:   node6 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node7 = Assign(node4, node6): node2;
-// CHECK:STDOUT:   node8 = FunctionDeclaration();
-// CHECK:STDOUT:   node9 = BindName(str1, node8);
-// CHECK:STDOUT:   node10 = FunctionDefinition(node8, block1);
-// CHECK:STDOUT:   node11 = VarStorage(): node2;
-// CHECK:STDOUT:   node12 = BindName(str2, node11): node2;
-// CHECK:STDOUT:   node13 = Assign(node11, node4): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node11;
-// CHECK:STDOUT:     node12;
-// CHECK:STDOUT:     node13;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - y
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node8}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node8, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node11, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node11, arg1: node4, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node11
+// CHECK:STDOUT:     - node12
+// CHECK:STDOUT:     - node13
 
 var x: i32 = 0;
 

--- a/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - x
 // CHECK:STDOUT:   - Main

--- a/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
@@ -5,40 +5,46 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - y
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node4, arg1: node6, type: node2}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node8}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node8, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str2, arg1: node11, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node11, arg1: node4, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node11
-// CHECK:STDOUT:     - node12
-// CHECK:STDOUT:     - node13
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   y,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node4, arg1: node6, type: node2},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node8},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node8, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str2, arg1: node11, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node11, arg1: node4, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node11,
+// CHECK:STDOUT:     node12,
+// CHECK:STDOUT:     node13,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 var x: i32 = 0;
 

--- a/toolchain/semantics/testdata/var/lookup.carbon
+++ b/toolchain/semantics/testdata/var/lookup.carbon
@@ -5,33 +5,39 @@
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - 0
-// CHECK:STDOUT: strings:
-// CHECK:STDOUT:   - Main
-// CHECK:STDOUT:   - x
-// CHECK:STDOUT: nodes:
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
-// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
-// CHECK:STDOUT:   - {kind: FunctionDeclaration}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
-// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
-// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
-// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
-// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
-// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
-// CHECK:STDOUT: node_blocks:
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node4
-// CHECK:STDOUT:     - node5
-// CHECK:STDOUT:     - node6
-// CHECK:STDOUT:   -
-// CHECK:STDOUT:     - node7
-// CHECK:STDOUT:     - node8
-// CHECK:STDOUT:     - node9
-// CHECK:STDOUT:     - node10
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   0,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   Main,
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block0, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block1, type: node1},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block2, type: node0},
+// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: block3, type: node0},
+// CHECK:STDOUT:   {kind: FunctionDeclaration},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node4},
+// CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node4, arg1: block1},
+// CHECK:STDOUT:   {kind: VarStorage, type: node2},
+// CHECK:STDOUT:   {kind: BindName, arg0: str1, arg1: node7, type: node2},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: node2},
+// CHECK:STDOUT:   {kind: Assign, arg0: node7, arg1: node9, type: node2},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node4,
+// CHECK:STDOUT:     node5,
+// CHECK:STDOUT:     node6,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node7,
+// CHECK:STDOUT:     node8,
+// CHECK:STDOUT:     node9,
+// CHECK:STDOUT:     node10,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
 
 fn Main() {
   var x: i32 = 0;

--- a/toolchain/semantics/testdata/var/lookup.carbon
+++ b/toolchain/semantics/testdata/var/lookup.carbon
@@ -6,7 +6,7 @@
 // RUN: %{carbon-run-semantics}
 // CHECK:STDOUT: cross_reference_irs_size: 1
 // CHECK:STDOUT: integer_literals:
-// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT:   - 0
 // CHECK:STDOUT: strings:
 // CHECK:STDOUT:   - Main
 // CHECK:STDOUT:   - x

--- a/toolchain/semantics/testdata/var/lookup.carbon
+++ b/toolchain/semantics/testdata/var/lookup.carbon
@@ -4,40 +4,34 @@
 //
 // AUTOUPDATE
 // RUN: %{carbon-run-semantics}
-// CHECK:STDOUT: cross_reference_irs.size == 1,
-// CHECK:STDOUT: integer_literals = {
-// CHECK:STDOUT:   int0 = 0;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: strings = {
-// CHECK:STDOUT:   str0 = "Main";
-// CHECK:STDOUT:   str1 = "x";
-// CHECK:STDOUT: },
-// CHECK:STDOUT: nodes = {
-// CHECK:STDOUT:   node0 = CrossReference(ir0, block0): node0;
-// CHECK:STDOUT:   node1 = CrossReference(ir0, block1): node1;
-// CHECK:STDOUT:   node2 = CrossReference(ir0, block2): node0;
-// CHECK:STDOUT:   node3 = CrossReference(ir0, block3): node0;
-// CHECK:STDOUT:   node4 = FunctionDeclaration();
-// CHECK:STDOUT:   node5 = BindName(str0, node4);
-// CHECK:STDOUT:   node6 = FunctionDefinition(node4, block1);
-// CHECK:STDOUT:   node7 = VarStorage(): node2;
-// CHECK:STDOUT:   node8 = BindName(str1, node7): node2;
-// CHECK:STDOUT:   node9 = IntegerLiteral(int0): node2;
-// CHECK:STDOUT:   node10 = Assign(node7, node9): node2;
-// CHECK:STDOUT: },
-// CHECK:STDOUT: node_blocks = {
-// CHECK:STDOUT:   block0 = {
-// CHECK:STDOUT:     node4;
-// CHECK:STDOUT:     node5;
-// CHECK:STDOUT:     node6;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT:   block1 = {
-// CHECK:STDOUT:     node7;
-// CHECK:STDOUT:     node8;
-// CHECK:STDOUT:     node9;
-// CHECK:STDOUT:     node10;
-// CHECK:STDOUT:   },
-// CHECK:STDOUT: }
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: integer_literals:
+// CHECK:STDOUT:   - "0"
+// CHECK:STDOUT: strings:
+// CHECK:STDOUT:   - Main
+// CHECK:STDOUT:   - x
+// CHECK:STDOUT: nodes:
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block0, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block1, type: node1}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block2, type: node0}
+// CHECK:STDOUT:   - {kind: CrossReference, arg0: ir0, arg1: block3, type: node0}
+// CHECK:STDOUT:   - {kind: FunctionDeclaration}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str0, arg1: node4}
+// CHECK:STDOUT:   - {kind: FunctionDefinition, arg0: node4, arg1: block1}
+// CHECK:STDOUT:   - {kind: VarStorage, type: node2}
+// CHECK:STDOUT:   - {kind: BindName, arg0: str1, arg1: node7, type: node2}
+// CHECK:STDOUT:   - {kind: IntegerLiteral, arg0: int0, type: node2}
+// CHECK:STDOUT:   - {kind: Assign, arg0: node7, arg1: node9, type: node2}
+// CHECK:STDOUT: node_blocks:
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node4
+// CHECK:STDOUT:     - node5
+// CHECK:STDOUT:     - node6
+// CHECK:STDOUT:   -
+// CHECK:STDOUT:     - node7
+// CHECK:STDOUT:     - node8
+// CHECK:STDOUT:     - node9
+// CHECK:STDOUT:     - node10
 
 fn Main() {
   var x: i32 = 0;


### PR DESCRIPTION
The parser and lexer already produce YAML, so this is fundamentally a consistency issue. I've been thinking about this, and was looking again because I'm working on adding callables, and figured I'd just fix it now.