### PR TITLE
Adjust phrasing to remove brew assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ As there is no compiler yet, to try out Carbon, you can use the Carbon explorer
 to interpret Carbon code and print its output. You can try it out immediately at
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
-To build the Carbon explorer yourself, follow these instructions:
+To build the Carbon explorer yourself, you'll need to get some dependencies setup (Bazel, Clang, libc++), and then you can follow these instructions:
 
 ```shell
 # Download Carbon's code.

--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ $ cd carbon-lang
 $ bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
 ```
 
-These instructions assume dependencies like bazel, llvm, and libc++ are
-installed; see our
+For complete instructions, including getting the dependencies setup, see our
 [contribution tools documentation](/docs/project/contribution_tools.md) for more
 extensive tooling instructions.
 

--- a/README.md
+++ b/README.md
@@ -273,14 +273,6 @@ to interpret Carbon code and print its output. You can try it out immediately at
 To build the Carbon explorer yourself, follow these instructions:
 
 ```shell
-# Install bazelisk using Homebrew.
-$ brew install bazelisk
-
-# Install Clang/LLVM using Homebrew.
-# Many Clang/LLVM releases aren't built with options we rely on.
-$ brew install llvm
-$ export PATH="$(brew --prefix llvm)/bin:${PATH}"
-
 # Download Carbon's code.
 $ git clone https://github.com/carbon-language/carbon-lang
 $ cd carbon-lang
@@ -289,7 +281,8 @@ $ cd carbon-lang
 $ bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
 ```
 
-These instructions assume [Homebrew](https://brew.sh/) is installed; see our
+These instructions assume dependencies like bazel, llvm, and libc++ are
+installed; see our
 [contribution tools documentation](/docs/project/contribution_tools.md) for more
 extensive tooling instructions.
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ to interpret Carbon code and print its output. You can try it out immediately at
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
 To build the Carbon explorer yourself, you'll need to install dependencies
-(Bazel, Clang, libc++), and then you can follow these instructions:
+(Bazel, Clang, libc++), and then you can run:
 
 ```shell
 # Download Carbon's code.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ As there is no compiler yet, to try out Carbon, you can use the Carbon explorer
 to interpret Carbon code and print its output. You can try it out immediately at
 [compiler-explorer.com](http://carbon.compiler-explorer.com/).
 
-To build the Carbon explorer yourself, you'll need to get some dependencies setup (Bazel, Clang, libc++), and then you can follow these instructions:
+To build the Carbon explorer yourself, you'll need to install dependencies
+(Bazel, Clang, libc++), and then you can follow these instructions:
 
 ```shell
 # Download Carbon's code.
@@ -281,9 +282,8 @@ $ cd carbon-lang
 $ bazel run //explorer -- ./explorer/testdata/print/format_only.carbon
 ```
 
-For complete instructions, including getting the dependencies setup, see our
-[contribution tools documentation](/docs/project/contribution_tools.md) for more
-extensive tooling instructions.
+For complete instructions, including installing dependencies, see our
+[contribution tools documentation](/docs/project/contribution_tools.md).
 
 Learn more about the Carbon project:
 


### PR DESCRIPTION
These instructions have fallen out of sync with the note that we've stopped recommending brew for linux (due to build issues). Rather than having instructions that only work for MacOS, take the bare minimum and just point at contribution_tools.md.

chandlerc, I believe you'd specifically requested the instructions here as part of #1390. An alternative approach would be to remove this entirely, and just say "See our contribution tools page for instructions on how to build locally."

i-khadra's change #2636 is what made me notice this issue. They're trying to add Windows notes to the README, but this change reflects my leaning it's better to let contribution_tools.md explain setup.