### PR TITLE
replaced `me` with `self`

### DIFF
--- a/docs/design/expressions/indexing.md
+++ b/docs/design/expressions/indexing.md
@@ -50,13 +50,13 @@ Its semantics are defined in terms of the following interfaces:
 ```
 interface IndexWith(SubscriptType:! type) {
   let ElementType:! type;
-  fn At[me: Self](subscript: SubscriptType) -> ElementType;
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType*;
+  fn At[self: Self](subscript: SubscriptType) -> ElementType;
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType*;
 }
 
 interface IndirectIndexWith(SubscriptType:! type) {
   impl as IndexWith(SubscriptType);
-  fn Addr[me: Self](subscript: SubscriptType) -> ElementType*;
+  fn Addr[self: Self](subscript: SubscriptType) -> ElementType*;
 }
 ```
 
@@ -78,11 +78,11 @@ final external impl forall
     [SubscriptType:! type, T:! IndirectIndexWith(SubscriptType)]
     T as IndexWith(SubscriptType) {
   let ElementType:! type = T.(IndirectIndexWith(SubscriptType)).ElementType;
-  fn At[me: Self](subscript: SubscriptType) -> ElementType {
-    return *(me.(IndirectIndexWith(SubscriptType).Addr)(index));
+  fn At[self: Self](subscript: SubscriptType) -> ElementType {
+    return *(self.(IndirectIndexWith(SubscriptType).Addr)(index));
   }
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType* {
-    return me->(IndirectIndexWith(SubscriptType).Addr)(index);
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType* {
+    return self->(IndirectIndexWith(SubscriptType).Addr)(index);
   }
 }
 ```
@@ -98,8 +98,8 @@ An array type could implement subscripting like so:
 class Array(template T:! type) {
   external impl as IndexWith(like i64) {
     let ElementType:! type = T;
-    fn At[me: Self](subscript: i64) -> T;
-    fn Addr[addr me: Self*](subscript: i64) -> T*;
+    fn At[self: Self](subscript: i64) -> T;
+    fn Addr[addr self: Self*](subscript: i64) -> T*;
   }
 }
 ```
@@ -110,7 +110,7 @@ And a type such as `std::span` could look like this:
 class Span(T:! type) {
   external impl as IndirectIndexWith(like i64) {
     let ElementType:! type = T;
-    fn Addr[me: Self](subscript: i64) -> T*;
+    fn Addr[self: Self](subscript: i64) -> T*;
   }
 }
 ```

--- a/docs/design/sum_types.md
+++ b/docs/design/sum_types.md
@@ -111,7 +111,7 @@ interface Match {
   }
 
   let template Continuation:! type;
-  fn Op[me: Self, C:! Continuation](continuation: C*)
+  fn Op[self: Self, C:! Continuation](continuation: C*)
     -> C.(MatchContinuation.ReturnType);
 }
 ```
@@ -146,13 +146,13 @@ class Optional(T:! type) {
   external impl as Match {
     interface Continuation {
       extends Match.BaseContinuation;
-      fn Some[addr me: Self*](value: T) -> ReturnType;
-      fn None[addr me: Self*]() -> ReturnType;
+      fn Some[addr self: Self*](value: T) -> ReturnType;
+      fn None[addr self: Self*]() -> ReturnType;
     }
 
-    fn Op[me: Self, C:! Continuation](continuation: C*) -> C.ReturnType {
-      if (me.has_value) {
-        return continuation->Some(me.value);
+    fn Op[self: Self, C:! Continuation](continuation: C*) -> C.ReturnType {
+      if (self.has_value) {
+        return continuation->Some(self.value);
       } else {
         return continuation->None();
       }

--- a/proposals/p0553.md
+++ b/proposals/p0553.md
@@ -77,7 +77,7 @@ The interface implementation syntax was decided in
 struct Song {
   // data and methods ...
   impl as Printable {
-    method (me: Self) Print() { ... }
+    method (self: Self) Print() { ... }
   }
 }
 external impl Song as Comparable { ... }
@@ -114,7 +114,7 @@ Disadvantages:
 struct Song {
   // data and methods ...
   impl Printable {
-    method (me: Self) Print() { ... }
+    method (self: Self) Print() { ... }
   }
 }
 ```

--- a/proposals/p0722.md
+++ b/proposals/p0722.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             -   [Full receiver type](#full-receiver-type)
             -   [Method names line up](#method-names-line-up)
             -   [Receiver in square brackets](#receiver-in-square-brackets)
-            -   [Receiver parameter is named `me`](#receiver-parameter-is-named-me)
+            -   [Receiver parameter is named `self`](#receiver-parameter-is-named-self)
             -   [Keyword to indicate pass by address](#keyword-to-indicate-pass-by-address)
     -   [Marking mutating methods at the call site](#marking-mutating-methods-at-the-call-site)
     -   [Differences between functions and methods](#differences-between-functions-and-methods)
@@ -165,7 +165,7 @@ the call and the function declaration. That motivated putting the receiver
 pattern inside square brackets (`[`...`]`) with deduced parameters. There were
 concerns, however, that this parameter did not act like deduced parameters.
 
-##### Receiver parameter is named `me`
+##### Receiver parameter is named `self`
 
 Having the receiver name be fixed is helpful for consistency. This benefits
 readers, and simplifies copying or moving code between functions. A fixed
@@ -176,7 +176,7 @@ associated with the type, like
 
 Finally, we wanted the bodies of methods to access members of the object using
 an explicit member access. This means we need the name used to access members to
-be short, and so we chose the name `me`.
+be short, and so we chose the name `self`.
 
 ##### Keyword to indicate pass by address
 
@@ -200,15 +200,15 @@ The marker means "first take the address of the argument and then match the rest
 of the pattern." We considered a few different possible ways to write this:
 
 ```
-fn Set[&me: Self*](n: Int);
-fn Set[*(me: Self*)](n: Int);
-fn Set[ref me: Self*](n: Int);
+fn Set[&self: Self*](n: Int);
+fn Set[*(self: Self*)](n: Int);
+fn Set[ref self: Self*](n: Int);
 ```
 
 We eventually settled on using a keyword `addr`.
 
 ```
-fn Set[addr me: Self*](n: Int);
+fn Set[addr self: Self*](n: Int);
 ```
 
 This doesn't use up a symbol, makes it easier to find in search engines, and

--- a/proposals/p0731.md
+++ b/proposals/p0731.md
@@ -90,7 +90,7 @@ values, matching the use in classes described in proposal
 ```
 interface Stack {
   let ElementType:! Type;
-  fn Push[addr me: Self*](value: ElementType);
+  fn Push[addr self: Self*](value: ElementType);
   ...
 }
 
@@ -98,7 +98,7 @@ class DynamicArray(T:! Type) {
   ...
   impl as Stack {
     let ElementType:! Type = T;
-    fn Push[addr me: Self*](value: ElementType);
+    fn Push[addr self: Self*](value: ElementType);
     ...
   }
 }
@@ -115,7 +115,7 @@ class DynamicArray(T:! Type) {
   ...
   impl as Stack {
     let ElementType:! auto = T;
-    fn Push[addr me: Self*](value: ElementType);
+    fn Push[addr self: Self*](value: ElementType);
     ...
   }
 }
@@ -139,7 +139,7 @@ class DynamicArray(T:! Type) {
   ...
   impl as Stack {
     let ElementType = T;
-    fn Push[addr me: Self*](value: ElementType);
+    fn Push[addr self: Self*](value: ElementType);
     ...
   }
 }
@@ -181,7 +181,7 @@ class DynamicArray(T:! Type) {
   ...
   impl as Stack {
     // Not needed: let ElementType:! Type = T;
-    fn Push[addr me: Self*](value: T);
+    fn Push[addr self: Self*](value: T);
     ...
   }
 }
@@ -198,15 +198,15 @@ since it might not be clear how they should match up, as in this example:
 ```
 interface Has2OverloadsWithDefaults {
   let T:! StackAssociatedType;
-  fn F[me: Self](x: DynamicArray(T), y: T) { ... }
-  fn F[me: Self](x: T, y: T.ElementType) { ... }
+  fn F[self: Self](x: DynamicArray(T), y: T) { ... }
+  fn F[self: Self](x: T, y: T.ElementType) { ... }
 }
 
 class S {
   impl as Has2OverloadsWithDefaults {
      // Unclear if T == DynamicArray(Int) or
      // T == DynamicArray(DynamicArray(Int)).
-     fn F[me: Self](
+     fn F[self: Self](
          x: DynamicArray(DynamicArray(Int)),
          y: DynamicArray(Int)) { ... }
   }

--- a/proposals/p0777.md
+++ b/proposals/p0777.md
@@ -170,7 +170,7 @@ signature:
 
 ```
 base class MyBaseClass {
-  fn Overridable[me: Self]() -> i32 virtual { return 7; }
+  fn Overridable[self: Self]() -> i32 virtual { return 7; }
 }
 ```
 
@@ -336,7 +336,7 @@ invariants of the class have been established for the object.
 ```
 class MyClass extends BaseClass {
   fn init(...) {
-    me.derived_field = ...;
+    self.derived_field = ...;
     super.init(base_arguments);
     phase_2_after_fields_are_set();
   }
@@ -370,7 +370,7 @@ between the parameter list and function body:
 ```
 class MyClass extends BaseClass {
   fn MyClass(...) : base(base_arguments) {
-    me.derived_field = ...;
+    self.derived_field = ...;
     phase_2_after_fields_are_set();
   }
 }

--- a/proposals/p0875.md
+++ b/proposals/p0875.md
@@ -544,9 +544,9 @@ class Base {
   var n: i32;
 }
 class Derived extends Base {
-  // Returns me.(Base.n), not me.(Derived.n), because the latter has not
+  // Returns se;f.(Base.n), not self.(Derived.n), because the latter has not
   // been declared yet.
-  fn Get[me: Self]() -> i32 { return me.n; }
+  fn Get[self: Self]() -> i32 { return self.n; }
   var n: i32;
 }
 ```
@@ -852,7 +852,7 @@ appeared within the class. For example, we would reinterpret:
 
 ```carbon
 class A {
-  fn F[me: Self]() -> i32 { return me.n; }
+  fn F[self: Self]() -> i32 { return self.n; }
   fn Make() -> A { return {.n = 5}; }
   var n: i32;
 }
@@ -862,11 +862,11 @@ exactly as if it were written with the member function bodies out of line:
 
 ```carbon
 class A {
-  fn F[me: Self]() -> i32;
+  fn F[self: Self]() -> i32;
   fn Make() -> A;
   var n: i32;
 }
-fn A.F[me: Self]() -> i32 { return me.n; }
+fn A.F[self: Self]() -> i32 { return self.n; }
 fn A.Make() -> A { return {.n = 5}; }
 ```
 

--- a/proposals/p0920.md
+++ b/proposals/p0920.md
@@ -314,10 +314,10 @@ that impl when a conditional impl's condition does not apply. This would allow
 ```
 class X(T:! Type) {
   impl X(i32) as Foo {
-    fn F[me: Self]();
+    fn F[self: Self]();
   }
   impl X(i64) as Bar {
-    fn F[me: Self](n: i64);
+    fn F[self: Self](n: i64);
   }
 }
 ```

--- a/proposals/p0950.md
+++ b/proposals/p0950.md
@@ -38,13 +38,13 @@ type, as in:
 ```
 interface Deref {
   let Result:! Type;
-  fn DoDeref[me: Self]() -> Result;
+  fn DoDeref[self: Self]() -> Result;
 }
 
 class IntHandle {
   impl Deref {
     let Result:! Type = i32;
-    fn DoDeref[me: Self]() -> Result { ... }
+    fn DoDeref[self: Self]() -> Result { ... }
   }
 }
 ```

--- a/proposals/p0989.md
+++ b/proposals/p0989.md
@@ -81,8 +81,8 @@ behaves as an archetype:
 ```carbon
 interface Hashable {
   let HashValue:! Type;
-  fn Hash[me: Self]() -> HashValue;
-  fn HashInto[me: Self](s: HashState);
+  fn Hash[self: Self]() -> HashValue;
+  fn HashInto[self: Self](s: HashState);
 }
 fn G[T:! Hashable](x: T) {
   // Can perform lookup inside the type-of-type if the type is
@@ -99,8 +99,8 @@ member access is invalid.
 
 ```carbon
 class Potato {
-  fn Mash[me: Self]();
-  fn Hash[me: Self]();
+  fn Mash[self: Self]();
+  fn Hash[self: Self]();
   alias HashValue = Hashable.HashValue;
 }
 external impl Potato as Hashable where .HashValue = u32 {
@@ -209,12 +209,12 @@ we could use various different rules to pick the outcome:
 
 ```
 class Potato {
-  fn Bake[me: Self]();
-  fn Hash[me: Self]();
+  fn Bake[self: Self]();
+  fn Hash[self: Self]();
 }
 interface Hashable {
-  fn Hash[me: Self]() -> HashState;
-  fn HashInto[me: Self](s: HashState);
+  fn Hash[self: Self]() -> HashState;
+  fn HashInto[self: Self](s: HashState);
 }
 external impl Potato as Hashable;
 
@@ -286,13 +286,13 @@ For example:
 ```
 interface MyInterface {
   fn F();
-  fn G[me: Self]();
+  fn G[self: Self]();
 }
 class MyClass {
   alias InterfaceAlias = MyInterface;
   impl as MyInterface {
     fn F();
-    fn G[me: Self]();
+    fn G[self: Self]();
   }
 }
 

--- a/proposals/p1013.md
+++ b/proposals/p1013.md
@@ -160,13 +160,13 @@ class Vector(T:! Type) {
 }
 
 // Probably okay:
-fn Vector(T:! Type).(Container.Begin)[me: Self]() ...
+fn Vector(T:! Type).(Container.Begin)[self: Self]() ...
 
 // Maybe okay:
 class Vector(T:! Type) {
   // Not repeating constraints on .Element and .Iter above:
   impl as Container {
-    fn Begin[me: Self]() ...
+    fn Begin[self: Self]() ...
   }
 }
 ```

--- a/proposals/p1084.md
+++ b/proposals/p1084.md
@@ -152,14 +152,14 @@ interface EdgeInterface;
 // `EdgeInterface`, not its definition.
 interface NodeBootstrap {
   let EdgeType:! EdgeInterface;
-  fn Edges[me: Self]() -> Vector(EdgeType);
+  fn Edges[self: Self]() -> Vector(EdgeType);
 }
 
 // Now can define `EdgeInterface` in terms of
 // `NodeBootstrap`.
 interface EdgeInterface {
   let NodeType:! NodeBootstrap where .EdgeType == Self;
-  fn Head[me: Self]() -> NodeType;
+  fn Head[self: Self]() -> NodeType;
 }
 
 // Make `NodeInterface` a named constraint defined in

--- a/proposals/p1154.md
+++ b/proposals/p1154.md
@@ -154,7 +154,7 @@ in Rust. As a result, the `me` parameter would be marked with a keyword like
 
 ```
 class MyClass {
-  fn MyDestroyer[destroy me: Self](x: i32) -> bool;
+  fn MyDestroyer[destroy self: Self](x: i32) -> bool;
 }
 ```
 
@@ -201,9 +201,9 @@ class Vector(T:! Movable) {
     // Express conditions by using a
     // specific `Self` type.
     destructor [U:! TriviallyDestructible,
-                me: Vector(U)];
+                self: Vector(U)];
     // If first doesn't apply:
-    destructor [me: Self];
+    destructor [self: Self];
   }
 }
 ```
@@ -224,7 +224,7 @@ class Optional(T:! Concrete) {
   // It's perfectly safe, I assure you
   impl [U:! TrivialDestructor] Optional(U) as TrivialDestructor {}
 
-  destructor [me: Self] { if (me.holds_value) value.Destroy(); }
+  destructor [self: Self] { if (self.holds_value) value.Destroy(); }
 }
 ```
 

--- a/proposals/p2173.md
+++ b/proposals/p2173.md
@@ -74,7 +74,7 @@ for the associated type to behave like that concrete type:
 
 ```
 interface Hashable {
-  fn Hash[me: Self]() -> u128;
+  fn Hash[self: Self]() -> u128;
 }
 interface X {
   let R:! Hashable;
@@ -266,7 +266,7 @@ with any mentioned parameters substituted into that type.
 interface Container {
   let Element:! type;
   let Slice:! Container where .Element = Element;
-  fn Add[addr me: Self*](x: Element);
+  fn Add[addr self: Self*](x: Element);
 }
 // `T.Slice.Element` rewritten to `T.Element`
 //     because type of `T.Slice` says `.Element = Element`.
@@ -595,7 +595,7 @@ declared type.
 
 ```
 interface SelfIface {
-  fn Get[me: Self]() -> Self;
+  fn Get[self: Self]() -> Self;
 }
 class UsesSelf(T:! type) {
   // Equivalent to `fn Make() -> UsesSelf(T)*;`
@@ -906,7 +906,7 @@ built-in implementation of `ImplicitAs`:
 
 ```
 final impl forall [T:! type, U:! type where .Self == T] T as ImplicitAs(U) {
-  fn Convert[me: Self](other: U) -> U { ... }
+  fn Convert[self: Self](other: U) -> U { ... }
 }
 ```
 

--- a/proposals/p2188.md
+++ b/proposals/p2188.md
@@ -1081,7 +1081,7 @@ _pattern_ syntax for matching a pointer to a polymorphic class type, meaning
 that we match the dynamic type rather than the static type of the pointer:
 
 ```
-abstract class Base { virtual fn F[me: Self](); }
+abstract class Base { virtual fn F[self: Self](); }
 class Derived1 extends Base {}
 class Derived2 extends Base {}
 
@@ -1300,7 +1300,7 @@ std::ostream& operator<<(std::ostream& stream, const command& cmd) {
 
 ```carbon
 impl command as Printable {
-  fn Print[me: Self](stream: Cpp.std.ostream*) {
+  fn Print[self: Self](stream: Cpp.std.ostream*) {
     match (me) {
       case .set_score(value: u64) => {
         stream->Print("Set the score to {0}.\n", value);
@@ -1654,7 +1654,7 @@ void Node<T>::balance() {
 choice Color { Red, Black }
 
 class Node(T:! Type) {
-  fn balance[addr me: Self*]();
+  fn balance[addr self: Self*]();
 
   var color: Color;
   var lhs: SharedPtr(Node);
@@ -1672,7 +1672,7 @@ fn MakeBalanced[T:! Type](a: SharedPtr(Node(T)), x: T,
           .rhs = MakeShared({.color = Color.Black, .lhs = c, .value = z, .rhs = d})};
 }
 
-fn Node(T:! Type).balance[addr me: Self*]() {
+fn Node(T:! Type).balance[addr self: Self*]() {
   match (*me) {
     {.color = .Black, .lhs = .PtrTo(
       {.color = .Red, .lhs = .PtrTo(
@@ -1709,7 +1709,7 @@ fn Node(T:! Type).balance[addr me: Self*]() {
 choice Color { Red, Black }
 
 class Node(T:! Type) {
-  fn balance[addr me: Self*]();
+  fn balance[addr self: Self*]();
 
   var color: Color;
   var lhs: SharedPtr(Self);
@@ -1719,13 +1719,13 @@ class Node(T:! Type) {
   external impl as Match {
     interface Continuation {
       extends Match.BaseContinuation;
-      fn Red[addr me: Self*](lhs: SharedPtr(Self), value: T, rhs: SharedPtr(Self)) -> ReturnType;
-      fn Black[addr me: Self*](lhs: SharedPtr(Self), value: T, rhs: SharedPtr(Self)) -> ReturnType;
+      fn Red[addr self: Self*](lhs: SharedPtr(Self), value: T, rhs: SharedPtr(Self)) -> ReturnType;
+      fn Black[addr self: Self*](lhs: SharedPtr(Self), value: T, rhs: SharedPtr(Self)) -> ReturnType;
     }
-    fn Op[me: Self, C:! Continuation](continuation: C*) -> C.ReturnType {
-      match (me.color) {
-        case .Red => { return continuation->Red(me.lhs, me.value, me.rhs); }
-        case .Black => { return continuation->Black(me.lhs, me.value, me.rhs); }
+    fn Op[self: Self, C:! Continuation](continuation: C*) -> C.ReturnType {
+      match (self.color) {
+        case .Red => { return continuation->Red(self.lhs, self.value, self.rhs); }
+        case .Black => { return continuation->Black(self.lhs, self.value, self.rhs); }
       }
     }
   }
@@ -1741,7 +1741,7 @@ fn MakeBalanced[T:! Type](a: SharedPtr(Node(T)), x: T,
           .rhs = MakeShared({.color = Color.Black, .lhs = c, .value = z, .rhs = d})};
 }
 
-fn Node(T:! Type).balance[addr me: Self*]() {
+fn Node(T:! Type).balance[addr self: Self*]() {
   match (*me) {
     .Black(.PtrTo(.Red(.PtrTo(.Red(a: auto, x: T, b: auto)), y: T, c: auto)), z: T, d: auto) => {
       *me = MakeBalanced(a, x, b, y, c, z, d);

--- a/proposals/p2200.md
+++ b/proposals/p2200.md
@@ -357,13 +357,13 @@ structural constraints must be found by member lookups in the type. It is not
 sufficient for them to be declared only in an external impl.
 
 ```carbon
-interface A { fn F[me: Self](); }
-interface B { fn F[me: Self](); }
+interface A { fn F[self: Self](); }
+interface B { fn F[self: Self](); }
 class C { }
 external impl C as A;
 external impl C as B;
 template constraint HasF {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 fn G[template T:! HasF](x: T);
 var y: C = {};
@@ -383,10 +383,10 @@ don't change the outcome.
 
 ```carbon
 template constraint HasF {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 class C {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 fn G[template T:! HasF](x: T) {
   x.F();
@@ -413,7 +413,7 @@ of an interface:
 
 ```carbon
 template constraint HasF {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 // ❓ If we allow a checked generic to use a template
 // constraint, as in:
@@ -450,25 +450,25 @@ fn F[template T:! Type](x: T) {
   x.M();
 }
 
-class C1 { fn M[me: Self](); }
+class C1 { fn M[self: Self](); }
 var x1: C1 = {};
 // Calls `F` with `T` equal to `C1`, which succeeds.
 F(x1);
 
-class C2 { fn M[addr me: Self*](); }
+class C2 { fn M[addr self: Self*](); }
 var x2: C2 = {};
 // Calls `F` with `T` equal to `C2`, which fails,
 // since `x` is an r-value in `F` and `C2.M` requires
 // an l-value.
 F(x2);
 
-class C3 { fn M[me: Self](p: i32); }
+class C3 { fn M[self: Self](p: i32); }
 var x3: C3 = {};
 // Calls `F` with `T` equal to `C3`, which fails,
 // since `C3.M` must be passed an argument value.
 F(x3);
 
-class C4 { fn M[me: Self](p: i32 = 4); }
+class C4 { fn M[self: Self](p: i32 = 4); }
 var x4: C4 = {};
 // Calls `F` with `T` equal to `C4`, which succeeds,
 // using the default value of `4` for `p` when
@@ -488,7 +488,7 @@ as in:
 
 ```carbon
 interface A {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 
 fn G[template T:! A](x: T) {
@@ -580,7 +580,7 @@ structural constraint:
 
 ```carbon
 template constraint HasF {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 
 fn G[template T:! HasF](x: T) {
@@ -588,7 +588,7 @@ fn G[template T:! HasF](x: T) {
 }
 
 class C {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 var y: C = {};
 G(y);
@@ -600,21 +600,21 @@ should be qualified to avoid ambiguity errors.
 
 ```carbon
 template constraint HasF {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 
 // New interface
 interface NewF {
-  fn DoF[me: Self]();
+  fn DoF[self: Self]();
 }
 
 // Blanket implementation
 external impl forall [template T:! HasF] T as NewF {
   // If the functions are identical, can instead do:
   //    alias DoF = T.F;
-  fn DoF[me: Self]() {
-    me.F();
-    // Or: me.(T.F)();
+  fn DoF[self: Self]() {
+    self.F();
+    // Or: self.(T.F)();
   }
 }
 
@@ -628,7 +628,7 @@ fn G[template T:! NewF](x: T) {
 }
 
 class C {
-  fn F[me: Self]();
+  fn F[self: Self]();
 }
 var y: C = {};
 // Still works since `C` implements `NewF`
@@ -643,9 +643,9 @@ Then the interface is implemented for types used as parameters:
 class C {
   impl as NewF {
     // `NewF.DoF` will be called by `G`, not `C.F`.
-    fn DoF[me: Self]();
+    fn DoF[self: Self]();
   }
-  // No longer needed: fn F[me: Self]();
+  // No longer needed: fn F[self: Self]();
 }
 // ...
 ```
@@ -658,7 +658,7 @@ can be removed:
 
 // New interface
 interface NewF {
-  fn DoF[me: Self]();
+  fn DoF[self: Self]();
 }
 
 // Blanket implementation no longer needed.
@@ -669,7 +669,7 @@ fn G[template T:! NewF](x: T) {
 
 class C {
   impl as NewF {
-    fn DoF[me: Self]();
+    fn DoF[self: Self]();
   }
 }
 var y: C = {};
@@ -786,16 +786,16 @@ dependent on the template parameter:
 
     ```carbon
     interface Serializable {
-      fn Serialize[me: Self]();
+      fn Serialize[self: Self]();
     }
 
     interface Printable {
-      fn Print[me: Self]();
+      fn Print[self: Self]();
     }
 
     interface Hashable {
       let HashType:! Type;
-      fn Hash[me: Self]() -> HashType;
+      fn Hash[self: Self]() -> HashType;
     }
 
     external impl forall [T:! Serializable] T as Hashable;
@@ -938,7 +938,7 @@ Consider a type with a template type parameter:
 
 ```carbon
 class Vector(template T:! Type) {
-  fn GetPointer[addr me: Self*](index: i32) -> T*;
+  fn GetPointer[addr self: Self*](index: i32) -> T*;
   // ...
 }
 ```
@@ -960,7 +960,7 @@ is correct. This won't in general be true if ad hoc specialization is allowed:
 class Vector(bool) {
   // `let p: T* = vec->GetPointer(0)` won't type check
   // in `SetFirst` with `T == bool`.
-  fn GetPointer[addr me: Self*](index: i32) -> BitProxy;
+  fn GetPointer[addr self: Self*](index: i32) -> BitProxy;
   // ...
 }
 ```
@@ -991,7 +991,7 @@ impl bool as VectorSpecialization
 class Vector(template T:! Type) {
   // Return type of `GetPointer` varies with `T`, but must
   // implement `Deref(T)`.
-  fn GetPointer[addr me: Self*](index: i32)
+  fn GetPointer[addr self: Self*](index: i32)
       -> T.(VectorSpecialization.PointerType) {
     return T.(VectorSpecialization.GetPointer)(me, index);
   }
@@ -1072,11 +1072,11 @@ fn TemplateFunction[template T:! Type](x: T) -> T;
 // `TemplateFunction`.
 
 interface Wrapper {
-  fn F[me: Self]() -> Self;
+  fn F[self: Self]() -> Self;
 }
 
 external impl forall [template T:! Type] T as Wrapper {
-  fn F[me: Self]() -> Self {
+  fn F[self: Self]() -> Self {
     TemplateFunction(me);
   }
 }

--- a/proposals/p2274.md
+++ b/proposals/p2274.md
@@ -107,13 +107,13 @@ Its semantics are defined in terms of the following interfaces:
 ```
 interface IndexWith(SubscriptType:! Type) {
   let ElementType:! Type;
-  fn At[me: Self](subscript: SubscriptType) -> ElementType;
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType*;
+  fn At[self: Self](subscript: SubscriptType) -> ElementType;
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType*;
 }
 
 interface IndirectIndexWith(SubscriptType:! Type) {
   impl as IndexWith(SubscriptType);
-  fn Addr[me: Self](subscript: SubscriptType) -> ElementType*;
+  fn Addr[self: Self](subscript: SubscriptType) -> ElementType*;
 }
 ```
 
@@ -139,11 +139,11 @@ final external impl forall
     [SubscriptType:! Type, T:! IndirectIndexWith(SubscriptType)]
     T as IndexWith(SubscriptType) {
   let ElementType:! Type = T.(IndirectIndexWith(SubscriptType)).ElementType;
-  fn At[me: Self](subscript: SubscriptType) -> ElementType {
-    return *(me.(IndirectIndexWith(SubscriptType).Addr)(index));
+  fn At[self: Self](subscript: SubscriptType) -> ElementType {
+    return *(self.(IndirectIndexWith(SubscriptType).Addr)(index));
   }
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType* {
-    return me->(IndirectIndexWith(SubscriptType).Addr)(index);
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType* {
+    return self->(IndirectIndexWith(SubscriptType).Addr)(index);
   }
 }
 ```
@@ -159,8 +159,8 @@ An array type could implement subscripting like so:
 class Array(template T:! Type) {
   external impl as IndexWith(like i64) {
     let ElementType:! Type = T;
-    fn At[me: Self](subscript: i64) -> T;
-    fn Addr[addr me: Self*](subscript: i64) -> T*;
+    fn At[self: Self](subscript: i64) -> T;
+    fn Addr[addr self: Self*](subscript: i64) -> T*;
   }
 }
 ```
@@ -171,7 +171,7 @@ And a slice type could look like this:
 class Slice(T:! Type) {
   external impl as IndirectIndexWith(like i64) {
     let ElementType:! Type = T;
-    fn Addr[me: Self](subscript: i64) -> T*;
+    fn Addr[self: Self](subscript: i64) -> T*;
   }
 }
 ```
@@ -184,14 +184,14 @@ but we can illustrate how it would look for a particular tuple type, such as
 ```
 external impl (i8, f64) as IndexWith(typeof(0)) {
   let ElementType:! Type = i8;
-  fn At[me: Self](0) -> i8;
-  fn Addr[addr me: Self*](0) -> i8*;
+  fn At[self: Self](0) -> i8;
+  fn Addr[addr self: Self*](0) -> i8*;
 }
 
 external impl (i8, f64) as IndexWith(typeof(1)) {
   let ElementType:! Type = f64;
-  fn At[me: Self](1) -> f64;
-  fn Addr[addr me: Self*](1) -> f64*;
+  fn At[self: Self](1) -> f64;
+  fn Addr[addr self: Self*](1) -> f64*;
 }
 ```
 
@@ -282,13 +282,13 @@ we would need a separate pair of interfaces that return by value:
 ```
 interface RValueIndexWith(SubscriptType:! Type) {
   let ElementType:! Type;
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType;
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType;
 }
 
 interface RValueIndirectIndexWith(SubscriptType:! Type) {
   extends RValueIndexWith(SubscriptType);
   let ElementType:! Type;
-  fn Addr[me: Self](subscript: SubscriptType) -> ElementType;
+  fn Addr[self: Self](subscript: SubscriptType) -> ElementType;
 }
 
 final external impl [SubscriptType:! Type,
@@ -296,8 +296,8 @@ final external impl [SubscriptType:! Type,
     T as IndexWith(SubscriptType) {
   let ElementType:! Type =
       T.(RValueIndirectIndexWith(SubscriptType)).ElementType;
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType {
-    return me->Addr(subscript);
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType {
+    return self->Addr(subscript);
   }
 }
 ```
@@ -343,27 +343,27 @@ form `m[i] = x;`, and defining separate methods for it:
 ```
 interface IndexWith(SubscriptType:! Type) {
   let ElementType:! Type;
-  fn At[me: Self](subscript: SubscriptType) -> ElementType;
-  fn Addr[addr me: Self*](subscript: SubscriptType) -> ElementType*;
-  fn Assign[addr me: Self*](subscript: SubscriptType, element: ElementType) {
-    (*me->Addr(index)) = element;
+  fn At[self: Self](subscript: SubscriptType) -> ElementType;
+  fn Addr[addr self: Self*](subscript: SubscriptType) -> ElementType*;
+  fn Assign[addr self: Self*](subscript: SubscriptType, element: ElementType) {
+    (*self->Addr(index)) = element;
   }
 }
 
 interface IndirectIndexWith(SubscriptType:! Type) {
   extends IndexWith(SubscriptType);
   let ElementType:! Type;
-  fn Addr[me: Self](subscript: SubscriptType) -> ElementType*;
-  fn Assign[me: Self](subscript: SubscriptType, element: ElementType) {
-    me->Addr(subscript) = element;
+  fn Addr[self: Self](subscript: SubscriptType) -> ElementType*;
+  fn Assign[self: Self](subscript: SubscriptType, element: ElementType) {
+    self->Addr(subscript) = element;
   }
 }
 
 final external impl [SubscriptType:! Type, T:! IndirectIndexWith(SubscriptType)]
     T as IndexWith(SubscriptType) {
   ...
-  fn Assign[addr me: Self*](subscript: SubscriptType, element: ElementType) {
-    me->(IndirectIndexWith.AssignAsRValue)(subscript, element);
+  fn Assign[addr self: Self*](subscript: SubscriptType, element: ElementType) {
+    self->(IndirectIndexWith.AssignAsRValue)(subscript, element);
   }
 }
 ```

--- a/proposals/p2287.md
+++ b/proposals/p2287.md
@@ -68,17 +68,17 @@ classes.
 
 ```carbon
 interface Vector {
-  fn Scale[me: Self](v: f64) -> Self;
+  fn Scale[self: Self](v: f64) -> Self;
   // Default definition of `Invert` calls `Scale`.
-  default fn Invert[me: Self]() -> Self;
+  default fn Invert[self: Self]() -> Self;
 }
 
 // `Self` is valid here because it's doing unqualified name lookup into
 // `Vector`.
-default fn Vector.Invert[me: Self]() -> Self {
+default fn Vector.Invert[self: Self]() -> Self {
   // `Scale` is valid here because it does unqualified name lookup into
   // `Vector`, then an instance binding with `me`.
-  return me.(Scale)(-1.0);
+  return self.(Scale)(-1.0);
 }
 ```
 

--- a/proposals/p2360.md
+++ b/proposals/p2360.md
@@ -286,7 +286,7 @@ whether a value is a type.
 ```
 interface Iface {
   fn Static();
-  fn Method[me: Self]();
+  fn Method[self: Self]();
 }
 
 impl type as Iface { ... }
@@ -317,7 +317,7 @@ fn F[T:! Iface](x: T) {
 
 base class Base {
   fn Static();
-  fn Method[me: Self]();
+  fn Method[self: Self]();
   alias IfaceStatic = Iface.Static;
   alias IfaceMethod = Iface.Method;
 }
@@ -496,13 +496,13 @@ method or class function member of the class.
 
 ```
 interface A {
-  fn F[me: Self]();
+  fn F[self: Self]();
   fn S();
 }
 class B {
   external impl as A;
   alias G = A.F;
-  fn H[me: Self]();
+  fn H[self: Self]();
   alias T = A.S;
   fn U();
 }


### PR DESCRIPTION
replaced `me` with `self` across documentation.