### PR TITLE
Rename ToString to mention Operator

### DIFF
--- a/explorer/ast/ast_test_matchers_internal.cpp
+++ b/explorer/ast/ast_test_matchers_internal.cpp
@@ -49,10 +49,11 @@ auto BinaryOperatorExpressionMatcher::MatchAndExplainImpl(
     return false;
   }
   if (op->op() != op_) {
-    *out << "whose operator is not " << ToString(op_);
+    *out << "whose operator is not " << OperatorToString(op_);
     return false;
   }
-  *out << "which is a " << ToString(op_) << " expression whose left operand ";
+  *out << "which is a " << OperatorToString(op_)
+       << " expression whose left operand ";
   bool matched = lhs_.MatchAndExplain(*op->arguments()[0], out);
   *out << " and right operand ";
   if (!rhs_.MatchAndExplain(*op->arguments()[1], out)) {
@@ -63,7 +64,7 @@ auto BinaryOperatorExpressionMatcher::MatchAndExplainImpl(
 
 void BinaryOperatorExpressionMatcher::DescribeToImpl(std::ostream* out,
                                                      bool negated) const {
-  *out << "is " << (negated ? "not " : "") << "a " << ToString(op_)
+  *out << "is " << (negated ? "not " : "") << "a " << OperatorToString(op_)
        << " expression whose ";
   *out << "left operand ";
   lhs_.DescribeTo(out);

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -105,7 +105,8 @@ auto TupleExpressionFromParenContents(
 
 Expression::~Expression() = default;
 
-auto ToString(Operator op) -> std::string_view {
+// Returns the lexical representation of `op`, such as "+" for `Add`.
+auto OperatorToString(Operator op) -> std::string_view {
   switch (op) {
     case Operator::Add:
       return "+";
@@ -211,13 +212,13 @@ void Expression::Print(llvm::raw_ostream& out) const {
       const auto& op = cast<OperatorExpression>(*this);
       switch (op.arguments().size()) {
         case 0:
-          out << ToString(op.op());
+          out << OperatorToString(op.op());
           break;
         case 1:
-          out << ToString(op.op()) << " " << *op.arguments()[0];
+          out << OperatorToString(op.op()) << " " << *op.arguments()[0];
           break;
         case 2:
-          out << *op.arguments()[0] << " " << ToString(op.op()) << " "
+          out << *op.arguments()[0] << " " << OperatorToString(op.op()) << " "
               << *op.arguments()[1];
           break;
         default:

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -105,7 +105,6 @@ auto TupleExpressionFromParenContents(
 
 Expression::~Expression() = default;
 
-// Returns the lexical representation of `op`, such as "+" for `Add`.
 auto OperatorToString(Operator op) -> std::string_view {
   switch (op) {
     case Operator::Add:

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -169,7 +169,7 @@ enum class Operator {
 };
 
 // Returns the lexical representation of `op`, such as "+" for `Add`.
-auto ToString(Operator op) -> std::string_view;
+auto OperatorToString(Operator op) -> std::string_view;
 
 class IdentifierExpression : public Expression {
  public:

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -253,7 +253,7 @@ auto Interpreter::EvalPrim(Operator op, Nonnull<const Value*> /*static_type*/,
     case Operator::BitShiftLeft:
     case Operator::BitShiftRight:
     case Operator::Complement:
-      CARBON_FATAL() << "operator " << ToString(op)
+      CARBON_FATAL() << "operator " << OperatorToString(op)
                      << " should always be rewritten";
   }
 }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2989,7 +2989,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
         if (!result.ok()) {
           // We couldn't find a matching `impl`.
           return ProgramError(e->source_loc())
-                 << "type error in `" << ToString(op.op()) << "`:\n"
+                 << "type error in `" << OperatorToString(op.op()) << "`:\n"
                  << result.error().message();
         }
         op.set_rewritten_form(*result);
@@ -3004,7 +3004,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
         if (!result.ok()) {
           // We couldn't find a matching `impl`.
           return ProgramError(e->source_loc())
-                 << "type error in `" << ToString(op.op()) << "`:\n"
+                 << "type error in `" << OperatorToString(op.op()) << "`:\n"
                  << result.error().message();
         }
         op.set_rewritten_form(*result);
@@ -3158,7 +3158,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
         case Operator::AddressOf:
           if (op.arguments()[0]->value_category() != ValueCategory::Var) {
             return ProgramError(op.arguments()[0]->source_loc())
-                   << "Argument to " << ToString(op.op())
+                   << "Argument to " << OperatorToString(op.op())
                    << " should be an lvalue.";
           }
           op.set_static_type(arena_->New<PointerType>(ts[0]));


### PR DESCRIPTION
Naming this ToString within the Carbon namespace encourages incidental overloading of the function, and that doesn't seem to be intentional; this feels questionable [under overloading style](https://google.github.io/styleguide/cppguide.html#Function_Overloading). OperatorToString seems helpful in that it makes it easy to see at a glance where it's being used.