### PR TITLE
Make stack detection more reliable.

### DIFF
--- a/explorer/interpreter/stack_space.cpp
+++ b/explorer/interpreter/stack_space.cpp
@@ -16,10 +16,15 @@ static constexpr int64_t DesiredStackSpace = 8 << 20;
 static LLVM_THREAD_LOCAL intptr_t bottom_of_stack = 0;
 
 // Returns the current bottom of stack.
-static auto GetStackPointer() -> intptr_t {
+LLVM_NO_SANITIZE("address")
+LLVM_ATTRIBUTE_NOINLINE static auto GetStackPointer() -> intptr_t {
+#if __GNUC__ || __has_builtin(__builtin_frame_address)
+  return reinterpret_cast<intptr_t>(__builtin_frame_address(0));
+#else
   char char_on_stack = 0;
   char* volatile ptr = &char_on_stack;
   return reinterpret_cast<intptr_t>(ptr);
+#endif
 }
 
 auto IsStackSpaceNearlyExhausted() -> bool {


### PR DESCRIPTION
The old version wasn't compatible with ASan's instrumentation. Instead, use a builtin when available, and even in the fallback disable inlining and sanitizing as they can't do anything useful in this routine.

This fixes a confusing internal ASan error seen by some folks since the stack detection was added.
