### PR TITLE
Replace ParseContext with an examination of state_stack_.

### DIFF
--- a/toolchain/parser/parser.h
+++ b/toolchain/parser/parser.h
@@ -46,10 +46,8 @@ class Parser {
   // Supported kinds for HandlePattern.
   enum class PatternKind { Parameter, Variable };
 
-  // Gives information about the language construct/context being parsed. For
-  // now, a simple enum but can be extended later to provide more information as
-  // necessary.
-  enum class ParseContext {
+  // Supported return values for GetDeclarationContext.
+  enum class DeclarationContext {
     File,  // Top-level context.
     Interface,
   };
@@ -258,6 +256,9 @@ class Parser {
         << "Excessive stack size: likely infinite loop";
   }
 
+  // Returns the current declaration context according to state_stack_.
+  auto GetDeclarationContext() -> DeclarationContext;
+
   // Propagates an error up the state stack, to the parent state.
   auto ReturnErrorOnState() -> void { state_stack_.back().has_error = true; }
 
@@ -328,8 +329,6 @@ class Parser {
   TokenizedBuffer::TokenIterator end_;
 
   llvm::SmallVector<StateStackEntry> state_stack_;
-  // TODO: This can be a mini-stack of contexts rather than a simple variable.
-  ParseContext stack_context_;
 };
 
 }  // namespace Carbon

--- a/toolchain/parser/parser.h
+++ b/toolchain/parser/parser.h
@@ -257,6 +257,9 @@ class Parser {
   }
 
   // Returns the current declaration context according to state_stack_.
+  // This is expected to be called in cases which are close to a context.
+  // Although it looks like it could be O(n) for state_stack_'s depth, valid
+  // parses should only need to look down a couple steps.
   auto GetDeclarationContext() -> DeclarationContext;
 
   // Propagates an error up the state stack, to the parent state.


### PR DESCRIPTION
Per [discussion](https://discord.com/channels/655572317891461132/655578254970716160/1078427629427904563), there's a preference for having the support this enables in the parser. For example, that the parser should detect and error on a non-default interface function's definition.

However, we do need to handle nesting of declarations. We could do that by making this a stack. I think though that it'll be more efficient to keep using state_stack_, since it'll be called in places which are a limited number of steps from the actual state. That may already be in cache since we frequently look at state_stack_, so I'm uncertain that maintaining an additional stack would be a net benefit.