### PR TITLE
Switch SemanticsIR::Print to range-based for loops

### DIFF
--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -78,35 +78,34 @@ auto SemanticsIR::Print(llvm::raw_ostream& out) const -> void {
   out << "cross_reference_irs_size: " << cross_reference_irs_.size() << "\n";
 
   out << "integer_literals: [\n";
-  for (int32_t i = 0; i < static_cast<int32_t>(integer_literals_.size()); ++i) {
+  for (const auto& integer_literal : integer_literals_) {
     out.indent(Indent);
-    out << integer_literals_[i] << ",\n";
+    out << integer_literal << ",\n";
   }
   out << "]\n";
 
   out << "strings: [\n";
-  for (int32_t i = 0; i < static_cast<int32_t>(strings_.size()); ++i) {
+  for (const auto& string : strings_) {
     out.indent(Indent);
-    out << strings_[i] << ",\n";
+    out << string << ",\n";
   }
   out << "]\n";
 
   out << "nodes: [\n";
-  for (int32_t i = 0; i < static_cast<int32_t>(nodes_.size()); ++i) {
+  for (const auto& node : nodes_) {
     out.indent(Indent);
-    out << nodes_[i] << ",\n";
+    out << node << ",\n";
   }
   out << "]\n";
 
   out << "node_blocks: [\n";
-  for (int32_t i = 0; i < static_cast<int32_t>(node_blocks_.size()); ++i) {
+  for (const auto& node_block : node_blocks_) {
     out.indent(Indent);
     out << "[\n";
 
-    const auto& node_block = node_blocks_[i];
-    for (int32_t i = 0; i < static_cast<int32_t>(node_block.size()); ++i) {
+    for (const auto& node : node_block) {
       out.indent(2 * Indent);
-      out << node_block[i] << ",\n";
+      out << node << ",\n";
     }
     out.indent(Indent);
     out << "],\n";


### PR DESCRIPTION
Cleanup, since indices are no longer needed.