### PR TITLE
Reenable dynamic linking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,13 +35,6 @@ build --incompatible_dont_enable_host_nonhost_crosstool_features=false
 build --per_file_copt=external/.*\.(c|cc|cpp|cxx)$@-w
 build --host_per_file_copt=external/.*\.(c|cc|cpp|cxx)$@-w
 
-# Default dynamic linking to off. While this can help build performance in some
-# edge cases with very large linked executables and a slow linker, between using
-# fast linkers on all platforms (LLD and the Apple linker), as well as having
-# relatively few such executables, shared objects simply waste too much space in
-# our builds.
-build --dynamic_mode=off
-
 # Always compile PIC code. There are few if any disadvantages on the platforms
 # and architectures we care about and it avoids the need to compile files twice.
 build --force_pic

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -535,19 +535,6 @@ def _impl(ctx):
                             "-fuse-ld=lld",
                             "-stdlib=libc++",
                             "-unwindlib=libunwind",
-                            # Force the C++ standard library and runtime
-                            # libraries to be statically linked. This works even
-                            # with libc++ and libunwind despite the names,
-                            # provided libc++ is built with two CMake options:
-                            # - `-DCMAKE_POSITION_INDEPENDENT_CODE=ON`
-                            # - `-DLIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY`
-                            # These are both required because of PR43604
-                            # (impacting at least Debian packages of libc++) and
-                            # PR46321 (impacting most other packages).
-                            # We recommend using Homebrew's LLVM install on
-                            # Linux.
-                            "-static-libstdc++",
-                            "-static-libgcc",
                             # Link with Clang's runtime library. This is always
                             # linked statically.
                             "-rtlib=compiler-rt",


### PR DESCRIPTION
This was disabled due to bugs in LLVM 12. The LLVM commit we are using is much newer and contains the fix (https://reviews.llvm.org/D110261).

The change now lets the host decide whether to link libcxx and friends statically or dynamically.

Fixes an issue where Gentoo won't be able to build carbon without portage flags that enable static libraries for libcxx and libunwind.
