### PR TITLE
[explorer] check signature when implementing methods

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4820,18 +4820,15 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
   for (Nonnull<Declaration*> m : class_decl->members()) {
     CARBON_RETURN_IF_ERROR(DeclareDeclaration(m, class_scope_info));
 
-    const auto* fun = dyn_cast<FunctionDeclaration>(m);
-    if (!fun) {
-      continue;
-    }
+    if (const auto* fun = dyn_cast<FunctionDeclaration>(m)) {
+      if (fun->virt_override() == VirtualOverride::Impl) {
+        const VTable& vtable = (*base_class)->vtable();
+        const auto* vtable_fun = vtable.find(fun->name())->second.first;
 
-    if (fun->virt_override() == VirtualOverride::Impl) {
-      auto vtable = (*base_class)->vtable();
-      const auto* vtable_fun = vtable[fun->name()].first;
-
-      CARBON_RETURN_IF_ERROR(ExpectExactType(fun->source_loc(), "impl method",
-                                             &vtable_fun->static_type(),
-                                             &fun->static_type(), class_scope));
+        CARBON_RETURN_IF_ERROR(ExpectExactType(
+            fun->source_loc(), "impl method", &vtable_fun->static_type(),
+            &fun->static_type(), class_scope));
+      }
     }
   }
 

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -5,7 +5,6 @@
 #include "explorer/interpreter/type_checker.h"
 
 #include <algorithm>
-#include <cstddef>
 #include <deque>
 #include <iterator>
 #include <map>
@@ -22,8 +21,6 @@
 #include "common/ostream.h"
 #include "explorer/ast/declaration.h"
 #include "explorer/ast/expression.h"
-#include "explorer/ast/pattern.h"
-#include "explorer/ast/return_term.h"
 #include "explorer/common/arena.h"
 #include "explorer/common/error_builders.h"
 #include "explorer/common/nonnull.h"
@@ -4788,7 +4785,6 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
                  << ": cannot override a method that is not declared "
                     "`abstract` or `virtual` in base class.";
         }
-
         break;
     }
     class_vtable[fun->name().inner_name()] = {fun, class_level};

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -5,6 +5,7 @@
 #include "explorer/interpreter/type_checker.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <deque>
 #include <iterator>
 #include <map>
@@ -4693,93 +4694,6 @@ auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
   return Success();
 }
 
-auto TypeChecker::CheckPatternEquality(Nonnull<const Pattern*> o_patt,
-                                       Nonnull<const Pattern*> e_patt)
-    -> ErrorOr<Success> {
-  if (o_patt->kind() != e_patt->kind()) {
-    return ProgramError(o_patt->source_loc())
-           << __FUNCTION__ << ":" << __LINE__ << " failed. kind mismatch";
-  }
-  switch (e_patt->kind()) {
-    case PatternKind::BindingPattern: {
-      const auto* o = cast<BindingPattern>(o_patt);
-      const auto* e = cast<BindingPattern>(e_patt);
-
-      CARBON_RETURN_IF_ERROR(CheckPatternEquality(&o->type(), &e->type()));
-
-      break;
-    }
-    case PatternKind::TuplePattern: {
-      const auto* o = cast<TuplePattern>(o_patt);
-      const auto* e = cast<TuplePattern>(e_patt);
-
-      if (o->fields().size() != e->fields().size()) {
-        return ProgramError(o->source_loc())
-               << __FUNCTION__ << ":" << __LINE__ << " failed. size mismatch";
-      }
-
-      for (auto pair : llvm::zip(o->fields(), e->fields())) {
-        CARBON_RETURN_IF_ERROR(
-            CheckPatternEquality(std::get<0>(pair), std::get<1>(pair)));
-      }
-
-      break;
-    }
-    case PatternKind::ExpressionPattern: {
-      const auto* o = cast<ExpressionPattern>(o_patt);
-      const auto* e = cast<ExpressionPattern>(e_patt);
-
-      CARBON_RETURN_IF_ERROR(
-          CheckExpressionEquality(&o->expression(), &e->expression()));
-      break;
-    }
-    default:
-      if (trace_stream_) {
-        **trace_stream_ << "cradtke: unexpected pattern kind - "
-                        << PatternKindName(e_patt->kind()) << "\n";
-      }
-      //      CARBON_CHECK(0 && "unreachable");
-      break;
-  }
-  return Success();
-}
-
-auto TypeChecker::CheckExpressionEquality(Nonnull<const Expression*> o_exp,
-                                          Nonnull<const Expression*> e_exp)
-    -> ErrorOr<Success> {
-  if (o_exp->kind() != e_exp->kind()) {
-    return ProgramError(o_exp->source_loc())
-           << __FUNCTION__ << ":" << __LINE__ << " failed. kind mismatch";
-  }
-
-  return Success();
-}
-
-auto TypeChecker::CheckReturnTermEquality(Nonnull<const ReturnTerm*> o_ret_term,
-                                          Nonnull<const ReturnTerm*> e_ret_term)
-    -> ErrorOr<Success> {
-  if (o_ret_term->type_expression().has_value() !=
-      o_ret_term->type_expression().has_value()) {
-    return ProgramError(o_ret_term->source_loc())
-           << __FUNCTION__ << ":" << __LINE__
-           << " failed. has type expression mismatch";
-  }
-
-  return CheckExpressionEquality(*o_ret_term->type_expression(),
-                                 *e_ret_term->type_expression());
-}
-
-auto TypeChecker::CheckFunctionSignatureEquality(
-    Nonnull<const CallableDeclaration*> o_fn,
-    Nonnull<const CallableDeclaration*> e_fn) -> ErrorOr<Success> {
-  CARBON_RETURN_IF_ERROR(
-      CheckPatternEquality(&o_fn->param_pattern(), &e_fn->param_pattern()));
-  CARBON_RETURN_IF_ERROR(
-      CheckReturnTermEquality(&o_fn->return_term(), &e_fn->return_term()));
-
-  return Success();
-}
-
 auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
                                           const ScopeInfo& scope_info)
     -> ErrorOr<Success> {
@@ -4875,9 +4789,6 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
                     "`abstract` or `virtual` in base class.";
         }
 
