### PR TITLE
Factor out a common base class from function and bound method values.

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4629,8 +4629,9 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
       std::move(impl_bindings)));
   switch (f->kind()) {
     case DeclarationKind::FunctionDeclaration:
-      f->set_constant_value(
-          arena_->New<FunctionValue>(cast<FunctionDeclaration>(f)));
+      // TODO: Should we pass in the bindings from the enclosing scope?
+      f->set_constant_value(arena_->New<FunctionValue>(
+          cast<FunctionDeclaration>(f), Bindings::None()));
       break;
     case DeclarationKind::DestructorDeclaration:
       f->set_constant_value(


### PR DESCRIPTION
This allows simplification of the interpreter in places where these two kinds of value can be handled with common code.