### PR TITLE
Add lowering for empty struct values.

### DIFF
--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -19,7 +19,8 @@ LoweringContext::LoweringContext(llvm::LLVMContext& llvm_context,
       builder_(llvm_context),
       semantics_ir_(&semantics_ir),
       vlog_stream_(vlog_stream),
-      lowered_nodes_(semantics_ir_->nodes_size(), nullptr) {
+      lowered_nodes_(semantics_ir_->nodes_size(), nullptr),
+      lowered_callables_(semantics_ir_->callables_size(), nullptr) {
   CARBON_CHECK(!semantics_ir.has_errors())
       << "Generating LLVM IR from invalid SemanticsIR is unsupported.";
 }

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -34,11 +34,8 @@ class LoweringContext {
   auto GetLoweredNodeAsType(SemanticsNodeId node_id) -> llvm::Type*;
 
   // Returns a value for the given node.
-  auto GetLoweredNodeAsValue(SemanticsNodeId node_id) -> llvm::Value* {
-    CARBON_CHECK(lowered_nodes_[node_id.index].is<llvm::Value*>())
-        << node_id << ": isNull == " << lowered_nodes_[node_id.index].isNull();
-    return lowered_nodes_[node_id.index].get<llvm::Value*>();
-  }
+  auto GetLoweredNodeAsValue(SemanticsNodeId node_id) -> llvm::Value*;
+
   // Sets the value for the given node.
   auto SetLoweredNodeAsValue(SemanticsNodeId node_id, llvm::Value* value) {
     CARBON_CHECK(lowered_nodes_[node_id.index].isNull()) << node_id;

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -45,6 +45,21 @@ class LoweringContext {
     lowered_nodes_[node_id.index] = value;
   }
 
+  // Gets a callable's function.
+  auto GetLoweredCallable(SemanticsCallableId callable_id) -> llvm::Function* {
+    CARBON_CHECK(lowered_callables_[callable_id.index] != nullptr)
+        << callable_id;
+    return lowered_callables_[callable_id.index];
+  }
+
+  // Sets a callable's function.
+  auto SetLoweredCallable(SemanticsCallableId callable_id,
+                          llvm::Function* function) {
+    CARBON_CHECK(lowered_callables_[callable_id.index] == nullptr)
+        << callable_id;
+    lowered_callables_[callable_id.index] = function;
+  }
+
   auto llvm_context() -> llvm::LLVMContext& { return *llvm_context_; }
   auto llvm_module() -> llvm::Module& { return *llvm_module_; }
   auto builder() -> llvm::IRBuilder<>& { return builder_; }
@@ -86,6 +101,10 @@ class LoweringContext {
   // unclear.
   llvm::SmallVector<llvm::PointerUnion<llvm::Type*, llvm::Value*>>
       lowered_nodes_;
+
+  // Maps callables to lowered functions. Semantics treats callables as the
+  // canonical form of a function, so lowering needs to do the same.
+  llvm::SmallVector<llvm::Function*> lowered_callables_;
 };
 
 // Declare handlers for each SemanticsIR node.

--- a/toolchain/lowering/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lowering/testdata/function/call/empty_struct.carbon
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
+// CHECK:STDOUT: source_filename = "empty_struct.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT: %EmptyStructType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Echo(%EmptyStructType %a) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Echo = call %EmptyTupleType @Echo(%EmptyStructType zeroinitializer)
+// CHECK:STDOUT: }
+
+fn Echo(a: {}) {
+}
+
+fn Main() {
+  Echo({});
+}

--- a/toolchain/lowering/testdata/function/call/i32.carbon
+++ b/toolchain/lowering/testdata/function/call/i32.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'i32.carbon'
+// CHECK:STDOUT: source_filename = "i32.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define i32 @Echo(i32 %a) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %var = alloca i32, align 4
+// CHECK:STDOUT:   %Echo = call i32 @Echo(i32 1)
+// CHECK:STDOUT:   store i32 %Echo, ptr %var, align 4
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder i32 1, { 1, 2, 0 }
+
+fn Echo(a: i32) -> i32 {
+  // TODO: `return a;` requires the parameter to be in name lookup.
+  return 1;
+}
+
+fn Main() {
+  var b: i32 = Echo(1);
+}

--- a/toolchain/lowering/testdata/function/call/params_one.carbon
+++ b/toolchain/lowering/testdata/function/call/params_one.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
+// CHECK:STDOUT: source_filename = "params_one.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Foo(i32 %a) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Foo = call %EmptyTupleType @Foo(i32 1)
+// CHECK:STDOUT: }
+
+fn Foo(a: i32) {}
+
+fn Main() {
+  Foo(1);
+}

--- a/toolchain/lowering/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/lowering/testdata/function/call/params_one_comma.carbon
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'params_one_comma.carbon'
+// CHECK:STDOUT: source_filename = "params_one_comma.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Foo(i32 %a) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Foo = call %EmptyTupleType @Foo(i32 1)
+// CHECK:STDOUT:   %Foo1 = call %EmptyTupleType @Foo(i32 1)
+// CHECK:STDOUT: }
+
+fn Foo(a: i32,) {}
+
+fn Main() {
+  Foo(1);
+  Foo(1,);
+}

--- a/toolchain/lowering/testdata/function/call/params_two.carbon
+++ b/toolchain/lowering/testdata/function/call/params_two.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
+// CHECK:STDOUT: source_filename = "params_two.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Foo(i32 %a, i32 %b) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Foo = call %EmptyTupleType @Foo(i32 1, i32 2)
+// CHECK:STDOUT: }
+
+fn Foo(a: i32, b: i32) {}
+
+fn Main() {
+  Foo(1, 2);
+}

--- a/toolchain/lowering/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/lowering/testdata/function/call/params_two_comma.carbon
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'params_two_comma.carbon'
+// CHECK:STDOUT: source_filename = "params_two_comma.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Foo(i32 %a, i32 %b) {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Foo = call %EmptyTupleType @Foo(i32 1, i32 2)
+// CHECK:STDOUT:   %Foo1 = call %EmptyTupleType @Foo(i32 1, i32 2)
+// CHECK:STDOUT: }
+
+fn Foo(a: i32, b: i32,) {}
+
+fn Main() {
+  Foo(1, 2);
+  Foo(1, 2,);
+}

--- a/toolchain/lowering/testdata/function/call/params_zero.carbon
+++ b/toolchain/lowering/testdata/function/call/params_zero.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
+// CHECK:STDOUT: source_filename = "params_zero.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: %EmptyTupleType = type {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Foo() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define %EmptyTupleType @Main() {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Foo = call %EmptyTupleType @Foo()
+// CHECK:STDOUT: }
+
+fn Foo() {}
+
+fn Main() {
+  Foo();
+}

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -163,6 +163,7 @@ class SemanticsIR {
   // Produces a string version of a node.
   auto StringifyNode(SemanticsNodeId node_id) -> std::string;
 
+  auto callables_size() const -> int { return callables_.size(); }
   auto nodes_size() const -> int { return nodes_.size(); }
 
   // The node blocks, for direct mutation.


### PR DESCRIPTION
I'm not sure this is really the best approach, as noted by the TODO. While it does reduce the generated IR in many cases (especially if we start eliding `()` in favor of void), it increases the amount of code in a common function which may have higher impact on performance. I was leaning towards the idea that review would favor the former for now, lacking benchmarking supporting adding unused content to the IR.