### PR TITLE
Fix local and global uninitialized array access

### DIFF
--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2114,6 +2114,17 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
         if (definition.has_init()) {
           CARBON_ASSIGN_OR_RETURN(
               v, Convert(act.results()[0], dest_type, stmt.source_loc()));
+        } else if (dest_type->kind() == Value::Kind::StaticArrayType) {
+          const auto& array = cast<StaticArrayType>(dest_type);
+          const auto& element_type = array->element_type();
+          const auto size = array->size();
+
+          std::vector<Nonnull<const Value*>> elements;
+          elements.reserve(size);
+          for (size_t i = 0; i < size; i++) {
+            elements.push_back(arena_->New<UninitializedValue>(&element_type));
+          }
+          v = arena_->New<TupleValueBase>(Value::Kind::TupleValue, elements);
         } else {
           v = arena_->New<UninitializedValue>(p);
         }
@@ -2258,6 +2269,7 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
   switch (decl.kind()) {
     case DeclarationKind::VariableDeclaration: {
       const auto& var_decl = cast<VariableDeclaration>(decl);
+      const auto* var_type = &var_decl.binding().static_type();
       if (var_decl.has_initializer()) {
         if (act.pos() == 0) {
           return todo_.Spawn(
@@ -2270,6 +2282,21 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
           todo_.Initialize(&var_decl.binding(), v);
           return todo_.FinishAction();
         }
+      } else if (var_type->kind() == Value::Kind::StaticArrayType) {
+        const auto& array = cast<StaticArrayType>(var_type);
+        const auto& element_type = array->element_type();
+        const auto size = array->size();
+
+        std::vector<Nonnull<const Value*>> elements;
+        elements.reserve(size);
+        for (size_t i = 0; i < size; i++) {
+          elements.push_back(arena_->New<UninitializedValue>(&element_type));
+        }
+
+        Nonnull<const Value*> v =
+            arena_->New<TupleValueBase>(Value::Kind::TupleValue, elements);
+        todo_.Initialize(&var_decl.binding(), v);
+        return todo_.FinishAction();
       } else {
         Nonnull<const Value*> v =
             arena_->New<UninitializedValue>(&var_decl.binding().value());

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1580,10 +1580,15 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
             case 0:
               *print_stream_ << llvm::formatv(format_string);
               break;
-            case 1:
+            case 1: {
+              if ((*args[1]).kind() == Value::Kind::UninitializedValue) {
+                return ProgramError(exp.source_loc())
+                       << "Printing uninitialized value";
+              }
               *print_stream_ << llvm::formatv(format_string,
                                               cast<IntValue>(*args[1]).value());
               break;
+            }
             default:
               CARBON_FATAL() << "Too many format args: " << num_format_args;
           }

--- a/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
+++ b/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{not} %{explorer-run}
+// RUN: %{not} %{explorer-run-trace}
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  var my_array : [i32; 1];
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/print/fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: Printing uninitialized value
+  Print("{0}", my_array[0]);
+  return 0;
+}

--- a/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
+++ b/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
@@ -10,7 +10,7 @@ package ExplorerTest impl;
 
 fn Main() -> i32 {
   var my_array : [i32; 1];
-  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/print/fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: Printing uninitialized value
+  // CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/testdata/array/fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: Printing uninitialized value
   Print("{0}", my_array[0]);
   return 0;
 }

--- a/explorer/testdata/array/uninitialized_global_array_access.carbon
+++ b/explorer/testdata/array/uninitialized_global_array_access.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: 100
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+var my_array : [i32; 1];
+
+fn Main() -> i32 {
+  my_array[0] = 100;
+  Print("{0}", my_array[0]);
+  return 0;
+}

--- a/explorer/testdata/array/uninitialized_local_array_access.carbon
+++ b/explorer/testdata/array/uninitialized_local_array_access.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// RUN: %{explorer-run}
+// RUN: %{explorer-run-trace}
+// CHECK:STDOUT: 100
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var my_array : [i32; 1];
+  my_array[0] = 100;
+  Print("{0}", my_array[0]);
+  return 0;
+}


### PR DESCRIPTION
Treat local and global initialization array as initialized array with uninitialized entries

Closes #2812
