### PR TITLE
Add some ls commands to help diagnose tool issues

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,6 +84,10 @@ jobs:
           echo '*** python'
           which python
           python --version
+          echo '*** ls "$(brew --prefix llvm@14)'
+          ls "$(brew --prefix llvm@14)"
+          echo '*** ls "$(brew --prefix llvm@14)/bin'
+          ls "$(brew --prefix llvm@14)/bin"
           echo '*** clang'
           which clang
           clang --version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,6 +65,10 @@ jobs:
         if: matrix.os == 'macos-12'
         run: |
           echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
+          echo '*** ls "$(brew --prefix llvm@14)"'
+          ls "$(brew --prefix llvm@14)"
+          echo '*** ls "$(brew --prefix llvm@14)/bin"'
+          ls "$(brew --prefix llvm@14)/bin"
 
       # Use LLVM 14 following:
       # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
@@ -72,6 +76,8 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: |
           echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH
+          echo '*** ls /usr/lib/llvm-14/bin'
+          ls /usr/lib/llvm-14/bin
 
       # Print the various tool paths and versions to help in debugging.
       - name: Print tool debugging info
@@ -84,10 +90,6 @@ jobs:
           echo '*** python'
           which python
           python --version
-          echo '*** ls "$(brew --prefix llvm@14)'
-          ls "$(brew --prefix llvm@14)"
-          echo '*** ls "$(brew --prefix llvm@14)/bin'
-          ls "$(brew --prefix llvm@14)/bin"
           echo '*** clang'
           which clang
           clang --version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [action-test]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [action-test]
+    branches: [trunk]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.
@@ -38,8 +38,8 @@ jobs:
         # At present, these images are newer than "latest". We use them to test
         # against more recent tooling versions.
         # https://github.com/actions/runner-images
-        os: [macos-12]
-        build_mode: [opt]
+        os: [ubuntu-22.04, macos-12]
+        build_mode: [fastbuild, opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,8 +38,8 @@ jobs:
         # At present, these images are newer than "latest". We use them to test
         # against more recent tooling versions.
         # https://github.com/actions/runner-images
-        os: [ubuntu-22.04, macos-12]
-        build_mode: [fastbuild, opt]
+        os: [macos-12]
+        build_mode: [opt]
     runs-on: ${{ matrix.os }}
     steps:
       # Checkout the pull request head or the branch.

--- a/explorer/main.cpp
+++ b/explorer/main.cpp
@@ -37,6 +37,7 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
       "Please report issues to "
       "https://github.com/carbon-language/carbon-lang/issues and include the "
       "crash backtrace.\n");
+      
   llvm::InitLLVM init_llvm(argc, argv);
 
   // Printing to stderr should flush stdout. This is most noticeable when stderr

--- a/explorer/main.cpp
+++ b/explorer/main.cpp
@@ -37,7 +37,6 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
       "Please report issues to "
       "https://github.com/carbon-language/carbon-lang/issues and include the "
       "crash backtrace.\n");
-      
   llvm::InitLLVM init_llvm(argc, argv);
 
   // Printing to stderr should flush stdout. This is most noticeable when stderr


### PR DESCRIPTION
We're seeing some test runs where `clang` isn't in the path on macos. I suspect it's a bad image, and can't reproduce it, but want to add these commands to help provide debug info for potential future problems.

e.g., the `ls` output: https://github.com/carbon-language/carbon-lang/actions/runs/3963366092/jobs/6791110228

e.g., the bad image: https://github.com/carbon-language/carbon-lang/actions/runs/3963270727/jobs/6790912681