### PR TITLE
Refactor toolchain tests so that driver API changes affect fewer files.

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -85,14 +85,14 @@ class ParseAndExecuteTestFile : public FileTestBase {
 extern auto RegisterFileTests(
     const llvm::SmallVector<std::filesystem::path>& paths) -> void {
   ParseAndExecuteTestFile::RegisterTests(
-      "ParseAndExecuteTestFile", paths, [=](const std::filesystem::path& path) {
+      "ParseAndExecuteTestFile", paths, [](const std::filesystem::path& path) {
         return new ParseAndExecuteTestFile(path, /*trace=*/false);
       });
-  ParseAndExecuteTestFile::RegisterTests(
-      "ParseAndExecuteTestFile.trace", paths,
-      [=](const std::filesystem::path& path) {
-        return new ParseAndExecuteTestFile(path, /*trace=*/true);
-      });
+  ParseAndExecuteTestFile::RegisterTests("ParseAndExecuteTestFile.trace", paths,
+                                         [](const std::filesystem::path& path) {
+                                           return new ParseAndExecuteTestFile(
+                                               path, /*trace=*/true);
+                                         });
 }
 
 }  // namespace Carbon::Testing

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -38,10 +38,20 @@ class FileTestBase : public testing::Test {
   ~FileTestBase() override;
 
   // Used by children to register tests with gtest.
-  static void RegisterTests(
+  static auto RegisterTests(
       const char* fixture_label,
       const llvm::SmallVector<std::filesystem::path>& paths,
-      std::function<FileTestBase*(const std::filesystem::path&)> factory);
+      std::function<FileTestBase*(const std::filesystem::path&)> factory)
+      -> void;
+
+  template <typename FileTestChildT>
+  static auto RegisterTests(
+      const char* fixture_label,
+      const llvm::SmallVector<std::filesystem::path>& paths) -> void {
+    RegisterTests(fixture_label, paths, [](const std::filesystem::path& path) {
+      return new FileTestChildT(path);
+    });
+  }
 
   // Implemented by children to run the test. Called by the TestBody
   // implementation, which will validate stdout and stderr. The return value

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -72,10 +72,7 @@ class FileTestBaseTest : public FileTestBase {
 
 auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
     -> void {
-  FileTestBaseTest::RegisterTests("FileTestBaseTest", paths,
-                                  [](const std::filesystem::path& path) {
-                                    return new FileTestBaseTest(path);
-                                  });
+  FileTestBaseTest::RegisterTests<FileTestBaseTest>("FileTestBaseTest", paths);
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -53,6 +53,17 @@ cc_fuzz_test(
     ],
 )
 
+cc_library(
+    name = "driver_file_test_base",
+    testonly = 1,
+    hdrs = ["driver_file_test_base.h"],
+    deps = [
+        ":driver",
+        "//testing/file_test:file_test_base",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
 cc_binary(
     name = "carbon",
     srcs = ["driver_main.cpp"],

--- a/toolchain/driver/driver_file_test_base.h
+++ b/toolchain/driver/driver_file_test_base.h
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
+#define CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "testing/file_test/file_test_base.h"
+#include "toolchain/driver/driver.h"
+
+namespace Carbon::Testing {
+
+// Provides common test support for the driver. This is used by file tests in
+// phase subdirectories.
+class DriverFileTestBase : public FileTestBase {
+ public:
+  using FileTestBase::FileTestBase;
+
+  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
+                    llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
+      -> bool override {
+    Driver driver(stdout, stderr);
+    return driver.RunFullCommand(MakeArgs(test_files));
+  }
+
+  virtual auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+      -> llvm::SmallVector<llvm::StringRef> = 0;
+};
+
+}  // namespace Carbon::Testing
+
+#endif  // CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_

--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -236,9 +236,7 @@ file_test(
     srcs = ["lexer_file_test.cpp"],
     tests = glob(["testdata/**/*.carbon"]),
     deps = [
-        "//testing/file_test:file_test_base",
-        "//toolchain/driver",
-        "@com_google_googletest//:gtest",
+        "//toolchain/driver:driver_file_test_base",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/lexer/lexer_file_test.cpp
+++ b/toolchain/lexer/lexer_file_test.cpp
@@ -2,33 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <filesystem>
+#include <string>
 
-#include <vector>
-
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
-#include "testing/file_test/file_test_base.h"
-#include "toolchain/driver/driver.h"
+#include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
 namespace {
 
-class LexerFileTest : public FileTestBase {
+class LexerFileTest : public DriverFileTestBase {
  public:
-  explicit LexerFileTest(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using DriverFileTestBase::DriverFileTestBase;
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
-                    llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
-      -> bool override {
+  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+      -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "tokens"});
     for (const auto& file : test_files) {
       args.push_back(file);
     }
-    Driver driver(stdout, stderr);
-    return driver.RunFullCommand(args);
+    return args;
   }
 };
 
@@ -36,10 +30,7 @@ class LexerFileTest : public FileTestBase {
 
 auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
     -> void {
-  LexerFileTest::RegisterTests("LexerFileTest", paths,
-                               [](const std::filesystem::path& path) {
-                                 return new LexerFileTest(path);
-                               });
+  LexerFileTest::RegisterTests<LexerFileTest>("LexerFileTest", paths);
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/lowering/BUILD
+++ b/toolchain/lowering/BUILD
@@ -42,9 +42,7 @@ file_test(
     srcs = ["lowering_file_test.cpp"],
     tests = glob(["testdata/**/*.carbon"]),
     deps = [
-        "//testing/file_test:file_test_base",
-        "//toolchain/driver",
-        "@com_google_googletest//:gtest",
+        "//toolchain/driver:driver_file_test_base",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -2,33 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <filesystem>
+#include <string>
 
-#include <vector>
-
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
-#include "testing/file_test/file_test_base.h"
-#include "toolchain/driver/driver.h"
+#include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
 namespace {
 
-class LoweringFileTest : public FileTestBase {
+class LoweringFileTest : public DriverFileTestBase {
  public:
-  explicit LoweringFileTest(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using DriverFileTestBase::DriverFileTestBase;
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
-                    llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
-      -> bool override {
+  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+      -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "llvm-ir"});
     for (const auto& file : test_files) {
       args.push_back(file);
     }
-    Driver driver(stdout, stderr);
-    return driver.RunFullCommand(args);
+    return args;
   }
 };
 
@@ -36,10 +30,7 @@ class LoweringFileTest : public FileTestBase {
 
 auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
     -> void {
-  LoweringFileTest::RegisterTests("LoweringFileTest", paths,
-                                  [=](const std::filesystem::path& path) {
-                                    return new LoweringFileTest(path);
-                                  });
+  LoweringFileTest::RegisterTests<LoweringFileTest>("LoweringFileTest", paths);
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -121,9 +121,7 @@ file_test(
     srcs = ["parse_tree_file_test.cpp"],
     tests = glob(["testdata/**/*.carbon"]),
     deps = [
-        "//testing/file_test:file_test_base",
-        "//toolchain/driver",
-        "@com_google_googletest//:gtest",
+        "//toolchain/driver:driver_file_test_base",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/parser/parse_tree_file_test.cpp
+++ b/toolchain/parser/parse_tree_file_test.cpp
@@ -2,33 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <filesystem>
+#include <string>
 
-#include <vector>
-
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
-#include "testing/file_test/file_test_base.h"
-#include "toolchain/driver/driver.h"
+#include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
 namespace {
 
-class ParserFileTest : public FileTestBase {
+class ParseTreeFileTest : public DriverFileTestBase {
  public:
-  explicit ParserFileTest(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using DriverFileTestBase::DriverFileTestBase;
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
-                    llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
-      -> bool override {
+  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+      -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "parse-tree"});
     for (const auto& file : test_files) {
       args.push_back(file);
     }
-    Driver driver(stdout, stderr);
-    return driver.RunFullCommand(args);
+    return args;
   }
 };
 
@@ -36,10 +30,8 @@ class ParserFileTest : public FileTestBase {
 
 auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
     -> void {
-  ParserFileTest::RegisterTests("ParserFileTest", paths,
-                                [](const std::filesystem::path& path) {
-                                  return new ParserFileTest(path);
-                                });
+  ParseTreeFileTest::RegisterTests<ParseTreeFileTest>("ParseTreeFileTest",
+                                                      paths);
 }
 
 }  // namespace Carbon::Testing

--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -119,9 +119,7 @@ file_test(
     srcs = ["semantics_file_test.cpp"],
     tests = glob(["testdata/**/*.carbon"]),
     deps = [
-        "//testing/file_test:file_test_base",
-        "//toolchain/driver",
-        "@com_google_googletest//:gtest",
+        "//toolchain/driver:driver_file_test_base",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -2,33 +2,27 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <filesystem>
+#include <string>
 
-#include <vector>
-
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
-#include "testing/file_test/file_test_base.h"
-#include "toolchain/driver/driver.h"
+#include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
 namespace {
 
-class SemanticsFileTest : public FileTestBase {
+class SemanticsFileTest : public DriverFileTestBase {
  public:
-  explicit SemanticsFileTest(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using DriverFileTestBase::DriverFileTestBase;
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
-                    llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
-      -> bool override {
+  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+      -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "semantics-ir"});
     for (const auto& file : test_files) {
       args.push_back(file);
     }
-    Driver driver(stdout, stderr);
-    return driver.RunFullCommand(args);
+    return args;
   }
 };
 
@@ -36,10 +30,8 @@ class SemanticsFileTest : public FileTestBase {
 
 auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
     -> void {
-  SemanticsFileTest::RegisterTests("SemanticsFileTest", paths,
-                                   [](const std::filesystem::path& path) {
-                                     return new SemanticsFileTest(path);
-                                   });
+  SemanticsFileTest::RegisterTests<SemanticsFileTest>("SemanticsFileTest",
+                                                      paths);
 }
 
 }  // namespace Carbon::Testing


### PR DESCRIPTION
This is really just about limiting the impact of changes, since I'm considering a driver API change to add vfs logic.