### PR TITLE
Refactor SemanticsNode factory functions into factory templates.

### DIFF
--- a/toolchain/lowering/lowering.cpp
+++ b/toolchain/lowering/lowering.cpp
@@ -111,7 +111,7 @@ auto Lowering::HandleFunctionDeclarationNode(SemanticsNodeId /*node_id*/,
   llvm::SmallVector<llvm::Type*> args;
   args.resize_for_overwrite(param_refs.size());
   for (int i = 0; i < static_cast<int>(param_refs.size()); ++i) {
-    args[i] = LowerNodeToType(semantics_ir_->GetNode(param_refs[i]).type());
+    args[i] = LowerNodeToType(semantics_ir_->GetNode(param_refs[i]).type_id());
   }
 
   llvm::Type* return_type = LowerNodeToType(

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -16,8 +16,8 @@ auto SemanticsIR::MakeBuiltinIR() -> SemanticsIR {
   SemanticsIR semantics(/*builtin_ir=*/nullptr);
   semantics.nodes_.reserve(SemanticsBuiltinKind::ValidCount);
 
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, Type, ...)   \
-  semantics.nodes_.push_back(SemanticsNode::MakeBuiltin( \
+#define CARBON_SEMANTICS_BUILTIN_KIND(Name, Type, ...)     \
+  semantics.nodes_.push_back(SemanticsNode::Builtin::Make( \
       SemanticsBuiltinKind::Name, SemanticsNodeId::Builtin##Type));
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
@@ -44,9 +44,9 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
   for (int i = 0; i < SemanticsBuiltinKind::ValidCount; ++i) {
     // We can reuse the type node ID because the offsets of cross-references
     // will be the same in this IR.
-    auto type = builtin_ir.nodes_[i].type();
-    semantics.nodes_[i] =
-        SemanticsNode::MakeCrossReference(type, BuiltinIR, SemanticsNodeId(i));
+    auto type = builtin_ir.nodes_[i].type_id();
+    semantics.nodes_[i] = SemanticsNode::CrossReference::Make(
+        type, BuiltinIR, SemanticsNodeId(i));
   }
 
   ParseTreeNodeLocationTranslator translator(&tokens, &parse_tree);

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -162,7 +162,7 @@ class SemanticsIR {
 
   // Returns the type of the requested node.
   auto GetType(SemanticsNodeId node_id) -> SemanticsNodeId {
-    return GetNode(node_id).type();
+    return GetNode(node_id).type_id();
   }
 
   // Adds an empty new node block, returning an ID to reference it and add

--- a/toolchain/semantics/semantics_node.cpp
+++ b/toolchain/semantics/semantics_node.cpp
@@ -31,8 +31,8 @@ void SemanticsNode::Print(llvm::raw_ostream& out) const {
     break;
 #include "toolchain/semantics/semantics_node_kind.def"
   }
-  if (type_.is_valid()) {
-    out << ", type: " << type_;
+  if (type_id_.is_valid()) {
+    out << ", type: " << type_id_;
   }
   out << "}";
 }

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -159,7 +159,7 @@ class SemanticsNode {
                            arg_ids.index...);
     }
 
-    static auto Get(SemanticsNode node) -> auto{
+    static auto Get(SemanticsNode node) {
       struct Unused {};
       return GetImpl<ArgTypes..., Unused>(node);
     }
@@ -195,7 +195,7 @@ class SemanticsNode {
   template <KindTemplateEnum Kind, int32_t TypeIndex, typename... ArgTypes>
   class FactoryPreTyped : public FactoryBase<Kind, ArgTypes...> {
    public:
-    static auto Make(ParseTree::Node parse_node, ArgTypes... args) -> auto{
+    static auto Make(ParseTree::Node parse_node, ArgTypes... args) {
       SemanticsNodeId type_id(TypeIndex);
       return FactoryBase<Kind, ArgTypes...>::Make(parse_node, type_id, args...);
     }
@@ -308,7 +308,7 @@ class SemanticsNode {
   // Provide `node.GetAsKind()` as an instance method for all kinds, essentially
   // an alias for`SemanticsNode::Kind::Get(node)`.
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
-  auto GetAs##Name() const->auto{ return Name::Get(*this); }
+  auto GetAs##Name() const { return Name::Get(*this); }
 #include "toolchain/semantics/semantics_node_kind.def"
 
   auto parse_node() const -> ParseTree::Node { return parse_node_; }

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -211,19 +211,18 @@ class SemanticsNode {
     }
   };
 
-  class Assign : public SemanticsNode::Factory<SemanticsNodeKind::Assign,
-                                               SemanticsNodeId /*lhs_id*/,
-                                               SemanticsNodeId /*rhs_id*/> {};
+  using Assign = SemanticsNode::Factory<SemanticsNodeKind::Assign,
+                                        SemanticsNodeId /*lhs_id*/,
+                                        SemanticsNodeId /*rhs_id*/>;
 
-  class BinaryOperatorAdd
-      : public SemanticsNode::Factory<SemanticsNodeKind::BinaryOperatorAdd,
-                                      SemanticsNodeId /*lhs_id*/,
-                                      SemanticsNodeId /*rhs_id*/> {};
+  using BinaryOperatorAdd =
+      SemanticsNode::Factory<SemanticsNodeKind::BinaryOperatorAdd,
+                             SemanticsNodeId /*lhs_id*/,
+                             SemanticsNodeId /*rhs_id*/>;
 
-  class BindName : public SemanticsNode::Factory<SemanticsNodeKind::BindName,
-                                                 SemanticsStringId /*name_id*/,
-                                                 SemanticsNodeId /*node_id*/> {
-  };
+  using BindName = SemanticsNode::Factory<SemanticsNodeKind::BindName,
+                                          SemanticsStringId /*name_id*/,
+                                          SemanticsNodeId /*node_id*/>;
 
   class Builtin {
    public:
@@ -241,14 +240,12 @@ class SemanticsNode {
     }
   };
 
-  class Call
-      : public Factory<SemanticsNodeKind::Call, SemanticsCallId /*call_id*/,
-                       SemanticsCallableId /*callable_id*/> {};
+  using Call = Factory<SemanticsNodeKind::Call, SemanticsCallId /*call_id*/,
+                       SemanticsCallableId /*callable_id*/>;
 
-  class CodeBlock
-      : public FactoryPreTyped<SemanticsNodeKind::CodeBlock,
-                               SemanticsNodeId::InvalidIndex,
-                               SemanticsNodeBlockId /*node_block_id*/> {};
+  using CodeBlock = FactoryPreTyped<SemanticsNodeKind::CodeBlock,
+                                    SemanticsNodeId::InvalidIndex,
+                                    SemanticsNodeBlockId /*node_block_id*/>;
 
   class CrossReference
       : public FactoryBase<SemanticsNodeKind::CrossReference,
@@ -266,40 +263,36 @@ class SemanticsNode {
     using FactoryBase::Get;
   };
 
-  class FunctionDeclaration
-      : public FactoryPreTyped<SemanticsNodeKind::FunctionDeclaration,
-                               SemanticsNodeId::InvalidIndex,
-                               SemanticsStringId /*name_id*/,
-                               SemanticsCallableId /*signature_id*/> {};
+  using FunctionDeclaration = FactoryPreTyped<
+      SemanticsNodeKind::FunctionDeclaration, SemanticsNodeId::InvalidIndex,
+      SemanticsStringId /*name_id*/, SemanticsCallableId /*signature_id*/>;
 
-  class FunctionDefinition
-      : public FactoryPreTyped<SemanticsNodeKind::FunctionDefinition,
-                               SemanticsNodeId::InvalidIndex,
-                               SemanticsNodeId /*decl_id*/,
-                               SemanticsNodeBlockId /*node_block_id*/> {};
+  using FunctionDefinition = FactoryPreTyped<
+      SemanticsNodeKind::FunctionDefinition, SemanticsNodeId::InvalidIndex,
+      SemanticsNodeId /*decl_id*/, SemanticsNodeBlockId /*node_block_id*/>;
 
-  class IntegerLiteral
-      : public FactoryPreTyped<SemanticsNodeKind::IntegerLiteral,
-                               SemanticsBuiltinKind::IntegerType.AsInt(),
-                               SemanticsIntegerLiteralId /*integer_id*/> {};
+  using IntegerLiteral =
+      FactoryPreTyped<SemanticsNodeKind::IntegerLiteral,
+                      SemanticsBuiltinKind::IntegerType.AsInt(),
+                      SemanticsIntegerLiteralId /*integer_id*/>;
 
-  class RealLiteral
-      : public FactoryPreTyped<SemanticsNodeKind::RealLiteral,
-                               SemanticsBuiltinKind::FloatingPointType.AsInt(),
-                               SemanticsRealLiteralId /*real_id*/> {};
+  using RealLiteral =
+      FactoryPreTyped<SemanticsNodeKind::RealLiteral,
+                      SemanticsBuiltinKind::FloatingPointType.AsInt(),
+                      SemanticsRealLiteralId /*real_id*/>;
 
-  class Return : public FactoryPreTyped<SemanticsNodeKind::Return,
-                                        SemanticsNodeId::InvalidIndex> {};
+  using Return =
+      FactoryPreTyped<SemanticsNodeKind::Return, SemanticsNodeId::InvalidIndex>;
 
-  class ReturnExpression : public Factory<SemanticsNodeKind::ReturnExpression,
-                                          SemanticsNodeId /*expr_id*/> {};
+  using ReturnExpression =
+      Factory<SemanticsNodeKind::ReturnExpression, SemanticsNodeId /*expr_id*/>;
 
-  class StringLiteral
-      : public FactoryPreTyped<SemanticsNodeKind::StringLiteral,
-                               SemanticsBuiltinKind::StringType.AsInt(),
-                               SemanticsStringId /*string_id*/> {};
+  using StringLiteral =
+      FactoryPreTyped<SemanticsNodeKind::StringLiteral,
+                      SemanticsBuiltinKind::StringType.AsInt(),
+                      SemanticsStringId /*string_id*/>;
 
-  class VarStorage : public Factory<SemanticsNodeKind::VarStorage> {};
+  using VarStorage = Factory<SemanticsNodeKind::VarStorage>;
 
   SemanticsNode()
       : SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Invalid,

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -124,15 +124,22 @@ struct SemanticsStringId : public IndexBase {
   }
 };
 
-// The standard structure for SemanticsNode. For each Kind in SemanticsNodeKind:
+// The standard structure for SemanticsNode. This is trying to provide a minimal
+// amount of information for a node:
+//
+// - parse_node for error placement.
+// - kind for run-time logic when the input Kind is unknown.
+// - type_id for quick type checking.
+// - Up to two Kind-specific arguments.
+//
+// For each Kind in SemanticsNodeKind, a typical flow looks like:
 //
 // - Create a `SemanticsNode` using `SemanticsNode::Kind::Make()`
 // - Access cross-Kind members using `node.type_id()` and similar.
 // - Access Kind-specific members using `node.GetAsKind()`, which depending on
 //   the number of members will return one of NoArgs, a single value, or a
 //   `std::pair` of values.
-//   - `node.kind()` can be used to ensure the correct Kind is accessed. Using
-//     the wrong `node.GetAsKind()` is a programming error, and should
+//   - Using the wrong `node.GetAsKind()` is a programming error, and should
 //     CHECK-fail in debug modes (opt may too, but it's not an API guarantee).
 //
 // Internally, each Kind uses the `Factory*` types to provide a boilerplate
@@ -329,7 +336,7 @@ class SemanticsNode {
   SemanticsNodeKind kind_;
   SemanticsNodeId type_id_;
 
-  // Use SemanticsKindNode::Get to access arg0 and arg1.
+  // Use GetAsKind to access arg0 and arg1.
   int32_t arg0_;
   int32_t arg1_;
 };

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -196,29 +196,10 @@ class SemanticsNode {
   class FactoryPreTyped : public FactoryBase<Kind, ArgTypes...> {
    public:
     static auto Make(ParseTree::Node parse_node, ArgTypes... args) -> auto{
-      return MakeImpl(parse_node, args...);
+      SemanticsNodeId type_id(TypeIndex);
+      return FactoryBase<Kind, ArgTypes...>::Make(parse_node, type_id, args...);
     }
     using FactoryBase<Kind, ArgTypes...>::Get;
-
-   private:
-    // MakeImpl handles the different parameterization based on ArgTypes.
-    template <typename Arg0Type, typename Arg1Type>
-    static auto MakeImpl(ParseTree::Node parse_node, Arg0Type arg0_id,
-                         Arg1Type arg1_id) -> SemanticsNode {
-      SemanticsNodeId type_id(TypeIndex);
-      return FactoryBase<Kind, Arg0Type, Arg1Type>::Make(parse_node, type_id,
-                                                         arg0_id, arg1_id);
-    }
-    template <typename Arg0Type>
-    static auto MakeImpl(ParseTree::Node parse_node, Arg0Type arg0_id)
-        -> SemanticsNode {
-      SemanticsNodeId type_id(TypeIndex);
-      return FactoryBase<Kind, Arg0Type>::Make(parse_node, type_id, arg0_id);
-    }
-    static auto MakeImpl(ParseTree::Node parse_node) -> SemanticsNode {
-      SemanticsNodeId type_id(TypeIndex);
-      return FactoryBase<Kind>::Make(parse_node, type_id);
-    }
   };
 
  public:

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -130,7 +130,7 @@ struct SemanticsStringId : public IndexBase {
 // - parse_node for error placement.
 // - kind for run-time logic when the input Kind is unknown.
 // - type_id for quick type checking.
-// - Up to two Kind-specific arguments.
+// - Up to two Kind-specific members.
 //
 // For each Kind in SemanticsNodeKind, a typical flow looks like:
 //

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -165,8 +165,7 @@ class SemanticsNode {
     }
 
    private:
-    // GetImpl handles the different parameterization and return types based on
-    // the size of ArgTypes.
+    // GetImpl handles the different return types based on ArgTypes.
     template <typename Arg0Type, typename Arg1Type, typename>
     static auto GetImpl(SemanticsNode node) -> std::pair<Arg0Type, Arg1Type> {
       CARBON_CHECK(node.kind() == Kind);
@@ -202,8 +201,7 @@ class SemanticsNode {
     using FactoryBase<Kind, ArgTypes...>::Get;
 
    private:
-    // MakeImpl handles the different parameterization and return types based on
-    // the size of ArgTypes.
+    // MakeImpl handles the different parameterization based on ArgTypes.
     template <typename Arg0Type, typename Arg1Type>
     static auto MakeImpl(ParseTree::Node parse_node, Arg0Type arg0_id,
                          Arg1Type arg1_id) -> SemanticsNode {

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -124,207 +124,246 @@ struct SemanticsStringId : public IndexBase {
   }
 };
 
-// The standard structure for nodes.
+// The standard structure for SemanticsNode. For each Kind in SemanticsNodeKind:
+//
+// - Create a `SemanticsNode` using `SemanticsNode::Kind::Make()`
+// - Access cross-Kind members using `node.type_id()` and similar.
+// - Access Kind-specific members using `node.GetAsKind()`, which depending on
+//   the number of members will return one of NoArgs, a single value, or a
+//   `std::pair` of values.
+//   - `node.kind()` can be used to ensure the correct Kind is accessed. Using
+//     the wrong `node.GetAsKind()` is a programming error, and should
+//     CHECK-fail in debug modes (opt may too, but it's not an API guarantee).
+//
+// Internally, each Kind uses the `Factory*` types to provide a boilerplate
+// `Make` and `Get` methods.
 class SemanticsNode {
  public:
   struct NoArgs {};
 
-  auto GetAsInvalid() const -> NoArgs { CARBON_FATAL() << "Invalid access"; }
+  // Factory base classes are private, then used for public classes. This class
+  // has two public and two private sections to prevent accidents.
+ private:
+  // Factory templates need to use the raw enum instead of the class wrapper.
+  using KindTemplateEnum = Internal::SemanticsNodeKindRawEnum;
 
-  static auto MakeAssign(ParseTree::Node parse_node, SemanticsNodeId type,
-                         SemanticsNodeId lhs, SemanticsNodeId rhs)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::Assign, type, lhs.index,
-                         rhs.index);
-  }
-  auto GetAsAssign() const -> std::pair<SemanticsNodeId, SemanticsNodeId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::Assign);
-    return {SemanticsNodeId(arg0_), SemanticsNodeId(arg1_)};
-  }
+  // The FactoryBase and FactoryNBase structs provide Make and Get to support 0,
+  // 1, or 2 arguments for a SemanticsNode. These are protected so that child
+  // factories can opt in to what pieces they want to use.
+  template <KindTemplateEnum Kind, typename... ArgTypes>
+  struct FactoryBase {
+   protected:
+    static auto Make(ParseTree::Node parse_node, SemanticsNodeId type_id,
+                     ArgTypes... arg_ids) -> SemanticsNode {
+      return SemanticsNode(parse_node, SemanticsNodeKind::Create(Kind), type_id,
+                           arg_ids.index...);
+    }
+  };
+  template <KindTemplateEnum Kind>
+  struct Factory0Base : public FactoryBase<Kind> {
+   protected:
+    static auto Get(SemanticsNode node) -> NoArgs {
+      CARBON_CHECK(node.kind() == Kind);
+      return NoArgs();
+    }
+  };
+  template <KindTemplateEnum Kind, typename Arg0Type>
+  struct Factory1Base : public FactoryBase<Kind, Arg0Type> {
+   protected:
+    static auto Get(SemanticsNode node) -> Arg0Type {
+      CARBON_CHECK(node.kind() == Kind);
+      return Arg0Type(node.arg0_);
+    }
+  };
+  template <KindTemplateEnum Kind, typename Arg0Type, typename Arg1Type>
+  struct Factory2Base : public FactoryBase<Kind, Arg0Type, Arg1Type> {
+   protected:
+    static auto Get(SemanticsNode node) -> std::pair<Arg0Type, Arg1Type> {
+      CARBON_CHECK(node.kind() == Kind);
+      return {Arg0Type(node.arg0_), Arg1Type(node.arg1_)};
+    }
+  };
 
-  static auto MakeBinaryOperatorAdd(ParseTree::Node parse_node,
-                                    SemanticsNodeId type, SemanticsNodeId lhs,
-                                    SemanticsNodeId rhs) -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::BinaryOperatorAdd, type,
-                         lhs.index, rhs.index);
-  }
-  auto GetAsBinaryOperatorAdd() const
-      -> std::pair<SemanticsNodeId, SemanticsNodeId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::BinaryOperatorAdd);
-    return {SemanticsNodeId(arg0_), SemanticsNodeId(arg1_)};
-  }
+  // The Factory structs provide public Make and Get for nodes.
+  template <KindTemplateEnum Kind>
+  struct Factory0 : public Factory0Base<Kind> {
+    using Factory0Base<Kind>::Make;
+    using Factory0Base<Kind>::Get;
+  };
+  template <KindTemplateEnum Kind, typename Arg0Type>
+  struct Factory1 : public Factory1Base<Kind, Arg0Type> {
+    using Factory1Base<Kind, Arg0Type>::Make;
+    using Factory1Base<Kind, Arg0Type>::Get;
+  };
+  template <KindTemplateEnum Kind, typename Arg0Type, typename Arg1Type>
+  struct Factory2 : public Factory2Base<Kind, Arg0Type, Arg1Type> {
+    using Factory2Base<Kind, Arg0Type, Arg1Type>::Make;
+    using Factory2Base<Kind, Arg0Type, Arg1Type>::Get;
+  };
 
-  static auto MakeBindName(ParseTree::Node parse_node, SemanticsNodeId type,
-                           SemanticsStringId name, SemanticsNodeId node)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::BindName, type,
-                         name.index, node.index);
-  }
-  auto GetAsBindName() const -> std::pair<SemanticsStringId, SemanticsNodeId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::BindName);
-    return {SemanticsStringId(arg0_), SemanticsNodeId(arg1_)};
-  }
+  // The FactoryNPreTyped structs provide a Make that assumes a non-changging
+  // type.
+  template <KindTemplateEnum Kind, int32_t TypeIndex>
+  struct Factory0PreTyped : public Factory0Base<Kind> {
+    static auto Make(ParseTree::Node parse_node) -> SemanticsNode {
+      SemanticsNodeId type_id(TypeIndex);
+      return Factory0Base<Kind>::Make(parse_node, type_id);
+    }
+    using Factory0Base<Kind>::Get;
+  };
+  template <KindTemplateEnum Kind, int32_t TypeIndex, typename Arg0Type>
+  struct Factory1PreTyped : public Factory1Base<Kind, Arg0Type> {
+    static auto Make(ParseTree::Node parse_node, Arg0Type arg0_id)
+        -> SemanticsNode {
+      SemanticsNodeId type_id(TypeIndex);
+      return Factory1Base<Kind, Arg0Type>::Make(parse_node, type_id, arg0_id);
+    }
+    using Factory1Base<Kind, Arg0Type>::Get;
+  };
+  template <KindTemplateEnum Kind, int32_t TypeIndex, typename Arg0Type,
+            typename Arg1Type>
+  struct Factory2PreTyped : public Factory2Base<Kind, Arg0Type, Arg1Type> {
+    static auto Make(ParseTree::Node parse_node, Arg0Type arg0_id,
+                     Arg1Type arg1_id) -> SemanticsNode {
+      SemanticsNodeId type_id(TypeIndex);
+      return Factory2Base<Kind, Arg0Type, Arg1Type>::Make(parse_node, type_id,
+                                                          arg0_id, arg1_id);
+    }
+    using Factory2Base<Kind, Arg0Type, Arg1Type>::Get;
+  };
 
-  static auto MakeBuiltin(SemanticsBuiltinKind builtin_kind,
-                          SemanticsNodeId type) -> SemanticsNode {
-    // Builtins won't have a ParseTree node associated, so we provide the
-    // default invalid one.
-    return SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Builtin,
-                         type, builtin_kind.AsInt());
-  }
-  auto GetAsBuiltin() const -> SemanticsBuiltinKind {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::Builtin);
-    return SemanticsBuiltinKind::FromInt(arg0_);
-  }
+ public:
+  // Invalid is in the SemanticsNodeKind enum, but should never be used.
+  struct Invalid {
+    static auto Get(SemanticsNode /*node*/) -> SemanticsNode::NoArgs {
+      CARBON_FATAL() << "Invalid access";
+    }
+  };
 
