### PR TITLE
Fix copy-paste error in name of pull request

### DIFF
--- a/docs/design/lexical_conventions/symbolic_tokens.md
+++ b/docs/design/lexical_conventions/symbolic_tokens.md
@@ -129,7 +129,7 @@ source file:
 -   Proposal
     [#1083: Arithmetic expressions](https://github.com/carbon-language/carbon-lang/pull/1083)
 -   Proposal
-    [#1191: Arithmetic expressions](https://github.com/carbon-language/carbon-lang/pull/1191)
+    [#1191: Bitwise operators](https://github.com/carbon-language/carbon-lang/pull/1191)
 -   Proposal
     [#2188: Pattern matching syntax and semantics](https://github.com/carbon-language/carbon-lang/pull/2188)
 -   Proposal


### PR DESCRIPTION
From a suggested change from @jonmeow that arrived after #2870 was merged.