### PR TITLE
fix: incorrect loop in builtins_indexes

### DIFF
--- a/explorer/interpreter/builtins.cpp
+++ b/explorer/interpreter/builtins.cpp
@@ -23,7 +23,7 @@ void Builtins::Register(Nonnull<const Declaration*> decl) {
 
     static std::map<std::string, int, std::less<>>* builtin_indexes = [] {
       std::map<std::string, int, std::less<>> builtin_indexes;
-      for (int index = 0; index <= Builtin::NumBuiltins; ++index) {
+      for (int index = 0; index < Builtin::NumBuiltins; ++index) {
         builtin_indexes.emplace(Builtin::FromInt(index).name(), index);
       }
       return new auto(std::move(builtin_indexes));

--- a/explorer/testdata/interface/interface_name_invalid.carbon
+++ b/explorer/testdata/interface/interface_name_invalid.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Invalid {}
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
Replaces the incorrect `<=` with `<`. Earlier this also included `Builtin::Invalid` which is meant to be used as count of Builtins.

Closes #2729 
