### PR TITLE
Clean up lit tests and config to reflect current uses.

### DIFF
--- a/explorer/autoupdate_lit_testdata.py
+++ b/explorer/autoupdate_lit_testdata.py
@@ -24,8 +24,9 @@ def main() -> None:
         # Flags to configure for explorer testing.
         "--tool=explorer",
         "--testdata=explorer/lit_testdata",
-        "--lit_run=%{explorer-run}",
-        "--lit_run=%{explorer-run-trace}",
+        "--lit_run=%{explorer} | %{FileCheck-strict}",
+        "--lit_run=%{explorer} --parser_debug --trace_file=- | "
+        "%{FileCheck-allow-unmatched}",
     ] + sys.argv[1:]
     exit(subprocess.call(args))
 

--- a/explorer/lit_testdata/fail_compile_error.carbon
+++ b/explorer/lit_testdata/fail_compile_error.carbon
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// NOAUTOUPDATE
+// RUN: %{not} %{explorer} | %{FileCheck-strict}
+// RUN: %{not} %{explorer} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched}
+
+package ExplorerTest api;
+
+// Just needs to produce an error to validate basic structure.
+fn Main() -> i32 {
+// CHECK:STDERR: COMPILATION ERROR: {{.*}}/explorer/lit_testdata/fail_compile_error.carbon:[[@LINE+1]]: {{.*}}
+}

--- a/explorer/lit_testdata/hello.carbon
+++ b/explorer/lit_testdata/hello.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// RUN: %{explorer-run}
-// RUN: %{explorer-run-trace}
+// RUN: %{explorer} | %{FileCheck-strict}
+// RUN: %{explorer} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched}
 // CHECK:STDOUT: Hello
 // CHECK:STDOUT: result: 0
 

--- a/explorer/lit_testdata/trace.carbon
+++ b/explorer/lit_testdata/trace.carbon
@@ -6,16 +6,16 @@
 // sanity checking on --parser_debug --trace_file=- along with filter flags output.
 //
 // NOAUTOUPDATE
-// RUN: %{explorer-run} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_execution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_source_program | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_name_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_control_flow_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_type_checking | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_unformed_variables_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_declarations | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_timing | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,TIMING
-// RUN: %{explorer-run} --parser_debug --trace_file=- -trace_all | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NAMES,NO-PRELUDE,FLOW,TYPE,UNFORMED,DECLS,EXEC,TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_execution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_source_program | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_name_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_control_flow_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_type_checking | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_unformed_variables_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_declarations | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_timing | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_all | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NAMES,NO-PRELUDE,FLOW,TYPE,UNFORMED,DECLS,EXEC,TIMING
 // NO-SOURCE-NOT:STDOUT: ********** source program **********
 //        SOURCE:STDOUT: ********** source program **********
 // NO-SOURCE-NOT:STDOUT: interface TestInterface {

--- a/explorer/lit_testdata/zero.carbon
+++ b/explorer/lit_testdata/zero.carbon
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// RUN: %{explorer-run}
-// RUN: %{explorer-run-trace}
+// RUN: %{explorer} | %{FileCheck-strict}
+// RUN: %{explorer} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched}
 // CHECK:STDOUT: result: 0
 
 package ExplorerTest api;

--- a/testing/lit_test/lit.cfg.py
+++ b/testing/lit_test/lit.cfg.py
@@ -46,27 +46,7 @@ def add_substitutions():
     )
 
     add_substitution("carbon", f"{run_carbon}")
-    add_substitution(
-        "carbon-run-lowering",
-        f"{run_carbon} dump llvm-ir %s | {filecheck_strict}",
-    )
-    add_substitution(
-        "carbon-run-parser",
-        f"{run_carbon} dump parse-tree %s | {filecheck_strict}",
-    )
-    add_substitution(
-        "carbon-run-semantics",
-        f"{run_carbon} dump semantics-ir %s | {filecheck_strict}",
-    )
-    add_substitution(
-        "carbon-run-tokens", f"{run_carbon} dump tokens %s | {filecheck_strict}"
-    )
-    add_substitution("explorer-run", f"{run_explorer}")
-    add_substitution(
-        "explorer-run-trace",
-        f"{run_explorer} --parser_debug --trace_file=- | "
-        f"{filecheck_allow_unmatched}",
-    )
+    add_substitution("explorer", f"{run_explorer}")
     add_substitution("FileCheck-allow-unmatched", filecheck_allow_unmatched)
     add_substitution("FileCheck-strict", filecheck_strict)
     add_substitution("not", tools["not"])

--- a/testing/scripts/autoupdate_testdata_base.py
+++ b/testing/scripts/autoupdate_testdata_base.py
@@ -294,7 +294,6 @@ def label_output(label: str, output: str) -> List[str]:
 
 def get_matchable_test_output(
     autoupdate_args: List[str],
-    for_lit: bool,
     extra_check_replacements: List[Tuple[Pattern, Pattern, str]],
     tool: str,
     bazel_runfiles: Pattern,
@@ -323,10 +322,6 @@ def get_matchable_test_output(
         # Escape things that mirror FileCheck special characters.
         line = line.replace("{{", "{{[{][{]}}")
         line = line.replace("[[", "{{[[][[]}}")
-        if for_lit:
-            # `lit` uses full paths to the test file, so use a regex to ignore
-            # paths when used.
-            line = line.replace(test, f"{{{{.*}}}}/{test}")
         line = bazel_runfiles.sub("{{.*}}/", line)
 
         for line_matcher, before, after in extra_check_replacements:
@@ -414,7 +409,6 @@ def update_check(
     # Determine the merged output lines.
     out_lines = get_matchable_test_output(
         parsed_args.autoupdate_args,
-        bool(parsed_args.lit_run),
         parsed_args.extra_check_replacements,
         parsed_args.tool,
         bazel_runfiles,

--- a/toolchain/driver/testdata/errors_sorted_test.carbon
+++ b/toolchain/driver/testdata/errors_sorted_test.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon-run-tokens}
+// RUN: %{not} %{carbon} dump tokens %s |  %{FileCheck-strict}
 // CHECK:STDOUT: [
 // CHECK-COUNT-17:STDOUT: {{.*}}
 // CHECK:STDOUT: ]


### PR DESCRIPTION
Overall, cleaning up remaining lit uses.

#2851 had removed FileCheck invocations from some of the explorer tests; this starts as just restoring that. But, now that we have far fewer `lit` tests, it seems best to refine `lit.cfg.py` to focus on providing fewer commands (not all were even used).

Also, adding testing of an error to explorer (which I noticed due to a change that would've broken that) made me notice that autoupdate_lit_test's for_lit logic didn't actually work, so I'm just cutting it and going to manual updates. Really, we might want to just remove lit autoupdate support altogether since it's only a couple tests using it, but I'm not ready to make that change right now.

Fixes #2912 