-  static auto MakeCall(ParseTree::Node parse_node, SemanticsNodeId type,
-                       SemanticsCallId call_id, SemanticsCallableId callable_id)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::Call, type,
-                         call_id.index, callable_id.index);
-  }
-  auto GetAsCall() const -> std::pair<SemanticsCallId, SemanticsCallableId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::Call);
-    return {SemanticsCallId(arg0_), SemanticsCallableId(arg1_)};
-  }
+  struct Assign : public SemanticsNode::Factory2<SemanticsNodeKind::Assign,
+                                                 SemanticsNodeId /*lhs_id*/,
+                                                 SemanticsNodeId /*rhs_id*/> {};
 
-  static auto MakeCodeBlock(ParseTree::Node parse_node,
-                            SemanticsNodeBlockId node_block) -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::CodeBlock,
-                         SemanticsNodeId::Invalid, node_block.index);
-  }
-  auto GetAsCodeBlock() const -> SemanticsNodeBlockId {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::CodeBlock);
-    return SemanticsNodeBlockId(arg0_);
-  }
+  struct BinaryOperatorAdd
+      : public SemanticsNode::Factory2<SemanticsNodeKind::BinaryOperatorAdd,
+                                       SemanticsNodeId /*lhs_id*/,
+                                       SemanticsNodeId /*rhs_id*/> {};
 
