### PR TITLE
Explorer: Move Concrete type check for Variable Definition to the type checker

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2031,14 +2031,6 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
     case StatementKind::VariableDefinition: {
       const auto& definition = cast<VariableDefinition>(stmt);
       const auto* dest_type = &definition.pattern().static_type();
-      if (const auto* dest_class = dyn_cast<NominalClassType>(dest_type)) {
-        if (dest_class->declaration().extensibility() ==
-            ClassExtensibility::Abstract) {
-          return ProgramError(stmt.source_loc())
-                 << "Cannot instantiate abstract class "
-                 << dest_class->declaration().name();
-        }
-      }
       if (act.pos() == 0 && definition.has_init()) {
         //    { {(var x = e) :: C, E, F} :: S, H}
         // -> { {e :: (var x = []) :: C, E, F} :: S, H}

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4557,7 +4557,8 @@ auto TypeChecker::TypeCheckStmt(Nonnull<Statement*> s,
           &var.pattern(), init_type, var_scope, var.expression_category()));
       CARBON_RETURN_IF_ERROR(ExpectCompleteType(
           var.source_loc(), "type of variable", &var.pattern().static_type()));
-
+      CARBON_RETURN_IF_ERROR(
+          ExpectConcreteType(var.source_loc(), &var.pattern().static_type()));
       if (var.has_init()) {
         CARBON_ASSIGN_OR_RETURN(
             Nonnull<Expression*> converted_init,

--- a/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
@@ -17,7 +17,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C = C.Create();
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
@@ -13,7 +13,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C;
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
@@ -13,7 +13,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C = { .a = 1 };
   return 0;
 }


### PR DESCRIPTION
Move concrete type check for Variable Definition (Local variable) from interpreter to type checker using the `ExpectConcreteType` function created in #2748
