### PR TITLE
Explorer: fix assignment error typo

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4558,9 +4558,8 @@ auto TypeChecker::TypeCheckStmt(Nonnull<Statement*> s,
       CARBON_RETURN_IF_ERROR(TypeCheckExp(&assign.lhs(), impl_scope));
       if (assign.lhs().expression_category() != ExpressionCategory::Reference) {
         return ProgramError(assign.source_loc())
-               << "Only assign a reference expression can be assigned, but got "
-                  "`'"
-               << assign.lhs() << "`'";
+               << "Only a reference expression can be assigned to, but got `"
+               << assign.lhs() << "`";
       }
       if (assign.op() == AssignOperator::Plain &&
           IsSameType(&assign.lhs().static_type(), &assign.rhs().static_type(),

--- a/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
@@ -12,7 +12,7 @@ fn F() {}
 fn G() {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_assign_to_function.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'F`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_assign_to_function.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `F`
   F = G;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
@@ -9,7 +9,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'1`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `1`
   1 = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_function_args.carbon
+++ b/explorer/testdata/let/fail_function_args.carbon
@@ -10,7 +10,7 @@ package ExplorerTest api;
 
 fn f((var x: i32, y: i32)) -> i32 {
   x = 0;
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_function_args.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'y`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_function_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `y`
   y = 0;
   return x - 1;
 }

--- a/explorer/testdata/let/fail_global_assign.carbon
+++ b/explorer/testdata/let/fail_global_assign.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 let x: i32 = 10;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_global_assign.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'x`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_global_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
   x = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_local_assign.carbon
+++ b/explorer/testdata/let/fail_local_assign.carbon
@@ -10,7 +10,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   let x: auto = 10;
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_local_assign.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'x`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_local_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
   x = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_match_choice.carbon
+++ b/explorer/testdata/let/fail_match_choice.carbon
@@ -25,7 +25,7 @@ fn Main() -> i32 {
       n = n - 1;
     }
     case Ints.Two(x: auto, y: auto) => {
-      // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_match_choice.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'x`'
+      // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_match_choice.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
       x = 0;
     }
   }

--- a/explorer/testdata/let/fail_method_args.carbon
+++ b/explorer/testdata/let/fail_method_args.carbon
@@ -14,7 +14,7 @@ class Point {
   }
 
   fn SetX[self: Point](x: i32) {
-    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_method_args.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'x`'
+    // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_method_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
     x = 10;
   }
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
@@ -12,7 +12,7 @@ fn Main() -> i32 {
   let (var a: auto, b: auto, c: auto, d: auto) = (1, 2, 3, 4);
   a = 0;
   // should fail
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_tuple_pattern_let_context.carbon:[[@LINE+1]]: Only assign a reference expression can be assigned, but got `'c`'
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/let/fail_tuple_pattern_let_context.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `c`
   c = 0;
   return 0;
 }


### PR DESCRIPTION
Fix typo in error message from expression categories renaming