-  static auto MakeCrossReference(SemanticsNodeId type,
-                                 SemanticsCrossReferenceIRId ir,
-                                 SemanticsNodeId node) -> SemanticsNode {
-    return SemanticsNode(ParseTree::Node::Invalid,
-                         SemanticsNodeKind::CrossReference, type, ir.index,
-                         node.index);
-  }
-  auto GetAsCrossReference() const
-      -> std::pair<SemanticsCrossReferenceIRId, SemanticsNodeId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::CrossReference);
-    return {SemanticsCrossReferenceIRId(arg0_), SemanticsNodeId(arg1_)};
-  }
+  struct BindName
+      : public SemanticsNode::Factory2<SemanticsNodeKind::BindName,
+                                       SemanticsStringId /*name_id*/,
+                                       SemanticsNodeId /*node_id*/> {};
 
-  static auto MakeFunctionDeclaration(ParseTree::Node parse_node,
-                                      SemanticsStringId name_id,
-                                      SemanticsCallableId signature_id)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::FunctionDeclaration,
-                         SemanticsNodeId::Invalid, name_id.index,
-                         signature_id.index);
-  }
-  auto GetAsFunctionDeclaration() const
-      -> std::pair<SemanticsStringId, SemanticsCallableId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::FunctionDeclaration);
-    return {SemanticsStringId(arg0_), SemanticsCallableId(arg1_)};
-  }
+  struct Builtin {
+    static auto Make(SemanticsBuiltinKind builtin_kind, SemanticsNodeId type_id)
+        -> SemanticsNode {
+      // Builtins won't have a ParseTree node associated, so we provide the
+      // default invalid one.
+      // This can't use the standard Make function because of the `AsInt()` cast
+      // instead of `.index`.
+      return SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Builtin,
+                           type_id, builtin_kind.AsInt());
+    }
+    static auto Get(SemanticsNode node) -> SemanticsBuiltinKind {
+      return SemanticsBuiltinKind::FromInt(node.arg0_);
+    }
+  };
 
