### PR TITLE
IWYU pass on toolchain

### DIFF
--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -4,6 +4,8 @@
 
 #include "common/check_internal.h"
 
+#include "llvm/Support/Signals.h"
+
 namespace Carbon::Internal {
 
 // Prints the buffered message.

--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -7,8 +7,6 @@
 
 #include <cstdlib>
 
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace Carbon::Internal {

--- a/common/ostream.h
+++ b/common/ostream.h
@@ -9,7 +9,8 @@
 
 #include "common/metaprogramming.h"
 #include "llvm/Support/raw_os_ostream.h"
-#include "llvm/Support/raw_ostream.h"
+// Libraries should include this header instead of raw_ostream.
+#include "llvm/Support/raw_ostream.h"  // IWYU pragma: export
 
 namespace Carbon {
 

--- a/toolchain/parser/parse_tree_fuzzer.cpp
+++ b/toolchain/parser/parse_tree_fuzzer.cpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <cstring>
 
-#include "common/check.h"
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/null_diagnostics.h"

--- a/toolchain/parser/parse_tree_test.cpp
+++ b/toolchain/parser/parse_tree_test.cpp
@@ -9,7 +9,6 @@
 
 #include <forward_list>
 
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/common/yaml_test_helpers.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/mocks.h"

--- a/toolchain/semantics/semantics_node_block_stack.h
+++ b/toolchain/semantics/semantics_node_block_stack.h
@@ -7,7 +7,6 @@
 
 #include <type_traits>
 
-#include "common/check.h"
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/semantics/semantics_node.h"
 

--- a/toolchain/semantics/semantics_parse_tree_handler.cpp
+++ b/toolchain/semantics/semantics_parse_tree_handler.cpp
@@ -13,7 +13,6 @@
 #include "toolchain/lexer/token_kind.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/parser/parse_node_kind.h"
-#include "toolchain/semantics/semantics_builtin_kind.h"
 #include "toolchain/semantics/semantics_ir.h"
 #include "toolchain/semantics/semantics_node.h"
 #include "toolchain/semantics/semantics_node_block_stack.h"


### PR DESCRIPTION
Just opening files in vscode and seeing what clangd flags.

Some edits to ostream.h to stop it from getting flagged (the usage pattern means it's not always obviously used).