### PR TITLE
Add real type

### DIFF
--- a/common/fuzzing/carbon.proto
+++ b/common/fuzzing/carbon.proto
@@ -119,6 +119,12 @@ message IntLiteral {
   optional int64 value = 1;
 }
 
+message RealTypeLiteral {}
+
+message RealLiteral {
+  optional double value = 1;
+}
+
 message StringLiteral {
   optional string value = 1;
 }
@@ -185,6 +191,8 @@ message Expression {
     CompoundMemberAccessExpression compound_member_access = 21;
     WhereExpression where = 22;
     DesignatorExpression designator = 23;
+    RealTypeLiteral real_type_literal = 24;
+    RealLiteral real_literal = 25;
   }
 }
 

--- a/common/fuzzing/proto_to_carbon.cpp
+++ b/common/fuzzing/proto_to_carbon.cpp
@@ -360,6 +360,15 @@ static auto ExpressionToCarbon(const Fuzzing::Expression& expression,
       break;
     }
 
+    case Fuzzing::Expression::kRealTypeLiteral:
+      out << "f64";
+      break;
+
+    case Fuzzing::Expression::kRealLiteral: {
+      out << expression.real_literal().value();
+      break;
+    }
+
     case Fuzzing::Expression::kStringLiteral:
       StringLiteralToCarbon(expression.string_literal().value(), out);
       break;

--- a/explorer/ast/ast_kinds.h
+++ b/explorer/ast/ast_kinds.h
@@ -122,6 +122,8 @@
   FINAL(IndexExpression)                               \
   FINAL(IntTypeLiteral)                                \
   FINAL(IntLiteral)                                    \
+  FINAL(RealTypeLiteral)                               \
+  FINAL(RealLiteral)                                   \
   FINAL(OperatorExpression)                            \
   FINAL(StringLiteral)                                 \
   FINAL(StringTypeLiteral)                             \

