### PR TITLE
Add -trace_phase option that takes list of allowed phases

### DIFF
--- a/explorer/README.md
+++ b/explorer/README.md
@@ -168,22 +168,21 @@ performed during execution.
 Printing directly to the standard output using the `--trace_file` option is
 supported by passing `-` in place of a filepath (`--trace_file=-`).
 
-To customize the trace output and include specific information, you can use the
-following compiler options along with `--trace_file=...` option:
+To customize the trace output and include specific information, you can pass the
+following list of options to `-trace_phase=...` option along with
+`--trace_file=...` option:
 
--   `-trace_source_program`: Include trace output for the source program phase.
--   `-trace_name_resolution`: Include trace output for the name resolution
-    phase.
--   `-trace_control_flow_resolution`: Include trace output for the control flow
+-   `source_program`: Include trace output for the source program phase.
+-   `name_resolution`: Include trace output for the name resolution phase.
+-   `control_flow_resolution`: Include trace output for the control flow
     resolution phase.
--   `-trace_type_checking`: Include trace output for the type checking phase.
--   `-trace_unformed_variables_resolution`: Include trace output for the
-    unformed variables resolution phase.
--   `-trace_declarations`: Include trace output for printing declarations.
--   `-trace_execution`: Include trace output for program execution.
--   `-trace_timing`: Include timing logs indicating the time taken by each
-    phase.
--   `-trace_all`: Include trace output for all phases.
+-   `type_checking`: Include trace output for the type checking phase.
+-   `unformed_variables_resolution`: Include trace output for the unformed
+    variables resolution phase.
+-   `declarations`: Include trace output for printing declarations.
+-   `execution`: Include trace output for program execution.
+-   `timing`: Include timing logs indicating the time taken by each phase.
+-   `all`: Include trace output for all phases.
 
 By default, only execution trace will be added to the trace output. You can use
 combination of these options to include trace of multiple program phases.

--- a/explorer/autoupdate_trace_testdata.py
+++ b/explorer/autoupdate_trace_testdata.py
@@ -26,7 +26,7 @@ def main() -> None:
         "--tool=explorer",
         "--testdata=explorer/trace_testdata",
         "--autoupdate_arg=--trace_file=-",
-        "--autoupdate_arg=-trace_all",
+        "--autoupdate_arg=-trace_phase=all",
     ] + sys.argv[1:]
     exit(subprocess.call(args))
 

--- a/explorer/lit_testdata/trace.carbon
+++ b/explorer/lit_testdata/trace.carbon
@@ -7,15 +7,15 @@
 //
 // NOAUTOUPDATE
 // RUN: %{explorer} --parser_debug --trace_file=- | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_execution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_source_program | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_name_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_control_flow_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_type_checking | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_unformed_variables_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_declarations | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,DECLS,NO-EXEC,NO-TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_timing | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,TIMING
-// RUN: %{explorer} --parser_debug --trace_file=- -trace_all | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NAMES,NO-PRELUDE,FLOW,TYPE,UNFORMED,DECLS,EXEC,TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=execution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=source_program | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=name_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=control_flow_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=type_checking | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=unformed_variables_resolution | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,UNFORMED,NO-DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=declarations | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,DECLS,NO-EXEC,NO-TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=timing | %{FileCheck-allow-unmatched} --check-prefixes=NO-SOURCE,NO-NAMES,NO-PRELUDE,NO-FLOW,NO-TYPE,NO-UNFORMED,NO-DECLS,NO-EXEC,TIMING
+// RUN: %{explorer} --parser_debug --trace_file=- -trace_phase=all | %{FileCheck-allow-unmatched} --check-prefixes=SOURCE,NAMES,NO-PRELUDE,FLOW,TYPE,UNFORMED,DECLS,EXEC,TIMING
 // NO-SOURCE-NOT:STDOUT: ********** source program **********
 //        SOURCE:STDOUT: ********** source program **********
 // NO-SOURCE-NOT:STDOUT: interface TestInterface {

--- a/explorer/main.cpp
+++ b/explorer/main.cpp
@@ -51,33 +51,33 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
       cl::desc("Output file for tracing; set to `-` to output to stdout."));
 
   cl::list<ProgramPhase> allowed_program_phases(
+      "trace_phase",
       cl::desc("Select the program phases to include in the output. By "
                "default, only the execution trace will be added to the trace "
                "output. Use a combination of the following flags to include "
                "outputs for multiple phases:"),
       cl::values(
-          clEnumValN(ProgramPhase::SourceProgram, "trace_source_program",
+          clEnumValN(ProgramPhase::SourceProgram, "source_program",
                      "Include trace output for the Source Program phase."),
-          clEnumValN(ProgramPhase::NameResolution, "trace_name_resolution",
+          clEnumValN(ProgramPhase::NameResolution, "name_resolution",
                      "Include trace output for the Name Resolution phase."),
           clEnumValN(
-              ProgramPhase::ControlFlowResolution,
-              "trace_control_flow_resolution",
+              ProgramPhase::ControlFlowResolution, "control_flow_resolution",
               "Include trace output for the Control Flow Resolution phase."),
-          clEnumValN(ProgramPhase::TypeChecking, "trace_type_checking",
+          clEnumValN(ProgramPhase::TypeChecking, "type_checking",
                      "Include trace output for the Type Checking phase."),
           clEnumValN(ProgramPhase::UnformedVariableResolution,
-                     "trace_unformed_variables_resolution",
+                     "unformed_variables_resolution",
                      "Include trace output for the Unformed Variables "
                      "Resolution phase."),
-          clEnumValN(ProgramPhase::Declarations, "trace_declarations",
+          clEnumValN(ProgramPhase::Declarations, "declarations",
                      "Include trace output for printing Declarations."),
-          clEnumValN(ProgramPhase::Execution, "trace_execution",
+          clEnumValN(ProgramPhase::Execution, "execution",
                      "Include trace output for Program Execution."),
           clEnumValN(
-              ProgramPhase::Timing, "trace_timing",
+              ProgramPhase::Timing, "timing",
               "Include timing logs for each phase, indicating the time taken."),
-          clEnumValN(ProgramPhase::All, "trace_all",
+          clEnumValN(ProgramPhase::All, "all",
                      "Include trace output for all phases.")));
 
   // Use the executable path as a base for the relative prelude path.


### PR DESCRIPTION
## Description
For filtering the trace output, we currently pass flags like `-trace_type_checking`, `-trace_execution` etc individually and these can be passed in a combination.
This PR introduces `-trace_phase` flag that takes a list of the following options:
-   `name_resolution`: Include trace output for the name resolution phase.
-   `control_flow_resolution`: Include trace output for the control flow
    resolution phase.
-   `type_checking`: Include trace output for the type checking phase.
-   `unformed_variables_resolution`: Include trace output for the unformed
    variables resolution phase.
-   `declarations`: Include trace output for printing declarations.
-   `execution`: Include trace output for program execution.
-   `timing`: Include timing logs indicating the time taken by each phase.
-   `all`: Include trace output for all phases. 

### Example usage:
```
bazel run //explorer -- <program_location> --trace_file=... -trace_phase=type_checking
```
