### PR TITLE
Break long ground rule bullet into multiple bullets

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ that we ask all community members to adhere to:
 -   be considerate,
 -   be kind,
 -   be careful in the words that we choose,
--   when we disagree, we try to understand why, and
+-   when we disagree, try to understand why, and
 -   recognize when progress has stopped, and take a step back.
 
 This list isn't exhaustive. Rather, take it in the spirit in which it’s intended

--- a/docs/project/transparency_reports.md
+++ b/docs/project/transparency_reports.md
@@ -34,7 +34,7 @@ that we ask all community members to adhere to:
 -   be considerate,
 -   be kind,
 -   be careful in the words that we choose,
--   when we disagree, we try to understand why, and
+-   when we disagree, try to understand why, and
 -   recognize when progress has stopped, and take a step back.
 
 The following summary is intended to help the community understand what kinds of

--- a/docs/project/transparency_reports.md
+++ b/docs/project/transparency_reports.md
@@ -33,9 +33,9 @@ that we ask all community members to adhere to:
 -   be friendly and patient,
 -   be considerate,
 -   be kind,
--   be careful in the words that we choose, when we disagree, we try to
-    understand why, and recognize when progress has stopped, and take a step
-    back.
+-   be careful in the words that we choose,
+-   when we disagree, we try to understand why, and
+-   recognize when progress has stopped, and take a step back.
 
 The following summary is intended to help the community understand what kinds of
 Code of Conduct (CoC) incidents were brought to our attention lately, and how we


### PR DESCRIPTION
This makes the bullets more self-consistent and easier to read, and makes this list match the list in the code of conduct.