-  static auto MakeFunctionDefinition(ParseTree::Node parse_node,
-                                     SemanticsNodeId decl,
-                                     SemanticsNodeBlockId node_block)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::FunctionDefinition,
-                         SemanticsNodeId::Invalid, decl.index,
-                         node_block.index);
-  }
-  auto GetAsFunctionDefinition() const
-      -> std::pair<SemanticsNodeId, SemanticsNodeBlockId> {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::FunctionDefinition);
-    return {SemanticsNodeId(arg0_), SemanticsNodeBlockId(arg1_)};
-  }
+  struct Call
+      : public Factory2<SemanticsNodeKind::Call, SemanticsCallId /*call_id*/,
+                        SemanticsCallableId /*callable_id*/> {};
 
-  static auto MakeIntegerLiteral(ParseTree::Node parse_node,
-                                 SemanticsIntegerLiteralId integer)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::IntegerLiteral,
-                         SemanticsNodeId::BuiltinIntegerType, integer.index);
-  }
-  auto GetAsIntegerLiteral() const -> SemanticsIntegerLiteralId {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::IntegerLiteral);
-    return SemanticsIntegerLiteralId(arg0_);
-  }
+  struct CodeBlock
+      : public Factory1PreTyped<SemanticsNodeKind::CodeBlock,
+                                SemanticsNodeId::InvalidIndex,
+                                SemanticsNodeBlockId /*node_block_id*/> {};
 
