### PR TITLE
Explorer: fix `CleanUpAction` class name case

### DIFF
--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -256,9 +256,9 @@ class DeclarationAction : public Action {
 };
 
 // An Action which implements destroying all local allocations in a scope.
-class CleanupAction : public Action {
+class CleanUpAction : public Action {
  public:
-  explicit CleanupAction(RuntimeScope scope)
+  explicit CleanUpAction(RuntimeScope scope)
       : Action(Kind::CleanUpAction),
         allocations_count_(scope.allocations().size()) {
     StartScope(std::move(scope));

--- a/explorer/interpreter/action_stack.cpp
+++ b/explorer/interpreter/action_stack.cpp
@@ -238,7 +238,7 @@ auto ActionStack::UnwindToWithCaptureScopesToDestroy(
     auto& scope = item->scope();
     if (scope && item->kind() != Action::Kind::CleanUpAction) {
       std::unique_ptr<Action> cleanup_action =
-          std::make_unique<CleanupAction>(std::move(*scope));
+          std::make_unique<CleanUpAction>(std::move(*scope));
       scopes_to_destroy.push(std::move(cleanup_action));
     }
   }
@@ -332,7 +332,7 @@ void ActionStack::PushCleanUpActions(
     auto& act = actions.top();
     if (act->scope()) {
       std::unique_ptr<Action> cleanup_action =
-          std::make_unique<CleanupAction>(std::move(*act->scope()));
+          std::make_unique<CleanUpAction>(std::move(*act->scope()));
       todo_.Push(std::move(cleanup_action));
     }
     actions.pop();
@@ -343,7 +343,7 @@ void ActionStack::PushCleanUpAction(std::unique_ptr<Action> act) {
   auto& scope = act->scope();
   if (scope && act->kind() != Action::Kind::CleanUpAction) {
     std::unique_ptr<Action> cleanup_action =
-        std::make_unique<CleanupAction>(std::move(*scope));
+        std::make_unique<CleanUpAction>(std::move(*scope));
     todo_.Push(std::move(cleanup_action));
   }
 }

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2150,7 +2150,7 @@ auto Interpreter::StepDestroy() -> ErrorOr<Success> {
 
 auto Interpreter::StepCleanUp() -> ErrorOr<Success> {
   Action& act = todo_.CurrentAction();
-  CleanupAction& cleanup = cast<CleanupAction>(act);
+  CleanUpAction& cleanup = cast<CleanUpAction>(act);
   if (act.pos() < cleanup.allocations_count()) {
     auto allocation =
         act.scope()->allocations()[cleanup.allocations_count() - act.pos() - 1];


### PR DESCRIPTION
Currently, only the action class uses the noun case (`Cleanup`), while the kind enum and functions are spelled `CleanUpAction`. Other actions use consistent casing between class and enum names. This change makes the name consistent, and unsurprising for developers. Mirrors `DestroyAction` (verb).
