### PR TITLE
[explorer] support abstract methods

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1859,6 +1859,25 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
                  << "Cannot instantiate abstract class "
                  << dest_class->declaration().name();
         }
+
+        if (dest_class->declaration().extensibility() ==
+            ClassExtensibility::Base) {
+          for (const auto& vt : dest_class->vtable()) {
+            const auto* const fun = vt.getValue().first;
+
+            if (!fun->is_method()) {
+              continue;
+            }
+
+            if (fun->virt_override() == VirtualOverride::Abstract) {
+              return ProgramError(stmt.source_loc())
+                     << "Cannot instantiate base class `"
+                     << dest_class->declaration().name()
+                     << "`: abstract method `" << fun->name()
+                     << "` should be implemented.";
+            }
+          }
+        }
       }
       if (act.pos() == 0 && definition.has_init()) {
         //    { {(var x = e) :: C, E, F} :: S, H}

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4524,7 +4524,7 @@ auto TypeChecker::DeclareClassDeclaration(Nonnull<ClassDeclaration*> class_decl,
         fun->body().has_value()) {
       return ProgramError(fun->source_loc())
              << "Error declaring `" << fun->name() << "`"
-             << ": abstract method cannot have a body.";
+             << ": abstract methods cannot have a body.";
     }
 
     bool has_vtable_entry =

--- a/explorer/testdata/class/abstract_method.carbon
+++ b/explorer/testdata/class/abstract_method.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+abstract class A {
+    abstract fn Foo[self: Self]();
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/abstract_method_base_instance.carbon
+++ b/explorer/testdata/class/abstract_method_base_instance.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+abstract class A {
+    abstract fn Foo[self: Self]();
+}
+
+base class B extends A {
+    impl fn Foo[self: Self]() {}
+}
+
+fn Main() -> i32 {
+  var b: B = { .base = {} };
+  return 0;
+}

--- a/explorer/testdata/class/abstract_method_base_no_instance.carbon
+++ b/explorer/testdata/class/abstract_method_base_no_instance.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+abstract class A {
+    abstract fn Foo[self: Self]();
+}
+
+base class B extends A {
+
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_abstract_method_base_instance.carbon
+++ b/explorer/testdata/class/fail_abstract_method_base_instance.carbon
@@ -8,17 +8,16 @@
 
 package ExplorerTest api;
 
-base class C {
+abstract class A {
+    abstract fn Foo[self: Self]();
 }
 
-class D extends C {
-  abstract fn Foo[self:Self]() -> i32 {
-    return 1;
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_not_supported.carbon:[[@LINE+1]]: Error declaring `Foo`: `abstract` methods are not yet supported.
-  }
+base class B extends A {
+
 }
 
 fn Main() -> i32 {
-  let d: D = {};
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_base_instance.carbon:[[@LINE+1]]: Cannot instantiate base class `B`: abstract method `Foo` should be implemented.
+  var b: B = { .base = {} };
   return 0;
 }

--- a/explorer/testdata/class/fail_abstract_method_body.carbon
+++ b/explorer/testdata/class/fail_abstract_method_body.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class A {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_body.carbon:[[@LINE+1]]: Error declaring `Foo`: abstract method cannot have a body.
+    abstract fn Foo[self: Self]() {}
+}
+
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_abstract_method_body.carbon
+++ b/explorer/testdata/class/fail_abstract_method_body.carbon
@@ -9,7 +9,7 @@
 package ExplorerTest api;
 
 abstract class A {
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_body.carbon:[[@LINE+1]]: Error declaring `Foo`: abstract method cannot have a body.
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_body.carbon:[[@LINE+1]]: Error declaring `Foo`: abstract methods cannot have a body.
     abstract fn Foo[self: Self]() {}
 }
 

--- a/explorer/testdata/class/fail_abstract_method_final_impl.carbon
+++ b/explorer/testdata/class/fail_abstract_method_final_impl.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class A {
+    abstract fn Foo[self: Self]();
+}
+
+class B extends A {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_final_impl.carbon:[[@LINE+1]]: Error declaring `B`: final class should implement abstract method `Foo`.
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_abstract_method_non_abstract_class.carbon
+++ b/explorer/testdata/class/fail_abstract_method_non_abstract_class.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+class A {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_abstract_method_non_abstract_class.carbon:[[@LINE+1]]: Error declaring `Foo`: `abstract` methods are allowed only in abstract classes.
+    abstract fn Foo[self: Self]();
+}
+
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
Added support for `abstract` methods.

Closes #2512
