### PR TITLE
Exempt leads questions from inactive labeling.

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,18 +18,18 @@ jobs:
             active work. If this issue should remain active or becomes active
             again, please comment or remove the `inactive` label. The `long
             term` label can also be added for issues which are expected to take
-            time. \n\n This issue is labeled `inactive` because the last
+            time. \n\n\n This issue is labeled `inactive` because the last
             activity was over 90 days ago.
           stale-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active, please comment or
-            remove the `inactive` label. \n\n This PR is labeled `inactive`
+            remove the `inactive` label. \n\n\n This PR is labeled `inactive`
             because the last activity was over 90 days ago. This PR will be
             closed and archived after 14 additional days without activity.
           close-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active or becomes active
-            again, please reopen it. \n\n This PR was closed and archived
+            again, please reopen it. \n\n\n This PR was closed and archived
             because there has been no new activity in the 14 days since the
             `inactive` label was added.
           stale-issue-label: 'inactive'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,29 +18,24 @@ jobs:
             active work. If this issue should remain active or becomes active
             again, please comment or remove the `inactive` label. The `long
             term` label can also be added for issues which are expected to take
-            time.
-
-            This issue is labeled `inactive` because the last activity was over
-            90 days ago.
+            time. \n\n This issue is labeled `inactive` because the last
+            activity was over 90 days ago.
           stale-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active, please comment or
-            remove the `inactive` label.
-
-            This PR is labeled `inactive` because the last activity was over 90
-            days ago. This PR will be closed and archived after 14 additional
-            days without activity.
+            remove the `inactive` label. \n\n This PR is labeled `inactive`
+            because the last activity was over 90 days ago. This PR will be
+            closed and archived after 14 additional days without activity.
           close-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active or becomes active
-            again, please reopen it.
-
-            This PR was closed and archived because there has been no new
-            activity in the 14 days since the `inactive` label was added.
+            again, please reopen it. \n\n This PR was closed and archived
+            because there has been no new activity in the 14 days since the
+            `inactive` label was added.
           stale-issue-label: 'inactive'
           stale-pr-label: 'inactive'
           exempt-issue-labels:
-            'long term,design idea,design update,good first issue'
+            'long term,design idea,design update,good first issue,leads question'
           days-before-stale: 90
           days-before-close: 14
           days-before-issue-close: -1


### PR DESCRIPTION
@chandlerc requested that leads questions not be marked inactive. These arise when there *isn't* a clear-cut answer, and so seem to make more sense to be effectively long-term.

The \n\n\n is trying to get a blank line between paragraphs. Right now it gets a newline, but the paragraphs sort of blend. I might need more \n's, don't know but I'll keep an eye on messages. The examples that I could find don't have multiple paragraphs.
