### PR TITLE
Add ErrorHandling include for some build configurations.

### DIFF
--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -4,6 +4,7 @@
 
 #include "common/check_internal.h"
 
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Signals.h"
 
 namespace Carbon::Internal {


### PR DESCRIPTION
While this isn't required by Carbon's normal build, others may require it for llvm_unreachable due to newer llvm versions.