### PR TITLE
Switch FileTest to use StringRefs instead of files.

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -32,7 +32,7 @@ class ParseAndExecuteTestFile : public FileTestBase {
     }
   }
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
+  auto RunWithFiles(const llvm::SmallVector<TestFile>& test_files,
                     llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
     if (test_files.size() != 1) {
@@ -58,9 +58,9 @@ class ParseAndExecuteTestFile : public FileTestBase {
 
     // Run the parse. Parser debug output is always off because it's difficult
     // to redirect.
-    auto result =
-        ParseAndExecuteFile(prelude_path, path().filename().string(),
-                            /*parser_debug=*/false, &trace_stream, &stdout);
+    auto result = ParseAndExecute(
+        prelude_path, test_files[0].filename, test_files[0].content,
+        /*parser_debug=*/false, &trace_stream, &stdout);
     // This mirrors printing currently done by main.cpp.
     if (result.ok()) {
       stdout << "result: " << *result << "\n";

--- a/explorer/fuzzing/fuzzer_util.cpp
+++ b/explorer/fuzzing/fuzzer_util.cpp
@@ -39,7 +39,9 @@ auto ParseAndExecuteProto(const Fuzzing::Carbon& carbon) -> ErrorOr<int> {
   CARBON_CHECK(prelude_path.ok()) << prelude_path.error();
 
   const std::string source = ProtoToCarbon(carbon, /*maybe_add_main=*/true);
-  return ParseAndExecute(*prelude_path, source);
+  TraceStream trace_stream;
+  return ParseAndExecute(*prelude_path, "fuzzer.carbon", source,
+                         /*parser_debug=*/false, &trace_stream, &llvm::nulls());
 }
 
 }  // namespace Carbon::Testing

--- a/explorer/parse_and_execute/parse_and_execute.cpp
+++ b/explorer/parse_and_execute/parse_and_execute.cpp
@@ -38,7 +38,7 @@ static auto PrintTimingOnExit(TraceStream* trace_stream, const char* label,
 }
 
 static auto ParseAndExecuteHelper(std::function<ErrorOr<AST>(Arena*)> parse,
-                                  const std::string& prelude_path,
+                                  std::string_view prelude_path,
                                   Nonnull<TraceStream*> trace_stream,
                                   Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<int> {
@@ -90,8 +90,8 @@ static auto ParseAndExecuteHelper(std::function<ErrorOr<AST>(Arena*)> parse,
   });
 }
 
-auto ParseAndExecuteFile(const std::string& prelude_path,
-                         const std::string& input_file_name, bool parser_debug,
+auto ParseAndExecuteFile(std::string_view prelude_path,
+                         std::string_view input_file_name, bool parser_debug,
                          Nonnull<TraceStream*> trace_stream,
                          Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<int> {
@@ -101,15 +101,15 @@ auto ParseAndExecuteFile(const std::string& prelude_path,
   return ParseAndExecuteHelper(parse, prelude_path, trace_stream, print_stream);
 }
 
-auto ParseAndExecute(const std::string& prelude_path, const std::string& source)
-    -> ErrorOr<int> {
+auto ParseAndExecute(std::string_view prelude_path,
+                     std::string_view input_file_name,
+                     std::string_view file_contents, bool parser_debug,
+                     Nonnull<TraceStream*> trace_stream,
+                     Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int> {
   auto parse = [&](Arena* arena) {
-    return ParseFromString(arena, "test.carbon", source,
-                           /*parser_debug=*/false);
+    return ParseFromString(arena, input_file_name, file_contents, parser_debug);
   };
-  TraceStream trace_stream;
-  return ParseAndExecuteHelper(parse, prelude_path, &trace_stream,
-                               &llvm::nulls());
+  return ParseAndExecuteHelper(parse, prelude_path, trace_stream, print_stream);
 }
 
 }  // namespace Carbon

--- a/explorer/parse_and_execute/parse_and_execute.h
+++ b/explorer/parse_and_execute/parse_and_execute.h
@@ -12,16 +12,19 @@ namespace Carbon {
 
 // Parses and executes the input file, returning the program result on success.
 // This API is intended for use by main execution.
-auto ParseAndExecuteFile(const std::string& prelude_path,
-                         const std::string& input_file_name, bool parser_debug,
+auto ParseAndExecuteFile(std::string_view prelude_path,
+                         std::string_view input_file_name, bool parser_debug,
                          Nonnull<TraceStream*> trace_stream,
                          Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<int>;
 
 // Parses and executes the source, returning the program result on success.
 // Discards output.
-auto ParseAndExecute(const std::string& prelude_path, const std::string& source)
-    -> ErrorOr<int>;
+auto ParseAndExecute(std::string_view prelude_path,
+                     std::string_view input_file_name,
+                     std::string_view file_contents, bool parser_debug,
+                     Nonnull<TraceStream*> trace_stream,
+                     Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int>;
 
 }  // namespace Carbon
 

--- a/explorer/parse_and_execute/parse_and_execute_test.cpp
+++ b/explorer/parse_and_execute/parse_and_execute_test.cpp
@@ -31,7 +31,10 @@ TEST(ParseAndExecuteTest, Recursion) {
         ;
     }
   )";
-  auto err = ParseAndExecute("explorer/data/prelude.carbon", source);
+  TraceStream trace_stream;
+  auto err =
+      ParseAndExecute("explorer/data/prelude.carbon", "test.carbon", source,
+                      /*parser_debug=*/false, &trace_stream, &llvm::nulls());
   ASSERT_FALSE(err.ok());
   EXPECT_THAT(err.error().message(),
               Eq("RUNTIME ERROR: overflow:1: stack overflow: too many "

--- a/toolchain/driver/driver_file_test_base.h
+++ b/toolchain/driver/driver_file_test_base.h
@@ -5,6 +5,10 @@
 #ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
 #define CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
 
+#include <filesystem>
+#include <fstream>
+
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "testing/file_test/file_test_base.h"
@@ -18,14 +22,47 @@ class DriverFileTestBase : public FileTestBase {
  public:
   using FileTestBase::FileTestBase;
 
-  auto RunWithFiles(const llvm::SmallVector<std::string>& test_files,
+  auto RunWithFiles(const llvm::SmallVector<TestFile>& test_files,
                     llvm::raw_ostream& stdout, llvm::raw_ostream& stderr)
       -> bool override {
+    // TODO: The working dir and file creation logic should be replaced with vfs
+    // use. That will require modifying Driver and SourceBuffer to use vfs.
+    // Get the working dir.
+    std::error_code ec;
+    auto orig_dir = std::filesystem::current_path(ec);
+    CARBON_CHECK(!ec) << ec.message();
+
+    // Set the working dir.
+    const char* tmpdir = getenv("TEST_TMPDIR");
+    CARBON_CHECK(tmpdir);
+    std::filesystem::current_path(tmpdir, ec);
+    CARBON_CHECK(!ec) << ec.message();
+
+    // Prepare a list of filenames for MakeArgs. Also create the files.
+    llvm::SmallVector<llvm::StringRef> test_file_names;
+    for (const auto& test_file : test_files) {
+      test_file_names.push_back(test_file.filename);
+
+      std::ofstream f(test_file.filename);
+      f << test_file.content;
+    }
+
+    auto cleanup = llvm::make_scope_exit([&]() {
+      // Remove the files.
+      for (const auto& test_file : test_files) {
+        std::filesystem::remove(test_file.filename, ec);
+        CARBON_CHECK(!ec) << ec.message();
+      }
+      // Restore the working dir.
+      std::filesystem::current_path(orig_dir, ec);
+      CARBON_CHECK(!ec) << ec.message();
+    });
+
     Driver driver(stdout, stderr);
-    return driver.RunFullCommand(MakeArgs(test_files));
+    return driver.RunFullCommand(MakeArgs(test_file_names));
   }
 
-  virtual auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+  virtual auto MakeArgs(const llvm::SmallVector<llvm::StringRef>& test_files)
       -> llvm::SmallVector<llvm::StringRef> = 0;
 };
 

--- a/toolchain/lexer/lexer_file_test.cpp
+++ b/toolchain/lexer/lexer_file_test.cpp
@@ -16,12 +16,10 @@ class LexerFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
-  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+  auto MakeArgs(const llvm::SmallVector<llvm::StringRef>& test_files)
       -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "tokens"});
-    for (const auto& file : test_files) {
-      args.push_back(file);
-    }
+    args.insert(args.end(), test_files.begin(), test_files.end());
     return args;
   }
 };

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -16,12 +16,10 @@ class LoweringFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
-  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+  auto MakeArgs(const llvm::SmallVector<llvm::StringRef>& test_files)
       -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "llvm-ir"});
-    for (const auto& file : test_files) {
-      args.push_back(file);
-    }
+    args.insert(args.end(), test_files.begin(), test_files.end());
     return args;
   }
 };

--- a/toolchain/parser/parse_tree_file_test.cpp
+++ b/toolchain/parser/parse_tree_file_test.cpp
@@ -16,12 +16,10 @@ class ParseTreeFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
-  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+  auto MakeArgs(const llvm::SmallVector<llvm::StringRef>& test_files)
       -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "parse-tree"});
-    for (const auto& file : test_files) {
-      args.push_back(file);
-    }
+    args.insert(args.end(), test_files.begin(), test_files.end());
     return args;
   }
 };

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -16,12 +16,10 @@ class SemanticsFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
-  auto MakeArgs(const llvm::SmallVector<std::string>& test_files)
+  auto MakeArgs(const llvm::SmallVector<llvm::StringRef>& test_files)
       -> llvm::SmallVector<llvm::StringRef> override {
     llvm::SmallVector<llvm::StringRef> args({"dump", "semantics-ir"});
-    for (const auto& file : test_files) {
-      args.push_back(file);
-    }
+    args.insert(args.end(), test_files.begin(), test_files.end());
     return args;
   }
 };


### PR DESCRIPTION
In explorer, we already support parsing a string_view, so use that. In toolchain, we need to build support, probably using vfs, so that's a todo.

bazel test //explorer:file_test --runs_per_test=5

- branch: Stats over 250 runs: max = 18.3s, min = 5.2s, avg = 11.2s, dev = 2.9s
- trunk: Stats over 250 runs: max = 22.3s, min = 5.9s, avg = 12.1s, dev = 2.8s

Not a dramatic improvement, but maybe more effective long-term, and this'd been requested on #2876