### PR TITLE
Roadmap for 2023 and retrospective for 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ and the language:
     Carbon. We call this the [Carbon Explorer](/explorer/).
 
 If you're interested in contributing, we would love help
-[completing the 0.1 language designs](/docs/project/roadmap.md#completing-the-language-design),
+[completing the 0.1 language designs](/docs/project/roadmap.md#complete-design-coverage-of-the-01-languages-necessary-features),
 and
-[completing the Carbon Explorer implementation of this design](/docs/project/roadmap.md#demo-implementation-of-core-features-with-working-examples).
+[completing the Carbon Explorer implementation of this design](/docs/project/roadmap.md#complete-01-language-implementation-coverage-in-the-carbon-explorer).
 We are also currently working to get more broad feedback and participation from
 the C++ community. Beyond that, we plan to prioritize C++ interoperability and a
 realistic toolchain that implements the 0.1 language and can be used to evaluate

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -10,18 +10,17 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Table of contents
 
--   [Objective for 2022: make Carbon public, finish 0.1 language](#objective-for-2022-make-carbon-public-finish-01-language)
-    -   [Completing the language design](#completing-the-language-design)
-    -   [Going public](#going-public)
--   [Key results in 2022](#key-results-in-2022)
-    -   [Broaden participation so no organization is >50%](#broaden-participation-so-no-organization-is-50)
-    -   [Example ports of C++ libraries to Carbon (100% of woff2, 99% of RE2)](#example-ports-of-c-libraries-to-carbon-100-of-woff2-99-of-re2)
-        -   [Language design covers the syntax and semantics of the example port code.](#language-design-covers-the-syntax-and-semantics-of-the-example-port-code)
-    -   [Demo implementation of core features with working examples](#demo-implementation-of-core-features-with-working-examples)
-    -   [Carbon explorer implementation of core features with test cases](#carbon-explorer-implementation-of-core-features-with-test-cases)
--   [Beyond 2022](#beyond-2022)
-    -   [Potential 2023 goals: finish 0.2 language, stop experimenting](#potential-2023-goals-finish-02-language-stop-experimenting)
-    -   [Potential 2024-2025 goals: _ship_ 1.0 language & organization](#potential-2024-2025-goals-ship-10-language--organization)
+-   [Objective for 2023: get ready to evaluate the Carbon Language.](#objective-for-2023-get-ready-to-evaluate-the-carbon-language)
+-   [Key results in 2023](#key-results-in-2023)
+    -   [A concrete definition of our Minimum Viable Product for evaluation, the 0.1 language](#a-concrete-definition-of-our-minimum-viable-product-for-evaluation-the-01-language)
+    -   [Complete design coverage of the 0.1 language's necessary features](#complete-design-coverage-of-the-01-languages-necessary-features)
+    -   [Complete 0.1 language implementation coverage in the Carbon Explorer](#complete-01-language-implementation-coverage-in-the-carbon-explorer)
+    -   [A toolchain that can build a minimal mixed C++ and Carbon program](#a-toolchain-that-can-build-a-minimal-mixed-c-and-carbon-program)
+    -   [Give talks at 2-3 conferences covering 3-4 different Carbon topics](#give-talks-at-2-3-conferences-covering-3-4-different-carbon-topics)
+-   [Beyond 2023](#beyond-2023)
+    -   [Potential 2024 goals: ship a working 0.1 language for evaluation](#potential-2024-goals-ship-a-working-01-language-for-evaluation)
+    -   [Potential 2025-2026 goals: finish 0.2 language, stop experimenting](#potential-2025-2026-goals-finish-02-language-stop-experimenting)
+    -   [Potential goals _beyond_ 2026: ship 1.0 language & organization](#potential-goals-beyond-2026-ship-10-language--organization)
 
 <!-- tocstop -->
 
@@ -59,8 +58,7 @@ We expect this to include a reasonably precise set of requirements across:
 -   Necessary documentation, strategy, or other supporting material
 
 We expect this to also include at least enough of Carbon's features and C++
-interop to support
-[our basic example](/docs/images/snippets.md#mixed).
+interop to support [our basic example](/docs/images/snippets.md#mixed).
 
 Note that we don't expect to finish the 0.1 language work in 2023. Our goal is
 to make sufficient progress that we can complete it in 2024, but there are still

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -25,167 +25,113 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 <!-- tocstop -->
 
-## Objective for 2022: make Carbon public, finish 0.1 language
+## Objective for 2023: get ready to evaluate the Carbon Language.
 
-We have two primary goals for 2022:
+Our focus throughout 2023 will be to get the Carbon Language and project ready
+for serious evaluation of the experiment. There are two aspects to this
+evaluation:
 
--   Shift the experiment to being public.
--   Reach the point where the core language design is substantially complete.
+1. The language and tools need to be complete enough to evaluate.
+2. The users and communities we are targeting need both context and awareness of
+   the technical ideas and design principles on which Carbon is built.
 
-### Completing the language design
+## Key results in 2023
 
-By the end of 2022, the core Carbon language design should be substantially
-complete, including designs for expressions and statements, classes, generics
-and templates, core built-in types and interfaces such as integers and pointers,
-and interoperability with C++. The design choices made to reach this point are
-expected to be experimental, and many of them may need revisiting before we
-reach 1.0, but the broad shape of the language should be clear at this point,
-and it should be possible to write non-trivial Carbon programs.
+### A concrete definition of our Minimum Viable Product for evaluation, the 0.1 language
 
-An initial rough framework for the core standard library functionality should be
-provided, as necessary to support the core language components. A largely
-complete implementation of the core language design should be available in
-Carbon explorer. The toolchain should be able to parse the core language design,
-with some support for name lookup and type-checking.
+While we have talked about our 0.1 language, or our Minimum Viable Product (MVP)
+for evaluation purposes, we need to pin down exactly what this includes. We need
+concrete milestones that need to be reached for us to have confidence in
+potential users and communities being able to evaluate Carbon as a successor to
+C++.
 
-We should have begun writing non-trivial portions of the standard library, such
-as common higher-level data structures and algorithms.
+We expect this to include a reasonably precise set of requirements across:
 
-### Going public
+-   Necessary language features
+-   Nice-to-have features
+-   Features can we omit and reasonably expect to not obstruct credible
+    evaluation
+-   Implementation coverage of those features in the Carbon Explorer to validate
+    the design
+-   Implementation coverage of those features in the toolchain
+-   Quality of implementation in the toolchain, both in general and for specific
+    features
+-   Necessary documentation, strategy, or other supporting material
 
-At some point in 2022 we should shift the experiment to be public. This will
-allow us to significantly expand both those directly involved and contributing
-to Carbon but also those able to evaluate and give us feedback.
+We expect this to also include at least enough of Carbon's features and C++
+interop to support
+[our basic example](/docs/images/snippets.md#mixed).
 
-We don't expect Carbon to shift away from an experiment until after it becomes
-public and after we have been able to collect and incorporate a reasonable
-amount of feedback from the broader industry and community. This feedback will
-be central in determining whether Carbon should continue past the experimental
-stage.
+Note that we don't expect to finish the 0.1 language work in 2023. Our goal is
+to make sufficient progress that we can complete it in 2024, but there are still
+many things that can go wrong and cause significant delays.
 
-## Key results in 2022
+### Complete design coverage of the 0.1 language's necessary features
 
-There are several milestones that we believe are on the critical path to
-successfully achieving our main goal for the year, and point to concrete areas
-of focus for the project.
+This year we plan to finish the design of the necessary feature-set that we
+define above for the 0.1 language.
 
-### Broaden participation so no organization is >50%
+### Complete 0.1 language implementation coverage in the Carbon Explorer
 
-Our goal is that no single organization makes up >50% of participation in the
-Carbon project, to ensure that we are including as broad and representative a
-set of perspectives in the evolution of Carbon as possible.
+We expect to complete the level of Carbon Explorer validation of the design
+needed for 0.1 in 2023 so that we have high confidence in the design's cohesion
+and behavior.
 
-As a proxy for the amount of participation, we will count the number of active
-participants from each organization in 2022, with the aim that each organization
-is represented by less than 50% of all active participants.
+### A toolchain that can build a minimal mixed C++ and Carbon program
 
-There are many ways in which someone could be an active participant, and when
-the leads come to reflect on this at the end of the year, we expect this to be a
-judgment call. We will consider at least the following when measuring our
-success on this objective:
+Our end goal is to compile a minimal but non-trivial example of bi-directionally
+mixing C++ and Carbon code such as our main
+[example](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/images/snippets.md#mixed)
+and run it successfully. However, completing everything involved in this example
+isn't expected to be realistic by the end of the year. We expect to work towards
+this example and in rough priority order across the following interop features
+and all the Carbon features they depend on:
 
--   Pull requests authored and reviewed, including proposals, code changes, and
-    documentation changes.
--   Contribution to discussions, including Discord, teleconferences, and GitHub
-    issues.
+-   Calling C++ functions from Carbon.
+-   Importing concrete C++ types as Carbon types.
+-   Using Carbon generics with a C++ type in Carbon.
+-   (stretch) Calling Carbon functions from C++.
+-   (stretch) Importing concrete Carbon types into C++.
 
-### Example ports of C++ libraries to Carbon (100% of [woff2](https://github.com/google/woff2), 99% of [RE2](https://github.com/google/re2))
+### Give talks at 2-3 conferences covering 3-4 different Carbon topics
 
-The first part of this result is that all of the woff2 library is ported to
-Carbon in a way that exports the same C++ API. There should be no gaps in this
-port given that woff2 has a very simple C++ API and uses few C++ language
-features.
+We want to engage both more broadly and in more depth with the C++ community as
+the Carbon 0.1 language becomes increasingly concrete. This should help set the
+stage for evaluations of Carbon when 0.1 is finished and available. To broaden
+our engagement, we want to give talks at 2-3 conferences spanning 2-3 geographic
+regions.
 
-RE2 is a larger library using significantly more language features. For that
-part of the result, fewer than 1% of its C++ lines of code should be missing a
-semantically meaningful port into Carbon code.
+We also want these talks to provide the C++ community a deeper understanding of
+the Carbon language and project, spanning 3-4 different topics. For example, we
+might share the details of the language design, governance, and implementation.
 
-An important nuance of this goal is that it doesn't include building a complete
-Carbon standard library beyond the most basic necessary types. The intent is to
-exercise and show the interoperability layers of Carbon by re-using the C++
-standard library in many cases and exporting a compatible C++ API to both woff2
-and RE2's current API.
-
-While this key result isn't directly tied to the main objective, we believe it
-represents a critical milestone for being able to achieve this objective. It
-both measures our progress solidifying Carbon's design and demonstrating the
-value proposition of Carbon.
-
-Note that both woff2 and RE2 libraries are chosen somewhat arbitrarily and could
-easily be replaced with a different, more effective libraries to achieve the
-fundamental result of demonstrating a compelling body of cohesive design and the
-overarching value proposition.
-
-#### Language design covers the syntax and semantics of the example port code.
-
-We should have a clear understanding of the syntax and semantics used by these
-example ports. We should be able to demonstrate that self-contained portions of
-the ported code work correctly using Carbon explorer.
-
-### Demo implementation of core features with working examples
-
-A core set of Carbon features should be implemented sufficiently to build
-working examples of those features and run them successfully. These features
-could include:
-
--   User-defined types, functions, namespaces, packages, and importing.
--   Basic generic functions and types using interfaces.
--   Initial/simple implementation of safety checking including at least bounds
-    checking, simple lifetime checking, and simple initialization checking.
--   Sum types sufficient for optional-types to model nullable pointers.
--   Pattern matching sufficient for basic function overloading on types and
-    arity, as well as unwrapping of optional types for guard statements.
-
-Stretch goals if we can hit the above:
-
--   Instantiating a basic C++ template through interop layer for use within
-    Carbon.
-
-The demo implementation should also provide demos outside of specific language
-features including:
-
--   Basic benchmarking of the different phases of compilation (lexing, parsing,
-    etc).
--   A basic REPL command line.
-
-Stretch goals if we can hit the above:
-
--   Automatic code formatter on top of the implementation infrastructure.
--   A [compiler explorer](https://compiler-explorer.com/) fork with REPL
-    integrated.
-
-Benchmarking at this stage isn't expected to include extensive optimization.
-Instead, it should focus on letting us track large/high-level impact on
-different phases as they are developed or features are added. They may also help
-illustrate initial high-level performance characteristics of the implementation,
-but the long term focus should be on end-to-end user metrics.
-
-Automatic code formatting could be achieved many ways, but it seems useful to
-ensure the language and implementation both support use cases like formatting.
-
-### Carbon explorer implementation of core features with test cases
-
-This should include both a human readable rendering of the formal semantics as
-well as an execution environment to run test cases through those semantics. The
-implementation should cover enough of the core language that example code, such
-as the above ports of woff2 and RE2 and the Carbon standard library, can be
-verified with Carbon explorer.
-
-## Beyond 2022
+## Beyond 2023
 
 Longer term goals are hard to pin down and always subject to change, but we want
 to give an idea of what kinds of things are expected at a high level further out
-in order to illustrate how the goals and priorities we have in 2022 feed into
+in order to illustrate how the goals and priorities we have in 2023 feed into
 subsequent years.
 
-### Potential 2023 goals: finish 0.2 language, stop experimenting
+### Potential 2024 goals: ship a working 0.1 language for evaluation
+
+As we adjust our schedule and roadmap to reflect the realistic rate of progress,
+the _earliest_ it seems feasible to have everything we need to evaluate the 0.1
+language is 2024. However, this is just a lower bound. We may discover as we
+progress things that further push out the schedule here. That is the nature of
+an experimental project like Carbon.
+
+We expect that once we reach this milestone the community will be able to start
+realistically evaluating Carbon as a C++ successor language. Of course, this
+evaluation will take some time.
+
+### Potential 2025-2026 goals: finish 0.2 language, stop experimenting
 
 Once Carbon is moving quickly and getting public feedback, we should be able to
 conclude the experiment. We should know if this is the right direction for
 moving C++ forward for a large enough portion of the industry and community, and
 whether the value proposition of this direction outweighs the cost.
 
-However, there will still be a _lot_ of work to make Carbon into a production
+However, there will still be a lot of work left to make Carbon into a production
 quality language, even if the experiment concludes successfully.
 
 Some concrete goals that might show up in this time frame:
@@ -201,15 +147,15 @@ Some concrete goals that might show up in this time frame:
 -   Create a foundation or similar organization to manage the Carbon project,
     separate from any corporate entities that fund work on Carbon.
 
-### Potential 2024-2025 goals: _ship_ 1.0 language & organization
+### Potential goals _beyond_ 2026: ship 1.0 language & organization
 
-A major milestone will be the first version of a production language. We should
-also have finished transferring all governance of Carbon to an independent open
+A major milestone will be the first version of a production language. We also
+plan to finish transferring all governance of Carbon to an independent open
 source organization at that point. However, we won't know what a more realistic
 or clear schedule for these milestones will be until we get closer.
 
-Another important aspect of our goals in this time frame is expanding them to
-encompass the broader ecosystem of the language:
+Goals in this time frame will expand to encompass the broader ecosystem of the
+language:
 
 -   End-to-end developer tooling and experience.
 -   Teaching and training material.

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -47,7 +47,7 @@ Our primary goals for 2023 are:
 -   Begin actively engaging and sharing Carbon's design and ideas with the C++
     community.
 
-See our [updated roadmap](/docs/project/roadmap.md) for more details and how we
+See our [updated roadmap](https://github.com/chandlerc/carbon-lang/blob/roadmap-2023/docs/project/roadmap.md) for more details and how we
 expect to measure our success.
 
 ## Retrospective on 2022

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -47,7 +47,7 @@ Our primary goals for 2023 are:
 -   Begin actively engaging and sharing Carbon's design and ideas with the C++
     community.
 
-See our [updated roadmap](...) for more details and how we expect to measure our
+See our [updated roadmap](/docs/project/roadmap.md) for more details and how we expect to measure our
 success.
 
 ## Retrospective on 2022

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -47,8 +47,9 @@ Our primary goals for 2023 are:
 -   Begin actively engaging and sharing Carbon's design and ideas with the C++
     community.
 
-See our [updated roadmap](https://github.com/chandlerc/carbon-lang/blob/roadmap-2023/docs/project/roadmap.md) for more details and how we
-expect to measure our success.
+See our
+[updated roadmap](https://github.com/chandlerc/carbon-lang/blob/roadmap-2023/docs/project/roadmap.md)
+for more details and how we expect to measure our success.
 
 ## Retrospective on 2022
 

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -47,9 +47,8 @@ Our primary goals for 2023 are:
 -   Begin actively engaging and sharing Carbon's design and ideas with the C++
     community.
 
-See our
-[updated roadmap](https://github.com/chandlerc/carbon-lang/blob/roadmap-2023/docs/project/roadmap.md)
-for more details and how we expect to measure our success.
+See our [updated roadmap](/docs/project/roadmap.md) for more details and how we
+expect to measure our success.
 
 ## Retrospective on 2022
 

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -47,8 +47,8 @@ Our primary goals for 2023 are:
 -   Begin actively engaging and sharing Carbon's design and ideas with the C++
     community.
 
-See our [updated roadmap](/docs/project/roadmap.md) for more details and how we expect to measure our
-success.
+See our [updated roadmap](/docs/project/roadmap.md) for more details and how we
+expect to measure our success.
 
 ## Retrospective on 2022
 

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -24,47 +24,111 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Abstract
 
-TODO: Describe, in a succinct paragraph, the gist of this document. This
-paragraph should be reproduced verbatim in the PR summary.
+We propose a roadmap for 2023 focus on:
 
-## Problem
+-   Progressing towards a concrete goal of an MVP / 0.1 language.
+-   Engaging more broadly and deeply with the C++ community.
 
-TODO: What problem are you trying to solve? How important is that problem? Who
-is impacted by it?
-
-## Background
-
-TODO: Is there any background that readers should consider to fully understand
-this problem and your approach to solving it?
+We also reflect on our overly ambitious
+[roadmap for 2022](https://github.com/carbon-language/carbon-lang/blob/3d90a85f2439bb74b71a553c5017012369ec0f63/docs/project/roadmap.md)
+and how the year went.
 
 ## Proposal
 
-TODO: Briefly and at a high level, how do you propose to solve the problem? Why
-will that in fact solve it?
+Our primary goals for 2023 are:
 
-## Details
+-   Define a concrete set of milestones for our Minimum Viable Product or MVP.
+    -   Because Carbon is an experiment, our MVP is focused on the _evaluation_
+        of the Carbon language, not any other usage.
+    -   We consider this MVP-for-evaluation our 0.1 language.
+-   Complete all of the 0.1 design and feature milestones.
+-   Complete as many of the 0.1 implementation milestones as we can.
+    -   Realistically, we don't expect to finish all of them in 2023.
+-   Begin actively engaging and sharing Carbon's design and ideas with the C++
+    community.
 
-TODO: Fully explain the details of the proposed solution.
+See our [updated roadmap](...) for more details and how we expect to measure our
+success.
 
-## Rationale
+## Retrospective on 2022
 
-TODO: How does this proposal effectively advance Carbon's goals? Rather than
-re-stating the full motivation, this should connect that motivation back to
-Carbon's stated goals and principles. This may evolve during review. Use links
-to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
-and/or to documents in [`/docs/project/principles`](/docs/project/principles).
-For example:
+Our
+[roadmap for 2022](https://github.com/carbon-language/carbon-lang/blob/3d90a85f2439bb74b71a553c5017012369ec0f63/docs/project/roadmap.md)
+was in retrospect wildly optimistic. We're sorry about that, and are going to
+work to set more realistic goals and milestones going forward. That said, we
+still achieved a tremendous amount and it's useful to look in some detail at how
+everything went.
 
--   [Community and culture](/docs/project/goals.md#community-and-culture)
--   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
--   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
--   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
--   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
--   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
--   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
--   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+We had two primary goals for 2022 and somewhat split the difference between
+them:
 
-## Alternatives considered
+-   Make the Carbon experiment public: **100%** as we
+    [announced](https://youtu.be/omrY53kbVoA) Carbon publicly in July at
+    [CppNorth](https://cppnorth.ca/)!
+-   Complete the language design: lots of progress, but nowhere near the finish
+    line here. This ended up also being poorly defined in some cases, which
+    we're going to try to address going forward.
 
-TODO: What alternative solutions have you considered?
+We can also measure the key results we had in mind with more precision.
+
+### Broaden participation so no organization >50%
+
+> Our goal is that no single organization makes up >50% of participation in the
+> Carbon project, to ensure that we are including as broad and representative a
+> set of perspectives in the evolution of Carbon as possible. As a proxy for the
+> amount of participation, we will count the number of active participants from
+> each organization in 2022, with the aim that each organization is represented
+> by less than 50% of all active participants.
+
+The simplest participation measures are from commits to the repository over 2022
+which shows 92 contributors over the year, and definitely fewer than 46 of those
+from a single organization. But it's hard to consider a single typo fix in July
+as being an _active_ participant. Some other measures:
+
+-   During the last quarter of 2022 we had 14 authors contributing to patches,
+    and likely the largest single organization was only 5 of them.
+-   We had 171 issue authors this year, and 43 filing more than one issue. Well
+    below 50% from any single organization.
+-   We had 258 issue commenters, and 64 making over 4 comments over the course
+    of the year, both _far_ below 50% from a single organization.
+-   Looking at the weekly meetings in August, September, and October, we had a
+    bit
+
+Largely, we feel we hit this goal solidly. However, we still see specific areas
+where we need to broaden participation, for example:
+
+-   Language proposal authors (as opposed to other kinds of PRs and commits).
+-   Design discussion and meeting participation.
+
+Some of this will likely need Carbon to make substantial progress beyond
+experimentation in order to have more organizations devote the significant
+resources that can be necessary for more in-depth participation.
+
+### Example ports of C++ libraries to Carbon (100% of woff2, 99% of RE2)
+
+We ended up de-prioritizing this entirely so we could focus on the design and
+moving the project public.
+
+### Carbon explorer implementation of core features with test cases
+
+Like the top-level goals for 2022, this specific result was much too ambitious.
+However, we have made tremendous progress on the design and the Carbon Explorer.
+For example, we have a
+[detailed mapping](https://github.com/carbon-language/carbon-lang/wiki/Are-we-explorer-yet%3F)
+of the implementation status of the designed features, with approximately 50% of
+these implemented.
+
+The Carbon Explorer is also now integrated into the amazing
+[compiler explorer](https://carbon.godbolt.org/)! This largely addresses the
+core of the "repl" and experimentation access goals, and our focus has otherwise
+been on completing the implementation.
+
+### Demo implementation of core features with working examples
+
+We ended up prioritizing the Carbon Explorer over the toolchain in 2022 in order
+to have an easier path to a minimal demo implementation.
+
+However, we did begin fleshing out more of the toolchain implementation that
+will eventually be used to compile Carbon into working binaries, and it has
+started to provide the first pieces of semantic analysis along with a much
+improved parser for Carbon.

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -1,0 +1,70 @@
+# Roadmap for 2023 and retrospective for 2022
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/2551)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Details](#details)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+
+<!-- tocstop -->
+
+## Abstract
+
+TODO: Describe, in a succinct paragraph, the gist of this document. This
+paragraph should be reproduced verbatim in the PR summary.
+
+## Problem
+
+TODO: What problem are you trying to solve? How important is that problem? Who
+is impacted by it?
+
+## Background
+
+TODO: Is there any background that readers should consider to fully understand
+this problem and your approach to solving it?
+
+## Proposal
+
+TODO: Briefly and at a high level, how do you propose to solve the problem? Why
+will that in fact solve it?
+
+## Details
+
+TODO: Fully explain the details of the proposed solution.
+
+## Rationale
+
+TODO: How does this proposal effectively advance Carbon's goals? Rather than
+re-stating the full motivation, this should connect that motivation back to
+Carbon's stated goals and principles. This may evolve during review. Use links
+to appropriate sections of [`/docs/project/goals.md`](/docs/project/goals.md),
+and/or to documents in [`/docs/project/principles`](/docs/project/principles).
+For example:
+
+-   [Community and culture](/docs/project/goals.md#community-and-culture)
+-   [Language tools and ecosystem](/docs/project/goals.md#language-tools-and-ecosystem)
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+-   [Software and language evolution](/docs/project/goals.md#software-and-language-evolution)
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+-   [Practical safety and testing mechanisms](/docs/project/goals.md#practical-safety-and-testing-mechanisms)
+-   [Fast and scalable development](/docs/project/goals.md#fast-and-scalable-development)
+-   [Modern OS platforms, hardware architectures, and environments](/docs/project/goals.md#modern-os-platforms-hardware-architectures-and-environments)
+-   [Interoperability with and migration from existing C++ code](/docs/project/goals.md#interoperability-with-and-migration-from-existing-c-code)
+
+## Alternatives considered
+
+TODO: What alternative solutions have you considered?

--- a/proposals/p2551.md
+++ b/proposals/p2551.md
@@ -13,12 +13,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Table of contents
 
 -   [Abstract](#abstract)
--   [Problem](#problem)
--   [Background](#background)
 -   [Proposal](#proposal)
--   [Details](#details)
--   [Rationale](#rationale)
--   [Alternatives considered](#alternatives-considered)
+-   [Retrospective on 2022](#retrospective-on-2022)
+    -   [Broaden participation so no organization >50%](#broaden-participation-so-no-organization-50)
+    -   [Example ports of C++ libraries to Carbon (100% of woff2, 99% of RE2)](#example-ports-of-c-libraries-to-carbon-100-of-woff2-99-of-re2)
+    -   [Carbon explorer implementation of core features with test cases](#carbon-explorer-implementation-of-core-features-with-test-cases)
+    -   [Demo implementation of core features with working examples](#demo-implementation-of-core-features-with-working-examples)
 
 <!-- tocstop -->
 


### PR DESCRIPTION
We propose a roadmap for 2023 focus on:

-   Progressing towards a concrete goal of an MVP / 0.1 language.
-   Engaging more broadly and deeply with the C++ community.

We also reflect on our overly ambitious [roadmap for 2022](https://github.com/carbon-language/carbon-lang/blob/3d90a85f2439bb74b71a553c5017012369ec0f63/docs/project/roadmap.md) and how the year went.