### PR TITLE
Explorer: Report compiletime error when global variable type is abstract

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2210,15 +2210,6 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
     case DeclarationKind::VariableDeclaration: {
       const auto& var_decl = cast<VariableDeclaration>(decl);
       if (var_decl.has_initializer()) {
-        auto initializer = &var_decl.binding().static_type();
-        if (const auto* dest_class = dyn_cast<NominalClassType>(initializer)) {
-          if (dest_class->declaration().extensibility() ==
-              ClassExtensibility::Abstract) {
-            return ProgramError(var_decl.source_loc())
-                   << "Cannot instantiate abstract class "
-                   << dest_class->declaration().name();
-          }
-        }
         if (act.pos() == 0) {
           return todo_.Spawn(
               std::make_unique<ExpressionAction>(&var_decl.initializer()));

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2210,6 +2210,15 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
     case DeclarationKind::VariableDeclaration: {
       const auto& var_decl = cast<VariableDeclaration>(decl);
       if (var_decl.has_initializer()) {
+        auto initializer = &var_decl.binding().static_type();
+        if (const auto* dest_class = dyn_cast<NominalClassType>(initializer)) {
+          if (dest_class->declaration().extensibility() ==
+              ClassExtensibility::Abstract) {
+            return ProgramError(var_decl.source_loc())
+                   << "Cannot instantiate abstract class "
+                   << dest_class->declaration().name();
+          }
+        }
         if (act.pos() == 0) {
           return todo_.Spawn(
               std::make_unique<ExpressionAction>(&var_decl.initializer()));

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -309,7 +309,7 @@ static auto ExpectCompleteType(SourceLocation source_loc,
          << "incomplete type `" << *type << "` used in " << context;
 }
 
-// Expect that a type is concreate. Issue a diagnostic if not.
+// Expect that a type is concrete. Issue a diagnostic if not.
 static auto ExpectConcreteType(SourceLocation source_loc,
                                Nonnull<const Value*> type) -> ErrorOr<Success> {
   CARBON_CHECK(IsType(type));

--- a/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
+++ b/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 abstract class B {
 }
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
 var b: B = {};
 
 fn Main() -> i32 {

--- a/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
+++ b/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 abstract class B {
 }
 
-// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
 var b: B = {};
 
 fn Main() -> i32 {

--- a/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
+++ b/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+abstract class B {
+}
+
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/global_variable/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
+var b: B = {};
+
+fn Main() -> i32 {
+    return 0;
+}


### PR DESCRIPTION
Add concrete type check for Variable Declaration to report a compile time error when the variable type is abstract

Closes #2747