--- a/explorer/ast/expression.cpp
+++ b/explorer/ast/expression.cpp
@@ -294,9 +294,11 @@ void Expression::Print(llvm::raw_ostream& out) const {
     case ExpressionKind::IdentifierExpression:
     case ExpressionKind::DotSelfExpression:
     case ExpressionKind::IntLiteral:
+    case ExpressionKind::RealLiteral:
     case ExpressionKind::BoolLiteral:
     case ExpressionKind::BoolTypeLiteral:
     case ExpressionKind::IntTypeLiteral:
+    case ExpressionKind::RealTypeLiteral:
     case ExpressionKind::StringLiteral:
     case ExpressionKind::StringTypeLiteral:
     case ExpressionKind::TypeTypeLiteral:
@@ -317,6 +319,9 @@ void Expression::PrintID(llvm::raw_ostream& out) const {
     case ExpressionKind::IntLiteral:
       out << cast<IntLiteral>(*this).value();
       break;
+    case ExpressionKind::RealLiteral:
+      out << cast<RealLiteral>(*this).value();
+      break;
     case ExpressionKind::BoolLiteral:
       out << (cast<BoolLiteral>(*this).value() ? "true" : "false");
       break;
@@ -325,6 +330,9 @@ void Expression::PrintID(llvm::raw_ostream& out) const {
       break;
     case ExpressionKind::IntTypeLiteral:
       out << "i32";
+      break;
+    case ExpressionKind::RealTypeLiteral:
+      out << "f64";
       break;
     case ExpressionKind::StringLiteral:
       out << "\"";

--- a/explorer/ast/expression.h
+++ b/explorer/ast/expression.h
@@ -515,6 +515,24 @@ class IntLiteral : public Expression {
   int value_;
 };
 
+class RealLiteral : public Expression {
+ public:
+  explicit RealLiteral(SourceLocation source_loc, double value)
+      : Expression(AstNodeKind::RealLiteral, source_loc), value_(value) {}
+
+  explicit RealLiteral(CloneContext& context, const RealLiteral& other)
+      : Expression(context, other), value_(other.value_) {}
+
+  static auto classof(const AstNode* node) -> bool {
+    return InheritsFromRealLiteral(node->kind());
+  }
+
+  auto value() const -> double { return value_; }
+
+ private:
+  double value_;
+};
+
 class BoolLiteral : public Expression {
  public:
   explicit BoolLiteral(SourceLocation source_loc, bool value)
@@ -814,6 +832,19 @@ class IntTypeLiteral : public Expression {
 
   static auto classof(const AstNode* node) -> bool {
     return InheritsFromIntTypeLiteral(node->kind());
+  }
+};
+
+class RealTypeLiteral : public Expression {
+ public:
+  explicit RealTypeLiteral(SourceLocation source_loc)
+      : Expression(AstNodeKind::RealTypeLiteral, source_loc) {}
+
+  explicit RealTypeLiteral(CloneContext& context, const RealTypeLiteral& other)
+      : Expression(context, other) {}
+
+  static auto classof(const AstNode* node) -> bool {
+    return InheritsFromRealTypeLiteral(node->kind());
   }
 };
 

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -428,6 +428,9 @@ void Value::Print(llvm::raw_ostream& out) const {
     case Value::Kind::IntValue:
       out << cast<IntValue>(*this).value();
       break;
+    case Value::Kind::RealValue:
+      out << cast<RealValue>(*this).value();
+      break;
     case Value::Kind::BoolValue:
       out << (cast<BoolValue>(*this).value() ? "true" : "false");
       break;
@@ -491,6 +494,9 @@ void Value::Print(llvm::raw_ostream& out) const {
       break;
     case Value::Kind::IntType:
       out << "i32";
+      break;
+    case Value::Kind::RealType:
+      out << "f64";
       break;
     case Value::Kind::TypeType:
       out << "type";
@@ -866,6 +872,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
       return true;
     }
     case Value::Kind::IntType:
+    case Value::Kind::RealType:
     case Value::Kind::BoolType:
     case Value::Kind::TypeType:
     case Value::Kind::StringType:
@@ -881,6 +888,7 @@ auto TypeEqual(Nonnull<const Value*> t1, Nonnull<const Value*> t2,
              array1.size() == array2.size();
     }
     case Value::Kind::IntValue:
+    case Value::Kind::RealValue:
     case Value::Kind::BoolValue:
     case Value::Kind::DestructorValue:
     case Value::Kind::FunctionValue:
@@ -931,6 +939,8 @@ auto ValueStructurallyEqual(
   switch (v1->kind()) {
     case Value::Kind::IntValue:
       return cast<IntValue>(*v1).value() == cast<IntValue>(*v2).value();
+    case Value::Kind::RealValue:
+      return cast<RealValue>(*v1).value() == cast<RealValue>(*v2).value();
     case Value::Kind::BoolValue:
       return cast<BoolValue>(*v1).value() == cast<BoolValue>(*v2).value();
     case Value::Kind::FunctionValue: {
@@ -1013,6 +1023,7 @@ auto ValueStructurallyEqual(
              TypeEqual(&assoc1.interface(), &assoc2.interface(), equality_ctx);
     }
     case Value::Kind::IntType:
+    case Value::Kind::RealType:
     case Value::Kind::BoolType:
     case Value::Kind::TypeType:
     case Value::Kind::FunctionType:

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -142,6 +142,26 @@ class IntValue : public Value {
   int value_;
 };
 
+// An real value.
+class RealValue : public Value {
+ public:
+  explicit RealValue(double value) : Value(Kind::RealValue), value_(value) {}
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::RealValue;
+  }
+
+  template <typename F>
+  auto Decompose(F f) const {
+    return f(value_);
+  }
+
+  auto value() const -> double { return value_; }
+
+ private:
+  double value_;
+};
+
 // A function or bound method value.
 class FunctionOrMethodValue : public Value {
  public:
@@ -569,6 +589,21 @@ class IntType : public Value {
 
   static auto classof(const Value* value) -> bool {
     return value->kind() == Kind::IntType;
+  }
+
+  template <typename F>
+  auto Decompose(F f) const {
+    return f();
+  }
+};
+
+// The real type.
+class RealType : public Value {
+ public:
+  RealType() : Value(Kind::RealType) {}
+
+  static auto classof(const Value* value) -> bool {
+    return value->kind() == Kind::RealType;
   }
 
   template <typename F>

--- a/explorer/ast/value_kinds.def
+++ b/explorer/ast/value_kinds.def
@@ -11,6 +11,7 @@
 #endif
 
 CARBON_VALUE_KIND(IntValue)
+CARBON_VALUE_KIND(RealValue)
 CARBON_VALUE_KIND(FunctionValue)
 CARBON_VALUE_KIND(DestructorValue)
 CARBON_VALUE_KIND(BoundMethodValue)
@@ -27,6 +28,7 @@ CARBON_VALUE_KIND(BindingWitness)
 CARBON_VALUE_KIND(ConstraintWitness)
 CARBON_VALUE_KIND(ConstraintImplWitness)
 CARBON_VALUE_KIND(IntType)
+CARBON_VALUE_KIND(RealType)
 CARBON_VALUE_KIND(BoolType)
 CARBON_VALUE_KIND(TypeType)
 CARBON_VALUE_KIND(FunctionType)

--- a/explorer/fuzzing/ast_to_proto.cpp
+++ b/explorer/fuzzing/ast_to_proto.cpp
@@ -326,8 +326,17 @@ static auto ExpressionToProto(const Expression& expression)
       expression_proto.mutable_int_type_literal();
       break;
 
+    case ExpressionKind::RealTypeLiteral:
+      expression_proto.mutable_real_type_literal();
+      break;
+
     case ExpressionKind::IntLiteral:
       expression_proto.mutable_int_literal()->set_value(
+          cast<IntLiteral>(expression).value());
+      break;
+
+    case ExpressionKind::RealLiteral:
+      expression_proto.mutable_real_literal()->set_value(
           cast<IntLiteral>(expression).value());
       break;
 

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -419,7 +419,9 @@ auto NameResolver::ResolveNames(Expression& expression,
     case ExpressionKind::BoolTypeLiteral:
     case ExpressionKind::BoolLiteral:
     case ExpressionKind::IntTypeLiteral:
+    case ExpressionKind::RealTypeLiteral:
     case ExpressionKind::IntLiteral:
+    case ExpressionKind::RealLiteral:
     case ExpressionKind::StringLiteral:
     case ExpressionKind::StringTypeLiteral:
     case ExpressionKind::TypeTypeLiteral:

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -128,9 +128,11 @@ static auto ResolveUnformed(Nonnull<const Expression*> expression,
       break;
     case ExpressionKind::DotSelfExpression:
     case ExpressionKind::IntLiteral:
+    case ExpressionKind::RealLiteral:
     case ExpressionKind::BoolLiteral:
     case ExpressionKind::BoolTypeLiteral:
     case ExpressionKind::IntTypeLiteral:
+    case ExpressionKind::RealTypeLiteral:
     case ExpressionKind::StringLiteral:
     case ExpressionKind::StringTypeLiteral:
     case ExpressionKind::TypeTypeLiteral:

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -66,14 +66,11 @@ auto TypeChecker::ExpectOneOfTypes(SourceLocation source_loc,
     }
   }
   if (!match) {
-    auto res = ProgramError(source_loc) << "type error in " << context << "\n"
-                                        << "expected:";
-    for (Nonnull<const Value*> expect : expected) {
-      res << " " << *expect;
-    }
-    res << "\n";
-    res << "actual: " << *actual;
-    return res;
+    return ProgramError(source_loc) << "type error in " << context << "\n"
+                                    << "expected: "
+                                    << "i32 or f64"
+                                    << "\n"
+                                    << "actual: " << *actual;
   }
   return Success();
 }
@@ -3656,10 +3653,11 @@ auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
               e->source_loc(), "Print argument 0", arena_->New<StringType>(),
               &args[0]->static_type(), impl_scope));
           if (args.size() >= 2) {
-            CARBON_RETURN_IF_ERROR(ExpectOneOfTypes(
-                e->source_loc(), "Print argument 1",
-                {arena_->New<IntType>(), arena_->New<RealType>()},
-                &args[1]->static_type(), impl_scope));
+            std::vector<Nonnull<const Value*>> expected = {
+                arena_->New<IntType>(), arena_->New<RealType>()};
+            CARBON_RETURN_IF_ERROR(
+                ExpectOneOfTypes(e->source_loc(), "Print argument 1", expected,
+                                 &args[1]->static_type(), impl_scope));
           }
           e->set_static_type(TupleType::Empty());
           e->set_expression_category(ExpressionCategory::Value);

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -446,6 +446,13 @@ class TypeChecker {
   auto IsSameType(Nonnull<const Value*> type1, Nonnull<const Value*> type2,
                   const ImplScope& impl_scope) const -> bool;
 
+  // Check whether `actual` is one of types in `expected` and halt with a
+  // fatal compilation error if it is not.
+  auto ExpectOneOfTypes(SourceLocation source_loc, std::string_view context,
+                        std::vector<Nonnull<const Value*>> expected,
+                        Nonnull<const Value*> actual,
+                        const ImplScope& impl_scope) const -> ErrorOr<Success>;
+
   // Check whether `actual` is the same type as `expected` and halt with a
   // fatal compilation error if it is not.
   auto ExpectExactType(SourceLocation source_loc, std::string_view context,

--- a/explorer/syntax/lexer.lpp
+++ b/explorer/syntax/lexer.lpp
@@ -135,6 +135,7 @@ identifier            [A-Za-z_][A-Za-z0-9_]*
 intrinsic_identifier  (Print|__intrinsic_[A-Za-z0-9_]*)
 sized_type_literal    [iuf][1-9][0-9]*
 integer_literal       [0-9]+
+real_literal          [0-9]+\.[0-9]+
 horizontal_whitespace [ \t\r]
 whitespace            [ \t\r\n]
 one_line_comment      \/\/[^\n]*\n
@@ -328,6 +329,16 @@ operand_start         [(A-Za-z0-9_\"]
         llvm::formatv("Invalid integer literal: {0}", yytext));
   }
   return CARBON_ARG_TOKEN(integer_literal, val);
+}
+
+{real_literal} {
+  BEGIN(AFTER_OPERAND);
+  double val = 0;
+  if (!llvm::to_float(yytext, val)) {
+    return context.RecordSyntaxError(
+        llvm::formatv("Invalid real literal: {0}", yytext));
+  }
+  return CARBON_ARG_TOKEN(real_literal, val);
 }
 
 #*\" {

--- a/explorer/syntax/parser.ypp
+++ b/explorer/syntax/parser.ypp
@@ -92,6 +92,7 @@
 }  // %code
 
 %token <int> integer_literal
+%token <double> real_literal
 %token <std::string> identifier
 %token <IntrinsicExpression::Intrinsic> intrinsic_identifier
 %token <std::string> sized_type_literal
@@ -381,6 +382,8 @@ primary_expression:
     { $$ = arena->New<DotSelfExpression>(context.source_loc()); }
 | integer_literal
     { $$ = arena->New<IntLiteral>(context.source_loc(), $[integer_literal]); }
+| real_literal
+    { $$ = arena->New<RealLiteral>(context.source_loc(), $[real_literal]); }
 | string_literal
     { $$ = arena->New<StringLiteral>(context.source_loc(), $[string_literal]); }
 | TRUE
@@ -395,12 +398,15 @@ primary_expression:
         context.RecordSyntaxError(
             llvm::formatv("Invalid type literal: {0}", $[sized_type_literal]));
         YYERROR;
-      } else if ($[sized_type_literal][0] != 'i' || val != 32) {
-        context.RecordSyntaxError(llvm::formatv(
-            "Only i32 is supported for now: {0}", $[sized_type_literal]));
-        YYERROR;
-      } else {
+      } else if ($[sized_type_literal][0] == 'i' && val == 32) {
         $$ = arena->New<IntTypeLiteral>(context.source_loc());
+      } else if ($[sized_type_literal][0] == 'f' && val == 64) {
+        $$ = arena->New<RealTypeLiteral>(context.source_loc());
+      } else {
+        context.RecordSyntaxError(
+            llvm::formatv("Only i32 and f64 is supported for now: {0}",
+                          $[sized_type_literal]));
+        YYERROR;
       }
     }
 | SELF

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 is supported for now: i64
+  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 and f64 is supported for now: i64
   var x: i64 = 1;
   return 0;
 }

--- a/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
+++ b/explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon
@@ -7,7 +7,7 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: SYNTAX ERROR: explorer/testdata/basic_syntax/fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 and f64 is supported for now: i64
+  // CHECK:STDERR: SYNTAX ERROR: fail_unsupported_integer_type.carbon:[[@LINE+1]]: Only i32 and f64 is supported for now: i64
   var x: i64 = 1;
   return 0;
 }

--- a/explorer/testdata/print/f64.carbon
+++ b/explorer/testdata/print/f64.carbon
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
+// CHECK:STDOUT: Printing 1.10
+// CHECK:STDOUT: Printing 1.01
+// CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_type.carbon:[[@LINE+2]]: type error in Print argument 1
-  // CHECK:STDERR: expected:
-  Print("{0}", {.x = 1});
+  Print("Printing {0}", 1.1);
+  Print("Printing {0}", 1.01);
   return 0;
 }

--- a/explorer/testdata/print/fail_intrinsic_type.carbon
+++ b/explorer/testdata/print/fail_intrinsic_type.carbon
@@ -7,9 +7,8 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_type.carbon:[[@LINE+3]]: type error in Print argument 1
-  // CHECK:STDERR: expected: i32
-  // CHECK:STDERR: actual: {.x: i32}
+  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_type.carbon:[[@LINE+2]]: type error in Print argument 1
+  // CHECK:STDERR: expected:
   __intrinsic_print("{0}", {.x = 1});
   return 0;
 }

--- a/explorer/testdata/print/fail_intrinsic_type.carbon
+++ b/explorer/testdata/print/fail_intrinsic_type.carbon
@@ -7,8 +7,9 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_intrinsic_type.carbon:[[@LINE+2]]: type error in Print argument 1
-  // CHECK:STDERR: expected:
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_type.carbon:[[@LINE+3]]: type error in Print argument 1
+  // CHECK:STDERR: expected: i32 or f64
+  // CHECK:STDERR: actual: {.x: i32}
   __intrinsic_print("{0}", {.x = 1});
   return 0;
 }

