### PR TITLE
Do a cleanup of the x-macro enum comments.

### DIFF
--- a/toolchain/lexer/token_kind.def
+++ b/toolchain/lexer/token_kind.def
@@ -2,25 +2,28 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Note that this is an X-macro header.
+// This is an X-macro header. It does not use `#include` guards, and instead is
+// designed to be `#include`ed after the x-macro is defined in order for its
+// inclusion to expand to the desired output. Macro definitions are cleaned up
+// at the end of this file.
 //
-// It does not use `#include` guards, and instead is designed to be `#include`ed
-// after some set of x-macros are defined in order for its inclusion to expand
-// to the desired output.
+// Supported x-macros are:
+// - CARBON_TOKEN(Name)
+//   Defines a token. Used directly when a token needs custom parsing, such as
+//   integer literals.
+//   - CARBON_SYMBOL_TOKEN(Name, Spelling)
+//     Defines a symbol which has the provided spelling, such as `*`. Spellings
+//     must be unique.
+//     - CARBON_OPENING_GROUP_SYMBOL_TOKEN(Name, Spelling, ClosingName)
+//     - CARBON_CLOSING_GROUP_SYMBOL_TOKEN(Name, Spelling, OpeningName)
+//       These two macros together define matches opening and closing symbols,
+//       such as `(` and `)`, and create an association between the two.
+//   - CARBON_KEYWORD_TOKEN(Name, Spelling)
+//     Defines a keyword which has the provided spelling, such as `if`.
+//     Spellings must be unique.
 //
-// The viable X-macros to define prior to including the header are:
-//
-// - `CARBON_TOKEN`
-//   - `CARBON_SYMBOL_TOKEN`
-//     - `CARBON_OPENING_GROUP_SYMBOL_TOKEN`
-//     - `CARBON_CLOSING_GROUP_SYMBOL_TOKEN`
-//   - `CARBON_KEYWORD_TOKEN`
-//
-// This tree represents the subset relationship between these macros.
-//
-// Regardless of which of these macros is defined prior to inclusion, all of the
-// definitions will be removed at the end of including this file to clean up the
-// set of defined macros.
+// This tree represents the subset relationship between these macros, where if a
+// specific x-macro isn't defined, it'll fall back to the parent macro.
 
 #ifndef CARBON_TOKEN
 #define CARBON_TOKEN(Name)

--- a/toolchain/parser/parse_node_kind.def
+++ b/toolchain/parser/parse_node_kind.def
@@ -2,23 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Note that this is an X-macro header.
+// This is an X-macro header. It does not use `#include` guards, and instead is
+// designed to be `#include`ed after the x-macro is defined in order for its
+// inclusion to expand to the desired output. Macro definitions are cleaned up
+// at the end of this file.
 //
-// It does not use `#include` guards, and instead is designed to be `#include`ed
-// after the x-macro is defined in order for its inclusion to expand to the
-// desired output.
-//
-// x-macros come in three forms:
-//   CARBON_PARSE_NODE_KIND(Name)
-//     Used as a fallback if other macros are missing.
-//   CARBON_PARSE_NODE_KIND_BRACKET(Name, BracketName)
-//     Defines a bracketed node kind. BracketName should refer to the node kind
-//     that is the _start_ of the bracketed range.
-//   CARBON_PARSE_NODE_KIND_CHILD_COUNT(Name, ChildCount)
+// Supported x-macros are:
+// - CARBON_PARSE_NODE_KIND(Name)
+//   Used as a fallback if other macros are missing. No kinds should use this
+//   directly.
+//   - CARBON_PARSE_NODE_KIND_BRACKET(Name, BracketName)
+//     Defines a bracketed node kind. BracketName should refer to the node
+//     kind that is the _start_ of the bracketed range.
+//   - CARBON_PARSE_NODE_KIND_CHILD_COUNT(Name, ChildCount)
 //     Defines a parse node with a set number of children, often 0. This count
 //     must be correct even when the node contains errors.
 //