-  static auto MakeRealLiteral(ParseTree::Node parse_node,
-                              SemanticsRealLiteralId real) -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::RealLiteral,
-                         SemanticsNodeId::BuiltinFloatingPointType, real.index);
-  }
-  auto GetAsRealLiteral() const -> SemanticsRealLiteralId {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::RealLiteral);
-    return SemanticsRealLiteralId(arg0_);
-  }
+  struct CrossReference
+      : public Factory2Base<SemanticsNodeKind::CrossReference,
+                            SemanticsCrossReferenceIRId /*ir_id*/,
+                            SemanticsNodeId /*node_id*/> {
+    static auto Make(SemanticsNodeId type_id, SemanticsCrossReferenceIRId ir_id,
+                     SemanticsNodeId node_id) -> SemanticsNode {
+      // A node's parse tree node must refer to a node in the current parse
+      // tree. This cannot use the cross-referenced node's parse tree node
+      // because it will be in a different parse tree.
+      return Factory2Base::Make(ParseTree::Node::Invalid, type_id, ir_id,
+                                node_id);
+    }
+    using Factory2Base::Get;
+  };
 
-  static auto MakeReturn(ParseTree::Node parse_node) -> SemanticsNode {
-    // The actual type is `()`. However, code dealing with `return;` should
-    // understand the type without checking, so it's not necessary but could be
-    // specified if needed.
-    return SemanticsNode(parse_node, SemanticsNodeKind::Return,
-                         SemanticsNodeId::Invalid);
-  }
-  auto GetAsReturn() const -> NoArgs {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::Return);
-    return {};
-  }
+  struct FunctionDeclaration
+      : public Factory2PreTyped<SemanticsNodeKind::FunctionDeclaration,
+                                SemanticsNodeId::InvalidIndex,
+                                SemanticsStringId /*name_id*/,
+                                SemanticsCallableId /*signature_id*/> {};
 
