### PR TITLE
replace `Run` with `Main`

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2114,7 +2114,7 @@ Parts of this declaration may be omitted:
     the default package.
 
 -   If the library keyword is not specified, as in `package Geometry api;`, this
-    file contributes to the default library.
+    file contributes to the default library of the package.
 
 -   If a file has no package declaration at all, it is the `api` file belonging
     to the default package and default library. This is particularly for tests
@@ -2123,8 +2123,8 @@ Parts of this declaration may be omitted:
     using a `package impl;` package declaration.
 
 A program need not use the default package, but if it does, it should contain
-the entry-point function. By default, the entry-point function is `Run` from the
-default package.
+the entry-point function. By default, the entry-point function is `Main` from
+the default package.
 
 > References:
 >

--- a/docs/spec/lang/execution.md
+++ b/docs/spec/lang/execution.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Entry points
 
-TODO: Entry points (Carbon and foreign). `fn Run()`.
+TODO: Entry points (Carbon and foreign). `fn Main()`.
 
 ## Object model
 


### PR DESCRIPTION
replace `Run` with `Main`
and default library is default to a package.