### PR TITLE
Don't return SemanticsFunction by value.

### DIFF
--- a/toolchain/semantics/semantics_handle_call_expression.cpp
+++ b/toolchain/semantics/semantics_handle_call_expression.cpp
@@ -24,7 +24,7 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
   }
 
   auto function_id = name_node.GetAsFunctionDeclaration();
-  auto callable = context.semantics_ir().GetFunction(function_id);
+  const auto& callable = context.semantics_ir().GetFunction(function_id);
 
   CARBON_DIAGNOSTIC(NoMatchingCall, Error, "No matching callable was found.");
   auto diagnostic =

--- a/toolchain/semantics/semantics_handle_statement.cpp
+++ b/toolchain/semantics/semantics_handle_statement.cpp
@@ -22,7 +22,7 @@ auto SemanticsHandleReturnStatement(SemanticsContext& context,
   CARBON_CHECK(!context.return_scope_stack().empty());
   const auto& fn_node =
       context.semantics_ir().GetNode(context.return_scope_stack().back());
-  const auto callable =
+  const auto& callable =
       context.semantics_ir().GetFunction(fn_node.GetAsFunctionDeclaration());
 
   if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -90,7 +90,8 @@ class SemanticsIR {
   }
 
   // Returns the requested callable.
-  auto GetFunction(SemanticsFunctionId function_id) const -> SemanticsFunction {
+  auto GetFunction(SemanticsFunctionId function_id) const
+      -> const SemanticsFunction& {
     return functions_[function_id.index];
   }
 


### PR DESCRIPTION
It contains a vector, so it's not cheap to copy. Return by const reference instead.

Thanks to @fasiddique for spotting this!