### PR TITLE
fix printing for single element tuple values

### DIFF
--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -516,15 +516,7 @@ void Value::Print(llvm::raw_ostream& out) const {
         }
         out << "]";
       }
-      const auto* params = dyn_cast<TupleType>(&fn_type.parameters());
-      CARBON_CHECK(params)
-          << "Parameters of function type must be a tuple type";
-      out << "(";
-      llvm::ListSeparator sep;
-      for (Nonnull<const Value*> element : params->elements()) {
-        out << sep << *element;
-      }
-      out << ") -> " << fn_type.return_type();
+      out << fn_type.parameters() << " -> " << fn_type.return_type();
       break;
     }
     case Value::Kind::StructType: {

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -418,7 +418,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       for (Nonnull<const Value*> element : elements) {
         out << sep << *element;
       }
-      // print trailing comma for single element tuples: (i32,)
+      // Print trailing comma for single element tuples: (i32,).
       if (elements.size() == 1) {
         out << ",";
       }

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -414,9 +414,13 @@ void Value::Print(llvm::raw_ostream& out) const {
     case Value::Kind::TupleValue: {
       out << "(";
       llvm::ListSeparator sep;
-      for (Nonnull<const Value*> element :
-           cast<TupleValueBase>(*this).elements()) {
+      const auto elements = cast<TupleValueBase>(*this).elements();
+      for (Nonnull<const Value*> element : elements) {
         out << sep << *element;
+      }
+      // print trailing comma for single element tuples: (i32,)
+      if (elements.size() == 1) {
+        out << ",";
       }
       out << ")";
       break;

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -517,7 +517,8 @@ void Value::Print(llvm::raw_ostream& out) const {
         out << "]";
       }
       const auto* params = dyn_cast<TupleType>(&fn_type.parameters());
-      CARBON_CHECK(params) << "Parameters of function type must be a tuple type";
+      CARBON_CHECK(params)
+          << "Parameters of function type must be a tuple type";
       out << "(";
       llvm::ListSeparator sep;
       for (Nonnull<const Value*> element : params->elements()) {

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -516,7 +516,14 @@ void Value::Print(llvm::raw_ostream& out) const {
         }
         out << "]";
       }
-      out << fn_type.parameters() << " -> " << fn_type.return_type();
+      const auto* params = dyn_cast<TupleType>(&fn_type.parameters());
+      CARBON_CHECK(params) << "Parameters of function type must be a tuple type";
+      out << "(";
+      llvm::ListSeparator sep;
+      for (Nonnull<const Value*> element : params->elements()) {
+        out << sep << *element;
+      }
+      out << ") -> " << fn_type.return_type();
       break;
     }
     case Value::Kind::StructType: {

--- a/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
@@ -8,7 +8,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon:[[@LINE+1]]: type error in type expression: '(i32)' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon:[[@LINE+1]]: type error in type expression: '(i32,)' is not implicitly convertible to 'type'
 choice C { X(42) }
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl_match/fail_tuple_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_tuple_recurse.carbon
@@ -17,7 +17,7 @@ fn F[T:! Foo](x: T) {}
 fn Main() -> i32 {
   // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/impl_match/fail_tuple_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface Foo
-  // CHECK:STDERR:   inner match: (i32) as interface Foo
+  // CHECK:STDERR:   inner match: (i32,) as interface Foo
   F(0);
   return 0;
 }

--- a/explorer/testdata/interface/fail_impl_bad_member.carbon
+++ b/explorer/testdata/interface/fail_impl_bad_member.carbon
@@ -23,8 +23,8 @@ class Point {
     fn Scale[self: Point](v: i32) -> i32 {
       return 0;
     // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/interface/fail_impl_bad_member.carbon:[[@LINE+3]]: type error in member of implementation
-    // CHECK:STDERR: expected: fn (i32) -> class Point
-    // CHECK:STDERR: actual: fn (i32) -> i32
+    // CHECK:STDERR: expected: fn (i32,) -> class Point
+    // CHECK:STDERR: actual: fn (i32,) -> i32
     }
   }
 }

--- a/explorer/testdata/tuple/fail_equality_type.carbon
+++ b/explorer/testdata/tuple/fail_equality_type.carbon
@@ -11,7 +11,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var t1: (i32, i32) = (5, 2);
   var t2: (i32,) = (5,);
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/tuple/fail_equality_type.carbon:[[@LINE+1]]: (i32, i32) is not equality comparable with (i32) (could not find implementation of interface EqWith(U = (i32)) for (i32, i32))
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/tuple/fail_equality_type.carbon:[[@LINE+1]]: (i32, i32) is not equality comparable with (i32,) (could not find implementation of interface EqWith(U = (i32,)) for (i32, i32))
   if (t1 == t2) {
     return 1;
   } else {


### PR DESCRIPTION
adds trailing comma to single element tuple

example:
```carbon
package ExplorerTest api;

fn Main() -> i32
{
  var a: (i32,) = (1, 2);
  return 0;
}

```

change in error message:
```diff
-type error in initializer of variable: '(i32, i32)' is not implicitly convertible to '(i32)'
+type error in initializer of variable: '(i32, i32)' is not implicitly convertible to '(i32,)'
```