### PR TITLE
Add style rule for field order in simple structs with member functions.

### DIFF
--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -155,7 +155,8 @@ these.
 ### Declaration order
 
 -   For a struct without constructors or factory functions, fields should be
-    declared at the start of the struct, not at the end.
+    declared at the start of the struct, immediately after any member types or
+    typedefs, not at the end.
 
 ### Copyable and movable types
 

--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [General naming rules](#general-naming-rules)
     -   [File names](#file-names)
     -   [Syntax and formatting](#syntax-and-formatting)
+    -   [Declaration order](#declaration-order)
     -   [Copyable and movable types](#copyable-and-movable-types)
     -   [Static and global variables](#static-and-global-variables)
     -   [Foundational libraries and data types](#foundational-libraries-and-data-types)
@@ -150,6 +151,11 @@ these.
     -   Tests are an exception and should typically be wrapped with
         `namespace Carbon::Testing { namespace { ... } }` to keep everything
         internal.
+
+### Declaration order
+
+-   For a struct without constructors or factory functions, fields should be
+    declared at the start of the struct, not at the end.
 
 ### Copyable and movable types
 

--- a/explorer/ast/paren_contents.h
+++ b/explorer/ast/paren_contents.h
@@ -26,13 +26,13 @@ namespace Carbon {
 // either `Expression` or `Pattern`.
 template <typename Term>
 struct ParenContents {
+  std::vector<Nonnull<Term*>> elements;
+  bool has_trailing_comma;
+
   // If this object represents a single term with no trailing comma, this
   // method returns that term. This typically means the parentheses can be
   // interpreted as grouping.
   auto SingleTerm() const -> std::optional<Nonnull<Term*>>;
-
-  std::vector<Nonnull<Term*>> elements;
-  bool has_trailing_comma;
 };
 
 // Implementation details only below here.

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -156,7 +156,7 @@ class ImplScope {
 // An equality context that considers two values to be equal if they are a
 // single step apart according to an equality constraint in the given impl
 // scope.
-struct SingleStepEqualityContext : public EqualityContext {
+class SingleStepEqualityContext : public EqualityContext {
  public:
   explicit SingleStepEqualityContext(Nonnull<const ImplScope*> impl_scope)
       : impl_scope_(impl_scope) {}

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -937,6 +937,8 @@ struct ImplConstraint {
 
 // A constraint that a collection of values are known to be the same.
 struct EqualityConstraint {
+  std::vector<Nonnull<const Value*>> values;
+
   // Visit the values in this equality constraint that are a single step away
   // from the given value according to this equality constraint. That is: if
   // `value` is identical to a value in `values`, then call the visitor on all
@@ -948,8 +950,6 @@ struct EqualityConstraint {
   auto VisitEqualValues(
       Nonnull<const Value*> value,
       llvm::function_ref<bool(Nonnull<const Value*>)> visitor) const -> bool;
-
-  std::vector<Nonnull<const Value*>> values;
 };
 
 // A constraint indicating that access to an associated constant should be

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -311,15 +311,15 @@ class TokenizedBuffer {
   // Specifies minimum widths to use when printing a token's fields via
   // `printToken`.
   struct PrintWidths {
-    // Widens `this` to the maximum of `this` and `new_width` for each
-    // dimension.
-    auto Widen(const PrintWidths& widths) -> void;
-
     int index;
     int kind;
     int line;
     int column;
     int indent;
+
+    // Widens `this` to the maximum of `this` and `new_width` for each
+    // dimension.
+    auto Widen(const PrintWidths& widths) -> void;
   };
 
   struct TokenInfo {

--- a/toolchain/lexer/tokenized_buffer_test_helpers.h
+++ b/toolchain/lexer/tokenized_buffer_test_helpers.h
@@ -26,6 +26,14 @@ inline void PrintTo(const TokenizedBuffer& buffer, std::ostream* output) {
 namespace Testing {
 
 struct ExpectedToken {
+  TokenKind kind;
+  int line = -1;
+  int column = -1;
+  int indent_column = -1;
+  bool recovery = false;
+  llvm::StringRef text = "";
+  std::optional<llvm::StringRef> string_contents = std::nullopt;
+
   friend auto operator<<(std::ostream& output, const ExpectedToken& expected)
       -> std::ostream& {
     output << "\ntoken: { kind: '" << expected.kind.name().str() << "'";
@@ -51,14 +59,6 @@ struct ExpectedToken {
     output << " }";
     return output;
   }
-
-  TokenKind kind;
-  int line = -1;
-  int column = -1;
-  int indent_column = -1;
-  bool recovery = false;
-  llvm::StringRef text = "";
-  std::optional<llvm::StringRef> string_contents = std::nullopt;
 };
 
 // TODO: Consider rewriting this into a `TokenEq` matcher which is used inside


### PR DESCRIPTION
The new rule is that for simple structs, where we expect instances to be created by specifying the values of the fields, those fields are listed first in the class definition, not at the end. Update existing code to follow the rule.

For example, instead of:

```
struct MyStruct {
  void HelperFunction();
  void SomethingElse();

  int field1;
  int field2;
};
```

we now recommend

```
struct MyStruct {
  int field1;
  int field2;

  void HelperFunction();
  void SomethingElse();
};
```

The intent is to keep the most important facts about the struct, and the information needed in order to create an instance, at the start, with implementation details and minor properties presented later on, "below the fold".

This layout is in violation of the current version of the Google style guide, but will be permitted by an upcoming version.