### PR TITLE
Follow-up to #2657: add operators from #2511 and more references

### DIFF
--- a/docs/design/lexical_conventions/symbolic_tokens.md
+++ b/docs/design/lexical_conventions/symbolic_tokens.md
@@ -64,12 +64,24 @@ source file:
 | `*`             | Indirection, multiplication, and forming pointer types                                                       |
 | `/`             | Division                                                                                                     |
 | `%`             | Modulus                                                                                                      |
-| `=`             | Assignment                                                                                                   |
 | `^`             | Complementing and Bitwise XOR                                                                                |
 | `&`             | Address-of and Bitwise AND                                                                                   |
 | `\|`            | Bitwise OR                                                                                                   |
 | `<<`            | Arithmetic and Logical Left-shift                                                                            |
 | `>>`            | Arithmetic and Logical Right-shift                                                                           |
+| `=`             | Assignment and initialization                                                                                |
+| `++`            | Increment                                                                                                    |
+| `--`            | Decrement                                                                                                    |
+| `+=`            | Add-and-assign                                                                                               |
+| `-=`            | Subtract-and-assign                                                                                          |
+| `*=`            | Multiply-and-assign                                                                                          |
+| `/=`            | Divide-and-assign                                                                                            |
+| `%=`            | Modulus-and-assign                                                                                           |
+| `&=`            | Bitwise-AND-and-assign                                                                                       |
+| `\|=`           | Bitwise-OR-and-assign                                                                                        |
+| `^=`            | Bitwise-XOR-and-assign                                                                                       |
+| `<<=`           | Left-shift-and-assign                                                                                        |
+| `>>=`           | Right-shift-and-assign                                                                                       |
 | `==`            | Equality or equal to                                                                                         |
 | `!=`            | Inequality or not equal to                                                                                   |
 | `>`             | Greater than                                                                                                 |
@@ -87,15 +99,42 @@ source file:
 | `:!`            | Generic binding                                                                                              |
 | `;`             | Statement separator                                                                                          |
 
-TODO: The assignment operators in
-[#2511](https://github.com/carbon-language/carbon-lang/pull/2511) are still to
-be added.
-
 ## Alternatives considered
 
--   [Proposal: p0601](/proposals/p0601.md#alternatives-considered)
+[Alternatives from proposal #601](/proposals/p0601.md#alternatives-considered):
+
+-   lex the longest sequence of symbolic characters rather than lexing only the
+    longest known operator
+-   support an extensible operator set
+-   different whitespace restrictions or no whitespace restrictions
 
 ## References
 
 -   Proposal
-    [#601: Symbolic tokens](https://github.com/carbon-language/carbon-lang/pull/601)
+    [#162: Basic Syntax](https://github.com/carbon-language/carbon-lang/pull/162)
+-   Proposal
+    [#339: Add `var <type> <identifier> [ = <value> ];` syntax for variables](https://github.com/carbon-language/carbon-lang/pull/339)
+-   Proposal
+    [#438: Add statement syntax for function declarations](https://github.com/carbon-language/carbon-lang/pull/438)
+-   Proposal
+    [#561: Basic classes: use cases, struct literals, struct types, and future work](https://github.com/carbon-language/carbon-lang/pull/561)
+-   Proposal
+    [#601: Operator tokens](https://github.com/carbon-language/carbon-lang/pull/601)
+-   Proposal
+    [#676: `:!` generic syntax](https://github.com/carbon-language/carbon-lang/pull/676)
+-   Proposal
+    [#702: Comparison operators](https://github.com/carbon-language/carbon-lang/pull/702)
+-   Proposal
+    [#989: Member access expressions](https://github.com/carbon-language/carbon-lang/pull/989)
+-   Proposal
+    [#1083: Arithmetic expressions](https://github.com/carbon-language/carbon-lang/pull/1083)
+-   Proposal
+    [#1191: Arithmetic expressions](https://github.com/carbon-language/carbon-lang/pull/1191)
+-   Proposal
+    [#2188: Pattern matching syntax and semantics](https://github.com/carbon-language/carbon-lang/pull/2188)
+-   Proposal
+    [#2274: Subscript syntax and semantics](https://github.com/carbon-language/carbon-lang/pull/2274)
+-   Proposal
+    [#2511: Assignment statements](https://github.com/carbon-language/carbon-lang/pull/2511)
+-   Proposal
+    [#2665: Semicolons terminate statements](https://github.com/carbon-language/carbon-lang/pull/2665)


### PR DESCRIPTION
With this change `docs/design/lexical_conventions/symbolic_tokens.md` should now include all operators and symbols from accepted proposals.