### PR TITLE
Reduce special-casing of parameters in ParamOrArgSave.

### DIFF
--- a/toolchain/semantics/semantics_context.cpp
+++ b/toolchain/semantics/semantics_context.cpp
@@ -412,29 +412,20 @@ auto SemanticsContext::ParamOrArgEnd(bool for_args, ParseNodeKind start_kind)
 }
 
 auto SemanticsContext::ParamOrArgSave(bool for_args) -> void {
-  SemanticsNodeId param_or_arg_id = SemanticsNodeId::Invalid;
+  auto [entry_parse_node, entry_node_id] =
+      node_stack_.PopExpressionWithParseNode();
   if (for_args) {
     // For an argument, we add a stub reference to the expression on the top of
     // the stack. There may not be anything on the IR prior to this.
-    auto [entry_parse_node, entry_node_id] =
-        node_stack_.PopExpressionWithParseNode();
-    param_or_arg_id = AddNode(SemanticsNode::StubReference::Make(
+    entry_node_id = AddNode(SemanticsNode::StubReference::Make(
         entry_parse_node, semantics_ir_->GetNode(entry_node_id).type_id(),
         entry_node_id));
-  } else {
-    // For a parameter, there should always be something in the IR.
-    node_stack_.PopAndIgnore();
-    auto ir_id = node_block_stack_.Peek();
-    CARBON_CHECK(ir_id.is_valid());
-    auto& ir = semantics_ir_->GetNodeBlock(ir_id);
-    CARBON_CHECK(!ir.empty()) << "Should have had a param";
-    param_or_arg_id = ir.back();
   }
 
   // Save the param or arg ID.
   auto& params_or_args =
       semantics_ir_->GetNodeBlock(params_or_args_stack_.PeekForAdd());
-  params_or_args.push_back(param_or_arg_id);
+  params_or_args.push_back(entry_node_id);
 }
 
 auto SemanticsContext::CanonicalizeType(SemanticsNodeId node_id)

--- a/toolchain/semantics/semantics_handle_struct.cpp
+++ b/toolchain/semantics/semantics_handle_struct.cpp
@@ -33,9 +33,8 @@ auto SemanticsHandleStructFieldType(SemanticsContext& context,
   auto [name_node, name_id] =
       context.node_stack().PopWithParseNode<ParseNodeKind::Name>();
 
-  context.AddNode(
-      SemanticsNode::StructTypeField::Make(name_node, cast_type_id, name_id));
-  context.node_stack().Push(parse_node);
+  context.AddNodeAndPush(parse_node, SemanticsNode::StructTypeField::Make(
+                                         name_node, cast_type_id, name_id));
   return true;
 }
 

--- a/toolchain/semantics/semantics_node_stack.h
+++ b/toolchain/semantics/semantics_node_stack.h
@@ -252,6 +252,7 @@ class SemanticsNodeStack {
       case Carbon::ParseNodeKind::PatternBinding:
       case Carbon::ParseNodeKind::PrefixOperator:
       case Carbon::ParseNodeKind::ShortCircuitOperand:
+      case Carbon::ParseNodeKind::StructFieldType:
       case Carbon::ParseNodeKind::StructFieldValue:
       case Carbon::ParseNodeKind::StructLiteral:
       case Carbon::ParseNodeKind::StructTypeLiteral:
@@ -274,7 +275,6 @@ class SemanticsNodeStack {
       case Carbon::ParseNodeKind::ParenExpressionOrTupleLiteralStart:
       case Carbon::ParseNodeKind::QualifiedDeclaration:
       case Carbon::ParseNodeKind::ReturnStatementStart:
-      case Carbon::ParseNodeKind::StructFieldType:
       case Carbon::ParseNodeKind::StructLiteralOrStructTypeLiteralStart:
       case Carbon::ParseNodeKind::VariableInitializer:
       case Carbon::ParseNodeKind::VariableIntroducer:


### PR DESCRIPTION
I think this is a simpler and more efficient way of achieving the same end result.