-  static auto MakeReturnExpression(ParseTree::Node parse_node,
-                                   SemanticsNodeId type, SemanticsNodeId expr)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::ReturnExpression, type,
-                         expr.index);
-  }
-  auto GetAsReturnExpression() const -> SemanticsNodeId {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::ReturnExpression);
-    return SemanticsNodeId(arg0_);
-  }
+  struct FunctionDefinition
+      : public Factory2PreTyped<SemanticsNodeKind::FunctionDefinition,
+                                SemanticsNodeId::InvalidIndex,
+                                SemanticsNodeId /*decl_id*/,
+                                SemanticsNodeBlockId /*node_block_id*/> {};
 
-  static auto MakeStringLiteral(ParseTree::Node parse_node,
-                                SemanticsStringId string_id) -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::StringLiteral,
-                         SemanticsNodeId::BuiltinStringType, string_id.index);
-  }
-  auto GetAsStringLiteral() const -> SemanticsStringId {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::StringLiteral);
-    return SemanticsStringId(arg0_);
-  }
+  struct IntegerLiteral
+      : public Factory1PreTyped<SemanticsNodeKind::IntegerLiteral,
+                                SemanticsBuiltinKind::IntegerType.AsInt(),
+                                SemanticsIntegerLiteralId /*integer_id*/> {};
 
