### PR TITLE
Support using llvm-15 if GH images provide it

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,25 +59,37 @@ jobs:
           # Match the min version listed in docs/project/contribution_tools.md
           python-version: '3.9'
 
-      # Use LLVM 14 following:
+      # Use LLVM following:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+      # Both 14 and 15 are candidates because GitHub is testing new images.
       - name: Setup LLVM and Clang (macOS)
         if: matrix.os == 'macos-12'
         run: |
-          echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
-          echo '*** ls "$(brew --prefix llvm@14)"'
-          ls "$(brew --prefix llvm@14)"
-          echo '*** ls "$(brew --prefix llvm@14)/bin"'
-          ls "$(brew --prefix llvm@14)/bin"
+          LLVM_PATH="$(brew --prefix llvm@15)"
+          if [[ ! -e "${LLVM_PATH}" ]]; then
+            LLVM_PATH="$(brew --prefix llvm@14)"
+          fi
+          echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
+          echo '*** ls "${LLVM_PATH}"'
+          ls "${LLVM_PATH}"
+          echo '*** ls "${LLVM_PATH}/bin"'
+          ls "${LLVM_PATH}/bin"
 
-      # Use LLVM 14 following:
+      # Use LLVM following:
       # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+      # Both 14 and 15 are candidates because GitHub is testing new images.
       - name: Setup LLVM and Clang (Linux)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          echo "/usr/lib/llvm-14/bin" >> $GITHUB_PATH
-          echo '*** ls /usr/lib/llvm-14/bin'
-          ls /usr/lib/llvm-14/bin
+          LLVM_PATH="/usr/lib/llvm-15"
+          if [[ ! -e "${LLVM_PATH}" ]]; then
+            LLVM_PATH="/usr/lib/llvm-14"
+          fi
+          echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
+          echo '*** ls "${LLVM_PATH}"'
+          ls "${LLVM_PATH}"
+          echo '*** ls "${LLVM_PATH}/bin"'
+          ls "${LLVM_PATH}/bin"
 
       # Print the various tool paths and versions to help in debugging.
       - name: Print tool debugging info

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [action-test]
+    branches: [trunk]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,8 @@ jobs:
 
       # Use LLVM following:
       # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
-      # Both 14 and 15 are candidates because GitHub is testing new images.
+      # Both 14 and 15 are candidates for forwards compatibility, although 15
+      # isn't provided.
       - name: Setup LLVM and Clang (Linux)
         if: matrix.os == 'ubuntu-22.04'
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [action-test]
     paths:
       # Conservatively run the tests. However, skip them if the only paths in
       # the pull request match files that we know don't impact the build.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,6 +69,7 @@ jobs:
           if [[ ! -e "${LLVM_PATH}" ]]; then
             LLVM_PATH="$(brew --prefix llvm@14)"
           fi
+          echo "Using ${LLVM_PATH}"
           echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
           echo '*** ls "${LLVM_PATH}"'
           ls "${LLVM_PATH}"
@@ -85,6 +86,7 @@ jobs:
           if [[ ! -e "${LLVM_PATH}" ]]; then
             LLVM_PATH="/usr/lib/llvm-14"
           fi
+          echo "Using ${LLVM_PATH}"
           echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
           echo '*** ls "${LLVM_PATH}"'
           ls "${LLVM_PATH}"


### PR DESCRIPTION
A migration by GH that drops LLVM 14 is breaking builds. It seems to still be getting canaried, so this is showing as flaky behavior. I think it's https://github.com/actions/runner-images/pull/6871

The set of runs at https://github.com/carbon-language/carbon-lang/actions/runs/3970825811/jobs/6807006626 show the fix behavior.