### PR TITLE
Add context to errors when instantiating a template

### DIFF
--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -1060,6 +1060,10 @@ class ConstraintType : public Value {
              equality_constraints_, rewrite_constraints_, lookup_contexts_);
   }
 
+  auto souce_loc() const -> SourceLocation {
+    return self_binding_->source_loc();
+  }
+
   auto self_binding() const -> Nonnull<const GenericBinding*> {
     return self_binding_;
   }

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -1060,10 +1060,6 @@ class ConstraintType : public Value {
              equality_constraints_, rewrite_constraints_, lookup_contexts_);
   }
 
-  auto souce_loc() const -> SourceLocation {
-    return self_binding_->source_loc();
-  }
-
   auto self_binding() const -> Nonnull<const GenericBinding*> {
     return self_binding_;
   }

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -6340,7 +6340,6 @@ auto TypeChecker::InstantiateImplDeclaration(
   CARBON_RETURN_IF_ERROR(type_checker->DeclareImplDeclaration(
       impl, ScopeInfo::ForNonClassScope(&scope),
       /*is_template_instantiation=*/true));
-
   CARBON_RETURN_IF_ERROR(type_checker->TypeCheckImplDeclaration(impl, scope));
 
   return std::pair{impl, arena_->New<Bindings>(std::move(new_bindings))};

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -6331,14 +6331,14 @@ auto TypeChecker::InstantiateImplDeclaration(
   auto result = type_checker->TypeCheckImplDeclaration(impl, scope);
 
   if (!result.ok()) {
-    std::string note;
-    llvm::raw_string_ostream note_stream(note);
+    auto note_stream = ErrorBuilder(result.error().location());
+    note_stream << result.error().message() << "\n";
     note_stream << "NOTE: " << source_loc.ToString()
                 << ": in instantiation of `impl " << *impl->impl_type()
                 << " as " << impl->interface() << "` with ";
     llvm::ListSeparator sep;
     for (auto* param : impl->deduced_parameters()) {
-      note_stream << sep << "`" << param->name();
+      note_stream << (llvm::StringRef(sep)) << "`" << param->name();
       if (auto value = param->constant_value()) {
         note_stream << " = " << **value;
       }
@@ -6346,9 +6346,7 @@ auto TypeChecker::InstantiateImplDeclaration(
     }
     note_stream << " required here";
 
-    return ErrorBuilder(result.error().location())
-           << result.error().message() << "\n"
-           << note;
+    return note_stream;
   }
 
   return std::pair{impl, arena_->New<Bindings>(std::move(new_bindings))};

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -6331,15 +6331,15 @@ auto TypeChecker::InstantiateImplDeclaration(
     note_stream << "NOTE: " << source_loc.ToString()
                 << ": in instantiation of `impl " << *impl->impl_type()
                 << " as " << impl->interface() << "` with ";
+    llvm::ListSeparator sep;
     for (auto* param : impl->deduced_parameters()) {
-      llvm::ListSeparator sep;
       note_stream << sep << "`" << param->name();
       if (auto value = param->constant_value()) {
         note_stream << " = " << **value;
       }
-      note_stream << "` ";
+      note_stream << "`";
     }
-    note_stream << "required here";
+    note_stream << " required here";
 
     return ErrorBuilder(result.error().location())
            << result.error().message() << "\n"

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -441,7 +441,8 @@ class TypeChecker {
   // Rebuild a value in the current type-checking context. Applies any rewrites
   // that are in scope and attempts to resolve associated constants using
   // implementations that have been declared since the value was formed.
-  auto RebuildValue(Nonnull<const Value*> value) const
+  auto RebuildValue(Nonnull<const Value*> value,
+                    SourceLocation source_loc) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // Implementation of Substitute and RebuildValue. Does not check that

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -52,18 +52,17 @@ class TypeChecker {
   // of generic parameters (aka. `GenericBinding` and references to
   // `ImplBinding`) are replaced by their corresponding value or witness in
   // `bindings`.
-  auto Substitute(
-      const Bindings& bindings, Nonnull<const Value*> value,
-      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
+  auto Substitute(const Bindings& bindings, Nonnull<const Value*> value,
+                  SourceLocation source_loc) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // Same as `Substitute`, but cast the result to the type given as a template
   // argument, which must be explicitly specified. The `remove_cv_t` here
   // blocks template argument deduction.
   template <typename T>
-  auto SubstituteCast(
-      const Bindings& bindings, Nonnull<const std::remove_cv_t<T>*> value,
-      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
+  auto SubstituteCast(const Bindings& bindings,
+                      Nonnull<const std::remove_cv_t<T>*> value,
+                      SourceLocation source_loc) const
       -> ErrorOr<Nonnull<const T*>> {
     CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> subst_value,
                             Substitute(bindings, value, source_loc));
@@ -447,9 +446,8 @@ class TypeChecker {
 
   // Implementation of Substitute and RebuildValue. Does not check that
   // bindings are nonempty, nor does it trace its progress.
-  auto SubstituteImpl(
-      const Bindings& bindings, Nonnull<const Value*> type,
-      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
+  auto SubstituteImpl(const Bindings& bindings, Nonnull<const Value*> type,
+                      SourceLocation source_loc) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // The name of a builtin interface, with any arguments.

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -19,6 +19,7 @@
 #include "explorer/ast/statement.h"
 #include "explorer/ast/value.h"
 #include "explorer/common/nonnull.h"
+#include "explorer/common/source_location.h"
 #include "explorer/interpreter/builtins.h"
 #include "explorer/interpreter/dictionary.h"
 #include "explorer/interpreter/impl_scope.h"
@@ -525,7 +526,8 @@ class TypeChecker {
   // template bindings.
   ErrorOr<std::pair<Nonnull<ImplDeclaration*>, Nonnull<Bindings*>>>
   InstantiateImplDeclaration(Nonnull<const ImplDeclaration*> pattern,
-                             Nonnull<const Bindings*> bindings) const;
+                             Nonnull<const Bindings*> bindings,
+                             SourceLocation source_loc) const;
 
   Nonnull<Arena*> arena_;
   Builtins builtins_;

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -52,18 +52,21 @@ class TypeChecker {
   // of generic parameters (aka. `GenericBinding` and references to
   // `ImplBinding`) are replaced by their corresponding value or witness in
   // `bindings`.
-  auto Substitute(const Bindings& bindings, Nonnull<const Value*> value) const
+  auto Substitute(
+      const Bindings& bindings, Nonnull<const Value*> value,
+      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // Same as `Substitute`, but cast the result to the type given as a template
   // argument, which must be explicitly specified. The `remove_cv_t` here
   // blocks template argument deduction.
   template <typename T>
-  auto SubstituteCast(const Bindings& bindings,
-                      Nonnull<const std::remove_cv_t<T>*> value) const
+  auto SubstituteCast(
+      const Bindings& bindings, Nonnull<const std::remove_cv_t<T>*> value,
+      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
       -> ErrorOr<Nonnull<const T*>> {
     CARBON_ASSIGN_OR_RETURN(Nonnull<const Value*> subst_value,
-                            Substitute(bindings, value));
+                            Substitute(bindings, value, source_loc));
     return llvm::cast<T>(subst_value);
   }
 
@@ -444,8 +447,9 @@ class TypeChecker {
 
   // Implementation of Substitute and RebuildValue. Does not check that
   // bindings are nonempty, nor does it trace its progress.
-  auto SubstituteImpl(const Bindings& bindings,
-                      Nonnull<const Value*> type) const
+  auto SubstituteImpl(
+      const Bindings& bindings, Nonnull<const Value*> type,
+      SourceLocation source_loc = SourceLocation::DiagnosticsIgnored()) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // The name of a builtin interface, with any arguments.

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -490,8 +490,9 @@ class TypeChecker {
       -> ErrorOr<Nonnull<const ConstraintType*>>;
 
   // Gets the type for the given associated constant.
-  auto GetTypeForAssociatedConstant(Nonnull<const AssociatedConstant*> assoc)
-      const -> ErrorOr<Nonnull<const Value*>>;
+  auto GetTypeForAssociatedConstant(Nonnull<const AssociatedConstant*> assoc,
+                                    SourceLocation source_loc) const
+      -> ErrorOr<Nonnull<const Value*>>;
 
   // Look up a member name in a constraint, which might be a single interface or
   // a compound constraint.
@@ -505,7 +506,8 @@ class TypeChecker {
   // of `type`.
   auto LookupRewriteInTypeOf(Nonnull<const Value*> type,
                              Nonnull<const InterfaceType*> interface,
-                             Nonnull<const Declaration*> member) const
+                             Nonnull<const Declaration*> member,
+                             SourceLocation source_loc) const
       -> ErrorOr<std::optional<const RewriteConstraint*>>;
 
   // Given a witness value, look for a rewrite for the given associated

--- a/explorer/testdata/template/fail_name_lookup.carbon
+++ b/explorer/testdata/template/fail_name_lookup.carbon
@@ -41,7 +41,7 @@ fn Main() -> i32 {
   var a: ClassWithInternalF = {};
   var b: ClassWithExternalF = {};
   a.(CallF.DoIt)();
-  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_name_lookup.carbon:[[@LINE+1]]: in instantiation of impl T as CallF with T = class ClassWithExternalF required here
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_name_lookup.carbon:[[@LINE+1]]: in instantiation of `impl T as CallF` with `T = class ClassWithExternalF` required here
   b.(CallF.DoIt)();
   return 0;
 }

--- a/explorer/testdata/template/fail_name_lookup.carbon
+++ b/explorer/testdata/template/fail_name_lookup.carbon
@@ -41,6 +41,7 @@ fn Main() -> i32 {
   var a: ClassWithInternalF = {};
   var b: ClassWithExternalF = {};
   a.(CallF.DoIt)();
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_name_lookup.carbon:[[@LINE+1]]: in instantiation of impl T as CallF with T = class ClassWithExternalF required here
   b.(CallF.DoIt)();
   return 0;
 }

--- a/explorer/testdata/template/fail_no_member.carbon
+++ b/explorer/testdata/template/fail_no_member.carbon
@@ -13,11 +13,11 @@ interface GetX {
 }
 
 impl forall [template T:! type] T as GetX {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: member access, unexpected i32 in self.x
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: member access into unexpected type `i32` in `self.x`
   fn DoIt[self: Self]() -> i32 { return self.x; }
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: in instantiation of impl T as GetX with T = i32 required here
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: in instantiation of `impl T as GetX` with `T = i32` required here
   return 0.(GetX.DoIt)();
 }

--- a/explorer/testdata/template/fail_no_member.carbon
+++ b/explorer/testdata/template/fail_no_member.carbon
@@ -18,5 +18,6 @@ impl forall [template T:! type] T as GetX {
 }
 
 fn Main() -> i32 {
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: in instantiation of impl T as GetX with T = i32 required here
   return 0.(GetX.DoIt)();
 }

--- a/explorer/testdata/template/fail_no_member_nested.carbon
+++ b/explorer/testdata/template/fail_no_member_nested.carbon
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface GetX {
+  fn DoIt[self: Self]() -> i32;
+}
+
+interface WrapGetX {
+  fn DoIt[self: Self]() -> i32;
+}
+
+impl forall [template T:! type] T as GetX {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/template/fail_no_member_nested.carbon:[[@LINE+1]]: member access into unexpected type `i32` in `self.x`
+  fn DoIt[self: Self]() -> i32 { return self.x; }
+}
+
+impl forall [template K:! type] K as WrapGetX {
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_no_member_nested.carbon:[[@LINE+1]]: in instantiation of `impl T as GetX` with `T = i32` required here
+  fn DoIt[self: Self]() -> i32 { return 0.(GetX.DoIt)(); }
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: NOTE: {{.*}}/explorer/testdata/template/fail_no_member_nested.carbon:[[@LINE+1]]: in instantiation of `impl K as WrapGetX` with `K = i32` required here
+  return 0.(WrapGetX.DoIt)();
+}


### PR DESCRIPTION
When template instantiation fails, the error that is produced doesn't mention that instantiation was being performed, nor what the template argument values were, nor why the template was instantiated (for example, the source location at which instantiation was required). This PR adds the required context to better understand and fix the error.

Closes #2705
