### PR TITLE
Fix crash on use of uninitialized array element, and improve unformed checking

### DIFF
--- a/explorer/data/prelude.carbon
+++ b/explorer/data/prelude.carbon
@@ -712,9 +712,8 @@ class Optional(T:! type) {
       }
     }
     Assert(false, "Attempted to unwrap empty Optional");
-    // TODO: Drop uninitialized variable & return when we can flag unreachable paths.
-    var y: T;
-    return y;
+    // TODO: Drop return when we can flag unreachable paths.
+    return self.Get();
   }
 
   var element: OptionalElement(T);

--- a/explorer/interpreter/BUILD
+++ b/explorer/interpreter/BUILD
@@ -219,6 +219,7 @@ cc_library(
         "resolve_unformed.h",
     ],
     deps = [
+        ":stack_space",
         "//common:check",
         "//explorer/ast",
         "//explorer/ast:static_scope",

--- a/explorer/interpreter/heap.cpp
+++ b/explorer/interpreter/heap.cpp
@@ -38,6 +38,11 @@ auto Heap::Write(const Address& a, Nonnull<const Value*> v,
                  SourceLocation source_loc) -> ErrorOr<Success> {
   CARBON_RETURN_IF_ERROR(this->CheckAlive(a.allocation_, source_loc));
   if (states_[a.allocation_.index_] == ValueState::Uninitialized) {
+    if (!a.element_path_.IsEmpty()) {
+      return ProgramError(source_loc)
+             << "undefined behavior: store to subobject of uninitialized value "
+             << *values_[a.allocation_.index_];
+    }
     states_[a.allocation_.index_] = ValueState::Alive;
   }
   CARBON_ASSIGN_OR_RETURN(values_[a.allocation_.index_],

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2278,7 +2278,6 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
   switch (decl.kind()) {
     case DeclarationKind::VariableDeclaration: {
       const auto& var_decl = cast<VariableDeclaration>(decl);
-      const auto* var_type = &var_decl.binding().static_type();
       if (var_decl.has_initializer()) {
         if (act.pos() == 0) {
           return todo_.Spawn(
@@ -2291,22 +2290,6 @@ auto Interpreter::StepDeclaration() -> ErrorOr<Success> {
           todo_.Initialize(&var_decl.binding(), v);
           return todo_.FinishAction();
         }
-      } else if (var_type->kind() == Value::Kind::StaticArrayType) {
-        const auto& array = cast<StaticArrayType>(var_type);
-        CARBON_CHECK(array->has_size());
-        const auto& element_type = array->element_type();
-        const auto size = array->size();
-
-        std::vector<Nonnull<const Value*>> elements;
-        elements.reserve(size);
-        for (size_t i = 0; i < size; i++) {
-          elements.push_back(arena_->New<UninitializedValue>(&element_type));
-        }
-
-        Nonnull<const Value*> v =
-            arena_->New<TupleValueBase>(Value::Kind::TupleValue, elements);
-        todo_.Initialize(&var_decl.binding(), v);
-        return todo_.FinishAction();
       } else {
         Nonnull<const Value*> v =
             arena_->New<UninitializedValue>(&var_decl.binding().value());

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1596,10 +1596,6 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
               *print_stream_ << llvm::formatv(format_string);
               break;
             case 1: {
-              if ((*args[1]).kind() == Value::Kind::UninitializedValue) {
-                return ProgramError(exp.source_loc())
-                       << "Printing uninitialized value";
-              }
               *print_stream_ << llvm::formatv(format_string,
                                               cast<IntValue>(*args[1]).value());
               break;

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2134,18 +2134,6 @@ auto Interpreter::StepStmt() -> ErrorOr<Success> {
         if (definition.has_init()) {
           CARBON_ASSIGN_OR_RETURN(
               v, Convert(act.results()[0], dest_type, stmt.source_loc()));
-        } else if (dest_type->kind() == Value::Kind::StaticArrayType) {
-          const auto& array = cast<StaticArrayType>(dest_type);
-          CARBON_CHECK(array->has_size());
-          const auto& element_type = array->element_type();
-          const auto size = array->size();
-
-          std::vector<Nonnull<const Value*>> elements;
-          elements.reserve(size);
-          for (size_t i = 0; i < size; i++) {
-            elements.push_back(arena_->New<UninitializedValue>(&element_type));
-          }
-          v = arena_->New<TupleValueBase>(Value::Kind::TupleValue, elements);
         } else {
           v = arena_->New<UninitializedValue>(p);
         }

--- a/explorer/interpreter/resolve_names.cpp
+++ b/explorer/interpreter/resolve_names.cpp
@@ -276,7 +276,7 @@ auto NameResolver::AddExposedNames(const Declaration& declaration,
 auto NameResolver::ResolveNames(Expression& expression,
                                 const StaticScope& enclosing_scope)
     -> ErrorOr<std::optional<ValueNodeView>> {
-  return RunWithExtraStack<ErrorOr<std::optional<ValueNodeView>>>(
+  return RunWithExtraStack(
       [&]() { return ResolveNamesImpl(expression, enclosing_scope); });
 }
 
@@ -463,7 +463,7 @@ auto NameResolver::ResolveNamesImpl(Expression& expression,
 auto NameResolver::ResolveNames(WhereClause& clause,
                                 const StaticScope& enclosing_scope)
     -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>(
+  return RunWithExtraStack(
       [&]() { return ResolveNamesImpl(clause, enclosing_scope); });
 }
 
@@ -499,7 +499,7 @@ auto NameResolver::ResolveNamesImpl(WhereClause& clause,
 
 auto NameResolver::ResolveNames(Pattern& pattern, StaticScope& enclosing_scope)
     -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>(
+  return RunWithExtraStack(
       [&]() { return ResolveNamesImpl(pattern, enclosing_scope); });
 }
 
@@ -560,7 +560,7 @@ auto NameResolver::ResolveNamesImpl(Pattern& pattern,
 auto NameResolver::ResolveNames(Statement& statement,
                                 StaticScope& enclosing_scope)
     -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>(
+  return RunWithExtraStack(
       [&]() { return ResolveNamesImpl(statement, enclosing_scope); });
 }
 
@@ -703,7 +703,7 @@ auto NameResolver::ResolveNames(Declaration& declaration,
                                 StaticScope& enclosing_scope,
                                 ResolveFunctionBodies bodies)
     -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>(
+  return RunWithExtraStack(
       [&]() { return ResolveNamesImpl(declaration, enclosing_scope, bodies); });
 }
 
@@ -922,7 +922,7 @@ auto NameResolver::ResolveNamesImpl(Declaration& declaration,
 }
 
 auto ResolveNames(AST& ast) -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>([&]() -> ErrorOr<Success> {
+  return RunWithExtraStack([&]() -> ErrorOr<Success> {
     NameResolver resolver;
 
     StaticScope file_scope;

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -68,19 +68,8 @@ static auto ResolveUnformed(Nonnull<const Statement*> statement,
 static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
     -> ErrorOr<Success>;
 
-namespace {
-struct PendingResolveUnformedStep {
-  Nonnull<const Expression*> expression;
-  FlowFacts::ActionType action;
-};
-}  // namespace
-
-// Resolve the formed/unformed state of an expression, and enqueue any
-// subexpressions to be checked, in reverse evaluation order.
-static auto ResolveOneUnformedExpression(
-    Nonnull<const Expression*> expression, FlowFacts& flow_facts,
-    FlowFacts::ActionType action,
-    llvm::SmallVectorImpl<PendingResolveUnformedStep>& queue)
+static auto ResolveUnformed(Nonnull<const Expression*> expression,
+                            FlowFacts& flow_facts, FlowFacts::ActionType action)
     -> ErrorOr<Success> {
   switch (expression->kind()) {
     case ExpressionKind::IdentifierExpression: {
@@ -92,18 +81,20 @@ static auto ResolveOneUnformedExpression(
     }
     case ExpressionKind::CallExpression: {
       const auto& call = cast<CallExpression>(*expression);
-      queue.push_back({&call.argument(), action});
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&call.argument(), flow_facts, action));
       break;
     }
     case ExpressionKind::IntrinsicExpression: {
       const auto& intrin = cast<IntrinsicExpression>(*expression);
-      queue.push_back({&intrin.args(), action});
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&intrin.args(), flow_facts, action));
       break;
     }
     case ExpressionKind::TupleLiteral:
       for (Nonnull<const Expression*> field :
-           llvm::reverse(cast<TupleLiteral>(*expression).fields())) {
-        queue.push_back({field, action});
+           cast<TupleLiteral>(*expression).fields()) {
+        CARBON_RETURN_IF_ERROR(ResolveUnformed(field, flow_facts, action));
       }
       break;
     case ExpressionKind::OperatorExpression: {
@@ -111,50 +102,57 @@ static auto ResolveOneUnformedExpression(
       if (opt_exp.op() == Operator::AddressOf) {
         CARBON_CHECK(opt_exp.arguments().size() == 1)
             << "OperatorExpression with op & can only have 1 argument";
-        // When a variable is taken address of, defer the unformed check to
-        // runtime. A more sound analysis can be implemented when a points-to
-        // analysis is available.
-        // TODO: This isn't enough to permit &x.y or &x[i] when x is
-        // uninitialized, because x.y and x[i] both require x to be
-        // initialized.
-        queue.push_back(
-            {opt_exp.arguments().front(), FlowFacts::ActionType::Form});
+        CARBON_RETURN_IF_ERROR(
+            // When a variable is taken address of, defer the unformed check to
+            // runtime. A more sound analysis can be implemented when a
+            // points-to analysis is available.
+            // TODO: This isn't enough to permit &x.y or &x[i] when x is
+            // uninitialized, because x.y and x[i] both require x to be
+            // initialized.
+            ResolveUnformed(opt_exp.arguments().front(), flow_facts,
+                            FlowFacts::ActionType::Form));
       } else {
-        for (Nonnull<const Expression*> operand :
-             llvm::reverse(opt_exp.arguments())) {
-          queue.push_back({operand, action});
+        for (Nonnull<const Expression*> operand : opt_exp.arguments()) {
+          CARBON_RETURN_IF_ERROR(ResolveUnformed(operand, flow_facts, action));
         }
       }
       break;
     }
     case ExpressionKind::StructLiteral:
       for (const FieldInitializer& init :
-           llvm::reverse(cast<StructLiteral>(*expression).fields())) {
-        queue.push_back({&init.expression(), FlowFacts::ActionType::Check});
+           cast<StructLiteral>(*expression).fields()) {
+        CARBON_RETURN_IF_ERROR(ResolveUnformed(&init.expression(), flow_facts,
+                                               FlowFacts::ActionType::Check));
       }
       break;
     case ExpressionKind::SimpleMemberAccessExpression:
     case ExpressionKind::CompoundMemberAccessExpression:
     case ExpressionKind::BaseAccessExpression:
-      queue.push_back({&cast<MemberAccessExpression>(*expression).object(),
-                       FlowFacts::ActionType::Check});
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<MemberAccessExpression>(*expression).object(),
+                          flow_facts, FlowFacts::ActionType::Check));
       break;
     case ExpressionKind::BuiltinConvertExpression:
-      queue.push_back(
-          {cast<BuiltinConvertExpression>(*expression).source_expression(),
-           FlowFacts::ActionType::Check});
+      CARBON_RETURN_IF_ERROR(ResolveUnformed(
+          cast<BuiltinConvertExpression>(*expression).source_expression(),
+          flow_facts, FlowFacts::ActionType::Check));
       break;
-    case ExpressionKind::IndexExpression: {
-      const auto& index_exp = cast<IndexExpression>(*expression);
-      queue.push_back({&index_exp.offset(), FlowFacts::ActionType::Check});
-      queue.push_back({&index_exp.object(), FlowFacts::ActionType::Check});
+    case ExpressionKind::IndexExpression:
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<IndexExpression>(*expression).object(),
+                          flow_facts, FlowFacts::ActionType::Check));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<IndexExpression>(*expression).offset(),
+                          flow_facts, FlowFacts::ActionType::Check));
       break;
-    }
     case ExpressionKind::IfExpression: {
       const auto& if_exp = cast<IfExpression>(*expression);
-      queue.push_back({&if_exp.else_expression(), action});
-      queue.push_back({&if_exp.then_expression(), action});
-      queue.push_back({&if_exp.condition(), FlowFacts::ActionType::Check});
+      CARBON_RETURN_IF_ERROR(ResolveUnformed(&if_exp.condition(), flow_facts,
+                                             FlowFacts::ActionType::Check));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&if_exp.then_expression(), flow_facts, action));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&if_exp.else_expression(), flow_facts, action));
       break;
     }
     case ExpressionKind::DotSelfExpression:
@@ -172,22 +170,6 @@ static auto ResolveOneUnformedExpression(
     case ExpressionKind::FunctionTypeLiteral:
     case ExpressionKind::ArrayTypeLiteral:
       break;
-  }
-  return Success();
-}
-
-static auto ResolveUnformed(Nonnull<const Expression*> expression,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
-    -> ErrorOr<Success> {
-  // We visit subexpressions in evaluation order, by performing a LIFO
-  // traversal here and enqueueing subexpressions in reverse order in
-  // ResolveOneUnformedExpression.
-  llvm::SmallVector<PendingResolveUnformedStep, 32> queue;
-  queue.push_back({expression, action});
-  while (!queue.empty()) {
-    auto [expr, act] = queue.pop_back_val();
-    CARBON_RETURN_IF_ERROR(
-        ResolveOneUnformedExpression(expr, flow_facts, act, queue));
   }
   return Success();
 }

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -135,8 +135,12 @@ static auto ResolveUnformed(Nonnull<const Expression*> expression,
           flow_facts, FlowFacts::ActionType::Check));
       break;
     case ExpressionKind::IndexExpression:
-      CARBON_RETURN_IF_ERROR(ResolveUnformed(
-          &cast<IndexExpression>(*expression).object(), flow_facts, action));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<IndexExpression>(*expression).object(),
+                          flow_facts, FlowFacts::ActionType::Check));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<IndexExpression>(*expression).offset(),
+                          flow_facts, FlowFacts::ActionType::Check));
       break;
     case ExpressionKind::IfExpression: {
       const auto& if_exp = cast<IfExpression>(*expression);

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -11,6 +11,7 @@
 #include "explorer/ast/expression.h"
 #include "explorer/ast/pattern.h"
 #include "explorer/common/nonnull.h"
+#include "explorer/interpreter/stack_space.h"
 
 using llvm::cast;
 
@@ -54,22 +55,35 @@ auto FlowFacts::TakeAction(Nonnull<const AstNode*> node, ActionType action,
   return Success();
 }
 
-// Traverses the sub-AST rooted at the given node, resolving the formed/unformed
-// states of local variables within it and updating the flow facts.
-static auto ResolveUnformed(Nonnull<const Expression*> expression,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+static auto ResolveUnformedImpl(Nonnull<const Expression*> expression,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success>;
-static auto ResolveUnformed(Nonnull<const Pattern*> pattern,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+static auto ResolveUnformedImpl(Nonnull<const Pattern*> pattern,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success>;
-static auto ResolveUnformed(Nonnull<const Statement*> statement,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+static auto ResolveUnformedImpl(Nonnull<const Statement*> statement,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success>;
-static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
+static auto ResolveUnformedImpl(Nonnull<const Expression*> expression,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success>;
 
-static auto ResolveUnformed(Nonnull<const Expression*> expression,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+// Traverses the sub-AST rooted at the given node, resolving the formed/unformed
+// states of local variables within it and updating the flow facts.
+template <typename T>
+static auto ResolveUnformed(Nonnull<const T*> expression, FlowFacts& flow_facts,
+                            FlowFacts::ActionType action) -> ErrorOr<Success> {
+  return RunWithExtraStack(
+      [&] { return ResolveUnformedImpl(expression, flow_facts, action); });
+}
+
+static auto ResolveUnformedImpl(Nonnull<const Expression*> expression,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success> {
   switch (expression->kind()) {
     case ExpressionKind::IdentifierExpression: {
@@ -174,8 +188,9 @@ static auto ResolveUnformed(Nonnull<const Expression*> expression,
   return Success();
 }
 
-static auto ResolveUnformed(Nonnull<const Pattern*> pattern,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+static auto ResolveUnformedImpl(Nonnull<const Pattern*> pattern,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success> {
   switch (pattern->kind()) {
     case PatternKind::BindingPattern: {
@@ -202,8 +217,9 @@ static auto ResolveUnformed(Nonnull<const Pattern*> pattern,
   return Success();
 }
 
-static auto ResolveUnformed(Nonnull<const Statement*> statement,
-                            FlowFacts& flow_facts, FlowFacts::ActionType action)
+static auto ResolveUnformedImpl(Nonnull<const Statement*> statement,
+                                FlowFacts& flow_facts,
+                                FlowFacts::ActionType action)
     -> ErrorOr<Success> {
   switch (statement->kind()) {
     case StatementKind::Block: {
@@ -304,13 +320,34 @@ static auto ResolveUnformed(Nonnull<const Statement*> statement,
       }
       break;
     }
+    case StatementKind::For: {
+      const auto& for_stmt = cast<For>(*statement);
+      CARBON_RETURN_IF_ERROR(ResolveUnformed(
+          &for_stmt.loop_target(), flow_facts, FlowFacts::ActionType::Check));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&for_stmt.body(), flow_facts, action));
+      break;
+    }
     case StatementKind::Break:
     case StatementKind::Continue:
-    case StatementKind::For:
       // do nothing
       break;
   }
   return Success();
+}
+
+static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
+    -> ErrorOr<Success>;
+
+static auto ResolveUnformed(
+    llvm::ArrayRef<Nonnull<const Declaration*>> declarations)
+    -> ErrorOr<Success> {
+  return RunWithExtraStack([declarations]() -> ErrorOr<Success> {
+    for (Nonnull<const Declaration*> declaration : declarations) {
+      CARBON_RETURN_IF_ERROR(ResolveUnformed(declaration));
+    }
+    return Success();
+  });
 }
 
 static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
@@ -330,12 +367,7 @@ static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
       break;
     }
     case DeclarationKind::NamespaceDeclaration:
-    case DeclarationKind::ClassDeclaration:
     case DeclarationKind::MixDeclaration:
-    case DeclarationKind::MixinDeclaration:
-    case DeclarationKind::InterfaceDeclaration:
-    case DeclarationKind::ConstraintDeclaration:
-    case DeclarationKind::ImplDeclaration:
     case DeclarationKind::MatchFirstDeclaration:
     case DeclarationKind::ChoiceDeclaration:
     case DeclarationKind::VariableDeclaration:
@@ -346,6 +378,16 @@ static auto ResolveUnformed(Nonnull<const Declaration*> declaration)
     case DeclarationKind::AliasDeclaration:
       // do nothing
       break;
+    case DeclarationKind::ClassDeclaration:
+      return ResolveUnformed(cast<ClassDeclaration>(declaration)->members());
+    case DeclarationKind::MixinDeclaration:
+      return ResolveUnformed(cast<MixinDeclaration>(declaration)->members());
+    case DeclarationKind::InterfaceDeclaration:
+    case DeclarationKind::ConstraintDeclaration:
+      return ResolveUnformed(
+          cast<ConstraintTypeDeclaration>(declaration)->members());
+    case DeclarationKind::ImplDeclaration:
+      return ResolveUnformed(cast<ImplDeclaration>(declaration)->members());
   }
   return Success();
 }

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -125,9 +125,9 @@ static auto ResolveUnformed(Nonnull<const Expression*> expression,
     case ExpressionKind::SimpleMemberAccessExpression:
     case ExpressionKind::CompoundMemberAccessExpression:
     case ExpressionKind::BaseAccessExpression:
-      CARBON_RETURN_IF_ERROR(ResolveUnformed(
-          &cast<MemberAccessExpression>(*expression).object(), flow_facts,
-          FlowFacts::ActionType::Check));
+      CARBON_RETURN_IF_ERROR(
+          ResolveUnformed(&cast<MemberAccessExpression>(*expression).object(),
+                          flow_facts, FlowFacts::ActionType::Check));
       break;
     case ExpressionKind::BuiltinConvertExpression:
       CARBON_RETURN_IF_ERROR(ResolveUnformed(

--- a/explorer/interpreter/resolve_unformed.cpp
+++ b/explorer/interpreter/resolve_unformed.cpp
@@ -179,8 +179,8 @@ static auto ResolveOneUnformedExpression(
 static auto ResolveUnformed(Nonnull<const Expression*> expression,
                             FlowFacts& flow_facts, FlowFacts::ActionType action)
     -> ErrorOr<Success> {
-  // We visit subexpressions in evaluation order, by performing a reverse
-  // postorder traversal here and enqueueing subexpressions in reverse order in
+  // We visit subexpressions in evaluation order, by performing a LIFO
+  // traversal here and enqueueing subexpressions in reverse order in
   // ResolveOneUnformedExpression.
   llvm::SmallVector<PendingResolveUnformedStep, 32> queue;
   queue.push_back({expression, action});

--- a/explorer/interpreter/stack_space.h
+++ b/explorer/interpreter/stack_space.h
@@ -27,11 +27,13 @@ auto RunWithExtraStackHelper(llvm::function_ref<void()> fn) -> void;
 // create the current thread.
 //
 // Usage:
-//   return RunWithExtraStack<ReturnType>([&]() -> ReturnType {
+//   return RunWithExtraStack([&]() -> ReturnType {
 //         <function body>
 //       });
-template <typename ReturnType>
-auto RunWithExtraStack(llvm::function_ref<ReturnType()> fn) -> ReturnType {
+template <typename Fn>
+auto RunWithExtraStack(Fn fn) -> decltype(fn()) {
+  using ReturnType = decltype(fn());
+  static_assert(!std::is_reference_v<ReturnType>);
   if (Internal::IsStackSpaceNearlyExhausted()) {
     std::optional<ReturnType> result;
     Internal::RunWithExtraStackHelper([&] { result = fn(); });

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2742,7 +2742,7 @@ auto TypeChecker::CheckAddrMeAccess(
 auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                                const ImplScope& impl_scope)
     -> ErrorOr<Success> {
-  return RunWithExtraStack<ErrorOr<Success>>(
+  return RunWithExtraStack(
       [&]() { return TypeCheckExpImpl(e, impl_scope); });
 }
 

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2742,8 +2742,7 @@ auto TypeChecker::CheckAddrMeAccess(
 auto TypeChecker::TypeCheckExp(Nonnull<Expression*> e,
                                const ImplScope& impl_scope)
     -> ErrorOr<Success> {
-  return RunWithExtraStack(
-      [&]() { return TypeCheckExpImpl(e, impl_scope); });
+  return RunWithExtraStack([&]() { return TypeCheckExpImpl(e, impl_scope); });
 }
 
 // NOLINTNEXTLINE(readability-function-size)

--- a/explorer/parse_and_execute/parse_and_execute.cpp
+++ b/explorer/parse_and_execute/parse_and_execute.cpp
@@ -40,7 +40,7 @@ static auto ParseAndExecuteHelper(std::function<ErrorOr<AST>(Arena*)> parse,
                                   Nonnull<TraceStream*> trace_stream,
                                   Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<int> {
-  return RunWithExtraStack<ErrorOr<int>>([&]() -> ErrorOr<int> {
+  return RunWithExtraStack([&]() -> ErrorOr<int> {
     Arena arena;
     auto cursor = std::chrono::steady_clock::now();
 

--- a/explorer/testdata/array/fail_store_to_uninitialized_array.carbon
+++ b/explorer/testdata/array/fail_store_to_uninitialized_array.carbon
@@ -4,11 +4,12 @@
 //
 // AUTOUPDATE
 
-package ExplorerTest impl;
+package ExplorerTest api;
 
 fn Main() -> i32 {
   var my_array : [i32; 1];
-  // CHECK:STDERR: COMPILATION ERROR: fail_print_uninitalized_array_element.carbon:[[@LINE+1]]: use of uninitialized variable my_array
+  // CHECK:STDERR: COMPILATION ERROR: fail_store_to_uninitialized_array.carbon:[[@LINE+1]]: use of uninitialized variable my_array
+  my_array[0] = 100;
   Print("{0}", my_array[0]);
   return 0;
 }

--- a/explorer/testdata/array/fail_store_to_uninitialized_global_array.carbon
+++ b/explorer/testdata/array/fail_store_to_uninitialized_global_array.carbon
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: 100
-// CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
 var my_array : [i32; 1];
 
 fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_store_to_uninitialized_global_array.carbon:[[@LINE+1]]: undefined behavior: store to subobject of uninitialized value Uninit<Placeholder<my_array>>
   my_array[0] = 100;
   Print("{0}", my_array[0]);
   return 0;

--- a/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
+++ b/explorer/testdata/choice/generic_choice_nested_in_template_class.carbon
@@ -31,14 +31,14 @@ class MyOptional(T:! type){
     }
 
     fn get[self: Self] () -> T {
-        var y: T;
         var x: MyOptionalElement(T) = self.element;
         match(x){
             case MyOptionalElement(T).Element( var x: T ) =>{
                 return x;
             }
         }
-        return y;
+        // TODO: Mark this as unreachable somehow.
+        return get();
     }
 
    var element: MyOptionalElement(T);

--- a/explorer/testdata/class/fail_store_to_uninitialized_class.carbon
+++ b/explorer/testdata/class/fail_store_to_uninitialized_class.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point;
+  if (1 == 0) {
+    p = {.x = 0, .y = 0};
+  }
+  // CHECK:STDERR: RUNTIME ERROR: fail_store_to_uninitialized_class.carbon:[[@LINE+1]]: undefined behavior: store to subobject of uninitialized value Uninit<Placeholder<p>>
+  p.x = 1;
+  p.y = 2;
+  return p.x;
+}

--- a/explorer/testdata/unformed/fail_array.carbon
+++ b/explorer/testdata/unformed/fail_array.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: [i32; 2];
+  // CHECK:STDERR: COMPILATION ERROR: fail_array.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return v[0];
+}

--- a/explorer/testdata/unformed/fail_array_dynamic.carbon
+++ b/explorer/testdata/unformed/fail_array_dynamic.carbon
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: 100
-// CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
 fn Main() -> i32 {
-  var my_array : [i32; 1];
-  my_array[0] = 100;
-  Print("{0}", my_array[0]);
-  return 0;
+  var v: [i32; 2];
+  if (0 == 1) {
+    v = (1, 2);
+  }
+  // CHECK:STDERR: RUNTIME ERROR: fail_array_dynamic.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<v>>
+  return v[0];
 }

--- a/explorer/testdata/unformed/fail_base_access.carbon
+++ b/explorer/testdata/unformed/fail_base_access.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+base class B {
+  var n: i32;
+}
+
+class D extends B {}
+
+fn Main() -> i32 {
+  var d: D;
+  // CHECK:STDERR: COMPILATION ERROR: fail_base_access.carbon:[[@LINE+1]]: use of uninitialized variable d
+  return d.n;
+}

--- a/explorer/testdata/unformed/fail_compound_member_access.carbon
+++ b/explorer/testdata/unformed/fail_compound_member_access.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  var n: i32;
+}
+
+fn Main() -> i32 {
+  var c: C;
+  // CHECK:STDERR: COMPILATION ERROR: fail_compound_member_access.carbon:[[@LINE+1]]: use of uninitialized variable c
+  return c.(C.n);
+}

--- a/explorer/testdata/unformed/fail_control_flow_defer_to_dynamic.carbon
+++ b/explorer/testdata/unformed/fail_control_flow_defer_to_dynamic.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  if (0 == 1) {
+    x = 0;
+  }
+  // Static analysis thinks `x` may be formed, defer the check to run-time.
+  // CHECK:STDERR: RUNTIME ERROR: fail_control_flow_defer_to_dynamic.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<x>>
+  return x;
+}

--- a/explorer/testdata/unformed/fail_if_cond.carbon
+++ b/explorer/testdata/unformed/fail_if_cond.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: bool;
+  // CHECK:STDERR: COMPILATION ERROR: fail_if_cond.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return if v then 1 else 2;
+}

--- a/explorer/testdata/unformed/fail_if_else.carbon
+++ b/explorer/testdata/unformed/fail_if_else.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_if_else.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return if false then 1 else v;
+}

--- a/explorer/testdata/unformed/fail_if_then.carbon
+++ b/explorer/testdata/unformed/fail_if_then.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_if_then.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return if true then v else 2;
+}

--- a/explorer/testdata/unformed/fail_in_class.carbon
+++ b/explorer/testdata/unformed/fail_in_class.carbon
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  fn F() -> i32 {
+    var n: i32;
+    // CHECK:STDERR: COMPILATION ERROR: fail_in_class.carbon:[[@LINE+1]]: use of uninitialized variable n
+    return n;
+  }
+}
+
+fn Main() -> i32 {
+  return C.F();
+}

--- a/explorer/testdata/unformed/fail_indirect_member_access.carbon
+++ b/explorer/testdata/unformed/fail_indirect_member_access.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var pt: {.x: i32, .y: i32};
+  // TODO: Without this, we don't allow taking the address of `pt.x`.
+  // That's probably too restrictive.
+  if (1 == 0) { pt = {.x = 1, .y = 2}; }
+  var p: i32* = &pt.x;
+  // CHECK:STDERR: RUNTIME ERROR: fail_indirect_member_access.carbon:[[@LINE+1]]: undefined behavior: access to uninitialized value Uninit<Placeholder<pt>>
+  return *p;
+}

--- a/explorer/testdata/unformed/fail_intrinsic.carbon
+++ b/explorer/testdata/unformed/fail_intrinsic.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return if __intrinsic_int_eq(v, v) then 1 else 2;
+}


### PR DESCRIPTION
Per #257, we should be treating unformedness as all-or-nothing, rather than being a per-field or per-array-element property. Previously we initialized an array with no explicit initializer as containing a sequence of uninitialized values, but that led to crashes when attempting to access those values, as the checks for reading an uninitialized value only expected values to be uninitialized at the top level.

Also, we had existing tests that attempt to store to an element of an uninitialized array. We now detect that and treat it as UB during evaluation, rather than crashing due to trying to perform field access into an uninitialized value.

Finally, many of these problems can be detected statically, but the resolve_unformed pass wasn't catching them because it missed a few expression and declaration forms. Support for those cases has been added too. This causes the pass to recurse more often, and in particular our existing recursion test started hitting a stack overflow after this, so resolve_unformed now uses `RunWithExtraStack`. In passing, remove the need to explicitly tell `RunWithExtraStack` the return type, and infer it as the return type of the callable instead.