### PR TITLE
[explorer] fix assert when aliasing interface as member

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2843,6 +2843,11 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                 access.set_expression_category(ExpressionCategory::Value);
                 break;
               }
+              case DeclarationKind::AliasDeclaration: {
+                const auto* alias = cast<AliasDeclaration>(member);
+                access.set_expression_category(alias->expression_category());
+                break;
+              }
               default:
                 CARBON_FATAL() << "member " << access.member_name()
                                << " is not a field or method";

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2843,11 +2843,9 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                 access.set_expression_category(ExpressionCategory::Value);
                 break;
               }
-              case DeclarationKind::AliasDeclaration: {
-                const auto* alias = cast<AliasDeclaration>(member);
-                access.set_expression_category(alias->expression_category());
-                break;
-              }
+              case DeclarationKind::AliasDeclaration:
+                return ProgramError(access.source_loc())
+                       << "Member access to aliases is not yet supported.";
               default:
                 CARBON_FATAL() << "member " << access.member_name()
                                << " is not a field or method";

--- a/explorer/testdata/alias/interface_method_as_class_member.carbon
+++ b/explorer/testdata/alias/interface_method_as_class_member.carbon
@@ -35,7 +35,7 @@ impl forall [U:! Printable] Vector(U) as Printable {
 
 fn Main() -> i32 {
   var v: Vector(String) = {.x = "test"};
-  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/alias/interface_method_as_class_member.carbon:[[@LINE+1]]: in call `v.PrintIt()`, expected callee to be a function, found `member name PrintIt`
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/alias/interface_method_as_class_member.carbon:[[@LINE+1]]: Member access to aliases is not yet supported.
   v.PrintIt();
   return 42;
 }

--- a/explorer/testdata/alias/interface_method_as_class_member.carbon
+++ b/explorer/testdata/alias/interface_method_as_class_member.carbon
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest api;
+
+interface Printable {
+  fn PrintIt[self: Self]();
+}
+
+impl String as Printable {
+  fn PrintIt[self: String]() {
+    Print(self);
+  }
+}
+
+class Vector(T:! type) {
+  var x: T;
+
+  alias PrintIt = Printable.PrintIt;
+}
+
+// Conditionally implement the API for certain `T`s.
+impl forall [U:! Printable] Vector(U) as Printable {
+  fn PrintIt[self: Self]() {
+    Print("{ ");
+    self.x.PrintIt();
+    Print(" }");
+  }
+}
+
+fn Main() -> i32 {
+  var v: Vector(String) = {.x = "test"};
+  // CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/testdata/alias/interface_method_as_class_member.carbon:[[@LINE+1]]: in call `v.PrintIt()`, expected callee to be a function, found `member name PrintIt`
+  v.PrintIt();
+  return 42;
+}


### PR DESCRIPTION
Note that this code still results in a compilation error pending the merge of #2628, this just prevents the assertion from happening.

Closes #2583.
