### PR TITLE
Fix check-diagnostics for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
               toolchain/.*\.cpp|
               toolchain/.*\.h|
               toolchain/diagnostics/check_diagnostics\.py|
-              toolchain/diagnostics/diagnostic_registry\.def
+              toolchain/diagnostics/diagnostic_kind\.def
           )$
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,8 +103,10 @@ repos:
           (?x)^(
               toolchain/.*\.cpp|
               toolchain/.*\.h|
+              toolchain/diagnostics/check_diagnostics\.py|
               toolchain/diagnostics/diagnostic_registry\.def
           )$
+        pass_filenames: false
 
   # Run linters last, as formatters and other checks may fix issues.
   - repo: local

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -106,6 +106,7 @@ def check_unused(decls: Set[str], uses: Dict[str, List[Location]]) -> bool:
 
 
 def main() -> None:
+    # Run from the repo root.
     os.chdir(Path(__file__).parent.parent.parent)
     decls = load_diagnostic_kind()
     uses = load_diagnostic_uses()

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -98,9 +98,11 @@ def check_uniqueness(uses: Dict[str, List[Location]]) -> bool:
 def check_unused(decls: Set[str], uses: Dict[str, List[Location]]) -> bool:
     """If any diagnostic is unused, prints an error and returns true."""
     unused = decls.difference(uses.keys())
+    if not unused:
+        return False
     for diag in sorted(unused):
         print(f"Unused diagnostic: {diag}")
-    return bool(unused)
+    return True
 
 
 def main() -> None:

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -4,6 +4,8 @@
 
 Validates that each diagnostic declared with CARBON_DIAGNOSTIC_KIND is
 referenced by one (and only one) CARBON_DIAGNOSTIC.
+
+This expects to be run from the repo root by pre-commit.
 """
 
 __copyright__ = """
@@ -15,8 +17,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import collections
 from concurrent import futures
 import itertools
-from pathlib import Path
 import os
+from pathlib import Path
 import re
 import sys
 from typing import Dict, List, NamedTuple, Set
@@ -100,11 +102,10 @@ def check_unused(decls: Set[str], uses: Dict[str, List[Location]]) -> bool:
     unused = decls.difference(uses.keys())
     for diag in sorted(unused):
         print(f"Unused diagnostic: {diag}")
-    return False
+    return bool(unused)
 
 
 def main() -> None:
-    # Run from the repo root.
     os.chdir(Path(__file__).parent.parent.parent)
     decls = load_diagnostic_kind()
     uses = load_diagnostic_uses()

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -4,8 +4,6 @@
 
 Validates that each diagnostic declared with CARBON_DIAGNOSTIC_KIND is
 referenced by one (and only one) CARBON_DIAGNOSTIC.
-
-This expects to be run from the repo root by pre-commit.
 """
 
 __copyright__ = """

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -84,9 +84,6 @@ CARBON_DIAGNOSTIC_KIND(ExpectedDeclarationName)
 CARBON_DIAGNOSTIC_KIND(ExpectedDeclarationSemiOrDefinition)
 CARBON_DIAGNOSTIC_KIND(MethodImplNotAllowed)
 
-// Class and interface diagnostics
-// TODO
-
 // ============================================================================
 // Semantics diagnostics
 // ============================================================================

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -85,7 +85,7 @@ CARBON_DIAGNOSTIC_KIND(ExpectedDeclarationSemiOrDefinition)
 CARBON_DIAGNOSTIC_KIND(MethodImplNotAllowed)
 
 // Class and interface diagnostics
-CARBON_DIAGNOSTIC_KIND(ExpectedDeducedParam)
+// TODO
 
 // ============================================================================
 // Semantics diagnostics


### PR DESCRIPTION
Unused diagnostics were incorrectly always returning "false" regardless of whether there was an issue. It was still looking for registry file changes, not kind file changes. Also, this should only be run once per pre-commit run (pass_filenames=false).

Remove the one unused diagnostic.