### PR TITLE
Unify handling of calls to functions and to methods.

### DIFF
--- a/explorer/testdata/class/fail_call_method_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_call_method_before_typecheck.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+class A {
+  fn F[self: Self]() -> type {
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_call_method_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `F` that has not been fully type-checked
+    var a: ({} as A).F() = 0;
+    return i32;
+  }
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/explorer/testdata/class/fail_call_undefined_method.carbon
+++ b/explorer/testdata/class/fail_call_undefined_method.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+class A {
+  fn F[self: Self]() -> i32;
+}
+
+fn Main() -> i32 {
+  var a: A = {};
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_call_undefined_method.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
+  return a.F();
+}

--- a/explorer/testdata/generic_function/instantiate_deduced.carbon
+++ b/explorer/testdata/generic_function/instantiate_deduced.carbon
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn ReturnIndirectly[T:! type](direct: bool, x: T) -> type {
+  if (direct) {
+    return T;
+  } else {
+    return ReturnIndirectly(true, x);
+  }
+}
+
+fn Main() -> ReturnIndirectly(false, 0) {
+  return 0;
+}


### PR DESCRIPTION
This fixes some bugs in each, where the fixes had only been made on one side of the switch or the other. Also don't forget to instantiate deduced generic arguments in a call when we read them out of the AST.