### PR TITLE
Decouple `Value` from interpreter-specific representation of continuations.

### DIFF
--- a/explorer/interpreter/BUILD
+++ b/explorer/interpreter/BUILD
@@ -41,11 +41,18 @@ cc_library(
 
 cc_library(
     name = "action_stack",
-    srcs = ["action_stack.cpp"],
-    hdrs = ["action_stack.h"],
+    srcs = [
+        "action_stack.cpp",
+        "stack_fragment.cpp",
+    ],
+    hdrs = [
+        "action_stack.h",
+        "stack_fragment.h",
+    ],
     deps = [
         ":action_and_value",
         ":stack",
+        "//common:check",
         "//common:error",
         "//common:ostream",
         "//explorer/ast",

--- a/explorer/interpreter/action_stack.cpp
+++ b/explorer/interpreter/action_stack.cpp
@@ -95,7 +95,7 @@ void ActionStack::MergeScope(RuntimeScope scope) {
   CARBON_FATAL() << "No current scope";
 }
 
-void ActionStack::InitializeFragment(ContinuationValue::StackFragment& fragment,
+void ActionStack::InitializeFragment(StackFragment& fragment,
                                      Nonnull<const Statement*> body) {
   std::vector<Nonnull<const RuntimeScope*>> scopes;
   for (const std::unique_ptr<Action>& action : todo_) {
@@ -271,7 +271,7 @@ auto ActionStack::Resume(Nonnull<const ContinuationValue*> continuation)
     -> ErrorOr<Success> {
   Action& action = *todo_.Top();
   action.set_pos(action.pos() + 1);
-  continuation->stack().RestoreTo(todo_);
+  static_cast<StackFragment&>(continuation->representation()).RestoreTo(todo_);
   return Success();
 }
 
@@ -290,7 +290,8 @@ auto ActionStack::Suspend() -> ErrorOr<Success> {
   const auto& continuation =
       llvm::cast<const ContinuationValue>(*todo_.Top()->results()[0]);
   // Update the continuation with the paused stack.
-  continuation.stack().StoreReversed(std::move(paused));
+  static_cast<StackFragment&>(continuation.representation())
+      .StoreReversed(std::move(paused));
   return Success();
 }
 

--- a/explorer/interpreter/action_stack.h
+++ b/explorer/interpreter/action_stack.h
@@ -12,6 +12,7 @@
 #include "common/ostream.h"
 #include "explorer/ast/statement.h"
 #include "explorer/interpreter/action.h"
+#include "explorer/interpreter/stack_fragment.h"
 #include "explorer/interpreter/value.h"
 
 namespace Carbon {
@@ -57,7 +58,7 @@ class ActionStack {
 
   // Initializes `fragment` so that, when resumed, it begins execution of
   // `body`.
-  void InitializeFragment(ContinuationValue::StackFragment& fragment,
+  void InitializeFragment(StackFragment& fragment,
                           Nonnull<const Statement*> body);
 
   // The result produced by the `action` argument of the most recent

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -26,6 +26,7 @@
 #include "explorer/interpreter/action.h"
 #include "explorer/interpreter/action_stack.h"
 #include "explorer/interpreter/stack.h"
+#include "explorer/interpreter/stack_fragment.h"
 #include "explorer/interpreter/value.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Casting.h"
@@ -180,7 +181,7 @@ class Interpreter {
   // The underlying states of continuation values. All StackFragments created
   // during execution are tracked here, in order to safely deallocate the
   // contents of any non-completed continuations at the end of execution.
-  std::vector<Nonnull<ContinuationValue::StackFragment*>> stack_fragments_;
+  std::vector<Nonnull<StackFragment*>> stack_fragments_;
 
   Nonnull<TraceStream*> trace_stream_;
   Phase phase_;
@@ -188,7 +189,7 @@ class Interpreter {
 
 Interpreter::~Interpreter() {
   // Clean up any remaining suspended continuations.
-  for (Nonnull<ContinuationValue::StackFragment*> fragment : stack_fragments_) {
+  for (Nonnull<StackFragment*> fragment : stack_fragments_) {
     fragment->Clear();
   }
 }
@@ -2051,7 +2052,7 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
       const auto& continuation = cast<Continuation>(stmt);
       // Create a continuation object by creating a frame similar the
       // way one is created in a function call.
-      auto* fragment = arena_->New<ContinuationValue::StackFragment>();
+      auto* fragment = arena_->New<StackFragment>();
       stack_fragments_.push_back(fragment);
       todo_.InitializeFragment(*fragment, &continuation.body());
       // Bind the continuation object to the continuation variable

--- a/explorer/interpreter/stack_fragment.cpp
+++ b/explorer/interpreter/stack_fragment.cpp
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "explorer/interpreter/stack_fragment.h"
+
+#include "common/check.h"
+#include "llvm/ADT/StringExtras.h"
+
+namespace Carbon {
+
+StackFragment::~StackFragment() {
+  CARBON_CHECK(reversed_todo_.empty())
+      << "All StackFragments must be empty before the Carbon program ends.";
+}
+
+void StackFragment::StoreReversed(
+    std::vector<std::unique_ptr<Action>> reversed_todo) {
+  CARBON_CHECK(reversed_todo_.empty());
+  reversed_todo_ = std::move(reversed_todo);
+}
+
+void StackFragment::RestoreTo(Stack<std::unique_ptr<Action>>& todo) {
+  while (!reversed_todo_.empty()) {
+    todo.Push(std::move(reversed_todo_.back()));
+    reversed_todo_.pop_back();
+  }
+}
+
+void StackFragment::Clear() {
+  // We destroy the underlying Actions explicitly to ensure they're
+  // destroyed in the correct order.
+  for (auto& action : reversed_todo_) {
+    action.reset();
+  }
+  reversed_todo_.clear();
+}
+
+void StackFragment::Print(llvm::raw_ostream& out) const {
+  out << "{";
+  llvm::ListSeparator sep(" :: ");
+  for (const std::unique_ptr<Action>& action : reversed_todo_) {
+    out << sep << *action;
+  }
+  out << "}";
+}
+
+}  // namespace Carbon

--- a/explorer/interpreter/stack_fragment.h
+++ b/explorer/interpreter/stack_fragment.h
@@ -1,0 +1,51 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_EXPLORER_INTERPRETER_STACK_FRAGMENT_H_
+#define CARBON_EXPLORER_INTERPRETER_STACK_FRAGMENT_H_
+
+#include <memory>
+#include <vector>
+
+#include "explorer/interpreter/action.h"
+#include "explorer/interpreter/stack.h"
+#include "explorer/interpreter/value.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace Carbon {
+
+// A continuation value behaves like a pointer to the underlying stack
+// fragment, which is exposed by `Stack()`.
+class StackFragment : public ContinuationValue::Representation {
+ public:
+  // Constructs an empty StackFragment.
+  StackFragment() = default;
+
+  // Requires *this to be empty, because by the time we're tearing down the
+  // Arena, it's no longer safe to invoke ~Action.
+  ~StackFragment() override;
+
+  // Store the given partial todo stack in *this, which must currently be
+  // empty. The stack is represented with the top of the stack at the
+  // beginning of the vector, the reverse of the usual order.
+  void StoreReversed(std::vector<std::unique_ptr<Action>> reversed_todo);
+
+  // Restore the currently stored stack fragment to the top of `todo`,
+  // leaving *this empty.
+  void RestoreTo(Stack<std::unique_ptr<Action>>& todo);
+
+  // Destroy the currently stored stack fragment.
+  void Clear();
+
+  void Print(llvm::raw_ostream& out) const override;
+
+ private:
+  // The todo stack of a suspended continuation, starting with the top
+  // Action.
+  std::vector<std::unique_ptr<Action>> reversed_todo_;
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_EXPLORER_INTERPRETER_STACK_FRAGMENT_H_

--- a/explorer/interpreter/value.cpp
+++ b/explorer/interpreter/value.cpp
@@ -674,7 +674,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       break;
     }
     case Value::Kind::ContinuationValue: {
-      out << cast<ContinuationValue>(*this).stack();
+      out << cast<ContinuationValue>(*this).representation();
       break;
     }
     case Value::Kind::StringType:
@@ -729,43 +729,6 @@ void IntrinsicConstraint::Print(llvm::raw_ostream& out) const {
     }
     out << ")";
   }
-}
-
-ContinuationValue::StackFragment::~StackFragment() {
-  CARBON_CHECK(reversed_todo_.empty())
-      << "All StackFragments must be empty before the Carbon program ends.";
-}
-
-void ContinuationValue::StackFragment::StoreReversed(
-    std::vector<std::unique_ptr<Action>> reversed_todo) {
-  CARBON_CHECK(reversed_todo_.empty());
-  reversed_todo_ = std::move(reversed_todo);
-}
-
-void ContinuationValue::StackFragment::RestoreTo(
-    Stack<std::unique_ptr<Action>>& todo) {
-  while (!reversed_todo_.empty()) {
-    todo.Push(std::move(reversed_todo_.back()));
-    reversed_todo_.pop_back();
-  }
-}
-
-void ContinuationValue::StackFragment::Clear() {
-  // We destroy the underlying Actions explicitly to ensure they're
-  // destroyed in the correct order.
-  for (auto& action : reversed_todo_) {
-    action.reset();
-  }
-  reversed_todo_.clear();
-}
-
-void ContinuationValue::StackFragment::Print(llvm::raw_ostream& out) const {
-  out << "{";
-  llvm::ListSeparator sep(" :: ");
-  for (const std::unique_ptr<Action>& action : reversed_todo_) {
-    out << sep << *action;
-  }
-  out << "}";
 }
 
 // Check whether two binding maps, which are assumed to have the same keys, are

--- a/explorer/interpreter/value.h
+++ b/explorer/interpreter/value.h
@@ -1424,7 +1424,10 @@ class AssociatedConstant : public Value {
 // interpreter.
 class ContinuationValue : public Value {
  public:
-  // The representation of a continuation is derived from this.
+  // Base class for the representation of a continuation, which is not defined
+  // here for layering reasons. The interpreter provides the derived class
+  // `StackFragment` that defines the concrete representation, which is
+  // expected to be the only derived class outside of tests.
   class Representation {
    public:
     virtual ~Representation() {}

--- a/explorer/interpreter/value_transform.h
+++ b/explorer/interpreter/value_transform.h
@@ -141,9 +141,9 @@ class ValueTransform : public TransformBase<Derived> {
     return node;
   }
 
-  auto operator()(Nonnull<ContinuationValue::StackFragment*> stack_fragment)
-      -> Nonnull<ContinuationValue::StackFragment*> {
-    return stack_fragment;
+  auto operator()(Nonnull<ContinuationValue::Representation*> continuation)
+      -> Nonnull<ContinuationValue::Representation*> {
+    return continuation;
   }
 
   auto operator()(Address addr) -> Address { return addr; }


### PR DESCRIPTION
`ContinuationValue` is the only dependency that `Value`s have on implementation details of the interpreter, and removing this allows `Value` to be moved from interpreter/ to ast/, as [discussed on #explorer](https://discord.com/channels/655572317891461132/763516049710120960/1081326038858092624).