### PR TITLE
Drop "Lowered" from various LoweringContext APIs.

### DIFF
--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -19,15 +19,15 @@ LoweringContext::LoweringContext(llvm::LLVMContext& llvm_context,
       builder_(llvm_context),
       semantics_ir_(&semantics_ir),
       vlog_stream_(vlog_stream),
-      lowered_nodes_(semantics_ir_->nodes_size(), nullptr),
-      lowered_callables_(semantics_ir_->callables_size(), nullptr) {
+      nodes_(semantics_ir_->nodes_size(), nullptr),
+      callables_(semantics_ir_->callables_size(), nullptr) {
   CARBON_CHECK(!semantics_ir.has_errors())
       << "Generating LLVM IR from invalid SemanticsIR is unsupported.";
 
   auto types = semantics_ir_->types();
-  lowered_types_.resize_for_overwrite(types.size());
+  types_.resize_for_overwrite(types.size());
   for (int i = 0; i < static_cast<int>(types.size()); ++i) {
-    lowered_types_[i] = BuildLoweredNodeAsType(types[i]);
+    types_[i] = BuildType(types[i]);
   }
 }
 
@@ -60,8 +60,7 @@ auto LoweringContext::LowerBlock(SemanticsNodeBlockId block_id) -> void {
   }
 }
 
-auto LoweringContext::BuildLoweredNodeAsType(SemanticsNodeId node_id)
-    -> llvm::Type* {
+auto LoweringContext::BuildType(SemanticsNodeId node_id) -> llvm::Type* {
   switch (node_id.index) {
     case SemanticsBuiltinKind::EmptyTupleType.AsInt():
       // Represent empty types as empty structs.

--- a/toolchain/semantics/semantics_context.h
+++ b/toolchain/semantics/semantics_context.h
@@ -145,7 +145,7 @@ class SemanticsContext {
 
   auto parse_tree() -> const ParseTree& { return *parse_tree_; }
 
-  auto semantics() -> SemanticsIR& { return *semantics_; }
+  auto semantics_ir() -> SemanticsIR& { return *semantics_ir_; }
 
   auto node_stack() -> SemanticsNodeStack& { return node_stack_; }
 
@@ -221,7 +221,7 @@ class SemanticsContext {
   const ParseTree* parse_tree_;
 
   // The SemanticsIR being added to.
-  SemanticsIR* semantics_;
+  SemanticsIR* semantics_ir_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/semantics/semantics_handle_call_expression.cpp
+++ b/toolchain/semantics/semantics_handle_call_expression.cpp
@@ -15,7 +15,7 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
   auto [call_expr_parse_node, name_id] =
       context.node_stack().PopForParseNodeAndNodeId(
           ParseNodeKind::CallExpressionStart);
-  auto name_node = context.semantics().GetNode(name_id);
+  auto name_node = context.semantics_ir().GetNode(name_id);
   if (name_node.kind() != SemanticsNodeKind::FunctionDeclaration) {
     // TODO: Work on error.
     context.TODO(parse_node, "Not a callable name");
@@ -24,7 +24,7 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
   }
 
   auto [_, callable_id] = name_node.GetAsFunctionDeclaration();
-  auto callable = context.semantics().GetCallable(callable_id);
+  auto callable = context.semantics_ir().GetCallable(callable_id);
 
   CARBON_DIAGNOSTIC(NoMatchingCall, Error, "No matching callable was found.");
   auto diagnostic =

--- a/toolchain/semantics/semantics_handle_function.cpp
+++ b/toolchain/semantics/semantics_handle_function.cpp
@@ -51,9 +51,9 @@ auto SemanticsHandleFunctionDefinitionStart(SemanticsContext& context,
       ParseNodeKind::FunctionIntroducer);
 
   auto name_str = context.parse_tree().GetNodeText(name_node);
-  auto name_id = context.semantics().AddString(name_str);
+  auto name_id = context.semantics_ir().AddString(name_str);
 
-  auto callable_id = context.semantics().AddCallable(
+  auto callable_id = context.semantics_ir().AddCallable(
       {.param_refs_id = param_refs_id, .return_type_id = return_type_id});
   auto decl_id = context.AddNode(
       SemanticsNode::FunctionDeclaration::Make(fn_node, name_id, callable_id));
@@ -61,8 +61,8 @@ auto SemanticsHandleFunctionDefinitionStart(SemanticsContext& context,
 
   context.node_block_stack().Push();
   context.PushScope();
-  for (auto ref_id : context.semantics().GetNodeBlock(param_refs_id)) {
-    auto ref = context.semantics().GetNode(ref_id);
+  for (auto ref_id : context.semantics_ir().GetNodeBlock(param_refs_id)) {
+    auto ref = context.semantics_ir().GetNode(ref_id);
     auto [name_id, target_id] = ref.GetAsBindName();
     context.AddNameToLookupIgnoreConflicts(name_id, target_id);
   }

--- a/toolchain/semantics/semantics_handle_struct.cpp
+++ b/toolchain/semantics/semantics_handle_struct.cpp
@@ -53,10 +53,10 @@ auto SemanticsHandleStructFieldValue(SemanticsContext& context,
 
   // Store the name for the type.
   auto type_block_id = context.args_type_info_stack().PeekForAdd();
-  context.semantics().AddNode(
+  context.semantics_ir().AddNode(
       type_block_id,
       SemanticsNode::StructTypeField::Make(
-          parse_node, context.semantics().GetNode(value_node_id).type_id(),
+          parse_node, context.semantics_ir().GetNode(value_node_id).type_id(),
           name_id));
 
   // Push the value back on the stack as an argument.
@@ -109,7 +109,8 @@ auto SemanticsHandleStructTypeLiteral(SemanticsContext& context,
       << "{} is handled by StructLiteral.";
 
   auto type_id = context.CanonicalizeStructType(parse_node, refs_id);
-  context.node_stack().Push(parse_node, context.semantics().GetType(type_id));
+  context.node_stack().Push(parse_node,
+                            context.semantics_ir().GetType(type_id));
   return true;
 }
 

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -14,27 +14,27 @@
 namespace Carbon {
 
 auto SemanticsIR::MakeBuiltinIR() -> SemanticsIR {
-  SemanticsIR semantics(/*builtin_ir=*/nullptr);
-  semantics.nodes_.reserve(SemanticsBuiltinKind::ValidCount);
+  SemanticsIR semantics_ir(/*builtin_ir=*/nullptr);
+  semantics_ir.nodes_.reserve(SemanticsBuiltinKind::ValidCount);
 
   // InvalidType uses a self-referential type so that it's not accidentally
   // treated as a normal type. Every other builtin is a type, including the
   // self-referential TypeType.
 #define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                      \
-  semantics.nodes_.push_back(SemanticsNode::Builtin::Make(            \
+  semantics_ir.nodes_.push_back(SemanticsNode::Builtin::Make(         \
       SemanticsBuiltinKind::Name,                                     \
       SemanticsBuiltinKind::Name == SemanticsBuiltinKind::InvalidType \
           ? SemanticsTypeId::InvalidType                              \
           : SemanticsTypeId::TypeType));
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
-  CARBON_CHECK(semantics.node_blocks_.size() == 1)
+  CARBON_CHECK(semantics_ir.node_blocks_.size() == 1)
       << "BuildBuiltins should only have the empty block, actual: "
-      << semantics.node_blocks_.size();
-  CARBON_CHECK(semantics.nodes_.size() == SemanticsBuiltinKind::ValidCount)
+      << semantics_ir.node_blocks_.size();
+  CARBON_CHECK(semantics_ir.nodes_.size() == SemanticsBuiltinKind::ValidCount)
       << "BuildBuiltins should produce " << SemanticsBuiltinKind::ValidCount
-      << " nodes, actual: " << semantics.nodes_.size();
-  return semantics;
+      << " nodes, actual: " << semantics_ir.nodes_.size();
+  return semantics_ir;
 }
 
 auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
@@ -43,16 +43,16 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
                                     DiagnosticConsumer& consumer,
                                     llvm::raw_ostream* vlog_stream)
     -> SemanticsIR {
-  SemanticsIR semantics(&builtin_ir);
+  SemanticsIR semantics_ir(&builtin_ir);
 
   // Copy builtins over.
-  semantics.nodes_.resize_for_overwrite(SemanticsBuiltinKind::ValidCount);
+  semantics_ir.nodes_.resize_for_overwrite(SemanticsBuiltinKind::ValidCount);
   static constexpr auto BuiltinIR = SemanticsCrossReferenceIRId(0);
   for (int i = 0; i < SemanticsBuiltinKind::ValidCount; ++i) {
     // We can reuse the type node ID because the offsets of cross-references
     // will be the same in this IR.
     auto type = builtin_ir.nodes_[i].type_id();
-    semantics.nodes_[i] = SemanticsNode::CrossReference::Make(
+    semantics_ir.nodes_[i] = SemanticsNode::CrossReference::Make(
         type, BuiltinIR, SemanticsNodeId(i));
   }
 
@@ -60,7 +60,8 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
   ErrorTrackingDiagnosticConsumer err_tracker(consumer);
   DiagnosticEmitter<ParseTree::Node> emitter(translator, err_tracker);
 
-  SemanticsContext context(tokens, emitter, parse_tree, semantics, vlog_stream);
+  SemanticsContext context(tokens, emitter, parse_tree, semantics_ir,
+                           vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -75,8 +76,8 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
 #define CARBON_PARSE_NODE_KIND(Name)                   \
   case ParseNodeKind::Name: {                          \
     if (!SemanticsHandle##Name(context, parse_node)) { \
-      semantics.has_errors_ = true;                    \
-      return semantics;                                \
+      semantics_ir.has_errors_ = true;                 \
+      return semantics_ir;                             \
     }                                                  \
     break;                                             \
   }
@@ -85,13 +86,13 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
   }
 
   // Pop information for the file-level scope.
-  semantics.top_node_block_id_ = context.node_block_stack().Pop();
+  semantics_ir.top_node_block_id_ = context.node_block_stack().Pop();
   context.PopScope();
 
   context.VerifyOnFinish();
 
-  semantics.has_errors_ = err_tracker.seen_error();
-  return semantics;
+  semantics_ir.has_errors_ = err_tracker.seen_error();
+  return semantics_ir;
 }
 
 static constexpr int Indent = 2;


### PR DESCRIPTION
As I've worked on this more, it's just felt verbosely redundant -- lowered should be the default assumption, needing no further explanation. This does mean there's `context.GetType()` and `context.semantics_ir().GetType()`, but I feel like that's still reasonably clear on reading.