### PR TITLE
Fix BindingPattern type check handling (#2777)

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -4152,7 +4152,7 @@ auto TypeChecker::TypeCheckPattern(
         return ProgramError(binding.type().source_loc())
                << "the type of a binding pattern cannot contain bindings";
       }
-      CARBON_RETURN_IF_ERROR(TypeCheckPattern(&binding.type(), std::nullopt,
+      CARBON_RETURN_IF_ERROR(TypeCheckPattern(&binding.type(), expected,
                                               impl_scope,
                                               enclosing_expression_category));
       Nonnull<const Value*> type = &binding.type().value();

--- a/explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon
+++ b/explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon:[[@LINE+1]]: tuples of different length
+  var a: (auto,) = (1, 2);
+  return 0;
+}

--- a/explorer/testdata/tuple/fail_unexpected_tuple.carbon
+++ b/explorer/testdata/tuple/fail_unexpected_tuple.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/tuple/fail_unexpected_tuple.carbon:[[@LINE+1]]: didn't expect a tuple
+  var a: (auto,) = 1;
+  return 0;
+}


### PR DESCRIPTION
**Recursive call of TypeCheckPattern ignored 'expected' parameter .**

Closes #2777
