### PR TITLE
Replace the map of lowered nodes with an array.

### DIFF
--- a/toolchain/lowering/lowering.cpp
+++ b/toolchain/lowering/lowering.cpp
@@ -14,7 +14,7 @@ Lowering::Lowering(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
       llvm_module_(std::make_unique<llvm::Module>(module_name, llvm_context)),
       builder_(llvm_context),
       semantics_ir_(&semantics_ir),
-      lowered_nodes_(semantics_ir_->nodes_size()) {
+      lowered_nodes_(semantics_ir_->nodes_size(), nullptr) {
   CARBON_CHECK(!semantics_ir.has_errors())
       << "Generating LLVM IR from invalid SemanticsIR is unsupported.";
 }

--- a/toolchain/lowering/lowering.cpp
+++ b/toolchain/lowering/lowering.cpp
@@ -13,7 +13,8 @@ Lowering::Lowering(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
     : llvm_context_(&llvm_context),
       llvm_module_(std::make_unique<llvm::Module>(module_name, llvm_context)),
       builder_(llvm_context),
-      semantics_ir_(&semantics_ir) {
+      semantics_ir_(&semantics_ir),
+      lowered_nodes_(semantics_ir_->nodes_size()) {
   CARBON_CHECK(!semantics_ir.has_errors())
       << "Generating LLVM IR from invalid SemanticsIR is unsupported.";
 }
@@ -151,7 +152,7 @@ auto Lowering::HandleIntegerLiteralNode(SemanticsNodeId node_id,
   llvm::APInt i = semantics_ir_->GetIntegerLiteral(int_id);
   llvm::Value* v =
       llvm::ConstantInt::get(builder_.getInt32Ty(), i.getLimitedValue());
-  node_values_[node_id] = v;
+  lowered_nodes_[node_id.index] = v;
 }
 
 auto Lowering::HandleRealLiteralNode(SemanticsNodeId /*node_id*/,
@@ -167,7 +168,7 @@ auto Lowering::HandleReturnNode(SemanticsNodeId /*node_id*/,
 auto Lowering::HandleReturnExpressionNode(SemanticsNodeId /*node_id*/,
                                           SemanticsNode node) -> void {
   SemanticsNodeId expr_id = node.GetAsReturnExpression();
-  builder_.CreateRet(node_values_[expr_id]);
+  builder_.CreateRet(lowered_nodes_[expr_id.index]);
 }
 
 auto Lowering::HandleStringLiteralNode(SemanticsNodeId /*node_id*/,

--- a/toolchain/lowering/lowering.h
+++ b/toolchain/lowering/lowering.h
@@ -27,25 +27,6 @@ class Lowering {
   auto Run() -> std::unique_ptr<llvm::Module>;
 
  private:
-  // Provides DenseMapInfo for SemanticsNodeId.
-  struct SemanticsNodeIdMapInfo {
-    static inline auto getEmptyKey() -> SemanticsNodeId {
-      return SemanticsNodeId(llvm::DenseMapInfo<int32_t>::getEmptyKey());
-    }
-    static inline auto getTombstoneKey() -> SemanticsNodeId {
-      return SemanticsNodeId(llvm::DenseMapInfo<int32_t>::getTombstoneKey());
-    }
-
-    static auto getHashValue(const SemanticsNodeId& val) -> unsigned {
-      return llvm::DenseMapInfo<int32_t>::getHashValue(val.index);
-    }
-
-    static auto isEqual(const SemanticsNodeId& lhs, const SemanticsNodeId& rhs)
-        -> bool {
-      return lhs == rhs;
-    }
-  };
-
   // Declare handlers for each SemanticsIR node.
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
   auto Handle##Name##Node(SemanticsNodeId node_id, SemanticsNode node)->void;
@@ -69,12 +50,8 @@ class Lowering {
   llvm::SmallVector<std::pair<llvm::BasicBlock*, SemanticsNodeBlockId>>
       todo_blocks_;
 
-  // A mapping of nodes to designated values.
-  // TODO: It might be worth considering other approaches, or at least if we
-  // stick with this we'll probably want to clean up nodes as they leave scope.
-  // However, for now, it's handy to make things work.
-  llvm::DenseMap<SemanticsNodeId, llvm::Value*, SemanticsNodeIdMapInfo>
-      node_values_;
+  // Maps nodes in SemanticsIR to a lowered value.
+  llvm::SmallVector<llvm::Value*> lowered_nodes_;
 };
 
 }  // namespace Carbon

--- a/toolchain/lowering/lowering.h
+++ b/toolchain/lowering/lowering.h
@@ -50,7 +50,13 @@ class Lowering {
   llvm::SmallVector<std::pair<llvm::BasicBlock*, SemanticsNodeBlockId>>
       todo_blocks_;
 
-  // Maps nodes in SemanticsIR to a lowered value.
+  // Maps nodes in SemanticsIR to a lowered value. This will have one entry per
+  // node, and will be non-null when lowered. It's expected to be sparse during
+  // execution because while expressions will have entries, statements won't.
+  // TODO: This will probably become a PointerUnion of Value and Type.
+  // TODO: Long-term, we may want to examine the trade-offs of making this a
+  // map, but for now a vector is easy to manage, gets cache efficiency, and may
+  // ultimately be the best choice.
   llvm::SmallVector<llvm::Value*> lowered_nodes_;
 };
 

--- a/toolchain/lowering/lowering.h
+++ b/toolchain/lowering/lowering.h
@@ -54,9 +54,10 @@ class Lowering {
   // node, and will be non-null when lowered. It's expected to be sparse during
   // execution because while expressions will have entries, statements won't.
   // TODO: This will probably become a PointerUnion of Value and Type.
-  // TODO: Long-term, we may want to examine the trade-offs of making this a
-  // map, but for now a vector is easy to manage, gets cache efficiency, and may
-  // ultimately be the best choice.
+  // TODO: Long-term, we should examine the practical trade-offs of making this
+  // a map; a map may end up lower memory consumption, but a vector offers cache
+  // efficiency and better performance. As a consequence, the right choice is
+  // unclear.
   llvm::SmallVector<llvm::Value*> lowered_nodes_;
 };
 

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -104,6 +104,8 @@ class SemanticsIR {
     return strings_[string_id.index];
   }
 
+  auto nodes_size() const -> int { return nodes_.size(); }
+
   auto top_node_block_id() const -> SemanticsNodeBlockId {
     return top_node_block_id_;
   }


### PR DESCRIPTION
This is something we'd discussed. I added a TODO that we may want to eventually make this a map, but I remain uncertain and think it's not something that's going to really cost us if we end up switching back. In the meantime, I think this approach does offer simplicity. As discussed too, the performance overhead of a map may ultimately not be worthwhile here versus the relative memory costs.