### PR TITLE
Fix crash if no input file is given to `carbon dump objcode`

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -167,15 +167,15 @@ auto Driver::RunDumpSubcommand(DiagnosticConsumer& consumer,
 
   llvm::StringRef output_file;
   if (dump_mode == DumpMode::ObjectCode) {
-    while (!args.empty() && (args.front().starts_with("--target_triple=") ||
-                             args.front().starts_with("--output_file="))) {
+    while (!args.empty()) {
       if (args.front().starts_with("--target_triple=")) {
         target_triple = args.front().split("=").second;
         args = args.drop_front();
-      }
-      if (args.front().starts_with("--output_file=")) {
+      } else if (args.front().starts_with("--output_file=")) {
         output_file = args.front().split("=").second;
         args = args.drop_front();
+      } else {
+        break;
       }
     }
 

--- a/toolchain/driver/testdata/error_codegen_objcode_no_input_file.carbon
+++ b/toolchain/driver/testdata/error_codegen_objcode_no_input_file.carbon
@@ -1,0 +1,8 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{not} %{carbon} dump objcode --output_file=%t --target_triple=x86_64-unknown-linux-gnu | %{FileCheck-strict}
+// CHECK:STDERR: ERROR: No input file specified.
+
+fn Main() -> i32 { return 0; }


### PR DESCRIPTION
If the final argument was `--target_triple=...`, we tried to read off the end of the arguments list. Found by fuzzer.