### PR TITLE
Switch nodes to a map, and relabel as locals.

### DIFF
--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -19,7 +19,6 @@ LoweringContext::LoweringContext(llvm::LLVMContext& llvm_context,
       builder_(llvm_context),
       semantics_ir_(&semantics_ir),
       vlog_stream_(vlog_stream),
-      nodes_(semantics_ir_->nodes_size(), nullptr),
       callables_(semantics_ir_->callables_size(), nullptr) {
   CARBON_CHECK(!semantics_ir.has_errors())
       << "Generating LLVM IR from invalid SemanticsIR is unsupported.";
@@ -58,6 +57,8 @@ auto LoweringContext::LowerBlock(SemanticsNodeBlockId block_id) -> void {
 #include "toolchain/semantics/semantics_node_kind.def"
     }
   }
+
+  locals_.clear();
 }
 
 auto LoweringContext::BuildType(SemanticsNodeId node_id) -> llvm::Type* {
@@ -102,8 +103,8 @@ auto LoweringContext::BuildType(SemanticsNodeId node_id) -> llvm::Type* {
   }
 }
 
-auto LoweringContext::GetNodeLoaded(SemanticsNodeId node_id) -> llvm::Value* {
-  auto* value = GetNode(node_id);
+auto LoweringContext::GetLocalLoaded(SemanticsNodeId node_id) -> llvm::Value* {
+  auto* value = GetLocal(node_id);
   if (llvm::isa<llvm::AllocaInst, llvm::GetElementPtrInst>(value)) {
     auto* load_type = GetType(semantics_ir().GetNode(node_id).type_id());
     return builder().CreateLoad(load_type, value);


### PR DESCRIPTION
The "locals" naming is intended to reflect that I haven't really thought through how globals work, but suspect they're going to end up at least partially separated. Stepping away from the "node" naming feels like it'll reduce confusion, although maybe "values" might be better? (but values seems imperfect in the presence of globals)

The map is the more important part here; I want to avoid anchoring on the prior vector approach.