### PR TITLE
Initial support for name lookup into namespaces

### DIFF
--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -304,13 +304,14 @@ class MemberAccessExpression : public Expression {
   std::optional<Nonnull<const Value*>> constant_value_;
 };
 
-class SimpleMemberAccessExpression : public MemberAccessExpression {
+class SimpleMemberAccessExpression
+    : public RewritableMixin<MemberAccessExpression> {
  public:
   explicit SimpleMemberAccessExpression(SourceLocation source_loc,
                                         Nonnull<Expression*> object,
                                         std::string member_name)
-      : MemberAccessExpression(AstNodeKind::SimpleMemberAccessExpression,
-                               source_loc, object),
+      : RewritableMixin(AstNodeKind::SimpleMemberAccessExpression, source_loc,
+                        object),
         member_name_(std::move(member_name)) {}
 
   static auto classof(const AstNode* node) -> bool {
@@ -343,10 +344,24 @@ class SimpleMemberAccessExpression : public MemberAccessExpression {
     found_in_interface_ = interface;
   }
 
+  // Returns the ValueNodeView this identifier refers to, if this was
+  // determined by name resolution. Cannot be called before name resolution.
+  auto value_node() const -> std::optional<ValueNodeView> {
+    return value_node_;
+  }
+
+  // Sets the value returned by value_node. Can be called only during name
+  // resolution.
+  void set_value_node(ValueNodeView value_node) {
+    CARBON_CHECK(!value_node_.has_value() || value_node_ == value_node);
+    value_node_ = std::move(value_node);
+  }
+
  private:
   std::string member_name_;
   std::optional<Nonnull<const NamedElement*>> member_;
   std::optional<Nonnull<const InterfaceType*>> found_in_interface_;
+  std::optional<ValueNodeView> value_node_;
 };
 
 // A compound member access expression of the form `object.(path)`.

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -411,6 +411,9 @@ auto Interpreter::StepLvalue() -> ErrorOr<Success> {
     }
     case ExpressionKind::SimpleMemberAccessExpression: {
       const auto& access = cast<SimpleMemberAccessExpression>(exp);
+      if (auto rewrite = access.rewritten_form()) {
+        return todo_.ReplaceWith(std::make_unique<LValAction>(*rewrite));
+      }
       if (act.pos() == 0) {
         //    { {e.f :: C, E, F} :: S, H}
         // -> { e :: [].f :: C, E, F} :: S, H}
@@ -1140,6 +1143,9 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
     }
     case ExpressionKind::SimpleMemberAccessExpression: {
       const auto& access = cast<SimpleMemberAccessExpression>(exp);
+      if (auto rewrite = access.rewritten_form()) {
+        return todo_.ReplaceWith(std::make_unique<ExpressionAction>(*rewrite));
+      }
       bool forming_member_name = isa<TypeOfMemberName>(&access.static_type());
       if (act.pos() == 0) {
         // First, evaluate the first operand.

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -22,6 +22,20 @@ using llvm::isa;
 namespace Carbon {
 namespace {
 
+// The name resolver implements a pass that traverses the AST, builds scope
+// objects for each scope encountered, and updates all name references to point
+// at the value node referenced by the corresponding name.
+//
+// In scopes where names are only visible below their point of declaration
+// (such as block scopes in C++), this is implemented as a single pass,
+// recursively calling ResolveNames on the elements of the scope in order. In
+// scopes where names are also visible above their point of declaration (such
+// as class scopes in C++), this is done in three passes: first calling
+// AddExposedNames on each element of the scope to populate a StaticScope, and
+// then calling ResolveNames on each element, passing it the already-populated
+// StaticScope but skipping member function bodies, and finally calling
+// ResolvedNames again on each element, and this time resolving member function
+// bodies.
 class NameResolver {
  public:
   enum class ResolveFunctionBodies {
@@ -52,26 +66,31 @@ class NameResolver {
                        StaticScope& enclosing_scope,
                        bool allow_qualified_names = false) -> ErrorOr<Success>;
 
-  // Traverse the sub-AST rooted at the given node, resolve all names within
-  // it using enclosing_scope, and update enclosing_scope to add names to
-  // it as they become available. In scopes where names are only visible below
-  // their point of declaration (such as block scopes in C++), this is
-  // implemented as a single pass, recursively calling ResolveNames on the
-  // elements of the scope in order. In scopes where names are also visible
-  // above their point of declaration (such as class scopes in C++), this
-  // requires three passes: first calling AddExposedNames on each element of the
-  // scope to populate a StaticScope, and then calling ResolveNames on each
-  // element, passing it the already-populated StaticScope but skipping member
-  // function bodies, and finally calling ResolvedNames again on each element,
-  // and this time resolving member function bodies.
+  // Resolve all names within the given expression by looking them up in the
+  // enclosing scope. The value returned is the value of the expression, if it
+  // is an expression within which we can immediately do further name lookup,
+  // such as a namespace.
   auto ResolveNames(Expression& expression, const StaticScope& enclosing_scope)
-      -> ErrorOr<Success>;
+      -> ErrorOr<std::optional<ValueNodeView>>;
+
+  // Resolve all names within the given where clause by looking them up in the
+  // enclosing scope.
   auto ResolveNames(WhereClause& clause, const StaticScope& enclosing_scope)
       -> ErrorOr<Success>;
+
+  // Resolve all names within the given pattern, extending the given scope with
+  // any introduced names.
   auto ResolveNames(Pattern& pattern, StaticScope& enclosing_scope)
       -> ErrorOr<Success>;
+
+  // Resolve all names within the given statement, extending the given scope
+  // with any names introduced by declaration statements.
   auto ResolveNames(Statement& statement, StaticScope& enclosing_scope)
       -> ErrorOr<Success>;
+
+  // Resolve all names within the given declaration, extending the given scope
+  // with the any names introduced by the declaration if they're not already
+  // present.
   auto ResolveNames(Declaration& declaration, StaticScope& enclosing_scope,
                     ResolveFunctionBodies bodies) -> ErrorOr<Success>;
 
@@ -233,7 +252,7 @@ auto NameResolver::AddExposedNames(const Declaration& declaration,
 
 auto NameResolver::ResolveNames(Expression& expression,
                                 const StaticScope& enclosing_scope)
-    -> ErrorOr<Success> {
+    -> ErrorOr<std::optional<ValueNodeView>> {
   switch (expression.kind()) {
     case ExpressionKind::CallExpression: {
       auto& call = cast<CallExpression>(expression);
@@ -249,11 +268,27 @@ auto NameResolver::ResolveNames(Expression& expression,
           ResolveNames(fun_type.return_type(), enclosing_scope));
       break;
     }
-    case ExpressionKind::SimpleMemberAccessExpression:
-      CARBON_RETURN_IF_ERROR(
-          ResolveNames(cast<SimpleMemberAccessExpression>(expression).object(),
-                       enclosing_scope));
+    case ExpressionKind::SimpleMemberAccessExpression: {
+      auto& access = cast<SimpleMemberAccessExpression>(expression);
+      CARBON_ASSIGN_OR_RETURN(std::optional<ValueNodeView> scope,
+                              ResolveNames(access.object(), enclosing_scope));
+
+      // If the left-hand side of the `.` is a namespace, resolve the name.
+      // TODO: Look through aliases.
+      if (scope && isa<NamespaceDeclaration>(scope->base())) {
+        auto ns_it =
+            namespace_scopes_.find(&cast<NamespaceDeclaration>(scope->base()));
+        CARBON_CHECK(ns_it != namespace_scopes_.end())
+            << "name resolved to undeclared namespace";
+        CARBON_ASSIGN_OR_RETURN(
+            const auto value_node,
+            ns_it->second.ResolveHere(access.member_name(), access.source_loc(),
+                                      /*allow_undeclared=*/false));
+        access.set_value_node(value_node);
+        return {value_node};
+      }
       break;
+    }
     case ExpressionKind::CompoundMemberAccessExpression: {
       auto& access = cast<CompoundMemberAccessExpression>(expression);
       CARBON_RETURN_IF_ERROR(ResolveNames(access.object(), enclosing_scope));
@@ -297,7 +332,7 @@ auto NameResolver::ResolveNames(Expression& expression,
           const auto value_node,
           enclosing_scope.Resolve(identifier.name(), identifier.source_loc()));
       identifier.set_value_node(value_node);
-      break;
+      return {value_node};
     }
     case ExpressionKind::DotSelfExpression: {
       auto& dot_self = cast<DotSelfExpression>(expression);
@@ -366,7 +401,7 @@ auto NameResolver::ResolveNames(Expression& expression,
     case ExpressionKind::UnimplementedExpression:
       return ProgramError(expression.source_loc()) << "Unimplemented";
   }
-  return Success();
+  return {std::nullopt};
 }
 
 auto NameResolver::ResolveNames(WhereClause& clause,
@@ -805,7 +840,8 @@ auto ResolveNames(AST& ast) -> ErrorOr<Success> {
         *declaration, file_scope,
         NameResolver::ResolveFunctionBodies::AfterDeclarations));
   }
-  return resolver.ResolveNames(**ast.main_call, file_scope);
+  CARBON_RETURN_IF_ERROR(resolver.ResolveNames(**ast.main_call, file_scope));
+  return Success();
 }
 
 }  // namespace Carbon

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2565,6 +2565,18 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
     }
     case ExpressionKind::SimpleMemberAccessExpression: {
       auto& access = cast<SimpleMemberAccessExpression>(*e);
+
+      // If name lookup resolved this member access statically, rewrite it to
+      // an identifier expression.
+      if (auto value_node = access.value_node()) {
+        auto* rewritten = arena_->New<IdentifierExpression>(
+            access.source_loc(), access.member_name());
+        rewritten->set_value_node(*value_node);
+        CARBON_RETURN_IF_ERROR(TypeCheckExp(rewritten, impl_scope));
+        access.set_rewritten_form(rewritten);
+        return Success();
+      }
+
       CARBON_RETURN_IF_ERROR(TypeCheckExp(&access.object(), impl_scope));
       const Value& object_type = access.object().static_type();
       CARBON_RETURN_IF_ERROR(ExpectCompleteType(access.source_loc(),
@@ -2850,11 +2862,6 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
               return ProgramError(access.source_loc())
                      << "unsupported member access into type " << *type;
           }
-        }
-        case Value::Kind::TypeOfNamespaceName: {
-          // TODO: Implement this.
-          return ProgramError(e->source_loc())
-                 << "member access into namespace is not implemented yet";
         }
         default:
           return ProgramError(e->source_loc())

--- a/explorer/testdata/namespace/fail_namespace_alias.carbon
+++ b/explorer/testdata/namespace/fail_namespace_alias.carbon
@@ -9,8 +9,12 @@
 package ExplorerTest api;
 
 namespace N;
+fn N.F() {}
+// TODO: This should work.
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/namespace/fail_namespace_alias.carbon:[[@LINE+1]]: could not find `namespace N;`
+alias M = N;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/namespace/fail_unknown_member.carbon:[[@LINE+1]]: could not resolve 'value' in this scope
-  return N.value;
+  M.F();
+  return 0;
 }

--- a/explorer/testdata/namespace/fail_namespace_alias_member.carbon
+++ b/explorer/testdata/namespace/fail_namespace_alias_member.carbon
@@ -9,8 +9,13 @@
 package ExplorerTest api;
 
 namespace N;
+alias M = N;
+// TODO: It's unclear whether this should be permitted. If not, we should
+// produce a better diagnostic.
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/namespace/fail_namespace_alias_member.carbon:[[@LINE+1]]: alias M cannot be used as a name qualifier
+fn M.F() {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/namespace/fail_unknown_member.carbon:[[@LINE+1]]: could not resolve 'value' in this scope
-  return N.value;
+  N.F();
+  return 0;
 }

--- a/explorer/testdata/namespace/lookup_scope.carbon
+++ b/explorer/testdata/namespace/lookup_scope.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
-// CHECK:STDOUT: result: 0
+// CHECK:STDOUT: result: 6
 
 package ExplorerTest api;
 
@@ -18,4 +18,4 @@ fn N.I32() -> type { return i32; }
 fn N.Five() -> I32() { return 5; }
 fn N.Six() -> OuterI32() { return Five() + One(); }
 
-fn Main() -> i32 { return 0; }
+fn Main() -> i32 { return N.Six(); }


### PR DESCRIPTION
Name lookup into namespaces needs to be resolved early, as part of name resolution, so that we can properly diagnose references to entities before they are fully declared.  Make name resolution set a target `value_node` on simple member accesses that name namespace members, and in type-checking rewrite those member accesses into `IdentifierExpression`s that directly reference the namespace member.