--- a/explorer/testdata/print/fail_type.carbon
+++ b/explorer/testdata/print/fail_type.carbon
@@ -7,8 +7,9 @@
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  // CHECK:STDERR: COMPILATION ERROR: explorer/testdata/print/fail_type.carbon:[[@LINE+2]]: type error in Print argument 1
-  // CHECK:STDERR: expected:
+  // CHECK:STDERR: COMPILATION ERROR: fail_type.carbon:[[@LINE+3]]: type error in Print argument 1
+  // CHECK:STDERR: expected: i32 or f64
+  // CHECK:STDERR: actual: {.x: i32}
   Print("{0}", {.x = 1});
   return 0;
 }

--- a/proposals/p0162.md
+++ b/proposals/p0162.md
@@ -113,6 +113,7 @@ expression:
 | expression '[' expression ']'
 | expression ':' identifier
 | integer_literal
+| real_literal
 | "true"
 | "false"
 | tuple


### PR DESCRIPTION
Support the real literal, real type.
And initialize to support print with real value.

  Current the ExpectOneOfTypes() will only check the type is
  i32 or f64, attemp to change the ProgramError() inside the function
  to for loop
  > error() << "i32 or f64" ;

  ->
  > for(auto *  expect : exptected) res << " " << expect;

  and return res at last will cause an error.
  Need to consider some better ways.

Also need some helps since the related fuzzing, proto may not fully handled yet.
It will be helpful if given the corresponding command.