### PR TITLE
add VSCode user debug settings to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # Directories created by python.
 **/__pycache__/
 
-# Ignore the user's VSCode settings.
+# Ignore the user's VSCode settings and debug setup.
 /.vscode/settings.json
 /.vscode/launch.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Ignore the user's VSCode settings.
 /.vscode/settings.json
+/.vscode/launch.json
 
 # Ignore the user's Idea settings.
 /.idea/


### PR DESCRIPTION
VSCode uses a `.vscode/launch.json` file for configuring the debugger.
This PR adds a line to the `.gitignore` file to also ignore it along
with the already-ignored `.vscode/settings.json` file.