### PR TITLE
Provide local paths for file tests.

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -8,23 +8,24 @@
 namespace Carbon::Testing {
 namespace {
 
-static constexpr char PreludePath[] = "explorer/data/prelude.carbon";
-
 class ParseAndExecuteTestFile : public FileTestBase {
  public:
-  explicit ParseAndExecuteTestFile(llvm::StringRef path, bool trace)
+  explicit ParseAndExecuteTestFile(const std::filesystem::path& path,
+                                   bool trace)
       : FileTestBase(path), trace_(trace) {}
 
   auto SetUp() -> void override {
     if (trace_) {
-      if (path().find("/limits/") != llvm::StringRef::npos) {
+      std::string path_str = path().string();
+      llvm::StringRef path_ref = path_str;
+      if (path_ref.find("/limits/") != llvm::StringRef::npos) {
         GTEST_SKIP()
             << "`limits` tests check for various limit conditions (such as an "
                "infinite loop). The tests collectively don't test tracing "
                "because it creates substantial additional overhead.";
-      } else if (path().endswith(
+      } else if (path_ref.endswith(
                      "testdata/assoc_const/rewrite_large_type.carbon") ||
-                 path().endswith(
+                 path_ref.endswith(
                      "testdata/linked_list/typed_linked_list.carbon")) {
         GTEST_SKIP() << "Expensive test to trace";
       }
@@ -41,10 +42,16 @@ class ParseAndExecuteTestFile : public FileTestBase {
       trace_stream.set_stream(&trace_stream_ostream);
     }
 
+    // Set the location of the prelude.
+    char* test_srcdir = getenv("TEST_SRCDIR");
+    CARBON_CHECK(test_srcdir != nullptr);
+    std::string prelude_path(test_srcdir);
+    prelude_path += "/carbon/explorer/data/prelude.carbon";
+
     // Run the parse. Parser debug output is always off because it's difficult
     // to redirect.
     auto result =
-        ParseAndExecuteFile(PreludePath, filename().str(),
+        ParseAndExecuteFile(prelude_path, path().filename().string(),
                             /*parser_debug=*/false, &trace_stream, &stdout);
     // This mirrors printing currently done by main.cpp.
     if (result.ok()) {
@@ -67,14 +74,15 @@ class ParseAndExecuteTestFile : public FileTestBase {
 
 }  // namespace
 
-extern auto RegisterFileTests(const std::vector<llvm::StringRef>& paths)
+extern auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
     -> void {
   ParseAndExecuteTestFile::RegisterTests(
-      "ParseAndExecuteTestFile", paths, [=](llvm::StringRef path) {
+      "ParseAndExecuteTestFile", paths, [=](const std::filesystem::path& path) {
         return new ParseAndExecuteTestFile(path, /*trace=*/false);
       });
   ParseAndExecuteTestFile::RegisterTests(
-      "ParseAndExecuteTestFile.trace", paths, [=](llvm::StringRef path) {
+      "ParseAndExecuteTestFile.trace", paths,
+      [=](const std::filesystem::path& path) {
         return new ParseAndExecuteTestFile(path, /*trace=*/true);
       });
 }

--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -44,7 +44,7 @@ class ParseAndExecuteTestFile : public FileTestBase {
     // Run the parse. Parser debug output is always off because it's difficult
     // to redirect.
     auto result =
-        ParseAndExecuteFile(PreludePath, path().str(),
+        ParseAndExecuteFile(PreludePath, filename().str(),
                             /*parser_debug=*/false, &trace_stream, &stdout);
     // This mirrors printing currently done by main.cpp.
     if (result.ok()) {

--- a/explorer/testdata/addr/fail_method_let.carbon
+++ b/explorer/testdata/addr/fail_method_let.carbon
@@ -24,7 +24,7 @@ class Point {
 
 fn Main() -> i32 {
   let p: Point = Point.Origin();
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/addr/fail_method_let.carbon:[[@LINE+1]]: method p.GetSetX requires its receiver to be a reference expression
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_let.carbon:[[@LINE+1]]: method p.GetSetX requires its receiver to be a reference expression
   var x: auto = p.GetSetX(42);
   if (p.x == 42) {
     return x;

--- a/explorer/testdata/addr/fail_method_self_misspelled.carbon
+++ b/explorer/testdata/addr/fail_method_self_misspelled.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class C {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/addr/fail_method_self_misspelled.carbon:[[@LINE+1]]: illegal binding pattern in implicit parameter list
+  // CHECK:STDERR: SYNTAX ERROR: fail_method_self_misspelled.carbon:[[@LINE+1]]: illegal binding pattern in implicit parameter list
   fn F[addr slef: Self*]() {}
 }
 

--- a/explorer/testdata/addr/fail_method_self_type.carbon
+++ b/explorer/testdata/addr/fail_method_self_type.carbon
@@ -28,7 +28,7 @@ class Point {
 
 fn Main() -> i32 {
   var p: Point = Point.Origin();
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/addr/fail_method_self_type.carbon:[[@LINE+3]]: type error in method access, receiver type
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_self_type.carbon:[[@LINE+3]]: type error in method access, receiver type
   // CHECK:STDERR: expected: class Shape
   // CHECK:STDERR: actual: class Point
   var x: auto = p.GetSetX(42);

--- a/explorer/testdata/alias/fail_alias_expression.carbon
+++ b/explorer/testdata/alias/fail_alias_expression.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_alias_expression.carbon:[[@LINE+1]]: invalid target for alias declaration
+// CHECK:STDERR: COMPILATION ERROR: fail_alias_expression.carbon:[[@LINE+1]]: invalid target for alias declaration
 alias A = 5;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/alias/fail_alias_var.carbon
+++ b/explorer/testdata/alias/fail_alias_var.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 var v: i32;
 // TODO: This should probably be valid if we allow global variables at all.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_alias_var.carbon:[[@LINE+1]]: invalid target for alias declaration
+// CHECK:STDERR: COMPILATION ERROR: fail_alias_var.carbon:[[@LINE+1]]: invalid target for alias declaration
 alias A = v;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/alias/fail_interface_method_as_class_member.carbon
+++ b/explorer/testdata/alias/fail_interface_method_as_class_member.carbon
@@ -33,7 +33,7 @@ impl forall [U:! Printable] Vector(U) as Printable {
 
 fn Main() -> i32 {
   var v: Vector(String) = {.x = "test"};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_interface_method_as_class_member.carbon:[[@LINE+1]]: Member access to aliases is not yet supported.
+  // CHECK:STDERR: COMPILATION ERROR: fail_interface_method_as_class_member.carbon:[[@LINE+1]]: Member access to aliases is not yet supported.
   v.PrintIt();
   return 42;
 }

--- a/explorer/testdata/alias/fail_namespace_alias_member.carbon
+++ b/explorer/testdata/alias/fail_namespace_alias_member.carbon
@@ -10,7 +10,7 @@ namespace N;
 alias M = N;
 // TODO: It's unclear whether this should be permitted. If not, we should
 // produce a better diagnostic.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_namespace_alias_member.carbon:[[@LINE+1]]: alias M cannot be used as a name qualifier
+// CHECK:STDERR: COMPILATION ERROR: fail_namespace_alias_member.carbon:[[@LINE+1]]: alias M cannot be used as a name qualifier
 fn M.F() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/alias/fail_self_alias.carbon
+++ b/explorer/testdata/alias/fail_self_alias.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_self_alias.carbon:[[@LINE+1]]: 'a' is not usable until after it has been completely declared
+// CHECK:STDERR: COMPILATION ERROR: fail_self_alias.carbon:[[@LINE+1]]: 'a' is not usable until after it has been completely declared
 alias a = a;
 
 fn Main() -> i32 {

--- a/explorer/testdata/alias/fail_wrong_fn_alias_use.carbon
+++ b/explorer/testdata/alias/fail_wrong_fn_alias_use.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn F() {}
 alias A = F;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_wrong_fn_alias_use.carbon:[[@LINE+1]]: alias A cannot be used as a name qualifier
+// CHECK:STDERR: COMPILATION ERROR: fail_wrong_fn_alias_use.carbon:[[@LINE+1]]: alias A cannot be used as a name qualifier
 fn A.Foo() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/alias/fail_wrong_fn_alias_use_expr.carbon
+++ b/explorer/testdata/alias/fail_wrong_fn_alias_use_expr.carbon
@@ -10,6 +10,6 @@ fn F() {}
 alias A = F;
 
 fn Main() -> i32 {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_wrong_fn_alias_use_expr.carbon:[[@LINE+1]]: member access, unexpected fn () -> () in A.x
+    // CHECK:STDERR: COMPILATION ERROR: fail_wrong_fn_alias_use_expr.carbon:[[@LINE+1]]: member access, unexpected fn () -> () in A.x
     return A.x;
 }

--- a/explorer/testdata/alias/fail_wrong_interface_alias_use.carbon
+++ b/explorer/testdata/alias/fail_wrong_interface_alias_use.carbon
@@ -10,6 +10,6 @@ interface Foo {}
 alias A = Foo;
 
 fn Main() -> i32 {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_wrong_interface_alias_use.carbon:[[@LINE+1]]: member access, bar not in interface Foo
+    // CHECK:STDERR: COMPILATION ERROR: fail_wrong_interface_alias_use.carbon:[[@LINE+1]]: member access, bar not in interface Foo
     return A.bar;
 }

--- a/explorer/testdata/alias/fail_wrong_namepsace_alias_use.carbon
+++ b/explorer/testdata/alias/fail_wrong_namepsace_alias_use.carbon
@@ -10,6 +10,6 @@ namespace Foo;
 alias A = Foo;
 
 fn Main() -> i32 {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/alias/fail_wrong_namepsace_alias_use.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace Foo
+    // CHECK:STDERR: COMPILATION ERROR: fail_wrong_namepsace_alias_use.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace Foo
     return A;
 }

--- a/explorer/testdata/array/fail_index.carbon
+++ b/explorer/testdata/array/fail_index.carbon
@@ -8,6 +8,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: [i32; 2] = (0, 1);
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/array/fail_index.carbon:[[@LINE+1]]: index 2 out of range in (0, 1)
+  // CHECK:STDERR: RUNTIME ERROR: fail_index.carbon:[[@LINE+1]]: index 2 out of range in (0, 1)
   return x[2];
 }

--- a/explorer/testdata/array/fail_negative_size.carbon
+++ b/explorer/testdata/array/fail_negative_size.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/array/fail_negative_size.carbon:[[@LINE+1]]: Array size cannot be negative
+  // CHECK:STDERR: COMPILATION ERROR: fail_negative_size.carbon:[[@LINE+1]]: Array size cannot be negative
   var x: [i32; -1] = ();
   return x[0];
 }

--- a/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
+++ b/explorer/testdata/array/fail_print_uninitalized_array_element.carbon
@@ -8,7 +8,7 @@ package ExplorerTest impl;
 
 fn Main() -> i32 {
   var my_array : [i32; 1];
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/array/fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: Printing uninitialized value
+  // CHECK:STDERR: RUNTIME ERROR: fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: Printing uninitialized value
   Print("{0}", my_array[0]);
   return 0;
 }

--- a/explorer/testdata/array/fail_size_mismatch.carbon
+++ b/explorer/testdata/array/fail_size_mismatch.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/array/fail_size_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, i32, i32)' is not implicitly convertible to '[i32; 2]'
+  // CHECK:STDERR: COMPILATION ERROR: fail_size_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, i32, i32)' is not implicitly convertible to '[i32; 2]'
   var x: [i32; 2] = (0, 1, 2);
   return x[0];
 }

--- a/explorer/testdata/as/fail_destination_not_type.carbon
+++ b/explorer/testdata/as/fail_destination_not_type.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_destination_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_destination_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
   return 4 as 7;
 }

--- a/explorer/testdata/as/fail_intrinsic_convert_no_args.carbon
+++ b/explorer/testdata/as/fail_intrinsic_convert_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_intrinsic_convert_no_args.carbon:[[@LINE+1]]: __intrinsic_implicit_as_convert takes 2 arguments
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_convert_no_args.carbon:[[@LINE+1]]: __intrinsic_implicit_as_convert takes 2 arguments
   __intrinsic_implicit_as_convert();
   return 0;
 }

--- a/explorer/testdata/as/fail_intrinsic_convert_non_type.carbon
+++ b/explorer/testdata/as/fail_intrinsic_convert_non_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_intrinsic_convert_non_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_convert_non_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
   __intrinsic_implicit_as_convert("example", 0);
   return 0;
 }

--- a/explorer/testdata/as/fail_intrinsic_no_args.carbon
+++ b/explorer/testdata/as/fail_intrinsic_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_intrinsic_no_args.carbon:[[@LINE+1]]: __intrinsic_implicit_as takes 1 argument
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_args.carbon:[[@LINE+1]]: __intrinsic_implicit_as takes 1 argument
   __intrinsic_implicit_as();
   return 0;
 }

--- a/explorer/testdata/as/fail_intrinsic_non_type.carbon
+++ b/explorer/testdata/as/fail_intrinsic_non_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_intrinsic_non_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_non_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
   __intrinsic_implicit_as(0);
   return 0;
 }

--- a/explorer/testdata/as/fail_no_conversion.carbon
+++ b/explorer/testdata/as/fail_no_conversion.carbon
@@ -10,7 +10,7 @@ class A { var n: i32; }
 
 fn Main() -> i32 {
   var a: A = {.n = 5};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/as/fail_no_conversion.carbon:[[@LINE+2]]: type error in `as`: `class A` is not explicitly convertible to `i32`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_conversion.carbon:[[@LINE+2]]: type error in `as`: `class A` is not explicitly convertible to `i32`:
   // CHECK:STDERR: could not find implementation of interface As(T = i32) for class A
   return a as i32;
 }

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assert/fail_convert.carbon
+++ b/explorer/testdata/assert/fail_convert.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: "Fail"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "Fail"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assert/fail_intrinsic_bool_type.carbon
+++ b/explorer/testdata/assert/fail_intrinsic_bool_type.carbon
@@ -14,7 +14,7 @@ class ConvertTo(T:! type) {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/assert/fail_intrinsic_bool_type.carbon:[[@LINE+1]]: syntax error, unexpected COMMA
+  // CHECK:STDERR: SYNTAX ERROR: fail_intrinsic_bool_type.carbon:[[@LINE+1]]: syntax error, unexpected COMMA
   __intrinsic_assert(, "unused");
   return 0;
 }

--- a/explorer/testdata/assert/fail_intrinsic_no_args.carbon
+++ b/explorer/testdata/assert/fail_intrinsic_no_args.carbon
@@ -14,7 +14,7 @@ class ConvertTo(T:! type) {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assert/fail_intrinsic_no_args.carbon:[[@LINE+1]]: __intrinsic_assert takes 2 arguments
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_args.carbon:[[@LINE+1]]: __intrinsic_assert takes 2 arguments
   __intrinsic_assert();
   return 0;
 }

--- a/explorer/testdata/assert/fail_intrinsic_no_convert.carbon
+++ b/explorer/testdata/assert/fail_intrinsic_no_convert.carbon
@@ -14,7 +14,7 @@ class ConvertTo(T:! type) {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assert/fail_intrinsic_no_convert.carbon:[[@LINE+3]]: type error in __intrinsic_assert argument 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_convert.carbon:[[@LINE+3]]: type error in __intrinsic_assert argument 0
   // CHECK:STDERR: expected: bool
   // CHECK:STDERR: actual: class ConvertTo(T = bool)
   __intrinsic_assert({.v = true} as ConvertTo(bool), {.v = "Pass"} as ConvertTo(String));

--- a/explorer/testdata/assert/fail_intrinsic_str_type.carbon
+++ b/explorer/testdata/assert/fail_intrinsic_str_type.carbon
@@ -14,7 +14,7 @@ class ConvertTo(T:! type) {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assert/fail_intrinsic_str_type.carbon:[[@LINE+3]]: type error in __intrinsic_assert argument 1
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_str_type.carbon:[[@LINE+3]]: type error in __intrinsic_assert argument 1
   // CHECK:STDERR: expected: String
   // CHECK:STDERR: actual: i32
   __intrinsic_assert(true, 1);

--- a/explorer/testdata/assoc_const/fail_anonymous.carbon
+++ b/explorer/testdata/assoc_const/fail_anonymous.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Iface {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/assoc_const/fail_anonymous.carbon:[[@LINE+1]]: syntax error, unexpected UNDERSCORE, expecting identifier or TEMPLATE
+  // CHECK:STDERR: SYNTAX ERROR: fail_anonymous.carbon:[[@LINE+1]]: syntax error, unexpected UNDERSCORE, expecting identifier or TEMPLATE
   let _:! type;
 }
 

--- a/explorer/testdata/assoc_const/fail_different_type.carbon
+++ b/explorer/testdata/assoc_const/fail_different_type.carbon
@@ -19,7 +19,7 @@ external impl Bad as Iface where .T = Bad {}
 
 fn Main() -> i32 {
   F(Good);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_different_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value class Bad) == i32, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_different_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value class Bad) == i32, which is not known to be true
   F(Bad);
   return 0;
 }

--- a/explorer/testdata/assoc_const/fail_different_value.carbon
+++ b/explorer/testdata/assoc_const/fail_different_value.carbon
@@ -19,7 +19,7 @@ external impl Bad as Iface where .N = 4 {}
 
 fn Main() -> i32 {
   F(Good);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_different_value.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.N) (with value 4) == 5, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_different_value.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.N) (with value 4) == 5, which is not known to be true
   F(Bad);
   return 0;
 }

--- a/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_indirectly.carbon
@@ -24,7 +24,7 @@ fn G[U:! type where .Self == i32, T:! Iface where .T = U](x: T, y: U) {
 
 // Not OK: would require looking through two levels of `==`.
 fn H[V:! type where .Self == i32, W:! Iface where .T == V](x: W, y: V) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_equal_indirectly.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value (W).(Iface.T)) == i32, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_equal_indirectly.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value (W).(Iface.T)) == i32, which is not known to be true
   F(x);
 }
 

--- a/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
+++ b/explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon
@@ -17,7 +17,7 @@ fn G[U:! Iface where .T == i32](x: U) {
 }
 
 fn H[V:! Iface](x: V) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_equal_to_dependent_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value (V).(Iface.T)) == i32, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_equal_to_dependent_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value (V).(Iface.T)) == i32, which is not known to be true
   F(x);
 }
 

--- a/explorer/testdata/assoc_const/fail_implied_constraints.carbon
+++ b/explorer/testdata/assoc_const/fail_implied_constraints.carbon
@@ -16,7 +16,7 @@ interface Z {
   // We reject this even though it is the responsibility of the `impl as Z` to
   // provide a type `N` such that `i32 is X(N)`. We might want to treat this as
   // an implied constraint and allow this in the future.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_implied_constraints.carbon:[[@LINE+1]]: could not find implementation of interface X(T = N) for i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_implied_constraints.carbon:[[@LINE+1]]: could not find implementation of interface X(T = N) for i32
   let N:! Y(.Self) where .M = i32;
 }
 

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon
@@ -12,7 +12,7 @@ interface HasThreeTypes {
   let C:! type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.B
+// CHECK:STDERR: COMPILATION ERROR: fail_incomplete_impl_1.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.B
 external impl i32 as HasThreeTypes where .A = i32 and .C = i32 {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
+++ b/explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon
@@ -12,7 +12,7 @@ interface HasThreeTypes {
   let C:! type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.C
+// CHECK:STDERR: COMPILATION ERROR: fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.C
 external impl i32 as HasThreeTypes where .A = i32 and .B = .C {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
+++ b/explorer/testdata/assoc_const/fail_indirectly_equal.carbon
@@ -21,7 +21,7 @@ fn F2[U:! A where .T == i32](x: i32) -> U.T {
 }
 
 fn F3[T:! A where .T == i32, U:! A where .T == i32](x: T.T) -> U.T {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_indirectly_equal.carbon:[[@LINE+1]]: type error in return value: '(T).(A.T)' is not implicitly convertible to '(U).(A.T)'
+  // CHECK:STDERR: COMPILATION ERROR: fail_indirectly_equal.carbon:[[@LINE+1]]: type error in return value: '(T).(A.T)' is not implicitly convertible to '(U).(A.T)'
   return x;
 }
 

--- a/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_match_in_deduction.carbon
@@ -20,7 +20,7 @@ fn F[Scalar:! type, V:! Vector where .Dim == 3](p: Point(Scalar, V.Dim), v: V) {
 fn G[Scalar:! type](p: Point(Scalar, 3)) {}
 fn H[V:! Vector where .Dim == 3](v: V) {
   var p: Point(i32, V.Dim) = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_match_in_deduction.carbon:[[@LINE+1]]: mismatch in non-deduced values, `(V).(Vector.Dim)` != `3`
+  // CHECK:STDERR: COMPILATION ERROR: fail_match_in_deduction.carbon:[[@LINE+1]]: mismatch in non-deduced values, `(V).(Vector.Dim)` != `3`
   G(p);
 }
 

--- a/explorer/testdata/assoc_const/fail_missing_equal.carbon
+++ b/explorer/testdata/assoc_const/fail_missing_equal.carbon
@@ -16,7 +16,7 @@ fn A[T:! Container where .Element == i32](x: T) -> T.Element {
 }
 
 fn B[T:! Container](x: T) -> T.Element {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_missing_equal.carbon:[[@LINE+1]]: constraint requires that (T).(Container.Element) (with value (T).(Container.Element)) == i32, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_equal.carbon:[[@LINE+1]]: constraint requires that (T).(Container.Element) (with value (T).(Container.Element)) == i32, which is not known to be true
   return A(x);
 }
 

--- a/explorer/testdata/assoc_const/fail_missing_rewrite.carbon
+++ b/explorer/testdata/assoc_const/fail_missing_rewrite.carbon
@@ -16,7 +16,7 @@ fn A[T:! Container where .Element = i32](x: T) -> T.Element {
 }
 
 fn B[T:! Container](x: T) -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_missing_rewrite.carbon:[[@LINE+1]]: constraint requires that (T).(Container.Element) (with value (T).(Container.Element)) == i32, which is not known to be true
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_rewrite.carbon:[[@LINE+1]]: constraint requires that (T).(Container.Element) (with value (T).(Container.Element)) == i32, which is not known to be true
   return A(x);
 }
 

--- a/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
+++ b/explorer/testdata/assoc_const/fail_multiple_deduction.carbon
@@ -14,7 +14,7 @@ interface HasThreeTypes {
 }
 fn F[T:! type](x: (T, T, T));
 fn G[X:! HasThreeTypes where .A == .B and .B == .C and .C == .A](x: X) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_multiple_deduction.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
+  // CHECK:STDERR: COMPILATION ERROR: fail_multiple_deduction.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
   // CHECK:STDERR:   (X).(HasThreeTypes.A)
   // CHECK:STDERR:   (X).(HasThreeTypes.B)
   F(x.Make());

--- a/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
+++ b/explorer/testdata/assoc_const/fail_overspecified_impl.carbon
@@ -10,7 +10,7 @@ interface HasType {
   let T:! type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_overspecified_impl.carbon:[[@LINE+3]]: multiple different rewrites for `(i32).(HasType.T)`:
+// CHECK:STDERR: COMPILATION ERROR: fail_overspecified_impl.carbon:[[@LINE+3]]: multiple different rewrites for `(i32).(HasType.T)`:
 // CHECK:STDERR:   i32
 // CHECK:STDERR:   {.a: i32}
 external impl i32 as HasType where .T = i32 and .T = {.a: i32} {}

--- a/explorer/testdata/assoc_const/fail_redefined.carbon
+++ b/explorer/testdata/assoc_const/fail_redefined.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 interface Iface {
   let T:! type;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_redefined.carbon:[[@LINE+1]]: Duplicate name `T` also found at explorer/testdata/assoc_const/fail_redefined.carbon:[[@LINE-1]]
+  // CHECK:STDERR: COMPILATION ERROR: fail_redefined.carbon:[[@LINE+1]]: Duplicate name `T` also found at fail_redefined.carbon:[[@LINE-1]]
   let T:! type;
 }
 

--- a/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon
@@ -10,7 +10,7 @@ interface HasType {
   let T:! type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_rewrite_creates_infinite_type.carbon:[[@LINE+1]]: rewrite of (H).(HasType.T) applies within its own resolved expansion of (H).(HasType.T)*
+// CHECK:STDERR: COMPILATION ERROR: fail_rewrite_creates_infinite_type.carbon:[[@LINE+1]]: rewrite of (H).(HasType.T) applies within its own resolved expansion of (H).(HasType.T)*
 fn F[H:! HasType where .T = .T*]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_cycle.carbon
@@ -30,7 +30,7 @@ fn F[
     .T6 = .T7 and
     .T7 = .T8 and
     .T8 = .T9 and
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T4) applies within its own resolved expansion of (M).(ManyTypes.T4)
+    // CHECK:STDERR: COMPILATION ERROR: fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T4) applies within its own resolved expansion of (M).(ManyTypes.T4)
     .T9 = .T0]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_rewrite_depends_on_later_rewrite.carbon
+++ b/explorer/testdata/assoc_const/fail_rewrite_depends_on_later_rewrite.carbon
@@ -11,7 +11,7 @@ interface HasTypeAndValue {
   let V:! T;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_rewrite_depends_on_later_rewrite.carbon:[[@LINE+1]]: type error in rewrite constraint: 'i32' is not implicitly convertible to '(X).(HasTypeAndValue.T)'
+// CHECK:STDERR: COMPILATION ERROR: fail_rewrite_depends_on_later_rewrite.carbon:[[@LINE+1]]: type error in rewrite constraint: 'i32' is not implicitly convertible to '(X).(HasTypeAndValue.T)'
 fn F(X:! HasTypeAndValue where .V = 5 and .T = i32) -> i32 { return X.V; }
 
 impl i32 as HasTypeAndValue where .T = i32 and .V = 5 {}

--- a/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon
+++ b/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon
@@ -13,7 +13,7 @@ interface TwoTypes {
 
 // Attempting to fully resolve the replacement for `.T` would never create a
 // situation where `.T`'s expansion involves `.T`. Ensure we catch this anyway.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_simple_rewrite_cycle_1.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
+// CHECK:STDERR: COMPILATION ERROR: fail_simple_rewrite_cycle_1.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
 fn F[X:! TwoTypes where .T = .U and .U = .U*]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon
+++ b/explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon
@@ -13,7 +13,7 @@ interface TwoTypes {
 
 // Attempting to fully resolve the replacement for `.T` would never create a
 // situation where `.T`'s expansion involves `.T`. Ensure we catch this anyway.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_simple_rewrite_cycle_2.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
+// CHECK:STDERR: COMPILATION ERROR: fail_simple_rewrite_cycle_2.carbon:[[@LINE+1]]: rewrite of (X).(TwoTypes.U) applies within its own resolved expansion of (X).(TwoTypes.U)*
 fn F[X:! TwoTypes where .U = .U* and .T = .U]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/assoc_const/fail_unknown_value.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value.carbon
@@ -11,7 +11,7 @@ interface Iface { let N:! i32; }
 fn PickType(N: i32) -> type { return i32; }
 
 fn F[T:! Iface](x: T) -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_unknown_value.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
+  // CHECK:STDERR: COMPILATION ERROR: fail_unknown_value.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
   var x: PickType(T.N) = 0;
   return x;
 }

--- a/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
+++ b/explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon
@@ -12,7 +12,7 @@ fn PickType(N: i32) -> type { return i32; }
 
 fn F[T:! Iface where .N == 5](x: T) -> i32 {
   // TODO: This should be valid: the value of T.N is known to be 5 here.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/assoc_const/fail_unknown_value_specified_in_constraint.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
+  // CHECK:STDERR: COMPILATION ERROR: fail_unknown_value_specified_in_constraint.carbon:[[@LINE+1]]: value of associated constant (T).(Iface.N) is not known
   var x: PickType(T.N) = 0;
   return x;
 }

--- a/explorer/testdata/auto/fail_use_in_init.carbon
+++ b/explorer/testdata/auto/fail_use_in_init.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   // TODO: The error here should be that we aren't allowed to refer to 'a' yet.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/auto/fail_use_in_init.carbon:[[@LINE+1]]: could not resolve 'a'
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_in_init.carbon:[[@LINE+1]]: could not resolve 'a'
   var a: auto = a;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_not_type.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_alternative_not_type.carbon:[[@LINE+1]]: type error in type expression: '(i32,)' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_alternative_not_type.carbon:[[@LINE+1]]: type error in type expression: '(i32,)' is not implicitly convertible to 'type'
 choice C { X(42) }
 
 fn Main() -> i32 {

--- a/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
+++ b/explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 choice Ch {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_alternative_uses_choice.carbon:[[@LINE+1]]: 'Ch' is not usable until after it has been completely declared
+  // CHECK:STDERR: COMPILATION ERROR: fail_alternative_uses_choice.carbon:[[@LINE+1]]: 'Ch' is not usable until after it has been completely declared
   Opt(Ch)
 }
 

--- a/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_function.carbon
@@ -10,7 +10,7 @@ fn F() {}
 fn G() {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_assign_to_function.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `F`
+  // CHECK:STDERR: COMPILATION ERROR: fail_assign_to_function.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `F`
   F = G;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
+++ b/explorer/testdata/basic_syntax/fail_assign_to_rval.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_assign_to_rval.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `1`
+  // CHECK:STDERR: COMPILATION ERROR: fail_assign_to_rval.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `1`
   1 = 0;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_block.carbon
+++ b/explorer/testdata/basic_syntax/fail_block.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   {
-    // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_block.carbon:[[@LINE+1]]: syntax error, unexpected RETURN, expecting PERIOD or RIGHT_CURLY_BRACE
+    // CHECK:STDERR: SYNTAX ERROR: fail_block.carbon:[[@LINE+1]]: syntax error, unexpected RETURN, expecting PERIOD or RIGHT_CURLY_BRACE
     return 0;
   }
 }

--- a/explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon
@@ -13,7 +13,7 @@ choice Ints {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_choice_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
+  // CHECK:STDERR: COMPILATION ERROR: fail_choice_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
   match (Ints.None()) {
     case Ints.None => { return 0; }
     default => { return 1; }

--- a/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_no_parens.carbon
@@ -15,7 +15,7 @@ choice Ints {
 fn Main() -> i32 {
   match (Ints.None) {
     case Ints.None() => { return 0; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_choice_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
+    // CHECK:STDERR: COMPILATION ERROR: fail_choice_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
     // CHECK:STDERR: expected: choice Ints
     // CHECK:STDERR: actual: fn () -> choice Ints
     default => { return 1; }

--- a/explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon
@@ -14,7 +14,7 @@ choice Ints {
 
 fn Main() -> i32 {
   match (Ints.None) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_choice_pattern_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
+    // CHECK:STDERR: COMPILATION ERROR: fail_choice_pattern_extra_parens.carbon:[[@LINE+1]]: alternative `choice Ints.None` does not expect an argument list
     case Ints.None() => { return 0; }
     default => { return 1; }
   }

--- a/explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon
+++ b/explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon
@@ -15,7 +15,7 @@ choice Ints {
 fn Main() -> i32 {
   match (Ints.None()) {
     case Ints.None => { return 0; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_choice_pattern_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
+    // CHECK:STDERR: COMPILATION ERROR: fail_choice_pattern_no_parens.carbon:[[@LINE+3]]: type error in `match` pattern type
     // CHECK:STDERR: expected: fn () -> choice Ints
     // CHECK:STDERR: actual: choice Ints
     default => { return 1; }

--- a/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
+++ b/explorer/testdata/basic_syntax/fail_compare_precedence.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn CompareBools(a: bool, b: bool) -> bool {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_compare_precedence.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
+  // CHECK:STDERR: SYNTAX ERROR: fail_compare_precedence.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
   return not a == b;
 }

--- a/explorer/testdata/basic_syntax/fail_invalid_char.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_char.carbon
@@ -4,5 +4,5 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_invalid_char.carbon:[[@LINE+1]]: invalid character '\xEF' in source file.
+// CHECK:STDERR: SYNTAX ERROR: fail_invalid_char.carbon:[[@LINE+1]]: invalid character '\xEF' in source file.
 �

--- a/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_invalid_integer.carbon:[[@LINE+1]]: Invalid integer literal: 11111111111111111111111111
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_integer.carbon:[[@LINE+1]]: Invalid integer literal: 11111111111111111111111111
   return 11111111111111111111111111;
 }

--- a/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_invalid_integer_type.carbon:[[@LINE+1]]: Invalid type literal: i11111111111111111111111111
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_integer_type.carbon:[[@LINE+1]]: Invalid type literal: i11111111111111111111111111
   var x: i11111111111111111111111111 = 1;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
+++ b/explorer/testdata/basic_syntax/fail_unimplemented_example.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/basic_syntax/fail_unimplemented_example.carbon:[[@LINE+1]]: Unimplemented
+  // CHECK:STDERR: COMPILATION ERROR: fail_unimplemented_example.carbon:[[@LINE+1]]: Unimplemented
   return 1 __unimplemented_example_infix 2;
 }

--- a/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
+++ b/explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_unknown_intrinsic.carbon:[[@LINE+1]]: Unknown intrinsic 'nonexistent'
+  // CHECK:STDERR: SYNTAX ERROR: fail_unknown_intrinsic.carbon:[[@LINE+1]]: Unknown intrinsic 'nonexistent'
   return __intrinsic_nonexistent();
 }

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 is supported for now: i64
+  // CHECK:STDERR: SYNTAX ERROR: fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 is supported for now: i64
   var x: i64 = 1;
   return 0;
 }

--- a/explorer/testdata/choice/fail_recursive_use.carbon
+++ b/explorer/testdata/choice/fail_recursive_use.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 choice C {
   X,
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/choice/fail_recursive_use.carbon:[[@LINE+1]]: 'C' is not usable until after it has been completely declared
+  // CHECK:STDERR: COMPILATION ERROR: fail_recursive_use.carbon:[[@LINE+1]]: 'C' is not usable until after it has been completely declared
   Y(if C.X then i32 else i32)
 }
 

--- a/explorer/testdata/class/fail_abstract_method_not_supported.carbon
+++ b/explorer/testdata/class/fail_abstract_method_not_supported.carbon
@@ -12,7 +12,7 @@ base class C {
 class D extends C {
   abstract fn Foo[self:Self]() -> i32 {
     return 1;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_abstract_method_not_supported.carbon:[[@LINE+1]]: Error declaring `Foo`: `abstract` methods are not yet supported.
+  // CHECK:STDERR: COMPILATION ERROR: fail_abstract_method_not_supported.carbon:[[@LINE+1]]: Error declaring `Foo`: `abstract` methods are not yet supported.
   }
 }
 

--- a/explorer/testdata/class/fail_call_method_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_call_method_before_typecheck.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class A {
   fn F[self: Self]() -> type {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_call_method_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `F` that has not been fully type-checked
+    // CHECK:STDERR: COMPILATION ERROR: fail_call_method_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `F` that has not been fully type-checked
     var a: ({} as A).F() = 0;
     return i32;
   }

--- a/explorer/testdata/class/fail_call_undefined_method.carbon
+++ b/explorer/testdata/class/fail_call_undefined_method.carbon
@@ -12,6 +12,6 @@ class A {
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/class/fail_call_undefined_method.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
+  // CHECK:STDERR: RUNTIME ERROR: fail_call_undefined_method.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
   return a.F();
 }

--- a/explorer/testdata/class/fail_class_named_self.carbon
+++ b/explorer/testdata/class/fail_class_named_self.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 // Error: Can't use keyword `Self` as the name of a class.
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/class/fail_class_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier or LEFT_PARENTHESIS
+// CHECK:STDERR: SYNTAX ERROR: fail_class_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier or LEFT_PARENTHESIS
 class Self {
   var x: i32;
   var y: i32;

--- a/explorer/testdata/class/fail_direct_base_class_init.carbon
+++ b/explorer/testdata/class/fail_direct_base_class_init.carbon
@@ -15,7 +15,7 @@ class B extends A {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_direct_base_class_init.carbon:[[@LINE+1]]: type error in initializer of variable: '{.a: i32, .b: i32}' is not implicitly convertible to 'class B'
+  // CHECK:STDERR: COMPILATION ERROR: fail_direct_base_class_init.carbon:[[@LINE+1]]: type error in initializer of variable: '{.a: i32, .b: i32}' is not implicitly convertible to 'class B'
   var b: B = {.a=0, .b=1};
   return 0;
 }

--- a/explorer/testdata/class/fail_extends_final_class.carbon
+++ b/explorer/testdata/class/fail_extends_final_class.carbon
@@ -12,7 +12,7 @@ class C {
 
 class D extends C {
   fn G() {}
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_extends_final_class.carbon:[[@LINE+1]]: Base class `C` is `final` and cannot be inherited. Add the `base` or `abstract` class prefix to `C` to allow it to be inherited
+// CHECK:STDERR: COMPILATION ERROR: fail_extends_final_class.carbon:[[@LINE+1]]: Base class `C` is `final` and cannot be inherited. Add the `base` or `abstract` class prefix to `C` to allow it to be inherited
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/class/fail_extends_non_class.carbon
+++ b/explorer/testdata/class/fail_extends_non_class.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_extends_non_class.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_extends_non_class.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
 class C extends 3 {
   var x: i32;
   var y: i32;

--- a/explorer/testdata/class/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_access_mismatch.carbon
@@ -13,6 +13,6 @@ class Point {
 
 fn Main() -> i32 {
   var p: Point = {.x = 1, .y = 2};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_field_access_mismatch.carbon:[[@LINE+1]]: class Point does not have a field named z
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_access_mismatch.carbon:[[@LINE+1]]: class Point does not have a field named z
   return p.z - 1;
 }

--- a/explorer/testdata/class/fail_field_access_mismatch_base.carbon
+++ b/explorer/testdata/class/fail_field_access_mismatch_base.carbon
@@ -17,6 +17,6 @@ class Point3D extends Point {
 
 fn Main() -> i32 {
   var p: Point3D = {.base={.x = 1, .y = 2}, .z = 3};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_field_access_mismatch_base.carbon:[[@LINE+1]]: class Point3D does not have a field named a
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_access_mismatch_base.carbon:[[@LINE+1]]: class Point3D does not have a field named a
   return p.a;
 }

--- a/explorer/testdata/class/fail_field_assign_mismatch_base.carbon
+++ b/explorer/testdata/class/fail_field_assign_mismatch_base.carbon
@@ -17,7 +17,7 @@ class Point3D extends Point {
 
 fn Main() -> i32 {
   var p: Point3D = {.base={.x = 1, .y = 2}, .z = 3};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_field_assign_mismatch_base.carbon:[[@LINE+1]]: class Point3D does not have a field named a
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_assign_mismatch_base.carbon:[[@LINE+1]]: class Point3D does not have a field named a
   p.a = 0;
   return 0;
 }

--- a/explorer/testdata/class/fail_field_mismatch.carbon
+++ b/explorer/testdata/class/fail_field_mismatch.carbon
@@ -12,7 +12,7 @@ class Point {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_field_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: '{.x: i32, .z: i32}' is not implicitly convertible to 'class Point'
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: '{.x: i32, .z: i32}' is not implicitly convertible to 'class Point'
   var p: Point = {.x = 1, .z = 2};
   return p.x - 1;
 }

--- a/explorer/testdata/class/fail_field_missing.carbon
+++ b/explorer/testdata/class/fail_field_missing.carbon
@@ -12,7 +12,7 @@ class Point {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_field_missing.carbon:[[@LINE+1]]: type error in initializer of variable: '{.x: i32}' is not implicitly convertible to 'class Point'
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_missing.carbon:[[@LINE+1]]: type error in initializer of variable: '{.x: i32}' is not implicitly convertible to 'class Point'
   var p: Point = {.x = 1};
   return p.x - 1;
 }

--- a/explorer/testdata/class/fail_impl_method_not_existing.carbon
+++ b/explorer/testdata/class/fail_impl_method_not_existing.carbon
@@ -12,7 +12,7 @@ base class C {
 class D extends C {
   impl fn Foo[self:Self]() -> i32 {
     return 1;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_impl_method_not_existing.carbon:[[@LINE+1]]: Error declaring `Foo`: cannot override a method that is not declared `abstract` or `virtual` in base class.
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_method_not_existing.carbon:[[@LINE+1]]: Error declaring `Foo`: cannot override a method that is not declared `abstract` or `virtual` in base class.
   }
 }
 

--- a/explorer/testdata/class/fail_impl_method_not_virtual.carbon
+++ b/explorer/testdata/class/fail_impl_method_not_virtual.carbon
@@ -15,7 +15,7 @@ base class C {
 class D extends C {
   impl fn Foo[self:Self]() -> i32 {
     return 1;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_impl_method_not_virtual.carbon:[[@LINE+1]]: Error declaring `Foo`: cannot override a method that is not declared `abstract` or `virtual` in base class.
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_method_not_virtual.carbon:[[@LINE+1]]: Error declaring `Foo`: cannot override a method that is not declared `abstract` or `virtual` in base class.
   }
 }
 

--- a/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon
@@ -15,7 +15,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_instantiate_abstract_class_constructor.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: fail_instantiate_abstract_class_constructor.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C = C.Create();
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon
@@ -11,7 +11,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_instantiate_abstract_class_empty.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: fail_instantiate_abstract_class_empty.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C;
   return 0;
 }

--- a/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
+++ b/explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon
@@ -11,7 +11,7 @@ abstract class C {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_instantiate_abstract_class_struct.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
+  // CHECK:STDERR: COMPILATION ERROR: fail_instantiate_abstract_class_struct.carbon:[[@LINE+1]]: Cannot instantiate abstract class C
   var c: C = { .a = 1 };
   return 0;
 }

--- a/explorer/testdata/class/fail_invalid_subtyping.carbon
+++ b/explorer/testdata/class/fail_invalid_subtyping.carbon
@@ -14,7 +14,7 @@ class D {
 
 fn Main() -> i32 {
   var d: D = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_invalid_subtyping.carbon:[[@LINE+1]]: type error in initializer of variable: 'class D*' is not implicitly convertible to 'class C*'
+  // CHECK:STDERR: COMPILATION ERROR: fail_invalid_subtyping.carbon:[[@LINE+1]]: type error in initializer of variable: 'class D*' is not implicitly convertible to 'class C*'
   var c: C* = &d;
   return 0;
 }

--- a/explorer/testdata/class/fail_member_call_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_member_call_before_typecheck.carbon
@@ -10,7 +10,7 @@ class C {
   fn PickType() -> type { return i32; }
   // This is invalid even though `PickType` is defined earlier, because
   // checking of member bodies is deferred until after the class is completed.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_member_call_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `PickType` that has not been fully type-checked
+  // CHECK:STDERR: COMPILATION ERROR: fail_member_call_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `PickType` that has not been fully type-checked
   fn GetZero() -> PickType() { return 0; }
 }
 

--- a/explorer/testdata/class/fail_member_of_self.carbon
+++ b/explorer/testdata/class/fail_member_of_self.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class C {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_member_of_self.carbon:[[@LINE+1]]: incomplete type `class C` used in type of variable
+  // CHECK:STDERR: COMPILATION ERROR: fail_member_of_self.carbon:[[@LINE+1]]: incomplete type `class C` used in type of variable
   var m: Self;
 }
 

--- a/explorer/testdata/class/fail_method_deduced.carbon
+++ b/explorer/testdata/class/fail_method_deduced.carbon
@@ -15,7 +15,7 @@ fn H[T:! type](x: T) {}
 
 fn Main() -> i32 {
   H(C.F);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_method_deduced.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_deduced.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
   H(C.G);
   return 0;
 }

--- a/explorer/testdata/class/fail_method_from_class.carbon
+++ b/explorer/testdata/class/fail_method_from_class.carbon
@@ -20,6 +20,6 @@ class Point {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_method_from_class.carbon:[[@LINE+1]]: in call `Point.GetX()`, expected callee to be a function, found `member name GetX`
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_from_class.carbon:[[@LINE+1]]: in call `Point.GetX()`, expected callee to be a function, found `member name GetX`
   return Point.GetX();
 }

--- a/explorer/testdata/class/fail_method_in_var.carbon
+++ b/explorer/testdata/class/fail_method_in_var.carbon
@@ -13,7 +13,7 @@ class C {
 
 fn Main() -> i32 {
   var f: auto = C.F;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_method_in_var.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_in_var.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
   var g: auto = C.G;
 
   return 0;

--- a/explorer/testdata/class/fail_override_virtual_with_non_virtual.carbon
+++ b/explorer/testdata/class/fail_override_virtual_with_non_virtual.carbon
@@ -11,7 +11,7 @@ base class A {
 }
 
 class B extends A {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_override_virtual_with_non_virtual.carbon:[[@LINE+1]]: Error declaring `Foo`: method is declared virtual in base class, use `impl` to override it.
+  // CHECK:STDERR: COMPILATION ERROR: fail_override_virtual_with_non_virtual.carbon:[[@LINE+1]]: Error declaring `Foo`: method is declared virtual in base class, use `impl` to override it.
   fn Foo[self: Self]() {}
 }
 

--- a/explorer/testdata/class/fail_qualified_method.carbon
+++ b/explorer/testdata/class/fail_qualified_method.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class Point {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
   fn Point.F[self: Self]() {}
 }
 

--- a/explorer/testdata/class/fail_redeclare_virtual_method.carbon
+++ b/explorer/testdata/class/fail_redeclare_virtual_method.carbon
@@ -11,7 +11,7 @@ base class C {
 }
 
 class D extends C {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_redeclare_virtual_method.carbon:[[@LINE+1]]: Error declaring `Foo`: method is declared virtual in base class, use `impl` to override it.
+  // CHECK:STDERR: COMPILATION ERROR: fail_redeclare_virtual_method.carbon:[[@LINE+1]]: Error declaring `Foo`: method is declared virtual in base class, use `impl` to override it.
   virtual fn Foo[self:Self]() {}
 }
 

--- a/explorer/testdata/class/fail_return_method.carbon
+++ b/explorer/testdata/class/fail_return_method.carbon
@@ -12,7 +12,7 @@ class C {
 }
 
 fn ReturnF() -> auto { return C.F; }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_return_method.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
+// CHECK:STDERR: COMPILATION ERROR: fail_return_method.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
 fn ReturnG() -> auto { return C.G; }
 
 fn Main() -> i32 {

--- a/explorer/testdata/class/fail_use_before_typecheck.carbon
+++ b/explorer/testdata/class/fail_use_before_typecheck.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class C {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_use_before_typecheck.carbon:[[@LINE+1]]: incomplete type `class C` used in member access
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_before_typecheck.carbon:[[@LINE+1]]: incomplete type `class C` used in member access
   var n: if not C.WrapInStruct() then i32 else {.n: i32};
   fn WrapInStruct() -> bool { return true; }
 }

--- a/explorer/testdata/class/fail_virtual_class_function.carbon
+++ b/explorer/testdata/class/fail_virtual_class_function.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 class C {
   virtual fn Foo() -> i32 {
     return 1;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_virtual_class_function.carbon:[[@LINE+1]]: Error declaring `Foo`: class functions cannot be virtual.
+  // CHECK:STDERR: COMPILATION ERROR: fail_virtual_class_function.carbon:[[@LINE+1]]: Error declaring `Foo`: class functions cannot be virtual.
   }
 }
 

--- a/explorer/testdata/class/fail_virtual_method_absent.carbon
+++ b/explorer/testdata/class/fail_virtual_method_absent.carbon
@@ -17,6 +17,6 @@ fn Main() -> i32 {
   var bp: B* = &b;
   var ap: A* = bp;
   // Shouldn't look into the vtable for B.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/class/fail_virtual_method_absent.carbon:[[@LINE+1]]: class A does not have a field named Foo
+  // CHECK:STDERR: COMPILATION ERROR: fail_virtual_method_absent.carbon:[[@LINE+1]]: class A does not have a field named Foo
   return ap->Foo();
 }

--- a/explorer/testdata/comparison/fail_no_impl.carbon
+++ b/explorer/testdata/comparison/fail_no_impl.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/comparison/fail_no_impl.carbon:[[@LINE+1]]: i32 is not equality comparable with String (could not find implementation of interface EqWith(U = String) for i32)
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_impl.carbon:[[@LINE+1]]: i32 is not equality comparable with String (could not find implementation of interface EqWith(U = String) for i32)
   Print("different types equal: {0}", if 1 == "1" then 1 else 0);
   return 0;
 }

--- a/explorer/testdata/constraint/fail_ambiguous_member.carbon
+++ b/explorer/testdata/constraint/fail_ambiguous_member.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface A { fn F() -> i32; }
 interface B { fn F() -> i32; }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_ambiguous_member.carbon:[[@LINE+1]]: ambiguous member access, F found in interface A and interface B
+// CHECK:STDERR: COMPILATION ERROR: fail_ambiguous_member.carbon:[[@LINE+1]]: ambiguous member access, F found in interface A and interface B
 fn Get[T:! A & B](n: T) -> i32 { return n.F(); }
 
 impl i32 as A {

--- a/explorer/testdata/constraint/fail_combine_equality.carbon
+++ b/explorer/testdata/constraint/fail_combine_equality.carbon
@@ -11,7 +11,7 @@ impl i32 as I {}
 
 fn F(A:! i32, B:! i32, C:! i32, D:! i32, E:! i32,
      T:! I where A == B and C == D and C == E and B == D) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_combine_equality.carbon:[[@LINE+1]]: member access, F not in interface I where T impls interface I and A == B and C == D and C == E and B == D
+  // CHECK:STDERR: COMPILATION ERROR: fail_combine_equality.carbon:[[@LINE+1]]: member access, F not in interface I where T impls interface I and A == B and C == D and C == E and B == D
   T.F();
 }
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface FrobWith(T:! type) {}
 
 fn F[T:! FrobWith(.Self)]
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_dot_self_after_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
+  // CHECK:STDERR: COMPILATION ERROR: fail_dot_self_after_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
   (U: .Self) {
 }
 

--- a/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface FrobWith(T:! type) {}
 
 fn F[T:! FrobWith(.Self),
-     // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_dot_self_after_scope_2.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `U`
+     // CHECK:STDERR: COMPILATION ERROR: fail_dot_self_after_scope_2.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `U`
      U:! .Self]() {
 }
 

--- a/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
+++ b/explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_dot_self_not_in_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
+// CHECK:STDERR: COMPILATION ERROR: fail_dot_self_not_in_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
 fn Main() -> .Self {
   return 0;
 }

--- a/explorer/testdata/constraint/fail_infinite_self.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_infinite_self.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
+// CHECK:STDERR: COMPILATION ERROR: fail_infinite_self.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
 fn F[T:! .Self]() {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
+++ b/explorer/testdata/constraint/fail_infinite_self_ptr.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_infinite_self_ptr.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
+// CHECK:STDERR: COMPILATION ERROR: fail_infinite_self_ptr.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
 fn F[T:! .Self*]() {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/fail_missing_member.carbon
+++ b/explorer/testdata/constraint/fail_missing_member.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface A { fn F() -> i32; }
 interface B { fn G() -> i32; }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_missing_member.carbon:[[@LINE+1]]: member access, H not in interface A & interface B where T impls interface A and T impls interface B
+// CHECK:STDERR: COMPILATION ERROR: fail_missing_member.carbon:[[@LINE+1]]: member access, H not in interface A & interface B where T impls interface A and T impls interface B
 fn Get[T:! A & B](n: T) -> i32 { return n.H(); }
 
 impl i32 as A {

--- a/explorer/testdata/constraint/fail_non_type_self.carbon
+++ b/explorer/testdata/constraint/fail_non_type_self.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class X(T:! type) {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_non_type_self.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
+// CHECK:STDERR: COMPILATION ERROR: fail_non_type_self.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
 fn F[T:! X(.Self)](x: T) {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/fail_where_equals_different_types.carbon
+++ b/explorer/testdata/constraint/fail_where_equals_different_types.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 interface A {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_where_equals_different_types.carbon:[[@LINE+3]]: type mismatch between values in `where LHS == RHS`
+// CHECK:STDERR: COMPILATION ERROR: fail_where_equals_different_types.carbon:[[@LINE+3]]: type mismatch between values in `where LHS == RHS`
 // CHECK:STDERR:   LHS type: i32
 // CHECK:STDERR:   RHS type: type
 alias B = A where 4 == i32;

--- a/explorer/testdata/constraint/fail_where_impls_non_constraint.carbon
+++ b/explorer/testdata/constraint/fail_where_impls_non_constraint.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 interface A {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_where_impls_non_constraint.carbon:[[@LINE+1]]: expected a constraint in expression after `impls`, found i32
+// CHECK:STDERR: COMPILATION ERROR: fail_where_impls_non_constraint.carbon:[[@LINE+1]]: expected a constraint in expression after `impls`, found i32
 alias B = A where i32 impls i32;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/fail_where_impls_non_type.carbon
+++ b/explorer/testdata/constraint/fail_where_impls_non_type.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 interface A {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_where_impls_non_type.carbon:[[@LINE+1]]: expression after `impls` does not resolve to a constraint, found i32
+// CHECK:STDERR: COMPILATION ERROR: fail_where_impls_non_type.carbon:[[@LINE+1]]: expression after `impls` does not resolve to a constraint, found i32
 alias B = A where i32 impls 5;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/constraint/fail_where_non_type_impls.carbon
+++ b/explorer/testdata/constraint/fail_where_non_type_impls.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 interface A {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/constraint/fail_where_non_type_impls.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_where_non_type_impls.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
 alias B = A where 4 impls A;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/destructor/fail_addr.carbon
+++ b/explorer/testdata/destructor/fail_addr.carbon
@@ -10,7 +10,7 @@ class A {
   destructor[addr self: Self*] {
     self->n += 1;
     Print("DESTRUCTOR A {0}", self->n);
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/destructor/fail_addr.carbon:[[@LINE+1]]: destructors currently don't support `addr self` bindings
+  // CHECK:STDERR: RUNTIME ERROR: fail_addr.carbon:[[@LINE+1]]: destructors currently don't support `addr self` bindings
   }
 
   var n: i32;

--- a/explorer/testdata/destructor/fail_delete_base_without_virtual_destructor.carbon
+++ b/explorer/testdata/destructor/fail_delete_base_without_virtual_destructor.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Deallocating a derived class from base class pointer requires a virtual destructor
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Deallocating a derived class from base class pointer requires a virtual destructor
 
 package ExplorerTest api;
 

--- a/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
+++ b/explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon
@@ -12,7 +12,7 @@ class A{
     }
     destructor[self: Self]{
         Print("DESTRUCTOR A2 {0}",self.n);
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon:[[@LINE+1]]: Duplicate name `destructor` also found at explorer/testdata/destructor/fail_multiple_destructor_declaration.carbon:[[@LINE-3]]
+    // CHECK:STDERR: COMPILATION ERROR: fail_multiple_destructor_declaration.carbon:[[@LINE+1]]: Duplicate name `destructor` also found at fail_multiple_destructor_declaration.carbon:[[@LINE-3]]
     }
     var n: i32;
 }

--- a/explorer/testdata/destructor/fail_override_abstract.carbon
+++ b/explorer/testdata/destructor/fail_override_abstract.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 
 base class A {
-    // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/destructor/fail_override_abstract.carbon:[[@LINE+1]]: syntax error, unexpected DESTRUCTOR, expecting CLASS
+    // CHECK:STDERR: SYNTAX ERROR: fail_override_abstract.carbon:[[@LINE+1]]: syntax error, unexpected DESTRUCTOR, expecting CLASS
     abstract destructor[self: Self]{}
 }
 

--- a/explorer/testdata/destructor/fail_override_impl_none.carbon
+++ b/explorer/testdata/destructor/fail_override_impl_none.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 
 base class A {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/destructor/fail_override_impl_none.carbon:[[@LINE+1]]: Error declaring destructor for `A`: cannot override a destructor that is not declared `virtual` in base class.
+    // CHECK:STDERR: COMPILATION ERROR: fail_override_impl_none.carbon:[[@LINE+1]]: Error declaring destructor for `A`: cannot override a destructor that is not declared `virtual` in base class.
     impl destructor[self: Self]{}
 }
 

--- a/explorer/testdata/destructor/fail_override_virtual_virtual.carbon
+++ b/explorer/testdata/destructor/fail_override_virtual_virtual.carbon
@@ -12,7 +12,7 @@ base class A {
 }
 
 class B extends A {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/destructor/fail_override_virtual_virtual.carbon:[[@LINE+1]]: Error declaring destructor for `B`: use `impl` to implement virtual destructor in child class.
+    // CHECK:STDERR: COMPILATION ERROR: fail_override_virtual_virtual.carbon:[[@LINE+1]]: Error declaring destructor for `B`: use `impl` to implement virtual destructor in child class.
     virtual destructor[self: Self]{}
 }
 

--- a/explorer/testdata/for/fail_convert.carbon
+++ b/explorer/testdata/for/fail_convert.carbon
@@ -20,7 +20,7 @@ fn Main() -> i32 {
   // representation to describe the conversion.
   for (x: IntLike in arr) {
     Print("{0}", x.n);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/for/fail_convert.carbon:[[@LINE+3]]: type error in `for` pattern
+  // CHECK:STDERR: COMPILATION ERROR: fail_convert.carbon:[[@LINE+3]]: type error in `for` pattern
   // CHECK:STDERR: expected: i32
   // CHECK:STDERR: actual: class IntLike
   }

--- a/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
+++ b/explorer/testdata/function/auto_return/fail_direct_recurse.carbon
@@ -10,7 +10,7 @@ package ExplorerTest api;
 // used.
 fn Recurse(x: i32, do_recurse: bool) -> auto {
   if (do_recurse) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/auto_return/fail_direct_recurse.carbon:[[@LINE+1]]: Function calls itself, but has a deduced return type
+    // CHECK:STDERR: COMPILATION ERROR: fail_direct_recurse.carbon:[[@LINE+1]]: Function calls itself, but has a deduced return type
     Recurse(x, false);
   }
   return x;

--- a/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
+++ b/explorer/testdata/function/auto_return/fail_multiple_returns.carbon
@@ -10,7 +10,7 @@ fn ComputeSum(x: i32, y: i32) -> auto {
   if (x == 0) {
     return x;
   } else if (y == 0) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/auto_return/fail_multiple_returns.carbon:[[@LINE+1]]: Only one return is allowed in a function with an `auto` return type.
+    // CHECK:STDERR: COMPILATION ERROR: fail_multiple_returns.carbon:[[@LINE+1]]: Only one return is allowed in a function with an `auto` return type.
     return y;
   } else {
     return x + y;

--- a/explorer/testdata/function/auto_return/fail_no_return.carbon
+++ b/explorer/testdata/function/auto_return/fail_no_return.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn NoReturn() -> auto {
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/auto_return/fail_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
+// CHECK:STDERR: COMPILATION ERROR: fail_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
 }
 
 fn Main() {

--- a/explorer/testdata/function/auto_return/fail_separate_decl.carbon
+++ b/explorer/testdata/function/auto_return/fail_separate_decl.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 // This declaration is not allowed.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/auto_return/fail_separate_decl.carbon:[[@LINE+1]]: Function declaration has deduced return type but no body
+// CHECK:STDERR: COMPILATION ERROR: fail_separate_decl.carbon:[[@LINE+1]]: Function declaration has deduced return type but no body
 fn ComputeSum(x: i32, y: i32) -> auto;
 
 fn Main() -> i32 {

--- a/explorer/testdata/function/fail_call_undefined.carbon
+++ b/explorer/testdata/function/fail_call_undefined.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 fn F() -> i32;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/function/fail_call_undefined.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
+  // CHECK:STDERR: RUNTIME ERROR: fail_call_undefined.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
   return F();
 }

--- a/explorer/testdata/function/fail_call_with_tuple.carbon
+++ b/explorer/testdata/function/fail_call_with_tuple.carbon
@@ -11,6 +11,6 @@ fn f(x: i32, y: i32) -> i32 { return x + y; }
 fn Main() -> i32 {
   var xy: (i32, i32) = (1, 2);
   // should fail to type-check
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_call_with_tuple.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 2 but got 1
+  // CHECK:STDERR: COMPILATION ERROR: fail_call_with_tuple.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 2 but got 1
   return f(xy);
 }

--- a/explorer/testdata/function/fail_invalid_fnty.carbon
+++ b/explorer/testdata/function/fail_invalid_fnty.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_invalid_fnty.carbon:[[@LINE+2]]: type error in `-`:
+// CHECK:STDERR: COMPILATION ERROR: fail_invalid_fnty.carbon:[[@LINE+2]]: type error in `-`:
 // CHECK:STDERR: could not find implementation of interface Negate for bool
 fn f(g: __Fn(-true) -> true) {
 }

--- a/explorer/testdata/function/fail_main_with_parameters.carbon
+++ b/explorer/testdata/function/fail_main_with_parameters.carbon
@@ -8,5 +8,5 @@ package ExplorerTest api;
 
 fn Main(i: i32) -> i32 {
     return 0;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_main_with_parameters.carbon:[[@LINE+1]]: `Main` must not take any parameters
+// CHECK:STDERR: COMPILATION ERROR: fail_main_with_parameters.carbon:[[@LINE+1]]: `Main` must not take any parameters
 }

--- a/explorer/testdata/function/fail_match_no_return.carbon
+++ b/explorer/testdata/function/fail_match_no_return.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: i32 = 0;
   match(0) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_match_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
+    // CHECK:STDERR: COMPILATION ERROR: fail_match_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
     case 1 => { x = 1; }
     case _: auto => { x = 2; }
   }

--- a/explorer/testdata/function/fail_match_partial_return.carbon
+++ b/explorer/testdata/function/fail_match_partial_return.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: i32 = 0;
   match (0) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_match_partial_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
+    // CHECK:STDERR: COMPILATION ERROR: fail_match_partial_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
     case 1 => { x = 1; }
     case _: auto => { return 0; }
   }

--- a/explorer/testdata/function/fail_non_exhaustive_match.carbon
+++ b/explorer/testdata/function/fail_non_exhaustive_match.carbon
@@ -11,5 +11,5 @@ fn Main() -> i32 {
   match (n) {
     case 1 => { return 0; }
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_non_exhaustive_match.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+// CHECK:STDERR: COMPILATION ERROR: fail_non_exhaustive_match.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
 }

--- a/explorer/testdata/function/fail_parameter_type.carbon
+++ b/explorer/testdata/function/fail_parameter_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 // 42 cannot be used as the type of a parameter.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_parameter_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_parameter_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
 fn f(x: 42) -> i32 {
   return x - 1;
 }

--- a/explorer/testdata/function/fail_parameter_type_only.carbon
+++ b/explorer/testdata/function/fail_parameter_type_only.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_parameter_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
+// CHECK:STDERR: COMPILATION ERROR: fail_parameter_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
 fn f(x: i32, i32) {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/function/fail_recurse_before_typecheck.carbon
+++ b/explorer/testdata/function/fail_recurse_before_typecheck.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn T() -> type {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_recurse_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `T` that has not been fully type-checked
+  // CHECK:STDERR: COMPILATION ERROR: fail_recurse_before_typecheck.carbon:[[@LINE+1]]: attempt to call function `T` that has not been fully type-checked
   var v: T() = 0;
   return i32;
 }

--- a/explorer/testdata/function/fail_recurse_in_return_type.carbon
+++ b/explorer/testdata/function/fail_recurse_in_return_type.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_recurse_in_return_type.carbon:[[@LINE+1]]: 'T' is not usable until after it has been completely declared
+// CHECK:STDERR: COMPILATION ERROR: fail_recurse_in_return_type.carbon:[[@LINE+1]]: 'T' is not usable until after it has been completely declared
 fn T() -> T() { return i32; }
 
 fn Main() -> i32 {

--- a/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
+++ b/explorer/testdata/function/fail_return_call_has_invalid_body.carbon
@@ -7,7 +7,7 @@
 package EmptyIdentifier impl;
 
 fn apply[T:! type, U:! type](f: T, EmptyIdentifier: U) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_return_call_has_invalid_body.carbon:[[@LINE+1]]: only arrays and tuples can be indexed, found bool
+  // CHECK:STDERR: COMPILATION ERROR: fail_return_call_has_invalid_body.carbon:[[@LINE+1]]: only arrays and tuples can be indexed, found bool
   match (true[true]) {}
 }
 

--- a/explorer/testdata/function/fail_var_type_is_call.carbon
+++ b/explorer/testdata/function/fail_var_type_is_call.carbon
@@ -11,7 +11,7 @@ fn test() -> i32 {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/function/fail_var_type_is_call.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_var_type_is_call.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
   var x: test() = 1;
   return 0;
 }

--- a/explorer/testdata/generic_class/fail_args_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_args_mismatch.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class Point(T:! type) {
   // Point(T, T) does not match class declaration
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_args_mismatch.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 1 but got 2
+  // CHECK:STDERR: COMPILATION ERROR: fail_args_mismatch.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 1 but got 2
   fn Origin(zero: T) -> Point(T, T) {
     return {.x = zero, .y = zero};
   }

--- a/explorer/testdata/generic_class/fail_argument_deduction.carbon
+++ b/explorer/testdata/generic_class/fail_argument_deduction.carbon
@@ -18,7 +18,7 @@ fn FirstOfTwoPoints[T:! type](a: Point(T), b: Point(T)) -> Point(T) {
 fn Main() -> i32 {
   var p: Point(i32) = {.x = 0, .y = 1};
   var q: Point(bool) = {.x = true, .y = false};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_argument_deduction.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
+  // CHECK:STDERR: COMPILATION ERROR: fail_argument_deduction.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
   // CHECK:STDERR:   i32
   // CHECK:STDERR:   bool
   return FirstOfTwoPoints(p, q).x;

--- a/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
+++ b/explorer/testdata/generic_class/fail_bad_parameter_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class Point(T:! i32) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_bad_parameter_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
   fn Origin(zero: T) -> Point(T) {
     return {.x = zero, .y = zero};
   }

--- a/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
+++ b/explorer/testdata/generic_class/fail_field_access_on_generic.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn BadSimpleMemberAccess[T:! type](a: T) -> T {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_field_access_on_generic.carbon:[[@LINE+1]]: member access in unconstrained type
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_access_on_generic.carbon:[[@LINE+1]]: member access in unconstrained type
   return a.x;
 }
 

--- a/explorer/testdata/generic_class/fail_generic_class_arg.carbon
+++ b/explorer/testdata/generic_class/fail_generic_class_arg.carbon
@@ -16,7 +16,7 @@ class Point(T:! type) {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_generic_class_arg.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 1 but got 2
+  // CHECK:STDERR: COMPILATION ERROR: fail_generic_class_arg.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 1 but got 2
   var p: Point(i32) = Point(i32, i32).Create(0, 1);
   return p.x;
 }

--- a/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
+++ b/explorer/testdata/generic_class/fail_generic_in_pattern.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var t: auto = 5;
   match (t) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_generic_in_pattern.carbon:[[@LINE+1]]: generic binding may not occur in pattern with expected type T:! i32
+    // CHECK:STDERR: COMPILATION ERROR: fail_generic_in_pattern.carbon:[[@LINE+1]]: generic binding may not occur in pattern with expected type T:! i32
     case T:! i32 => { return 0; }
     default => { return 1; }
   }

--- a/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
+++ b/explorer/testdata/generic_class/fail_instantiate_non_generic.carbon
@@ -15,7 +15,7 @@ class Point {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_instantiate_non_generic.carbon:[[@LINE+1]]: in call `Point(i32)`, expected callee to be a function, found `type`
+  // CHECK:STDERR: COMPILATION ERROR: fail_instantiate_non_generic.carbon:[[@LINE+1]]: in call `Point(i32)`, expected callee to be a function, found `type`
   var p: Point(i32) = Point.Origin();
   return 0;
 }

--- a/explorer/testdata/generic_class/fail_no_args.carbon
+++ b/explorer/testdata/generic_class/fail_no_args.carbon
@@ -12,7 +12,7 @@ class Point(T:! type) {
   }
 
   // Error: wrote `Point` instead of `Point(T)`, `Point` by itself is not a type.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_no_args.carbon:[[@LINE+1]]: 'Point' must be given an argument list
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_args.carbon:[[@LINE+1]]: 'Point' must be given an argument list
   fn GetX[self: Point]() -> T {
     return self.x;
   }

--- a/explorer/testdata/generic_class/fail_point_equal.carbon
+++ b/explorer/testdata/generic_class/fail_point_equal.carbon
@@ -13,7 +13,7 @@ class Point(T:! type) {
 
 fn Main() -> i32 {
   var p: Point(i32) = {.x = 0, .y = 0};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_point_equal.carbon:[[@LINE+1]]: type error in initializer of variable: 'class Point(T = i32)' is not implicitly convertible to 'class Point(T = bool)'
+  // CHECK:STDERR: COMPILATION ERROR: fail_point_equal.carbon:[[@LINE+1]]: type error in initializer of variable: 'class Point(T = i32)' is not implicitly convertible to 'class Point(T = bool)'
   var q: Point(bool) = p;
   return 0;
 }

--- a/explorer/testdata/generic_class/fail_return_type_is_type.carbon
+++ b/explorer/testdata/generic_class/fail_return_type_is_type.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class Point(T:! type) {
   // The return type should be Point(T). Point by itself is not a type.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_return_type_is_type.carbon:[[@LINE+1]]: 'Point' must be given an argument list
+  // CHECK:STDERR: COMPILATION ERROR: fail_return_type_is_type.carbon:[[@LINE+1]]: 'Point' must be given an argument list
   fn Create(x: T, y: T) -> Point {
     return {.x = x, .y = y};
   }

--- a/explorer/testdata/generic_class/fail_self_with_arg.carbon
+++ b/explorer/testdata/generic_class/fail_self_with_arg.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 class Point(T:! type) {
 
   // Error: wrote `Self(T)` instead of `Self`.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_self_with_arg.carbon:[[@LINE+1]]: in call `Self(T)`, expected callee to be a function, found `type`
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_with_arg.carbon:[[@LINE+1]]: in call `Self(T)`, expected callee to be a function, found `type`
   fn Origin(zero: T) -> Self(T) {
     return {.x = zero, .y = zero};
   }

--- a/explorer/testdata/generic_class/fail_two_arg_lists.carbon
+++ b/explorer/testdata/generic_class/fail_two_arg_lists.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class Point(T:! type) {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_two_arg_lists.carbon:[[@LINE+1]]: in call `Point(T)(T)`, expected callee to be a function, found `type`
+  // CHECK:STDERR: COMPILATION ERROR: fail_two_arg_lists.carbon:[[@LINE+1]]: in call `Point(T)(T)`, expected callee to be a function, found `type`
   fn Origin(zero: T) -> Point(T)(T) {
     return {.x = zero, .y = zero};
   }

--- a/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
+++ b/explorer/testdata/generic_class/fail_value_param_mismatch.carbon
@@ -12,7 +12,7 @@ fn F(x: HasI32Param(1)) {}
 
 fn Main() -> i32 {
   var n: HasI32Param(0) = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_class/fail_value_param_mismatch.carbon:[[@LINE+1]]: mismatch in non-deduced values, `0` != `1`
+  // CHECK:STDERR: COMPILATION ERROR: fail_value_param_mismatch.carbon:[[@LINE+1]]: mismatch in non-deduced values, `0` != `1`
   F(n);
   return 0;
 }

--- a/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Bad[T:! type](x: {.a: i32, .b: T}) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_implicit_conversion_extra_field.carbon:[[@LINE+1]]: mismatch in field names, source field `c` not in destination type `{.a: i32, .b: T}`
+  // CHECK:STDERR: COMPILATION ERROR: fail_implicit_conversion_extra_field.carbon:[[@LINE+1]]: mismatch in field names, source field `c` not in destination type `{.a: i32, .b: T}`
   Bad({.b = 5, .a = 7, .c = 2});
   return 0;
 }

--- a/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
+++ b/explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Bad[T:! type](x: {.a: i32, .b: T}) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_implicit_conversion_missing_field.carbon:[[@LINE+1]]: mismatch in field names, destination field `b` not in source type `{.a: i32}`
+  // CHECK:STDERR: COMPILATION ERROR: fail_implicit_conversion_missing_field.carbon:[[@LINE+1]]: mismatch in field names, destination field `b` not in source type `{.a: i32}`
   Bad({.a = 5});
   return 0;
 }

--- a/explorer/testdata/generic_function/fail_missing_exclam.carbon
+++ b/explorer/testdata/generic_function/fail_missing_exclam.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/generic_function/fail_missing_exclam.carbon:[[@LINE+1]]: illegal binding pattern in implicit parameter list
+// CHECK:STDERR: SYNTAX ERROR: fail_missing_exclam.carbon:[[@LINE+1]]: illegal binding pattern in implicit parameter list
 fn F[T: type]();
 
 fn Main() -> i32 {

--- a/explorer/testdata/generic_function/fail_not_addable.carbon
+++ b/explorer/testdata/generic_function/fail_not_addable.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn id[T:! type](x: T) -> T {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_not_addable.carbon:[[@LINE+2]]: type error in `+`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_not_addable.carbon:[[@LINE+2]]: type error in `+`:
   // CHECK:STDERR: could not find implementation of interface AddWith(U = i32) for T
   return x + 0;
 }

--- a/explorer/testdata/generic_function/fail_not_type.carbon
+++ b/explorer/testdata/generic_function/fail_not_type.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
 fn F[a:! 42]();
 
 fn Main() -> i32 {

--- a/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon
@@ -11,7 +11,7 @@ fn fst[T:! type](x: T, y: T) -> T {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_type_deduction_mismatch.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
+  // CHECK:STDERR: COMPILATION ERROR: fail_type_deduction_mismatch.carbon:[[@LINE+3]]: deduced multiple different values for T:! type:
   // CHECK:STDERR:   i32
   // CHECK:STDERR:   bool
   return fst(0, true);

--- a/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
+++ b/explorer/testdata/generic_function/fail_type_deduction_unused.carbon
@@ -11,6 +11,6 @@ fn id[T:! type](x: i32) -> i32 {
 }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_type_deduction_unused.carbon:[[@LINE+1]]: could not deduce type argument for type parameter T in call
+  // CHECK:STDERR: COMPILATION ERROR: fail_type_deduction_unused.carbon:[[@LINE+1]]: could not deduce type argument for type parameter T in call
   return id(0);
 }

--- a/explorer/testdata/generic_function/fail_type_only.carbon
+++ b/explorer/testdata/generic_function/fail_type_only.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class C {}
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/generic_function/fail_type_only.carbon:[[@LINE+1]]: syntax error, unexpected RIGHT_SQUARE_BRACKET, expecting COLON
+// CHECK:STDERR: SYNTAX ERROR: fail_type_only.carbon:[[@LINE+1]]: syntax error, unexpected RIGHT_SQUARE_BRACKET, expecting COLON
 fn f[x:! i32, addr C]() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
+++ b/explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon
@@ -13,7 +13,7 @@ fn Get[T:! ()](n: T) -> i32 {  return 2; }
 
 fn Main() -> i32 {
   var x : X = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/generic_function/fail_wrong_variable_substituation.carbon:[[@LINE+1]]: cannot convert deduced value class X for T to parameter type ()
+  // CHECK:STDERR: COMPILATION ERROR: fail_wrong_variable_substituation.carbon:[[@LINE+1]]: cannot convert deduced value class X for T to parameter type ()
   Get(x);
   return 0;
 }

--- a/explorer/testdata/impl/fail_bad_member_kind.carbon
+++ b/explorer/testdata/impl/fail_bad_member_kind.carbon
@@ -12,7 +12,7 @@ interface A {
 }
 
 external impl i32 as A {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/impl/fail_bad_member_kind.carbon:[[@LINE+1]]: syntax error, unexpected CLASS
+  // CHECK:STDERR: SYNTAX ERROR: fail_bad_member_kind.carbon:[[@LINE+1]]: syntax error, unexpected CLASS
   class T {}
 }
 

--- a/explorer/testdata/impl/fail_impl_as.carbon
+++ b/explorer/testdata/impl/fail_impl_as.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_impl_as.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found i32
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_as.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found i32
 external impl i32 as i32 {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl/fail_impl_as_non_interface.carbon
+++ b/explorer/testdata/impl/fail_impl_as_non_interface.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_impl_as_non_interface.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found String
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_as_non_interface.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found String
 external impl i32 as String {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/impl/fail_impl_as_not_constraint.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_impl_as_not_constraint.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found i32
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_as_not_constraint.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found i32
 external impl i32 as i32 {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl/fail_impl_as_parameterized.carbon
+++ b/explorer/testdata/impl/fail_impl_as_parameterized.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface Vector(Scalar:! type) {
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_impl_as_parameterized.carbon:[[@LINE+1]]: 'Vector' must be given an argument list
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_as_parameterized.carbon:[[@LINE+1]]: 'Vector' must be given an argument list
 external impl i32 as Vector {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl/fail_impl_redefinition.carbon
+++ b/explorer/testdata/impl/fail_impl_redefinition.carbon
@@ -33,7 +33,7 @@ external impl Point as Vector {
   fn Scale[self: Point](v: i32) -> Point {
       return {.x = self.x * v, .y = self.y * v};
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_impl_redefinition.carbon:[[@LINE+1]]: ambiguous implementations of interface Vector for class Point
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_redefinition.carbon:[[@LINE+1]]: ambiguous implementations of interface Vector for class Point
 }
 
 fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {

--- a/explorer/testdata/impl/fail_nondeducible_parameter.carbon
+++ b/explorer/testdata/impl/fail_nondeducible_parameter.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface A(T:! type) {}
 interface B {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_nondeducible_parameter.carbon:[[@LINE+1]]: parameter `T:! type` is not deducible from `impl i32 as interface B`
+// CHECK:STDERR: COMPILATION ERROR: fail_nondeducible_parameter.carbon:[[@LINE+1]]: parameter `T:! type` is not deducible from `impl i32 as interface B`
 external impl forall [T:! type] i32 as A(T) & B {}
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/impl/fail_param_interface_in_impl.carbon
+++ b/explorer/testdata/impl/fail_param_interface_in_impl.carbon
@@ -17,7 +17,7 @@ fn Main() -> i32 {
   let n: i32 = 0;
   CheckSimilar(true, false);
   CheckSimilar(true, n);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_param_interface_in_impl.carbon:[[@LINE+1]]: could not find implementation of interface Similar(T = i32) for bool
+  // CHECK:STDERR: COMPILATION ERROR: fail_param_interface_in_impl.carbon:[[@LINE+1]]: could not find implementation of interface Similar(T = i32) for bool
   CheckSimilar(n, false);
   return 0;
 }

--- a/explorer/testdata/impl/fail_unmet_impls_constraint.carbon
+++ b/explorer/testdata/impl/fail_unmet_impls_constraint.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface A {}
 interface B {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl/fail_unmet_impls_constraint.carbon:[[@LINE+1]]: could not find implementation of interface B for i32
+// CHECK:STDERR: COMPILATION ERROR: fail_unmet_impls_constraint.carbon:[[@LINE+1]]: could not find implementation of interface B for i32
 external impl i32 as A where i32 impls B {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/impl_match/fail_self_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_self_recurse.carbon
@@ -13,7 +13,7 @@ impl forall [T:! type where .Self* impls Foo] T as Foo {}
 fn F[T:! Foo](x: T) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_self_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface Foo
   // CHECK:STDERR:   inner match: i32* as interface Foo
   F(0);

--- a/explorer/testdata/impl_match/fail_self_recurse_without_match_first.carbon
+++ b/explorer/testdata/impl_match/fail_self_recurse_without_match_first.carbon
@@ -17,7 +17,7 @@ fn Main() -> i32 {
   // When checking the second impl, we recursively look for a match for
   // i32* as Foo, which considers the second impl again, even though the first
   // impl would match.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_self_recurse_without_match_first.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_recurse_without_match_first.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface Foo
   // CHECK:STDERR:   inner match: i32* as interface Foo
   F(0);

--- a/explorer/testdata/impl_match/fail_simple_self_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_simple_self_recurse.carbon
@@ -13,7 +13,7 @@ impl forall [T:! Foo] T as Foo {}
 fn F[T:! Foo](x: T) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_simple_self_recurse.carbon:[[@LINE+1]]: impl matching for i32 as interface Foo recursively performed a match for the same type and interface
+  // CHECK:STDERR: COMPILATION ERROR: fail_simple_self_recurse.carbon:[[@LINE+1]]: impl matching for i32 as interface Foo recursively performed a match for the same type and interface
   F(0);
   return 0;
 }

--- a/explorer/testdata/impl_match/fail_struct_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_struct_recurse.carbon
@@ -13,7 +13,7 @@ impl forall [T:! type where {.a: .Self} impls Foo] T as Foo {}
 fn F[T:! Foo](x: T) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_struct_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR: COMPILATION ERROR: fail_struct_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface Foo
   // CHECK:STDERR:   inner match: {.a: i32} as interface Foo
   F(0);

--- a/explorer/testdata/impl_match/fail_three_step_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_three_step_recurse.carbon
@@ -17,7 +17,7 @@ impl forall [T:! type where .Self* impls C] T as A {}
 fn F[T:! A](x: T) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_three_step_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR: COMPILATION ERROR: fail_three_step_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface A
   // CHECK:STDERR:   inner match: i32*** as interface A
   F(0);

--- a/explorer/testdata/impl_match/fail_tuple_recurse.carbon
+++ b/explorer/testdata/impl_match/fail_tuple_recurse.carbon
@@ -13,7 +13,7 @@ impl forall [T:! type where (.Self,) impls Foo] T as Foo {}
 fn F[T:! Foo](x: T) {}
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/impl_match/fail_tuple_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
+  // CHECK:STDERR: COMPILATION ERROR: fail_tuple_recurse.carbon:[[@LINE+3]]: impl matching recursively performed a more complex match using the same impl
   // CHECK:STDERR:   outer match: i32 as interface Foo
   // CHECK:STDERR:   inner match: (i32,) as interface Foo
   F(0);

--- a/explorer/testdata/import/fail_order.carbon
+++ b/explorer/testdata/import/fail_order.carbon
@@ -10,5 +10,5 @@ fn Main() -> i32 {
   return 0;
 }
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/import/fail_order.carbon:[[@LINE+1]]: syntax error, unexpected IMPORT, expecting END_OF_FILE
+// CHECK:STDERR: SYNTAX ERROR: fail_order.carbon:[[@LINE+1]]: syntax error, unexpected IMPORT, expecting END_OF_FILE
 import ExplorerTest library "Nonexistent";

--- a/explorer/testdata/interface/fail_bad_member_kind.carbon
+++ b/explorer/testdata/interface/fail_bad_member_kind.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Bad {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/interface/fail_bad_member_kind.carbon:[[@LINE+1]]: syntax error, unexpected VAR
+  // CHECK:STDERR: SYNTAX ERROR: fail_bad_member_kind.carbon:[[@LINE+1]]: syntax error, unexpected VAR
   var V: i32;
 }
 

--- a/explorer/testdata/interface/fail_extends_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_extends_not_constraint.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Vector {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_extends_not_constraint.carbon:[[@LINE+1]]: expected a constraint in extends declaration, found i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_extends_not_constraint.carbon:[[@LINE+1]]: expected a constraint in extends declaration, found i32
   extends i32;
 }
 

--- a/explorer/testdata/interface/fail_external_impl_omit_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_omit_self.carbon
@@ -17,7 +17,7 @@ class Point {
 }
 
 // Error: need to specify which type implementing `Vector` for.
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_external_impl_omit_self.carbon:[[@LINE+1]]: could not resolve 'Self'
+// CHECK:STDERR: COMPILATION ERROR: fail_external_impl_omit_self.carbon:[[@LINE+1]]: could not resolve 'Self'
 external impl as Vector {
   fn Add[self: Point](b: Point) -> Point {
     return {.x = self.x + b.x, .y = self.y + b.y};

--- a/explorer/testdata/interface/fail_external_impl_self.carbon
+++ b/explorer/testdata/interface/fail_external_impl_self.carbon
@@ -16,7 +16,7 @@ class Point {
   var y: i32;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_external_impl_self.carbon:[[@LINE+1]]: could not resolve 'Self'
+// CHECK:STDERR: COMPILATION ERROR: fail_external_impl_self.carbon:[[@LINE+1]]: could not resolve 'Self'
 external impl Self as Vector {
   fn Add[self: Point](b: Point) -> Point {
     return {.x = self.x + b.x, .y = self.y + b.y};

--- a/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_constraint.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Vector {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_impl_as_not_constraint.carbon:[[@LINE+1]]: expected a constraint in impl as declaration, found i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_as_not_constraint.carbon:[[@LINE+1]]: expected a constraint in impl as declaration, found i32
   impl Self as i32;
 }
 

--- a/explorer/testdata/interface/fail_impl_as_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_as_not_type.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface A {}
 
 interface B {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_impl_as_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_as_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
   impl 5 as A;
 }
 

--- a/explorer/testdata/interface/fail_impl_bad_member.carbon
+++ b/explorer/testdata/interface/fail_impl_bad_member.carbon
@@ -20,7 +20,7 @@ class Point {
     }
     fn Scale[self: Point](v: i32) -> i32 {
       return 0;
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_impl_bad_member.carbon:[[@LINE+3]]: type error in member of implementation
+    // CHECK:STDERR: COMPILATION ERROR: fail_impl_bad_member.carbon:[[@LINE+3]]: type error in member of implementation
     // CHECK:STDERR: expected: fn (i32,) -> class Point
     // CHECK:STDERR: actual: fn (i32,) -> i32
     }

--- a/explorer/testdata/interface/fail_impl_missing_member.carbon
+++ b/explorer/testdata/interface/fail_impl_missing_member.carbon
@@ -18,7 +18,7 @@ class Point {
     fn Add[self: Point](b: Point) -> Point {
       return {.x = self.x + b.x, .y = self.y + b.y};
     }
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_impl_missing_member.carbon:[[@LINE+1]]: implementation missing Scale
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_missing_member.carbon:[[@LINE+1]]: implementation missing Scale
   }
 }
 

--- a/explorer/testdata/interface/fail_impl_not_type.carbon
+++ b/explorer/testdata/interface/fail_impl_not_type.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 interface Vector {
   fn Zero() -> i32;
 }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_impl_not_type.carbon:[[@LINE+1]]: type error in type expression: 'String' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_not_type.carbon:[[@LINE+1]]: type error in type expression: 'String' is not implicitly convertible to 'type'
 impl "hello" as Vector {
   fn Zero() -> i32 { return 0; }
 }

--- a/explorer/testdata/interface/fail_interface_missing_member.carbon
+++ b/explorer/testdata/interface/fail_interface_missing_member.carbon
@@ -11,7 +11,7 @@ interface Vector {
 }
 
 fn ScaleGeneric[T:! Vector](a: T, s: i32) -> T {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_interface_missing_member.carbon:[[@LINE+1]]: member access, Scale not in interface Vector where T impls interface Vector
+  // CHECK:STDERR: COMPILATION ERROR: fail_interface_missing_member.carbon:[[@LINE+1]]: member access, Scale not in interface Vector where T impls interface Vector
   return a.Scale(s);
 }
 

--- a/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_member_lookup_in_definition.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Vector {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_member_lookup_in_definition.carbon:[[@LINE+1]]: incomplete type `interface Vector` used in member access
+  // CHECK:STDERR: COMPILATION ERROR: fail_member_lookup_in_definition.carbon:[[@LINE+1]]: incomplete type `interface Vector` used in member access
   fn ScalarZero() -> Vector.ScalarType;
   let ScalarType:! type;
 }

--- a/explorer/testdata/interface/fail_no_impl.carbon
+++ b/explorer/testdata/interface/fail_no_impl.carbon
@@ -23,7 +23,7 @@ fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {
 fn Main() -> i32 {
   var a: Point = {.x = 0, .y = 0};
   var b: Point = {.x = 2, .y = 3};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_no_impl.carbon:[[@LINE+1]]: could not find implementation of interface Vector for class Point
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_impl.carbon:[[@LINE+1]]: could not find implementation of interface Vector for class Point
   var p: Point = AddAndScaleGeneric(a, b, 3);
   return p.x - 6;
 }

--- a/explorer/testdata/interface/fail_qualified_method.carbon
+++ b/explorer/testdata/interface/fail_qualified_method.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Vector {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
   fn Vector.Zero() -> i32;
 }
 

--- a/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
+++ b/explorer/testdata/interface/fail_self_lookup_in_definition.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface Vector {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_self_lookup_in_definition.carbon:[[@LINE+1]]: incomplete type `interface Vector` used in member access
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_lookup_in_definition.carbon:[[@LINE+1]]: incomplete type `interface Vector` used in member access
   fn ScalarZero() -> Self.ScalarType;
   let ScalarType:! type;
 }

--- a/explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon
+++ b/explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface IFace {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_use_assoc_const_before_decl.carbon:[[@LINE+1]]: 'C' has not been declared yet
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_assoc_const_before_decl.carbon:[[@LINE+1]]: 'C' has not been declared yet
   let B:! C;
   let C:! IFace;
 }

--- a/explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon
+++ b/explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 interface IFace {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_use_assoc_const_in_defn.carbon:[[@LINE+1]]: 'T' is not usable until after it has been completely declared
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_assoc_const_in_defn.carbon:[[@LINE+1]]: 'T' is not usable until after it has been completely declared
   let T:! T.IFace;
 }
 

--- a/explorer/testdata/interface/fail_use_symbolic_member.carbon
+++ b/explorer/testdata/interface/fail_use_symbolic_member.carbon
@@ -10,7 +10,7 @@ interface X {
   fn F() -> type;
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/interface/fail_use_symbolic_member.carbon:[[@LINE+1]]: member lookup for F in symbolic witness 0 of witness for T:! X
+// CHECK:STDERR: COMPILATION ERROR: fail_use_symbolic_member.carbon:[[@LINE+1]]: member lookup for F in symbolic witness 0 of witness for T:! X
 fn G[T:! X]() -> T.F() {
   return {};
 }

--- a/explorer/testdata/let/fail_function_args.carbon
+++ b/explorer/testdata/let/fail_function_args.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn f((var x: i32, y: i32)) -> i32 {
   x = 0;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_function_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `y`
+  // CHECK:STDERR: COMPILATION ERROR: fail_function_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `y`
   y = 0;
   return x - 1;
 }

--- a/explorer/testdata/let/fail_global_assign.carbon
+++ b/explorer/testdata/let/fail_global_assign.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 let x: i32 = 10;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_global_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
+  // CHECK:STDERR: COMPILATION ERROR: fail_global_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
   x = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_global_named_self.carbon
+++ b/explorer/testdata/let/fail_global_named_self.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 // Error: Can't use keyword `Self` as the name of a global.
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/let/fail_global_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier
+// CHECK:STDERR: SYNTAX ERROR: fail_global_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier
 let Self: i32 = 10;
 
 fn Main() -> i32 {

--- a/explorer/testdata/let/fail_local_assign.carbon
+++ b/explorer/testdata/let/fail_local_assign.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   let x: auto = 10;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_local_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
+  // CHECK:STDERR: COMPILATION ERROR: fail_local_assign.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
   x = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_local_named_self.carbon
+++ b/explorer/testdata/let/fail_local_named_self.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   // Error: Can't use keyword `Self` as the name of a local.
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/let/fail_local_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL
+  // CHECK:STDERR: SYNTAX ERROR: fail_local_named_self.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL
   let Self: auto = 10;
   return 0;
 }

--- a/explorer/testdata/let/fail_match_choice.carbon
+++ b/explorer/testdata/let/fail_match_choice.carbon
@@ -23,7 +23,7 @@ fn Main() -> i32 {
       n = n - 1;
     }
     case Ints.Two(x: auto, y: auto) => {
-      // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_match_choice.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
+      // CHECK:STDERR: COMPILATION ERROR: fail_match_choice.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
       x = 0;
     }
   }

--- a/explorer/testdata/let/fail_method_args.carbon
+++ b/explorer/testdata/let/fail_method_args.carbon
@@ -12,7 +12,7 @@ class Point {
   }
 
   fn SetX[self: Point](x: i32) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_method_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
+    // CHECK:STDERR: COMPILATION ERROR: fail_method_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
     x = 10;
   }
 

--- a/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context.carbon
@@ -10,7 +10,7 @@ fn Main() -> i32 {
   let (var a: auto, b: auto, c: auto, d: auto) = (1, 2, 3, 4);
   a = 0;
   // should fail
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/let/fail_tuple_pattern_let_context.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `c`
+  // CHECK:STDERR: COMPILATION ERROR: fail_tuple_pattern_let_context.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `c`
   c = 0;
   return 0;
 }

--- a/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/let/fail_tuple_pattern_let_context_nested.carbon:[[@LINE+1]]: syntax error, unexpected LET
+  // CHECK:STDERR: SYNTAX ERROR: fail_tuple_pattern_let_context_nested.carbon:[[@LINE+1]]: syntax error, unexpected LET
   let (var a: auto, b: auto, c: auto, var (d: auto, let e: auto)) =
       (1, 2, 3, (4, 5));
   return 0;

--- a/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
+++ b/explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/let/fail_tuple_pattern_let_in_var.carbon:[[@LINE+1]]: syntax error, unexpected LET
+  // CHECK:STDERR: SYNTAX ERROR: fail_tuple_pattern_let_in_var.carbon:[[@LINE+1]]: syntax error, unexpected LET
   var (var a: auto, b: auto, let c: auto, d: auto) = (1, 2, 3, 4);
   return 0;
 }

--- a/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_9x.carbon
@@ -27,5 +27,5 @@ fn Main() -> i32 {
     case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A()) => { return 8; }
     case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 9; }
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_exhaustive_exponential_9x.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+// CHECK:STDERR: COMPILATION ERROR: fail_exhaustive_exponential_9x.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
 }

--- a/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
+++ b/explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon
@@ -36,5 +36,5 @@ fn Main() -> i32 {
     case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A()) => { return 16; }
     case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 17; }
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_exhaustive_exponential_series_t.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+// CHECK:STDERR: COMPILATION ERROR: fail_exhaustive_exponential_series_t.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
 }

--- a/explorer/testdata/match/fail_exhaustive_int.carbon
+++ b/explorer/testdata/match/fail_exhaustive_int.carbon
@@ -11,7 +11,7 @@ fn A(n: i32) -> i32 {
     case 1 => { return 1; }
     case 2 => { return 2; }
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_exhaustive_int.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+// CHECK:STDERR: COMPILATION ERROR: fail_exhaustive_int.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/match/fail_not_alternative.carbon
+++ b/explorer/testdata/match/fail_not_alternative.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: i32 = 0;
   match (x) {
-    // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/match/fail_not_alternative.carbon:[[@LINE+1]]: Alternative pattern must have the form of a field access.
+    // CHECK:STDERR: SYNTAX ERROR: fail_not_alternative.carbon:[[@LINE+1]]: Alternative pattern must have the form of a field access.
     case i32(n: i32) => {
       return 1;
     }

--- a/explorer/testdata/match/fail_not_exhaustive.carbon
+++ b/explorer/testdata/match/fail_not_exhaustive.carbon
@@ -16,7 +16,7 @@ fn A(a: Opt, b: Opt) -> i32 {
     case (Opt.Some(n: i32), _: auto) => { return n; }
     case (_: auto, Opt.Some(n: i32)) => { return n; }
   }
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_not_exhaustive.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+// CHECK:STDERR: COMPILATION ERROR: fail_not_exhaustive.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/match/fail_not_reachable.carbon
+++ b/explorer/testdata/match/fail_not_reachable.carbon
@@ -15,7 +15,7 @@ fn A(a: Opt, b: Opt) -> i32 {
   match ((a, b)) {
     case (Opt.Some(n: i32), _: auto) => { return n; }
     case (_: auto, Opt.Some(n: i32)) => { return n; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_not_reachable.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
+    // CHECK:STDERR: COMPILATION ERROR: fail_not_reachable.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
     case (Opt.Some(m: i32), Opt.Some(n: i32)) => { return m + n; }
   }
   return 0;

--- a/explorer/testdata/match/fail_not_reachable_default.carbon
+++ b/explorer/testdata/match/fail_not_reachable_default.carbon
@@ -16,7 +16,7 @@ fn A(a: Opt, b: Opt) -> i32 {
     case (Opt.None(), Opt.None()) => { return 0; }
     case (Opt.Some(n: i32), _: auto) => { return n; }
     case (_: auto, Opt.Some(n: i32)) => { return n; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_not_reachable_default.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
+    // CHECK:STDERR: COMPILATION ERROR: fail_not_reachable_default.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
     default => { return -1; }
   }
   return 0;

--- a/explorer/testdata/match/fail_pattern_type_mismatch.carbon
+++ b/explorer/testdata/match/fail_pattern_type_mismatch.carbon
@@ -19,7 +19,7 @@ fn Main() -> i32 {
   // expression when checking each pattern.
   match ((a, a)) {
     case (0, n: A) => { return 1; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_pattern_type_mismatch.carbon:[[@LINE+3]]: type error in `match` pattern type
+    // CHECK:STDERR: COMPILATION ERROR: fail_pattern_type_mismatch.carbon:[[@LINE+3]]: type error in `match` pattern type
     // CHECK:STDERR: expected: (i32, class A)
     // CHECK:STDERR: actual: (class A, i32)
     case (n: A, 0) => { return 1; }

--- a/explorer/testdata/match/fail_redundant_int.carbon
+++ b/explorer/testdata/match/fail_redundant_int.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn A(n: i32) -> i32 {
   match (n) {
     case 1 => { return 1; }
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/match/fail_redundant_int.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
+    // CHECK:STDERR: COMPILATION ERROR: fail_redundant_int.carbon:[[@LINE+1]]: unreachable case: all values matched by this case are matched by earlier cases
     case 1 => { return 2; }
     case (_: i32) => { return 3; }
   }

--- a/explorer/testdata/member_access/fail_qualified_non_member.carbon
+++ b/explorer/testdata/member_access/fail_qualified_non_member.carbon
@@ -9,7 +9,7 @@ fn F[self: i32]() {}
 fn Main() -> i32 {
   // TODO: It's unclear whether this is valid per the current rules. See
   // https://github.com/carbon-language/carbon-lang/pull/1122
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/member_access/fail_qualified_non_member.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> ()
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_non_member.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> ()
   42.(F)();
   return 0;
 }

--- a/explorer/testdata/member_access/fail_vacuous_access.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access.carbon
@@ -13,6 +13,6 @@ class X {
 }
 fn Main() -> i32 {
   var a: X = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/member_access/fail_vacuous_access.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_vacuous_access.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> i32
   return a.(X.(A.F))();
 }

--- a/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
+++ b/explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon
@@ -12,7 +12,7 @@ class X {
   }
 }
 fn F[T:! A](a: T) -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/member_access/fail_vacuous_access_via_type_param.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_vacuous_access_via_type_param.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn () -> i32
   return a.(T.F)();
 }
 fn Main() -> i32 {

--- a/explorer/testdata/mixin/fail_circular_mixing.carbon
+++ b/explorer/testdata/mixin/fail_circular_mixing.carbon
@@ -9,7 +9,7 @@ __mixin M1 {
   fn F1[self: Self](x: Self) -> Self{
      return x;
   }
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_circular_mixing.carbon:[[@LINE+1]]: 'M3' has not been declared yet
+  // CHECK:STDERR: COMPILATION ERROR: fail_circular_mixing.carbon:[[@LINE+1]]: 'M3' has not been declared yet
   __mix M3;
 }
 

--- a/explorer/testdata/mixin/fail_field_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_field_member_name_clash.carbon
@@ -15,7 +15,7 @@ __mixin M {
 class C {
   let F: i32 = 0;
   __mix M;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_field_member_name_clash.carbon:[[@LINE+1]]: Member named F (declared at explorer/testdata/mixin/fail_field_member_name_clash.carbon:[[@LINE-6]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at explorer/testdata/mixin/fail_field_member_name_clash.carbon:[[@LINE-2]])
+// CHECK:STDERR: COMPILATION ERROR: fail_field_member_name_clash.carbon:[[@LINE+1]]: Member named F (declared at fail_field_member_name_clash.carbon:[[@LINE-6]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at fail_field_member_name_clash.carbon:[[@LINE-2]])
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/mixin/fail_method_member_name_clash.carbon
+++ b/explorer/testdata/mixin/fail_method_member_name_clash.carbon
@@ -17,7 +17,7 @@ class C {
      return x;
   }
   __mix M;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_method_member_name_clash.carbon:[[@LINE+1]]: Member named F (declared at explorer/testdata/mixin/fail_method_member_name_clash.carbon:[[@LINE-8]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at explorer/testdata/mixin/fail_method_member_name_clash.carbon:[[@LINE-2]])
+// CHECK:STDERR: COMPILATION ERROR: fail_method_member_name_clash.carbon:[[@LINE+1]]: Member named F (declared at fail_method_member_name_clash.carbon:[[@LINE-8]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at fail_method_member_name_clash.carbon:[[@LINE-2]])
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
+++ b/explorer/testdata/mixin/fail_mix_as_type_expr.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 __mixin Operations {}
 
 fn Main() -> i32 {
-   // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_mix_as_type_expr.carbon:[[@LINE+1]]: invalid use of mixin Operations
+   // CHECK:STDERR: COMPILATION ERROR: fail_mix_as_type_expr.carbon:[[@LINE+1]]: invalid use of mixin Operations
    var a: Operations;
    return 0;
 }

--- a/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_diamond_clash.carbon
@@ -26,7 +26,7 @@ __mixin M3 {
 class C {
   __mix M2;
   __mix M3;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_mix_diamond_clash.carbon:[[@LINE+1]]: Member named F1 (declared at explorer/testdata/mixin/fail_mix_diamond_clash.carbon:[[@LINE-18]]) is being mixed multiple times into C
+// CHECK:STDERR: COMPILATION ERROR: fail_mix_diamond_clash.carbon:[[@LINE+1]]: Member named F1 (declared at fail_mix_diamond_clash.carbon:[[@LINE-18]]) is being mixed multiple times into C
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/mixin/fail_mix_in_global.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_global.carbon
@@ -12,7 +12,7 @@ __mixin Operations {
   }
 }
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/mixin/fail_mix_in_global.carbon:[[@LINE+1]]: syntax error, unexpected MIX, expecting END_OF_FILE
+// CHECK:STDERR: SYNTAX ERROR: fail_mix_in_global.carbon:[[@LINE+1]]: syntax error, unexpected MIX, expecting END_OF_FILE
 __mix Operations;
 
 class Point {

--- a/explorer/testdata/mixin/fail_mix_in_impl.carbon
+++ b/explorer/testdata/mixin/fail_mix_in_impl.carbon
@@ -17,7 +17,7 @@ interface A {
 }
 
 external impl i32 as A {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/mixin/fail_mix_in_impl.carbon:[[@LINE+1]]: syntax error, unexpected MIX
+  // CHECK:STDERR: SYNTAX ERROR: fail_mix_in_impl.carbon:[[@LINE+1]]: syntax error, unexpected MIX
   __mix Operations;
   fn F() {}
 }

--- a/explorer/testdata/mixin/fail_mix_invalid.carbon
+++ b/explorer/testdata/mixin/fail_mix_invalid.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 __mixin Mixin {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_mix_invalid.carbon:[[@LINE+1]]: Not a valid mixin: `()`
+  // CHECK:STDERR: COMPILATION ERROR: fail_mix_invalid.carbon:[[@LINE+1]]: Not a valid mixin: `()`
   __mix ();
 }
 

--- a/explorer/testdata/mixin/fail_mix_invalid_array.carbon
+++ b/explorer/testdata/mixin/fail_mix_invalid_array.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 class C {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_mix_invalid_array.carbon:[[@LINE+1]]: type error in type expression: 'bool' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_mix_invalid_array.carbon:[[@LINE+1]]: type error in type expression: 'bool' is not implicitly convertible to 'type'
   __mix [true; true];
 }
 

--- a/explorer/testdata/mixin/fail_mix_members_clash.carbon
+++ b/explorer/testdata/mixin/fail_mix_members_clash.carbon
@@ -19,7 +19,7 @@ __mixin M2 {
 class C {
   __mix M1;
   __mix M2;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_mix_members_clash.carbon:[[@LINE+1]]: Member named F1 (declared at explorer/testdata/mixin/fail_mix_members_clash.carbon:[[@LINE-6]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at explorer/testdata/mixin/fail_mix_members_clash.carbon:[[@LINE-11]])
+// CHECK:STDERR: COMPILATION ERROR: fail_mix_members_clash.carbon:[[@LINE+1]]: Member named F1 (declared at fail_mix_members_clash.carbon:[[@LINE-6]]) cannot be mixed into C because it clashes with an existing member with the same name (declared at fail_mix_members_clash.carbon:[[@LINE-11]])
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/mixin/fail_qualified_method.carbon
+++ b/explorer/testdata/mixin/fail_qualified_method.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 __mixin Operations {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
   fn Operations.Square[self: Self](x:i32) -> i32{
     return x * x;
   }

--- a/explorer/testdata/mixin/fail_recursive_mixing.carbon
+++ b/explorer/testdata/mixin/fail_recursive_mixing.carbon
@@ -9,7 +9,7 @@ __mixin M1 {
   fn F1[self: Self](x: Self) -> Self{
      return x;
   }
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_recursive_mixing.carbon:[[@LINE+1]]: incomplete mixin `M1` used in mix declaration
+  // CHECK:STDERR: COMPILATION ERROR: fail_recursive_mixing.carbon:[[@LINE+1]]: incomplete mixin `M1` used in mix declaration
   __mix M1;
 }
 

--- a/explorer/testdata/mixin/fail_self_substitution.carbon
+++ b/explorer/testdata/mixin/fail_self_substitution.carbon
@@ -34,7 +34,7 @@ class Complex {
 fn Main() -> i32 {
   var p: Point = Point.Origin();
   var c: Complex = {.r = 42, .i = 1};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/mixin/fail_self_substitution.carbon:[[@LINE+1]]: mismatch in non-deduced types, `class Complex` is not implicitly convertible to `class Point`
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_substitution.carbon:[[@LINE+1]]: mismatch in non-deduced types, `class Complex` is not implicitly convertible to `class Point`
   var p1: Point = p.F(c);
 
   return p1.x - 42;

--- a/explorer/testdata/name_lookup/fail_block_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_block_duplicate.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32 = 0;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_block_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at explorer/testdata/name_lookup/fail_block_duplicate.carbon:[[@LINE-1]]
+  // CHECK:STDERR: COMPILATION ERROR: fail_block_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at fail_block_duplicate.carbon:[[@LINE-1]]
   var x: i32 = 0;
   return 0;
 }

--- a/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_choice_duplicate.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 choice Ints {
   None,
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_choice_duplicate.carbon:[[@LINE+1]]: Duplicate name `None` in choice type
+  // CHECK:STDERR: COMPILATION ERROR: fail_choice_duplicate.carbon:[[@LINE+1]]: Duplicate name `None` in choice type
   None,
 }
 

--- a/explorer/testdata/name_lookup/fail_class_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_class_duplicate.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class Foo {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_class_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at explorer/testdata/name_lookup/fail_class_duplicate.carbon:[[@LINE-1]]
+  // CHECK:STDERR: COMPILATION ERROR: fail_class_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at fail_class_duplicate.carbon:[[@LINE-1]]
   var x: i32;
 }
 

--- a/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon
@@ -17,7 +17,7 @@ class A {
     return 0;
   }
 
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_class_fn_use_before_declaration.carbon:[[@LINE+1]]: 'I' has not been declared yet
+  // CHECK:STDERR: COMPILATION ERROR: fail_class_fn_use_before_declaration.carbon:[[@LINE+1]]: 'I' has not been declared yet
   fn H() -> I() {
     return 0;
   }

--- a/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
+++ b/explorer/testdata/name_lookup/fail_class_use_in_params.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_class_use_in_params.carbon:[[@LINE+1]]: 'A' is not usable until after it has been completely declared
+// CHECK:STDERR: COMPILATION ERROR: fail_class_use_in_params.carbon:[[@LINE+1]]: 'A' is not usable until after it has been completely declared
 class A(X:! A(i32)) {
 }
 

--- a/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_param.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_fn_use_in_param.carbon:[[@LINE+1]]: 'F' is not usable until after it has been completely declared
+// CHECK:STDERR: COMPILATION ERROR: fail_fn_use_in_param.carbon:[[@LINE+1]]: 'F' is not usable until after it has been completely declared
 fn F(x: F(0)) -> type {
   return i32;
 }

--- a/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
+++ b/explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_fn_use_in_return_type.carbon:[[@LINE+1]]: 'F' is not usable until after it has been completely declared
+// CHECK:STDERR: COMPILATION ERROR: fail_fn_use_in_return_type.carbon:[[@LINE+1]]: 'F' is not usable until after it has been completely declared
 fn F() -> F() {
   return type;
 }

--- a/explorer/testdata/name_lookup/fail_global_duplicate.carbon
+++ b/explorer/testdata/name_lookup/fail_global_duplicate.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 var x: i32 = 0;
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_global_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at explorer/testdata/name_lookup/fail_global_duplicate.carbon:[[@LINE-1]]
+// CHECK:STDERR: COMPILATION ERROR: fail_global_duplicate.carbon:[[@LINE+1]]: Duplicate name `x` also found at fail_global_duplicate.carbon:[[@LINE-1]]
 var x: i32 = 0;
 
 fn Main() -> i32 {

--- a/explorer/testdata/name_lookup/fail_use_before_declare.carbon
+++ b/explorer/testdata/name_lookup/fail_use_before_declare.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_use_before_declare.carbon:[[@LINE+1]]: could not resolve 'x'
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_before_declare.carbon:[[@LINE+1]]: could not resolve 'x'
   x = 0;
   var x: i32 = 0;
   return 0;

--- a/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
+++ b/explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 // Test that a global variable may not depend on a later global.
 // Error expected.
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/name_lookup/fail_var_use_before_declaration.carbon:[[@LINE+1]]: 'y' has not been declared yet
+// CHECK:STDERR: COMPILATION ERROR: fail_var_use_before_declaration.carbon:[[@LINE+1]]: 'y' has not been declared yet
 var x: i32 = y;
 
 var y: i32 = 0;

--- a/explorer/testdata/named_constraint/fail_associated_constant.carbon
+++ b/explorer/testdata/named_constraint/fail_associated_constant.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 constraint X {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/named_constraint/fail_associated_constant.carbon:[[@LINE+1]]: associated constant not permitted in named constraint
+  // CHECK:STDERR: COMPILATION ERROR: fail_associated_constant.carbon:[[@LINE+1]]: associated constant not permitted in named constraint
   let N:! type;
 }
 

--- a/explorer/testdata/named_constraint/fail_associated_function.carbon
+++ b/explorer/testdata/named_constraint/fail_associated_function.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 constraint X {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/named_constraint/fail_associated_function.carbon:[[@LINE+1]]: associated function not permitted in named constraint
+  // CHECK:STDERR: COMPILATION ERROR: fail_associated_function.carbon:[[@LINE+1]]: associated function not permitted in named constraint
   fn F();
 }
 

--- a/explorer/testdata/named_constraint/fail_compound_member_access.carbon
+++ b/explorer/testdata/named_constraint/fail_compound_member_access.carbon
@@ -25,6 +25,6 @@ fn Main() -> i32 {
   // MemberName value. We will likely need MemberName to remember the
   // constraint as written, not only the interface in which the member was
   // found.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/named_constraint/fail_compound_member_access.carbon:[[@LINE+1]]: could not find implementation of interface MyAddWith(T = Self) for i32
+  // CHECK:STDERR: COMPILATION ERROR: fail_compound_member_access.carbon:[[@LINE+1]]: could not find implementation of interface MyAddWith(T = Self) for i32
   return n.(MyAdd.Op)(n);
 }

--- a/explorer/testdata/named_constraint/fail_impl_as_member_access.carbon
+++ b/explorer/testdata/named_constraint/fail_impl_as_member_access.carbon
@@ -17,7 +17,7 @@ constraint ImplAsHasFoo {
 fn CallFoo[T:! ImplAsHasFoo](x: T) {
   // OK, T is HasFoo.
   x.(HasFoo.Foo)();
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/named_constraint/fail_impl_as_member_access.carbon:[[@LINE+1]]: member access, Foo not in constraint ImplAsHasFoo where T impls interface HasFoo
+  // CHECK:STDERR: COMPILATION ERROR: fail_impl_as_member_access.carbon:[[@LINE+1]]: member access, Foo not in constraint ImplAsHasFoo where T impls interface HasFoo
   x.Foo();
 }
 

--- a/explorer/testdata/namespace/fail_members_not_in_outer_scope.carbon
+++ b/explorer/testdata/namespace/fail_members_not_in_outer_scope.carbon
@@ -11,6 +11,6 @@ namespace N;
 fn N.F() -> i32 { return 0; }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_members_not_in_outer_scope.carbon:[[@LINE+1]]: could not resolve 'F'
+  // CHECK:STDERR: COMPILATION ERROR: fail_members_not_in_outer_scope.carbon:[[@LINE+1]]: could not resolve 'F'
   return F();
 }

--- a/explorer/testdata/namespace/fail_missing_nested.carbon
+++ b/explorer/testdata/namespace/fail_missing_nested.carbon
@@ -10,7 +10,7 @@ namespace A;
 namespace A.B;
 namespace A.B.C;
 fn A.B.C.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_missing_nested.carbon:[[@LINE+1]]: name 'D' has not been declared in namespace A.B.C
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_nested.carbon:[[@LINE+1]]: name 'D' has not been declared in namespace A.B.C
   D
   // Don't combine with the previous line. This test is verifying that the
   // diagnostic points at the right token.

--- a/explorer/testdata/namespace/fail_qualifier_not_namespace.carbon
+++ b/explorer/testdata/namespace/fail_qualifier_not_namespace.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn F() {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_qualifier_not_namespace.carbon:[[@LINE+1]]: fn F cannot be used as a name qualifier
+// CHECK:STDERR: COMPILATION ERROR: fail_qualifier_not_namespace.carbon:[[@LINE+1]]: fn F cannot be used as a name qualifier
 fn F.G() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/namespace/fail_unknown_member.carbon
+++ b/explorer/testdata/namespace/fail_unknown_member.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 namespace N;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_unknown_member.carbon:[[@LINE+1]]: name 'value' has not been declared in namespace N
+  // CHECK:STDERR: COMPILATION ERROR: fail_unknown_member.carbon:[[@LINE+1]]: name 'value' has not been declared in namespace N
   return N.value;
 }

--- a/explorer/testdata/namespace/fail_unknown_namespace.carbon
+++ b/explorer/testdata/namespace/fail_unknown_namespace.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_unknown_namespace.carbon:[[@LINE+1]]: name 'N' has not been declared in this scope
+// CHECK:STDERR: COMPILATION ERROR: fail_unknown_namespace.carbon:[[@LINE+1]]: name 'N' has not been declared in this scope
 fn N.F() {}
 
 fn Main() -> i32 {

--- a/explorer/testdata/namespace/fail_use_as_expression.carbon
+++ b/explorer/testdata/namespace/fail_use_as_expression.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 namespace N;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_use_as_expression.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace N
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_as_expression.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace N
   N;
   return 0;
 }

--- a/explorer/testdata/namespace/fail_use_as_value.carbon
+++ b/explorer/testdata/namespace/fail_use_as_value.carbon
@@ -11,6 +11,6 @@ namespace N;
 fn F[T:! type](x: T) -> T { return x; }
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/namespace/fail_use_as_value.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace N
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_as_value.carbon:[[@LINE+1]]: expected `.member_name` after name of namespace N
   return F(N);
 }

--- a/explorer/testdata/operators/fail_combine_lhs.carbon
+++ b/explorer/testdata/operators/fail_combine_lhs.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_combine_lhs.carbon:[[@LINE+1]]: expected a constraint in first operand of `&`, found i32
+// CHECK:STDERR: COMPILATION ERROR: fail_combine_lhs.carbon:[[@LINE+1]]: expected a constraint in first operand of `&`, found i32
 fn F[T:! i32 & type]();
 
 fn Main() -> i32 {

--- a/explorer/testdata/operators/fail_combine_rhs.carbon
+++ b/explorer/testdata/operators/fail_combine_rhs.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 class C {}
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_combine_rhs.carbon:[[@LINE+1]]: expected a constraint in second operand of `&`, found class C
+// CHECK:STDERR: COMPILATION ERROR: fail_combine_rhs.carbon:[[@LINE+1]]: expected a constraint in second operand of `&`, found class C
 fn F[T:! type & C]();
 
 fn Main() -> i32 {

--- a/explorer/testdata/operators/fail_div_by_zero.carbon
+++ b/explorer/testdata/operators/fail_div_by_zero.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_div_by_zero.carbon:[[@LINE+1]]: division by zero
+  // CHECK:STDERR: RUNTIME ERROR: fail_div_by_zero.carbon:[[@LINE+1]]: division by zero
   var a: auto = 5 / 0;
   return 0;
 }

--- a/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_mod_by_zero.carbon
+++ b/explorer/testdata/operators/fail_mod_by_zero.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_mod_by_zero.carbon:[[@LINE+1]]: division by zero
+  // CHECK:STDERR: RUNTIME ERROR: fail_mod_by_zero.carbon:[[@LINE+1]]: division by zero
   var a: auto = 5 % 0;
   return 0;
 }

--- a/explorer/testdata/operators/fail_no_add.carbon
+++ b/explorer/testdata/operators/fail_no_add.carbon
@@ -10,7 +10,7 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_no_add.carbon:[[@LINE+2]]: type error in `+`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_add.carbon:[[@LINE+2]]: type error in `+`:
   // CHECK:STDERR: could not find implementation of interface AddWith(U = i32) for class A
   a + 1;
   return 0;

--- a/explorer/testdata/operators/fail_no_mul.carbon
+++ b/explorer/testdata/operators/fail_no_mul.carbon
@@ -10,7 +10,7 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_no_mul.carbon:[[@LINE+2]]: type error in `*`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_mul.carbon:[[@LINE+2]]: type error in `*`:
   // CHECK:STDERR: could not find implementation of interface MulWith(U = i32) for class A
   a * 1;
   return 0;

--- a/explorer/testdata/operators/fail_no_negate.carbon
+++ b/explorer/testdata/operators/fail_no_negate.carbon
@@ -10,7 +10,7 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_no_negate.carbon:[[@LINE+2]]: type error in `-`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_negate.carbon:[[@LINE+2]]: type error in `-`:
   // CHECK:STDERR: could not find implementation of interface Negate for class A
   -a;
   return 0;

--- a/explorer/testdata/operators/fail_no_sub.carbon
+++ b/explorer/testdata/operators/fail_no_sub.carbon
@@ -10,7 +10,7 @@ class A {}
 
 fn Main() -> i32 {
   var a: A = {};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/operators/fail_no_sub.carbon:[[@LINE+2]]: type error in `-`:
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_sub.carbon:[[@LINE+2]]: type error in `-`:
   // CHECK:STDERR: could not find implementation of interface SubWith(U = i32) for class A
   a - 1;
   return 0;

--- a/explorer/testdata/operators/fail_overflow_add.carbon
+++ b/explorer/testdata/operators/fail_overflow_add.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_overflow_add.carbon:[[@LINE+1]]: integer overflow
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_add.carbon:[[@LINE+1]]: integer overflow
   var a: auto = 2147483647 + 1;
   return 0;
 }

--- a/explorer/testdata/operators/fail_overflow_div.carbon
+++ b/explorer/testdata/operators/fail_overflow_div.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_overflow_div.carbon:[[@LINE+1]]: integer overflow
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_div.carbon:[[@LINE+1]]: integer overflow
   var a: auto = (-2147483647 -1) /-1;
   return 0;
 }

--- a/explorer/testdata/operators/fail_overflow_multiply.carbon
+++ b/explorer/testdata/operators/fail_overflow_multiply.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_overflow_multiply.carbon:[[@LINE+1]]: integer overflow
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_multiply.carbon:[[@LINE+1]]: integer overflow
   var a: auto = 1000000000 * 1000000000;
   return 0;
 }

--- a/explorer/testdata/operators/fail_overflow_sub.carbon
+++ b/explorer/testdata/operators/fail_overflow_sub.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/operators/fail_overflow_sub.carbon:[[@LINE+1]]: integer overflow
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_sub.carbon:[[@LINE+1]]: integer overflow
   var a: auto = -2147483647 - 2;
   return 0;
 }

--- a/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/optional/fail_optional_get_empty.carbon
+++ b/explorer/testdata/optional/fail_optional_get_empty.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/package/fail_missing.carbon
+++ b/explorer/testdata/package/fail_missing.carbon
@@ -4,7 +4,7 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/package/fail_missing.carbon:[[@LINE+1]]: syntax error, unexpected FN, expecting PACKAGE
+// CHECK:STDERR: SYNTAX ERROR: fail_missing.carbon:[[@LINE+1]]: syntax error, unexpected FN, expecting PACKAGE
 fn Main() -> i32 {
   return 0;
 }

--- a/explorer/testdata/pointer/fail_delete_uninit.carbon
+++ b/explorer/testdata/pointer/fail_delete_uninit.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var p: i32*;
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/pointer/fail_delete_uninit.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<p>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_delete_uninit.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<p>>
   heap.Delete(p);
   return 0;
 }

--- a/explorer/testdata/pointer/fail_intrinsic_delete_no_args.carbon
+++ b/explorer/testdata/pointer/fail_intrinsic_delete_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_intrinsic_delete_no_args.carbon:[[@LINE+1]]: __intrinsic_delete takes 1 argument
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_delete_no_args.carbon:[[@LINE+1]]: __intrinsic_delete takes 1 argument
   __intrinsic_delete();
   return 0;
 }

--- a/explorer/testdata/pointer/fail_intrinsic_delete_type.carbon
+++ b/explorer/testdata/pointer/fail_intrinsic_delete_type.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_intrinsic_delete_type.carbon:[[@LINE+3]]: type error in *
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_delete_type.carbon:[[@LINE+3]]: type error in *
   // CHECK:STDERR: expected a pointer type
   // CHECK:STDERR: actual: i32
   __intrinsic_delete(x);

--- a/explorer/testdata/pointer/fail_intrinsic_new_no_args.carbon
+++ b/explorer/testdata/pointer/fail_intrinsic_new_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_intrinsic_new_no_args.carbon:[[@LINE+1]]: __intrinsic_new takes 1 argument
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_new_no_args.carbon:[[@LINE+1]]: __intrinsic_new takes 1 argument
   __intrinsic_new();
   return 0;
 }

--- a/explorer/testdata/pointer/fail_invalid_ptr_conversion1.carbon
+++ b/explorer/testdata/pointer/fail_invalid_ptr_conversion1.carbon
@@ -11,7 +11,7 @@ class A {}
 fn Main() -> i32 {
   var a: A = {};
   var b: A* = &a;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_invalid_ptr_conversion1.carbon:[[@LINE+1]]: type error in initializer of variable: 'class A*' is not implicitly convertible to 'i32'
+  // CHECK:STDERR: COMPILATION ERROR: fail_invalid_ptr_conversion1.carbon:[[@LINE+1]]: type error in initializer of variable: 'class A*' is not implicitly convertible to 'i32'
   var c: i32 = b;
   return 1;
 }

--- a/explorer/testdata/pointer/fail_invalid_ptr_conversion2.carbon
+++ b/explorer/testdata/pointer/fail_invalid_ptr_conversion2.carbon
@@ -11,7 +11,7 @@ class A {}
 fn Main() -> i32 {
   var a: i32 = 0;
   var b: i32* = &a;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_invalid_ptr_conversion2.carbon:[[@LINE+1]]: type error in initializer of variable: 'i32*' is not implicitly convertible to 'class A*'
+  // CHECK:STDERR: COMPILATION ERROR: fail_invalid_ptr_conversion2.carbon:[[@LINE+1]]: type error in initializer of variable: 'i32*' is not implicitly convertible to 'class A*'
   var c: A* = b;
   return 1;
 }

--- a/explorer/testdata/pointer/fail_rvalue_addressof.carbon
+++ b/explorer/testdata/pointer/fail_rvalue_addressof.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32 = 5;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/pointer/fail_rvalue_addressof.carbon:[[@LINE+1]]: Argument to & should be a reference expression.
+  // CHECK:STDERR: COMPILATION ERROR: fail_rvalue_addressof.carbon:[[@LINE+1]]: Argument to & should be a reference expression.
   var p: i32* = &5;
   return 0;
 }

--- a/explorer/testdata/pointer/fail_use_after_free.carbon
+++ b/explorer/testdata/pointer/fail_use_after_free.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var p: i32* = heap.New(5);
   heap.Delete(p);
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/pointer/fail_use_after_free.carbon:[[@LINE+1]]: undefined behavior: access to dead value 5
+  // CHECK:STDERR: RUNTIME ERROR: fail_use_after_free.carbon:[[@LINE+1]]: undefined behavior: access to dead value 5
   return *p;
 }

--- a/explorer/testdata/print/fail_index_bounds0.carbon
+++ b/explorer/testdata/print/fail_index_bounds0.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_bounds0.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {0}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_bounds0.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {0}`
   Print("Print: {0}");
   return 0;
 }

--- a/explorer/testdata/print/fail_index_bounds1.carbon
+++ b/explorer/testdata/print/fail_index_bounds1.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_bounds1.carbon:[[@LINE+1]]: Index invalid with argument count of 1 at offset 12 in `Print: {0} {1}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_bounds1.carbon:[[@LINE+1]]: Index invalid with argument count of 1 at offset 12 in `Print: {0} {1}`
   Print("Print: {0} {1}", 1);
   return 0;
 }

--- a/explorer/testdata/print/fail_index_empty.carbon
+++ b/explorer/testdata/print/fail_index_empty.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_empty.carbon:[[@LINE+1]]: Invalid `{}` in `Print: {}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_empty.carbon:[[@LINE+1]]: Invalid `{}` in `Print: {}`
   Print("Print: {}");
   return 0;
 }

--- a/explorer/testdata/print/fail_index_incomplete.carbon
+++ b/explorer/testdata/print/fail_index_incomplete.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_incomplete.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {0`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_incomplete.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {0`
   Print("Print: {0");
   return 0;
 }

--- a/explorer/testdata/print/fail_index_limit.carbon
+++ b/explorer/testdata/print/fail_index_limit.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_limit.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {2147483648}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_limit.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {2147483648}`
   Print("Print: {2147483648}");
   return 0;
 }

--- a/explorer/testdata/print/fail_index_negative.carbon
+++ b/explorer/testdata/print/fail_index_negative.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_negative.carbon:[[@LINE+1]]: Non-numeric character in index at offset 8 in `Print: {-1}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_negative.carbon:[[@LINE+1]]: Non-numeric character in index at offset 8 in `Print: {-1}`
   Print("Print: {-1}");
   return 0;
 }

--- a/explorer/testdata/print/fail_index_text.carbon
+++ b/explorer/testdata/print/fail_index_text.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_index_text.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {1a}`
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_text.carbon:[[@LINE+1]]: Index invalid with argument count of 0 at offset 8 in `Print: {1a}`
   Print("Print: {1a}");
   return 0;
 }

--- a/explorer/testdata/print/fail_intrinsic_int_format.carbon
+++ b/explorer/testdata/print/fail_intrinsic_int_format.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_int_format.carbon:[[@LINE+3]]: type error in Print argument 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_int_format.carbon:[[@LINE+3]]: type error in Print argument 0
   // CHECK:STDERR: expected: String
   // CHECK:STDERR: actual: i32
   __intrinsic_print(0);

--- a/explorer/testdata/print/fail_intrinsic_no_args.carbon
+++ b/explorer/testdata/print/fail_intrinsic_no_args.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_no_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 0
   __intrinsic_print();
 }

--- a/explorer/testdata/print/fail_intrinsic_too_many_args.carbon
+++ b/explorer/testdata/print/fail_intrinsic_too_many_args.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 4
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 4
   __intrinsic_print("", 1, 2, 3);
 }

--- a/explorer/testdata/print/fail_intrinsic_type.carbon
+++ b/explorer/testdata/print/fail_intrinsic_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_type.carbon:[[@LINE+3]]: type error in Print argument 1
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_type.carbon:[[@LINE+3]]: type error in Print argument 1
   // CHECK:STDERR: expected: i32
   // CHECK:STDERR: actual: {.x: i32}
   __intrinsic_print("{0}", {.x = 1});

--- a/explorer/testdata/print/fail_no_args.carbon
+++ b/explorer/testdata/print/fail_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_no_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 0
   Print();
   return 0;
 }

--- a/explorer/testdata/print/fail_not_str.carbon
+++ b/explorer/testdata/print/fail_not_str.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_not_str.carbon:[[@LINE+3]]: type error in Print argument 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_not_str.carbon:[[@LINE+3]]: type error in Print argument 0
   // CHECK:STDERR: expected: String
   // CHECK:STDERR: actual: {.x: i32}
   Print({.x = 1});

--- a/explorer/testdata/print/fail_single_brace.carbon
+++ b/explorer/testdata/print/fail_single_brace.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest impl;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/print/fail_single_brace.carbon:[[@LINE+1]]: `{` must be followed by a second `{` or index in `{`
+  // CHECK:STDERR: RUNTIME ERROR: fail_single_brace.carbon:[[@LINE+1]]: `{` must be followed by a second `{` or index in `{`
   Print("{");
   return 0;
 }

--- a/explorer/testdata/print/fail_too_many_args.carbon
+++ b/explorer/testdata/print/fail_too_many_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 5
+  // CHECK:STDERR: COMPILATION ERROR: fail_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 5
   Print("too", "many", "args", "to", "print");
   return 0;
 }

--- a/explorer/testdata/print/fail_type.carbon
+++ b/explorer/testdata/print/fail_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_type.carbon:[[@LINE+3]]: type error in Print argument 1
+  // CHECK:STDERR: COMPILATION ERROR: fail_type.carbon:[[@LINE+3]]: type error in Print argument 1
   // CHECK:STDERR: expected: i32
   // CHECK:STDERR: actual: {.x: i32}
   Print("{0}", {.x = 1});

--- a/explorer/testdata/random/fail_empty_range.carbon
+++ b/explorer/testdata/random/fail_empty_range.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Rand inputs must be ordered for a non-empty range: 0 must be less than 0
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Rand inputs must be ordered for a non-empty range: 0 must be less than 0
 
 package ExplorerTest api;
 

--- a/explorer/testdata/random/fail_intrinsic_no_args.carbon
+++ b/explorer/testdata/random/fail_intrinsic_no_args.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/random/fail_intrinsic_no_args.carbon:[[@LINE+1]]: Rand takes 2 arguments, received 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_args.carbon:[[@LINE+1]]: Rand takes 2 arguments, received 0
   __intrinsic_rand();
   return 0;
 }

--- a/explorer/testdata/random/fail_intrinsic_type0.carbon
+++ b/explorer/testdata/random/fail_intrinsic_type0.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/random/fail_intrinsic_type0.carbon:[[@LINE+3]]: type error in Rand argument 0
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_type0.carbon:[[@LINE+3]]: type error in Rand argument 0
   // CHECK:STDERR: expected: i32
   // CHECK:STDERR: actual: String
   __intrinsic_rand("a", 1);

--- a/explorer/testdata/random/fail_intrinsic_type1.carbon
+++ b/explorer/testdata/random/fail_intrinsic_type1.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/random/fail_intrinsic_type1.carbon:[[@LINE+3]]: type error in Rand argument 1
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_type1.carbon:[[@LINE+3]]: type error in Rand argument 1
   // CHECK:STDERR: expected: i32
   // CHECK:STDERR: actual: String
   __intrinsic_rand(1, "a");

--- a/explorer/testdata/random/fail_reverse_range.carbon
+++ b/explorer/testdata/random/fail_reverse_range.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: explorer/data/prelude.carbon:{{.*}}: Rand inputs must be ordered for a non-empty range: 1 must be less than -1
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Rand inputs must be ordered for a non-empty range: 1 must be less than -1
 
 package ExplorerTest api;
 

--- a/explorer/testdata/return/fail_explicit_with_no_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_no_return.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn F() -> () {
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/return/fail_explicit_with_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
+// CHECK:STDERR: COMPILATION ERROR: fail_explicit_with_no_return.carbon:[[@LINE+1]]: control-flow reaches end of function that provides a `->` return type without reaching a return statement
 }
 
 fn Main() -> i32 {

--- a/explorer/testdata/return/fail_explicit_with_plain_return.carbon
+++ b/explorer/testdata/return/fail_explicit_with_plain_return.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn F() -> () {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/return/fail_explicit_with_plain_return.carbon:[[@LINE+1]]: return; should provide a return value, to match the function's signature.
+  // CHECK:STDERR: COMPILATION ERROR: fail_explicit_with_plain_return.carbon:[[@LINE+1]]: return; should provide a return value, to match the function's signature.
   return;
 }
 

--- a/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
+++ b/explorer/testdata/return/fail_implicit_with_explicit_return.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn F() {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/return/fail_implicit_with_explicit_return.carbon:[[@LINE+1]]: return (); should not provide a return value, to match the function's signature.
+  // CHECK:STDERR: COMPILATION ERROR: fail_implicit_with_explicit_return.carbon:[[@LINE+1]]: return (); should not provide a return value, to match the function's signature.
   return ();
 }
 

--- a/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
+  // CHECK:STDERR: SYNTAX ERROR: fail_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
   var s: String = '''
     error: closing ''' is not on its own line.
   ''';

--- a/explorer/testdata/string/fail_hex_lower.carbon
+++ b/explorer/testdata/string/fail_hex_lower.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_hex_lower.carbon:[[@LINE+1]]: Invalid escaping in string: "str\xaa"
+  // CHECK:STDERR: SYNTAX ERROR: fail_hex_lower.carbon:[[@LINE+1]]: Invalid escaping in string: "str\xaa"
   Print("str\xaa");
   return 0;
 }

--- a/explorer/testdata/string/fail_hex_truncated.carbon
+++ b/explorer/testdata/string/fail_hex_truncated.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_hex_truncated.carbon:[[@LINE+1]]: Invalid escaping in string: "str\x"
+  // CHECK:STDERR: SYNTAX ERROR: fail_hex_truncated.carbon:[[@LINE+1]]: Invalid escaping in string: "str\x"
   Print("str\x");
   return 0;
 }

--- a/explorer/testdata/string/fail_invalid_escape.carbon
+++ b/explorer/testdata/string/fail_invalid_escape.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_invalid_escape.carbon:[[@LINE+1]]: Invalid escaping in string: "str\e"
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_escape.carbon:[[@LINE+1]]: Invalid escaping in string: "str\e"
   Print("str\e");
   return 0;
 }

--- a/explorer/testdata/string/fail_newline.carbon
+++ b/explorer/testdata/string/fail_newline.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_newline.carbon:[[@LINE+2]]: missing closing quote in single-line string: "new
+  // CHECK:STDERR: SYNTAX ERROR: fail_newline.carbon:[[@LINE+2]]: missing closing quote in single-line string: "new
   // CHECK:STDERR:
   Print("new
 line");

--- a/explorer/testdata/string/fail_octal.carbon
+++ b/explorer/testdata/string/fail_octal.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_octal.carbon:[[@LINE+1]]: Invalid escaping in string: "str\01"
+  // CHECK:STDERR: SYNTAX ERROR: fail_octal.carbon:[[@LINE+1]]: Invalid escaping in string: "str\01"
   Print("str\01");
   return 0;
 }

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_block_more_hash_tags_on_left.carbon:[[@LINE+1]]: Unexpected end of file
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_more_hash_tags_on_left.carbon:[[@LINE+1]]: Unexpected end of file
   var s: String = ##'''
     error: there are more #s on the left than the right.
   '''#;

--- a/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_block_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
   var s: String = #'''
     error: there are more #s on the right than the left.
   '''##;

--- a/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
   var s: String = #'''
     error: closing '''# is not on its own line.
   '''#;

--- a/explorer/testdata/string/fail_raw_block_single_line.carbon
+++ b/explorer/testdata/string/fail_raw_block_single_line.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn CompareStr(s: String) -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_block_single_line.carbon:[[@LINE+1]]: Invalid block string: Too few lines
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_single_line.carbon:[[@LINE+1]]: Invalid block string: Too few lines
   if (s == #'''raw string literal starting with '''#) {
     return 0;
   }

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn CompareStr(s: String) -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_more_hash_tags_on_left.carbon:[[@LINE+2]]: missing closing quote in single-line string: ##"str"#) {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_more_hash_tags_on_left.carbon:[[@LINE+2]]: missing closing quote in single-line string: ##"str"#) {
   // CHECK:STDERR:
   if (s == ##"str"#) {
     return 0;

--- a/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
+++ b/explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn CompareStr(s: String) -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_raw_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
   if (s == "str"#) {
     return 0;
   }

--- a/explorer/testdata/string/fail_tab.carbon
+++ b/explorer/testdata/string/fail_tab.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/string/fail_tab.carbon:[[@LINE+1]]: Invalid escaping in string: "new	line"
+  // CHECK:STDERR: SYNTAX ERROR: fail_tab.carbon:[[@LINE+1]]: Invalid escaping in string: "new	line"
   Print("new	line");
   return 0;
 }

--- a/explorer/testdata/struct/fail_assign_different_types.carbon
+++ b/explorer/testdata/struct/fail_assign_different_types.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var p: auto = {.x = 0, .y = 0};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/struct/fail_assign_different_types.carbon:[[@LINE+1]]: could not find implementation of interface AssignWith(U = {.y: i32}) for {.x: i32, .y: i32}
+  // CHECK:STDERR: COMPILATION ERROR: fail_assign_different_types.carbon:[[@LINE+1]]: could not find implementation of interface AssignWith(U = {.y: i32}) for {.x: i32, .y: i32}
   p = {.y = 0};
   return 0;
 }

--- a/explorer/testdata/struct/fail_equality_type.carbon
+++ b/explorer/testdata/struct/fail_equality_type.carbon
@@ -19,7 +19,7 @@ external impl {.x: i32, .y: i32} as EqWith(Self) {
 fn Main() -> i32 {
   var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
   var t2: {.x: i32,} = {.x = 5,};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/struct/fail_equality_type.carbon:[[@LINE+1]]: {.x: i32, .y: i32} is not equality comparable with {.x: i32} (could not find implementation of interface EqWith(U = {.x: i32}) for {.x: i32, .y: i32})
+  // CHECK:STDERR: COMPILATION ERROR: fail_equality_type.carbon:[[@LINE+1]]: {.x: i32, .y: i32} is not equality comparable with {.x: i32} (could not find implementation of interface EqWith(U = {.x: i32}) for {.x: i32, .y: i32})
   if (t1 == t2) {
     return 1;
   } else {

--- a/explorer/testdata/struct/fail_field_access_mismatch.carbon
+++ b/explorer/testdata/struct/fail_field_access_mismatch.carbon
@@ -7,6 +7,6 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/struct/fail_field_access_mismatch.carbon:[[@LINE+1]]: struct {.x: i32, .y: i32} does not have a field named z
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_access_mismatch.carbon:[[@LINE+1]]: struct {.x: i32, .y: i32} does not have a field named z
   return {.x = 1, .y = 2}.z - 1;
 }

--- a/explorer/testdata/struct/fail_struct_literal_duplicate_member.carbon
+++ b/explorer/testdata/struct/fail_struct_literal_duplicate_member.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/struct/fail_struct_literal_duplicate_member.carbon:[[@LINE+1]]: Duplicate name `x` in struct literal
+  // CHECK:STDERR: COMPILATION ERROR: fail_struct_literal_duplicate_member.carbon:[[@LINE+1]]: Duplicate name `x` in struct literal
   var x: auto = {.x = 0, .x = 0};
   return 0;
 }

--- a/explorer/testdata/struct/fail_struct_type_literal_duplicate_member.carbon
+++ b/explorer/testdata/struct/fail_struct_type_literal_duplicate_member.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/struct/fail_struct_type_literal_duplicate_member.carbon:[[@LINE+1]]: Duplicate name `x` in struct type literal
+  // CHECK:STDERR: COMPILATION ERROR: fail_struct_type_literal_duplicate_member.carbon:[[@LINE+1]]: Duplicate name `x` in struct type literal
   var y: {.x: i32, .x: i32};
   return 0;
 }

--- a/explorer/testdata/template/fail_name_lookup.carbon
+++ b/explorer/testdata/template/fail_name_lookup.carbon
@@ -17,7 +17,7 @@ interface HasF {
 impl forall [template T:! HasF] T as CallF {
   // TODO: This case should be accepted, using `ClassWithExternalF.(HasF.F)`.
   // TODO: The other case should be rejected due to ambiguity.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/template/fail_name_lookup.carbon:[[@LINE+1]]: class ClassWithExternalF does not have a field named F
+  // CHECK:STDERR: COMPILATION ERROR: fail_name_lookup.carbon:[[@LINE+1]]: class ClassWithExternalF does not have a field named F
   fn DoIt[self: Self]() { self.F(); }
 }
 

--- a/explorer/testdata/template/fail_no_member.carbon
+++ b/explorer/testdata/template/fail_no_member.carbon
@@ -11,7 +11,7 @@ interface GetX {
 }
 
 impl forall [template T:! type] T as GetX {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/template/fail_no_member.carbon:[[@LINE+1]]: member access, unexpected i32 in self.x
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_member.carbon:[[@LINE+1]]: member access, unexpected i32 in self.x
   fn DoIt[self: Self]() -> i32 { return self.x; }
 }
 

--- a/explorer/testdata/tuple/fail_equality_type.carbon
+++ b/explorer/testdata/tuple/fail_equality_type.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var t1: (i32, i32) = (5, 2);
   var t2: (i32,) = (5,);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_equality_type.carbon:[[@LINE+1]]: (i32, i32) is not equality comparable with (i32,) (could not find implementation of interface EqWith(U = (i32,)) for (i32, i32))
+  // CHECK:STDERR: COMPILATION ERROR: fail_equality_type.carbon:[[@LINE+1]]: (i32, i32) is not equality comparable with (i32,) (could not find implementation of interface EqWith(U = (i32,)) for (i32, i32))
   if (t1 == t2) {
     return 1;
   } else {

--- a/explorer/testdata/tuple/fail_implicit_convert_with_as.carbon
+++ b/explorer/testdata/tuple/fail_implicit_convert_with_as.carbon
@@ -19,7 +19,7 @@ external impl A as As(B) {
 
 fn Main() -> i32 {
   var a: (i32, A) = (1, {.a = 2});
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_implicit_convert_with_as.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, class A)' is not implicitly convertible to '(i32, class B)'
+  // CHECK:STDERR: COMPILATION ERROR: fail_implicit_convert_with_as.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, class A)' is not implicitly convertible to '(i32, class B)'
   var b: (i32, B) = a;
   return b[1].b;
 }

--- a/explorer/testdata/tuple/fail_index.carbon
+++ b/explorer/testdata/tuple/fail_index.carbon
@@ -8,6 +8,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: auto = (0, 1);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_index.carbon:[[@LINE+1]]: index 2 is out of range for type (i32, i32)
+  // CHECK:STDERR: COMPILATION ERROR: fail_index.carbon:[[@LINE+1]]: index 2 is out of range for type (i32, i32)
   return x[2];
 }

--- a/explorer/testdata/tuple/fail_index_var.carbon
+++ b/explorer/testdata/tuple/fail_index_var.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: auto = (0, 1);
   var index: i32 = 0;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_index_var.carbon:[[@LINE+1]]: could not find `index: i32`
+  // CHECK:STDERR: COMPILATION ERROR: fail_index_var.carbon:[[@LINE+1]]: could not find `index: i32`
   return x[index];
 }

--- a/explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon
+++ b/explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_length_mismatch_with_auto.carbon:[[@LINE+1]]: tuples of different length
+  // CHECK:STDERR: COMPILATION ERROR: fail_length_mismatch_with_auto.carbon:[[@LINE+1]]: tuples of different length
   var a: (auto,) = (1, 2);
   return 0;
 }

--- a/explorer/testdata/tuple/fail_nontype_tuple_as_type.carbon
+++ b/explorer/testdata/tuple/fail_nontype_tuple_as_type.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_nontype_tuple_as_type.carbon:[[@LINE+1]]: type error in type of name binding: '(i32, i32)' is not implicitly convertible to 'type'
+// CHECK:STDERR: COMPILATION ERROR: fail_nontype_tuple_as_type.carbon:[[@LINE+1]]: type error in type of name binding: '(i32, i32)' is not implicitly convertible to 'type'
 fn F[T:! (i32, i32)](x: T);
 
 fn Main() -> i32;

--- a/explorer/testdata/tuple/fail_to_array.carbon
+++ b/explorer/testdata/tuple/fail_to_array.carbon
@@ -8,6 +8,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var t: auto = (1, 2);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_to_array.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, i32)' is not implicitly convertible to '[i32; 3]'
+  // CHECK:STDERR: COMPILATION ERROR: fail_to_array.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, i32)' is not implicitly convertible to '[i32; 3]'
   var a: [i32; 3] = t;
 }

--- a/explorer/testdata/tuple/fail_type_tuple_as_type.carbon
+++ b/explorer/testdata/tuple/fail_type_tuple_as_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn F[T:! ((), ())](x: T) -> () {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_type_tuple_as_type.carbon:[[@LINE+1]]: only arrays and tuples can be indexed, found T
+  // CHECK:STDERR: COMPILATION ERROR: fail_type_tuple_as_type.carbon:[[@LINE+1]]: only arrays and tuples can be indexed, found T
   return x[0];
 }
 

--- a/explorer/testdata/tuple/fail_unexpected_tuple.carbon
+++ b/explorer/testdata/tuple/fail_unexpected_tuple.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/tuple/fail_unexpected_tuple.carbon:[[@LINE+1]]: didn't expect a tuple
+  // CHECK:STDERR: COMPILATION ERROR: fail_unexpected_tuple.carbon:[[@LINE+1]]: didn't expect a tuple
   var a: (auto,) = 1;
   return 0;
 }

--- a/explorer/testdata/unformed/dynamic/fail_global.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_global.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 var x: i32;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_global.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_global.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return x;
 }

--- a/explorer/testdata/unformed/dynamic/fail_param.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_param.carbon
@@ -16,6 +16,6 @@ fn Main() -> i32 {
     x = 0;
   }
   // Static analysis thinks `x` may be formed, defer the check to run-time.
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_param.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_param.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return AddInt(x, 2);
 }

--- a/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon
@@ -13,6 +13,6 @@ fn Main() -> i32 {
     y = 0;
   }
   // Static analysis thinks `y` may be formed, defer the check to run-time.
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_pattern_declare.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<y>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_pattern_declare.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<y>>
   return y;
 }

--- a/explorer/testdata/unformed/dynamic/fail_return.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_return.carbon
@@ -12,6 +12,6 @@ fn Main() -> i32 {
     x = 0;
   }
   // Static analysis thinks `x` may be formed, defer the check to run-time.
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_return.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_return.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return x;
 }

--- a/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_returned_var.carbon
@@ -12,6 +12,6 @@ fn Main() -> i32 {
     x = 0;
   }
   // Static analysis thinks `x` may be formed, defer the check to run-time.
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_returned_var.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_returned_var.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   return var;
 }

--- a/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
+++ b/explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon
@@ -13,7 +13,7 @@ fn Main() -> i32 {
     x = 0;
   }
   // Static analysis thinks `x` may be formed, defer the check to run-time.
-  // CHECK:STDERR: RUNTIME ERROR: explorer/testdata/unformed/dynamic/fail_rhs_assign.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  // CHECK:STDERR: RUNTIME ERROR: fail_rhs_assign.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
   y = x;
   return y;
 }

--- a/explorer/testdata/unformed/static/fail_compound_assign.carbon
+++ b/explorer/testdata/unformed/static/fail_compound_assign.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_compound_assign.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_compound_assign.carbon:[[@LINE+1]]: use of uninitialized variable x
   x += 1;
   return x;
 }

--- a/explorer/testdata/unformed/static/fail_field_value.carbon
+++ b/explorer/testdata/unformed/static/fail_field_value.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_field_value.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_value.carbon:[[@LINE+1]]: use of uninitialized variable x
   var p: auto = {.x = x,};
   return 0;
 }

--- a/explorer/testdata/unformed/static/fail_if_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_if_cond.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_if_cond.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_if_cond.carbon:[[@LINE+1]]: use of uninitialized variable x
   if (x == 0) {
     return 0;
   }

--- a/explorer/testdata/unformed/static/fail_if_else.carbon
+++ b/explorer/testdata/unformed/static/fail_if_else.carbon
@@ -13,7 +13,7 @@ fn Main() -> i32 {
   if (Foo() == 0) {
     return 0;
   } else {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_if_else.carbon:[[@LINE+1]]: use of uninitialized variable x
+    // CHECK:STDERR: COMPILATION ERROR: fail_if_else.carbon:[[@LINE+1]]: use of uninitialized variable x
     return x;
   }
 }

--- a/explorer/testdata/unformed/static/fail_if_then.carbon
+++ b/explorer/testdata/unformed/static/fail_if_then.carbon
@@ -11,7 +11,7 @@ fn Foo() -> i32;
 fn Main() -> i32 {
   var x: i32;
   if (Foo() == 0) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_if_then.carbon:[[@LINE+1]]: use of uninitialized variable x
+    // CHECK:STDERR: COMPILATION ERROR: fail_if_then.carbon:[[@LINE+1]]: use of uninitialized variable x
     return x;
   }
   return 1;

--- a/explorer/testdata/unformed/static/fail_increment.carbon
+++ b/explorer/testdata/unformed/static/fail_increment.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_increment.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_increment.carbon:[[@LINE+1]]: use of uninitialized variable x
   ++x;
   return x;
 }

--- a/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
+++ b/explorer/testdata/unformed/static/fail_local_pattern_declare.carbon
@@ -9,6 +9,6 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var (x: i32, y: i32);
   x = 1;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_local_pattern_declare.carbon:[[@LINE+1]]: use of uninitialized variable y
+  // CHECK:STDERR: COMPILATION ERROR: fail_local_pattern_declare.carbon:[[@LINE+1]]: use of uninitialized variable y
   return y;
 }

--- a/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
+++ b/explorer/testdata/unformed/static/fail_local_rhs_assign.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn Main() -> i32 {
   var x: i32;
   var y: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_local_rhs_assign.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_local_rhs_assign.carbon:[[@LINE+1]]: use of uninitialized variable x
   y = x;
   return y;
 }

--- a/explorer/testdata/unformed/static/fail_match_clause.carbon
+++ b/explorer/testdata/unformed/static/fail_match_clause.carbon
@@ -15,7 +15,7 @@ fn Main() -> i32 {
       return 2;
     }
     case 1 => {
-      // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_match_clause.carbon:[[@LINE+1]]: use of uninitialized variable x
+      // CHECK:STDERR: COMPILATION ERROR: fail_match_clause.carbon:[[@LINE+1]]: use of uninitialized variable x
       return x;
     }
     default => {

--- a/explorer/testdata/unformed/static/fail_match_expression.carbon
+++ b/explorer/testdata/unformed/static/fail_match_expression.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x : i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_match_expression.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_match_expression.carbon:[[@LINE+1]]: use of uninitialized variable x
   match (x) {
     case 0 => {
       return 1;

--- a/explorer/testdata/unformed/static/fail_param.carbon
+++ b/explorer/testdata/unformed/static/fail_param.carbon
@@ -12,6 +12,6 @@ fn AddInt(a: i32, b: i32) -> auto {
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_param.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_param.carbon:[[@LINE+1]]: use of uninitialized variable x
   return AddInt(x, 2);
 }

--- a/explorer/testdata/unformed/static/fail_return.carbon
+++ b/explorer/testdata/unformed/static/fail_return.carbon
@@ -8,6 +8,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_return.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_return.carbon:[[@LINE+1]]: use of uninitialized variable x
   return x;
 }

--- a/explorer/testdata/unformed/static/fail_returned_var.carbon
+++ b/explorer/testdata/unformed/static/fail_returned_var.carbon
@@ -8,6 +8,6 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   returned var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_returned_var.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_returned_var.carbon:[[@LINE+1]]: use of uninitialized variable x
   return var;
 }

--- a/explorer/testdata/unformed/static/fail_rhs_def.carbon
+++ b/explorer/testdata/unformed/static/fail_rhs_def.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var x: i32;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_rhs_def.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_rhs_def.carbon:[[@LINE+1]]: use of uninitialized variable x
   var y: i32 = x;
   return x;
 }

--- a/explorer/testdata/unformed/static/fail_struct_member_access.carbon
+++ b/explorer/testdata/unformed/static/fail_struct_member_access.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var p: {.x: i32, .y: i32};
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_struct_member_access.carbon:[[@LINE+1]]: use of uninitialized variable p
+  // CHECK:STDERR: COMPILATION ERROR: fail_struct_member_access.carbon:[[@LINE+1]]: use of uninitialized variable p
   p.x = p.y;
   return 0;
 }

--- a/explorer/testdata/unformed/static/fail_while_body.carbon
+++ b/explorer/testdata/unformed/static/fail_while_body.carbon
@@ -11,7 +11,7 @@ fn Foo() -> i32;
 fn Main() -> i32 {
   var (x: i32, y: i32);
   while (Foo() == 0) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_while_body.carbon:[[@LINE+1]]: use of uninitialized variable x
+    // CHECK:STDERR: COMPILATION ERROR: fail_while_body.carbon:[[@LINE+1]]: use of uninitialized variable x
     y = x;
   }
   return 1;

--- a/explorer/testdata/unformed/static/fail_while_cond.carbon
+++ b/explorer/testdata/unformed/static/fail_while_cond.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   var (x: i32, y: i32);
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/unformed/static/fail_while_cond.carbon:[[@LINE+1]]: use of uninitialized variable x
+  // CHECK:STDERR: COMPILATION ERROR: fail_while_cond.carbon:[[@LINE+1]]: use of uninitialized variable x
   while (x == 0) {
     y = 1;
   }

--- a/explorer/testdata/var/global/fail_init_type_mismatch.carbon
+++ b/explorer/testdata/var/global/fail_init_type_mismatch.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 // Test type checking of global variable. Error expected.
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/global/fail_init_type_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: 'bool' is not implicitly convertible to 'i32'
+// CHECK:STDERR: COMPILATION ERROR: fail_init_type_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: 'bool' is not implicitly convertible to 'i32'
 var flag: i32 = true;
 
 fn Main() -> i32 {

--- a/explorer/testdata/var/global/fail_instantiate_global_abstract.carbon
+++ b/explorer/testdata/var/global/fail_instantiate_global_abstract.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 abstract class B {
 }
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/global/fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
+// CHECK:STDERR: COMPILATION ERROR: fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
 var b: B = {};
 
 fn Main() -> i32 {

--- a/explorer/testdata/var/global/fail_invalid_var_expression.carbon
+++ b/explorer/testdata/var/global/fail_invalid_var_expression.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/global/fail_invalid_var_expression.carbon:[[@LINE+1]]: Expected expression for variable type
+// CHECK:STDERR: COMPILATION ERROR: fail_invalid_var_expression.carbon:[[@LINE+1]]: Expected expression for variable type
 var a: auto;
 
 fn Main() -> i32 { return 0; }

--- a/explorer/testdata/var/global/fail_modify_in_constant_expr.carbon
+++ b/explorer/testdata/var/global/fail_modify_in_constant_expr.carbon
@@ -11,7 +11,7 @@ var n: i32 = 0;
 fn F() -> type {
   // TODO: This isn't a very good description of the problem, which is that
   // compile-time evaluation doesn't have a mutable `n` value available.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/global/fail_modify_in_constant_expr.carbon:[[@LINE+1]]: could not find `n: i32`
+  // CHECK:STDERR: COMPILATION ERROR: fail_modify_in_constant_expr.carbon:[[@LINE+1]]: could not find `n: i32`
   n = 1;
   return i32;
 }

--- a/explorer/testdata/var/global/fail_named_self.carbon
+++ b/explorer/testdata/var/global/fail_named_self.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 // Error: global variable may not be named with keyword `Self`.
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/var/global/fail_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier
+// CHECK:STDERR: SYNTAX ERROR: fail_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier
 var Self: i32 = 0;
 
 fn Main() -> i32 {

--- a/explorer/testdata/var/global/fail_nested_binding.carbon
+++ b/explorer/testdata/var/global/fail_nested_binding.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 // If support for this is added, it'll be necessary to verify that either the
 // implementation is shared with locals or that tests are copied over for edge
 // cases.
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/var/global/fail_nested_binding.carbon:[[@LINE+1]]: syntax error, unexpected LEFT_PARENTHESIS, expecting identifier
+// CHECK:STDERR: SYNTAX ERROR: fail_nested_binding.carbon:[[@LINE+1]]: syntax error, unexpected LEFT_PARENTHESIS, expecting identifier
 var (x: i32,);
 
 fn Main() -> i32 {

--- a/explorer/testdata/var/global/fail_type_only.carbon
+++ b/explorer/testdata/var/global/fail_type_only.carbon
@@ -6,7 +6,7 @@
 
 package ExplorerTest api;
 
-// CHECK:STDERR: SYNTAX ERROR: explorer/testdata/var/global/fail_type_only.carbon:[[@LINE+1]]: syntax error, unexpected sized_type_literal, expecting identifier
+// CHECK:STDERR: SYNTAX ERROR: fail_type_only.carbon:[[@LINE+1]]: syntax error, unexpected sized_type_literal, expecting identifier
 var i32;
 
 fn Main() -> i32 {

--- a/explorer/testdata/var/local/fail_generic_binding_in_type.carbon
+++ b/explorer/testdata/var/local/fail_generic_binding_in_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/local/fail_generic_binding_in_type.carbon:[[@LINE+1]]: Binding types cannot contain bindings, but `T:! type` is a binding.
+  // CHECK:STDERR: COMPILATION ERROR: fail_generic_binding_in_type.carbon:[[@LINE+1]]: Binding types cannot contain bindings, but `T:! type` is a binding.
   var x: (T:! type) = 1;
   return 1;
 }

--- a/explorer/testdata/var/local/fail_missing_intro.carbon
+++ b/explorer/testdata/var/local/fail_missing_intro.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/var/local/fail_missing_intro.carbon:[[@LINE+1]]: syntax error, unexpected COLON
+  // CHECK:STDERR: SYNTAX ERROR: fail_missing_intro.carbon:[[@LINE+1]]: syntax error, unexpected COLON
   x: i32;
   return 1;
 }

--- a/explorer/testdata/var/local/fail_named_self_type.carbon
+++ b/explorer/testdata/var/local/fail_named_self_type.carbon
@@ -10,7 +10,7 @@ fn Main() -> i32 {
   // Error: can't use keyword `Self` as the name of a variable.
   // TODO: Current error message is unclear, better would be to say
   // something like: unexpected `Self`, expecting identifier
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/var/local/fail_named_self_type.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL or SEMICOLON
+  // CHECK:STDERR: SYNTAX ERROR: fail_named_self_type.carbon:[[@LINE+1]]: syntax error, unexpected COLON, expecting EQUAL or SEMICOLON
   var Self: i32 = 0;
   return 0;
 }

--- a/explorer/testdata/var/local/fail_nested_binding_in_type.carbon
+++ b/explorer/testdata/var/local/fail_nested_binding_in_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/local/fail_nested_binding_in_type.carbon:[[@LINE+1]]: Binding types cannot contain bindings, but `T: type` is a binding.
+  // CHECK:STDERR: COMPILATION ERROR: fail_nested_binding_in_type.carbon:[[@LINE+1]]: Binding types cannot contain bindings, but `T: type` is a binding.
   var x: (T: type) = 1;
   return 1;
 }

--- a/explorer/testdata/var/local/fail_nested_type_only.carbon
+++ b/explorer/testdata/var/local/fail_nested_type_only.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/local/fail_nested_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
+  // CHECK:STDERR: COMPILATION ERROR: fail_nested_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
   var (x: i32, i32);
   return 0;
 }

--- a/explorer/testdata/var/local/fail_type_only.carbon
+++ b/explorer/testdata/var/local/fail_type_only.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/local/fail_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
+  // CHECK:STDERR: COMPILATION ERROR: fail_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
   var i32;
   return 0;
 }

--- a/explorer/testdata/var/local/fail_value_as_type.carbon
+++ b/explorer/testdata/var/local/fail_value_as_type.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Main() -> i32 {
   // 42 cannot be used as the type of a variable.
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/local/fail_value_as_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
+  // CHECK:STDERR: COMPILATION ERROR: fail_value_as_type.carbon:[[@LINE+1]]: type error in type of name binding: 'i32' is not implicitly convertible to 'type'
   var x: 42 = 0;
   return x;
 }

--- a/explorer/testdata/var/returned/fail_duplicate_return_var.carbon
+++ b/explorer/testdata/var/returned/fail_duplicate_return_var.carbon
@@ -9,7 +9,7 @@ package ExplorerTest api;
 fn AddInt(a: i32, b: i32) -> i32 {
   returned var ret: i32 = a + b;
   if (a == b) {
-    // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_duplicate_return_var.carbon:[[@LINE+1]]: Duplicate definition of returned var also found at explorer/testdata/var/returned/fail_duplicate_return_var.carbon:[[@LINE-2]]
+    // CHECK:STDERR: COMPILATION ERROR: fail_duplicate_return_var.carbon:[[@LINE+1]]: Duplicate definition of returned var also found at fail_duplicate_return_var.carbon:[[@LINE-2]]
     returned var ret2: i32 = a + b;
   }
   return var;

--- a/explorer/testdata/var/returned/fail_missing_declaration.carbon
+++ b/explorer/testdata/var/returned/fail_missing_declaration.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn AddInt(a: i32, b: i32) -> i32 {
   var ret: i32 = a + b;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_missing_declaration.carbon:[[@LINE+1]]: `return var` is not allowed without a returned var defined in scope.
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_declaration.carbon:[[@LINE+1]]: `return var` is not allowed without a returned var defined in scope.
   return var;
 }
 

--- a/explorer/testdata/var/returned/fail_missing_return.carbon
+++ b/explorer/testdata/var/returned/fail_missing_return.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn AddInt(a: i32, b: i32) -> i32 {
   returned var ret: i32 = a + b;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_missing_return.carbon:[[@LINE+1]]: `return <expression>` is not allowed with a returned var defined in scope: explorer/testdata/var/returned/fail_missing_return.carbon:[[@LINE-1]]
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_return.carbon:[[@LINE+1]]: `return <expression>` is not allowed with a returned var defined in scope: fail_missing_return.carbon:[[@LINE-1]]
   return ret;
 }
 

--- a/explorer/testdata/var/returned/fail_returned_var_mismatch_signature.carbon
+++ b/explorer/testdata/var/returned/fail_returned_var_mismatch_signature.carbon
@@ -8,7 +8,7 @@ package ExplorerTest api;
 
 fn Foo() {
   returned var x: () = ();
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_returned_var_mismatch_signature.carbon:[[@LINE+1]]: return var; should not provide a return value, to match the function's signature.
+  // CHECK:STDERR: COMPILATION ERROR: fail_returned_var_mismatch_signature.carbon:[[@LINE+1]]: return var; should not provide a return value, to match the function's signature.
   return var;
 }
 

--- a/explorer/testdata/var/returned/fail_returned_var_multi_auto.carbon
+++ b/explorer/testdata/var/returned/fail_returned_var_multi_auto.carbon
@@ -13,7 +13,7 @@ fn Foo(a: i32, b: i32) -> auto {
     return var;
   }
   ret = a - b;
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_returned_var_multi_auto.carbon:[[@LINE+1]]: Only one return is allowed in a function with an `auto` return type.
+  // CHECK:STDERR: COMPILATION ERROR: fail_returned_var_multi_auto.carbon:[[@LINE+1]]: Only one return is allowed in a function with an `auto` return type.
   return var;
 }
 

--- a/explorer/testdata/var/returned/fail_returned_var_type_mismatch.carbon
+++ b/explorer/testdata/var/returned/fail_returned_var_type_mismatch.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn AddInt(a: i32, b: i32) -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/var/returned/fail_returned_var_type_mismatch.carbon:[[@LINE+1]]: type of returned var `bool` does not match return type `i32`
+  // CHECK:STDERR: COMPILATION ERROR: fail_returned_var_type_mismatch.carbon:[[@LINE+1]]: type of returned var `bool` does not match return type `i32`
   returned var ret: bool = true;
   return var;
 }

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -19,7 +19,7 @@ cc_library(
 )
 
 file_test(
-    name = "file_test",
+    name = "file_test_base_test",
     srcs = ["file_test_base_test.cpp"],
     tests = ["example.carbon"],
     deps = [

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -17,11 +17,13 @@ namespace {
 
 class FileTestBaseTest : public FileTestBase {
  public:
-  explicit FileTestBaseTest(llvm::StringRef path) : FileTestBase(path) {}
+  explicit FileTestBaseTest(const std::filesystem::path& path)
+      : FileTestBase(path) {}
 
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
-    if (filename() == "example.carbon") {
+    auto filename = path().filename();
+    if (filename == "example.carbon") {
       stdout << "something\n"
                 "\n"
                 "8: Line delta\n"
@@ -29,11 +31,11 @@ class FileTestBaseTest : public FileTestBase {
                 "+*[]{}\n"
                 "Foo baz\n";
       return true;
-    } else if (filename() == "fail_example.carbon") {
+    } else if (filename == "fail_example.carbon") {
       stderr << "Oops\n";
       return false;
     } else {
-      ADD_FAILURE() << "Unexpected file: " << path().str();
+      ADD_FAILURE() << "Unexpected file: " << filename;
       return false;
     }
   }
@@ -41,10 +43,12 @@ class FileTestBaseTest : public FileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const std::vector<llvm::StringRef>& paths) -> void {
-  FileTestBaseTest::RegisterTests(
-      "FileTestBaseTest", paths,
-      [](llvm::StringRef path) { return new FileTestBaseTest(path); });
+auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
+    -> void {
+  FileTestBaseTest::RegisterTests("FileTestBaseTest", paths,
+                                  [](const std::filesystem::path& path) {
+                                    return new FileTestBaseTest(path);
+                                  });
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/lexer/lexer_file_test.cpp
+++ b/toolchain/lexer/lexer_file_test.cpp
@@ -17,21 +17,25 @@ namespace {
 
 class LexerFileTest : public FileTestBase {
  public:
-  explicit LexerFileTest(llvm::StringRef path) : FileTestBase(path) {}
+  explicit LexerFileTest(const std::filesystem::path& path)
+      : FileTestBase(path) {}
 
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "tokens", filename()});
+    return driver.RunFullCommand(
+        {"dump", "tokens", path().filename().string()});
   }
 };
 
 }  // namespace
 
-auto RegisterFileTests(const std::vector<llvm::StringRef>& paths) -> void {
-  LexerFileTest::RegisterTests(
-      "LexerFileTest", paths,
-      [](llvm::StringRef path) { return new LexerFileTest(path); });
+auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
+    -> void {
+  LexerFileTest::RegisterTests("LexerFileTest", paths,
+                               [](const std::filesystem::path& path) {
+                                 return new LexerFileTest(path);
+                               });
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/lexer/lexer_file_test.cpp
+++ b/toolchain/lexer/lexer_file_test.cpp
@@ -22,7 +22,7 @@ class LexerFileTest : public FileTestBase {
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "tokens", path()});
+    return driver.RunFullCommand({"dump", "tokens", filename()});
   }
 };
 

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -22,7 +22,7 @@ class LoweringFileTest : public FileTestBase {
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "llvm-ir", path()});
+    return driver.RunFullCommand({"dump", "llvm-ir", filename()});
   }
 };
 

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -17,21 +17,25 @@ namespace {
 
 class LoweringFileTest : public FileTestBase {
  public:
-  explicit LoweringFileTest(llvm::StringRef path) : FileTestBase(path) {}
+  explicit LoweringFileTest(const std::filesystem::path& path)
+      : FileTestBase(path) {}
 
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "llvm-ir", filename()});
+    return driver.RunFullCommand(
+        {"dump", "llvm-ir", path().filename().string()});
   }
 };
 
 }  // namespace
 
-auto RegisterFileTests(const std::vector<llvm::StringRef>& paths) -> void {
-  LoweringFileTest::RegisterTests(
-      "LoweringFileTest", paths,
-      [](llvm::StringRef path) { return new LoweringFileTest(path); });
+auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
+    -> void {
+  LoweringFileTest::RegisterTests("LoweringFileTest", paths,
+                                  [=](const std::filesystem::path& path) {
+                                    return new LoweringFileTest(path);
+                                  });
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/lowering/testdata/basics/empty.carbon
+++ b/toolchain/lowering/testdata/basics/empty.carbon
@@ -3,5 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/basics/empty.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/basics/empty.carbon"
+// CHECK:STDOUT: ; ModuleID = 'empty.carbon'
+// CHECK:STDOUT: source_filename = "empty.carbon"

--- a/toolchain/lowering/testdata/basics/fail_before_lowering.carbon
+++ b/toolchain/lowering/testdata/basics/fail_before_lowering.carbon
@@ -5,5 +5,5 @@
 // This validates that earlier errors prevent lowering, without crashing.
 // AUTOUPDATE
 
-// CHECK:STDERR: toolchain/lowering/testdata/basics/fail_before_lowering.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: fail_before_lowering.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 a;

--- a/toolchain/lowering/testdata/basics/zero.carbon
+++ b/toolchain/lowering/testdata/basics/zero.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/basics/zero.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/basics/zero.carbon"
+// CHECK:STDOUT: ; ModuleID = 'zero.carbon'
+// CHECK:STDOUT: source_filename = "zero.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Main() {
 // CHECK:STDOUT: entry:

--- a/toolchain/lowering/testdata/function/definition/params_one.carbon
+++ b/toolchain/lowering/testdata/function/definition/params_one.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/function/definition/params_one.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/function/definition/params_one.carbon"
+// CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
+// CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type {}
 // CHECK:STDOUT:

--- a/toolchain/lowering/testdata/function/definition/params_two.carbon
+++ b/toolchain/lowering/testdata/function/definition/params_two.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/function/definition/params_two.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/function/definition/params_two.carbon"
+// CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
+// CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type {}
 // CHECK:STDOUT:

--- a/toolchain/lowering/testdata/function/definition/params_zero.carbon
+++ b/toolchain/lowering/testdata/function/definition/params_zero.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/function/definition/params_zero.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/function/definition/params_zero.carbon"
+// CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
+// CHECK:STDOUT: source_filename = "params_zero.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type {}
 // CHECK:STDOUT:

--- a/toolchain/lowering/testdata/return/no_value.carbon
+++ b/toolchain/lowering/testdata/return/no_value.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/return/no_value.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/return/no_value.carbon"
+// CHECK:STDOUT: ; ModuleID = 'no_value.carbon'
+// CHECK:STDOUT: source_filename = "no_value.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type {}
 // CHECK:STDOUT:

--- a/toolchain/lowering/testdata/return/value.carbon
+++ b/toolchain/lowering/testdata/return/value.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/return/value.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/return/value.carbon"
+// CHECK:STDOUT: ; ModuleID = 'value.carbon'
+// CHECK:STDOUT: source_filename = "value.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Main() {
 // CHECK:STDOUT: entry:

--- a/toolchain/lowering/testdata/struct/empty.carbon
+++ b/toolchain/lowering/testdata/struct/empty.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/struct/empty.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/struct/empty.carbon"
+// CHECK:STDOUT: ; ModuleID = 'empty.carbon'
+// CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type {}
 // CHECK:STDOUT:

--- a/toolchain/lowering/testdata/struct/member_access.carbon
+++ b/toolchain/lowering/testdata/struct/member_access.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/struct/member_access.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/struct/member_access.carbon"
+// CHECK:STDOUT: ; ModuleID = 'member_access.carbon'
+// CHECK:STDOUT: source_filename = "member_access.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type { double, i32 }
 // CHECK:STDOUT: %1 = type { double, i32 }

--- a/toolchain/lowering/testdata/struct/one_entry.carbon
+++ b/toolchain/lowering/testdata/struct/one_entry.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/struct/one_entry.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/struct/one_entry.carbon"
+// CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
+// CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type { i32 }
 // CHECK:STDOUT: %1 = type { i32 }

--- a/toolchain/lowering/testdata/struct/two_entries.carbon
+++ b/toolchain/lowering/testdata/struct/two_entries.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/struct/two_entries.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/struct/two_entries.carbon"
+// CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
+// CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: %0 = type { i32, i32 }
 // CHECK:STDOUT: %1 = type { i32, i32 }

--- a/toolchain/lowering/testdata/var/local.carbon
+++ b/toolchain/lowering/testdata/var/local.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: ; ModuleID = 'toolchain/lowering/testdata/var/local.carbon'
-// CHECK:STDOUT: source_filename = "toolchain/lowering/testdata/var/local.carbon"
+// CHECK:STDOUT: ; ModuleID = 'local.carbon'
+// CHECK:STDOUT: source_filename = "local.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Run() {
 // CHECK:STDOUT: entry:

--- a/toolchain/parser/parse_tree_file_test.cpp
+++ b/toolchain/parser/parse_tree_file_test.cpp
@@ -22,7 +22,7 @@ class ParserFileTest : public FileTestBase {
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "parse-tree", path()});
+    return driver.RunFullCommand({"dump", "parse-tree", filename()});
   }
 };
 

--- a/toolchain/parser/parse_tree_file_test.cpp
+++ b/toolchain/parser/parse_tree_file_test.cpp
@@ -17,21 +17,25 @@ namespace {
 
 class ParserFileTest : public FileTestBase {
  public:
-  explicit ParserFileTest(llvm::StringRef path) : FileTestBase(path) {}
+  explicit ParserFileTest(const std::filesystem::path& path)
+      : FileTestBase(path) {}
 
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "parse-tree", filename()});
+    return driver.RunFullCommand(
+        {"dump", "parse-tree", path().filename().string()});
   }
 };
 
 }  // namespace
 
-auto RegisterFileTests(const std::vector<llvm::StringRef>& paths) -> void {
-  ParserFileTest::RegisterTests(
-      "ParserFileTest", paths,
-      [](llvm::StringRef path) { return new ParserFileTest(path); });
+auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
+    -> void {
+  ParserFileTest::RegisterTests("ParserFileTest", paths,
+                                [](const std::filesystem::path& path) {
+                                  return new ParserFileTest(path);
+                                });
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
+++ b/toolchain/parser/testdata/basics/fail_invalid_designators.carbon
@@ -27,10 +27,10 @@
 
 // NOTE: Move to its own directory when more tests are added.
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.;
-  // CHECK:STDERR: toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.fn;
-  // CHECK:STDERR: toolchain/parser/testdata/basics/fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
+  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+1]]:5: Expected identifier after `.`.
   a.42;
 }

--- a/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon
@@ -8,5 +8,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/basics/fail_no_intro_with_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: fail_no_intro_with_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 foo;

--- a/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
+++ b/toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon
@@ -8,5 +8,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/basics/fail_no_intro_without_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: fail_no_intro_without_semi.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 foo bar baz

--- a/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
+++ b/toolchain/parser/testdata/basics/fail_paren_match_regression.carbon
@@ -16,7 +16,7 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+3]]:5: Expected pattern in `var` declaration.
-// CHECK:STDERR: toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+2]]:12: Expected `,` or `)`.
-// CHECK:STDERR: toolchain/parser/testdata/basics/fail_paren_match_regression.carbon:[[@LINE+1]]:15: Expected `;` after expression.
+// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+3]]:5: Expected pattern in `var` declaration.
+// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+2]]:12: Expected `,` or `)`.
+// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+1]]:15: Expected `;` after expression.
 var = (foo {})

--- a/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
+++ b/toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon
@@ -30,7 +30,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: toolchain/parser/testdata/for/fail_colon_instead_of_in.carbon:[[@LINE+1]]:19: `:` should be replaced by `in`.
+  // CHECK:STDERR: fail_colon_instead_of_in.carbon:[[@LINE+1]]:19: `:` should be replaced by `in`.
   for (var x: i32 : y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/for/fail_missing_in.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_in.carbon
@@ -30,7 +30,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: toolchain/parser/testdata/for/fail_missing_in.carbon:[[@LINE+1]]:19: Expected `in` after loop `var` declaration.
+  // CHECK:STDERR: fail_missing_in.carbon:[[@LINE+1]]:19: Expected `in` after loop `var` declaration.
   for (var x: i32 y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/for/fail_missing_var.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_var.carbon
@@ -25,7 +25,7 @@
 // CHECK:STDOUT: ]
 
 fn foo() {
-  // CHECK:STDERR: toolchain/parser/testdata/for/fail_missing_var.carbon:[[@LINE+1]]:8: Expected `var` declaration.
+  // CHECK:STDERR: fail_missing_var.carbon:[[@LINE+1]]:8: Expected `var` declaration.
   for (x: i32 in y) {
     Print(x);
   }

--- a/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon
@@ -10,5 +10,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_identifier_instead_of_sig.carbon:[[@LINE+1]]:8: `fn` requires a `(` for parameters.
+// CHECK:STDERR: fail_identifier_instead_of_sig.carbon:[[@LINE+1]]:8: `fn` requires a `(` for parameters.
 fn foo bar;

--- a/toolchain/parser/testdata/function/declaration/fail_missing_deduced_close.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_missing_deduced_close.carbon
@@ -16,7 +16,7 @@
 // CHECK:STDOUT: ]
 
 // Fix and uncomment this to test error handling.
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_missing_deduced_close.carbon:[[@LINE+2]]:7: Closing symbol does not match most recent opening symbol.
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_missing_deduced_close.carbon:[[@LINE+1]]:8: Expected parameter declaration.
+// CHECK:STDERR: fail_missing_deduced_close.carbon:[[@LINE+2]]:7: Closing symbol does not match most recent opening symbol.
+// CHECK:STDERR: fail_missing_deduced_close.carbon:[[@LINE+1]]:8: Expected parameter declaration.
 fn Div[();
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_missing_deduced_close.carbon:[[@LINE+0]]:174: A `(` for parameters is required after deduced parameters.
+// CHECK:STDERR: fail_missing_deduced_close.carbon:[[@LINE+0]]:127: A `(` for parameters is required after deduced parameters.

--- a/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_missing_name.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_missing_name.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_missing_name.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn ();

--- a/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon
@@ -10,5 +10,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_no_sig_or_semi.carbon:[[@LINE+1]]:7: `fn` requires a `(` for parameters.
+// CHECK:STDERR: fail_no_sig_or_semi.carbon:[[@LINE+1]]:7: `fn` requires a `(` for parameters.
 fn foo

--- a/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_only_fn_and_semi.carbon:[[@LINE+1]]:3: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_only_fn_and_semi.carbon:[[@LINE+1]]:3: `fn` introducer should be followed by a name.
 fn;

--- a/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_repeated_fn_and_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_repeated_fn_and_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn fn;

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon
@@ -14,7 +14,7 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-  // CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_until_outdent.carbon:[[@LINE+1]]:6: `fn` introducer should be followed by a name.
+  // CHECK:STDERR: fail_skip_indented_newline_until_outdent.carbon:[[@LINE+1]]:6: `fn` introducer should be followed by a name.
   fn (x,
       y,
       z)

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon
@@ -14,7 +14,7 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_with_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_skip_indented_newline_with_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn (x,
     y,
     z);

--- a/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon
@@ -14,7 +14,7 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_skip_indented_newline_without_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_skip_indented_newline_without_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn (x,
     y,
     z)

--- a/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon
@@ -14,6 +14,6 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_skip_to_newline_without_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_skip_to_newline_without_semi.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn ()
 fn F();

--- a/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon
@@ -13,6 +13,6 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_skip_without_semi_to_curly.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
+// CHECK:STDERR: fail_skip_without_semi_to_curly.carbon:[[@LINE+1]]:1: Unrecognized declaration introducer.
 struct X { fn () }
 fn F();

--- a/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon
@@ -15,5 +15,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_with_identifier_as_param.carbon:[[@LINE+1]]:11: Expected parameter declaration.
+// CHECK:STDERR: fail_with_identifier_as_param.carbon:[[@LINE+1]]:11: Expected parameter declaration.
 fn foo(bar);

--- a/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
+++ b/toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/function/declaration/fail_without_name_and_many_tokens_in_params.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_without_name_and_many_tokens_in_params.carbon:[[@LINE+1]]:4: `fn` introducer should be followed by a name.
 fn (a tokens c d e f g h i j k l m n o p q r s t u v w x y z);

--- a/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
+++ b/toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon
@@ -18,5 +18,5 @@ fn F() {
   // Note: this might become valid depending on the expression syntax. This test
   // shouldn't be taken as a sign it should remain invalid.
   bar
-// CHECK:STDERR: toolchain/parser/testdata/function/definition/fail_identifier_in_statements.carbon:[[@LINE+1]]:1: Expected `;` after expression.
+// CHECK:STDERR: fail_identifier_in_statements.carbon:[[@LINE+1]]:1: Expected `;` after expression.
 }

--- a/toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon
+++ b/toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon
@@ -33,14 +33,14 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon:[[@LINE+1]]:12: A `(` for parameters is required after deduced parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+1]]:12: A `(` for parameters is required after deduced parameters.
 class Foo[];
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon:[[@LINE+1]]:18: A `(` for parameters is required after deduced parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+1]]:18: A `(` for parameters is required after deduced parameters.
 class Foo[a: i32];
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon:[[@LINE+1]]:17: A `(` for parameters is required after deduced parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+1]]:17: A `(` for parameters is required after deduced parameters.
 interface Bar[] {}
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/deduced_params/fail_no_parens.carbon:[[@LINE+1]]:23: A `(` for parameters is required after deduced parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+1]]:23: A `(` for parameters is required after deduced parameters.
 interface Bar[a: i32] {}

--- a/toolchain/parser/testdata/generics/interface/fail_missing_name.carbon
+++ b/toolchain/parser/testdata/generics/interface/fail_missing_name.carbon
@@ -9,6 +9,6 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_missing_name.carbon:[[@LINE+1]]:11: `interface` introducer should be followed by a name.
+// CHECK:STDERR: fail_missing_name.carbon:[[@LINE+1]]:11: `interface` introducer should be followed by a name.
 interface {
 }

--- a/toolchain/parser/testdata/generics/interface/fail_missing_open_curly.carbon
+++ b/toolchain/parser/testdata/generics/interface/fail_missing_open_curly.carbon
@@ -13,8 +13,8 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_missing_open_curly.carbon:[[@LINE+1]]:15: `interface` should either end with a `;` for a declaration or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_missing_open_curly.carbon:[[@LINE+1]]:15: `interface` should either end with a `;` for a declaration or have a `{ ... }` block for a definition.
 interface Bar Baz {}
 
-// CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_missing_open_curly.carbon:[[@LINE+1]]:14: `interface` should either end with a `;` for a declaration or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_missing_open_curly.carbon:[[@LINE+1]]:14: `interface` should either end with a `;` for a declaration or have a `{ ... }` block for a definition.
 interface Foo

--- a/toolchain/parser/testdata/generics/interface/fail_no_impl_allowed.carbon
+++ b/toolchain/parser/testdata/generics/interface/fail_no_impl_allowed.carbon
@@ -27,7 +27,7 @@
 // CHECK:STDOUT: ]
 
 interface Foo {
-  // CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_no_impl_allowed.carbon:[[@LINE+1]]:39: Method implementations are not allowed in interfaces.
+  // CHECK:STDERR: fail_no_impl_allowed.carbon:[[@LINE+1]]:39: Method implementations are not allowed in interfaces.
   fn Add[self: Self](b: Self) -> Self {
     print("You can't do that.");
   }

--- a/toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon
+++ b/toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon
@@ -42,9 +42,9 @@
 // CHECK:STDOUT: ]
 
 interface Foo {
-  // CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon:[[@LINE+1]]:13: Expected parameter declaration.
+  // CHECK:STDERR: fail_self_param_syntax.carbon:[[@LINE+1]]:13: Expected parameter declaration.
   fn Sub[me Self](b: Self) -> Self;
 
-  // CHECK:STDERR: toolchain/parser/testdata/generics/interface/fail_self_param_syntax.carbon:[[@LINE+1]]:10: Expected parameter declaration.
+  // CHECK:STDERR: fail_self_param_syntax.carbon:[[@LINE+1]]:10: Expected parameter declaration.
   fn Mul[Self](b: Self) -> Self;
 }

--- a/toolchain/parser/testdata/generics/named_constraint/fail_no_impl_allowed.carbon
+++ b/toolchain/parser/testdata/generics/named_constraint/fail_no_impl_allowed.carbon
@@ -27,6 +27,6 @@
 // CHECK:STDOUT: ]
 
 constraint Foo {
-  // CHECK:STDERR: toolchain/parser/testdata/generics/named_constraint/fail_no_impl_allowed.carbon:[[@LINE+1]]:39: Method implementations are not allowed in interfaces.
+  // CHECK:STDERR: fail_no_impl_allowed.carbon:[[@LINE+1]]:39: Method implementations are not allowed in interfaces.
   fn Add[self: Self](b: Self) -> Self {}
 }

--- a/toolchain/parser/testdata/if/fail_else_unbraced.carbon
+++ b/toolchain/parser/testdata/if/fail_else_unbraced.carbon
@@ -61,15 +61,15 @@
 
 fn F() {
   if (a)
-    // CHECK:STDERR: toolchain/parser/testdata/if/fail_else_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
+    // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
     if (b)
-      // CHECK:STDERR: toolchain/parser/testdata/if/fail_else_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
+      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
       c;
     else
-      // CHECK:STDERR: toolchain/parser/testdata/if/fail_else_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
+      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
       d;
   else
-    // CHECK:STDERR: toolchain/parser/testdata/if/fail_else_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
+    // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
     e;
   if (x) { f; }
   else if (x) { g; }

--- a/toolchain/parser/testdata/if/fail_errors.carbon
+++ b/toolchain/parser/testdata/if/fail_errors.carbon
@@ -39,13 +39,13 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:6: Expected `(` after `if`.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+1]]:6: Expected `(` after `if`.
   if a {}
-  // CHECK:STDERR: toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:7: Expected expression.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+1]]:7: Expected expression.
   if () {}
-  // CHECK:STDERR: toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:9: Unexpected tokens before `)`.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+1]]:9: Unexpected tokens before `)`.
   if (b c) {}
   if (d)
-// CHECK:STDERR: toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+2]]:1: Expected braced code block.
-// CHECK:STDERR: toolchain/parser/testdata/if/fail_errors.carbon:[[@LINE+1]]:1: Expected expression.
+// CHECK:STDERR: fail_errors.carbon:[[@LINE+2]]:1: Expected braced code block.
+// CHECK:STDERR: fail_errors.carbon:[[@LINE+1]]:1: Expected expression.
 }

--- a/toolchain/parser/testdata/if/fail_unbraced.carbon
+++ b/toolchain/parser/testdata/if/fail_unbraced.carbon
@@ -36,10 +36,10 @@
 
 fn F() {
   if (a)
-    // CHECK:STDERR: toolchain/parser/testdata/if/fail_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
+    // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
     if (b)
-      // CHECK:STDERR: toolchain/parser/testdata/if/fail_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
+      // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+1]]:7: Expected braced code block.
       if (c)
-        // CHECK:STDERR: toolchain/parser/testdata/if/fail_unbraced.carbon:[[@LINE+1]]:9: Expected braced code block.
+        // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+1]]:9: Expected braced code block.
         d;
 }

--- a/toolchain/parser/testdata/operators/fail_infix_uneven_space_after.carbon
+++ b/toolchain/parser/testdata/operators/fail_infix_uneven_space_after.carbon
@@ -17,5 +17,5 @@
 
 // TODO: We could figure out that this first Failed example is infix
 // with one-token lookahead.
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_infix_uneven_space_after.carbon:[[@LINE+1]]:16: Expected `;` after expression.
+// CHECK:STDERR: fail_infix_uneven_space_after.carbon:[[@LINE+1]]:16: Expected `;` after expression.
 var n: i8 = n* n;

--- a/toolchain/parser/testdata/operators/fail_invalid_infix.carbon
+++ b/toolchain/parser/testdata/operators/fail_invalid_infix.carbon
@@ -34,10 +34,10 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_invalid_infix.carbon:[[@LINE+1]]:19: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+1]]:19: Expected expression.
 var a: i32 = n == ;
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_invalid_infix.carbon:[[@LINE+1]]:14: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+1]]:14: Expected expression.
 var b: i32 = == n;
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_invalid_infix.carbon:[[@LINE+2]]:14: Expected expression.
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_invalid_infix.carbon:[[@LINE+1]]:17: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+2]]:14: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+1]]:17: Expected expression.
 var c: i32 = == ;

--- a/toolchain/parser/testdata/operators/fail_precedence_and_or.carbon
+++ b/toolchain/parser/testdata/operators/fail_precedence_and_or.carbon
@@ -20,6 +20,6 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_precedence_and_or.carbon:[[@LINE+1]]:11: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_precedence_and_or.carbon:[[@LINE+1]]:11: Parentheses are required to disambiguate operator precedence.
   a and b or c;
 }

--- a/toolchain/parser/testdata/operators/fail_precedence_or_and.carbon
+++ b/toolchain/parser/testdata/operators/fail_precedence_or_and.carbon
@@ -20,6 +20,6 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_precedence_or_and.carbon:[[@LINE+1]]:10: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_precedence_or_and.carbon:[[@LINE+1]]:10: Parentheses are required to disambiguate operator precedence.
   a or b and c;
 }

--- a/toolchain/parser/testdata/operators/fail_precedence_star_minus.carbon
+++ b/toolchain/parser/testdata/operators/fail_precedence_star_minus.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_precedence_star_minus.carbon:[[@LINE+1]]:16: Parentheses are required to disambiguate operator precedence.
+// CHECK:STDERR: fail_precedence_star_minus.carbon:[[@LINE+1]]:16: Parentheses are required to disambiguate operator precedence.
 var n: i8 = n* -n;

--- a/toolchain/parser/testdata/operators/fail_precedence_star_star.carbon
+++ b/toolchain/parser/testdata/operators/fail_precedence_star_star.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_precedence_star_star.carbon:[[@LINE+1]]:16: Parentheses are required to disambiguate operator precedence.
+// CHECK:STDERR: fail_precedence_star_star.carbon:[[@LINE+1]]:16: Parentheses are required to disambiguate operator precedence.
 var n: i8 = n* *p;

--- a/toolchain/parser/testdata/operators/fail_star_star_no_space.carbon
+++ b/toolchain/parser/testdata/operators/fail_star_star_no_space.carbon
@@ -20,5 +20,5 @@
 // before we notice the missing whitespace around the second `*`.
 // It'd be better to (somehow) form n*(*p) and reject due to the missing
 // whitespace around the first `*`.
-// CHECK:STDERR: toolchain/parser/testdata/operators/fail_star_star_no_space.carbon:[[@LINE+1]]:16: Expected `;` after expression.
+// CHECK:STDERR: fail_star_star_no_space.carbon:[[@LINE+1]]:16: Expected `;` after expression.
 var n: i8 = n**p;

--- a/toolchain/parser/testdata/operators/fail_variety.carbon
+++ b/toolchain/parser/testdata/operators/fail_variety.carbon
@@ -35,9 +35,9 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+4]]:29: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+3]]:34: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+2]]:38: Parentheses are required to disambiguate operator precedence.
-  // CHECK:STDERR: toolchain/parser/testdata/operators/fail_variety.carbon:[[@LINE+1]]:40: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+4]]:29: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+3]]:34: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+2]]:38: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+1]]:40: Parentheses are required to disambiguate operator precedence.
   n = a * b + c * d = d * d << e & f - not g;
 }

--- a/toolchain/parser/testdata/operators/missing_precedence_not.carbon
+++ b/toolchain/parser/testdata/operators/missing_precedence_not.carbon
@@ -23,8 +23,8 @@
 // CHECK:STDOUT: ]
 
 fn F() {
-  // CHECK:STDERR: toolchain/parser/testdata/operators/missing_precedence_not.carbon:[[@LINE+3]]:3: Whitespace is required before this unary operator.
-  // CHECK:STDERR: toolchain/parser/testdata/operators/missing_precedence_not.carbon:[[@LINE+2]]:13: Whitespace is required before this unary operator.
-  // CHECK:STDERR: toolchain/parser/testdata/operators/missing_precedence_not.carbon:[[@LINE+1]]:23: Whitespace is required before this unary operator.
+  // CHECK:STDERR: missing_precedence_not.carbon:[[@LINE+3]]:3: Whitespace is required before this unary operator.
+  // CHECK:STDERR: missing_precedence_not.carbon:[[@LINE+2]]:13: Whitespace is required before this unary operator.
+  // CHECK:STDERR: missing_precedence_not.carbon:[[@LINE+1]]:23: Whitespace is required before this unary operator.
   not a and not b and not c;
 }

--- a/toolchain/parser/testdata/operators/recover_infix_uneven_space_before.carbon
+++ b/toolchain/parser/testdata/operators/recover_infix_uneven_space_before.carbon
@@ -16,5 +16,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_infix_uneven_space_before.carbon:[[@LINE+1]]:15: Whitespace missing after binary operator.
+// CHECK:STDERR: recover_infix_uneven_space_before.carbon:[[@LINE+1]]:15: Whitespace missing after binary operator.
 var n: i8 = n *n;

--- a/toolchain/parser/testdata/operators/recover_postfix_space.carbon
+++ b/toolchain/parser/testdata/operators/recover_postfix_space.carbon
@@ -15,5 +15,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_postfix_space.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: recover_postfix_space.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
 var v: type = i8 *;

--- a/toolchain/parser/testdata/operators/recover_postfix_space_before_comma.carbon
+++ b/toolchain/parser/testdata/operators/recover_postfix_space_before_comma.carbon
@@ -20,5 +20,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_postfix_space_before_comma.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: recover_postfix_space_before_comma.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
 var n: i8 = F(i8 *, 0);

--- a/toolchain/parser/testdata/operators/recover_postfix_space_in_call.carbon
+++ b/toolchain/parser/testdata/operators/recover_postfix_space_in_call.carbon
@@ -18,5 +18,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_postfix_space_in_call.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: recover_postfix_space_in_call.carbon:[[@LINE+1]]:18: Whitespace is not allowed before this unary operator.
 var n: i8 = F(i8 *);

--- a/toolchain/parser/testdata/operators/recover_postfix_space_surrounding.carbon
+++ b/toolchain/parser/testdata/operators/recover_postfix_space_surrounding.carbon
@@ -15,6 +15,6 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_postfix_space_surrounding.carbon:[[@LINE+2]]:18: Whitespace is not allowed before this unary operator.
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_postfix_space_surrounding.carbon:[[@LINE+1]]:18: Whitespace is required after this unary operator.
+// CHECK:STDERR: recover_postfix_space_surrounding.carbon:[[@LINE+2]]:18: Whitespace is not allowed before this unary operator.
+// CHECK:STDERR: recover_postfix_space_surrounding.carbon:[[@LINE+1]]:18: Whitespace is required after this unary operator.
 var v: type = i8 * ;

--- a/toolchain/parser/testdata/operators/recover_prefix_space.carbon
+++ b/toolchain/parser/testdata/operators/recover_prefix_space.carbon
@@ -15,6 +15,6 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_prefix_space.carbon:[[@LINE+2]]:13: Whitespace is not allowed after this unary operator.
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_prefix_space.carbon:[[@LINE+1]]:13: Whitespace is required before this unary operator.
+// CHECK:STDERR: recover_prefix_space.carbon:[[@LINE+2]]:13: Whitespace is not allowed after this unary operator.
+// CHECK:STDERR: recover_prefix_space.carbon:[[@LINE+1]]:13: Whitespace is required before this unary operator.
 var n: i8 = - n;

--- a/toolchain/parser/testdata/operators/recover_prefix_uneven_space_with_assign.carbon
+++ b/toolchain/parser/testdata/operators/recover_prefix_uneven_space_with_assign.carbon
@@ -15,5 +15,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/operators/recover_prefix_uneven_space_with_assign.carbon:[[@LINE+1]]:12: Whitespace is not allowed after this unary operator.
+// CHECK:STDERR: recover_prefix_uneven_space_with_assign.carbon:[[@LINE+1]]:12: Whitespace is not allowed after this unary operator.
 var n: i8 =- n;

--- a/toolchain/parser/testdata/package/fail_extra_string.carbon
+++ b/toolchain/parser/testdata/package/fail_extra_string.carbon
@@ -12,5 +12,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_extra_string.carbon:[[@LINE+1]]:27: Expected a `api` or `impl`.
+// CHECK:STDERR: fail_extra_string.carbon:[[@LINE+1]]:27: Expected a `api` or `impl`.
 package Foo library "bar" "baz";

--- a/toolchain/parser/testdata/package/fail_library_is_identifier.carbon
+++ b/toolchain/parser/testdata/package/fail_library_is_identifier.carbon
@@ -10,5 +10,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_library_is_identifier.carbon:[[@LINE+1]]:26: Expected a string literal to specify the library name.
+// CHECK:STDERR: fail_library_is_identifier.carbon:[[@LINE+1]]:26: Expected a string literal to specify the library name.
 package Geometry library Shapes api;

--- a/toolchain/parser/testdata/package/fail_library_skips_name.carbon
+++ b/toolchain/parser/testdata/package/fail_library_skips_name.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_library_skips_name.carbon:[[@LINE+1]]:9: Expected identifier after `package`.
+// CHECK:STDERR: fail_library_skips_name.carbon:[[@LINE+1]]:9: Expected identifier after `package`.
 package library "Shapes" api;

--- a/toolchain/parser/testdata/package/fail_name_is_keyword.carbon
+++ b/toolchain/parser/testdata/package/fail_name_is_keyword.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_name_is_keyword.carbon:[[@LINE+1]]:9: Expected identifier after `package`.
+// CHECK:STDERR: fail_name_is_keyword.carbon:[[@LINE+1]]:9: Expected identifier after `package`.
 package fn;

--- a/toolchain/parser/testdata/package/fail_no_name.carbon
+++ b/toolchain/parser/testdata/package/fail_no_name.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_no_name.carbon:[[@LINE+1]]:8: Expected identifier after `package`.
+// CHECK:STDERR: fail_no_name.carbon:[[@LINE+1]]:8: Expected identifier after `package`.
 package;

--- a/toolchain/parser/testdata/package/fail_no_semi.carbon
+++ b/toolchain/parser/testdata/package/fail_no_semi.carbon
@@ -11,5 +11,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_no_semi.carbon:[[@LINE+1]]:21: Expected `;` to end package directive.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+1]]:21: Expected `;` to end package directive.
 package Geometry api

--- a/toolchain/parser/testdata/package/fail_no_type.carbon
+++ b/toolchain/parser/testdata/package/fail_no_type.carbon
@@ -10,5 +10,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_no_type.carbon:[[@LINE+1]]:17: Expected a `api` or `impl`.
+// CHECK:STDERR: fail_no_type.carbon:[[@LINE+1]]:17: Expected a `api` or `impl`.
 package Geometry;

--- a/toolchain/parser/testdata/package/fail_omit_library_keyword.carbon
+++ b/toolchain/parser/testdata/package/fail_omit_library_keyword.carbon
@@ -10,5 +10,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/package/fail_omit_library_keyword.carbon:[[@LINE+1]]:18: Missing `library` keyword.
+// CHECK:STDERR: fail_omit_library_keyword.carbon:[[@LINE+1]]:18: Missing `library` keyword.
 package Geometry "Shapes" api;

--- a/toolchain/parser/testdata/return/fail_expr_no_semi.carbon
+++ b/toolchain/parser/testdata/return/fail_expr_no_semi.carbon
@@ -18,5 +18,5 @@
 
 fn F() {
   return x
-// CHECK:STDERR: toolchain/parser/testdata/return/fail_expr_no_semi.carbon:[[@LINE+1]]:1: Expected `;` after `return`.
+// CHECK:STDERR: fail_expr_no_semi.carbon:[[@LINE+1]]:1: Expected `;` after `return`.
 }

--- a/toolchain/parser/testdata/return/fail_no_semi.carbon
+++ b/toolchain/parser/testdata/return/fail_no_semi.carbon
@@ -18,6 +18,6 @@
 
 fn F() {
   return
-// CHECK:STDERR: toolchain/parser/testdata/return/fail_no_semi.carbon:[[@LINE+2]]:1: Expected expression.
-// CHECK:STDERR: toolchain/parser/testdata/return/fail_no_semi.carbon:[[@LINE+1]]:1: Expected `;` after `return`.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+2]]:1: Expected expression.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+1]]:1: Expected `;` after `return`.
 }

--- a/toolchain/parser/testdata/struct/fail_comma_only.carbon
+++ b/toolchain/parser/testdata/struct/fail_comma_only.carbon
@@ -18,5 +18,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_comma_only.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_comma_only.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
 var x: {,} = {};

--- a/toolchain/parser/testdata/struct/fail_comma_repeat_in_type.carbon
+++ b/toolchain/parser/testdata/struct/fail_comma_repeat_in_type.carbon
@@ -23,5 +23,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_comma_repeat_in_type.carbon:[[@LINE+1]]:17: Expected `.field: field_type`.
+// CHECK:STDERR: fail_comma_repeat_in_type.carbon:[[@LINE+1]]:17: Expected `.field: field_type`.
 var x: {.a: i32,,} = {};

--- a/toolchain/parser/testdata/struct/fail_comma_repeat_in_value.carbon
+++ b/toolchain/parser/testdata/struct/fail_comma_repeat_in_value.carbon
@@ -23,5 +23,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_comma_repeat_in_value.carbon:[[@LINE+1]]:16: Expected `.field = value`.
+// CHECK:STDERR: fail_comma_repeat_in_value.carbon:[[@LINE+1]]:16: Expected `.field = value`.
 var x: {.a = 0,,} = {};

--- a/toolchain/parser/testdata/struct/fail_dot_only.carbon
+++ b/toolchain/parser/testdata/struct/fail_dot_only.carbon
@@ -19,5 +19,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_dot_only.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
+// CHECK:STDERR: fail_dot_only.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
 var x: {.} = {};

--- a/toolchain/parser/testdata/struct/fail_dot_string_colon.carbon
+++ b/toolchain/parser/testdata/struct/fail_dot_string_colon.carbon
@@ -25,5 +25,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_dot_string_colon.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
+// CHECK:STDERR: fail_dot_string_colon.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
 var x: {."hello": i32, .y: i32} = {};

--- a/toolchain/parser/testdata/struct/fail_dot_string_equals.carbon
+++ b/toolchain/parser/testdata/struct/fail_dot_string_equals.carbon
@@ -25,5 +25,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_dot_string_equals.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
+// CHECK:STDERR: fail_dot_string_equals.carbon:[[@LINE+1]]:10: Expected identifier after `.`.
 var x: {."hello" = 0, .y = 4} = {};

--- a/toolchain/parser/testdata/struct/fail_extra_token_in_type.carbon
+++ b/toolchain/parser/testdata/struct/fail_extra_token_in_type.carbon
@@ -24,5 +24,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_extra_token_in_type.carbon:[[@LINE+1]]:17: Expected `,` or `}`.
+// CHECK:STDERR: fail_extra_token_in_type.carbon:[[@LINE+1]]:17: Expected `,` or `}`.
 var x: {.a: i32 banana} = {.a = 0};

--- a/toolchain/parser/testdata/struct/fail_extra_token_in_value.carbon
+++ b/toolchain/parser/testdata/struct/fail_extra_token_in_value.carbon
@@ -24,5 +24,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_extra_token_in_value.carbon:[[@LINE+1]]:28: Expected `,` or `}`.
+// CHECK:STDERR: fail_extra_token_in_value.carbon:[[@LINE+1]]:28: Expected `,` or `}`.
 var x: {.a: i32} = {.a = 0 banana};

--- a/toolchain/parser/testdata/struct/fail_identifier_colon.carbon
+++ b/toolchain/parser/testdata/struct/fail_identifier_colon.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_identifier_colon.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_identifier_colon.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
 var x: {a:} = {};

--- a/toolchain/parser/testdata/struct/fail_identifier_equals.carbon
+++ b/toolchain/parser/testdata/struct/fail_identifier_equals.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_identifier_equals.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_identifier_equals.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
 var x: {a=} = {};

--- a/toolchain/parser/testdata/struct/fail_identifier_only.carbon
+++ b/toolchain/parser/testdata/struct/fail_identifier_only.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_identifier_only.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_identifier_only.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
 var x: {a} = {};

--- a/toolchain/parser/testdata/struct/fail_missing_type.carbon
+++ b/toolchain/parser/testdata/struct/fail_missing_type.carbon
@@ -20,5 +20,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_missing_type.carbon:[[@LINE+1]]:12: Expected expression.
+// CHECK:STDERR: fail_missing_type.carbon:[[@LINE+1]]:12: Expected expression.
 var x: {.a:} = {};

--- a/toolchain/parser/testdata/struct/fail_missing_value.carbon
+++ b/toolchain/parser/testdata/struct/fail_missing_value.carbon
@@ -20,5 +20,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_missing_value.carbon:[[@LINE+1]]:12: Expected expression.
+// CHECK:STDERR: fail_missing_value.carbon:[[@LINE+1]]:12: Expected expression.
 var x: {.a=} = {};

--- a/toolchain/parser/testdata/struct/fail_mix_type_and_value.carbon
+++ b/toolchain/parser/testdata/struct/fail_mix_type_and_value.carbon
@@ -24,5 +24,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_type_and_value.carbon:[[@LINE+1]]:21: Expected `.field: field_type`.
+// CHECK:STDERR: fail_mix_type_and_value.carbon:[[@LINE+1]]:21: Expected `.field: field_type`.
 var x: {.a: i32, .b = 0} = {};

--- a/toolchain/parser/testdata/struct/fail_mix_value_and_type.carbon
+++ b/toolchain/parser/testdata/struct/fail_mix_value_and_type.carbon
@@ -22,5 +22,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_value_and_type.carbon:[[@LINE+1]]:17: Expected `.field = value`.
+// CHECK:STDERR: fail_mix_value_and_type.carbon:[[@LINE+1]]:17: Expected `.field = value`.
 var x: {.a = 0, b: i32} = {};

--- a/toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon
+++ b/toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon
@@ -47,10 +47,10 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon:[[@LINE+2]]:25: Expected `.field = value`.
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon:[[@LINE+1]]:29: Expected `.field = value`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+2]]:25: Expected `.field = value`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+1]]:29: Expected `.field = value`.
 var x: i32 = {.a = 1, .b, .c: i32};
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon:[[@LINE+2]]:26: Expected `.field: field_type`.
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_mix_with_unknown.carbon:[[@LINE+1]]:31: Expected `.field: field_type`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+2]]:26: Expected `.field: field_type`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+1]]:31: Expected `.field: field_type`.
 var x: i32 = {.a: i32, .b, .c = 1};

--- a/toolchain/parser/testdata/struct/fail_no_colon_or_equals.carbon
+++ b/toolchain/parser/testdata/struct/fail_no_colon_or_equals.carbon
@@ -19,5 +19,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_no_colon_or_equals.carbon:[[@LINE+1]]:11: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_no_colon_or_equals.carbon:[[@LINE+1]]:11: Expected `.field: field_type` or `.field = value`.
 var x: {.a} = {};

--- a/toolchain/parser/testdata/struct/fail_type_no_designator.carbon
+++ b/toolchain/parser/testdata/struct/fail_type_no_designator.carbon
@@ -17,5 +17,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/struct/fail_type_no_designator.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
+// CHECK:STDERR: fail_type_no_designator.carbon:[[@LINE+1]]:9: Expected `.field: field_type` or `.field = value`.
 var x: {i32} = {};

--- a/toolchain/parser/testdata/var/fail_bad_name.carbon
+++ b/toolchain/parser/testdata/var/fail_bad_name.carbon
@@ -12,5 +12,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/var/fail_bad_name.carbon:[[@LINE+1]]:5: Expected pattern in `var` declaration.
+// CHECK:STDERR: fail_bad_name.carbon:[[@LINE+1]]:5: Expected pattern in `var` declaration.
 var *;

--- a/toolchain/parser/testdata/var/fail_empty.carbon
+++ b/toolchain/parser/testdata/var/fail_empty.carbon
@@ -12,5 +12,5 @@
 // CHECK:STDOUT: {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/parser/testdata/var/fail_empty.carbon:[[@LINE+1]]:4: Expected pattern in `var` declaration.
+// CHECK:STDERR: fail_empty.carbon:[[@LINE+1]]:4: Expected pattern in `var` declaration.
 var;

--- a/toolchain/parser/testdata/while/fail_no_semi.carbon
+++ b/toolchain/parser/testdata/while/fail_no_semi.carbon
@@ -39,11 +39,11 @@ fn F() {
   while (a) {
     if (b) {
       break
-    // CHECK:STDERR: toolchain/parser/testdata/while/fail_no_semi.carbon:[[@LINE+1]]:5: Expected `;` after `break`.
+    // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+1]]:5: Expected `;` after `break`.
     }
     if (c) {
       continue
-    // CHECK:STDERR: toolchain/parser/testdata/while/fail_no_semi.carbon:[[@LINE+1]]:5: Expected `;` after `continue`.
+    // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+1]]:5: Expected `;` after `continue`.
     }
   }
 }

--- a/toolchain/parser/testdata/while/fail_unbraced.carbon
+++ b/toolchain/parser/testdata/while/fail_unbraced.carbon
@@ -24,6 +24,6 @@
 
 fn F() {
   while (a)
-    // CHECK:STDERR: toolchain/parser/testdata/while/fail_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
+    // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+1]]:5: Expected braced code block.
     break;
 }

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -22,7 +22,7 @@ class SemanticsFileTest : public FileTestBase {
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "semantics-ir", path()});
+    return driver.RunFullCommand({"dump", "semantics-ir", filename()});
   }
 };
 

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -17,21 +17,25 @@ namespace {
 
 class SemanticsFileTest : public FileTestBase {
  public:
-  explicit SemanticsFileTest(llvm::StringRef path) : FileTestBase(path) {}
+  explicit SemanticsFileTest(const std::filesystem::path& path)
+      : FileTestBase(path) {}
 
   auto RunOverFile(llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand({"dump", "semantics-ir", filename()});
+    return driver.RunFullCommand(
+        {"dump", "semantics-ir", path().filename().string()});
   }
 };
 
 }  // namespace
 
-auto RegisterFileTests(const std::vector<llvm::StringRef>& paths) -> void {
-  SemanticsFileTest::RegisterTests(
-      "SemanticsFileTest", paths,
-      [](llvm::StringRef path) { return new SemanticsFileTest(path); });
+auto RegisterFileTests(const std::vector<std::filesystem::path>& paths)
+    -> void {
+  SemanticsFileTest::RegisterTests("SemanticsFileTest", paths,
+                                   [](const std::filesystem::path& path) {
+                                     return new SemanticsFileTest(path);
+                                   });
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
@@ -30,6 +30,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/basics/fail_name_lookup.carbon:[[@LINE+1]]:3: Name x not found
+  // CHECK:STDERR: fail_name_lookup.carbon:[[@LINE+1]]:3: Name x not found
   x;
 }

--- a/toolchain/semantics/testdata/designators/fail_unsupported.carbon
+++ b/toolchain/semantics/testdata/designators/fail_unsupported.carbon
@@ -37,5 +37,5 @@
 // CHECK:STDOUT: ]
 
 var x: i32;
-// CHECK:STDERR: toolchain/semantics/testdata/designators/fail_unsupported.carbon:[[@LINE+1]]:15: Type `i32` does not support designator expressions.
+// CHECK:STDERR: fail_unsupported.carbon:[[@LINE+1]]:15: Type `i32` does not support designator expressions.
 var y: i32 = x.b;

--- a/toolchain/semantics/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_param_count.carbon
@@ -129,24 +129,24 @@ fn Run1(a: i32) {}
 fn Run2(a: i32, b: i32) {}
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-6]]:1: Callable cannot be used: Received 1 argument(s), but require 0 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-6]]:1: Callable cannot be used: Received 1 argument(s), but require 0 argument(s).
   Run0(1);
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-9]]:1: Callable cannot be used: Received 2 argument(s), but require 0 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-9]]:1: Callable cannot be used: Received 2 argument(s), but require 0 argument(s).
   Run0(0, 1);
 
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-12]]:1: Callable cannot be used: Received 0 argument(s), but require 1 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-12]]:1: Callable cannot be used: Received 0 argument(s), but require 1 argument(s).
   Run1();
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-15]]:1: Callable cannot be used: Received 2 argument(s), but require 1 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-15]]:1: Callable cannot be used: Received 2 argument(s), but require 1 argument(s).
   Run1(0, 1);
 
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-18]]:1: Callable cannot be used: Received 0 argument(s), but require 2 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-18]]:1: Callable cannot be used: Received 0 argument(s), but require 2 argument(s).
   Run2();
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_count.carbon:[[@LINE-21]]:1: Callable cannot be used: Received 1 argument(s), but require 2 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+2]]:7: No matching callable was found.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-21]]:1: Callable cannot be used: Received 1 argument(s), but require 2 argument(s).
   Run2(0);
 }

