### PR TITLE
Clean up a couple non-proposal docs links that had access issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ A license is required at the top of all documents and files.
 ### Google Docs
 
 Google Docs all use
-[this template](https://docs.google.com/document/d/1tAwE0230PDxweVruHUVY6DSfSnrJF2LnLOWXQYqNJuI/edit?resourcekey=0-zsrwCWP7ictbxhCuePk-fw).
+[this template](https://docs.google.com/document/d/1tAwE0230PDxweVruHUVY6DSfSnrJF2LnLOWXQYqNJuI/template/preview?usp=sharing&resourcekey=0-zsrwCWP7ictbxhCuePk-fw).
 It puts the license at the top of every page if printed.
 
 ### Markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ A license is required at the top of all documents and files.
 ### Google Docs
 
 Google Docs all use
-[this template](https://docs.google.com/document/d/1tAwE0230PDxweVruHUVY6DSfSnrJF2LnLOWXQYqNJuI/template/preview?usp=sharing&resourcekey=0-zsrwCWP7ictbxhCuePk-fw).
+[this template](https://docs.google.com/document/d/1tAwE0230PDxweVruHUVY6DSfSnrJF2LnLOWXQYqNJuI/edit?resourcekey=0-zsrwCWP7ictbxhCuePk-fw).
 It puts the license at the top of every page if printed.
 
 ### Markdown

--- a/docs/design/classes.md
+++ b/docs/design/classes.md
@@ -1966,7 +1966,8 @@ There are some opportunities to improve on and simplify the C++ story:
     overload resolution on instances of the derived class, in functions that
     aren't friends of the base class.
 
-**References:** This was discussed in the open discussion on 2021-07-12.
+**References:** This was discussed in
+[the open discussion on 2021-07-12](https://docs.google.com/document/d/1TvHK6HWAcCtnseMpcNsLYrgdtNy9qNrv6EaY9n063ok/edit#heading=h.40jlsrcgp8mr).
 
 #### Interop with C++ inheritance
 

--- a/docs/design/classes.md
+++ b/docs/design/classes.md
@@ -1966,8 +1966,7 @@ There are some opportunities to improve on and simplify the C++ story:
     overload resolution on instances of the derived class, in functions that
     aren't friends of the base class.
 
-**References:** This was discussed in
-[the open discussion on 2021-07-12](https://docs.google.com/document/d/14vAcURDKeH6LZ_TQCMRGpNJrXSZCACQqDy29YH19XGo/edit#heading=h.40jlsrcgp8mr).
+**References:** This was discussed in the open discussion on 2021-07-12.
 
 #### Interop with C++ inheritance
 

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -7,5 +7,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 A design is currently maintained in
-[Google Drive](https://docs.google.com/document/d/1RRYMm42osyqhI2LyjrjockYCutQ5dOf8Abu50kTrkX0/edit).
+[Google Drive](https://docs.google.com/document/d/1RRYMm42osyqhI2LyjrjockYCutQ5dOf8Abu50kTrkX0/edit?resourcekey=0-kHyqOESbOHmzZphUbtLrTw).
 It'll be migrated to markdown once we are confident in its stability.


### PR DESCRIPTION
The toolchain link just needed a resourcekey.

The open discussion link may just not work because it was pre-go-public, so it points at a doc that we probably copied.