### PR TITLE
Add nested array size deduction from tuple

### DIFF
--- a/explorer/interpreter/BUILD
+++ b/explorer/interpreter/BUILD
@@ -306,6 +306,7 @@ cc_library(
     ],
     deps = [
         ":action",
+        ":type_utils",
         "//explorer/ast",
         "//explorer/base:arena",
         "//explorer/base:nonnull",

--- a/explorer/interpreter/interpreter.h
+++ b/explorer/interpreter/interpreter.h
@@ -26,7 +26,6 @@ auto InterpExp(Nonnull<const Expression*> e, Nonnull<Arena*> arena,
                Nonnull<TraceStream*> trace_stream,
                Nonnull<llvm::raw_ostream*> print_stream)
     -> ErrorOr<Nonnull<const Value*>>;
-
 }  // namespace Carbon
 
 #endif  // CARBON_EXPLORER_INTERPRETER_INTERPRETER_H_

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -565,6 +565,10 @@ class TypeChecker {
   auto InterpExp(Nonnull<const Expression*> e)
       -> ErrorOr<Nonnull<const Value*>>;
 
+  // Deduces concrete type for 'type' based on 'expected'
+  auto Deduce(Nonnull<const Value*> type, Nonnull<const Value*> expected)
+      -> Nonnull<const Value*>;
+
   Nonnull<Arena*> arena_;
   Builtins builtins_;
 

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -565,10 +565,6 @@ class TypeChecker {
   auto InterpExp(Nonnull<const Expression*> e)
       -> ErrorOr<Nonnull<const Value*>>;
 
-  // Deduces concrete type for 'type' based on 'expected'
-  auto Deduce(Nonnull<const Value*> type, Nonnull<const Value*> expected)
-      -> Nonnull<const Value*>;
-
   Nonnull<Arena*> arena_;
   Builtins builtins_;
 

--- a/explorer/interpreter/type_utils.h
+++ b/explorer/interpreter/type_utils.h
@@ -10,6 +10,7 @@
 namespace Carbon {
 
 class Value;
+class Arena;
 
 // Returns whether `value` is a concrete type, which would be valid as the
 // static type of an expression. This is currently any type other than `auto`.
@@ -30,6 +31,11 @@ auto GetSize(Nonnull<const Value*> from) -> size_t;
 // Returns whether the value is a type whose values are themselves known to be
 // types.
 auto IsTypeOfType(Nonnull<const Value*> value) -> bool;
+
+// Deduces concrete type for 'type' based on 'expected'
+auto DeducePatternType(Nonnull<const Value*> type,
+                       Nonnull<const Value*> expected, Nonnull<Arena*> arena)
+    -> Nonnull<const Value*>;
 }  // namespace Carbon
 
 #endif  // CARBON_EXPLORER_INTERPRETER_TYPE_UTILS_H_

--- a/explorer/testdata/array/fail_to_deduce_nested_array_size_from_tuple_different_subtuples_size.carbon
+++ b/explorer/testdata/array/fail_to_deduce_nested_array_size_from_tuple_different_subtuples_size.carbon
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_to_deduce_nested_array_size_from_tuple_different_subtuples_size.carbon:[[@LINE+1]]: type pattern '{{\[\[}}i32;];]' does not match actual type '((i32, i32), (i32, i32, i32))'
+  var x: [[i32;];] = ((1,2), (3,4,5));
+
+  return x[0][2];
+}

--- a/explorer/testdata/array/fail_to_deduce_nested_array_size_from_tuple_of_different_types.carbon
+++ b/explorer/testdata/array/fail_to_deduce_nested_array_size_from_tuple_of_different_types.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_to_deduce_nested_array_size_from_tuple_of_different_types.carbon:[[@LINE+1]]: type pattern '{{\[\[}}i32;]; 2]' does not match actual type '((i32, i32), (String, String))'
+  var x: [[i32;];2] = ((1,2), ("foo", "bar"));
+  return x[0];
+}

--- a/explorer/testdata/array/fail_to_deduce_size_from_tuple_of_different_types.carbon
+++ b/explorer/testdata/array/fail_to_deduce_size_from_tuple_of_different_types.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_to_deduce_size_from_tuple_of_different_types.carbon:[[@LINE+1]]: type pattern '[i32;]' does not match actual type '(i32, String)'
+  var x: [i32;] = (42, "foo");
+  return x[0];
+}

--- a/explorer/testdata/array/fail_to_index_deduced_nested_size_from_array.carbon
+++ b/explorer/testdata/array/fail_to_index_deduced_nested_size_from_array.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var arr: [[i32;2];2] = ((1,2), (3,4));
+
+  var x : [[i32;];] = arr;
+  // CHECK:STDERR: RUNTIME ERROR: fail_to_index_deduced_nested_size_from_array.carbon:[[@LINE+1]]: index 2 out of range in (1, 2)
+  return x[0][2];
+}

