### PR TITLE
Expect parentheses after an alternative only if they were present in its declaration

### DIFF
--- a/common/fuzzing/proto_to_carbon.cpp
+++ b/common/fuzzing/proto_to_carbon.cpp
@@ -853,7 +853,9 @@ static auto DeclarationToCarbon(const Fuzzing::Declaration& declaration,
       for (const auto& alternative : choice.alternatives()) {
         out << sep;
         IdentifierToCarbon(alternative.name(), out);
-        TupleLiteralExpressionToCarbon(alternative.signature(), out);
+        if (alternative.has_signature()) {
+          TupleLiteralExpressionToCarbon(alternative.signature(), out);
+        }
       }
       out << "}";
       break;

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -429,11 +429,24 @@ auto ImplDeclaration::Create(Nonnull<Arena*> arena, SourceLocation source_loc,
 }
 
 void AlternativeSignature::Print(llvm::raw_ostream& out) const {
-  out << "alt " << name() << " " << signature();
+  out << "alt " << name();
+  if (auto sig = signature()) {
+    out << **signature();
+  }
 }
 
 void AlternativeSignature::PrintID(llvm::raw_ostream& out) const {
   out << name();
+}
+
+auto ChoiceDeclaration::FindAlternative(std::string_view name) const
+    -> std::optional<const AlternativeSignature*> {
+  for (auto* alt : alternatives()) {
+    if (alt->name() == name) {
+      return alt;
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace Carbon

--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -181,15 +181,15 @@ impl i32 as CompareWith(Self) {
   fn Compare[self: Self](other: Self) -> Ordering {
     var comp: i32 = __intrinsic_int_compare(self, other);
     if (comp == -1) {
-      return Ordering.Less();
+      return Ordering.Less;
     }
     if (comp == 0) {
-      return Ordering.Equivalent();
+      return Ordering.Equivalent;
     }
     if (comp == 1) {
-      return Ordering.Greater();
+      return Ordering.Greater;
     }
-    return Ordering.Incomparable();
+    return Ordering.Incomparable;
 
   }
 }
@@ -198,15 +198,15 @@ impl String as CompareWith(Self) {
   fn Compare[self: Self](other: Self) -> Ordering {
     var comp: i32 = __intrinsic_str_compare(self, other);
     if (comp == -1) {
-      return Ordering.Less();
+      return Ordering.Less;
     }
     if (comp == 0) {
-      return Ordering.Equivalent();
+      return Ordering.Equivalent;
     }
     if (comp == 1) {
-      return Ordering.Greater();
+      return Ordering.Greater;
     }
-    return Ordering.Incomparable();
+    return Ordering.Incomparable;
   }
 }
 
@@ -230,7 +230,7 @@ impl i32 as LessWith(Self) {
   fn Less[self: Self](other: Self) -> bool {
     var comp: Ordering = self.(CompareWith(i32).Compare)(other);
     match (comp) {
-      case Ordering.Less() => {
+      case Ordering.Less => {
         return true;
       }
     }
@@ -242,7 +242,7 @@ impl String as LessWith(Self) {
   fn Less[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(String).Compare)(other);
     match(comp){
-      case Ordering.Less() => {
+      case Ordering.Less => {
         return true;
       }
     }
@@ -254,10 +254,10 @@ impl i32 as LessEqWith(Self) {
   fn LessEq[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(i32).Compare)(other);
     match(comp){
-      case Ordering.Less() => {
+      case Ordering.Less => {
         return true;
       }
-      case Ordering.Equivalent() => {
+      case Ordering.Equivalent => {
         return true;
       }
     }
@@ -269,10 +269,10 @@ impl String as LessEqWith(Self) {
   fn LessEq[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(String).Compare)(other);
     match(comp){
-      case Ordering.Less() => {
+      case Ordering.Less => {
         return true;
       }
-      case Ordering.Equivalent() => {
+      case Ordering.Equivalent => {
         return true;
       }
     }
@@ -284,7 +284,7 @@ impl i32 as GreaterWith(Self) {
   fn Greater[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(i32).Compare)(other);
     match(comp){
-      case Ordering.Greater() => {
+      case Ordering.Greater => {
         return true;
       }
     }
@@ -296,7 +296,7 @@ impl String as GreaterWith(Self) {
   fn Greater[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(String).Compare)(other);
     match(comp){
-      case Ordering.Greater() => {
+      case Ordering.Greater => {
         return true;
       }
     }
@@ -308,10 +308,10 @@ impl i32 as GreaterEqWith(Self) {
   fn GreaterEq[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(i32).Compare)(other);
     match(comp){
-      case Ordering.Greater() => {
+      case Ordering.Greater => {
         return true;
       }
-      case Ordering.Equivalent() => {
+      case Ordering.Equivalent => {
         return true;
       }
     }
@@ -323,10 +323,10 @@ impl String as GreaterEqWith(Self) {
   fn GreaterEq[self: Self](other: Self) -> bool {
     var comp: Ordering =  self.(CompareWith(String).Compare)(other);
     match(comp){
-      case Ordering.Greater() => {
+      case Ordering.Greater => {
         return true;
       }
-      case Ordering.Equivalent() => {
+      case Ordering.Equivalent => {
         return true;
       }
     }

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -750,8 +750,12 @@ static auto DeclarationToProto(const Declaration& declaration)
            choice.alternatives()) {
         auto* alternative_proto = choice_proto->add_alternatives();
         alternative_proto->set_name(alternative->name());
-        *alternative_proto->mutable_signature() =
-            TupleLiteralExpressionToProto(alternative->signature());
+        if (auto sig = alternative->signature()) {
+          *alternative_proto->mutable_signature() =
+              TupleLiteralExpressionToProto(**sig);
+        } else {
+          CARBON_CHECK(!alternative_proto->has_signature());
+        }
       }
       break;
     }

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -753,8 +753,6 @@ static auto DeclarationToProto(const Declaration& declaration)
         if (auto sig = alternative->signature()) {
           *alternative_proto->mutable_signature() =
               TupleLiteralExpressionToProto(**sig);
-        } else {
-          CARBON_CHECK(!alternative_proto->has_signature());
         }
       }
       break;

--- a/explorer/interpreter/pattern_analysis.cpp
+++ b/explorer/interpreter/pattern_analysis.cpp
@@ -34,7 +34,7 @@ auto AbstractPattern::discriminator() const -> std::string_view {
     }
   } else if (const auto* value = value_.dyn_cast<const Value*>()) {
     if (const auto* alt = dyn_cast<AlternativeValue>(value)) {
-      return alt->alt_name();
+      return alt->alternative().name();
     } else if (const auto* bool_val = dyn_cast<BoolValue>(value)) {
       return bool_val->value() ? "true" : "false";
     }
@@ -47,13 +47,16 @@ auto AbstractPattern::elements_size() const -> int {
     if (const auto* tuple_pattern = dyn_cast<TuplePattern>(pattern)) {
       return tuple_pattern->fields().size();
     } else if (isa<AlternativePattern>(pattern)) {
+      // Note, AlternativePattern is only used for a pattern with arguments. An
+      // alternative pattern without arguments is represented as an
+      // AlternativeValue.
       return 1;
     }
   } else if (const auto* value = value_.dyn_cast<const Value*>()) {
     if (const auto* tuple = dyn_cast<TupleValue>(value)) {
       return tuple->elements().size();
     } else if (const auto* alt = dyn_cast<AlternativeValue>(value)) {
-      return 1;
+      return alt->argument() ? 1 : 0;
     }
   }
   return 0;
@@ -78,9 +81,9 @@ void AbstractPattern::AppendElementsTo(
             AbstractPattern(tuple->elements()[i], tuple_type->elements()[i]));
       }
     } else if (const auto* alt = dyn_cast<AlternativeValue>(value)) {
-      out.push_back(AbstractPattern(
-          &alt->argument(),
-          *cast<ChoiceType>(type_)->FindAlternative(alt->alt_name())));
+      if (auto arg = alt->argument()) {
+        out.push_back(AbstractPattern(*arg, *alt->alternative().static_type()));
+      }
     }
   }
 }

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -792,8 +792,9 @@ auto NameResolver::ResolveNames(Declaration& declaration,
       // need to check for duplicates.
       std::set<std::string_view> alternative_names;
       for (Nonnull<AlternativeSignature*> alternative : choice.alternatives()) {
-        CARBON_RETURN_IF_ERROR(
-            ResolveNames(alternative->signature(), choice_scope));
+        if (auto sig = alternative->signature()) {
+          CARBON_RETURN_IF_ERROR(ResolveNames(**sig, choice_scope));
+        }
         if (!alternative_names.insert(alternative->name()).second) {
           return ProgramError(alternative->source_loc())
                  << "Duplicate name `" << alternative->name()

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -1029,10 +1029,10 @@ auto ValueStructurallyEqual(
       const auto& alt1 = cast<AlternativeValue>(*v1);
       const auto& alt2 = cast<AlternativeValue>(*v2);
       if (!TypeEqual(&alt1.choice(), &alt2.choice(), equality_ctx) ||
-          alt1.alternative().name() != alt2.alternative().name() ||
-          alt1.argument().has_value() != alt2.argument().has_value()) {
+          &alt1.alternative() != &alt2.alternative()) {
         return false;
       }
+      CARBON_CHECK(alt1.argument().has_value() == alt2.argument().has_value());
       return !alt1.argument().has_value() ||
              ValueEqual(*alt1.argument(), *alt2.argument(), equality_ctx);
     }

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -26,6 +26,8 @@ namespace Carbon {
 
 class Action;
 class AssociatedConstant;
+class ChoiceType;
+class TupleValue;
 
 // A trait type that describes how to allocate an instance of `T` in an arena.
 // Returns the created object, which is not required to be of type `T`.
@@ -379,16 +381,30 @@ class NominalClassValue : public Value {
   Nonnull<const NominalClassValue** const> class_value_ptr_;
 };
 
-// An alternative constructor value.
-// TODO: The representation here is inappropriate: at least the choice type
-// should be identified symbolically rather than by name.
-class AlternativeConstructorValue : public Value {
+// Common implementation of alternative values and alternative constructors.
+class AlternativeValueBase : public Value {
  public:
-  AlternativeConstructorValue(std::string_view alt_name,
-                              std::string_view choice_name)
-      : Value(Kind::AlternativeConstructorValue),
-        alt_name_(alt_name),
-        choice_name_(choice_name) {}
+  AlternativeValueBase(Kind kind, Nonnull<const ChoiceType*> choice,
+                       Nonnull<const AlternativeSignature*> alternative)
+      : Value(kind), choice_(choice), alternative_(alternative) {}
+
+  auto choice() const -> const ChoiceType& { return *choice_; }
+  auto alternative() const -> const AlternativeSignature& {
+    return *alternative_;
+  }
+
+ private:
+  Nonnull<const ChoiceType*> choice_;
+  Nonnull<const AlternativeSignature*> alternative_;
+};
+
+// An alternative constructor value.
+class AlternativeConstructorValue : public AlternativeValueBase {
+ public:
+  AlternativeConstructorValue(Nonnull<const ChoiceType*> choice,
+                              Nonnull<const AlternativeSignature*> alternative)
+      : AlternativeValueBase(Kind::AlternativeConstructorValue, choice,
+                             alternative) {}
 
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::AlternativeConstructorValue;
@@ -396,27 +412,17 @@ class AlternativeConstructorValue : public Value {
 
   template <typename F>
   auto Decompose(F f) const {
-    return f(alt_name_, choice_name_);
+    return f(&choice(), &alternative());
   }
-
-  auto alt_name() const -> const std::string& { return alt_name_; }
-  auto choice_name() const -> const std::string& { return choice_name_; }
-
- private:
-  std::string alt_name_;
-  std::string choice_name_;
 };
 
 // An alternative value.
-// TODO: The representation here is inappropriate: at least the choice type
-// should be identified symbolically rather than by name.
-class AlternativeValue : public Value {
+class AlternativeValue : public AlternativeValueBase {
  public:
-  AlternativeValue(std::string_view alt_name, std::string_view choice_name,
-                   Nonnull<const Value*> argument)
-      : Value(Kind::AlternativeValue),
-        alt_name_(alt_name),
-        choice_name_(choice_name),
+  AlternativeValue(Nonnull<const ChoiceType*> choice,
+                   Nonnull<const AlternativeSignature*> alternative,
+                   std::optional<Nonnull<const TupleValue*>> argument)
+      : AlternativeValueBase(Kind::AlternativeValue, choice, alternative),
         argument_(argument) {}
 
   static auto classof(const Value* value) -> bool {
@@ -425,17 +431,15 @@ class AlternativeValue : public Value {
 
   template <typename F>
   auto Decompose(F f) const {
-    return f(alt_name_, choice_name_, argument_);
+    return f(&choice(), &alternative(), argument_);
   }
 
-  auto alt_name() const -> const std::string& { return alt_name_; }
-  auto choice_name() const -> const std::string& { return choice_name_; }
-  auto argument() const -> const Value& { return *argument_; }
+  auto argument() const -> std::optional<Nonnull<const TupleValue*>> {
+    return argument_;
+  }
 
  private:
-  std::string alt_name_;
-  std::string choice_name_;
-  Nonnull<const Value*> argument_;
+  std::optional<Nonnull<const TupleValue*>> argument_;
 };
 
 // Base class for tuple types and tuple values. These are the same other than
@@ -1253,16 +1257,6 @@ class ChoiceType : public Value {
   auto Decompose(F f) const {
     return f(declaration_, bindings_);
   }
-
-  // TODO: Remove this.
-  auto name() const -> std::string_view {
-    return declaration_->name().inner_name();
-  }
-
-  // Returns the parameter types of the alternative with the given name,
-  // or nullopt if no such alternative is present.
-  auto FindAlternative(std::string_view name) const
-      -> std::optional<Nonnull<const Value*>>;
 
   auto bindings() const -> const Bindings& { return *bindings_; }
 

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -1181,9 +1181,8 @@ alternative:
     { $$ = arena->New<AlternativeSignature>(context.source_loc(), $1, $2); }
 | identifier
     {
-      $$ = arena->New<AlternativeSignature>(
-          context.source_loc(), $1,
-          arena->New<TupleLiteral>(context.source_loc()));
+      $$ = arena->New<AlternativeSignature>(context.source_loc(), $1,
+                                            std::nullopt);
     }
 ;
 alternative_list:

--- a/explorer/testdata/basic_syntax/choice.carbon
+++ b/explorer/testdata/basic_syntax/choice.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 // RUN: %{explorer-run}
 // RUN: %{explorer-run-trace}
-// CHECK:STDOUT: result: 0
+// CHECK:STDOUT: result: 1
 
 package ExplorerTest api;
 
@@ -15,26 +15,30 @@ choice Ints {
   Two(i32, i32)
 }
 
-fn Main() -> i32 {
-  var x: Ints = Ints.None();
-  var y: Ints = Ints.One(42);
-  var n: i32 = 0;
-  match (y) {
-    case Ints.None() => { n = n + 2; }
-    case Ints.One(x: auto) => { n = x + 1 - 42; }
-    case Ints.Two(a: auto, b: auto) => { n = 2; }
-  }
-  match (x) {
-    case Ints.One(x: auto) => { n = x + 2; }
-    case Ints.None() => { n = n - 1; }
-    case Ints.Two(x: auto, y: auto) => { n = 5; }
-  }
-  return n;
-}
-
 // Test some alternate syntaxes
 choice MoreInts {
   None(),
   One(i32),
   Two(i32, i32),
+}
+
+fn Main() -> i32 {
+  var x: Ints = Ints.None;
+  var y: Ints = Ints.One(42);
+  var z: MoreInts = MoreInts.None();
+  var n: i32 = 0;
+  match (y) {
+    case Ints.None => { n = n + 2; }
+    case Ints.One(x: auto) => { n = x + 1 - 42; }
+    case Ints.Two(a: auto, b: auto) => { n = 2; }
+  }
+  match (x) {
+    case Ints.One(x: auto) => { n = x + 2; }
+    case Ints.None => { n = n - 1; }
+    case Ints.Two(x: auto, y: auto) => { n = 5; }
+  }
+  match (z) {
+    case MoreInts.None() => { ++n; }
+  }
+  return n;
 }

--- a/explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon
@@ -9,17 +9,15 @@
 package ExplorerTest api;
 
 choice Ints {
-  None(),
+  None,
   One(i32),
   Two(i32, i32)
 }
 
 fn Main() -> i32 {
-  match (Ints.None) {
-    case Ints.None() => { return 0; }
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
-    // CHECK:STDERR: expected: choice Ints
-    // CHECK:STDERR: actual: fn () -> choice Ints
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
+  match (Ints.None()) {
+    case Ints.None => { return 0; }
     default => { return 1; }
   }
 }

--- a/explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon
@@ -9,17 +9,15 @@
 package ExplorerTest api;
 
 choice Ints {
-  None(),
+  None,
   One(i32),
   Two(i32, i32)
 }
 
 fn Main() -> i32 {
   match (Ints.None) {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
     case Ints.None() => { return 0; }
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
-    // CHECK:STDERR: expected: choice Ints
-    // CHECK:STDERR: actual: fn () -> choice Ints
     default => { return 1; }
   }
 }

--- a/explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon
@@ -15,11 +15,11 @@ choice Ints {
 }
 
 fn Main() -> i32 {
-  match (Ints.None) {
-    case Ints.None() => { return 0; }
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
-    // CHECK:STDERR: expected: choice Ints
-    // CHECK:STDERR: actual: fn () -> choice Ints
+  match (Ints.None()) {
+    case Ints.None => { return 0; }
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
+    // CHECK:STDERR: expected: fn () -> choice Ints
+    // CHECK:STDERR: actual: choice Ints
     default => { return 1; }
   }
 }

--- a/explorer/testdata/let/fail_match_choice.carbon
+++ b/explorer/testdata/let/fail_match_choice.carbon
@@ -15,13 +15,13 @@ choice Ints {
 }
 
 fn Main() -> i32 {
-  var x: auto = Ints.None();
+  var x: auto = Ints.None;
   var n: auto = 0;
   match (x) {
     case Ints.One(var x: auto) => {
       x = 2;
     }
-    case Ints.None() => {
+    case Ints.None => {
       n = n - 1;
     }
     case Ints.Two(x: auto, y: auto) => {


### PR DESCRIPTION
The design of choice types expects the declaration of an alternative to match the usage: if an alternative is declared as `None`, then it should be used as `None` not `None()`, and if it is declared as `None()` then it should be used as `None()` not `None`. Update explorer to match.

Also clean up the handling of choice types and alternative values a little in general, by moving away from identifying choice types and alternatives as strings and towards identifying them symbolically.

Closes #2422