-// Macro definitions  will be removed at the end of this file to clean up.
+// This tree represents the subset relationship between these macros, where if a
+// specific x-macro isn't defined, it'll fall back to the parent macro.
+//
+// Parse nodes are clustered based on language feature. Comments will show their
+// relationship in postorder, using indentation for child node relationships.
 
 #if !(defined(CARBON_PARSE_NODE_KIND) ||          \
       (defined(CARBON_PARSE_NODE_KIND_BRACKET) && \
@@ -251,7 +255,6 @@ CARBON_PARSE_NODE_KIND_CHILD_COUNT(PostfixOperator, 1)
 //   StructFieldValue
 //   StructComma
 // StructLiteral
-//
 //
 // Struct type literals, such as `{.a: i32}`:
 //       _external_: DesignatedName

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -2,12 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Note that this is an X-macro header.
+// This is an X-macro header. It does not use `#include` guards, and instead is
+// designed to be `#include`ed after the x-macro is defined in order for its
+// inclusion to expand to the desired output. Macro definitions are cleaned up
+// at the end of this file.
 //
-// It does not use `#include` guards, and instead is designed to be `#include`ed
-// after the x-macro is defined in order for its inclusion to expand to the
-// desired output. The x-macro for this header is `CARBON_PARSE_NODE_KIND`. The
-// definition provided will be removed at the end of this file to clean up.
+// Supported x-macros are:
+// - CARBON_PARSER_STATE(Name)
+//   Defines a parser state.
+//
+// Parser states may be clustered when there are multiple related variants,
+// named `StateAsVariant`. When there are variants, they share a common helper
+// function for most logic.
+//
+// Comments will describe a series of possible output states. States are listed
+// in the order they'll be executed; in other words, `1` is the top of the state
+// stack. The comment `(state done)` indicates that no new states are added to
+// the stack.
+//
+// Where state output is conditional on a lexed token, the name of
+// the TokenKind should be used rather than the string name in order to make it
+// easier to compare with code.
 
 #ifndef CARBON_PARSER_STATE
 #error "Must define the x-macro to use this file."

--- a/toolchain/semantics/semantics_builtin_kind.def
+++ b/toolchain/semantics/semantics_builtin_kind.def
@@ -2,21 +2,21 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Note that this is an X-macro header.
+// This is an X-macro header. It does not use `#include` guards, and instead is
+// designed to be `#include`ed after the x-macro is defined in order for its
+// inclusion to expand to the desired output. Macro definitions are cleaned up
+// at the end of this file.
 //
-// It does not use `#include` guards, and instead is designed to be `#include`ed
-// after the x-macro is defined in order for its inclusion to expand to the
-// desired output.
-//
-// x-macros come in two forms:
-//   CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)
-//     Used as a fallback if other macros are missing.
-//   CARBON_SEMANTICS_BUILTIN_KIND(Name, Type)
+// Supported x-macros are:
+// - CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)
+//   Used as a fallback if other macros are missing. Used directly by Invalid
+//   only, which is defined last.
+//   - CARBON_SEMANTICS_BUILTIN_KIND(Name, Type)
 //     Defines a builtin kind with the associated type, which must also be
 //     builtin.
 //
-// Note that Invalid is provided with CARBON_SEMANTICS_BUILTIN_KIND_NAME but not
-// CARBON_SEMANTICS_BUILTIN_KIND.
+// This tree represents the subset relationship between these macros, where if a
+// specific x-macro isn't defined, it'll fall back to the parent macro.
 
 #if !(defined(CARBON_SEMANTICS_BUILTIN_KIND_NAME) || \
       defined(CARBON_SEMANTICS_BUILTIN_KIND))

--- a/toolchain/semantics/semantics_node_kind.def
+++ b/toolchain/semantics/semantics_node_kind.def
@@ -2,12 +2,14 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Note that this is an X-macro header.
+// This is an X-macro header. It does not use `#include` guards, and instead is
+// designed to be `#include`ed after the x-macro is defined in order for its
+// inclusion to expand to the desired output. Macro definitions are cleaned up
+// at the end of this file.
 //
-// It does not use `#include` guards, and instead is designed to be `#include`ed
-// after the x-macro is defined in order for its inclusion to expand to the
-// desired output. The x-macro for this header is `CARBON_PARSE_NODE_KIND`. The
-// definition provided will be removed at the end of this file to clean up.
+// Supported x-macros are:
+// - CARBON_SEMANTICS_NODE_KIND(Name)
+//   Defines a node kind.
 
 #ifndef CARBON_SEMANTICS_NODE_KIND
 #error "Must define the x-macro to use this file."


### PR DESCRIPTION
Trying to make some boilerplate-y comments more boilerplate, and also explain what's in the files a little more.