### PR TITLE
Fix false positive in potential cycle detection.

### DIFF
--- a/explorer/interpreter/matching_impl_set.h
+++ b/explorer/interpreter/matching_impl_set.h
@@ -36,6 +36,7 @@ class MatchingImplSet {
  private:
   class LeafCollector;
   enum class Label : int;
+  using Signature = llvm::DenseMap<Label, int>;
 
  public:
   // An RAII type that tracks an impl match that we're currently performing.
@@ -69,7 +70,7 @@ class MatchingImplSet {
     // The interface that is being matched against the impl.
     Nonnull<const Value*> interface_;
     // The number of times each label appears in the type or interface.
-    llvm::DenseMap<Label, int> signature_;
+    Signature signature_;
   };
 
  private:

--- a/explorer/testdata/impl_match/non_overlapping_labels.carbon
+++ b/explorer/testdata/impl_match/non_overlapping_labels.carbon
@@ -1,0 +1,46 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: T as Iface
+// CHECK:STDOUT: T as Iface
+// CHECK:STDOUT: A as Iface
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface HasType {
+  let AssocType:! type;
+}
+
+interface Iface {
+  fn F();
+}
+
+external impl forall [T:! HasType where .Self.AssocType impls Iface] T as Iface {
+  fn F() {
+    Print("T as Iface");
+    T.AssocType.(Iface.F)();
+  }
+}
+
+class A {
+  impl as Iface {
+    fn F() { Print("A as Iface"); }
+  }
+}
+
+class B {
+  impl as HasType where .AssocType = A {}
+}
+
+class C {
+  impl as HasType where .AssocType = B {}
+}
+
+fn Main() -> i32 {
+  let c: C = {};
+  c.(Iface.F)();
+  return 0;
+}


### PR DESCRIPTION
Fix misidentification of a potential cycle in the case where the inner match is missing labels from the outer match, and the inner match is strictly more complex when considering only its labels. We previously ignored labels in the outer match that are absent in the inner match, but the existence of any such label should cause us to treat the inner match as not being strictly more complex.