### PR TITLE
Update clang-tidy details for the toolchain

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,7 @@ Checks:
 WarningsAsErrors: true
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantCase, value: CamelCase }
   - {
       key: readability-identifier-naming.ConstexprVariableCase,
       value: CamelCase,

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -82,7 +82,7 @@ class TokenizedBuffer {
   struct Identifier : public IndexBase {
     using IndexBase::IndexBase;
 
-    static const Identifier Invalid;
+    static const Identifier invalid;
   };
 
   // Random-access iterator over tokens within the buffer.
@@ -345,7 +345,7 @@ class TokenizedBuffer {
           sizeof(Token) <= sizeof(int32_t),
           "Unable to pack token and identifier index into the same space!");
 
-      Identifier id = Identifier::Invalid;
+      Identifier id = Identifier::invalid;
       int32_t literal_index;
       Token closing_token;
       Token opening_token;
@@ -406,7 +406,7 @@ class TokenizedBuffer {
   bool has_errors_ = false;
 };
 
-constexpr TokenizedBuffer::Identifier TokenizedBuffer::Identifier::Invalid =
+constexpr TokenizedBuffer::Identifier TokenizedBuffer::Identifier::invalid =
     TokenizedBuffer::Identifier(TokenizedBuffer::Identifier::InvalidIndex);
 
 // A diagnostic emitter that uses positions within a source buffer's text as

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -82,7 +82,7 @@ class TokenizedBuffer {
   struct Identifier : public IndexBase {
     using IndexBase::IndexBase;
 
-    static const Identifier invalid;
+    static const Identifier Invalid;
   };
 
   // Random-access iterator over tokens within the buffer.
@@ -345,7 +345,7 @@ class TokenizedBuffer {
           sizeof(Token) <= sizeof(int32_t),
           "Unable to pack token and identifier index into the same space!");
 
-      Identifier id = Identifier::invalid;
+      Identifier id = Identifier::Invalid;
       int32_t literal_index;
       Token closing_token;
       Token opening_token;
@@ -406,7 +406,7 @@ class TokenizedBuffer {
   bool has_errors_ = false;
 };
 
-constexpr TokenizedBuffer::Identifier TokenizedBuffer::Identifier::invalid =
+constexpr TokenizedBuffer::Identifier TokenizedBuffer::Identifier::Invalid =
     TokenizedBuffer::Identifier(TokenizedBuffer::Identifier::InvalidIndex);
 
 // A diagnostic emitter that uses positions within a source buffer's text as

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -135,7 +135,7 @@ auto ParseTree::Print(llvm::raw_ostream& output) const -> void {
 
   output << "[\n";
   for (Node n : postorder()) {
-    PrintNode(output, n, indents[n.index], /*adding_children=*/false);
+    PrintNode(output, n, indents[n.index], /*preorder=*/false);
     output << ",\n";
   }
   output << "]\n";
@@ -165,7 +165,7 @@ auto ParseTree::Print(llvm::raw_ostream& output, bool preorder) const -> void {
     int depth;
     std::tie(n, depth) = node_stack.pop_back_val();
 
-    if (PrintNode(output, n, depth, /*adding_children=*/true)) {
+    if (PrintNode(output, n, depth, /*preorder=*/true)) {
       // Has children, so we descend. We append the children in order here as
       // well because they will get reversed when popped off the stack.
       for (Node sibling_n : children(n)) {

--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -243,7 +243,6 @@ class ParseTree {
 // sequence across all nodes in the parse tree.
 struct ParseTree::Node : public ComparableIndexBase {
   // An explicitly invalid instance.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   static const Node Invalid;
 
   using ComparableIndexBase::ComparableIndexBase;

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -27,7 +27,6 @@ class SemanticsBuiltinKind : public CARBON_ENUM_BASE(SemanticsBuiltinKind) {
   //
   // Note that we *define* this as `constexpr` making it a true compile-time
   // constant, and so we name it accordingly and disable the lint error here.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   static const uint8_t ValidCount;
 
   // Support conversion to and from an int32_t for SemanticNode storage.

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -26,7 +26,7 @@ class SemanticsBuiltinKind : public CARBON_ENUM_BASE(SemanticsBuiltinKind) {
   // The count of enum values excluding Invalid.
   //
   // Note that we *define* this as `constexpr` making it a true compile-time
-  // constant, and so we name it accordingly and disable the lint error here.
+  // constant.
   static const uint8_t ValidCount;
 
   // Support conversion to and from an int32_t for SemanticNode storage.

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -18,7 +18,6 @@ namespace Carbon {
 // The ID of a node.
 struct SemanticsNodeId : public IndexBase {
   // An explicitly invalid node ID.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   static const SemanticsNodeId Invalid;
 
 // Builtin node IDs.
@@ -82,11 +81,9 @@ struct SemanticsIntegerLiteralId : public IndexBase {
 // The ID of a node block.
 struct SemanticsNodeBlockId : public IndexBase {
   // All SemanticsIR instances must provide the 0th node block as empty.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   static const SemanticsNodeBlockId Empty;
 
   // An explicitly invalid ID.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   static const SemanticsNodeBlockId Invalid;
 
   using IndexBase::IndexBase;


### PR DESCRIPTION
Adjusts handling of class constants (`static const`) to use CamelCase. This probably better reflects how we use it in C++ code, treating as appropriate for CamelCase instead of under_score.

Fixes adding_children to be preorder in caller (not sure why this wasn't automated).

No automated changes.