### PR TITLE
Fix mishandling of struct and tuple types in impl matching termination check

### DIFF
--- a/explorer/interpreter/matching_impl_set.cpp
+++ b/explorer/interpreter/matching_impl_set.cpp
@@ -30,12 +30,6 @@ class MatchingImplSet::LeafCollector {
   // Most kinds of value don't contribute to the signature.
   void VisitValue(const Value*) {}
 
-  void VisitValue(const TupleType* tuple) {
-    for (auto* elem : tuple->elements()) {
-      Collect(elem);
-    }
-  }
-
   void VisitValue(const TypeType*) { Collect(Label::TypeType); }
 
   void VisitValue(const BoolType*) { Collect(Label::BoolType); }
@@ -55,8 +49,16 @@ class MatchingImplSet::LeafCollector {
   }
 
   void VisitValue(const StructType* struct_type) {
+    Collect(Label::StructType);
     for (auto [name, type] : struct_type->fields()) {
       Collect(type);
+    }
+  }
+
+  void VisitValue(const TupleType* tuple_type) {
+    Collect(Label::TupleType);
+    for (auto* elem_type : tuple_type->elements()) {
+      Collect(elem_type);
     }
   }
 

--- a/explorer/interpreter/matching_impl_set.h
+++ b/explorer/interpreter/matching_impl_set.h
@@ -91,6 +91,12 @@ class MatchingImplSet {
     ArrayType,
     // Label for `_*` type constructor.
     PointerType,
+    // Label for `{.a: _, .b: _, ...}` struct type constructor. We use the same
+    // label regardless of the arity of the struct type and any field names.
+    StructType,
+    // Label for `(_, _, ..., _)` tuple type constructor. We use the same label
+    // regardless of the arity of the tuple type.
+    TupleType,
     // First Label value corresponding to a Declaration. Must be kept at the
     // end of the enum.
     FirstDeclarationLabel

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -3682,10 +3682,10 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
 
         switch (clause->kind()) {
           case WhereClauseKind::IsWhereClause: {
-            const auto& is_clause = cast<IsWhereClause>(*clause);
+            auto& is_clause = cast<IsWhereClause>(*clause);
             CARBON_ASSIGN_OR_RETURN(
                 Nonnull<const Value*> type,
-                InterpExp(&is_clause.type(), arena_, trace_stream_));
+                TypeCheckTypeExp(&is_clause.type(), inner_impl_scope));
             CARBON_ASSIGN_OR_RETURN(
                 Nonnull<const Value*> constraint,
                 InterpExp(&is_clause.constraint(), arena_, trace_stream_));
@@ -3889,7 +3889,8 @@ auto TypeChecker::TypeCheckWhereClause(Nonnull<WhereClause*> clause,
   switch (clause->kind()) {
     case WhereClauseKind::IsWhereClause: {
       auto& is_clause = cast<IsWhereClause>(*clause);
-      CARBON_RETURN_IF_ERROR(TypeCheckTypeExp(&is_clause.type(), impl_scope));
+      // TODO: `type` is checked in the caller, because its converted value is
+      // needed. Find a way to move that checking back here.
       CARBON_RETURN_IF_ERROR(TypeCheckExp(&is_clause.constraint(), impl_scope));
       if (!isa<TypeType>(is_clause.constraint().static_type())) {
         return ProgramError(is_clause.constraint().source_loc())

--- a/explorer/testdata/impl_match/fail_struct_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_struct_recurse.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface Foo {}
+
+impl forall [T:! type where {.a: .Self} is Foo] T as Foo {}
+
+fn F[T:! Foo](x: T) {}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/impl_match/fail_struct_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR:   outer match: i32 as interface Foo
+  // CHECK:STDERR:   inner match: {.a: i32} as interface Foo
+  F(0);
+  return 0;
+}

--- a/explorer/testdata/impl_match/fail_tuple_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_tuple_recurse.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface Foo {}
+
+impl forall [T:! type where (.Self,) is Foo] T as Foo {}
+
+fn F[T:! Foo](x: T) {}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/impl_match/fail_tuple_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR:   outer match: i32 as interface Foo
+  // CHECK:STDERR:   inner match: (i32) as interface Foo
+  F(0);
+  return 0;
+}


### PR DESCRIPTION
Both cases need a label for each level of struct and tuple type appearing in the impl query, because we can have an unbounded number of such levels with the types otherwise being the same.

Prior to this, both added testcases exhibit unbounded recursion.