### PR TITLE
Modernize the LLVM `lit` build rule.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,6 +121,7 @@ http_archive(
     patches = [
         "@carbon//bazel/patches/llvm:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
         "@carbon//bazel/patches/llvm:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
+        "@carbon//bazel/patches/llvm:0003_Modernize_py_binary_rule_for_lit.patch",
     ],
     sha256 = "8b2fa8ae3e434577b4fdd1e91b8990b0651776bd78cf4fbf9b709dcdcdbfbd21",
     strip_prefix = "llvm-project-{0}".format(llvm_version),

--- a/bazel/patches/llvm/0003_Modernize_py_binary_rule_for_lit.patch
+++ b/bazel/patches/llvm/0003_Modernize_py_binary_rule_for_lit.patch
@@ -1,0 +1,29 @@
+From 6cf44cd419a6171ced8e830cd9bdcb2da2667a0b Mon Sep 17 00:00:00 2001
+From: Chandler Carruth <chandlerc@gmail.com>
+Date: Sun, 12 Mar 2023 10:33:27 +0000
+Subject: [PATCH] Modernize `py_binary` rule for `lit`.
+
+This adds the a `main` attribute to clarify where the script should
+start execution, and more importantly adds the `imports` list to setup
+`PYTHONPATH` correctly for the tool's `import`s to find the internal
+libraries.
+---
+ utils/bazel/llvm-project-overlay/llvm/BUILD.bazel | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+index c4b1998e647f..ae615f23a98c 100644
+--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+@@ -4555,6 +4555,8 @@ py_binary(
+     name = "lit",
+     testonly = True,
+     srcs = ["utils/lit/lit.py"] + glob(["utils/lit/lit/**/*.py"]),
++    imports = ["utils/lit"],
++    main = "utils/lit/lit.py",
+ )
+ 
+ cc_library(
+-- 
+2.39.2
+


### PR DESCRIPTION
This resolves an issue I was seeing where none of the `lit` based test executions could import the `lit` module. The `imports` attribute this adds seems like the essential part, but I added both while there.

I'm not sure if this is the right fix though as no one else seems to have been having trouble and worried this is actually something weird with my setup that is broken. Ideas or suggestions welcome!