### PR TITLE
some issues in docs-file, replacing orange with apple

### DIFF
--- a/docs/design/control_flow/conditionals.md
+++ b/docs/design/control_flow/conditionals.md
@@ -65,7 +65,7 @@ This code will:
     -   When `False`, evaluate `fruit.IsOrange()`:
         -   When `True`, print `Orange!` and resume execution at `fruit.Eat()`.
         -   When `False`, evaluate `fruit.IsGreen()`:
-            -   When `True`, print `Orange!` and resume execution at
+            -   When `True`, print `Apple!` and resume execution at
                 `fruit.Eat()`.
             -   When `False`, print `Vegetable!` and resume execution at
                 `fruit.Eat()`.


### PR DESCRIPTION
**### There is issue in conditionals.md readme file** 
**In example of fruits conditionals** 
                            **there are fruits.IsGreen() if it is False then continue. 
                            if it is True then print "Apple" but in readme file there is "Orange"** 


I replaced "Orange" with "Apple" because in example there is "Apple" 
                    ```carbon
                                if (fruit.IsYellow()) {
                                  Print("Banana!");
                                } else if (fruit.IsOrange()) {
                                  Print("Orange!");
                                } else if (fruit.IsGreen()) {
                                  Print("Apple!");
                                } else {
                                  Print("Vegetable!");
                                }
                       fruit.Eat();
                        ```

Closes #ISSUE
