### PR TITLE
Use lit to provide a temp for driver output files.

### DIFF
--- a/toolchain/driver/testdata/error_codegen_objcode_target_triple.carbon
+++ b/toolchain/driver/testdata/error_codegen_objcode_target_triple.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{not} %{carbon} dump objcode --target_triple=x86_684-unknown-linux-gnu --output_file=output.o %s | %{FileCheck-strict}
+// RUN: %{not} %{carbon} dump objcode --target_triple=x86_684-unknown-linux-gnu --output_file=%t %s | %{FileCheck-strict}
 // CHECK:STDERR: ERROR: Invalid -target_triple:{{.*}}
 
 fn Main() -> i32 { return 0; }

--- a/toolchain/driver/testdata/success_codegen_objfile.carbon
+++ b/toolchain/driver/testdata/success_codegen_objfile.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// RUN: %{carbon} dump objcode --target_triple=x86_64-unknown-linux-gnu --output_file=objfile.o %s | %{FileCheck-strict}
+// RUN: %{carbon} dump objcode --target_triple=x86_64-unknown-linux-gnu --output_file=%t %s | %{FileCheck-strict}
 // CHECK:STDOUT: Success: Object file is generated!
 
 fn Main() -> i32 { return 0; }


### PR DESCRIPTION
Specifying output.o causes issues if it's not writable, which it may not be in some test environments.