### PR TITLE
Stop printing per-input results in fuzzer

### DIFF
--- a/explorer/fuzzing/explorer_fuzzer.cpp
+++ b/explorer/fuzzing/explorer_fuzzer.cpp
@@ -10,5 +10,5 @@
 
 DEFINE_TEXT_PROTO_FUZZER(const Carbon::Fuzzing::Carbon& input) {
   // Only verifying it doesn't crash.
-  Carbon::ParseAndExecute(input.compilation_unit());
+  (void)Carbon::ParseAndExecute(input.compilation_unit());
 }

--- a/explorer/fuzzing/explorer_fuzzer.cpp
+++ b/explorer/fuzzing/explorer_fuzzer.cpp
@@ -9,10 +9,6 @@
 #include "llvm/Support/raw_ostream.h"
 
 DEFINE_TEXT_PROTO_FUZZER(const Carbon::Fuzzing::Carbon& input) {
-  const auto result = Carbon::ParseAndExecute(input.compilation_unit());
-  if (result.ok()) {
-    llvm::outs() << "Executed OK: " << *result << "\n";
-  } else {
-    llvm::errs() << "Execution failed: " << result.error() << "\n";
-  }
+  // Only verifying it doesn't crash.
+  Carbon::ParseAndExecute(input.compilation_unit());
 }


### PR DESCRIPTION
Right now, running the fuzzer in fuzzing mode is pretty noisy due to this output; it makes it hard to see the fuzzer's own progress output. It's also not really needed: users can run explorer on inputs more directly, without using this tool (albeit with fuzzverter), if they want to see detailed results.