-  static auto MakeVarStorage(ParseTree::Node parse_node, SemanticsNodeId type)
-      -> SemanticsNode {
-    return SemanticsNode(parse_node, SemanticsNodeKind::VarStorage, type);
-  }
-  auto GetAsVarStorage() const -> NoArgs {
-    CARBON_CHECK(kind_ == SemanticsNodeKind::VarStorage);
-    return NoArgs();
-  }
+  struct RealLiteral
+      : public Factory1PreTyped<SemanticsNodeKind::RealLiteral,
+                                SemanticsBuiltinKind::FloatingPointType.AsInt(),
+                                SemanticsRealLiteralId /*real_id*/> {};
+
+  struct Return : public Factory0PreTyped<SemanticsNodeKind::Return,
+                                          SemanticsNodeId::InvalidIndex> {};
+
+  struct ReturnExpression : public Factory1<SemanticsNodeKind::ReturnExpression,
+                                            SemanticsNodeId /*expr_id*/> {};
+
+  struct StringLiteral
+      : public Factory1PreTyped<SemanticsNodeKind::StringLiteral,
+                                SemanticsBuiltinKind::StringType.AsInt(),
+                                SemanticsStringId /*string_id*/> {};
+
+  struct VarStorage : public Factory0<SemanticsNodeKind::VarStorage> {};
 
   SemanticsNode()
       : SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Invalid,
                       SemanticsNodeId::Invalid) {}
 
