### PR TITLE
Require a complete type when enumerating the fields of a class.

### DIFF
--- a/explorer/interpreter/impl_scope.cpp
+++ b/explorer/interpreter/impl_scope.cpp
@@ -192,9 +192,9 @@ auto ImplScope::TryResolve(Nonnull<const Value*> constraint_type,
               type_checker.Substitute(local_bindings, argument));
           converted.arguments.push_back(subst_arg);
         }
-        CARBON_ASSIGN_OR_RETURN(
-            bool intrinsic_satisfied,
-            type_checker.IsIntrinsicConstraintSatisfied(converted, *this));
+        CARBON_ASSIGN_OR_RETURN(bool intrinsic_satisfied,
+                                type_checker.IsIntrinsicConstraintSatisfied(
+                                    source_loc, converted, *this));
         if (!intrinsic_satisfied) {
           if (!diagnose_missing_impl) {
             return {std::nullopt};

--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -135,7 +135,8 @@ class TypeChecker {
 
   // Determine whether the given intrinsic constraint is known to be satisfied
   // in the given scope.
-  auto IsIntrinsicConstraintSatisfied(const IntrinsicConstraint& constraint,
+  auto IsIntrinsicConstraintSatisfied(SourceLocation source_loc,
+                                      const IntrinsicConstraint& constraint,
                                       const ImplScope& impl_scope) const
       -> ErrorOr<bool>;
 
@@ -397,21 +398,14 @@ class TypeChecker {
                               SourceLocation source_loc) -> ErrorOr<Success>;
 
   // Returns the field names of the class together with their types.
-  auto FieldTypes(const NominalClassType& class_type) const
+  auto FieldTypes(SourceLocation source_loc, std::string_view context,
+                  const NominalClassType& class_type) const
       -> ErrorOr<std::vector<NamedValue>>;
 
   // Returns the field names and types of the class and its parents.
-  auto FieldTypesWithBase(const NominalClassType& class_type) const
+  auto FieldTypesWithBase(SourceLocation source_loc, std::string_view context,
+                          const NominalClassType& class_type) const
       -> ErrorOr<std::vector<NamedValue>>;
-
-  // Returns true if source_fields and destination_fields contain the same set
-  // of names, and each value in source_fields is implicitly convertible to
-  // the corresponding value in destination_fields. All values in both arguments
-  // must be types.
-  auto FieldTypesImplicitlyConvertible(
-      llvm::ArrayRef<NamedValue> source_fields,
-      llvm::ArrayRef<NamedValue> destination_fields,
-      const ImplScope& impl_scope) const -> ErrorOr<bool>;
 
   // Returns true if *source is implicitly convertible to *destination. *source
   // and *destination must be concrete types.
@@ -419,7 +413,8 @@ class TypeChecker {
   // If allow_user_defined_conversions, conversions requiring a user-defined
   // `ImplicitAs` implementation are not considered, and only builtin
   // conversions will be allowed.
-  auto IsImplicitlyConvertible(Nonnull<const Value*> source,
+  auto IsImplicitlyConvertible(SourceLocation source_loc,
+                               Nonnull<const Value*> source,
                                Nonnull<const Value*> destination,
                                const ImplScope& impl_scope,
                                bool allow_user_defined_conversions) const
@@ -427,7 +422,8 @@ class TypeChecker {
 
   // Returns true if the conversion from `source` to `destination` is a builtin
   // conversion that `BuildBuiltinConversion` can perform.
-  auto IsBuiltinConversion(Nonnull<const Value*> source,
+  auto IsBuiltinConversion(SourceLocation source_loc,
+                           Nonnull<const Value*> source,
                            Nonnull<const Value*> destination,
                            const ImplScope& impl_scope,
                            bool allow_user_defined_conversions) const

--- a/explorer/testdata/class/fail_incomplete_in_conversion.carbon
+++ b/explorer/testdata/class/fail_incomplete_in_conversion.carbon
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  // CHECK:STDERR: COMPILATION ERROR: fail_incomplete_in_conversion.carbon:[[@LINE+2]]: type error in `as`: `{}` is not explicitly convertible to `class C`:
+  // CHECK:STDERR: incomplete type `class C` used in implicit conversion
+  var x: ({} as C);
+}
+
+fn Main() -> i32 { return 0; }


### PR DESCRIPTION
Fixes a crash on invalid found by fuzzing.