### PR TITLE
Fix reference to update_checks.py

### DIFF
--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -444,7 +444,9 @@ def main() -> None:
     if parsed_args.tests:
         tests = {test.relative_to(root) for test in parsed_args.tests}
     else:
-        print("HINT: run `update_checks.py f1 f2 ...` to update specific tests")
+        print(
+            "HINT: run `lit_autoupdate.py f1 f2 ...` to update specific tests"
+        )
         tests = get_tests(parsed_args.testdata)
 
     # Build inputs.


### PR DESCRIPTION
Scripts used to be named update_checks.py, now they're lit_autoupdate.py. This isn't dynamic due to execv; it felt odd to pass along the call.