+  // Provide `node.GetAsKind()` as an instance method for all kinds, essentially
+  // an alias for`SemanticsNode::Kind::Get(node)`.
+#define CARBON_SEMANTICS_NODE_KIND(Name) \
+  auto GetAs##Name() const->auto{ return Name::Get(*this); }
+#include "toolchain/semantics/semantics_node_kind.def"
+
   auto parse_node() const -> ParseTree::Node { return parse_node_; }
   auto kind() const -> SemanticsNodeKind { return kind_; }
-  auto type() const -> SemanticsNodeId { return type_; }
+  auto type_id() const -> SemanticsNodeId { return type_id_; }
 
   auto Print(llvm::raw_ostream& out) const -> void;
 
  private:
+  // Builtins have peculiar construction, so they are a friend rather than using
+  // a factory base class.
+  friend struct SemanticsNodeForBuiltin;
+
   explicit SemanticsNode(ParseTree::Node parse_node, SemanticsNodeKind kind,
-                         SemanticsNodeId type, int32_t arg0 = -1,
-                         int32_t arg1 = -1)
+                         SemanticsNodeId type_id,
+                         int32_t arg0 = SemanticsNodeId::InvalidIndex,
+                         int32_t arg1 = SemanticsNodeId::InvalidIndex)
       : parse_node_(parse_node),
         kind_(kind),
-        type_(type),
+        type_id_(type_id),
         arg0_(arg0),
         arg1_(arg1) {}
 
   ParseTree::Node parse_node_;
   SemanticsNodeKind kind_;
-  SemanticsNodeId type_;
+  SemanticsNodeId type_id_;
+
+  // Use SemanticsKindNode::Get to access arg0 and arg1.
   int32_t arg0_;
   int32_t arg1_;
 };

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -20,6 +20,8 @@ class SemanticsNodeKind : public CARBON_ENUM_BASE(SemanticsNodeKind) {
  public:
 #define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_ENUM_CONSTANT_DECLARATION(Name)
 #include "toolchain/semantics/semantics_node_kind.def"
+
+  using EnumBase::Create;
 };
 
 #define CARBON_SEMANTICS_NODE_KIND(Name) \


### PR DESCRIPTION
I'm trying to reduce the amount of per-SemanticsNodeKind boilerplate, and make mistakes (e.g., SemanticsNodeKind not matching the Make name, misplacing the type, or Get/Make type mismatches) easier to see.

I could've done this with (more) macros, but felt that the template approach was reasonable enough and likely easier to understand/debug. I'm not sure whether there's more that I could be doing with variadics to reduce the amount of factory code, but this feels good right now.