### PR TITLE
Consolidate ParseTree onto PrettyStackTraceFunction

### DIFF
--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "//common:error",
         "//common:ostream",
         "//common:vlog",
+        "//toolchain/common:pretty_stack_trace_function",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lexer:token_kind",
         "//toolchain/lexer:tokenized_buffer",

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -11,42 +11,12 @@
 #include "common/error.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/PrettyStackTrace.h"
+#include "toolchain/common/pretty_stack_trace_function.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/parser/parse_node_kind.h"
 #include "toolchain/parser/parser_context.h"
 
 namespace Carbon {
-
-class PrettyStackTraceParserContext : public llvm::PrettyStackTraceEntry {
- public:
-  explicit PrettyStackTraceParserContext(const ParserContext* context)
-      : context_(context) {}
-  ~PrettyStackTraceParserContext() override = default;
-
-  auto print(llvm::raw_ostream& output) const -> void override {
-    output << "Parser stack:\n";
-    for (int i = 0; i < static_cast<int>(context_->state_stack().size()); ++i) {
-      const auto& entry = context_->state_stack()[i];
-      output << "\t" << i << ".\t" << entry.state;
-      Print(output, entry.token);
-    }
-    output << "\tcursor\tposition_";
-    Print(output, *context_->position());
-  }
-
- private:
-  auto Print(llvm::raw_ostream& output, TokenizedBuffer::Token token) const
-      -> void {
-    auto line = context_->tokens().GetLine(token);
-    output << " @ " << context_->tokens().GetLineNumber(line) << ":"
-           << context_->tokens().GetColumnNumber(token) << ":"
-           << " token " << token << " : " << context_->tokens().GetKind(token)
-           << "\n";
-  }
-
-  const ParserContext* context_;
-};
 
 auto ParseTree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                       llvm::raw_ostream* vlog_stream) -> ParseTree {
@@ -57,7 +27,8 @@ auto ParseTree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
   // Delegate to the parser.
   ParseTree tree(tokens);
   ParserContext context(tree, tokens, emitter, vlog_stream);
-  PrettyStackTraceParserContext pretty_context(&context);
+  PrettyStackTraceFunction context_dumper(
+      [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
   context.PushState(ParserState::DeclarationScopeLoop);
 

--- a/toolchain/parser/parser_context.cpp
+++ b/toolchain/parser/parser_context.cpp
@@ -442,4 +442,23 @@ auto ParserContext::EmitExpectedDeclarationSemiOrDefinition(
                  expected_kind);
 }
 
+auto ParserContext::PrintForStackDump(llvm::raw_ostream& output) const -> void {
+  output << "Parser stack:\n";
+  for (int i = 0; i < static_cast<int>(state_stack_.size()); ++i) {
+    const auto& entry = state_stack_[i];
+    output << "\t" << i << ".\t" << entry.state;
+    PrintTokenForStackDump(output, entry.token);
+  }
+  output << "\tcursor\tposition_";
+  PrintTokenForStackDump(output, *position_);
+}
+
+auto ParserContext::PrintTokenForStackDump(llvm::raw_ostream& output,
+                                           TokenizedBuffer::Token token) const
+    -> void {
+  output << " @ " << tokens_->GetLineNumber(tokens_->GetLine(token)) << ":"
+         << tokens_->GetColumnNumber(token) << ": token " << token << " : "
+         << tokens_->GetKind(token) << "\n";
+}
+
 }  // namespace Carbon

--- a/toolchain/parser/parser_context.h
+++ b/toolchain/parser/parser_context.h
@@ -277,6 +277,9 @@ class ParserContext {
                                    ParseNodeKind parse_node_kind,
                                    bool skip_past_likely_end) -> void;
 
+  // Prints information for a stack dump.
+  auto PrintForStackDump(llvm::raw_ostream& output) const -> void;
+
   auto tree() const -> const ParseTree& { return *tree_; }
 
   auto tokens() const -> const TokenizedBuffer& { return *tokens_; }
@@ -295,6 +298,10 @@ class ParserContext {
   }
 
  private:
+  // Prints a single token for a stack dump. Used by PrintForStackDump.
+  auto PrintTokenForStackDump(llvm::raw_ostream& output,
+                              TokenizedBuffer::Token token) const -> void;
+
   ParseTree* tree_;
   TokenizedBuffer* tokens_;
   TokenDiagnosticEmitter* emitter_;


### PR DESCRIPTION
The function is already in use by semantics, it's intended to be cleaner than having to write a dedicated printer class.