### PR TITLE
Add a name to glob_lit_tests

### DIFF
--- a/explorer/lit_testdata/BUILD
+++ b/explorer/lit_testdata/BUILD
@@ -6,6 +6,7 @@ load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/lit_test:rules.bzl", "glob_lit_tests")
 
 glob_lit_tests(
+    name = "all_lit_tests",
     data = [
         "//explorer",
         "//testing/lit_test:merge_output",

--- a/toolchain/driver/testdata/BUILD
+++ b/toolchain/driver/testdata/BUILD
@@ -5,6 +5,7 @@
 load("//testing/lit_test:rules.bzl", "glob_lit_tests")
 
 glob_lit_tests(
+    name = "all_lit_tests",
     data = [
         "//testing/lit_test:merge_output",
         "//toolchain/driver:carbon",


### PR DESCRIPTION
Adding `name` to `glob_lit_tests` will make it conform with other implementations of `glob_lit_tests` out there. If someone uses this repo while providing a different version of `glob_lit_tests` that requires a name, those build rules will become invalid.