### PR TITLE
Fix test_arg for file_test.subset

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -64,8 +64,12 @@ static auto SplitOutput(llvm::StringRef output)
 // Runs a test and compares output. This keeps output split by line so that
 // issues are a little easier to identify by the different line.
 auto FileTestBase::TestBody() -> void {
+  const char* src_dir = getenv("TEST_SRCDIR");
+  CARBON_CHECK(src_dir);
+  std::string test_file = path().lexically_relative(
+      std::filesystem::path(src_dir).append("carbon"));
   llvm::errs() << "\nTo test this file alone, run:\n  bazel test "
-               << *subset_target << " --test_arg=" << path() << "\n\n";
+               << *subset_target << " --test_arg=" << test_file << "\n\n";
 
   // Load expected output.
   std::vector<testing::Matcher<std::string>> expected_stdout;


### PR DESCRIPTION
I believe this broke when I was changing path handling.

Bad:

```
  bazel test //testing/file_test:file_test_base_test.subset --test_arg=/usr/local/...elided.../execroot/carbon/bazel-out/k8-fastbuild/bin/testing/file_test/file_test_base_test.runfiles/carbon/testing/file_test/example.carbon
```

Good:

```
  bazel test //testing/file_test:file_test_base_test.subset --test_arg=testing/file_test/example.carbon
```