--- a/toolchain/semantics/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_param_type.carbon
@@ -58,7 +58,7 @@
 fn Run(a: i32) {}
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_type.carbon:[[@LINE+2]]:6: No matching callable was found.
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_param_type.carbon:[[@LINE-4]]:1: Callable cannot be used: Cannot implicityly convert argument 0 from `f64` to `i32`.
+  // CHECK:STDERR: fail_param_type.carbon:[[@LINE+2]]:6: No matching callable was found.
+  // CHECK:STDERR: fail_param_type.carbon:[[@LINE-4]]:1: Callable cannot be used: Cannot implicityly convert argument 0 from `f64` to `i32`.
   Run(1.0);
 }

--- a/toolchain/semantics/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_return_type_mismatch.carbon
@@ -57,6 +57,6 @@
 fn Foo() -> f64 { return 1.0; }
 
 fn Run() {
-  // CHECK:STDERR: toolchain/semantics/testdata/function/call/fail_return_type_mismatch.carbon:[[@LINE+1]]:21: Cannot implicitly convert from `f64` to `i32`.
+  // CHECK:STDERR: fail_return_type_mismatch.carbon:[[@LINE+1]]:21: Cannot implicitly convert from `f64` to `i32`.
   var x: i32 = Foo();
 }

--- a/toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon
@@ -44,6 +44,6 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon:[[@LINE+2]]:16: Redefining a in the same scope.
-// CHECK:STDERR: toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon:[[@LINE+1]]:8: Previous definition is here.
+// CHECK:STDERR: fail_param_name_conflict.carbon:[[@LINE+2]]:16: Redefining a in the same scope.
+// CHECK:STDERR: fail_param_name_conflict.carbon:[[@LINE+1]]:8: Previous definition is here.
 fn Bar(a: i32, a: i32) {}

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
@@ -42,6 +42,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() -> i32 {
-  // CHECK:STDERR: toolchain/semantics/testdata/operators/fail_type_mismatch.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `i32` to `f64`.
+  // CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `i32` to `f64`.
   return 12 + 3.4;
 }

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
@@ -49,6 +49,6 @@
 fn Main() -> i32 {
   // The following line has two mismatches, but after the first, it shouldn't
   // keep erroring.
-  // CHECK:STDERR: toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `i32` to `f64`.
+  // CHECK:STDERR: fail_type_mismatch_once.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `i32` to `f64`.
   return 12 + 3.4 + 12;
 }