-        CARBON_RETURN_IF_ERROR(CheckFunctionSignatureEquality(
-            fun, class_vtable[fun->name()].first));
-
         break;
     }
     class_vtable[fun->name().inner_name()] = {fun, class_level};
@@ -4912,6 +4823,20 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
       ScopeInfo::ForClassScope(scope_info, &class_scope, std::move(bindings));
   for (Nonnull<Declaration*> m : class_decl->members()) {
     CARBON_RETURN_IF_ERROR(DeclareDeclaration(m, class_scope_info));
+
+    const auto* fun = dyn_cast<FunctionDeclaration>(m);
+    if (!fun) {
+      continue;
+    }
+
+    if (fun->virt_override() == VirtualOverride::Impl) {
+      auto vtable = (*base_class)->vtable();
+      const auto* vtable_fun = vtable[fun->name()].first;
+
+      CARBON_RETURN_IF_ERROR(ExpectExactType(fun->source_loc(), "impl method",
+                                             &vtable_fun->static_type(),
+                                             &fun->static_type(), class_scope));
+    }
   }
 
   if (trace_stream_) {

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -34,6 +34,21 @@ using GlobalMembersMap =
 
 class TypeChecker {
  public:
+  // TODO (@cradtke): delete me
+  auto CheckPatternEquality(Nonnull<const Pattern*> o_patt,
+                            Nonnull<const Pattern*> e_patt) -> ErrorOr<Success>;
+  auto CheckFunctionSignatureEquality(Nonnull<const CallableDeclaration*> o_fn,
+                                      Nonnull<const CallableDeclaration*> e_fn)
+      -> ErrorOr<Success>;
+  auto CheckReturnTermEquality(Nonnull<const ReturnTerm*> o_ret_term,
+                               Nonnull<const ReturnTerm*> e_ret_term)
+      -> ErrorOr<Success>;
+
+  auto CheckExpressionEquality(Nonnull<const Expression*> o_exp,
+                               Nonnull<const Expression*> e_exp)
+      -> ErrorOr<Success>;
+  // end TODO (@cradtke)
+
   explicit TypeChecker(Nonnull<Arena*> arena,
                        std::optional<Nonnull<llvm::raw_ostream*>> trace_stream)
       : arena_(arena), trace_stream_(trace_stream) {}

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -34,21 +34,6 @@ using GlobalMembersMap =
 
 class TypeChecker {
  public:
-  // TODO (@cradtke): delete me
-  auto CheckPatternEquality(Nonnull<const Pattern*> o_patt,
-                            Nonnull<const Pattern*> e_patt) -> ErrorOr<Success>;
-  auto CheckFunctionSignatureEquality(Nonnull<const CallableDeclaration*> o_fn,
-                                      Nonnull<const CallableDeclaration*> e_fn)
-      -> ErrorOr<Success>;
-  auto CheckReturnTermEquality(Nonnull<const ReturnTerm*> o_ret_term,
-                               Nonnull<const ReturnTerm*> e_ret_term)
-      -> ErrorOr<Success>;
-
-  auto CheckExpressionEquality(Nonnull<const Expression*> o_exp,
-                               Nonnull<const Expression*> e_exp)
-      -> ErrorOr<Success>;
-  // end TODO (@cradtke)
-
   explicit TypeChecker(Nonnull<Arena*> arena,
                        std::optional<Nonnull<llvm::raw_ostream*>> trace_stream)
       : arena_(arena), trace_stream_(trace_stream) {}

--- a/explorer/testdata/class/fail_fn_check_signature_param_size.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_param_size.carbon
@@ -13,7 +13,9 @@ base class B {
 }
 
 class D extends B {
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_size.carbon:[[@LINE+1]]: CheckPatternEquality:4488 failed. size mismatch
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_size.carbon:[[@LINE+3]]: type error in impl method
+    // CHECK:STDERR: expected: fn (i32) -> i32
+    // CHECK:STDERR: actual: fn (i32, i32) -> i32
     impl fn foo[self: Self](a: i32, b: i32) -> i32 { return a + b; }
 }
 

--- a/explorer/testdata/class/fail_fn_check_signature_param_size.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_param_size.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+base class B {
+    virtual fn foo[self: Self](i: i32) -> i32 { return i; }
+}
+
+class D extends B {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_size.carbon:[[@LINE+1]]: CheckPatternEquality:4488 failed. size mismatch
+    impl fn foo[self: Self](a: i32, b: i32) -> i32 { return a + b; }
+}
+
+fn Main() -> i32 {
+    return 0;
+}

--- a/explorer/testdata/class/fail_fn_check_signature_param_type.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_param_type.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+base class B {
+    virtual fn foo[self: Self](i: i32) -> i32 { return i; }
+}
+
+class D extends B {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_type.carbon:[[@LINE+1]]: CheckExpressionEquality:4520 failed. kind mismatch
+    impl fn foo[self: Self](a: String) -> i32 { return 0; }
+}
+
+fn Main() -> i32 {
+    return 0;
+}

--- a/explorer/testdata/class/fail_fn_check_signature_param_type.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_param_type.carbon
@@ -13,7 +13,9 @@ base class B {
 }
 
 class D extends B {
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_type.carbon:[[@LINE+1]]: CheckExpressionEquality:4520 failed. kind mismatch
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_param_type.carbon:[[@LINE+3]]: type error in impl method
+    // CHECK:STDERR: expected: fn (i32) -> i32
+    // CHECK:STDERR: actual: fn (String) -> i32
     impl fn foo[self: Self](a: String) -> i32 { return 0; }
 }
 

--- a/explorer/testdata/class/fail_fn_check_signature_return_type.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_return_type.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+base class B {
+    virtual fn foo[self: Self](i: i32) -> i32 { return i; }
+}
+
+class D extends B {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_return_type.carbon:[[@LINE+1]]: CheckExpressionEquality:4520 failed. kind mismatch
+    impl fn foo[self: Self](i: i32) -> String { return ""; }
+}
+
+fn Main() -> i32 {
+    return 0;
+}

--- a/explorer/testdata/class/fail_fn_check_signature_return_type.carbon
+++ b/explorer/testdata/class/fail_fn_check_signature_return_type.carbon
@@ -13,7 +13,9 @@ base class B {
 }
 
 class D extends B {
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_return_type.carbon:[[@LINE+1]]: CheckExpressionEquality:4520 failed. kind mismatch
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_fn_check_signature_return_type.carbon:[[@LINE+3]]: type error in impl method
+    // CHECK:STDERR: expected: fn (i32) -> i32
+    // CHECK:STDERR: actual: fn (i32) -> String
     impl fn foo[self: Self](i: i32) -> String { return ""; }
 }
 

--- a/explorer/testdata/class/fn_check_signature.carbon
+++ b/explorer/testdata/class/fn_check_signature.carbon
@@ -11,18 +11,11 @@ package ExplorerTest api;
 
 base class B {
     virtual fn foo[self: Self](i: i32) -> i32 { return i; }
-    // * should be part of the test when abstract is implemented *
-    // abstract fn bar[self: Self](a: i32, b: i32);
 }
 
 class D1 extends B {
     impl fn foo[self: Self](i: i32) -> i32 { return 0; }
 }
-
-// * Doesn't work right now, but should as 0 is narrower than i32 *
-// class D2 extends B {
-//     impl fn foo[self: Self](i: i32) -> 0 { return 0; }
-// }
 
 fn Main() -> i32 {
     return 0;

--- a/explorer/testdata/class/fn_check_signature.carbon
+++ b/explorer/testdata/class/fn_check_signature.carbon
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class B {
+    virtual fn foo[self: Self](i: i32) -> i32 { return i; }
+    // * should be part of the test when abstract is implemented *
+    // abstract fn bar[self: Self](a: i32, b: i32);
+}
+
+class D1 extends B {
+    impl fn foo[self: Self](i: i32) -> i32 { return 0; }
+}
+
+// * Doesn't work right now, but should as 0 is narrower than i32 *
+// class D2 extends B {
+//     impl fn foo[self: Self](i: i32) -> 0 { return 0; }
+// }
+
+fn Main() -> i32 {
+    return 0;
+}


### PR DESCRIPTION
The goal of this PR is to verify overridden methods maintain the correct signature (name, parameters, return type). Pertains to [this discord message](https://discord.com/channels/655572317891461132/763516049710120960/1060788299528146974).

This PR produces a similar error message as a type mismatch in an interface `impl`. 