### PR TITLE
Remove AlternativeValueBase, per review comments on #2605.

### DIFF
--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -430,8 +430,8 @@ auto ImplDeclaration::Create(Nonnull<Arena*> arena, SourceLocation source_loc,
 
 void AlternativeSignature::Print(llvm::raw_ostream& out) const {
   out << "alt " << name();
-  if (auto sig = signature()) {
-    out << **signature();
+  if (auto params = parameters()) {
+    out << **params;
   }
 }
 

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -468,10 +468,10 @@ class MixDeclaration : public Declaration {
 class AlternativeSignature : public AstNode {
  public:
   AlternativeSignature(SourceLocation source_loc, std::string name,
-                       std::optional<Nonnull<TupleLiteral*>> signature)
+                       std::optional<Nonnull<TupleLiteral*>> parameters)
       : AstNode(AstNodeKind::AlternativeSignature, source_loc),
         name_(std::move(name)),
-        signature_(signature) {}
+        parameters_(parameters) {}
 
   void Print(llvm::raw_ostream& out) const override;
   void PrintID(llvm::raw_ostream& out) const override;
@@ -481,31 +481,31 @@ class AlternativeSignature : public AstNode {
   }
 
   auto name() const -> const std::string& { return name_; }
-  auto signature() const -> std::optional<Nonnull<const TupleLiteral*>> {
-    return signature_;
+  auto parameters() const -> std::optional<Nonnull<const TupleLiteral*>> {
+    return parameters_;
   }
-  auto signature() -> std::optional<Nonnull<TupleLiteral*>> {
-    return signature_;
+  auto parameters() -> std::optional<Nonnull<TupleLiteral*>> {
+    return parameters_;
   }
 
-  // The static type signature, if any. Cannot be called before type checking.
-  // This will be nullopt after type checking if this alternative has no
-  // declared signature.
-  auto static_type() const -> std::optional<Nonnull<const Value*>> {
-    return static_type_;
+  // The static type described by the parameters expression, if any. Cannot be
+  // called before type checking. This will be nullopt after type checking if
+  // this alternative does not have a parameter list.
+  auto parameters_static_type() const -> std::optional<Nonnull<const Value*>> {
+    return parameters_static_type_;
   }
 
   // Sets the static type of the declared entity. Can only be called once,
   // during typechecking.
-  void set_static_type(Nonnull<const Value*> type) {
-    CARBON_CHECK(!static_type_.has_value());
-    static_type_ = type;
+  void set_parameters_static_type(Nonnull<const Value*> type) {
+    CARBON_CHECK(!parameters_static_type_.has_value());
+    parameters_static_type_ = type;
   }
 
  private:
   std::string name_;
-  std::optional<Nonnull<TupleLiteral*>> signature_;
-  std::optional<Nonnull<const Value*>> static_type_;
+  std::optional<Nonnull<TupleLiteral*>> parameters_;
+  std::optional<Nonnull<const Value*>> parameters_static_type_;
 };
 
 class ChoiceDeclaration : public Declaration {

--- a/explorer/ast/declaration.h
+++ b/explorer/ast/declaration.h
@@ -489,6 +489,8 @@ class AlternativeSignature : public AstNode {
   }
 
   // The static type signature, if any. Cannot be called before type checking.
+  // This will be nullopt after type checking if this alternative has no
+  // declared signature.
   auto static_type() const -> std::optional<Nonnull<const Value*>> {
     return static_type_;
   }

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -750,9 +750,9 @@ static auto DeclarationToProto(const Declaration& declaration)
            choice.alternatives()) {
         auto* alternative_proto = choice_proto->add_alternatives();
         alternative_proto->set_name(alternative->name());
-        if (auto sig = alternative->signature()) {
+        if (auto params = alternative->parameters()) {
           *alternative_proto->mutable_signature() =
-              TupleLiteralExpressionToProto(**sig);
+              TupleLiteralExpressionToProto(**params);
         }
       }
       break;

--- a/explorer/interpreter/pattern_analysis.cpp
+++ b/explorer/interpreter/pattern_analysis.cpp
@@ -82,7 +82,8 @@ void AbstractPattern::AppendElementsTo(
       }
     } else if (const auto* alt = dyn_cast<AlternativeValue>(value)) {
       if (auto arg = alt->argument()) {
-        out.push_back(AbstractPattern(*arg, *alt->alternative().static_type()));
+        out.push_back(AbstractPattern(
+            *arg, *alt->alternative().parameters_static_type()));
       }
     }
   }

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -792,8 +792,8 @@ auto NameResolver::ResolveNames(Declaration& declaration,
       // need to check for duplicates.
       std::set<std::string_view> alternative_names;
       for (Nonnull<AlternativeSignature*> alternative : choice.alternatives()) {
-        if (auto sig = alternative->signature()) {
-          CARBON_RETURN_IF_ERROR(ResolveNames(**sig, choice_scope));
+        if (auto params = alternative->parameters()) {
+          CARBON_RETURN_IF_ERROR(ResolveNames(**params, choice_scope));
         }
         if (!alternative_names.insert(alternative->name()).second) {
           return ProgramError(alternative->source_loc())

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2794,7 +2794,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
 
               // If we find an alternative with no declared signature, we are
               // constructing an unparameterized alternative value.
-              if (!(*signature)->static_type()) {
+              if (!(*signature)->parameters_static_type()) {
                 access.set_member(
                     arena_->New<NamedElement>(arena_->New<NamedValue>(
                         NamedValue{access.member_name(), &choice})));
@@ -2803,8 +2803,8 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                 return Success();
               }
 
-              Nonnull<const Value*> parameter_type =
-                  Substitute(choice.bindings(), *(*signature)->static_type());
+              Nonnull<const Value*> parameter_type = Substitute(
+                  choice.bindings(), *(*signature)->parameters_static_type());
               Nonnull<const Value*> type =
                   arena_->New<FunctionType>(parameter_type, &choice);
               // TODO: Should there be a Declaration corresponding to each
@@ -4028,15 +4028,15 @@ auto TypeChecker::TypeCheckPattern(
                << "`" << alternative.alternative_name()
                << "` is not an alternative of " << choice_type;
       }
-      if (!(*signature)->static_type()) {
+      if (!(*signature)->parameters_static_type()) {
         return ProgramError(alternative.source_loc())
                << "alternative `" << choice_type << "."
                << alternative.alternative_name()
                << "` does not expect an argument list";
       }
 
-      Nonnull<const Value*> parameter_type =
-          Substitute(choice_type.bindings(), *(*signature)->static_type());
+      Nonnull<const Value*> parameter_type = Substitute(
+          choice_type.bindings(), *(*signature)->parameters_static_type());
       CARBON_RETURN_IF_ERROR(TypeCheckPattern(&alternative.arguments(),
                                               parameter_type, impl_scope,
                                               enclosing_value_category));
@@ -5498,10 +5498,10 @@ auto TypeChecker::DeclareChoiceDeclaration(Nonnull<ChoiceDeclaration*> choice,
   }
 
   for (Nonnull<AlternativeSignature*> alternative : choice->alternatives()) {
-    if (auto signature = alternative->signature()) {
+    if (auto params = alternative->parameters()) {
       CARBON_ASSIGN_OR_RETURN(
-          auto type, TypeCheckTypeExp(*signature, *scope_info.innermost_scope));
-      alternative->set_static_type(type);
+          auto type, TypeCheckTypeExp(*params, *scope_info.innermost_scope));
+      alternative->set_parameters_static_type(type);
     }
   }
 

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -200,7 +200,7 @@ static auto GetNamedElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
         return ProgramError(source_loc)
                << "alternative " << f << " not in " << *v;
       }
-      if ((*alt)->signature()) {
+      if ((*alt)->parameters()) {
         return arena->New<AlternativeConstructorValue>(&choice, *alt);
       }
       return arena->New<AlternativeValue>(&choice, *alt, std::nullopt);


### PR DESCRIPTION
Also extend comment on `AlternativeSignature::static_type` as requested.