--- a/toolchain/semantics/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/return/fail_type_mismatch.carbon
@@ -37,6 +37,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() -> i32 {
-  // CHECK:STDERR: toolchain/semantics/testdata/return/fail_type_mismatch.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `f64` to `i32`.
+  // CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+1]]:13: Cannot implicitly convert from `f64` to `i32`.
   return 1.0;
 }

--- a/toolchain/semantics/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/semantics/testdata/return/fail_value_disallowed.carbon
@@ -37,7 +37,7 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/return/fail_value_disallowed.carbon:[[@LINE+2]]:11: No return expression should be provided in this context.
-  // CHECK:STDERR: toolchain/semantics/testdata/return/fail_value_disallowed.carbon:[[@LINE-2]]:1: There was no return type provided.
+  // CHECK:STDERR: fail_value_disallowed.carbon:[[@LINE+2]]:11: No return expression should be provided in this context.
+  // CHECK:STDERR: fail_value_disallowed.carbon:[[@LINE-2]]:1: There was no return type provided.
   return 0;
 }

--- a/toolchain/semantics/testdata/return/fail_value_missing.carbon
+++ b/toolchain/semantics/testdata/return/fail_value_missing.carbon
@@ -34,6 +34,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() -> i32 {
-  // CHECK:STDERR: toolchain/semantics/testdata/return/fail_value_missing.carbon:[[@LINE+1]]:9: Must return a i32.
+  // CHECK:STDERR: fail_value_missing.carbon:[[@LINE+1]]:9: Must return a i32.
   return;
 }

