### PR TITLE
Add a macro to simplify XAsY variant state generation

### DIFF
--- a/toolchain/parser/parser.cpp
+++ b/toolchain/parser/parser.cpp
@@ -1391,7 +1391,7 @@ auto Parser::HandleParenExpressionState() -> void {
     state.state = ParserState::ParenExpressionFinishAsTuple;
     PushState(state);
   } else {
-    state.state = ParserState::ParenExpressionFinish;
+    state.state = ParserState::ParenExpressionFinishAsNormal;
     PushState(state);
     PushState(ParserState::ParenExpressionParameterFinishAsUnknown);
     PushState(ParserState::Expression);
@@ -1414,7 +1414,8 @@ auto Parser::HandleParenExpressionParameterFinish(bool as_tuple) -> void {
     state.state = ParserState::ParenExpressionParameterFinishAsTuple;
 
     auto finish_state = PopState();
-    CARBON_CHECK(finish_state.state == ParserState::ParenExpressionFinish)
+    CARBON_CHECK(finish_state.state ==
+                 ParserState::ParenExpressionFinishAsNormal)
         << "Unexpected parent state, found: " << finish_state.state;
     finish_state.state = ParserState::ParenExpressionFinishAsTuple;
     PushState(finish_state);
@@ -1435,7 +1436,7 @@ auto Parser::HandleParenExpressionParameterFinishAsTupleState() -> void {
   HandleParenExpressionParameterFinish(/*as_tuple=*/true);
 }
 
-auto Parser::HandleParenExpressionFinishState() -> void {
+auto Parser::HandleParenExpressionFinishAsNormalState() -> void {
   auto state = PopState();
 
   AddNode(ParseNodeKind::ParenExpression, Consume(), state.subtree_start,

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -28,6 +28,15 @@
 #error "Must define the x-macro to use this file."
 #endif
 
+// Invokes CARBON_PARSER_STATE to generate StateAsCase1, StateAsCase2, ...
+// states.
+#define CARBON_PARSER_STATE_CASES2(State, Case1, Case2) \
+  CARBON_PARSER_STATE(State##As##Case1)                 \
+  CARBON_PARSER_STATE(State##As##Case2)
+#define CARBON_PARSER_STATE_CASES3(State, Case1, ...) \
+  CARBON_PARSER_STATE(State##As##Case1)               \
+  CARBON_PARSER_STATE_CASES2(State, __VA_ARGS__)
+
 // Handles the `{` of a brace expression.
 //
 // If `CloseCurlyBrace`:
@@ -46,9 +55,7 @@ CARBON_PARSER_STATE(BraceExpression)
 //   2. BraceExpressionParameterAfterDesignatorAs(Type|Value|Unknown)
 // Else:
 //   1. BraceExpressionParameterFinishAs(Type|Value|Unknown)
-CARBON_PARSER_STATE(BraceExpressionParameterAsType)
-CARBON_PARSER_STATE(BraceExpressionParameterAsValue)
-CARBON_PARSER_STATE(BraceExpressionParameterAsUnknown)
+CARBON_PARSER_STATE_CASES3(BraceExpressionParameter, Type, Value, Unknown)
 
 // Handles a brace expression parameter after the initial designator. This
 // should be at a `:` or `=`, depending on whether it's a type or value literal.
@@ -58,9 +65,8 @@ CARBON_PARSER_STATE(BraceExpressionParameterAsUnknown)
 //   2. BraceExpressionParameterFinishAs(Type|Value|Unknown)
 // Else:
 //   1. BraceExpressionParameterFinishAs(Type|Value|Unknown)
-CARBON_PARSER_STATE(BraceExpressionParameterAfterDesignatorAsType)
-CARBON_PARSER_STATE(BraceExpressionParameterAfterDesignatorAsValue)
-CARBON_PARSER_STATE(BraceExpressionParameterAfterDesignatorAsUnknown)
+CARBON_PARSER_STATE_CASES3(BraceExpressionParameterAfterDesignator, Type, Value,
+                           Unknown)
 
 // Handles the end of a brace expression parameter.
 //
@@ -68,17 +74,13 @@ CARBON_PARSER_STATE(BraceExpressionParameterAfterDesignatorAsUnknown)
 //   1. BraceExpressionParameterAsUnknown
 // Else:
 //   (state done)
-CARBON_PARSER_STATE(BraceExpressionParameterFinishAsType)
-CARBON_PARSER_STATE(BraceExpressionParameterFinishAsValue)
-CARBON_PARSER_STATE(BraceExpressionParameterFinishAsUnknown)
+CARBON_PARSER_STATE_CASES3(BraceExpressionParameterFinish, Type, Value, Unknown)
 
 // Handles the `}` of a brace expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE(BraceExpressionFinishAsType)
-CARBON_PARSER_STATE(BraceExpressionFinishAsValue)
-CARBON_PARSER_STATE(BraceExpressionFinishAsUnknown)
+CARBON_PARSER_STATE_CASES3(BraceExpressionFinish, Type, Value, Unknown)
 
 // Handles a call expression `(...)`.
 //
@@ -171,8 +173,7 @@ CARBON_PARSER_STATE(DeducedParameterListFinish)
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE(DesignatorAsExpression)
-CARBON_PARSER_STATE(DesignatorAsStruct)
+CARBON_PARSER_STATE_CASES2(Designator, Expression, Struct)
 
 // Handles processing of an expression.
 //
@@ -358,15 +359,13 @@ CARBON_PARSER_STATE(Package)
 // Always:
 //   1. Expression
 //   2. ParenConditionAs(If|While)Finish
-CARBON_PARSER_STATE(ParenConditionAsIf)
-CARBON_PARSER_STATE(ParenConditionAsWhile)
+CARBON_PARSER_STATE_CASES2(ParenCondition, If, While)
 
 // Finishes the processing of a `(condition)` after the expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE(ParenConditionFinishAsIf)
-CARBON_PARSER_STATE(ParenConditionFinishAsWhile)
+CARBON_PARSER_STATE_CASES2(ParenConditionFinish, If, While)
 
 // Handles the `(` of a parenthesized expression.
 //
@@ -391,15 +390,13 @@ CARBON_PARSER_STATE(ParenExpression)
 //   SPECIAL: Parent becomes ParenExpressionFinishAsTuple
 // Else `CloseParen`:
 //   (state done)
-CARBON_PARSER_STATE(ParenExpressionParameterFinishAsUnknown)
-CARBON_PARSER_STATE(ParenExpressionParameterFinishAsTuple)
+CARBON_PARSER_STATE_CASES2(ParenExpressionParameterFinish, Unknown, Tuple)
 
 // Handles the `)` of a parenthesized expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE(ParenExpressionFinish)
-CARBON_PARSER_STATE(ParenExpressionFinishAsTuple)
+CARBON_PARSER_STATE_CASES2(ParenExpressionFinish, Normal, Tuple)
 
 // Handles pattern parsing for a pattern, enqueuing type expression processing.
 // This covers parameter and `var` support.
@@ -409,9 +406,8 @@ CARBON_PARSER_STATE(ParenExpressionFinishAsTuple)
 //   2. PatternFinish
 // Else:
 //   1. PatternFinish
-CARBON_PARSER_STATE(PatternAsDeducedParameter)
-CARBON_PARSER_STATE(PatternAsFunctionParameter)
-CARBON_PARSER_STATE(PatternAsVariable)
+CARBON_PARSER_STATE_CASES3(Pattern, DeducedParameter, FunctionParameter,
+                           Variable)
 
 // Handles `addr` in a pattern.
 //
@@ -581,8 +577,7 @@ CARBON_PARSER_STATE(StatementWhileBlockFinish)
 //   1. PatternAsVariable
 //   2. VarAfterPattern
 //   3. VarFinishAs(Semicolon|For)
-CARBON_PARSER_STATE(VarAsSemicolon)
-CARBON_PARSER_STATE(VarAsFor)
+CARBON_PARSER_STATE_CASES2(Var, Semicolon, For)
 
 // Handles `var` after the pattern, either followed by an initializer or the
 // semicolon.
@@ -597,7 +592,6 @@ CARBON_PARSER_STATE(VarAfterPattern)
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE(VarFinishAsSemicolon)
-CARBON_PARSER_STATE(VarFinishAsFor)
+CARBON_PARSER_STATE_CASES2(VarFinish, Semicolon, For)
 
 #undef CARBON_PARSER_STATE

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -28,7 +28,7 @@
 #error "Must define the x-macro to use this file."
 #endif
 
-// Use CARBON_PARSER_STATE_VARIANTS#(State, Variant1, Variant2, ...) to generate
+// Use CARBON_PARSER_STATE_VARIANTSN(State, Variant1, Variant2, ...) to generate
 // StateAsVariant1, StateAsVariant2, ... states.
 #define CARBON_PARSER_STATE_VARIANT(State, Variant) \
   CARBON_PARSER_STATE(State##As##Variant)

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -35,9 +35,9 @@
 #define CARBON_PARSER_STATE_VARIANTS2(State, Variant1, Variant2) \
   CARBON_PARSER_STATE_VARIANT(State, Variant1)                   \
   CARBON_PARSER_STATE_VARIANT(State, Variant2)
-#define CARBON_PARSER_STATE_VARIANTS3(State, Variant1, ...) \
-  CARBON_PARSER_STATE_VARIANT(State, Variant1)              \
-  CARBON_PARSER_STATE_VARIANTS2(State, __VA_ARGS__)
+#define CARBON_PARSER_STATE_VARIANTS3(State, Variant1, Variant2, Variant3) \
+  CARBON_PARSER_STATE_VARIANT(State, Variant1)                             \
+  CARBON_PARSER_STATE_VARIANTS2(State, Variant2, Variant3)
 
 // Handles the `{` of a brace expression.
 //

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -28,13 +28,17 @@
 #error "Must define the x-macro to use this file."
 #endif
 
+// Helper for CARBON_PARSER_STATE_CASES# to do the actual StateAsCase.
+#define CARBON_PARSER_STATE_CASE(State, Case) \
+  CARBON_PARSER_STATE(State##As##Case)
+
 // Invokes CARBON_PARSER_STATE to generate StateAsCase1, StateAsCase2, ...
 // states.
 #define CARBON_PARSER_STATE_CASES2(State, Case1, Case2) \
-  CARBON_PARSER_STATE(State##As##Case1)                 \
-  CARBON_PARSER_STATE(State##As##Case2)
+  CARBON_PARSER_STATE_CASE(State, Case1)                \
+  CARBON_PARSER_STATE_CASE(State, Case2)
 #define CARBON_PARSER_STATE_CASES3(State, Case1, ...) \
-  CARBON_PARSER_STATE(State##As##Case1)               \
+  CARBON_PARSER_STATE_CASE(State, Case1)              \
   CARBON_PARSER_STATE_CASES2(State, __VA_ARGS__)
 
 // Handles the `{` of a brace expression.

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -28,18 +28,16 @@
 #error "Must define the x-macro to use this file."
 #endif
 
-// Helper for CARBON_PARSER_STATE_CASES# to do the actual StateAsCase.
-#define CARBON_PARSER_STATE_CASE(State, Case) \
-  CARBON_PARSER_STATE(State##As##Case)
-
-// Invokes CARBON_PARSER_STATE to generate StateAsCase1, StateAsCase2, ...
-// states.
-#define CARBON_PARSER_STATE_CASES2(State, Case1, Case2) \
-  CARBON_PARSER_STATE_CASE(State, Case1)                \
-  CARBON_PARSER_STATE_CASE(State, Case2)
-#define CARBON_PARSER_STATE_CASES3(State, Case1, ...) \
-  CARBON_PARSER_STATE_CASE(State, Case1)              \
-  CARBON_PARSER_STATE_CASES2(State, __VA_ARGS__)
+// Use CARBON_PARSER_STATE_VARIANTS#(State, Variant1, Variant2, ...) to generate
+// StateAsVariant1, StateAsVariant2, ... states.
+#define CARBON_PARSER_STATE_VARIANT(State, Variant) \
+  CARBON_PARSER_STATE(State##As##Variant)
+#define CARBON_PARSER_STATE_VARIANTS2(State, Variant1, Variant2) \
+  CARBON_PARSER_STATE_VARIANT(State, Variant1)                   \
+  CARBON_PARSER_STATE_VARIANT(State, Variant2)
+#define CARBON_PARSER_STATE_VARIANTS3(State, Variant1, ...) \
+  CARBON_PARSER_STATE_VARIANT(State, Variant1)              \
+  CARBON_PARSER_STATE_VARIANTS2(State, __VA_ARGS__)
 
 // Handles the `{` of a brace expression.
 //
@@ -59,7 +57,7 @@ CARBON_PARSER_STATE(BraceExpression)
 //   2. BraceExpressionParameterAfterDesignatorAs(Type|Value|Unknown)
 // Else:
 //   1. BraceExpressionParameterFinishAs(Type|Value|Unknown)
-CARBON_PARSER_STATE_CASES3(BraceExpressionParameter, Type, Value, Unknown)
+CARBON_PARSER_STATE_VARIANTS3(BraceExpressionParameter, Type, Value, Unknown)
 
 // Handles a brace expression parameter after the initial designator. This
 // should be at a `:` or `=`, depending on whether it's a type or value literal.
@@ -69,8 +67,8 @@ CARBON_PARSER_STATE_CASES3(BraceExpressionParameter, Type, Value, Unknown)
 //   2. BraceExpressionParameterFinishAs(Type|Value|Unknown)
 // Else:
 //   1. BraceExpressionParameterFinishAs(Type|Value|Unknown)
-CARBON_PARSER_STATE_CASES3(BraceExpressionParameterAfterDesignator, Type, Value,
-                           Unknown)
+CARBON_PARSER_STATE_VARIANTS3(BraceExpressionParameterAfterDesignator, Type,
+                              Value, Unknown)
 
 // Handles the end of a brace expression parameter.
 //
@@ -78,13 +76,14 @@ CARBON_PARSER_STATE_CASES3(BraceExpressionParameterAfterDesignator, Type, Value,
 //   1. BraceExpressionParameterAsUnknown
 // Else:
 //   (state done)
-CARBON_PARSER_STATE_CASES3(BraceExpressionParameterFinish, Type, Value, Unknown)
+CARBON_PARSER_STATE_VARIANTS3(BraceExpressionParameterFinish, Type, Value,
+                              Unknown)
 
 // Handles the `}` of a brace expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE_CASES3(BraceExpressionFinish, Type, Value, Unknown)
+CARBON_PARSER_STATE_VARIANTS3(BraceExpressionFinish, Type, Value, Unknown)
 
 // Handles a call expression `(...)`.
 //
@@ -177,7 +176,7 @@ CARBON_PARSER_STATE(DeducedParameterListFinish)
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE_CASES2(Designator, Expression, Struct)
+CARBON_PARSER_STATE_VARIANTS2(Designator, Expression, Struct)
 
 // Handles processing of an expression.
 //
@@ -363,13 +362,13 @@ CARBON_PARSER_STATE(Package)
 // Always:
 //   1. Expression
 //   2. ParenConditionAs(If|While)Finish
-CARBON_PARSER_STATE_CASES2(ParenCondition, If, While)
+CARBON_PARSER_STATE_VARIANTS2(ParenCondition, If, While)
 
 // Finishes the processing of a `(condition)` after the expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE_CASES2(ParenConditionFinish, If, While)
+CARBON_PARSER_STATE_VARIANTS2(ParenConditionFinish, If, While)
 
 // Handles the `(` of a parenthesized expression.
 //
@@ -394,13 +393,13 @@ CARBON_PARSER_STATE(ParenExpression)
 //   SPECIAL: Parent becomes ParenExpressionFinishAsTuple
 // Else `CloseParen`:
 //   (state done)
-CARBON_PARSER_STATE_CASES2(ParenExpressionParameterFinish, Unknown, Tuple)
+CARBON_PARSER_STATE_VARIANTS2(ParenExpressionParameterFinish, Unknown, Tuple)
 
 // Handles the `)` of a parenthesized expression.
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE_CASES2(ParenExpressionFinish, Normal, Tuple)
+CARBON_PARSER_STATE_VARIANTS2(ParenExpressionFinish, Normal, Tuple)
 
 // Handles pattern parsing for a pattern, enqueuing type expression processing.
 // This covers parameter and `var` support.
@@ -410,8 +409,8 @@ CARBON_PARSER_STATE_CASES2(ParenExpressionFinish, Normal, Tuple)
 //   2. PatternFinish
 // Else:
 //   1. PatternFinish
-CARBON_PARSER_STATE_CASES3(Pattern, DeducedParameter, FunctionParameter,
-                           Variable)
+CARBON_PARSER_STATE_VARIANTS3(Pattern, DeducedParameter, FunctionParameter,
+                              Variable)
 
 // Handles `addr` in a pattern.
 //
@@ -581,7 +580,7 @@ CARBON_PARSER_STATE(StatementWhileBlockFinish)
 //   1. PatternAsVariable
 //   2. VarAfterPattern
 //   3. VarFinishAs(Semicolon|For)
-CARBON_PARSER_STATE_CASES2(Var, Semicolon, For)
+CARBON_PARSER_STATE_VARIANTS2(Var, Semicolon, For)
 
 // Handles `var` after the pattern, either followed by an initializer or the
 // semicolon.
@@ -596,6 +595,6 @@ CARBON_PARSER_STATE(VarAfterPattern)
 //
 // Always:
 //   (state done)
-CARBON_PARSER_STATE_CASES2(VarFinish, Semicolon, For)
+CARBON_PARSER_STATE_VARIANTS2(VarFinish, Semicolon, For)
 
 #undef CARBON_PARSER_STATE


### PR DESCRIPTION
This is just a mild simplification to address repeat macro use. I'm hoping it makes it clearer and easier in parser_state.def to write down the multiple variants.

I'm writing these macros in a simple form that I think is easy to read, versus some complex macro recursion which I think is _possible_ but would be harder to reason. And, we don't really need arbitrary arg counts -- this is probably going to stay fairly limited long-term, although I could easily see something like a half dozen in some cases so maybe I'll be wrong and it'll go higher. But, I feel like these macros still make it easier to focus on the _intent_ of cases, rather than visually comparing each line for differences.

(note, I'm also really tempted to replace the `As` with `_`, happy to take thoughts on that)