### PR TITLE
LLVM should be included using quotes.

### DIFF
--- a/explorer/ast/BUILD
+++ b/explorer/ast/BUILD
@@ -157,4 +157,5 @@ cc_library(
 cc_library(
     name = "expression_category",
     hdrs = ["expression_category.h"],
+    deps = ["@llvm-project//llvm:Support"],
 )

--- a/explorer/ast/expression_category.h
+++ b/explorer/ast/expression_category.h
@@ -5,7 +5,7 @@
 #ifndef CARBON_EXPLORER_AST_EXPRESSION_CATEGORY_H_
 #define CARBON_EXPLORER_AST_EXPRESSION_CATEGORY_H_
 
-#include <llvm/ADT/StringRef.h>
+#include "llvm/ADT/StringRef.h"
 
 namespace Carbon {
 

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -4,8 +4,6 @@
 
 #include "explorer/interpreter/interpreter.h"
 
-#include <llvm/Support/raw_ostream.h>
-
 #include <iterator>
 #include <limits>
 #include <map>
@@ -34,6 +32,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
 
 using llvm::cast;
 using llvm::dyn_cast;


### PR DESCRIPTION
This also results in correct dependency discovery (the missing LLVM dep on expression_category).