### PR TITLE
Reduce dumped context on parse verify errors.

### DIFF
--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -146,7 +146,7 @@ class ParseTree {
   // This is primarily intended to be used as a
   // debugging aid. This routine doesn't directly CHECK so that it can be used
   // within a debugger.
-  [[nodiscard]] auto Verify() const -> std::optional<Error>;
+  [[nodiscard]] auto Verify() const -> ErrorOr<Success>;
 
  private:
   friend class Parser;


### PR DESCRIPTION
I'm suspicious this is responsible for some OOMs in fuzzing... Specifically, it dumps a really big parse tree, then the auto fuzzing system OOMs trying to cache the entire output in memory.