--- a/explorer/testdata/array/fail_to_index_deduced_nested_size_from_tuple.carbon
+++ b/explorer/testdata/array/fail_to_index_deduced_nested_size_from_tuple.carbon
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [[i32;];] = ((1,2), (3,4));
+  // CHECK:STDERR: RUNTIME ERROR: fail_to_index_deduced_nested_size_from_tuple.carbon:[[@LINE+1]]: index 2 out of range in (1, 2)
+  return x[0][2];
+}

--- a/explorer/testdata/array/nested_and_external_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/nested_and_external_array_size_deduction_from_tuple.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 7
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [[i32;];] = ((1,2), (3,4));
+  x[0][1] = 1;
+  x[1][0] = 1;
+  return x[0][0] + x[0][1] + x[1][0] + x[1][1];
+}

--- a/explorer/testdata/array/nested_and_external_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/nested_and_external_array_size_deduction_from_tuple.carbon
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: result: 7
 
 package ExplorerTest api;
 
@@ -13,3 +12,5 @@ fn Main() -> i32 {
   x[1][0] = 1;
   return x[0][0] + x[0][1] + x[1][0] + x[1][1];
 }
+
+// CHECK:STDOUT: result: 7

--- a/explorer/testdata/array/nested_array_size_deduction_from_array.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_array.carbon
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: result: 7
 
 package ExplorerTest api;
 
@@ -15,3 +14,5 @@ fn Main() -> i32 {
   x[1][0] = 1;
   return x[0][0] + x[0][1] + x[1][0] + x[1][1];
 }
+
+// CHECK:STDOUT: result: 7

--- a/explorer/testdata/array/nested_array_size_deduction_from_array.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_array.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 7
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var arr: [[i32;2];2] = ((1,2), (3,4));
+
+  var x : [[i32;];] = arr;
+  x[0][1] = 1;
+  x[1][0] = 1;
+  return x[0][0] + x[0][1] + x[1][0] + x[1][1];
+}

--- a/explorer/testdata/array/nested_array_size_deduction_from_empty_tuple.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_empty_tuple.carbon
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [[i32;];2] = ((), ());
+  return 42;
+}
+
+// CHECK:STDOUT: result: 42

--- a/explorer/testdata/array/nested_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_tuple.carbon
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: result: 7
 
 package ExplorerTest api;
 
@@ -13,3 +12,5 @@ fn Main() -> i32 {
   x[1][0] = 1;
   return x[0][0] + x[0][1] + x[1][0] + x[1][1];
 }
+
+// CHECK:STDOUT: result: 7

--- a/explorer/testdata/array/nested_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_tuple.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 7
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [[i32;];2] = ((1,2), (3,4));
+  x[0][1] = 1;
+  x[1][0] = 1;
+  return x[0][0] + x[0][1] + x[1][0] + x[1][1];
+}

--- a/explorer/testdata/array/nested_array_size_deduction_from_tuple_of_tuple_and_array.carbon
+++ b/explorer/testdata/array/nested_array_size_deduction_from_tuple_of_tuple_and_array.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [i32; 2] = (1, 2);
+  var y: [[i32;];] = (x, (3,4));
+  y[0][1] = 1;
+  y[1][0] = 1;
+  return y[0][0] + y[0][1] + y[1][0] + y[1][1];
+}
+
+// CHECK:STDOUT: result: 7

--- a/explorer/testdata/array/three_dim_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/three_dim_array_size_deduction_from_tuple.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  let v: i32 = 8;
+  var x: [[[i32;];];] = (((1,2), (3,4)), ((5,6), (7,v)));
+  x[1][1][1] -= v;
+  return x[1][1][1];
+}

--- a/explorer/testdata/array/three_dim_array_size_deduction_from_tuple.carbon
+++ b/explorer/testdata/array/three_dim_array_size_deduction_from_tuple.carbon
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDOUT: result: 0
 
 package ExplorerTest api;
 
@@ -13,3 +12,5 @@ fn Main() -> i32 {
   x[1][1][1] -= v;
   return x[1][1][1];
 }
+
+// CHECK:STDOUT: result: 0


### PR DESCRIPTION
As a follow up to #2825 this pr implements size deduction for nested arrays.
E.g. `var x: [[i32;];] = ((1,2), (3,4));`.

Also updated the pattern matching logic for arrays, now it also checks element types of the tuple size being deduced from. As a result code like `var x: [i32;] = ("foo", "bar");`(note, that it tries to init an array of i32 with a tuple of strings) fails to compile with a pattern match error instead of an implicit cast failed error.

Moved some common type-related logic used in type_checker.cpp and interpreter.cpp to the separate file.
