### PR TITLE
Explorer: move deallocation to `StepCleanUp`

### DIFF
--- a/explorer/interpreter/action.cpp
+++ b/explorer/interpreter/action.cpp
@@ -35,13 +35,6 @@ auto RuntimeScope::operator=(RuntimeScope&& rhs) noexcept -> RuntimeScope& {
   return *this;
 }
 
-RuntimeScope::~RuntimeScope() {
-  for (auto allocation : allocations_) {
-    // TODO: move this into StepCleanUp
-    heap_->Deallocate(allocation);
-  }
-}
-
 void RuntimeScope::Print(llvm::raw_ostream& out) const {
   out << "{";
   llvm::ListSeparator sep;

--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -42,8 +42,6 @@ class RuntimeScope {
   RuntimeScope(RuntimeScope&&) noexcept;
   auto operator=(RuntimeScope&&) noexcept -> RuntimeScope&;
 
-  ~RuntimeScope() = default;
-
   void Print(llvm::raw_ostream& out) const;
   LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }
 

--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -42,8 +42,7 @@ class RuntimeScope {
   RuntimeScope(RuntimeScope&&) noexcept;
   auto operator=(RuntimeScope&&) noexcept -> RuntimeScope&;
 
-  // Deallocates any allocations in this scope from `heap`.
-  ~RuntimeScope();
+  ~RuntimeScope() = default;
 
   void Print(llvm::raw_ostream& out) const;
   LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2213,7 +2213,7 @@ auto Interpreter::StepCleanUp() -> ErrorOr<Success> {
       auto* lvalue = arena_->New<LValue>(Address(allocation));
       auto value =
           heap_.Read(lvalue->address(), SourceLocation("destructor", 1));
-      // Step over uninitialized values
+      // Step over uninitialized values.
       if (value.ok()) {
         return todo_.Spawn(std::make_unique<DestroyAction>(lvalue, *value));
       }

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2229,6 +2229,7 @@ auto Interpreter::StepCleanUp() -> ErrorOr<Success> {
       }
     } else {
       heap_.Deallocate(allocation);
+      return todo_.RunAgain();
     }
   }
   todo_.Pop();

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2207,13 +2207,12 @@ auto Interpreter::StepCleanUp() -> ErrorOr<Success> {
   const Action& act = todo_.CurrentAction();
   const auto& cleanup = cast<CleanUpAction>(act);
   if (act.pos() < cleanup.allocations_count() * 2) {
-    auto allocation =
-        act.scope()
-            ->allocations()[cleanup.allocations_count() - act.pos() / 2 - 1];
+    const size_t alloc_index = cleanup.allocations_count() - act.pos() / 2 - 1;
+    auto allocation = act.scope()->allocations()[alloc_index];
     if (act.pos() % 2 == 0) {
       auto* lvalue = arena_->New<LValue>(Address(allocation));
-      SourceLocation source_loc("destructor", 1);
-      auto value = heap_.Read(lvalue->address(), source_loc);
+      auto value =
+          heap_.Read(lvalue->address(), SourceLocation("destructor", 1));
       // Step over uninitialized values
       if (value.ok()) {
         return todo_.Spawn(std::make_unique<DestroyAction>(lvalue, *value));


### PR DESCRIPTION
Move deallocation logic to `StepCleanUp` to have all necessary cleanup actions in the same place. Currently this means `DestroyAction` and `heap_.Deallocate`.