--- a/toolchain/semantics/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/semantics/testdata/struct/fail_assign_empty.carbon
@@ -40,5 +40,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_assign_empty.carbon:[[@LINE+1]]:22: Cannot implicitly convert from `{} as Type` to `{.a: i32}`.
+// CHECK:STDERR: fail_assign_empty.carbon:[[@LINE+1]]:22: Cannot implicitly convert from `{} as Type` to `{.a: i32}`.
 var x: {.a: i32} = {};

--- a/toolchain/semantics/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/semantics/testdata/struct/fail_assign_to_empty.carbon
@@ -49,5 +49,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_assign_to_empty.carbon:[[@LINE+1]]:21: Cannot implicitly convert from `{.a: i32}` to `{} as Type`.
+// CHECK:STDERR: fail_assign_to_empty.carbon:[[@LINE+1]]:21: Cannot implicitly convert from `{.a: i32}` to `{} as Type`.
 var x: {} = {.a = 1};

--- a/toolchain/semantics/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/semantics/testdata/struct/fail_field_name_mismatch.carbon
@@ -59,5 +59,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_field_name_mismatch.carbon:[[@LINE+1]]:28: Cannot implicitly convert from `{.b: i32}` to `{.a: i32}`.
+// CHECK:STDERR: fail_field_name_mismatch.carbon:[[@LINE+1]]:28: Cannot implicitly convert from `{.b: i32}` to `{.a: i32}`.
 var x: {.a: i32} = {.b = 1};

