### PR TITLE
Remove check_diagnostic's chdir which interferes with pre-commit.

### DIFF
--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -4,6 +4,8 @@
 
 Validates that each diagnostic declared with CARBON_DIAGNOSTIC_KIND is
 referenced by one (and only one) CARBON_DIAGNOSTIC.
+
+This expects to be run from the repo root by pre-commit.
 """
 
 __copyright__ = """
@@ -16,7 +18,6 @@ import collections
 from concurrent import futures
 import itertools
 from pathlib import Path
-import os
 import re
 import sys
 from typing import Dict, List, NamedTuple, Set
@@ -104,8 +105,6 @@ def check_unused(decls: Set[str], uses: Dict[str, List[Location]]) -> bool:
 
 
 def main() -> None:
-    # Run from the repo root.
-    os.chdir(Path(__file__).parent.parent.parent)
     decls = load_diagnostic_kind()
     uses = load_diagnostic_uses()
 


### PR DESCRIPTION
I think the chdir was going to a different copy than what pre-commit is trying to validate. This seems to fix an issue where I wasn't seeing errors that I expected when changing diagnostic behavior.