### PR TITLE
Avoid allocating storage for `let` variable declaration initialized from l-value

### DIFF
--- a/explorer/ast/element_path.h
+++ b/explorer/ast/element_path.h
@@ -92,9 +92,10 @@ class ElementPath {
 
   // Removes all trailing `BaseElement`s, errors if there are no base elements.
   auto RemoveTrailingBaseElements() -> void {
-    CARBON_CHECK(!components_.empty() && components_.back().element()->kind() ==
-                                             ElementKind::BaseElement)
-        << "No base elements to remove.";
+    if (components_.empty() ||
+        components_.back().element()->kind() != ElementKind::BaseElement) {
+      return;
+    }
     const auto r_it = std::find_if(
         components_.rbegin(), components_.rend(), [](const Component& c) {
           return c.element()->kind() != ElementKind::BaseElement;

--- a/explorer/interpreter/action.h
+++ b/explorer/interpreter/action.h
@@ -172,8 +172,10 @@ class Action {
 // LValue.
 class LValAction : public Action {
  public:
-  explicit LValAction(Nonnull<const Expression*> expression)
-      : Action(Kind::LValAction), expression_(expression) {}
+  explicit LValAction(Nonnull<const Expression*> expression, bool optional)
+      : Action(Kind::LValAction),
+        expression_(expression),
+        optional_(optional) {}
 
   static auto classof(const Action* action) -> bool {
     return action->kind() == Kind::LValAction;
@@ -182,8 +184,11 @@ class LValAction : public Action {
   // The Expression this Action evaluates.
   auto expression() const -> const Expression& { return *expression_; }
 
+  auto is_optional() const -> bool { return optional_; }
+
  private:
   Nonnull<const Expression*> expression_;
+  bool optional_;
 };
 
 // An Action which implements evaluation of an Expression to produce an

--- a/explorer/interpreter/heap.cpp
+++ b/explorer/interpreter/heap.cpp
@@ -31,7 +31,7 @@ auto Heap::Read(const Address& a, SourceLocation source_loc) const
   CARBON_RETURN_IF_ERROR(this->CheckInit(a.allocation_, source_loc));
   CARBON_RETURN_IF_ERROR(this->CheckAlive(a.allocation_, source_loc));
   Nonnull<const Value*> value = values_[a.allocation_.index_];
-  return value->GetElement(arena_, a.element_path_, source_loc, value);
+  return value->GetElement(arena_, a.element_path_, source_loc, value, a);
 }
 
 auto Heap::Write(const Address& a, Nonnull<const Value*> v,
@@ -44,18 +44,6 @@ auto Heap::Write(const Address& a, Nonnull<const Value*> v,
                           values_[a.allocation_.index_]->SetField(
                               arena_, a.element_path_, v, source_loc));
   return Success();
-}
-
-auto Heap::GetAllocationId(Nonnull<const Value*> v) const
-    -> std::optional<AllocationId> {
-  auto iter = std::find(values_.begin(), values_.end(), v);
-  if (iter != values_.end()) {
-    auto index = iter - values_.begin();
-    if (states_[index] == ValueState::Alive) {
-      return AllocationId(index);
-    }
-  }
-  return std::nullopt;
 }
 
 auto Heap::CheckAlive(AllocationId allocation, SourceLocation source_loc) const

--- a/explorer/interpreter/heap.h
+++ b/explorer/interpreter/heap.h
@@ -41,9 +41,6 @@ class Heap : public HeapAllocationInterface {
   auto Write(const Address& a, Nonnull<const Value*> v,
              SourceLocation source_loc) -> ErrorOr<Success>;
 
-  auto GetAllocationId(Nonnull<const Value*> v) const
-      -> std::optional<AllocationId> override;
-
   // Put the given value on the heap and mark its state.
   // Mark UninitializedValue as uninitialized and other values as alive.
   auto AllocateValue(Nonnull<const Value*> v) -> AllocationId override;

--- a/explorer/interpreter/heap_allocation_interface.h
+++ b/explorer/interpreter/heap_allocation_interface.h
@@ -30,11 +30,6 @@ class HeapAllocationInterface {
   // Returns the arena used to allocate the values in this heap.
   virtual auto arena() const -> Arena& = 0;
 
-  // Returns the ID of the first allocation that holds `v`, if one exists.
-  // TODO: Find a way to remove this.
-  virtual auto GetAllocationId(Nonnull<const Value*> v) const
-      -> std::optional<AllocationId> = 0;
-
  protected:
   HeapAllocationInterface() = default;
   virtual ~HeapAllocationInterface() = default;

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1171,14 +1171,8 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
       // First, evaluate the first operand.
       if (act.pos() == 0) {
         const bool optional = !access.is_addr_me_method();
-        const bool REVERT = false;
-        if (optional && REVERT) {
-          act.AddResult(arena_->New<BoolValue>(false));
-          return todo_.RunAgain();
-        } else {
-          return todo_.Spawn(
-              std::make_unique<LValAction>(&access.object(), optional));
-        }
+        return todo_.Spawn(
+            std::make_unique<LValAction>(&access.object(), optional));
       } else if (act.pos() == 1) {
         if (access.is_addr_me_method()) {
           act.AddResult(arena_->New<BoolValue>(false));
@@ -2020,10 +2014,11 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
 
         std::optional<Address> addr;
         if (definition.has_init()) {
-          addr = (act.results()[1]->kind() == Value::Kind::LValue /*&&
-                    v == act.results()[0]*/)
-                       ? std::make_optional(cast<LValue>(act.results()[1])->address())
-                       : std::nullopt;
+          addr = (act.results()[1]->kind() == Value::Kind::LValue &&
+                  v == act.results()[0])
+                     ? std::make_optional(
+                           cast<LValue>(act.results()[1])->address())
+                     : std::nullopt;
         }
         RuntimeScope matches(&heap_);
         BindingMap generic_args;

--- a/explorer/interpreter/interpreter.h
+++ b/explorer/interpreter/interpreter.h
@@ -44,7 +44,8 @@ auto InterpExp(Nonnull<const Expression*> e, Nonnull<Arena*> arena,
 // `generic_args`.
 // TODO: consider moving this to a separate header.
 [[nodiscard]] auto PatternMatch(
-    Nonnull<const Value*> p, Nonnull<const Value*> v, SourceLocation source_loc,
+    Nonnull<const Value*> p, Nonnull<const Value*> v,
+    std::optional<Address> v_addr, SourceLocation source_loc,
     std::optional<Nonnull<RuntimeScope*>> bindings, BindingMap& generic_args,
     Nonnull<TraceStream*> trace_stream, Nonnull<Arena*> arena) -> bool;
 

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -803,9 +803,9 @@ auto TypeChecker::GetBuiltinInterfaceType(SourceLocation source_loc,
   BindingMap binding_args;
   if (has_arguments) {
     TupleValue args(interface.arguments);
-    if (!PatternMatch(&iface_decl->params().value()->value(), &args, source_loc,
-                      std::nullopt, binding_args, trace_stream_,
-                      this->arena_)) {
+    if (!PatternMatch(&iface_decl->params().value()->value(), &args,
+                      std::nullopt, source_loc, std::nullopt, binding_args,
+                      trace_stream_, this->arena_)) {
       return bad_builtin();
     }
   }
@@ -4103,9 +4103,9 @@ auto TypeChecker::TypeCheckPattern(
         // this level rather than on the overall initializer.
         if (!IsConcreteType(type)) {
           BindingMap generic_args;
-          if (!PatternMatch(type, *expected, binding.type().source_loc(),
-                            std::nullopt, generic_args, trace_stream_,
-                            this->arena_)) {
+          if (!PatternMatch(type, *expected, std::nullopt,
+                            binding.type().source_loc(), std::nullopt,
+                            generic_args, trace_stream_, this->arena_)) {
             return ProgramError(binding.type().source_loc())
                    << "type pattern '" << *type
                    << "' does not match actual type '" << **expected << "'";

--- a/explorer/testdata/destructor/destructor_var_and_let.carbon
+++ b/explorer/testdata/destructor/destructor_var_and_let.carbon
@@ -1,0 +1,133 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: VarDeclaration
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: VarDeclaration - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: LetDeclaration
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: LetDeclaration - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: VarAndLetDeclaration
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: VarAndLetDeclaration - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: LetParamVarDeclaration-Passing LValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: LetParamVarDeclaration-Passing LValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: LetParamLetDeclaration-Passing LValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: LetParamLetDeclaration-Passing LValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: LetParamVarDeclaration-Passing RValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: LetParamVarDeclaration-Passing RValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: LetParamLetDeclaration-Passing RValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: LetParamLetDeclaration-Passing RValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: VarParamVarDeclaration-Passing RValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: VarParamVarDeclaration-Passing RValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: VarParamLetDeclaration-Passing RValue
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: VarParamLetDeclaration-Passing RValue - end
+// CHECK-EMPTY:
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: DESTRUCTOR CALLED
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+
+class A {
+  destructor[self: Self] {
+    Print("DESTRUCTOR CALLED");
+  }
+}
+
+fn VarDeclaration() {
+  var a: A = {};
+}
+
+fn VarAndLetDeclaration() {
+  var a: A = {};
+  let b: A = a;
+}
+
+fn LetDeclaration() {
+  let a: A = {};
+}
+
+fn LetParamVarDeclaration(a: A) {
+  var b: A = a;
+}
+
+fn LetParamLetDeclaration(a: A) {
+  let b: A = a;
+}
+
+fn VarParamVarDeclaration(var a: A) {
+  var b: A = a;
+}
+
+fn VarParamLetDeclaration(var a: A) {
+  let b: A = a;
+}
+
+fn Main() -> i32 {
+  Print("VarDeclaration");
+  VarDeclaration();
+  Print("VarDeclaration - end\n");
+
+  Print("LetDeclaration");
+  LetDeclaration();
+  Print("LetDeclaration - end\n");
+
+  Print("VarAndLetDeclaration");
+  VarAndLetDeclaration();
+  Print("VarAndLetDeclaration - end\n");
+
+  Print("LetParamVarDeclaration-Passing LValue");
+  var a1: A = {};
+  LetParamVarDeclaration(a1);
+  Print("LetParamVarDeclaration-Passing LValue - end\n");
+
+  Print("LetParamLetDeclaration-Passing LValue");
+  var a2: A = {};
+  LetParamLetDeclaration(a2);
+  Print("LetParamLetDeclaration-Passing LValue - end\n");
+
+  Print("LetParamVarDeclaration-Passing RValue");
+  LetParamVarDeclaration({});
+  Print("LetParamVarDeclaration-Passing RValue - end\n");
+
+  Print("LetParamLetDeclaration-Passing RValue");
+  LetParamLetDeclaration({});
+  Print("LetParamLetDeclaration-Passing RValue - end\n");
+
+  Print("VarParamVarDeclaration-Passing RValue");
+  VarParamVarDeclaration({});
+  Print("VarParamVarDeclaration-Passing RValue - end\n");
+
+  Print("VarParamLetDeclaration-Passing RValue");
+  VarParamLetDeclaration({});
+  Print("VarParamLetDeclaration-Passing RValue - end\n");
+
+  return 0;
+}

--- a/explorer/testdata/destructor/destructor_var_and_let.carbon
+++ b/explorer/testdata/destructor/destructor_var_and_let.carbon
@@ -15,7 +15,6 @@
 // CHECK-EMPTY:
 // CHECK:STDOUT: VarAndLetDeclaration
 // CHECK:STDOUT: DESTRUCTOR CALLED
-// CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: VarAndLetDeclaration - end
 // CHECK-EMPTY:
 // CHECK:STDOUT: LetParamVarDeclaration-Passing LValue
@@ -24,7 +23,6 @@
 // CHECK:STDOUT: LetParamVarDeclaration-Passing LValue - end
 // CHECK-EMPTY:
 // CHECK:STDOUT: LetParamLetDeclaration-Passing LValue
-// CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: LetParamLetDeclaration-Passing LValue - end
 // CHECK-EMPTY:
@@ -35,7 +33,6 @@
 // CHECK-EMPTY:
 // CHECK:STDOUT: LetParamLetDeclaration-Passing RValue
 // CHECK:STDOUT: DESTRUCTOR CALLED
-// CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: LetParamLetDeclaration-Passing RValue - end
 // CHECK-EMPTY:
 // CHECK:STDOUT: VarParamVarDeclaration-Passing RValue
@@ -44,7 +41,6 @@
 // CHECK:STDOUT: VarParamVarDeclaration-Passing RValue - end
 // CHECK-EMPTY:
 // CHECK:STDOUT: VarParamLetDeclaration-Passing RValue
-// CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: DESTRUCTOR CALLED
 // CHECK:STDOUT: VarParamLetDeclaration-Passing RValue - end
 // CHECK-EMPTY:
@@ -65,13 +61,13 @@ fn VarDeclaration() {
   var a: A = {};
 }
 
+fn LetDeclaration() {
+  let a: A = {};
+}
+
 fn VarAndLetDeclaration() {
   var a: A = {};
   let b: A = a;
-}
-
-fn LetDeclaration() {
-  let a: A = {};
 }
 
 fn LetParamVarDeclaration(a: A) {

--- a/explorer/testdata/destructor/rvalue_class.carbon
+++ b/explorer/testdata/destructor/rvalue_class.carbon
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A{
+    fn Create(n: i32) -> Self{
+         return {.n = n};
+    }
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  A.Create(1);
+  let a: A = A.Create(2);
+  return 0;
+}


### PR DESCRIPTION
Mostly as a proof of concept currently. The optional `LValAction` is very hackish.
See commit https://github.com/carbon-language/carbon-lang/pull/2740/commits/e25164d61c51d0ba24edbe09ca698926bd681d2e for the diff with #2736 

Depends on #2736 