--- a/toolchain/semantics/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/struct/fail_field_type_mismatch.carbon
@@ -59,5 +59,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_field_type_mismatch.carbon:[[@LINE+1]]:30: Cannot implicitly convert from `{.b: f64}` to `{.a: i32}`.
+// CHECK:STDERR: fail_field_type_mismatch.carbon:[[@LINE+1]]:30: Cannot implicitly convert from `{.b: f64}` to `{.a: i32}`.
 var x: {.a: i32} = {.b = 1.0};

--- a/toolchain/semantics/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/semantics/testdata/struct/fail_member_access_type.carbon
@@ -67,5 +67,5 @@
 // CHECK:STDOUT: ]
 
 var x: {.a: f64} = {.a = 4.0};
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_member_access_type.carbon:[[@LINE+1]]:15: Type `{.a: f64}` does not have a member `b`.
+// CHECK:STDERR: fail_member_access_type.carbon:[[@LINE+1]]:15: Type `{.a: f64}` does not have a member `b`.
 var y: i32 = x.b;

--- a/toolchain/semantics/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/semantics/testdata/struct/fail_non_member_access.carbon
@@ -67,5 +67,5 @@
 // CHECK:STDOUT: ]
 
 var x: {.a: i32} = {.a = 4};
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_non_member_access.carbon:[[@LINE+1]]:15: Type `{.a: i32}` does not have a member `b`.
+// CHECK:STDERR: fail_non_member_access.carbon:[[@LINE+1]]:15: Type `{.a: i32}` does not have a member `b`.
 var y: i32 = x.b;

