### PR TITLE
Implemented RAII Type to set current program phase

### DIFF
--- a/explorer/common/BUILD
+++ b/explorer/common/BUILD
@@ -58,3 +58,13 @@ cc_library(
         "//explorer/common:nonnull",
     ],
 )
+
+cc_test(
+    name = "set_program_phase_raii_test",
+    srcs = ["set_program_phase_raii_test.cpp"],
+    deps = [
+        ":trace_stream",
+        "//common:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/explorer/common/set_program_phase_raii_test.cpp
+++ b/explorer/common/set_program_phase_raii_test.cpp
@@ -1,0 +1,36 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "explorer/common/trace_stream.h"
+
+namespace Carbon::Testing {
+namespace {
+
+TEST(SetProgramPhaseRaiiTest, Simple) {
+  TraceStream trace_stream;
+  trace_stream.set_current_phase(ProgramPhase::Unknown);
+  {
+    SetProgramPhase set_prog_phase(trace_stream, ProgramPhase::Execution);
+    EXPECT_TRUE(trace_stream.current_phase() == ProgramPhase::Execution);
+  }
+  EXPECT_TRUE(trace_stream.current_phase() == ProgramPhase::Unknown);
+}
+
+TEST(SetProgramPhaseRaiiTest, UpdatePhase) {
+  TraceStream trace_stream;
+  trace_stream.set_current_phase(ProgramPhase::Unknown);
+  {
+    SetProgramPhase set_prog_phase(trace_stream, ProgramPhase::Execution);
+    EXPECT_TRUE(trace_stream.current_phase() == ProgramPhase::Execution);
+    set_prog_phase.update_phase(ProgramPhase::TypeChecking);
+    EXPECT_TRUE(trace_stream.current_phase() == ProgramPhase::TypeChecking);
+  }
+  EXPECT_TRUE(trace_stream.current_phase() == ProgramPhase::Unknown);
+}
+
+}  // namespace
+}  // namespace Carbon::Testing

--- a/explorer/common/trace_stream.h
+++ b/explorer/common/trace_stream.h
@@ -109,26 +109,21 @@ class SetProgramPhase {
   explicit SetProgramPhase(TraceStream& trace_stream,
                            ProgramPhase program_phase)
       : trace_stream_(trace_stream) {
-    previous_phases_.push_back(trace_stream.current_phase());
+    initial_phase_ = trace_stream.current_phase();
     trace_stream.set_current_phase(program_phase);
   }
 
   // This can be used for cases when current phase is set multiple times within
   // the same scope
   auto update_phase(ProgramPhase program_phase) -> void {
-    previous_phases_.push_back(trace_stream_.current_phase());
     trace_stream_.set_current_phase(program_phase);
   }
 
-  ~SetProgramPhase() {
-    if (!previous_phases_.empty()) {
-      trace_stream_.set_current_phase(previous_phases_.front());
-    }
-  }
+  ~SetProgramPhase() { trace_stream_.set_current_phase(initial_phase_); }
 
  private:
   TraceStream& trace_stream_;
-  std::vector<ProgramPhase> previous_phases_;
+  ProgramPhase initial_phase_;
 };
 
 }  // namespace Carbon

--- a/explorer/common/trace_stream.h
+++ b/explorer/common/trace_stream.h
@@ -108,8 +108,7 @@ class SetProgramPhase {
  public:
   explicit SetProgramPhase(TraceStream& trace_stream,
                            ProgramPhase program_phase)
-      : trace_stream_(trace_stream) {
-    initial_phase_ = trace_stream.current_phase();
+      : trace_stream_(trace_stream), initial_phase_(trace_stream.current_phase()) {
     trace_stream.set_current_phase(program_phase);
   }
 

--- a/explorer/common/trace_stream.h
+++ b/explorer/common/trace_stream.h
@@ -108,7 +108,8 @@ class SetProgramPhase {
  public:
   explicit SetProgramPhase(TraceStream& trace_stream,
                            ProgramPhase program_phase)
-      : trace_stream_(trace_stream), initial_phase_(trace_stream.current_phase()) {
+      : trace_stream_(trace_stream),
+        initial_phase_(trace_stream.current_phase()) {
     trace_stream.set_current_phase(program_phase);
   }
 


### PR DESCRIPTION
Within `explorer/common/trace_stream.h`, implemented RAII Type `SetProgramPhase`.
This RAII type simplifies the process by automatically setting the desired program phase upon construction and restoring the previous phase upon destruction.