### PR TITLE
fixing word for greater and greater than equal symbol from comparison_operators doc

### DIFF
--- a/docs/design/expressions/comparison_operators.md
+++ b/docs/design/expressions/comparison_operators.md
@@ -40,8 +40,8 @@ standard mathematical meaning:
 | Equality   | `!=`     | `x != y` | ≠                    | Inequality or not equal to |
 | Relational | `<`      | `x < y`  | <                    | Less than                  |
 | Relational | `<=`     | `x <= y` | ≤                    | Less than or equal to      |
-| Relational | `>`      | `x > y`  | >                    | Less than                  |
-| Relational | `>=`     | `x >= y` | ≥                    | Less than or equal to      |
+| Relational | `>`      | `x > y`  | >                    | Greater than               |
+| Relational | `>=`     | `x >= y` | ≥                    | Greater than or equal to   |
 
 Comparison operators all return a `bool`; they evaluate to `true` when the
 indicated comparison is true. All comparison operators are infix binary


### PR DESCRIPTION
### Greater symbol issue in doc file of comparison_operators

In doc, symbol of greater or greater than equal is write but word is miswritten  
so i just fix the word which is miswritten.

Closes #greater and greater than or equal in comparison_operators doc