### PR TITLE
[explorer] clarify warning when declaring arguments for 'Main'

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4420,7 +4420,10 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
         ExpectExactType(f->return_term().source_loc(), "return type of `Main`",
                         arena_->New<IntType>(), &f->return_term().static_type(),
                         function_scope));
-    // TODO: Check that main doesn't have any parameters.
+    if (!f->param_pattern().fields().empty()) {
+      return ProgramError(f->source_loc())
+             << "`Main` must not take any parameters";
+    }
   }
 
   if (trace_stream_) {

--- a/explorer/testdata/function/fail_main_with_parameters.carbon
+++ b/explorer/testdata/function/fail_main_with_parameters.carbon
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+fn Main(i: i32) -> i32 {
+    return 0;
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/function/fail_main_with_parameters.carbon:[[@LINE+1]]: `Main` must not take any parameters
+}


### PR DESCRIPTION
Improves the error produced when 'Main' is declared with parameters. Resolves a TODO in the typechecker. Explorer only. 

PR also adds a test for this error message. 