### PR TITLE
Fix test env setup in macOS

### DIFF
--- a/testing/lit_test/lit_test.py
+++ b/testing/lit_test/lit_test.py
@@ -9,7 +9,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import argparse
 import os
 from pathlib import Path
-import shutil
 import subprocess
 
 
@@ -34,20 +33,9 @@ def main():
         "-v",
     ]
 
-    # Force tests to be explicit about command paths. Some tools are required by
-    # bazel's py_binary output in order to find python3, so we add these. The
-    # list of tools may prove to be fragile: if so, we may need to change or
-    # remove the PATH hiding.
-    system_tools = Path(os.environ["TEST_TMPDIR"]).joinpath("system_tools")
-    system_tools.mkdir()
-    for tool in ("env", "grep", "python3", "sh", "which"):
-        system_tools.joinpath(tool).symlink_to(shutil.which(tool))
-    env = os.environ.copy()
-    env["PATH"] = str(system_tools)
-
     # Run lit.
     try:
-        subprocess.check_call(args=args + parsed_args.lit_args, env=env)
+        subprocess.check_call(args=args + parsed_args.lit_args)
     except subprocess.CalledProcessError as e:
         # Print without the stack trace.
         exit(e)


### PR DESCRIPTION
Some tests failed to run in my macOS (13.3.1) setup:

```
$bazel test //...:all
...
//toolchain/source:source_buffer_test                                    PASSED in 0.3s
//explorer/lit_testdata:hello.carbon.test                                FAILED in 2.2s
  /private/var/tmp/_bazel_ming.chen/308b02a1da3e82e017b979084b8d8d91/execroot/carbon/bazel-out/darwin_arm64-fastbuild/testlogs/explorer/lit_testdata/hello.carbon.test/test.log
//explorer/lit_testdata:trace.carbon.test                                FAILED in 1.3s
//explorer/lit_testdata:zero.carbon.test                                 FAILED in 1.6s
//toolchain/driver/testdata:errors_sorted_test.carbon.test               FAILED in 2.2s
//toolchain/driver/testdata:errors_streamed_test.carbon.test             FAILED in 1.2s
//toolchain/driver/testdata:semantics_builtin_nodes.carbon.test          FAILED in 0.7s
...
```

The log of the failed tests shows that `bash` is not found in path:

```
(trunk)$ cat /private/var/tmp/_bazel_ming.chen/308b02a1da3e82e017b979084b8d8d91/execroot/carbon/bazel-out/darwin_arm64-fastbuild/testlogs/explorer/lit_testdata/hello.carbon.test/test.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //explorer/lit_testdata:hello.carbon.test
-----------------------------------------------------------------------------
env: bash: No such file or directory
...
```

Some digging revealed that we hide the PATH in `lit_test.py` and the PATH does not include `bash` (zsh has replaced bash as the default shell in macOS). For example, `bash` is not at a common path on my machine:

```
(fixtest)$ type bash
bash is /opt/homebrew/bin/bash
```

Trying to add bash in the tool list lead to more problems:

```
-    for tool in ("env", "grep", "python3", "sh", "which"):
+    for tool in ("env", "bash", "grep", "python3", "sh", "which"):
```

```
INFO: From Testing //explorer/lit_testdata:hello.carbon.test:
==================== Test output for //explorer/lit_testdata:hello.carbon.test:
/opt/homebrew/Cellar/pyenv/2.3.18/libexec/pyenv-which: line 61: basename: command not found
```

Further adding `basename` didn't work either. So it seems to me that the way we hide PATH is indeed fragile as the comment hinted.

Removing the PATH hiding enables all tests to pass. So this PR does so to fix the tests.