--- a/toolchain/semantics/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/semantics/testdata/struct/fail_too_few_values.carbon
@@ -62,5 +62,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_too_few_values.carbon:[[@LINE+1]]:37: Cannot implicitly convert from `{.a: i32}` to `{.a: i32, .b: i32}`.
+// CHECK:STDERR: fail_too_few_values.carbon:[[@LINE+1]]:37: Cannot implicitly convert from `{.a: i32}` to `{.a: i32, .b: i32}`.
 var x: {.a: i32, .b: i32} = {.a = 1};

--- a/toolchain/semantics/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/semantics/testdata/struct/fail_type_assign.carbon
@@ -49,5 +49,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_type_assign.carbon:[[@LINE+1]]:29: Cannot implicitly convert from `Type` to `{.a: i32}`.
+// CHECK:STDERR: fail_type_assign.carbon:[[@LINE+1]]:29: Cannot implicitly convert from `Type` to `{.a: i32}`.
 var x: {.a: i32} = {.a: i32};

--- a/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
@@ -47,5 +47,5 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: toolchain/semantics/testdata/struct/fail_value_as_type.carbon:[[@LINE+1]]:15: Cannot implicitly convert from `{.a: i32}` to `Type`.
+// CHECK:STDERR: fail_value_as_type.carbon:[[@LINE+1]]:15: Cannot implicitly convert from `{.a: i32}` to `Type`.
 var x: {.a = 1};

