### PR TITLE
clang-tidy cleanup

### DIFF
--- a/explorer/ast/clone_context.cpp
+++ b/explorer/ast/clone_context.cpp
@@ -64,7 +64,7 @@ class CloneContext::CloneValueTransform
   // A FunctionType may or may not own its bindings.
   auto operator()(Nonnull<const FunctionType*> fn_type)
       -> Nonnull<const FunctionType*> {
-    for (auto* binding : fn_type->deduced_bindings()) {
+    for (const auto* binding : fn_type->deduced_bindings()) {
       context_->MaybeCloneBase(binding);
     }
     for (auto [index, binding] : fn_type->generic_parameters()) {

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -158,7 +158,7 @@ void Declaration::PrintID(llvm::raw_ostream& out) const {
       if (!impl_decl.deduced_parameters().empty()) {
         out << "forall [";
         llvm::ListSeparator sep;
-        for (auto* param : impl_decl.deduced_parameters()) {
+        for (const auto* param : impl_decl.deduced_parameters()) {
           out << sep << *param;
         }
         out << "] ";

--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -11,7 +11,6 @@
 
 using llvm::cast;
 using llvm::dyn_cast;
-using llvm::isa;
 
 namespace Carbon {
 
@@ -251,10 +250,7 @@ auto ImplScope::VisitEqualValues(
       return false;
     }
   }
-  if (parent_scope_ && !(*parent_scope_)->VisitEqualValues(value, visitor)) {
-    return false;
-  }
-  return true;
+  return !parent_scope_ || (*parent_scope_)->VisitEqualValues(value, visitor);
 }
 
 auto ImplScope::TryResolveInterface(Nonnull<const InterfaceType*> iface_type,

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -411,7 +411,7 @@ static auto IsConcreteType(Nonnull<const Value*> value) -> bool {
 // depends on any template paramaeter.
 static auto IsTemplateDependent(Nonnull<const Value*> value) -> bool {
   // A VariableType is template dependent if it names a template binding.
-  if (auto* var_type = dyn_cast<VariableType>(value)) {
+  if (const auto* var_type = dyn_cast<VariableType>(value)) {
     return var_type->binding().binding_kind() ==
            GenericBinding::BindingKind::Template;
   }
@@ -448,7 +448,7 @@ static auto IsTemplateSaturated(const Bindings& bindings) -> bool {
 // have template argument values specified.
 static auto IsTemplateSaturated(
     llvm::ArrayRef<Nonnull<const GenericBinding*>> bindings) -> bool {
-  for (auto* binding : bindings) {
+  for (const auto* binding : bindings) {
     if (binding->binding_kind() == GenericBinding::BindingKind::Template &&
         !binding->has_template_value()) {
       return false;
@@ -5583,7 +5583,7 @@ auto TypeChecker::CheckAndAddImplBindings(
                                                  iface_witness, iface_scope));
 
       std::optional<TypeStructureSortKey> sort_key;
-      if (deduced_bindings.size()) {
+      if (!deduced_bindings.empty()) {
         sort_key = TypeStructureSortKey::ForImpl(impl_type, iface_type);
         if (trace_stream_->is_enabled()) {
           *trace_stream_ << "type structure sort key for `impl " << *impl_type
@@ -5622,7 +5622,7 @@ auto TypeChecker::DeclareImplDeclaration(Nonnull<ImplDeclaration*> impl_decl,
   if (!IsTemplateSaturated(impl_decl->deduced_parameters())) {
     CloneContext context(arena_);
     TemplateInfo template_info = {.pattern = context.Clone(impl_decl)};
-    for (auto deduced : impl_decl->deduced_parameters()) {
+    for (const auto* deduced : impl_decl->deduced_parameters()) {
       template_info.param_map.insert(
           {deduced, context.GetExistingClone(deduced)});
     }


### PR DESCRIPTION
running clang-tidy locally got a bunch of warning. 

I have ignored `bugprone-unchecked-optional-access` for now, because there are large number of occurrences.