### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,10 @@ repos:
 
   # Formatters should be run late so that they can re-format any prior changes.
   - repo: https://github.com/psf/black
-    rev: 2ddea293a88919650266472186620a98a4a8bb37 # frozen: 22.12.0
+    rev: b0d1fba7ac3be53c71fb0d3211d911e629f8aecb # frozen: 23.1.0
     hooks:
       - id: black
+        language: python
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: cafd5506f18eea191804850dacc0a4264772d59d # frozen: v3.0.0-alpha.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,6 @@ repos:
     rev: b0d1fba7ac3be53c71fb0d3211d911e629f8aecb # frozen: 23.1.0
     hooks:
       - id: black
-        language: python
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: cafd5506f18eea191804850dacc0a4264772d59d # frozen: v3.0.0-alpha.4
     hooks:


### PR DESCRIPTION
pre-commit autoupdate --freeze && pre-commit run -a

This update may be triggering incompatibilities with old installs. If you see an issue such as:

```
An unexpected error has occurred: CalledProcessError: command: ('python', '-mpip', 'install', '.')
```

Try updating pip packages, particularly:

```
pip3 install -U pre-commit
pip3 install -U virtualenv
```