### PR TITLE
Update BUILD

### DIFF
--- a/proposals/scripts/BUILD
+++ b/proposals/scripts/BUILD
@@ -5,13 +5,13 @@
 py_binary(
     name = "new_proposal",
     srcs = ["new_proposal.py"],
-    python_version = "PY3",
+    python_version = "PY37",  # Update to the desired Python version
 )
 
 py_test(
     name = "new_proposal_test",
     srcs = ["new_proposal_test.py"],
     data = ["template.md"],
-    python_version = "PY3",
+    python_version = "PY37",  # Update to the desired Python version
     deps = [":new_proposal"],
 )


### PR DESCRIPTION
The provided code, you can make the following changes:

1. Update the `py_binary` and `py_test` rules to use the `python_version` attribute instead of the deprecated `PY3` value. You can set it to the desired Python version, such as `PY37` for Python 3.7.

2. Verify and update the `data` and `deps` attributes if necessary. Ensure that the `template.md` file exists in the specified location and adjust the dependencies (`deps`) according to your project structure.

That's it! These changes will update the code to use the proper `python_version` attribute and ensure that the code is compatible with the specified Python version.

**Replace this paragraph with a description of what this PR is changing or
adding, and why.**

Closes #ISSUE
