### PR TITLE
Remove cstdint from enum_base.h

### DIFF
--- a/toolchain/common/enum_base.h
+++ b/toolchain/common/enum_base.h
@@ -5,7 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_COMMON_ENUM_BASE_H_
 #define CARBON_TOOLCHAIN_COMMON_ENUM_BASE_H_
 
-#include <cstdint>
 #include <type_traits>
 
 #include "common/ostream.h"

--- a/toolchain/parser/parse_node_kind.h
+++ b/toolchain/parser/parse_node_kind.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
 #define CARBON_TOOLCHAIN_PARSER_PARSE_NODE_KIND_H_
 
+#include <cstdint>
+
 #include "toolchain/common/enum_base.h"
 
 namespace Carbon {

--- a/toolchain/parser/parser_state.h
+++ b/toolchain/parser/parser_state.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_PARSER_PARSER_STATE_H_
 #define CARBON_TOOLCHAIN_PARSER_PARSER_STATE_H_
 
+#include <cstdint>
+
 #include "toolchain/common/enum_base.h"
 
 namespace Carbon {

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_BUILTIN_KIND_H_
 #define CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_BUILTIN_KIND_H_
 
+#include <cstdint>
+
 #include "toolchain/common/enum_base.h"
 
 namespace Carbon {

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_KIND_H_
 #define CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_KIND_H_
 
+#include <cstdint>
+
 #include "toolchain/common/enum_base.h"
 
 namespace Carbon {


### PR DESCRIPTION
Enums are generally using uint8_t right now. enum_base.h doesn't use cstdint directly, and direct includes are preferred.