### PR TITLE
Fix a fuzzer-found crash.

### DIFF
--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -6168,7 +6168,6 @@ static auto IsValidTypeForAliasTarget(Nonnull<const Value*> type) -> bool {
     case Value::Kind::StructValue:
     case Value::Kind::NominalClassValue:
     case Value::Kind::MixinPseudoType:
-    case Value::Kind::TypeOfMixinPseudoType:
     case Value::Kind::AlternativeValue:
     case Value::Kind::TupleValue:
     case Value::Kind::ImplWitness:
@@ -6182,11 +6181,11 @@ static auto IsValidTypeForAliasTarget(Nonnull<const Value*> type) -> bool {
     case Value::Kind::AlternativeConstructorValue:
     case Value::Kind::StringValue:
     case Value::Kind::UninitializedValue:
-      CARBON_FATAL() << "type of alias target is not a type";
+      CARBON_FATAL() << "type of alias target is not a type: " << *type;
 
     case Value::Kind::AutoType:
     case Value::Kind::VariableType:
-      CARBON_FATAL() << "pattern type in alias target";
+      CARBON_FATAL() << "pattern type in alias target: " << *type;
 
     case Value::Kind::IntType:
     case Value::Kind::BoolType:
@@ -6198,6 +6197,7 @@ static auto IsValidTypeForAliasTarget(Nonnull<const Value*> type) -> bool {
     case Value::Kind::ChoiceType:
     case Value::Kind::StringType:
     case Value::Kind::AssociatedConstant:
+    case Value::Kind::TypeOfMixinPseudoType:
       return false;
 
     case Value::Kind::FunctionType:

--- a/explorer/testdata/mixin/fail_mix_as_alias_target.carbon
+++ b/explorer/testdata/mixin/fail_mix_as_alias_target.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+__mixin Operations {}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_mix_as_alias_target.carbon:[[@LINE+1]]: invalid target for alias declaration
+alias OperationsAlias = Operations;
+
+fn Main() -> i32 {
+   return 0;
+}


### PR DESCRIPTION
The crash occurred because of an alias target of a mixin. While eventually, we should probably have some ability to alias mixins, this isn't yet setup in the explorer and doesn't seem like a current priority.

We got here because the mixin type checking made it far enough to not reject this within the type checker, but the next step wasn't prepared for this to come out of the type checker. The simplest fix seems to be to reflect that it *can* escape the type checker, but still isn't (yet) a valid alias target.

Test case added.