### PR TITLE
Fixed typo in comments of numeric literal

### DIFF
--- a/toolchain/lexer/numeric_literal.cpp
+++ b/toolchain/lexer/numeric_literal.cpp
@@ -196,7 +196,7 @@ auto LexedNumericLiteral::Parser::Check() -> bool {
 //
 // Ignoring '.' is used when parsing a real literal. For example, when
 // parsing 123.456e7, we want to decompose it into an integer mantissa
-// (123456) and an exponent (7 - 3 = 2), and this routine is given the
+// (123456) and an exponent (7 - 3 = 4), and this routine is given the
 // "123.456" to parse as the mantissa.
 static auto ParseInteger(llvm::StringRef digits,
                          LexedNumericLiteral::Radix radix, bool needs_cleaning)


### PR DESCRIPTION
As I went through and analyzed the Carbon source code, I saw that there is typo in the comments, which may need to be modified to avoid misleading other people.
