### PR TITLE
Explorer: error on bit-shift overflow

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1589,17 +1589,22 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
         }
         case IntrinsicExpression::Intrinsic::IntLeftShift: {
           CARBON_CHECK(args.size() == 2);
-          // TODO: Runtime error if RHS is too large.
-          return todo_.FinishAction(arena_->New<IntValue>(
-              static_cast<uint32_t>(cast<IntValue>(*args[0]).value())
-              << cast<IntValue>(*args[1]).value()));
+          const auto& lhs = cast<IntValue>(*args[0]).value();
+          const auto& rhs = cast<IntValue>(*args[1]).value();
+          if (rhs >= 0 && rhs < 32) {
+            return todo_.FinishAction(
+                arena_->New<IntValue>(static_cast<uint32_t>(lhs) << rhs));
+          }
+          return ProgramError(exp.source_loc()) << "Integer overflow";
         }
         case IntrinsicExpression::Intrinsic::IntRightShift: {
           CARBON_CHECK(args.size() == 2);
-          // TODO: Runtime error if RHS is too large.
-          return todo_.FinishAction(
-              arena_->New<IntValue>(cast<IntValue>(*args[0]).value() >>
-                                    cast<IntValue>(*args[1]).value()));
+          const auto& lhs = cast<IntValue>(*args[0]).value();
+          const auto& rhs = cast<IntValue>(*args[1]).value();
+          if (rhs >= 0 && rhs < 32) {
+            return todo_.FinishAction(arena_->New<IntValue>(lhs >> rhs));
+          }
+          return ProgramError(exp.source_loc()) << "Integer overflow";
         }
       }
     }

--- a/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This won't auto-update because it uses a regex for the prelude line number,
+// so that it doesn't need to be updated on every prelude change.
+//
+// This can't be autoupdated because the error line comes form a different file.
+// NOAUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 << 75;
+  return 0;
+}

--- a/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This won't auto-update because it uses a regex for the prelude line number,
+// so that it doesn't need to be updated on every prelude change.
+//
+// This can't be autoupdated because the error line comes form a different file.
+// NOAUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 << -1;
+  return 0;
+}

--- a/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This won't auto-update because it uses a regex for the prelude line number,
+// so that it doesn't need to be updated on every prelude change.
+//
+// This can't be autoupdated because the error line comes form a different file.
+// NOAUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 >> 75;
+  return 0;
+}

--- a/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This won't auto-update because it uses a regex for the prelude line number,
+// so that it doesn't need to be updated on every prelude change.
+//
+// This can't be autoupdated because the error line comes form a different file.
+// NOAUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 >> -1;
+  return 0;
+}


### PR DESCRIPTION
Return Integer overflow Runtime error for bit shift if The second operand is less than zero or bigger than or equal bit width of the first operand in this case (32 bit for int)

Issue #2595
