### PR TITLE
Fix handling of struct conversions in deduction

### DIFF
--- a/explorer/testdata/impl/struct.carbon
+++ b/explorer/testdata/impl/struct.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Interface {}
+impl {} as Interface {}
+impl {.x: i32} as Interface {}
+
+fn Main() -> i32 {
+  return 0;
+}


### PR DESCRIPTION
This case previously crashed. Trying to handle allow_implicit_conversion better per discussion; I've split out the for loop for each path because I think it's now clearer this way.