### PR TITLE
Doc: replace references to #821 by #2006

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -682,7 +682,7 @@ values if constant evaluation of the runtime expression succeeds.
 
 > **Note:** Conversion of runtime values to other phases is provisional, as are
 > the semantics of r-values. See pending proposal
-> [#821: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/821).
+> [#2006: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/2006).
 
 ## Composite types
 
@@ -776,7 +776,7 @@ or restrictions on casts between pointers and integers.
 
 > **Note:** While the syntax for pointers has been decided, the semantics of
 > pointers are provisional, as is the syntax for optionals. See pending proposal
-> [#821: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/821).
+> [#2006: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/2006).
 
 > References:
 >
@@ -1048,7 +1048,7 @@ value to match, `42`. The names from [binding patterns](#binding-patterns) are
 introduced into the enclosing [scope](#declarations-definitions-and-scopes).
 
 > **Note:** `let` declarations are provisional. See pending proposal
-> [#821: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/821).
+> [#2006: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/2006).
 
 ### Variable `var` declarations
 
@@ -1167,7 +1167,7 @@ returned using a [tuple](#tuples) or [struct](#struct-types) type.
 
 > **Note:** The semantics of parameter passing are provisional. See pending
 > proposal
-> [#821: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/821).
+> [#2006: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/2006).
 
 ### `auto` return type
 
@@ -1957,7 +1957,7 @@ value.
 > proposed in accepted proposal
 > [#257: Initialization of memory and variables](https://github.com/carbon-language/carbon-lang/pull/257).
 > See pending proposal
-> [#821: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/821).
+> [#2006: Values, variables, pointers, and references](https://github.com/carbon-language/carbon-lang/pull/2006).
 
 #### Mixins
 


### PR DESCRIPTION
Replaces references to PR #821 (closed) by #2006 (draft) which tracks the same feature definition.