### PR TITLE
Fixed linting errors in resolve_names.cpp

### DIFF
--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -604,7 +604,7 @@ auto NameResolver::ResolveNamesImpl(Statement& statement,
           ResolveNames(if_stmt.condition(), enclosing_scope));
       CARBON_RETURN_IF_ERROR(
           ResolveNames(if_stmt.then_block(), enclosing_scope));
-      if (auto else_block = if_stmt.else_block(); else_block.has_value()) {
+      if (auto else_block = if_stmt.else_block()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**else_block, enclosing_scope));
       }
       break;
@@ -727,7 +727,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
                               ResolveQualifier(iface.name(), enclosing_scope));
       StaticScope iface_scope(scope);
       scope->MarkDeclared(iface.name().inner_name());
-      if (auto params = iface.params(); params.has_value()) {
+      if (auto params = iface.params()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**params, iface_scope));
       }
       scope->MarkUsable(iface.name().inner_name());
@@ -788,8 +788,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
       }
       CARBON_RETURN_IF_ERROR(
           ResolveNames(function.param_pattern(), function_scope));
-      if (auto return_type_expr = function.return_term().type_expression();
-          return_type_expr.has_value()) {
+      if (auto return_type_expr = function.return_term().type_expression()) {
         CARBON_RETURN_IF_ERROR(
             ResolveNames(**return_type_expr, function_scope));
       }
@@ -807,11 +806,10 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
           ResolveQualifier(class_decl.name(), enclosing_scope));
       StaticScope class_scope(scope);
       scope->MarkDeclared(class_decl.name().inner_name());
-      if (auto base_expr = class_decl.base_expr(); base_expr.has_value()) {
+      if (auto base_expr = class_decl.base_expr()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**base_expr, class_scope));
       }
-      if (auto type_params = class_decl.type_params();
-          type_params.has_value()) {
+      if (auto type_params = class_decl.type_params()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**type_params, class_scope));
       }
       scope->MarkUsable(class_decl.name().inner_name());
@@ -827,7 +825,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
           ResolveQualifier(mixin_decl.name(), enclosing_scope));
       StaticScope mixin_scope(scope);
       scope->MarkDeclared(mixin_decl.name().inner_name());
-      if (auto params = mixin_decl.params(); params.has_value()) {
+      if (auto params = mixin_decl.params()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**params, mixin_scope));
       }
       scope->MarkUsable(mixin_decl.name().inner_name());
@@ -847,7 +845,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
                               ResolveQualifier(choice.name(), enclosing_scope));
       StaticScope choice_scope(scope);
       scope->MarkDeclared(choice.name().inner_name());
-      if (auto type_params = choice.type_params(); type_params.has_value()) {
+      if (auto type_params = choice.type_params()) {
         CARBON_RETURN_IF_ERROR(ResolveNames(**type_params, choice_scope));
       }
       // Alternative names are never used unqualified, so we don't need to
@@ -908,8 +906,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
       CARBON_ASSIGN_OR_RETURN(auto target,
                               ResolveNames(alias.target(), *scope));
       if (target && isa<Declaration>(target->base())) {
-        if (auto resolved_declaration = alias.resolved_declaration();
-            resolved_declaration.has_value()) {
+        if (auto resolved_declaration = alias.resolved_declaration()) {
           // Skip if the declaration is already resolved in a previous name
           // resolution phase.
           CARBON_CHECK(*resolved_declaration == &target->base());


### PR DESCRIPTION
Tried to get rid of `Unchecked access to optional value` clang-tidy warnings in `resolve_names.cpp`.