### PR TITLE
Refactor `name` property into `FunctionDeclaration`

### DIFF
--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -368,7 +368,9 @@ auto FunctionDeclaration::Create(Nonnull<Arena*> arena,
 }
 
 void CallableDeclaration::PrintDepth(int depth, llvm::raw_ostream& out) const {
-  out << "fn " << name_ << " ";
+  if (auto name = GetName(*this)) {
+    out << "fn " << *name << " ";
+  }
   if (!deduced_parameters_.empty()) {
     out << "[";
     llvm::ListSeparator sep;

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -156,7 +156,7 @@ void Declaration::PrintID(llvm::raw_ostream& out) const {
       out << "fn " << cast<FunctionDeclaration>(*this).name();
       break;
     case DeclarationKind::DestructorDeclaration:
-      out << cast<DestructorDeclaration>(*this).name();
+      out << "destructor";
       break;
     case DeclarationKind::ClassDeclaration: {
       const auto& class_decl = cast<ClassDeclaration>(*this);
@@ -224,7 +224,7 @@ auto GetName(const Declaration& declaration)
     case DeclarationKind::FunctionDeclaration:
       return cast<FunctionDeclaration>(declaration).name();
     case DeclarationKind::DestructorDeclaration:
-      return cast<DestructorDeclaration>(declaration).name();
+      return "destructor";
     case DeclarationKind::ClassDeclaration:
       return cast<ClassDeclaration>(declaration).name();
     case DeclarationKind::MixinDeclaration: {

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -156,7 +156,7 @@ void Declaration::PrintID(llvm::raw_ostream& out) const {
       out << "fn " << cast<FunctionDeclaration>(*this).name();
       break;
     case DeclarationKind::DestructorDeclaration:
-      out << "destructor";
+      out << *GetName(*this);
       break;
     case DeclarationKind::ClassDeclaration: {
       const auto& class_decl = cast<ClassDeclaration>(*this);

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -368,9 +368,9 @@ auto FunctionDeclaration::Create(Nonnull<Arena*> arena,
 }
 
 void CallableDeclaration::PrintDepth(int depth, llvm::raw_ostream& out) const {
-  if (auto name = GetName(*this)) {
-    out << "fn " << *name << " ";
-  }
+  auto name = GetName(*this);
+  CARBON_CHECK(name) << "Unexpected missing name for `" << *this << "`.";
+  out << "fn " << *name << " ";
   if (!deduced_parameters_.empty()) {
     out << "[";
     llvm::ListSeparator sep;

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -806,7 +806,6 @@ class AliasDeclaration : public Declaration {
   auto value_category() const -> ValueCategory { return ValueCategory::Let; }
 
  private:
-  std::string name_;
   Nonnull<Expression*> target_;
 };
 

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -131,7 +131,7 @@ enum class VirtualOverride { None, Abstract, Virtual, Impl };
 
 class CallableDeclaration : public Declaration {
  public:
-  CallableDeclaration(AstNodeKind kind, SourceLocation loc, std::string name,
+  CallableDeclaration(AstNodeKind kind, SourceLocation loc,
                       std::vector<Nonnull<GenericBinding*>> deduced_params,
                       std::optional<Nonnull<Pattern*>> self_pattern,
                       Nonnull<TuplePattern*> param_pattern,
@@ -139,7 +139,6 @@ class CallableDeclaration : public Declaration {
                       std::optional<Nonnull<Block*>> body,
                       VirtualOverride virt_override)
       : Declaration(kind, loc),
-        name_(std::move(name)),
         deduced_parameters_(std::move(deduced_params)),
         self_pattern_(self_pattern),
         param_pattern_(param_pattern),
@@ -149,8 +148,6 @@ class CallableDeclaration : public Declaration {
 
   void PrintDepth(int depth, llvm::raw_ostream& out) const;
 
-  // TODO: Move name() and name_ to FunctionDeclaration
-  auto name() const -> const std::string& { return name_; }
   auto deduced_parameters() const
       -> llvm::ArrayRef<Nonnull<const GenericBinding*>> {
     return deduced_parameters_;
@@ -204,13 +201,18 @@ class FunctionDeclaration : public CallableDeclaration {
                       std::optional<Nonnull<Block*>> body,
                       VirtualOverride virt_override)
       : CallableDeclaration(AstNodeKind::FunctionDeclaration, source_loc,
-                            std::move(name), std::move(deduced_params),
-                            self_pattern, param_pattern, return_term, body,
-                            virt_override) {}
+                            std::move(deduced_params), self_pattern,
+                            param_pattern, return_term, body, virt_override),
+        name_(std::move(name)) {}
 
   static auto classof(const AstNode* node) -> bool {
     return InheritsFromFunctionDeclaration(node->kind());
   }
+
+  auto name() const -> const std::string& { return name_; }
+
+ private:
+  std::string name_;
 };
 
 class DestructorDeclaration : public CallableDeclaration {
@@ -232,8 +234,8 @@ class DestructorDeclaration : public CallableDeclaration {
                         ReturnTerm return_term,
                         std::optional<Nonnull<Block*>> body)
       : CallableDeclaration(AstNodeKind::DestructorDeclaration, source_loc,
-                            "destructor", std::move(deduced_params),
-                            self_pattern, param_pattern, return_term, body,
+                            std::move(deduced_params), self_pattern,
+                            param_pattern, return_term, body,
                             // TODO: Add virtual destructors
                             VirtualOverride::None) {}
 

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -170,7 +170,6 @@ class CallableDeclaration : public Declaration {
   auto is_method() const -> bool { return self_pattern_.has_value(); }
 
  private:
-  std::string name_;
   std::vector<Nonnull<GenericBinding*>> deduced_parameters_;
   std::optional<Nonnull<Pattern*>> self_pattern_;
   Nonnull<TuplePattern*> param_pattern_;
@@ -806,6 +805,7 @@ class AliasDeclaration : public Declaration {
   auto value_category() const -> ValueCategory { return ValueCategory::Let; }
 
  private:
+  std::string name_;
   Nonnull<Expression*> target_;
 };
 

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -576,8 +576,9 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
       auto& function = cast<CallableDeclaration>(declaration);
       StaticScope function_scope;
       function_scope.AddParent(&enclosing_scope);
-      std::string name(*GetName(declaration));
-      enclosing_scope.MarkDeclared(name);
+      const auto name = GetName(function);
+      CARBON_CHECK(name) << "Unexpected missing name for `" << function << "`.";
+      enclosing_scope.MarkDeclared(std::string(*name));
       for (Nonnull<GenericBinding*> binding : function.deduced_parameters()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(*binding, function_scope));
       }
@@ -591,7 +592,7 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
         CARBON_RETURN_IF_ERROR(ResolveNames(
             **function.return_term().type_expression(), function_scope));
       }
-      enclosing_scope.MarkUsable(name);
+      enclosing_scope.MarkUsable(std::string(*name));
       if (function.body().has_value() &&
           bodies != ResolveFunctionBodies::Skip) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**function.body(), function_scope));

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -576,7 +576,7 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
       auto& function = cast<CallableDeclaration>(declaration);
       StaticScope function_scope;
       function_scope.AddParent(&enclosing_scope);
-      auto name = std::string(GetName(*declaration));
+      std::string name(*GetName(declaration));
       enclosing_scope.MarkDeclared(name);
       for (Nonnull<GenericBinding*> binding : function.deduced_parameters()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(*binding, function_scope));

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -576,7 +576,8 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
       auto& function = cast<CallableDeclaration>(declaration);
       StaticScope function_scope;
       function_scope.AddParent(&enclosing_scope);
-      enclosing_scope.MarkDeclared(function.name());
+      auto name = std::string(GetName(*declaration));
+      enclosing_scope.MarkDeclared(name);
       for (Nonnull<GenericBinding*> binding : function.deduced_parameters()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(*binding, function_scope));
       }
@@ -590,7 +591,7 @@ static auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
         CARBON_RETURN_IF_ERROR(ResolveNames(
             **function.return_term().type_expression(), function_scope));
       }
-      enclosing_scope.MarkUsable(function.name());
+      enclosing_scope.MarkUsable(name);
       if (function.body().has_value() &&
           bodies != ResolveFunctionBodies::Skip) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**function.body(), function_scope));

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4554,8 +4554,8 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
   }
 
   if (trace_stream_ && name) {
-    **trace_stream_ << "** finished declaring function " << *name
-                    << " of type " << f->static_type() << "\n";
+    **trace_stream_ << "** finished declaring function " << *name << " of type "
+                    << f->static_type() << "\n";
   }
   return Success();
 }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4564,7 +4564,9 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
 auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
                                                const ImplScope& impl_scope)
     -> ErrorOr<Success> {
-  if (auto name = GetName(*f); trace_stream_ && name) {
+  auto name = GetName(*f);
+  CARBON_CHECK(name) << "Unexpected missing name for `" << *f << "`.";
+  if (trace_stream_) {
     **trace_stream_ << "** checking function " << *name << "\n";
   }
   // If f->return_term().is_auto(), the function body was already
@@ -4584,7 +4586,7 @@ auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
           ExpectReturnOnAllPaths(f->body(), f->source_loc()));
     }
   }
-  if (auto name = GetName(*f); trace_stream_ && name) {
+  if (trace_stream_) {
     **trace_stream_ << "** finished checking function " << *name << "\n";
   }
   return Success();

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4455,8 +4455,9 @@ auto TypeChecker::ExpectReturnOnAllPaths(
 auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
                                              const ScopeInfo& scope_info)
     -> ErrorOr<Success> {
-  if (trace_stream_) {
-    **trace_stream_ << "** declaring function " << f->name() << "\n";
+  auto name = GetName(*f);
+  if (trace_stream_ && name) {
+    **trace_stream_ << "** declaring function " << *name << "\n";
   }
   ImplScope function_scope;
   function_scope.AddParent(scope_info.innermost_scope);
@@ -4537,7 +4538,7 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
       CARBON_FATAL() << "f is not a callable declaration";
   }
 
-  if (f->name() == "Main") {
+  if (name == "Main") {
     if (!f->return_term().type_expression().has_value()) {
       return ProgramError(f->return_term().source_loc())
              << "`Main` must have an explicit return type";
@@ -4552,8 +4553,8 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
     }
   }
 
-  if (trace_stream_) {
-    **trace_stream_ << "** finished declaring function " << f->name()
+  if (trace_stream_ && name) {
+    **trace_stream_ << "** finished declaring function " << *name
                     << " of type " << f->static_type() << "\n";
   }
   return Success();
@@ -4562,8 +4563,8 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
 auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
                                                const ImplScope& impl_scope)
     -> ErrorOr<Success> {
-  if (trace_stream_) {
-    **trace_stream_ << "** checking function " << f->name() << "\n";
+  if (auto name = GetName(*f); trace_stream_ && name) {
+    **trace_stream_ << "** checking function " << *name << "\n";
   }
   // If f->return_term().is_auto(), the function body was already
   // type checked in DeclareFunctionDeclaration.
@@ -4582,8 +4583,8 @@ auto TypeChecker::TypeCheckCallableDeclaration(Nonnull<CallableDeclaration*> f,
           ExpectReturnOnAllPaths(f->body(), f->source_loc()));
     }
   }
-  if (trace_stream_) {
-    **trace_stream_ << "** finished checking function " << f->name() << "\n";
+  if (auto name = GetName(*f); trace_stream_ && name) {
+    **trace_stream_ << "** finished checking function " << *name << "\n";
   }
   return Success();
 }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4455,8 +4455,9 @@ auto TypeChecker::ExpectReturnOnAllPaths(
 auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
                                              const ScopeInfo& scope_info)
     -> ErrorOr<Success> {
-  auto name = GetName(*f);
-  if (trace_stream_ && name) {
+  const auto name = GetName(*f);
+  CARBON_CHECK(name) << "Unexpected missing name for `" << *f << "`.";
+  if (trace_stream_) {
     **trace_stream_ << "** declaring function " << *name << "\n";
   }
   ImplScope function_scope;
@@ -4553,7 +4554,7 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
     }
   }
 
-  if (trace_stream_ && name) {
+  if (trace_stream_) {
     **trace_stream_ << "** finished declaring function " << *name << " of type "
                     << f->static_type() << "\n";
   }

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -1167,7 +1167,7 @@ auto FindFunction(std::string_view name,
       }
       case DeclarationKind::FunctionDeclaration: {
         const auto& fun = cast<CallableDeclaration>(*member);
-        if (fun.name() == name) {
+        if (GetName(fun) == name) {
           return &cast<FunctionValue>(**fun.constant_value());
         }
         break;
@@ -1195,7 +1195,7 @@ auto MixinPseudoType::FindFunction(const std::string_view& name) const
       }
       case DeclarationKind::FunctionDeclaration: {
         const auto& fun = cast<CallableDeclaration>(*member);
-        if (fun.name() == name) {
+        if (GetName(fun) == name) {
           return &cast<FunctionValue>(**fun.constant_value());
         }
         break;

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -1166,8 +1166,8 @@ auto FindFunction(std::string_view name,
         break;
       }
       case DeclarationKind::FunctionDeclaration: {
-        const auto& fun = cast<CallableDeclaration>(*member);
-        if (GetName(fun) == name) {
+        const auto& fun = cast<FunctionDeclaration>(*member);
+        if (fun.name() == name) {
           return &cast<FunctionValue>(**fun.constant_value());
         }
         break;
@@ -1194,8 +1194,8 @@ auto MixinPseudoType::FindFunction(const std::string_view& name) const
         break;
       }
       case DeclarationKind::FunctionDeclaration: {
-        const auto& fun = cast<CallableDeclaration>(*member);
-        if (GetName(fun) == name) {
+        const auto& fun = cast<FunctionDeclaration>(*member);
+        if (fun.name() == name) {
           return &cast<FunctionValue>(**fun.constant_value());
         }
         break;


### PR DESCRIPTION
As per the `TODO` comment in the file, the `CallableDeclaration::name` property was refactored into `FunctionDeclaration`, which is currently the only namable callable declaration kind. I was able to rely on the existing `GetName` function to replace call sites of the accessor function with nearly identical swaps.

Fixes #2531
