### PR TITLE
fix: set StaticScope::NameStatus correctly for Associated Constants

### DIFF
--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -227,7 +227,9 @@ auto NameResolver::AddExposedNames(const Declaration& declaration,
     case DeclarationKind::AssociatedConstantDeclaration: {
       const auto& let = cast<AssociatedConstantDeclaration>(declaration);
       if (let.binding().name() != AnonymousName) {
-        CARBON_RETURN_IF_ERROR(enclosing_scope.Add(let.binding().name(), &let));
+        CARBON_RETURN_IF_ERROR(
+            enclosing_scope.Add(let.binding().name(), &let,
+                                StaticScope::NameStatus::KnownButNotDeclared));
       }
       break;
     }
@@ -829,7 +831,9 @@ auto NameResolver::ResolveNames(Declaration& declaration,
     case DeclarationKind::AssociatedConstantDeclaration: {
       auto& let = cast<AssociatedConstantDeclaration>(declaration);
       StaticScope constant_scope(&enclosing_scope);
+      enclosing_scope.MarkDeclared(let.binding().name());
       CARBON_RETURN_IF_ERROR(ResolveNames(let.binding(), constant_scope));
+      enclosing_scope.MarkUsable(let.binding().name());
       break;
     }
 

--- a/explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon
+++ b/explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface IFace {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon:[[@LINE+1]]: 'C' has not been declared yet
+  let B:! C;
+  let C:! IFace;
+}
+
+fn Main() -> i32 {
+  // return T;
+}

--- a/explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon
+++ b/explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface IFace {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon:[[@LINE+1]]: 'T' is not usable until after it has been completely declared
+  let T:! T.IFace;
+}
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
The StaticScope::NameStatus pattern is not being correctly follow for associated constant deceleration. 

Closes #2728
Closes #2730
