### PR TITLE
Suppress Print intrinsic output in the fuzzer.

### DIFF
--- a/explorer/fuzzing/fuzzer_util.cpp
+++ b/explorer/fuzzing/fuzzer_util.cpp
@@ -86,8 +86,11 @@ auto ParseAndExecute(const Fuzzing::CompilationUnit& compilation_unit)
   AddPrelude(*prelude_path, &arena, &ast.declarations,
              &ast.num_prelude_declarations);
   TraceStream trace_stream;
-  CARBON_ASSIGN_OR_RETURN(ast, AnalyzeProgram(&arena, ast, &trace_stream));
-  return ExecProgram(&arena, ast, &trace_stream);
+
+  // Use llvm::nulls() to suppress output from the Print intrinsic.
+  CARBON_ASSIGN_OR_RETURN(
+      ast, AnalyzeProgram(&arena, ast, &trace_stream, &llvm::nulls()));
+  return ExecProgram(&arena, ast, &trace_stream, &llvm::nulls());
 }
 
 }  // namespace Carbon

--- a/explorer/interpreter/exec_program.cpp
+++ b/explorer/interpreter/exec_program.cpp
@@ -19,7 +19,8 @@
 namespace Carbon {
 
 auto AnalyzeProgram(Nonnull<Arena*> arena, AST ast,
-                    Nonnull<TraceStream*> trace_stream) -> ErrorOr<AST> {
+                    Nonnull<TraceStream*> trace_stream,
+                    Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<AST> {
   if (trace_stream->is_enabled()) {
     *trace_stream << "********** source program **********\n";
     for (int i = ast.num_prelude_declarations;
@@ -46,7 +47,8 @@ auto AnalyzeProgram(Nonnull<Arena*> arena, AST ast,
   if (trace_stream->is_enabled()) {
     *trace_stream << "********** type checking **********\n";
   }
-  CARBON_RETURN_IF_ERROR(TypeChecker(arena, trace_stream).TypeCheck(ast));
+  CARBON_RETURN_IF_ERROR(
+      TypeChecker(arena, trace_stream, print_stream).TypeCheck(ast));
 
   if (trace_stream->is_enabled()) {
     *trace_stream << "********** resolving unformed variables **********\n";
@@ -64,11 +66,12 @@ auto AnalyzeProgram(Nonnull<Arena*> arena, AST ast,
 }
 
 auto ExecProgram(Nonnull<Arena*> arena, AST ast,
-                 Nonnull<TraceStream*> trace_stream) -> ErrorOr<int> {
+                 Nonnull<TraceStream*> trace_stream,
+                 Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int> {
   if (trace_stream->is_enabled()) {
     *trace_stream << "********** starting execution **********\n";
   }
-  return InterpProgram(ast, arena, trace_stream);
+  return InterpProgram(ast, arena, trace_stream, print_stream);
 }
 
 }  // namespace Carbon

--- a/explorer/interpreter/exec_program.h
+++ b/explorer/interpreter/exec_program.h
@@ -17,11 +17,13 @@ namespace Carbon {
 
 // Perform semantic analysis on the AST.
 auto AnalyzeProgram(Nonnull<Arena*> arena, AST ast,
-                    Nonnull<TraceStream*> trace_stream) -> ErrorOr<AST>;
+                    Nonnull<TraceStream*> trace_stream,
+                    Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<AST>;
 
 // Run the program's `Main` function.
 auto ExecProgram(Nonnull<Arena*> arena, AST ast,
-                 Nonnull<TraceStream*> trace_stream) -> ErrorOr<int>;
+                 Nonnull<TraceStream*> trace_stream,
+                 Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int>;
 
 }  // namespace Carbon
 

--- a/explorer/interpreter/interpreter.h
+++ b/explorer/interpreter/interpreter.h
@@ -25,13 +25,15 @@ namespace Carbon {
 // Interprets the program defined by `ast`, allocating values on `arena` and
 // printing traces if `trace` is true.
 auto InterpProgram(const AST& ast, Nonnull<Arena*> arena,
-                   Nonnull<TraceStream*> trace_stream) -> ErrorOr<int>;
+                   Nonnull<TraceStream*> trace_stream,
+                   Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int>;
 
 // Interprets `e` at compile-time, allocating values on `arena` and
 // printing traces if `trace` is true. The caller must ensure that all the
 // code this evaluates has been typechecked.
 auto InterpExp(Nonnull<const Expression*> e, Nonnull<Arena*> arena,
-               Nonnull<TraceStream*> trace_stream)
+               Nonnull<TraceStream*> trace_stream,
+               Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<Nonnull<const Value*>>;
 
 // Attempts to match `v` against the pattern `p`, returning whether matching

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -38,8 +38,11 @@ using GlobalMembersMap =
 class TypeChecker {
  public:
   explicit TypeChecker(Nonnull<Arena*> arena,
-                       Nonnull<TraceStream*> trace_stream)
-      : arena_(arena), trace_stream_(trace_stream) {}
+                       Nonnull<TraceStream*> trace_stream,
+                       Nonnull<llvm::raw_ostream*> print_stream)
+      : arena_(arena),
+        trace_stream_(trace_stream),
+        print_stream_(print_stream) {}
 
   // Type-checks `ast` and sets properties such as `static_type`, as documented
   // on the individual nodes.
@@ -523,9 +526,14 @@ class TypeChecker {
 
   // Instantiate an impl with the given set of bindings, including one or more
   // template bindings.
-  ErrorOr<std::pair<Nonnull<ImplDeclaration*>, Nonnull<Bindings*>>>
-  InstantiateImplDeclaration(Nonnull<const ImplDeclaration*> pattern,
-                             Nonnull<const Bindings*> bindings) const;
+  auto InstantiateImplDeclaration(Nonnull<const ImplDeclaration*> pattern,
+                                  Nonnull<const Bindings*> bindings) const
+      -> ErrorOr<std::pair<Nonnull<ImplDeclaration*>, Nonnull<Bindings*>>>;
+
+  // Wraps the interpreter's InterpExp, forwarding TypeChecker members as
+  // arguments.
+  auto InterpExp(Nonnull<const Expression*> e)
+      -> ErrorOr<Nonnull<const Value*>>;
 
   Nonnull<Arena*> arena_;
   Builtins builtins_;
@@ -534,6 +542,9 @@ class TypeChecker {
   GlobalMembersMap collected_members_;
 
   Nonnull<TraceStream*> trace_stream_;
+
+  // The stream for the Print intrinsic.
+  Nonnull<llvm::raw_ostream*> print_stream_;
 
   // The top-level ImplScope, containing `impl` declarations that should be
   // usable from any context. This is used when we want to try to refine a

--- a/explorer/main.cpp
+++ b/explorer/main.cpp
@@ -105,7 +105,8 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
   auto time_after_prelude = std::chrono::system_clock::now();
 
   // Semantically analyze the parsed program.
-  if (ErrorOr<AST> analyze_result = AnalyzeProgram(&arena, ast, &trace_stream);
+  if (ErrorOr<AST> analyze_result =
+          AnalyzeProgram(&arena, ast, &trace_stream, &llvm::outs());
       analyze_result.ok()) {
     ast = *std::move(analyze_result);
   } else {
@@ -117,7 +118,8 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
 
   // Run the program.
   auto ret = EXIT_SUCCESS;
-  if (ErrorOr<int> exec_result = ExecProgram(&arena, ast, &trace_stream);
+  if (ErrorOr<int> exec_result =
+          ExecProgram(&arena, ast, &trace_stream, &llvm::outs());
       exec_result.ok()) {
     // Print the return code to stdout.
     llvm::outs() << "result: " << *exec_result << "\n";


### PR DESCRIPTION
Related to #2780, but mostly an issue when running over the committed corpus since we use Print a lot.