### PR TITLE
Update clang-format to 16.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,14 +71,14 @@ repos:
         types_or: [c++, proto]
         language: python
         args: ['-i']
-        additional_dependencies: ['clang-format==14.0.6']
+        additional_dependencies: ['clang-format==16.0.0']
       - id: explorer-format-grammar
         name: Format the explorer grammar file
         entry: explorer/syntax/format_grammar.py
         language: python
         files: ^explorer/syntax/(lexer.lpp|parser.ypp)$
         pass_filenames: false
-        additional_dependencies: ['clang-format==14.0.6']
+        additional_dependencies: ['clang-format==16.0.0']
 
   - repo: local
     hooks:

--- a/explorer/ast/value_transform.h
+++ b/explorer/ast/value_transform.h
@@ -140,7 +140,7 @@ class TransformBase {
   // default.
   template <typename T,
             std::enable_if_t<IsRecursivelyTransformable<T>, void*> = nullptr>
-  auto operator()(Nonnull<const T*> value) -> auto{
+  auto operator()(Nonnull<const T*> value) -> auto {
     return value->Decompose([&](const auto&... elements) {
       return [&](auto&&... transformed_elements)
                  -> decltype(AllocateTrait<T>::New(


### PR DESCRIPTION
This is just the python package used for clang-format. Just pulling the latest version from https://pypi.org/project/clang-format/9.0.0/#history. I don't think it should matter if it's out of sync slightly with what people have locally.