### PR TITLE
Feature interface impl without cast

### DIFF
--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -362,24 +362,24 @@ void ImplScope::Print(llvm::raw_ostream& out) const {
   }
 }
 
-auto ImplScope::GetInterfacesOfType(Nonnull<const Value*> type) const -> std::vector<Nonnull<const InterfaceType*>>{
-
+auto ImplScope::GetInterfacesOfType(Nonnull<const Value*> type) const
+    -> std::vector<Nonnull<const InterfaceType*>> {
   std::vector<Nonnull<const InterfaceType*>> result;
-  if(type->kind() == Value::Kind::NominalClassType ){
+  if (type->kind() == Value::Kind::NominalClassType) {
     for (const Impl& impl : impls_) {
-      if(impl.type->kind() == Value::Kind::NominalClassType){
-        const auto & p1 = cast<NominalClassType>(*type);
-        const auto & p2 = cast<NominalClassType>(*impl.type);
-        if(&p1.declaration() == &p2.declaration()){
-         result.push_back(impl.interface);
+      if (impl.type->kind() == Value::Kind::NominalClassType) {
+        const auto& p1 = cast<NominalClassType>(*type);
+        const auto& p2 = cast<NominalClassType>(*impl.type);
+        if (&p1.declaration() == &p2.declaration()) {
+          result.push_back(impl.interface);
         }
       }
     }
     for (const Nonnull<const ImplScope*>& parent : parent_scopes_) {
-       auto part = parent->GetInterfacesOfType(type);
-       for(const auto & x: part){
-          result.push_back(x);
-       }
+      auto part = parent->GetInterfacesOfType(type);
+      for (const auto& x : part) {
+        result.push_back(x);
+      }
     }
   }
   return result;

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -362,6 +362,29 @@ void ImplScope::Print(llvm::raw_ostream& out) const {
   }
 }
 
+auto ImplScope::GetInterfacesOfType(Nonnull<const Value*> type) const -> std::vector<Nonnull<const InterfaceType*>>{
+
+  std::vector<Nonnull<const InterfaceType*>> result;
+  if(type->kind() == Value::Kind::NominalClassType ){
+    for (const Impl& impl : impls_) {
+      if(impl.type->kind() == Value::Kind::NominalClassType){
+        const auto & p1 = cast<NominalClassType>(*type);
+        const auto & p2 = cast<NominalClassType>(*impl.type);
+        if(&p1.declaration() == &p2.declaration()){
+         result.push_back(impl.interface);
+        }
+      }
+    }
+    for (const Nonnull<const ImplScope*>& parent : parent_scopes_) {
+       auto part = parent->GetInterfacesOfType(type);
+       for(const auto & x: part){
+          result.push_back(x);
+       }
+    }
+  }
+  return result;
+}
+
 auto SingleStepEqualityContext::VisitEqualValues(
     Nonnull<const Value*> value,
     llvm::function_ref<bool(Nonnull<const Value*>)> visitor) const -> bool {

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -109,7 +109,8 @@ class ImplScope {
 
   void Print(llvm::raw_ostream& out) const;
 
-  auto GetInterfacesOfType(Nonnull<const Value*> type) const -> std::vector<Nonnull<const InterfaceType*>>;
+  auto GetInterfacesOfType(Nonnull<const Value*> type) const
+      -> std::vector<Nonnull<const InterfaceType*>>;
 
   // The `Impl` struct is a key-value pair where the key is the
   // combination of a type and an interface, e.g., `List` and `Container`,

--- a/explorer/interpreter/impl_scope.h
+++ b/explorer/interpreter/impl_scope.h
@@ -109,6 +109,8 @@ class ImplScope {
 
   void Print(llvm::raw_ostream& out) const;
 
+  auto GetInterfacesOfType(Nonnull<const Value*> type) const -> std::vector<Nonnull<const InterfaceType*>>;
+
   // The `Impl` struct is a key-value pair where the key is the
   // combination of a type and an interface, e.g., `List` and `Container`,
   // and the value is the result of statically resolving to the `impl`

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -815,7 +815,7 @@ auto TypeChecker::BuildBuiltinMethodCall(const ImplScope& impl_scope,
 auto TypeChecker::ExpectNonPlaceholderType(SourceLocation source_loc,
                                            Nonnull<const Value*> type)
     -> ErrorOr<Success> {
-  if (!IsPlaceholderType(type)) {
+  if (!IsPlaceholderType(type)  ) {
     return Success();
   }
   if (const auto* member_name = dyn_cast<TypeOfMemberName>(type)) {

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -815,7 +815,7 @@ auto TypeChecker::BuildBuiltinMethodCall(const ImplScope& impl_scope,
 auto TypeChecker::ExpectNonPlaceholderType(SourceLocation source_loc,
                                            Nonnull<const Value*> type)
     -> ErrorOr<Success> {
-  if (!IsPlaceholderType(type)  ) {
+  if (!IsPlaceholderType(type)) {
     return Success();
   }
   if (const auto* member_name = dyn_cast<TypeOfMemberName>(type)) {
@@ -2664,6 +2664,12 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                 access.set_value_category(ValueCategory::Let);
                 break;
               }
+              case DeclarationKind::AliasDeclaration:{
+                //auto* alias_decl = cast<AliasDeclaration>(member);
+                //auto& target = alias_decl->target();
+                access.set_value_category(ValueCategory::Let);
+                break;
+              }
               default:
                 CARBON_FATAL() << "member " << access.member_name()
                                << " is not a field or method";
@@ -2671,9 +2677,37 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
             }
             return Success();
           } else {
-            return ProgramError(e->source_loc())
-                   << "class " << t_class.declaration().name()
-                   << " does not have a field named " << access.member_name();
+            auto ifaces = impl_scope.GetInterfacesOfType(&object_type);
+            if(ifaces.size() > 0){
+              CARBON_ASSIGN_OR_RETURN(
+                  ConstraintLookupResult result,
+                  LookupInConstraint(e->source_loc(), "member access", ifaces[0],
+                                     access.member_name()));
+
+              CARBON_ASSIGN_OR_RETURN(Nonnull<const Witness*> witness,
+                                      impl_scope.Resolve(ifaces[0], &object_type,
+                                                         e->source_loc(), *this));
+
+              CARBON_ASSIGN_OR_RETURN(Nonnull<const Witness*> impl,
+                                      impl_scope.Resolve(ifaces[0], &object_type,
+                                                         e->source_loc(), *this));
+              access.set_member(arena_->New<NamedElement>(result.member));
+              access.set_impl(impl);
+              access.set_found_in_interface(ifaces[0]);
+              const Value& member_type = result.member->static_type();
+              Bindings bindings = result.interface->bindings();
+              bindings.Add(result.interface->declaration().self(),
+                           &object_type, witness);
+              Nonnull<const Value*> inst_member_type =
+                  Substitute(bindings, &member_type);
+              access.set_static_type(inst_member_type);
+              access.set_value_category(ValueCategory::Let);
+              return Success();
+            }else {
+              return ProgramError(e->source_loc())
+                     << "class " << t_class.declaration().name()
+                     << " does not have a field named " << access.member_name();
+            }
           }
         }
         case Value::Kind::VariableType:
@@ -3360,6 +3394,32 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
               << "unknown type of ParameterizedEntityName for " << param_name;
           call.set_static_type(arena_->New<TypeType>());
           call.set_value_category(ValueCategory::Let);
+          return Success();
+        }
+        case Value::Kind::TypeOfMemberName:{
+          const auto& typeOfMember = cast<TypeOfMemberName>(call.function().static_type());
+          switch(typeOfMember.member().type().kind()){
+            case Value::Kind::FunctionType:{
+              const auto& fun_t = cast<FunctionType>(typeOfMember.member().type());
+              CARBON_RETURN_IF_ERROR(DeduceCallBindings(
+                  call, &fun_t.parameters(), fun_t.generic_parameters(),
+                  fun_t.deduced_bindings(), impl_scope));
+
+              // Substitute into the return type to determine the type of the call
+              // expression.
+              Nonnull<const Value*> return_type =
+                  Substitute(call.bindings(), &fun_t.return_type());
+              call.set_static_type(return_type);
+              call.set_value_category(ValueCategory::Let);
+            }
+
+              break;
+            default:
+              return ProgramError(e->source_loc())
+                     << "in call `" << *e
+                     << "`, expected callee to be a function, found `"
+                     << call.function().static_type() << "`";
+          }
           return Success();
         }
         case Value::Kind::ChoiceType: {

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2672,21 +2672,18 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
             return Success();
           } else {
             auto ifaces = impl_scope.GetInterfacesOfType(&object_type);
-            for(const auto & iface : ifaces){
+            for (const auto& iface : ifaces) {
               ErrorOr<ConstraintLookupResult> result =
-              LookupInConstraint(e->source_loc(), "member access",
-                                 iface, access.member_name());
+                  LookupInConstraint(e->source_loc(), "member access", iface,
+                                     access.member_name());
 
+              ErrorOr<Nonnull<const Witness*>> witness = impl_scope.Resolve(
+                  iface, &object_type, e->source_loc(), *this);
 
-              ErrorOr<Nonnull<const Witness*>> witness =
-              impl_scope.Resolve(iface, &object_type, e->source_loc(),
-                                 *this);
+              ErrorOr<Nonnull<const Witness*>> impl = impl_scope.Resolve(
+                  iface, &object_type, e->source_loc(), *this);
 
-              ErrorOr<Nonnull<const Witness*>> impl =
-              impl_scope.Resolve(iface, &object_type, e->source_loc(),
-                                 *this);
-
-              if(result.ok() && witness.ok() && impl.ok()) {
+              if (result.ok() && witness.ok() && impl.ok()) {
                 access.set_member(arena_->New<NamedElement>(result->member));
                 access.set_impl(*impl);
                 access.set_found_in_interface(iface);
@@ -2700,12 +2697,10 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                 access.set_value_category(ValueCategory::Let);
                 return Success();
               }
-
             }
             return ProgramError(e->source_loc())
                    << "class " << t_class.declaration().name()
                    << " does not have a field named " << access.member_name();
-
           }
         }
         case Value::Kind::VariableType:

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2672,7 +2672,7 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
             return Success();
           } else {
             auto ifaces = impl_scope.GetInterfacesOfType(&object_type);
-            if (ifaces.size() > 0) {
+            if (!ifaces.empty()) {
               CARBON_ASSIGN_OR_RETURN(
                   ConstraintLookupResult result,
                   LookupInConstraint(e->source_loc(), "member access",

--- a/explorer/testdata/alias/fail_alias.carbon
+++ b/explorer/testdata/alias/fail_alias.carbon
@@ -1,5 +1,12 @@
 package sample api;
 
+class Foo{
+    fn Create() -> Foo{
+        return {.x = 12};
+    }
+    var x: i32;
+}
+
 interface Printable {
   fn PrintIt[self: Self]();
 }
@@ -10,24 +17,27 @@ impl String as Printable {
   }
 }
 
+impl Foo as Printable{
+   fn PrintIt[self: Foo]() {
+       Print("foo");
+     }
+}
+
 class Vector(T:! type) {
   var x: T;
-
-  alias PrintIt = Printable.PrintIt;
 }
 
 // Conditionally implement the API for certain `T`s.
 impl forall [U:! Printable] Vector(U) as Printable {
   fn PrintIt[self: Self]() {
-    Print("{");
+    Print("(");
     self.x.PrintIt();
-    Print("}");
+    Print(")");
   }
 }
 
 fn Main() -> i32 {
   var v: Vector(String) = {.x = "test"};
-  v.(Printable.PrintIt)();
- // v.PrintIt();
+  v.PrintIt();
   return 42;
 }

--- a/explorer/testdata/alias/fail_alias.carbon
+++ b/explorer/testdata/alias/fail_alias.carbon
@@ -1,0 +1,33 @@
+package sample api;
+
+interface Printable {
+  fn PrintIt[self: Self]();
+}
+
+impl String as Printable {
+  fn PrintIt[self: String]() {
+    Print(self);
+  }
+}
+
+class Vector(T:! type) {
+  var x: T;
+
+  alias PrintIt = Printable.PrintIt;
+}
+
+// Conditionally implement the API for certain `T`s.
+impl forall [U:! Printable] Vector(U) as Printable {
+  fn PrintIt[self: Self]() {
+    Print("{");
+    self.x.PrintIt();
+    Print("}");
+  }
+}
+
+fn Main() -> i32 {
+  var v: Vector(String) = {.x = "test"};
+  v.(Printable.PrintIt)();
+  v.PrintIt();
+  return 42;
+}

--- a/explorer/testdata/alias/fail_alias.carbon
+++ b/explorer/testdata/alias/fail_alias.carbon
@@ -28,6 +28,6 @@ impl forall [U:! Printable] Vector(U) as Printable {
 fn Main() -> i32 {
   var v: Vector(String) = {.x = "test"};
   v.(Printable.PrintIt)();
-  v.PrintIt();
+ // v.PrintIt();
   return 42;
 }

--- a/explorer/testdata/interface/find_interface_impl_for_class.carbon
+++ b/explorer/testdata/interface/find_interface_impl_for_class.carbon
@@ -8,6 +8,7 @@
 // CHECK:STDOUT: (
 // CHECK:STDOUT: test
 // CHECK:STDOUT: )
+// CHECK:STDOUT: Hello World
 // CHECK:STDOUT: result: 42
 
 package ExplorerTest api;
@@ -15,6 +16,11 @@ package ExplorerTest api;
 interface Printable {
   fn PrintIt[self: Self]();
 }
+
+interface Printable2{
+    fn PrintIt2[self: Self]();
+}
+
 
 impl String as Printable {
   fn PrintIt[self: String]() {
@@ -35,8 +41,15 @@ impl forall [U:! Printable] Vector(U) as Printable {
   }
 }
 
+impl forall [U:! Printable] Vector(U) as Printable2 {
+  fn PrintIt2[self: Self]() {
+    Print("Hello World");
+  }
+}
+
 fn Main() -> i32 {
   var v: Vector(String) = {.x = "test"};
   v.PrintIt();
+  v.PrintIt2();
   return 42;
 }

--- a/explorer/testdata/interface/find_interface_impl_for_class.carbon
+++ b/explorer/testdata/interface/find_interface_impl_for_class.carbon
@@ -1,11 +1,16 @@
-package sample api;
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: (
+// CHECK:STDOUT: test
+// CHECK:STDOUT: )
+// CHECK:STDOUT: result: 42
 
-class Foo{
-    fn Create() -> Foo{
-        return {.x = 12};
-    }
-    var x: i32;
-}
+package ExplorerTest api;
 
 interface Printable {
   fn PrintIt[self: Self]();
@@ -15,12 +20,6 @@ impl String as Printable {
   fn PrintIt[self: String]() {
     Print(self);
   }
-}
-
-impl Foo as Printable{
-   fn PrintIt[self: Foo]() {
-       Print("foo");
-     }
 }
 
 class Vector(T:! type) {


### PR DESCRIPTION
Hello folks,
with this PR it is possible to write this Carbon code:

```carbon
package sample api;

interface Printable {
  fn PrintIt[self: Self]();
}

impl String as Printable {
  fn PrintIt[self: String]() {
    Print(self);
  }
}

class Vector(T:! type) {
  var x: T;
}

// Conditionally implement the API for certain `T`s.
impl forall [U:! Printable] Vector(U) as Printable {
  fn PrintIt[self: Self]() {
    Print("{ ");
    self.x.PrintIt();
    Print(" }");
  }
}

fn Main() -> i32 {
  var v: Vector(String) = {.x = "test"};
  v.(Printable.PrintIt)();
  v.PrintIt();
  return 42;
}
```

I hope it is usefull

Releated issues #2583 and #2580