### PR TITLE
Add testonly to file_test

### DIFF
--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -8,6 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "file_test_base",
+    testonly = 1,
     srcs = ["file_test_base.cpp"],
     hdrs = ["file_test_base.h"],
     deps = [


### PR DESCRIPTION
I don't know why gtest doesn't have testonly set in public, but that's the root of this.