### PR TITLE
Extract a test helper to its own library.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -147,6 +147,26 @@ cc_test(
 )
 
 cc_library(
+    name = "test_raw_ostream",
+    testonly = 1,
+    hdrs = ["test_raw_ostream.h"],
+    deps = [
+        ":ostream",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "test_raw_ostream_test",
+    srcs = ["test_raw_ostream_test.cpp"],
+    deps = [
+        ":test_raw_ostream",
+        "//common:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "vlog",
     srcs = ["vlog_internal.h"],
     hdrs = ["vlog.h"],

--- a/common/test_raw_ostream.h
+++ b/common/test_raw_ostream.h
@@ -1,0 +1,49 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TEST_RAW_OSTREAM_H_
+#define CARBON_COMMON_TEST_RAW_OSTREAM_H_
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "common/ostream.h"
+
+namespace Carbon::Testing {
+
+/// A raw_ostream that makes it easy to repeatedly check streamed output.
+class TestRawOstream : public llvm::raw_ostream {
+ public:
+  ~TestRawOstream() override {
+    flush();
+    if (!buffer_.empty()) {
+      ADD_FAILURE() << "Unchecked output:\n" << buffer_;
+    }
+  }
+
+  /// Flushes the stream and returns the contents so far, clearing the stream
+  /// back to empty.
+  auto TakeStr() -> std::string {
+    flush();
+    std::string result = std::move(buffer_);
+    buffer_.clear();
+    return result;
+  }
+
+ private:
+  void write_impl(const char* ptr, size_t size) override {
+    buffer_.append(ptr, ptr + size);
+  }
+
+  [[nodiscard]] auto current_pos() const -> uint64_t override {
+    return buffer_.size();
+  }
+
+  std::string buffer_;
+};
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_COMMON_TEST_RAW_OSTREAM_H_

--- a/common/test_raw_ostream.h
+++ b/common/test_raw_ostream.h
@@ -13,34 +13,26 @@
 
 namespace Carbon::Testing {
 
-/// A raw_ostream that makes it easy to repeatedly check streamed output.
-class TestRawOstream : public llvm::raw_ostream {
+// A raw_ostream that makes it easy to repeatedly check streamed output.
+class TestRawOstream : public llvm::raw_string_ostream {
  public:
+  explicit TestRawOstream() : llvm::raw_string_ostream(buffer_) {}
+
   ~TestRawOstream() override {
-    flush();
     if (!buffer_.empty()) {
       ADD_FAILURE() << "Unchecked output:\n" << buffer_;
     }
   }
 
-  /// Flushes the stream and returns the contents so far, clearing the stream
-  /// back to empty.
+  // Flushes the stream and returns the contents so far, clearing the stream
+  // back to empty.
   auto TakeStr() -> std::string {
-    flush();
     std::string result = std::move(buffer_);
     buffer_.clear();
     return result;
   }
 
  private:
-  void write_impl(const char* ptr, size_t size) override {
-    buffer_.append(ptr, ptr + size);
-  }
-
-  [[nodiscard]] auto current_pos() const -> uint64_t override {
-    return buffer_.size();
-  }
-
   std::string buffer_;
 };
 

--- a/common/test_raw_ostream_test.cpp
+++ b/common/test_raw_ostream_test.cpp
@@ -1,0 +1,63 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/test_raw_ostream.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace Carbon::Testing {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::StrEq;
+
+TEST(TestRawOstreamTest, Basics) {
+  TestRawOstream os;
+
+  os << "test 1";
+  EXPECT_THAT(os.TakeStr(), StrEq("test 1"));
+
+  os << "test"
+     << " "
+     << "2";
+  EXPECT_THAT(os.TakeStr(), StrEq("test 2"));
+
+  os << "test";
+  os << " ";
+  os << "3";
+  EXPECT_THAT(os.TakeStr(), StrEq("test 3"));
+}
+
+TEST(TestRawOstreamTest, MultipleStreams) {
+  TestRawOstream os1;
+  TestRawOstream os2;
+
+  os1 << "test ";
+  os2 << "test stream 2";
+  os1 << "stream 1";
+  EXPECT_THAT(os1.TakeStr(), StrEq("test stream 1"));
+  EXPECT_THAT(os2.TakeStr(), StrEq("test stream 2"));
+}
+
+TEST(TestRawOstreamTest, MultipleLines) {
+  TestRawOstream os;
+
+  os << "test line 1\n";
+  os << "test line 2\n";
+  os << "test line 3\n";
+  EXPECT_THAT(os.TakeStr(), StrEq("test line 1\ntest line 2\ntest line 3\n"));
+}
+
+TEST(TestRawOstreamTest, Substring) {
+  TestRawOstream os;
+
+  os << "test line 1\n";
+  os << "test line 2\n";
+  os << "test line 3\n";
+  EXPECT_THAT(os.TakeStr(), HasSubstr("test line 2"));
+}
+
+}  // namespace
+}  // namespace Carbon::Testing

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -33,6 +33,7 @@ cc_test(
     deps = [
         ":driver",
         "//common:gtest_main",
+        "//common:test_raw_ostream",
         "//toolchain/common:yaml_test_helpers",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lexer:tokenized_buffer_test_helpers",


### PR DESCRIPTION
This is a convenient test helper for anything that can use injected
streams. Extract this to where it can be used by other tests and add
some basic tests, mostly documenting how it works.