### PR TITLE
Modify lit_autoupdate so that it can handle errors in prelude.carbon

### DIFF
--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -15,7 +15,17 @@ import os
 from pathlib import Path
 import re
 import subprocess
-from typing import Any, Dict, List, NamedTuple, Optional, Pattern, Set, Tuple
+from typing import (
+    Any,
+    Dict,
+    List,
+    Match,
+    NamedTuple,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+)
 
 # A prefix followed by a command to run for autoupdating checked output.
 AUTOUPDATE_MARKER = "// AUTOUPDATE"
@@ -48,7 +58,7 @@ class ParsedArgs(NamedTuple):
     autoupdate_args: List[str]
     build_mode: str
     extra_check_replacements: List[Tuple[Pattern, Pattern, str]]
-    line_number_format: str
+    line_number_delta_prefix: str
     line_number_pattern: Pattern
     lit_run: List[str]
     testdata: str
@@ -83,17 +93,18 @@ def parse_args() -> ParsedArgs:
         "BEFORE with AFTER.",
     )
     parser.add_argument(
-        "--line_number_format",
-        metavar="FORMAT",
-        default="[[@LINE%(delta)s]]",
-        help="An optional format string for line number delta replacements.",
+        "--line_number_delta_prefix",
+        metavar="PREFIX",
+        default="",
+        help="An optional prefix to add before the [[@LINE+delta]] marker.",
     )
     parser.add_argument(
         "--line_number_pattern",
         metavar="PATTERN",
         required=True,
         help="A regular expression which matches line numbers to update as its "
-        "only group.",
+        "only group. A capture group named `filename` should be provided to "
+        "help this determine file associations.",
     )
     parser.add_argument(
         "--lit_run",
@@ -125,7 +136,7 @@ def parse_args() -> ParsedArgs:
         autoupdate_args=parsed_args.autoupdate_arg,
         build_mode=parsed_args.build_mode,
         extra_check_replacements=extra_check_replacements,
-        line_number_format=parsed_args.line_number_format,
+        line_number_delta_prefix=parsed_args.line_number_delta_prefix,
         line_number_pattern=re.compile(parsed_args.line_number_pattern),
         lit_run=parsed_args.lit_run,
         testdata=parsed_args.testdata,
@@ -190,18 +201,25 @@ class CheckLine(Line):
 
     def __init__(
         self,
+        test: str,
         out_line: str,
-        line_number_format: str,
+        line_number_delta_prefix: str,
         line_number_pattern: Pattern,
     ) -> None:
         super().__init__()
+        self.filename = Path(test).name
         self.indent = ""
         self.out_line = out_line.rstrip()
-        self.line_number_format = line_number_format
+        self.line_number_delta_prefix = line_number_delta_prefix
         self.line_number_pattern = line_number_pattern
-        self.line_numbers = [
-            int(n) - 1 for n in line_number_pattern.findall(self.out_line)
-        ]
+
+        # If any match has a match specific to this file, use the first line for
+        # the location of the CHECK comment.
+        self.line_in_file = None
+        for match in line_number_pattern.finditer(self.out_line):
+            if self.matches_filename(match):
+                self.line_in_file = int(match.group("line")) - 1
+                break
 
     def format(
         self, *, output_line_number: int, line_number_remap: Dict[int, int]
@@ -209,15 +227,34 @@ class CheckLine(Line):
         if not self.out_line:
             return f"{self.indent}// CHECK-EMPTY:\n"
         result = self.out_line
-        for line_number in self.line_numbers:
-            delta = line_number_remap[line_number] - output_line_number
-            # We use `:+d` here to produce `LINE-n` or `LINE+n` as appropriate.
-            result = self.line_number_pattern.sub(
-                self.line_number_format % {"delta": f"{delta:+d}"},
-                result,
-                count=1,
-            )
+        while True:
+            match = self.line_number_pattern.search(result)
+            if not match:
+                break
+            if self.matches_filename(match):
+                line_number = int(match.group("line")) - 1
+                delta = line_number_remap[line_number] - output_line_number
+                # We use `:+d` here to produce `LINE-n` or `LINE+n` as
+                # appropriate.
+                result = self.line_number_pattern.sub(
+                    rf"\g<prefix>{self.line_number_delta_prefix}"
+                    rf"[[@LINE{delta:+d}]]\g<suffix>",
+                    result,
+                    count=1,
+                )
+            else:
+                result = self.line_number_pattern.sub(
+                    r"\g<prefix>{{.*}}\g<suffix>",
+                    result,
+                    count=1,
+                )
         return f"{self.indent}// CHECK:{result}\n"
+
+    def matches_filename(self, match: Match) -> bool:
+        return (
+            "filename" not in match.groups()
+            or match.group("filename") == self.filename
+        )
 
 
 def find_autoupdate(test: str, orig_lines: List[str]) -> Optional[int]:
@@ -249,7 +286,7 @@ def find_autoupdate(test: str, orig_lines: List[str]) -> Optional[int]:
 def replace_all(s: str, replacements: List[Tuple[str, str]]) -> str:
     """Runs multiple replacements on a string."""
     for before, after in replacements:
-        s = s.replace(before, after)
+        s = s.replace(str(before), str(after))
     return s
 
 
@@ -257,19 +294,20 @@ def get_matchable_test_output(
     autoupdate_args: List[str],
     extra_check_replacements: List[Tuple[Pattern, Pattern, str]],
     tool: str,
+    bazel_runfiles: Pattern,
     llvm_symbolizer: str,
     test: str,
 ) -> List[str]:
     """Runs the autoupdate command and returns the output lines."""
     # Run the autoupdate command to generate output.
     # (`bazel run` would serialize)
-    p = subprocess.run(
+    out = subprocess.run(
         tools[tool].autoupdate_cmd + autoupdate_args + [test],
         env={"LLVM_SYMBOLIZER_PATH": llvm_symbolizer},
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-    )
-    out = p.stdout.decode("utf-8")
+        encoding="utf-8",
+    ).stdout
 
     # `lit` uses full paths to the test file, so use a regex to ignore paths
     # when used.
@@ -283,6 +321,9 @@ def get_matchable_test_output(
             (test, f"{{{{.*}}}}/{test}"),
         ],
     )
+    out = bazel_runfiles.sub("{{.*}}/", out)
+    # Replacing runfiles is a more complex replacement.
+    # We have some things show up under runfiles; this removes them.
     out_lines = out.splitlines()
 
     for i, line in enumerate(out_lines):
@@ -300,7 +341,7 @@ def is_replaced(line: str) -> bool:
 
 
 def merge_lines(
-    line_number_format: str,
+    line_number_delta_prefix: str,
     line_number_pattern: Pattern,
     lit_run: List[str],
     test: str,
@@ -315,7 +356,7 @@ def merge_lines(
         if not is_replaced(line)
     ]
     check_lines = [
-        CheckLine(out_line, line_number_format, line_number_pattern)
+        CheckLine(test, out_line, line_number_delta_prefix, line_number_pattern)
         for out_line in out_lines
     ]
 
@@ -332,8 +373,8 @@ def merge_lines(
     while orig_lines and check_lines:
         # Original lines go first when the CHECK line is known and later.
         if (
-            check_lines[0].line_numbers
-            and check_lines[0].line_numbers[0] > orig_lines[0].line_number
+            check_lines[0].line_in_file is not None
+            and check_lines[0].line_in_file > orig_lines[0].line_number
         ):
             result_lines.append(orig_lines.pop(0))
         else:
@@ -349,7 +390,10 @@ def merge_lines(
 
 
 def update_check(
-    parsed_args: ParsedArgs, llvm_symbolizer: str, test: Path
+    parsed_args: ParsedArgs,
+    bazel_runfiles: Pattern,
+    llvm_symbolizer: str,
+    test: Path,
 ) -> bool:
     """Updates the CHECK: lines for `test` by running the tool.
 
@@ -368,11 +412,12 @@ def update_check(
         parsed_args.autoupdate_args,
         parsed_args.extra_check_replacements,
         parsed_args.tool,
+        bazel_runfiles,
         llvm_symbolizer,
         str(test),
     )
     result_lines = merge_lines(
-        parsed_args.line_number_format,
+        parsed_args.line_number_delta_prefix,
         parsed_args.line_number_pattern,
         parsed_args.lit_run,
         str(test),
@@ -411,13 +456,18 @@ def update_check(
 
 
 def update_checks(
-    parsed_args: ParsedArgs, llvm_symbolizer: str, tests: Set[Path]
+    parsed_args: ParsedArgs,
+    bazel_runfiles: Pattern,
+    llvm_symbolizer: str,
+    tests: Set[Path],
 ) -> None:
     """Updates CHECK: lines in lit tests."""
 
     def map_helper(test: Path) -> bool:
         try:
-            updated = update_check(parsed_args, llvm_symbolizer, test)
+            updated = update_check(
+                parsed_args, bazel_runfiles, llvm_symbolizer, test
+            )
         except Exception as e:
             raise ValueError(f"Failed to update {test}") from e
         print(".", end="", flush=True)
@@ -459,6 +509,13 @@ def main() -> None:
             tools[parsed_args.tool].build_target,
         ]
     )
+    bazel_bin_dir = subprocess.check_output(
+        ["bazel", "info", "-c", parsed_args.build_mode, "bazel-bin"],
+        encoding="utf-8",
+    ).strip()
+    bazel_runfiles = re.compile(
+        r"{0}/.*\.runfiles/".format(re.escape(bazel_bin_dir))
+    )
 
     # Grab the symbolizer.
     clang_var_content = Path(
@@ -471,7 +528,7 @@ def main() -> None:
     assert llvm_symbolizer is not None
 
     # Run updates.
-    update_checks(parsed_args, llvm_symbolizer[1], tests)
+    update_checks(parsed_args, bazel_runfiles, llvm_symbolizer[1], tests)
 
 
 if __name__ == "__main__":

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -101,10 +101,12 @@ def parse_args() -> ParsedArgs:
     parser.add_argument(
         "--line_number_pattern",
         metavar="PATTERN",
-        required=True,
+        default=r"(?P<prefix>/(?P<filename>\w+\.carbon):)"
+        r"(?P<line>\d+)(?P<suffix>(?:\D|$))",
         help="A regular expression which matches line numbers to update as its "
-        "only group. A capture group named `filename` should be provided to "
-        "help this determine file associations.",
+        "only group. Capture groups 'prefix', 'line', and 'suffix' are "
+        "required for structure. The 'filename' capture group is optional and "
+        "should be provided when lines may belong to different files.",
     )
     parser.add_argument(
         "--lit_run",
@@ -252,7 +254,7 @@ class CheckLine(Line):
 
     def matches_filename(self, match: Match) -> bool:
         return (
-            "filename" not in match.groups()
+            "filename" not in match.groupdict()
             or match.group("filename") == self.filename
         )
 

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -215,7 +215,7 @@ class CheckLine(Line):
         self.line_number_delta_prefix = line_number_delta_prefix
         self.line_number_pattern = line_number_pattern
 
-        # If any match has a match specific to this file, use the first line for
+        # If any match is specific to this file, use the first line for
         # the location of the CHECK comment.
         self.line_in_file = None
         for match in line_number_pattern.finditer(self.out_line):

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -518,7 +518,7 @@ def main() -> None:
         encoding="utf-8",
     ).strip()
     bazel_runfiles = re.compile(
-        r"{0}/.*\.runfiles/".format(re.escape(bazel_bin_dir))
+        r"{0}/.*\.runfiles/carbon/".format(re.escape(bazel_bin_dir))
     )
 
     # Grab the symbolizer.

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -323,9 +323,9 @@ def get_matchable_test_output(
             (test, f"{{{{.*}}}}/{test}"),
         ],
     )
-    out = bazel_runfiles.sub("{{.*}}/", out)
     # Replacing runfiles is a more complex replacement.
     # We have some things show up under runfiles; this removes them.
+    out = bazel_runfiles.sub("{{.*}}/", out)
     out_lines = out.splitlines()
 
     for i, line in enumerate(out_lines):

--- a/bazel/testing/lit_autoupdate_base.py
+++ b/bazel/testing/lit_autoupdate_base.py
@@ -219,7 +219,7 @@ class CheckLine(Line):
         # the location of the CHECK comment.
         self.line_in_file = None
         for match in line_number_pattern.finditer(self.out_line):
-            if self.matches_filename(match):
+            if self._matches_filename(match):
                 self.line_in_file = int(match.group("line")) - 1
                 break
 
@@ -233,7 +233,7 @@ class CheckLine(Line):
             match = self.line_number_pattern.search(result)
             if not match:
                 break
-            if self.matches_filename(match):
+            if self._matches_filename(match):
                 line_number = int(match.group("line")) - 1
                 delta = line_number_remap[line_number] - output_line_number
                 # We use `:+d` here to produce `LINE-n` or `LINE+n` as
@@ -252,7 +252,7 @@ class CheckLine(Line):
                 )
         return f"{self.indent}// CHECK:{result}\n"
 
-    def matches_filename(self, match: Match) -> bool:
+    def _matches_filename(self, match: Match) -> bool:
         return (
             "filename" not in match.groupdict()
             or match.group("filename") == self.filename
@@ -288,7 +288,7 @@ def find_autoupdate(test: str, orig_lines: List[str]) -> Optional[int]:
 def replace_all(s: str, replacements: List[Tuple[str, str]]) -> str:
     """Runs multiple replacements on a string."""
     for before, after in replacements:
-        s = s.replace(str(before), str(after))
+        s = s.replace(before, after)
     return s
 
 

--- a/explorer/lit_autoupdate.py
+++ b/explorer/lit_autoupdate.py
@@ -20,12 +20,16 @@ def main() -> None:
     actual_py = this_py.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
     )
+    line_number_pattern = (
+        r"(?P<prefix>/(?P<filename>\w+\.carbon):)"
+        r"(?P<line>\d+)(?P<suffix>(?:\D|$))"
+    )
     args = [
         sys.argv[0],
         # Flags to configure for explorer testing.
         "--tool=explorer",
         "--testdata=explorer/testdata",
-        r"--line_number_pattern=(?<=\.carbon:)(\d+)(?=(?:\D|$))",
+        f"--line_number_pattern={line_number_pattern}"
         "--lit_run=%{explorer-run}",
         "--lit_run=%{explorer-run-trace}",
     ] + sys.argv[1:]

--- a/explorer/lit_autoupdate.py
+++ b/explorer/lit_autoupdate.py
@@ -20,16 +20,11 @@ def main() -> None:
     actual_py = this_py.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
     )
-    line_number_pattern = (
-        r"(?P<prefix>/(?P<filename>\w+\.carbon):)"
-        r"(?P<line>\d+)(?P<suffix>(?:\D|$))"
-    )
     args = [
         sys.argv[0],
         # Flags to configure for explorer testing.
         "--tool=explorer",
         "--testdata=explorer/testdata",
-        f"--line_number_pattern={line_number_pattern}"
         "--lit_run=%{explorer-run}",
         "--lit_run=%{explorer-run-trace}",
     ] + sys.argv[1:]

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -9,7 +9,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -5,7 +5,6 @@
 // This won't auto-update because it uses a regex for the prelude line number,
 // so that it doesn't need to be updated on every prelude change.
 //
-// This can't be autoupdated because the error line comes form a different file.
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -6,10 +6,10 @@
 // so that it doesn't need to be updated on every prelude change.
 //
 // This can't be autoupdated because the error line comes form a different file.
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
@@ -9,7 +9,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
@@ -6,10 +6,10 @@
 // so that it doesn't need to be updated on every prelude change.
 //
 // This can't be autoupdated because the error line comes form a different file.
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
@@ -9,7 +9,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
@@ -6,10 +6,10 @@
 // so that it doesn't need to be updated on every prelude change.
 //
 // This can't be autoupdated because the error line comes form a different file.
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
@@ -9,7 +9,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
@@ -6,10 +6,10 @@
 // so that it doesn't need to be updated on every prelude change.
 //
 // This can't be autoupdated because the error line comes form a different file.
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
@@ -9,7 +9,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
@@ -6,10 +6,10 @@
 // so that it doesn't need to be updated on every prelude change.
 //
 // This can't be autoupdated because the error line comes form a different file.
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/optional/fail_optional_get_empty.carbon
+++ b/explorer/testdata/optional/fail_optional_get_empty.carbon
@@ -2,14 +2,14 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// NOAUTOUPDATE
+// AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
 
 package ExplorerTest api;
 
 fn Main() -> i32{
   var x: Optional(i32) = Optional(i32).CreateEmpty();
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
   return x.Get();
 }

--- a/explorer/testdata/optional/fail_optional_get_empty.carbon
+++ b/explorer/testdata/optional/fail_optional_get_empty.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 // RUN: %{not} %{explorer-run}
 // RUN: %{not} %{explorer-run-trace}
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/carbon/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
 
 package ExplorerTest api;
 

--- a/toolchain/lexer/lit_autoupdate.py
+++ b/toolchain/lexer/lit_autoupdate.py
@@ -20,7 +20,6 @@ def main() -> None:
     actual_py = this_py.parent.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
     )
-    line_number_pattern = r"(?P<prefix> line: )(?P<line> *\d+)(?P<suffix>,)"
     args = [
         sys.argv[0],
         # Flags to configure for lexer testing.
@@ -35,7 +34,8 @@ def main() -> None:
         "column: {{[0-9]+}}",
         # Ignore spaces that are used to columnize lines.
         "--line_number_delta_prefix={{ *}}",
-        f"--line_number_pattern={line_number_pattern}",
+        "--line_number_pattern="
+        r"(?P<prefix> line: )(?P<line> *\d+)(?P<suffix>,)",
         "--lit_run=%{carbon-run-tokens}",
         "--testdata=toolchain/lexer/testdata",
     ] + sys.argv[1:]

--- a/toolchain/lexer/lit_autoupdate.py
+++ b/toolchain/lexer/lit_autoupdate.py
@@ -20,6 +20,7 @@ def main() -> None:
     actual_py = this_py.parent.parent.parent.joinpath(
         "bazel", "testing", "lit_autoupdate_base.py"
     )
+    line_number_pattern = r"(?P<prefix> line: )(?P<line> *\d+)(?P<suffix>,)"
     args = [
         sys.argv[0],
         # Flags to configure for lexer testing.
@@ -33,8 +34,8 @@ def main() -> None:
         r"column: (?:\d+)",
         "column: {{[0-9]+}}",
         # Ignore spaces that are used to columnize lines.
-        "--line_number_format={{ *}}[[@LINE%(delta)s]]",
-        r"--line_number_pattern=(?<= line: )( *\d+)(?=,)",
+        "--line_number_delta_prefix={{ *}}",
+        f"--line_number_pattern={line_number_pattern}",
         "--lit_run=%{carbon-run-tokens}",
         "--testdata=toolchain/lexer/testdata",
     ] + sys.argv[1:]

--- a/toolchain/parser/lit_autoupdate.py
+++ b/toolchain/parser/lit_autoupdate.py
@@ -26,7 +26,6 @@ def main() -> None:
         "--tool=carbon",
         "--autoupdate_arg=dump",
         "--autoupdate_arg=parse-tree",
-        r"--line_number_pattern=(?<=\.carbon:)(\d+)(?=(?:\D|$))",
         "--lit_run=%{carbon-run-parser}",
         "--testdata=toolchain/parser/testdata",
     ] + sys.argv[1:]

--- a/toolchain/semantics/lit_autoupdate.py
+++ b/toolchain/semantics/lit_autoupdate.py
@@ -26,7 +26,6 @@ def main() -> None:
         "--tool=carbon",
         "--autoupdate_arg=dump",
         "--autoupdate_arg=semantics-ir",
-        r"--line_number_pattern=(?<=\.carbon:)(\d+)(?=(?:\D|$))",
         "--lit_run=%{carbon-run-semantics}",
         "--testdata=toolchain/semantics/testdata",
     ] + sys.argv[1:]


### PR DESCRIPTION
The intent here is that changes to prelude.carbon shouldn't break every test that expects some error from prelude.carbon; that would be too fragile. As a consequence, this effectively ignores the line number in prelude.carbon.

This is a little complex because we don't know which line in the original source file is actually causing the error, just that there is an error. Also, the previous look-behind approach required a fixed-with prefix, whereas we want a little more than that in order to capture the filename for comparison.

This would be hard to do with extra_check_replacement because the path to bazel.runfiles is complex to calculate. As a consequence, this is basically all new code.