--- a/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
@@ -53,7 +53,7 @@
 
 fn Main() {
   var x: i32 = 0;
-  // CHECK:STDERR: toolchain/semantics/testdata/var/fail_duplicate_decl.carbon:[[@LINE+2]]:7: Redefining x in the same scope.
-  // CHECK:STDERR: toolchain/semantics/testdata/var/fail_duplicate_decl.carbon:[[@LINE-2]]:7: Previous definition is here.
+  // CHECK:STDERR: fail_duplicate_decl.carbon:[[@LINE+2]]:7: Redefining x in the same scope.
+  // CHECK:STDERR: fail_duplicate_decl.carbon:[[@LINE-2]]:7: Previous definition is here.
   var x: i32 = 0;
 }

--- a/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
@@ -42,6 +42,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon:[[@LINE+1]]:19: Cannot implicitly convert from `f64` to `i32`.
+  // CHECK:STDERR: fail_init_type_mismatch.carbon:[[@LINE+1]]:19: Cannot implicitly convert from `f64` to `i32`.
   var x: i32 = 1.0;
 }

--- a/toolchain/semantics/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_with_self.carbon
@@ -39,6 +39,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/var/fail_init_with_self.carbon:[[@LINE+1]]:16: Name x not found
+  // CHECK:STDERR: fail_init_with_self.carbon:[[@LINE+1]]:16: Name x not found
   var x: i32 = x;
 }

--- a/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
@@ -47,5 +47,5 @@ fn Main() {
   var x: i32;
 }
 
-// CHECK:STDERR: toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon:[[@LINE+1]]:14: Name x not found
+// CHECK:STDERR: fail_lookup_outside_scope.carbon:[[@LINE+1]]:14: Name x not found
 var y: i32 = x;

--- a/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
@@ -45,6 +45,6 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: toolchain/semantics/testdata/var/fail_storage_is_literal.carbon:[[@LINE+1]]:10: Cannot implicitly convert from `i32` to `Type`.
+  // CHECK:STDERR: fail_storage_is_literal.carbon:[[@LINE+1]]:10: Cannot implicitly convert from `i32` to `Type`.
   var x: 1 = 1;
 }


### PR DESCRIPTION
The intent of this change is that instead of paths looking like `explorer/testdata/foo/bar.carbon` (repo-relative), they're now just `bar.carbon` (local). The consequence is that paths should be a bit more durable in various environments, and just paths should be shorter and easier to read.

The explorer's prelude is an exception to this since it comes from data, rather than being the test target. Due to the change in approaches, it needs the regex again.

Uses #2829