### PR TITLE
Remove obsolete TAG arg for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
   "name": "carbon-lang",
   "build": {
-    "dockerfile": "../docker/ubuntu2204/base/Dockerfile",
-    "args": {
-      "TAG": "3.5.6"
-    }
+    "dockerfile": "../docker/ubuntu2204/base/Dockerfile"
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
This shouldn't be used anymore, as of #2186