### PR TITLE
fixed a linting error in action.cpp

### DIFF
--- a/explorer/interpreter/action.cpp
+++ b/explorer/interpreter/action.cpp
@@ -152,8 +152,8 @@ void Action::Print(llvm::raw_ostream& out) const {
     }
     out << "]]";
   }
-  if (this->scope().has_value()) {
-    out << " " << *this->scope();
+  if (scope_.has_value()) {
+    out << " " << *scope_;
   }
 }
 


### PR DESCRIPTION
There was a warning "Unchecked access to optional value" in this piece of code inside `action.cpp`
```cpp
  if (this->scope().has_value()) {
    out << " " << *this->scope();
  }
```
Fixed it by accessing `scope_` directly rather than using `this->scope()`.
