### PR TITLE
Start refactoring type handling to track which types are in-use.

### DIFF
--- a/toolchain/driver/testdata/semantics_builtin_nodes.carbon
+++ b/toolchain/driver/testdata/semantics_builtin_nodes.carbon
@@ -13,6 +13,8 @@
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeTypeType, type: nodeTypeType},
 // CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeInvalidType, type: nodeInvalidType},

--- a/toolchain/semantics/semantics_handle.cpp
+++ b/toolchain/semantics/semantics_handle.cpp
@@ -223,7 +223,11 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
       auto id = context.semantics().AddIntegerLiteral(
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
-          parse_node, SemanticsNode::IntegerLiteral::Make(parse_node, id));
+          parse_node,
+          SemanticsNode::IntegerLiteral::Make(
+              parse_node,
+              context.CanonicalizeType(SemanticsNodeId::BuiltinIntegerType),
+              id));
       break;
     }
     case TokenKind::RealLiteral: {
@@ -233,14 +237,22 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
            .exponent = token_value.Exponent(),
            .is_decimal = token_value.IsDecimal()});
       context.AddNodeAndPush(parse_node,
-                             SemanticsNode::RealLiteral::Make(parse_node, id));
+                             SemanticsNode::RealLiteral::Make(
+                                 parse_node,
+                                 context.CanonicalizeType(
+                                     SemanticsNodeId::BuiltinFloatingPointType),
+                                 id));
       break;
     }
     case TokenKind::StringLiteral: {
       auto id = context.semantics().AddString(
           context.tokens().GetStringLiteral(token));
       context.AddNodeAndPush(
-          parse_node, SemanticsNode::StringLiteral::Make(parse_node, id));
+          parse_node,
+          SemanticsNode::StringLiteral::Make(
+              parse_node,
+              context.CanonicalizeType(SemanticsNodeId::BuiltinStringType),
+              id));
       break;
     }
     case TokenKind::IntegerTypeLiteral: {
@@ -352,8 +364,8 @@ auto SemanticsHandlePatternBinding(SemanticsContext& context,
                                    ParseTree::Node parse_node) -> bool {
   auto [type_node, parsed_type_id] =
       context.node_stack().PopForParseNodeAndNodeId();
-  SemanticsNodeId cast_type_id = context.ImplicitAsRequired(
-      type_node, parsed_type_id, SemanticsNodeId::BuiltinTypeType);
+  SemanticsNodeId cast_type_id =
+      context.ExpressionAsType(type_node, parsed_type_id);
 
   // Get the name.
   auto name_node = context.node_stack().PopForSoloParseNode();
@@ -447,8 +459,7 @@ auto SemanticsHandleReturnType(SemanticsContext& context,
   // Propagate the type expression.
   auto [type_parse_node, type_node_id] =
       context.node_stack().PopForParseNodeAndNodeId();
-  auto cast_node_id = context.ImplicitAsRequired(
-      type_parse_node, type_node_id, SemanticsNodeId::BuiltinTypeType);
+  auto cast_node_id = context.ExpressionAsType(type_parse_node, type_node_id);
   context.node_stack().Push(parse_node, cast_node_id);
   return true;
 }

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -109,6 +109,7 @@ auto SemanticsIR::Print(llvm::raw_ostream& out, bool include_builtins) const
   PrintList(out, "integer_literals", integer_literals_);
   PrintList(out, "real_literals", real_literals_);
   PrintList(out, "strings", strings_);
+  PrintList(out, "types", types_);
 
   out << "nodes: [\n";
   for (int i = include_builtins ? 0 : SemanticsBuiltinKind::ValidCount;

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -160,11 +160,18 @@ class SemanticsIR {
     return std::nullopt;
   }
 
+  // Adds a type.
+  auto AddType(SemanticsNodeId node_id) -> void { types_.push_back(node_id); }
+
   // Produces a string version of a node.
   auto StringifyNode(SemanticsNodeId node_id) -> std::string;
 
   auto callables_size() const -> int { return callables_.size(); }
   auto nodes_size() const -> int { return nodes_.size(); }
+
+  auto types() const -> const llvm::SmallVector<SemanticsNodeId>& {
+    return types_;
+  }
 
   // The node blocks, for direct mutation.
   auto node_blocks() -> llvm::SmallVector<llvm::SmallVector<SemanticsNodeId>>& {
@@ -205,6 +212,10 @@ class SemanticsIR {
   // string_to_id_ provides a mapping to identify strings.
   llvm::StringMap<SemanticsStringId> string_to_id_;
   llvm::SmallVector<llvm::StringRef> strings_;
+
+  // Nodes which correspond to in-use types. Stored separately for easy access
+  // by lowering.
+  llvm::SmallVector<SemanticsNodeId> types_;
 
   // All nodes. The first entries will always be cross-references to builtins,
   // at indices matching SemanticsBuiltinKind ordering.

--- a/toolchain/semantics/semantics_ir_test.cpp
+++ b/toolchain/semantics/semantics_ir_test.cpp
@@ -54,6 +54,7 @@ TEST(SemanticsIRTest, YAML) {
           Pair("integer_literals", Yaml::Sequence(ElementsAre("0"))),
           Pair("real_literals", Yaml::Sequence(IsEmpty())),
           Pair("strings", Yaml::Sequence(ElementsAre("x"))),
+          Pair("types", Yaml::Sequence(ElementsAre(node_builtin))),
           Pair(
               "nodes",
               Yaml::Sequence(AllOf(

--- a/toolchain/semantics/testdata/basics/builtin_types.carbon
+++ b/toolchain/semantics/testdata/basics/builtin_types.carbon
@@ -18,6 +18,11 @@
 // CHECK:STDOUT:   test_str,
 // CHECK:STDOUT:   Test,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT:   nodeStringType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/basics/empty.carbon
+++ b/toolchain/semantics/testdata/basics/empty.carbon
@@ -12,6 +12,8 @@
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: node_blocks: [

--- a/toolchain/semantics/testdata/basics/empty_decl.carbon
+++ b/toolchain/semantics/testdata/basics/empty_decl.carbon
@@ -12,6 +12,8 @@
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: node_blocks: [

--- a/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/semantics/testdata/basics/fail_name_lookup.carbon
@@ -14,6 +14,8 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node+0, arg1: block0},

--- a/toolchain/semantics/testdata/designators/fail_unsupported.carbon
+++ b/toolchain/semantics/testdata/designators/fail_unsupported.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/empty_struct.carbon
+++ b/toolchain/semantics/testdata/function/call/empty_struct.carbon
@@ -17,6 +17,9 @@
 // CHECK:STDOUT:   Echo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeEmptyStructType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeEmptyStructType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeEmptyStructType},

--- a/toolchain/semantics/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_param_count.carbon
@@ -28,6 +28,9 @@
 // CHECK:STDOUT:   Run2,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node+0, arg1: block0},

--- a/toolchain/semantics/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_param_type.carbon
@@ -18,6 +18,10 @@
 // CHECK:STDOUT:   Run,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/function/call/fail_return_type_mismatch.carbon
@@ -18,6 +18,10 @@
 // CHECK:STDOUT:   Run,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: RealLiteral, arg0: real0, type: nodeFloatingPointType},

--- a/toolchain/semantics/testdata/function/call/i32.carbon
+++ b/toolchain/semantics/testdata/function/call/i32.carbon
@@ -19,6 +19,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/semantics/testdata/function/call/more_param_ir.carbon
@@ -25,6 +25,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/params_one.carbon
+++ b/toolchain/semantics/testdata/function/call/params_one.carbon
@@ -18,6 +18,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/semantics/testdata/function/call/params_one_comma.carbon
@@ -19,6 +19,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/params_two.carbon
+++ b/toolchain/semantics/testdata/function/call/params_two.carbon
@@ -20,6 +20,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/semantics/testdata/function/call/params_two_comma.carbon
@@ -22,6 +22,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/call/params_zero.carbon
+++ b/toolchain/semantics/testdata/function/call/params_zero.carbon
@@ -16,6 +16,8 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node+0, arg1: block0},

--- a/toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/semantics/testdata/function/definition/fail_param_name_conflict.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   Bar,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/definition/order.carbon
+++ b/toolchain/semantics/testdata/function/definition/order.carbon
@@ -18,6 +18,8 @@
 // CHECK:STDOUT:   Bar,
 // CHECK:STDOUT:   Baz,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node+0, arg1: block0},

--- a/toolchain/semantics/testdata/function/definition/params_one.carbon
+++ b/toolchain/semantics/testdata/function/definition/params_one.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/definition/params_one_comma.carbon
+++ b/toolchain/semantics/testdata/function/definition/params_one_comma.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/definition/params_two.carbon
+++ b/toolchain/semantics/testdata/function/definition/params_two.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/definition/params_two_comma.carbon
+++ b/toolchain/semantics/testdata/function/definition/params_two_comma.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/function/definition/params_zero.carbon
+++ b/toolchain/semantics/testdata/function/definition/params_zero.carbon
@@ -14,6 +14,8 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: FunctionDefinition, arg0: node+0, arg1: block0},

--- a/toolchain/semantics/testdata/function/definition/same_param_name.carbon
+++ b/toolchain/semantics/testdata/function/definition/same_param_name.carbon
@@ -17,6 +17,9 @@
 // CHECK:STDOUT:   Foo,
 // CHECK:STDOUT:   Bar,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/operators/binary_op.carbon
+++ b/toolchain/semantics/testdata/operators/binary_op.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch.carbon
@@ -16,6 +16,10 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/semantics/testdata/operators/fail_type_mismatch_once.carbon
@@ -17,6 +17,10 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/return/fail_type_mismatch.carbon
@@ -15,6 +15,10 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: RealLiteral, arg0: real0, type: nodeFloatingPointType},

--- a/toolchain/semantics/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/semantics/testdata/return/fail_value_disallowed.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/return/fail_value_missing.carbon
+++ b/toolchain/semantics/testdata/return/fail_value_missing.carbon
@@ -14,6 +14,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: Return},

--- a/toolchain/semantics/testdata/return/no_value.carbon
+++ b/toolchain/semantics/testdata/return/no_value.carbon
@@ -14,6 +14,8 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: Return},

--- a/toolchain/semantics/testdata/return/struct.carbon
+++ b/toolchain/semantics/testdata/return/struct.carbon
@@ -16,6 +16,11 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   node+6,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/return/value.carbon
+++ b/toolchain/semantics/testdata/return/value.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/struct/empty.carbon
+++ b/toolchain/semantics/testdata/struct/empty.carbon
@@ -14,6 +14,9 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeEmptyStructType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeEmptyStructType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeEmptyStructType},

--- a/toolchain/semantics/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/semantics/testdata/struct/fail_assign_empty.carbon
@@ -14,6 +14,10 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/semantics/testdata/struct/fail_assign_to_empty.carbon
@@ -15,6 +15,11 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeEmptyStructType,
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+5,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeEmptyStructType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeEmptyStructType},

--- a/toolchain/semantics/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/semantics/testdata/struct/fail_field_name_mismatch.carbon
@@ -16,6 +16,11 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   node+7,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/struct/fail_field_type_mismatch.carbon
@@ -16,6 +16,12 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT:   node+7,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/semantics/testdata/struct/fail_member_access_type.carbon
@@ -17,6 +17,12 @@
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   node+7,
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeFloatingPointType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/semantics/testdata/struct/fail_non_member_access.carbon
@@ -17,6 +17,11 @@
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   node+7,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/semantics/testdata/struct/fail_too_few_values.carbon
@@ -16,6 +16,11 @@
 // CHECK:STDOUT:   b,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+2,
+// CHECK:STDOUT:   node+8,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str1, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/semantics/testdata/struct/fail_type_assign.carbon
@@ -14,6 +14,10 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
@@ -15,6 +15,10 @@
 // CHECK:STDOUT:   a,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+3,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/struct/member_access.carbon
+++ b/toolchain/semantics/testdata/struct/member_access.carbon
@@ -19,6 +19,12 @@
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT:   z,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+2,
+// CHECK:STDOUT:   node+11,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeFloatingPointType},
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str1, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/struct/one_entry.carbon
+++ b/toolchain/semantics/testdata/struct/one_entry.carbon
@@ -16,6 +16,12 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+1,
+// CHECK:STDOUT:   node+7,
+// CHECK:STDOUT:   node+11,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructType, arg0: block2, type: nodeTypeType},

--- a/toolchain/semantics/testdata/struct/two_entries.carbon
+++ b/toolchain/semantics/testdata/struct/two_entries.carbon
@@ -18,6 +18,12 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   node+2,
+// CHECK:STDOUT:   node+11,
+// CHECK:STDOUT:   node+16,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str0, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: StructTypeField, arg0: str1, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/decl.carbon
+++ b/toolchain/semantics/testdata/var/decl.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/decl_with_init.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/semantics/testdata/var/fail_duplicate_decl.carbon
@@ -17,6 +17,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_type_mismatch.carbon
@@ -16,6 +16,10 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT:   nodeFloatingPointType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/semantics/testdata/var/fail_init_with_self.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/semantics/testdata/var/fail_lookup_outside_scope.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
@@ -17,6 +17,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/global_decl.carbon
+++ b/toolchain/semantics/testdata/var/global_decl.carbon
@@ -13,6 +13,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/semantics/testdata/var/global_decl_with_init.carbon
@@ -14,6 +14,9 @@
 // CHECK:STDOUT: strings: [
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/global_lookup.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup.carbon
@@ -15,6 +15,9 @@
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/semantics/testdata/var/global_lookup_in_scope.carbon
@@ -17,6 +17,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   y,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},
 // CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: nodeIntegerType},

--- a/toolchain/semantics/testdata/var/lookup.carbon
+++ b/toolchain/semantics/testdata/var/lookup.carbon
@@ -16,6 +16,9 @@
 // CHECK:STDOUT:   Main,
 // CHECK:STDOUT:   x,
 // CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
 // CHECK:STDOUT: nodes: [
 // CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: str0, arg1: callable0},
 // CHECK:STDOUT:   {kind: VarStorage, type: nodeIntegerType},


### PR DESCRIPTION
This is the first step to refactoring types into a SemanticsTypeId. This only tracks what's in-use, but as a consequence starts funneling type information through in ways similar to how I'd want it to do SemanticsTypeId.