### PR TITLE
Fuzz semantics when it passes parsing without errors.

### DIFF
--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//bazel/fuzzing:rules.bzl", "cc_fuzz_test")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")
 
@@ -111,6 +112,17 @@ file_test(
     tests = glob(["testdata/**/*.carbon"]),
     deps = [
         "//toolchain/driver:driver_file_test_base",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_fuzz_test(
+    name = "semantics_fuzzer",
+    size = "small",
+    srcs = ["semantics_fuzzer.cpp"],
+    corpus = glob(["fuzzer_corpus/*"]),
+    deps = [
+        "//toolchain/driver",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/semantics/fuzzer_corpus/005cacf2254cee9c357347503a715e3b680b7284
+++ b/toolchain/semantics/fuzzer_corpus/005cacf2254cee9c357347503a715e3b680b7284
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == "str\n") {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("str\n");
+}

--- a/toolchain/semantics/fuzzer_corpus/010856053137c0432260e9145d6f171ae227c715
+++ b/toolchain/semantics/fuzzer_corpus/010856053137c0432260e9145d6f171ae227c715
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t2: {.x: i32, .y: i32} = {.x = 2, .y = 5};
+  t2.y = 3;
+  // 3 - 2 - 1
+  return t2.y - t2.x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/0112278cfd21507f5266dfd89b7dc51a6ea801b3
+++ b/toolchain/semantics/fuzzer_corpus/0112278cfd21507f5266dfd89b7dc51a6ea801b3
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  returned var x: i32;
+  x = 1;
+  return var;
+}

--- a/toolchain/semantics/fuzzer_corpus/01cd4d9d3357b42f67e7b85e3b971ade1ab4a3d5
+++ b/toolchain/semantics/fuzzer_corpus/01cd4d9d3357b42f67e7b85e3b971ade1ab4a3d5
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+class A {
+  var n: i32;
+  fn Get[self: Self]() -> i32 { return self.n; }
+}
+
+fn Main() -> i32 {
+  return ({.n = 5} as A).Get();
+}

--- a/toolchain/semantics/fuzzer_corpus/03a9b31a0b80b5c661d405b654a51932bf3dabad
+++ b/toolchain/semantics/fuzzer_corpus/03a9b31a0b80b5c661d405b654a51932bf3dabad
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface HasTypes {
+  let A:! type;
+  let B:! type;
+  let C:! type;
+  let D:! type;
+  let E:! type;
+  let F:! type;
+}
+
+interface HasParams(A:! type, B:! type, C:! type, D:! type) {
+  let V:! HasTypes;
+}
+
+// Here we discover that there is a rewrite for `HasParams(...).V` only after
+// substitution converts each one to `HasParam(X, X, X, X).V`.
+fn F[X:! (HasTypes & HasParams(.Self, .Self, .Self, .Self)) where
+       .Self impls HasParams(.A, .A, .A, .A) and
+       .Self impls HasParams(.B, .B, .B, .B) and
+       .Self impls HasParams(.C, .C, .C, .C) and
+       .Self impls HasParams(.D, .D, .D, .D) and
+       .Self impls HasParams(.E, .E, .E, .E) and
+       .F = .Self.(HasParams(.E, .E, .E, .E).V).A and
+       .E = .Self.(HasParams(.D, .D, .D, .D).V).A and
+       .D = .Self.(HasParams(.C, .C, .C, .C).V).A and
+       .C = .Self.(HasParams(.B, .B, .B, .B).V).A and
+       .B = .Self.(HasParams(.A, .A, .A, .A).V).A and
+       .A = .Self and .V = .Self](x: X) -> X.F { return x; }
+
+impl i32 as HasTypes
+  where .A = .B and .B = .C and .C = .D and .D = .E and .E = .F and .F = i32 {}
+impl i32 as HasParams(i32, i32, i32, i32) where .V = i32 {}
+
+fn Main() -> i32 {
+  return F(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/0447b0030b48fa60d3d9f9c9163d05acd789796f
+++ b/toolchain/semantics/fuzzer_corpus/0447b0030b48fa60d3d9f9c9163d05acd789796f
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+package ExplorerTest api;
+
+__mixin M1 {
+  fn F1[self: Self](x: Self) -> Self{
+     return x;
+  }
+  // CHECK:STDERR: COMPILATION ERROR: fail_recursive_mixing.carbon:[[@LINE+1]]: incomplete mixin `M1` used in mix declaration
+  __mix M1;
+}
+
+class C {
+  __mix M1;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/0686bcb78820140c8d024e5b7d35adaa5eec3621
+++ b/toolchain/semantics/fuzzer_corpus/0686bcb78820140c8d024e5b7d35adaa5eec3621
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+choice Ints {
+  None,
+  One(i32),
+  Two(i32, i32)
+}
+
+fn Main() -> i32 {
+  let (var Ints.Two(a1: auto, var a2: auto),
+       ((b: auto, var c: auto), var (d: auto, e: auto))) =
+      (Ints.Two(1, 10), ((2, 3), (4, 5)));
+  a1 = 0;
+  a2 = 0;
+  c = 0;
+  d = 0;
+  e = 0;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/08187c797a711bdfbd1e48edcba3d9102766cb9d
+++ b/toolchain/semantics/fuzzer_corpus/08187c797a711bdfbd1e48edcba3d9102766cb9d
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn ReturnSecond(_: i32, x: i32) -> i32 {
+  return x;
+}
+
+fn Main() -> i32 {
+  return ReturnSecond(1, 0);
+}

--- a/toolchain/semantics/fuzzer_corpus/086087f87f7a0618c32aaf7e1d9fb0408e54a448
+++ b/toolchain/semantics/fuzzer_corpus/086087f87f7a0618c32aaf7e1d9fb0408e54a448
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  fn Create(x: T, y: T) -> Point(T) {
+    return {.x = x, .y = y};
+  }
+
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_generic_class_arg.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 1 but got 2
+  var p: Point(i32) = Point(i32, i32).Create(0, 1);
+  return p.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/0896c31a99907299ead911e234074c472a70de30
+++ b/toolchain/semantics/fuzzer_corpus/0896c31a99907299ead911e234074c472a70de30
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test a global variable depending on another global.
+
+var x: i32 = 0;
+
+var y: i32 = x;
+
+fn Main() -> i32 {
+  return y;
+}

--- a/toolchain/semantics/fuzzer_corpus/08ea37d96dee020359a3cd25344d9b33b23fbe8c
+++ b/toolchain/semantics/fuzzer_corpus/08ea37d96dee020359a3cd25344d9b33b23fbe8c
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_newline.carbon:[[@LINE+2]]: missing closing quote in single-line string: "new
+  // CHECK:STDERR:
+  Print("new
+line");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/091db65a1b8f6119b3ba148eccc667ac14e7b9b5
+++ b/toolchain/semantics/fuzzer_corpus/091db65a1b8f6119b3ba148eccc667ac14e7b9b5
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn snd[T:! type](x: i32, y: T) -> T {
+  return y;
+}
+
+fn Main() -> i32 {
+  return snd(0, 1);
+}

--- a/toolchain/semantics/fuzzer_corpus/0a16a746ed273e210abe5ee6cd3c63a475479a39
+++ b/toolchain/semantics/fuzzer_corpus/0a16a746ed273e210abe5ee6cd3c63a475479a39
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Iface {
+  let T:! type;
+}
+
+fn F[T:! Iface where .T == i32](x: T) {}
+
+fn G[U:! Iface where .T == i32](x: U) {
+  F(x);
+}
+
+fn H[V:! Iface](x: V) {
+  // CHECK:STDERR: COMPILATION ERROR: fail_equal_to_dependent_type.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.T) (with value (V).(Iface.T)) == i32, which is not known to be true
+  F(x);
+}
+
+class Class {
+  extend impl as Iface where .T = i32 {}
+}
+
+fn Main() -> i32 {
+  var x: Class = {};
+  G(x);
+  H(x);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/0ad9d1e319b4e0ff9813edf6706823127c78cca5
+++ b/toolchain/semantics/fuzzer_corpus/0ad9d1e319b4e0ff9813edf6706823127c78cca5
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  returned var x: i32 = 1;
+  if (true) {
+    var x: i32 = 2;
+    return var;
+  }
+  x = 3;
+  return var;
+}

--- a/toolchain/semantics/fuzzer_corpus/0c6afa669d8b0036a28c74fa19c7370515938300
+++ b/toolchain/semantics/fuzzer_corpus/0c6afa669d8b0036a28c74fa19c7370515938300
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_combine_rhs.carbon:[[@LINE+1]]: expected a constraint in second operand of `&`, found class C
+fn F[T:! type & C]();
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/0d8919c02ea985fe0c9e02b75d4d01ac98e1ada7
+++ b/toolchain/semantics/fuzzer_corpus/0d8919c02ea985fe0c9e02b75d4d01ac98e1ada7
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_impl.carbon:[[@LINE+1]]: i32 is not equality comparable with String (could not find implementation of interface EqWith(U = String) for i32)
+  Print("different types equal: {0}", if 1 == "1" then 1 else 0);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/0e4dff74694458253dfba70df99260d46c4f7049
+++ b/toolchain/semantics/fuzzer_corpus/0e4dff74694458253dfba70df99260d46c4f7049
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_compound_assign.carbon:[[@LINE+1]]: use of uninitialized variable x
+  x += 1;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/0f16578e125b372618b0f999fa14d20e64baa5c5
+++ b/toolchain/semantics/fuzzer_corpus/0f16578e125b372618b0f999fa14d20e64baa5c5
@@ -1,0 +1,42 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: A
+// CHECK:STDOUT: c.a: 1
+// CHECK:STDOUT: c.b: 2
+// CHECK:STDOUT: c.c: 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class A {
+  fn FunctionA() {}
+  var a: i32;
+  var aa: String;
+}
+
+base class B {
+  extend base: A;
+  fn FunctionB() {}
+  var b: i32;
+}
+
+class C {
+  extend base: B;
+  fn FunctionC() {}
+  var c: i32;
+}
+
+fn Main() -> i32 {
+  var c: C = {.base={.base={.aa="A", .a=1}, .b=2, }, .c=3};
+  c.FunctionA();
+  c.FunctionB();
+  c.FunctionC();
+  Print(c.aa);
+  Print("c.a: {0}", c.a);
+  Print("c.b: {0}", c.b);
+  Print("c.c: {0}", c.c);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/0f51cb18d302c1493cbf5389ca74fa97a49090c5
+++ b/toolchain/semantics/fuzzer_corpus/0f51cb18d302c1493cbf5389ca74fa97a49090c5
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class Point(T:! type, V:! T) {
+  fn Get[self: Self]() -> T {
+    return V;
+  }
+}
+
+fn F(p: Point(i32, 1)) -> i32 {
+  return p.Get();
+}
+
+fn Main() -> i32 {
+  var v: Point(i32, 1) = {};
+  return F(v);
+}

--- a/toolchain/semantics/fuzzer_corpus/1016cb8abba49330ca337c3c650f8b887a8eec56
+++ b/toolchain/semantics/fuzzer_corpus/1016cb8abba49330ca337c3c650f8b887a8eec56
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Add[self: Point](b: Point) -> Point {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point](v: i32) -> Point {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+  }
+}
+
+fn ScaleGeneric[U:! Vector](c: U, s: i32) -> U {
+  return c.Scale(s);
+}
+
+fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {
+  return ScaleGeneric(a.Add(b), s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 1, .y = 1};
+  var b: Point = {.x = 2, .y = 3};
+  var p: Point = AddAndScaleGeneric(a, b, 5);
+  return p.x - 15;
+}

--- a/toolchain/semantics/fuzzer_corpus/105bf041eb0ec468660023a131981170036c4aa4
+++ b/toolchain/semantics/fuzzer_corpus/105bf041eb0ec468660023a131981170036c4aa4
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == ##"str"##) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr(#####"str"#####);
+}

--- a/toolchain/semantics/fuzzer_corpus/10d1744fbabedd2d7b67aeeba5ccfad33dde54eb
+++ b/toolchain/semantics/fuzzer_corpus/10d1744fbabedd2d7b67aeeba5ccfad33dde54eb
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// TODO: Implement this with some kind of reflection?
+impl {.x: i32, .y: i32} as EqWith(Self) {
+  fn Equal[self: Self](other: Self) -> bool {
+    return self.x == other.x and self.y == other.y;
+  }
+  fn NotEqual[self: Self](other: Self) -> bool {
+    return self.x != other.x or self.y != other.y;
+  }
+}
+
+fn Main() -> i32 {
+  var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
+  var t2: {.x: i32,} = {.x = 5,};
+  // CHECK:STDERR: COMPILATION ERROR: fail_equality_type.carbon:[[@LINE+1]]: {.x: i32, .y: i32} is not equality comparable with {.x: i32} (could not find implementation of interface EqWith(U = {.x: i32}) for {.x: i32, .y: i32})
+  if (t1 == t2) {
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/10ed248ac6874c3c6ee8fed1ffff5e2d4f0c5ec5
+++ b/toolchain/semantics/fuzzer_corpus/10ed248ac6874c3c6ee8fed1ffff5e2d4f0c5ec5
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn F() {}
+alias A = F;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_wrong_fn_alias_use.carbon:[[@LINE+1]]: alias A cannot be used as a name qualifier
+fn A.Foo() {}
+
+fn Main() -> i32 {
+    return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1171a926d8aa677aec7042fe5f9e29c1632f5300
+++ b/toolchain/semantics/fuzzer_corpus/1171a926d8aa677aec7042fe5f9e29c1632f5300
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package EmptyIdentifier impl;
+
+fn A() {
+  // CHECK:STDERR: RUNTIME ERROR: fail_function_recursion.carbon:[[@LINE+1]]: stack overflow: too many interpreter actions on stack
+  A();
+}
+
+fn Main() -> i32 {
+  A();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/119ac0fd33bccc1f9d8d4c78f485db62b8261039
+++ b/toolchain/semantics/fuzzer_corpus/119ac0fd33bccc1f9d8d4c78f485db62b8261039
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_rhs_def.carbon:[[@LINE+1]]: use of uninitialized variable x
+  var y: i32 = x;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/119e4e694e8b998c45200f2f9bba291c8f18de86
+++ b/toolchain/semantics/fuzzer_corpus/119e4e694e8b998c45200f2f9bba291c8f18de86
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: i32 = 1;
+  let a_pinned: i32 = a;
+  // OK: Value unused after being mutated.
+  a = 2;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1259d0decfb6c2fd6808fda42a9654bbad1640de
+++ b/toolchain/semantics/fuzzer_corpus/1259d0decfb6c2fd6808fda42a9654bbad1640de
@@ -1,0 +1,45 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: DESTRUCTOR A 4
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn ident(x: bool)-> bool{
+    return x;
+}
+
+fn ident_i32(x: i32)-> i32{
+    return x;
+}
+// It should be enforced that different runtime scopes are on the stack.
+//So that it can be tested that the wrong scopes are not removed from the stack.
+fn Main() -> i32 {
+  var i: i32 = 0;
+  var d: A = {.n = 4};
+  if(ident(true)){
+    var a: A = {.n = 3};
+    if(true){
+       var b: A = {.n = 2};
+       ident_i32(2);
+       if(ident_i32(0) == 0){
+         var c: A = {.n = 1};
+         return 2;
+       }
+    }
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/128de0e2a70878988fcd7bf60bdd862ef764b92f
+++ b/toolchain/semantics/fuzzer_corpus/128de0e2a70878988fcd7bf60bdd862ef764b92f
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
+  var s: String = #'''
+    error: there are more #s on the right than the left.
+  '''##;
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/12b34eb2c07d14c7b6c964bed06d9cd9b295570a
+++ b/toolchain/semantics/fuzzer_corpus/12b34eb2c07d14c7b6c964bed06d9cd9b295570a
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+var call_count: i32 = 0;
+fn ReturnFalse() -> bool {
+  call_count = call_count + 1;
+  return false;
+}
+
+fn Main() -> i32 {
+  var result: bool = ReturnFalse() or ReturnFalse();
+  return if not result then call_count else -1;
+}

--- a/toolchain/semantics/fuzzer_corpus/137565f0078baddcd33c03bcb752cd91e0c15195
+++ b/toolchain/semantics/fuzzer_corpus/137565f0078baddcd33c03bcb752cd91e0c15195
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+abstract class B {
+}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_instantiate_global_abstract.carbon:[[@LINE+1]]: Cannot instantiate abstract class B
+var b: B = {};
+
+fn Main() -> i32 {
+    return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/13936e89e497ed4f7b0555ad0fe8142c71385208
+++ b/toolchain/semantics/fuzzer_corpus/13936e89e497ed4f7b0555ad0fe8142c71385208
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn add1(x: i32) -> i32 {
+  return x + 1;
+}
+
+fn Main() -> i32 {
+  var f: __Fn(i32)->i32 = add1;
+  return f(-1);
+}

--- a/toolchain/semantics/fuzzer_corpus/1397a4fbdf1addb0892345321c7fbc14adf77b4c
+++ b/toolchain/semantics/fuzzer_corpus/1397a4fbdf1addb0892345321c7fbc14adf77b4c
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Has(T:! type) {
+  fn Get() -> T;
+}
+impl i32 as Has(type) {
+  fn Get() -> type { return Self; }
+}
+
+class WithType(T:! Has(type)) {
+  fn Get() -> type { return T.Get(); }
+}
+
+fn Main() -> i32 {
+  var v: WithType(i32).Get() = 0;
+  return v;
+}

--- a/toolchain/semantics/fuzzer_corpus/14bf3c7665fe5282a469b474df3d2485550adbd4
+++ b/toolchain/semantics/fuzzer_corpus/14bf3c7665fe5282a469b474df3d2485550adbd4
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+constraint X {
+  // CHECK:STDERR: COMPILATION ERROR: fail_associated_constant.carbon:[[@LINE+1]]: associated constant not permitted in named constraint
+  let N:! type;
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/1554c1eb73ff3932ad2e83351d6b0c98fca9492c
+++ b/toolchain/semantics/fuzzer_corpus/1554c1eb73ff3932ad2e83351d6b0c98fca9492c
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == "str;\x07") {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("\x73\x74\x72\x3B\x07");
+}

--- a/toolchain/semantics/fuzzer_corpus/164cd743faa60d9495a35aeeaaac5ebcbaaed5c8
+++ b/toolchain/semantics/fuzzer_corpus/164cd743faa60d9495a35aeeaaac5ebcbaaed5c8
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_destination_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+  return 4 as 7;
+}

--- a/toolchain/semantics/fuzzer_corpus/17ec5002557db4205de08c6daad9a3f6cb529076
+++ b/toolchain/semantics/fuzzer_corpus/17ec5002557db4205de08c6daad9a3f6cb529076
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn IntDiff(a: i32, b: i32) -> i32 {
+  if (a == b) {
+    returned var ret: i32 = a - b;
+    return var;
+  } else {
+    returned var ret2: i32 = b - a;
+    return var;
+  }
+}
+
+fn Main() -> i32 {
+  return IntDiff(1, 2);
+}

--- a/toolchain/semantics/fuzzer_corpus/188ed5d12d9c374702dfc38ab438dfe4b8cbabfd
+++ b/toolchain/semantics/fuzzer_corpus/188ed5d12d9c374702dfc38ab438dfe4b8cbabfd
@@ -1,0 +1,46 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: c.Foo() -> 1
+// CHECK:STDOUT: c.Bar() -> 2
+// CHECK:STDOUT: d.Foo() -> 3
+// CHECK:STDOUT: d.Bar() -> 4
+// CHECK:STDOUT: cc.Foo() -> 3
+// CHECK:STDOUT: cc.Bar() -> 2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  virtual fn Foo[self: Self]() -> i32 {
+    return 1;
+  }
+  fn Bar[self: Self]() -> i32 {
+    return 2;
+  }
+}
+
+class D {
+  extend base: C;
+  impl fn Foo[self: Self]() -> i32 {
+    return 3;
+  }
+  fn Bar[self: Self]() -> i32 {
+    return 4;
+  }
+}
+
+fn Main() -> i32 {
+  var c: C = {};
+  Print("c.Foo() -> {0}", c.Foo());
+  Print("c.Bar() -> {0}", c.Bar());
+  var d: D = {.base = {}};
+  Print("d.Foo() -> {0}", d.Foo());
+  Print("d.Bar() -> {0}", d.Bar());
+  var cc: C* = &d;
+  Print("cc.Foo() -> {0}", (*cc).Foo());
+  Print("cc.Bar() -> {0}", (*cc).Bar());
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/18ec728eade91679104b23c3a949271089132321
+++ b/toolchain/semantics/fuzzer_corpus/18ec728eade91679104b23c3a949271089132321
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+var p: Point = {.x = 1, .y = 2};
+
+fn Main() -> i32 {
+  return p.y - p.x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/1913a5458321a159544fff949d3f7b0f9d52065a
+++ b/toolchain/semantics/fuzzer_corpus/1913a5458321a159544fff949d3f7b0f9d52065a
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn fst[T:! type](x: T, y: T) -> T {
+  return x;
+}
+
+fn Main() -> i32 {
+  return fst(0, 1);
+}

--- a/toolchain/semantics/fuzzer_corpus/19d6f8cf04b59808515a78af96abc89cd4c2583e
+++ b/toolchain/semantics/fuzzer_corpus/19d6f8cf04b59808515a78af96abc89cd4c2583e
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  fn F() {}
+  fn G[self: Self]() {}
+}
+
+fn H[T:! type](x: T) {}
+
+fn Main() -> i32 {
+  H(C.F);
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_deduced.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
+  H(C.G);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1ad7c0030d4448143955e4e047868426e46a08e6
+++ b/toolchain/semantics/fuzzer_corpus/1ad7c0030d4448143955e4e047868426e46a08e6
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_value.carbon:[[@LINE+1]]: use of uninitialized variable x
+  var p: auto = {.x = x,};
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1af0cf0cfeabefdff968d557c1b67a32a424f357
+++ b/toolchain/semantics/fuzzer_corpus/1af0cf0cfeabefdff968d557c1b67a32a424f357
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  x = 1;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/1b5911a616ba8ae35eb39f855270fa9b766c3afc
+++ b/toolchain/semantics/fuzzer_corpus/1b5911a616ba8ae35eb39f855270fa9b766c3afc
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Foo(c1): 1
+// CHECK:STDOUT: Foo(c2): 1
+// CHECK:STDOUT: Foo(d): 1
+// CHECK:STDOUT: Foo(&e): 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  var val: i32;
+}
+
+base class D {
+  extend base: C;
+  var val: i32;
+}
+
+class E {
+  extend base: D;
+  var val: i32;
+}
+
+fn Foo(c: C*) -> i32 {
+  return (*c).val;
+}
+
+fn Main() -> i32 {
+  var e: E = { .val = 3, .base = {.val = 2,.base = {.val = 1}}};
+  var d: D* = &e;
+  var c1: C* = &e;
+  var c2: C* = d;
+
+  Print("Foo(c1): {0}", Foo(c1));
+  Print("Foo(c2): {0}", Foo(c2));
+  Print("Foo(d): {0}", Foo(d));
+  Print("Foo(&e): {0}", Foo(&e));
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1c939f5777f53aaf53300f4e54c1f2380b8b4f6a
+++ b/toolchain/semantics/fuzzer_corpus/1c939f5777f53aaf53300f4e54c1f2380b8b4f6a
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class A {
+  var a: i32;
+}
+
+base class B {
+  extend base: A;
+  var b: i32;
+}
+
+class C {
+  extend base: B;
+  var c: i32;
+}
+
+fn Main() -> i32 {
+  var c: C = {.base = {.base = {.a = 1}, .b = 2}, .c = 3};
+  let (pa: A*, pb: B*, pc: C*) = (&c, &c, &c);
+  Print("{0}", pa->a);
+  Print("{0}", pb->b);
+  Print("{0}", pc->c);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1d5b8ef87c518dfd90dfaf7e98886a4ef791ab93
+++ b/toolchain/semantics/fuzzer_corpus/1d5b8ef87c518dfd90dfaf7e98886a4ef791ab93
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Class 1
+// CHECK:STDOUT: Class 2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  fn BasePrint(v: i32) {
+    Print("Class {0}", v);
+  }
+  fn Method1[self: Self]() {
+    self.BasePrint(self.value_c);
+  }
+
+  var value_c: i32;
+}
+
+class D {
+  extend base: C;
+  fn Method2[self: Self]() {
+    self.BasePrint(self.value_d);
+  }
+
+  var value_d: i32;
+}
+
+fn Main() -> i32 {
+  var d: D = {.base = {.value_c = 1}, .value_d = 2};
+  d.Method1();
+  d.Method2();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1d6d70723cfa13913d715a7ba2d7efa03d521df9
+++ b/toolchain/semantics/fuzzer_corpus/1d6d70723cfa13913d715a7ba2d7efa03d521df9
@@ -1,0 +1,55 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point1 {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Add[self: Point1](b: Point1) -> Point1 {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point1](v: i32) -> Point1 {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+  }
+}
+
+class Point2 {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Add[self: Point2](b: Point2) -> Point2 {
+      return {.x = self.x + b.x + 1, .y = self.y + b.y + 1};
+    }
+    fn Scale[self: Point2](v: i32) -> Point2 {
+      return {.x = self.x * v * 2, .y = self.y * v * 2};
+    }
+  }
+}
+
+fn ScaleGeneric[U:! Vector](c: U, s: i32) -> U {
+  return c.Scale(s);
+}
+
+fn AddAndScaleGeneric[T:! Vector, V:! Vector](a: T, b: V, s: i32) -> (T, V) {
+  return (ScaleGeneric(a.Add(a), s),
+  	  ScaleGeneric(b.Add(b), s));
+}
+
+fn Main() -> i32 {
+  var a: Point1 = {.x = 1, .y = 1};
+  var b: Point2 = {.x = 2, .y = 3};
+  var (p: Point1, q: Point2) = AddAndScaleGeneric(a, b, 5);
+  return q.x - p.x - 40;
+}

--- a/toolchain/semantics/fuzzer_corpus/1dddc76f0ab71e0db413ccbd3eb8440ce69fe0e0
+++ b/toolchain/semantics/fuzzer_corpus/1dddc76f0ab71e0db413ccbd3eb8440ce69fe0e0
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Iface {
+  let N:! i32;
+}
+
+fn F(T:! Iface where .N == 5) {}
+
+class Good {}
+class Bad {}
+impl Good as Iface where .N = 5 {}
+impl Bad as Iface where .N = 4 {}
+
+fn Main() -> i32 {
+  F(Good);
+  // CHECK:STDERR: COMPILATION ERROR: fail_different_value.carbon:[[@LINE+1]]: constraint requires that (T).(Iface.N) (with value 4) == 5, which is not known to be true
+  F(Bad);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1e4c94040dcf313929b6e45bb96932198f296d9e
+++ b/toolchain/semantics/fuzzer_corpus/1e4c94040dcf313929b6e45bb96932198f296d9e
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 4
+
+package ExplorerTest api;
+
+alias TypeAlias = i32;
+
+fn Main() -> TypeAlias {
+  var n: TypeAlias = 1;
+  var m: i32 = n;
+  var p: i32* = &n;
+  var q: TypeAlias* = &m;
+  return *p + *q + m + n;
+}

--- a/toolchain/semantics/fuzzer_corpus/1ee86793bb703120496039d708f7562e9abfbc5c
+++ b/toolchain/semantics/fuzzer_corpus/1ee86793bb703120496039d708f7562e9abfbc5c
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn F() {}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_qualifier_not_namespace.carbon:[[@LINE+1]]: fn F cannot be used as a name qualifier
+fn F.G() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1f287f6a07c7bf4e14bd2563f2877e1ca28c52c3
+++ b/toolchain/semantics/fuzzer_corpus/1f287f6a07c7bf4e14bd2563f2877e1ca28c52c3
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  Assert(true, "HALLO WELT");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/1fc793d170552ec217bfa6554c43444b5bc1a30d
+++ b/toolchain/semantics/fuzzer_corpus/1fc793d170552ec217bfa6554c43444b5bc1a30d
@@ -1,0 +1,46 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as Inc {
+  fn Op[addr self: Self*]() { ++self->n; }
+}
+impl A as Dec {
+  fn Op[addr self: Self*]() { --self->n; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  ++a.n;
+  Print("{0}", a.n);
+  --a.n;
+  Print("{0}", a.n);
+  ++a;
+  Print("{0}", a.n);
+  --a;
+  Print("{0}", a.n);
+  a.n.(Inc.Op)();
+  Print("{0}", a.n);
+  a.n.(Dec.Op)();
+  Print("{0}", a.n);
+  a.(Inc.Op)();
+  Print("{0}", a.n);
+  a.(Dec.Op)();
+  Print("{0}", a.n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2038a206d7fa99068235bb2ba54820e768b29cb9
+++ b/toolchain/semantics/fuzzer_corpus/2038a206d7fa99068235bb2ba54820e768b29cb9
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package Foo api;
+interface A { fn F[self: Self]() -> i32; }
+class X {
+  extend impl as A {
+    fn F[self: Self]() -> i32 { return 1; }
+  }
+}
+fn Main() -> i32 {
+  var a: X = {};
+  return a.(X.(A.F))();
+}

--- a/toolchain/semantics/fuzzer_corpus/20bbc444ffd3b0a688732fe0aa1eeff6969c33cc
+++ b/toolchain/semantics/fuzzer_corpus/20bbc444ffd3b0a688732fe0aa1eeff6969c33cc
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_single_brace.carbon:[[@LINE+1]]: `{` must be followed by a second `{` or index in `{`
+  Print("{");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/21e0d305628d54204f02591a43b61527cda5d976
+++ b/toolchain/semantics/fuzzer_corpus/21e0d305628d54204f02591a43b61527cda5d976
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_nontype_tuple_as_type.carbon:[[@LINE+1]]: type error in type of name binding: '(i32, i32)' is not implicitly convertible to 'type'
+fn F[T:! (i32, i32)](x: T);
+
+fn Main() -> i32;

--- a/toolchain/semantics/fuzzer_corpus/22d9a3333ee8d54f7e1233bf62920026ca8f3a1d
+++ b/toolchain/semantics/fuzzer_corpus/22d9a3333ee8d54f7e1233bf62920026ca8f3a1d
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface X { fn F(); }
+impl i32 as X { fn F() {} }
+
+fn G[T:! X](v: T) -> type {
+  v.F();
+  return i32;
+}
+
+fn Main() -> i32 {
+  var v: G(0) = 0;
+  return v;
+}

--- a/toolchain/semantics/fuzzer_corpus/23e9f18ca5b5c85f4a44e3c472bbd23d1420013b
+++ b/toolchain/semantics/fuzzer_corpus/23e9f18ca5b5c85f4a44e3c472bbd23d1420013b
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_bounds1.carbon:[[@LINE+1]]: Index invalid with argument count of 1 at offset 12 in `Print: {0} {1}`
+  Print("Print: {0} {1}", 1);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2464b8df7ccb3280edff4bce116483b5b165a953
+++ b/toolchain/semantics/fuzzer_corpus/2464b8df7ccb3280edff4bce116483b5b165a953
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn add(x: i32, y: i32) -> auto { return x + y; }
+
+fn Main() -> i32 {
+  return add(1, 2) - 3;
+}

--- a/toolchain/semantics/fuzzer_corpus/25337ce57e0a62b2091a8b41a217cc54d65d0d80
+++ b/toolchain/semantics/fuzzer_corpus/25337ce57e0a62b2091a8b41a217cc54d65d0d80
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 8
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (1 << 0 != 1) { return 1; }
+  if (1 << 3 != 8) { return 2; }
+  if (0 << 3 != 0) { return 3; }
+  if (3 << 1 != 6) { return 4; }
+  if (-1 << 2 != -4) { return 5; }
+  if (1 >> 0 != 1) { return 6; }
+  if (1 >> 1 != 0) { return 7; }
+  if (3 >> 1 != 1) { return 8; }
+  if (-1 >> 1 != -1) { return 9; }
+  if (-2 >> 1 != -1) { return 10; }
+
+  var n: i32 = 1;
+  n <<= 3;
+  Print("{0}", n);
+  n >>= 1;
+  Print("{0}", n);
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/25502eb01b8fec80bd8f99258c8e2c4db7ebd1dd
+++ b/toolchain/semantics/fuzzer_corpus/25502eb01b8fec80bd8f99258c8e2c4db7ebd1dd
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_add.carbon:[[@LINE+1]]: integer overflow
+  var a: auto = 2147483647 + 1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2552f1d3328f74b706d9138c53a14ff62b3b6bb3
+++ b/toolchain/semantics/fuzzer_corpus/2552f1d3328f74b706d9138c53a14ff62b3b6bb3
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == "HELLO WORLD!!") {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("\u{0048}\u{0045}\u{004C}\u{004C}\u{004F} \u{0057}\u{004F}\u{0052}\u{004C}\u{0044}\u{0021}\u{21}");
+}

--- a/toolchain/semantics/fuzzer_corpus/26ce51c2c7f8a1d9f1b0c03722e8619f4e6eb1a5
+++ b/toolchain/semantics/fuzzer_corpus/26ce51c2c7f8a1d9f1b0c03722e8619f4e6eb1a5
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {}
+
+// CHECK:STDERR: SYNTAX ERROR: fail_type_only.carbon:[[@LINE+1]]: syntax error, unexpected RIGHT_SQUARE_BRACKET, expecting COLON
+fn f[x:! i32, addr C]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/27b81cef471374f0e9d02dcf2be5e79e45c0de2c
+++ b/toolchain/semantics/fuzzer_corpus/27b81cef471374f0e9d02dcf2be5e79e45c0de2c
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Zero() -> Self;
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point(T:! type) {
+  var x: T;
+  var y: T;
+}
+
+impl Point(i32) as Vector {
+  // Allowed: `Self` means `Point(i32)` here.
+  fn Zero() -> Self {
+    return {.x = 0, .y = 0};
+  }
+
+  fn Add[self: Self](b: Self) -> Self {
+    return {.x = self.x + b.x, .y = self.y + b.y};
+  }
+
+  fn Scale[self: Self](v: i32) -> Self {
+    return {.x = self.x * v, .y = self.y * v};
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](a: T, s: i32) -> T {
+  return a.Add(T.Zero()).Scale(s);
+}
+
+fn Main() -> i32 {
+  var a: Point(i32) = {.x = 2, .y = 1};
+  var p: Point(i32) = AddAndScaleGeneric(a, 5);
+  return p.x - 10;
+}

--- a/toolchain/semantics/fuzzer_corpus/28720cdeeeba8921f97c137876b6dbe6e2a3225f
+++ b/toolchain/semantics/fuzzer_corpus/28720cdeeeba8921f97c137876b6dbe6e2a3225f
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+interface Vector {
+  let Dim:! i32;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector where .Dim = 2 {}
+}
+
+fn Main() -> i32 {
+  return Point.(Vector.Dim);
+}

--- a/toolchain/semantics/fuzzer_corpus/291af82d79bec74264cef40a43fcd6198593d0b5
+++ b/toolchain/semantics/fuzzer_corpus/291af82d79bec74264cef40a43fcd6198593d0b5
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+class TypeLike {
+  extend impl as ImplicitAs(type) {
+    fn Convert[self: Self]() -> type { return i32; }
+  }
+  fn Make() -> Self { return {}; }
+}
+
+fn Main() -> TypeLike.Make() {
+  var x: {.a: TypeLike.Make(), .b: TypeLike.Make()} = {.a = 1, .b = 2};
+  return x.a + x.b;
+}

--- a/toolchain/semantics/fuzzer_corpus/292afba18cbb0ca2936ed77ebc79534ac76eeea4
+++ b/toolchain/semantics/fuzzer_corpus/292afba18cbb0ca2936ed77ebc79534ac76eeea4
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (0 == 1) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/29366dc2c3a372bec197172efb4c3b245a6b6e95
+++ b/toolchain/semantics/fuzzer_corpus/29366dc2c3a372bec197172efb4c3b245a6b6e95
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package EmptyIdentifier impl;
+
+fn Main() -> i32 {
+  while (true) {
+    // Ideally we would hit an OOM here, but it's too difficult to OOM from heap
+    // allocations before hitting max steps. Maybe with string operations we
+    // could trigger actual excessive memory allocations by just doubling the
+    // size of the string each time.
+    // CHECK:STDERR: RUNTIME ERROR: fail_allocate.carbon:[[@LINE+1]]: possible infinite loop: too many interpreter steps executed
+    heap.New((0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0));
+  }
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/293b69131b73f32057424dee21a24ea04530399a
+++ b/toolchain/semantics/fuzzer_corpus/293b69131b73f32057424dee21a24ea04530399a
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_single_line.carbon:[[@LINE+1]]: Invalid block string: Too few lines
+  if (s == #'''raw string literal starting with '''#) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("\"\"raw string literal starting with \"\"");
+}

--- a/toolchain/semantics/fuzzer_corpus/299dc67e6adcc047d41fb7c54c8733ae1f5a730f
+++ b/toolchain/semantics/fuzzer_corpus/299dc67e6adcc047d41fb7c54c8733ae1f5a730f
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/2c68b43d8a3accf3dffde64ee1346170c321cf8a
+++ b/toolchain/semantics/fuzzer_corpus/2c68b43d8a3accf3dffde64ee1346170c321cf8a
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_div_by_zero.carbon:[[@LINE+1]]: division by zero
+  var a: auto = 5 / 0;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2c8bd9d51c37b6e039d31465180dcd971e372a33
+++ b/toolchain/semantics/fuzzer_corpus/2c8bd9d51c37b6e039d31465180dcd971e372a33
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn ReturnIndirectly[T:! type](direct: bool, x: T) -> type {
+  if (direct) {
+    return T;
+  } else {
+    return ReturnIndirectly(true, x);
+  }
+}
+
+fn Main() -> ReturnIndirectly(false, 0) {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2cd24a29608035201b59f604b1c06ffd230df13e
+++ b/toolchain/semantics/fuzzer_corpus/2cd24a29608035201b59f604b1c06ffd230df13e
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+class A(T:! type) {
+  var v: T;
+}
+fn F(T:! type, x: T) -> T {
+  var v: A(T) = {.v = x};
+  return v.v;
+}
+fn Main() -> i32 {
+  return F(i32, 1);
+}

--- a/toolchain/semantics/fuzzer_corpus/2e7f4e15df56d8a05046d80c7a7ce01e6cb6779b
+++ b/toolchain/semantics/fuzzer_corpus/2e7f4e15df56d8a05046d80c7a7ce01e6cb6779b
@@ -1,0 +1,75 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: MemberF.F
+// CHECK:STDOUT: ImplF.(HasF.F)
+// CHECK:STDOUT: BothFs.(HasF.F)
+// CHECK:STDOUT: BothFs.F
+// CHECK:STDOUT: BothFs.F
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+choice ImplKind {
+  Checked,
+  ConstrainedTemplate,
+  UnconstrainedTemplate
+}
+
+interface CallF(K:! ImplKind) {
+  fn DoIt[self: Self]();
+}
+
+interface HasF {
+  fn F[self: Self]();
+}
+
+impl forall [T:! HasF] T as CallF(ImplKind.Checked) {
+  fn DoIt[self: Self]() { self.F(); }
+}
+
+impl forall [template T:! HasF] T as CallF(ImplKind.ConstrainedTemplate) {
+  fn DoIt[self: Self]() { self.F(); }
+}
+
+impl forall [template T:! type] T as CallF(ImplKind.UnconstrainedTemplate) {
+  fn DoIt[self: Self]() { self.F(); }
+}
+
+class MemberF {
+  fn F[self: Self]() { Print("MemberF.F"); }
+}
+
+class ImplF {}
+impl ImplF as HasF {
+  fn F[self: Self]() { Print("ImplF.(HasF.F)"); }
+}
+
+class BothFs {
+  fn F[self: Self]() { Print("BothFs.F"); }
+}
+impl BothFs as HasF {
+  fn F[self: Self]() { Print("BothFs.(HasF.F)"); }
+}
+
+fn Main() -> i32 {
+  var mem: MemberF = {};
+  var imp: ImplF = {};
+  var both: BothFs = {};
+
+  mem.(CallF(ImplKind.UnconstrainedTemplate).DoIt)();
+
+  imp.(CallF(ImplKind.Checked).DoIt)();
+  // TODO: Should be valid, but currently fails during instantiation.
+  //imp.(CallF(ImplKind.ConstrainedTemplate).DoIt)();
+
+  both.(CallF(ImplKind.Checked).DoIt)();
+  // TODO: Should be rejected, but currently incorrectly accepted.
+  // This line can be deleted once it starts failing; we test that this is
+  // rejected in fail_name_lookup.carbon.
+  both.(CallF(ImplKind.ConstrainedTemplate).DoIt)();
+  both.(CallF(ImplKind.UnconstrainedTemplate).DoIt)();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/2f13aa997ff8ff9e53fa3e0d38fd27ff214319d9
+++ b/toolchain/semantics/fuzzer_corpus/2f13aa997ff8ff9e53fa3e0d38fd27ff214319d9
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (0 == 1) {
+    return 1;
+  } else if (0 == 0) {
+    return 0;
+  }
+
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/2f1e5bc51212e421a902e31273599bea2ede8c62
+++ b/toolchain/semantics/fuzzer_corpus/2f1e5bc51212e421a902e31273599bea2ede8c62
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var n: i32 = 0;
+  match (n) {
+    case 1 => { return 0; }
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/2fb9acfa600396821f70f238b1c20f95e40a25b9
+++ b/toolchain/semantics/fuzzer_corpus/2fb9acfa600396821f70f238b1c20f95e40a25b9
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface I {}
+impl i32 as I {}
+
+fn F(A:! i32, B:! i32, C:! i32, D:! i32, E:! i32,
+     T:! I where A == B and C == D and C == E and B == D) {
+  // CHECK:STDERR: COMPILATION ERROR: fail_combine_equality.carbon:[[@LINE+1]]: member access, F not in interface I where T impls interface I and A == B and C == D and C == E and B == D
+  T.F();
+}
+
+fn Main() -> i32 {
+  F(1, 1, 1, 1, 1, i32);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/30243c0f830ca810070c9dc52e11026d673fd3de
+++ b/toolchain/semantics/fuzzer_corpus/30243c0f830ca810070c9dc52e11026d673fd3de
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 6
+
+package ExplorerTest api;
+
+namespace N;
+
+fn OuterI32() -> type { return i32; }
+fn One() -> i32 { return 1; }
+
+fn N.I32() -> type { return i32; }
+fn N.Five() -> I32() { return 5; }
+fn N.Six() -> OuterI32() { return Five() + One(); }
+
+fn Main() -> i32 { return N.Six(); }

--- a/toolchain/semantics/fuzzer_corpus/3079f1de829d6dad1caef247d2d2965ab0a2233f
+++ b/toolchain/semantics/fuzzer_corpus/3079f1de829d6dad1caef247d2d2965ab0a2233f
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+__mixin M1 {
+  fn Scale10[self: Self](x:i32) -> i32{
+     return x * 10;
+  }
+}
+
+__mixin M2 {
+  __mix M1;
+  fn Square[self: Self](x:i32) -> i32{
+    return x * x;
+  }
+}
+
+class C {
+  __mix M2;
+}
+
+fn Main() -> i32 {
+  var c: C = {};
+  return c.Square(11) - c.Scale10(10) - 21;
+}

--- a/toolchain/semantics/fuzzer_corpus/307b97c6b60b4f05d53a656201995e1fb502af02
+++ b/toolchain/semantics/fuzzer_corpus/307b97c6b60b4f05d53a656201995e1fb502af02
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_before_typecheck.carbon:[[@LINE+1]]: incomplete type `class C` used in member access
+  var n: if not C.WrapInStruct() then i32 else {.n: i32};
+  fn WrapInStruct() -> bool { return true; }
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/3161b5f7fb9fc09982d28e2255f3d2ae27fc5ce1
+++ b/toolchain/semantics/fuzzer_corpus/3161b5f7fb9fc09982d28e2255f3d2ae27fc5ce1
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+var x: i32;
+
+fn Main() -> i32 {
+  x = 1;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/31e0e6f587bdffffc37922b7b3f771680232bb31
+++ b/toolchain/semantics/fuzzer_corpus/31e0e6f587bdffffc37922b7b3f771680232bb31
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [[i32; 3]; 2] = ((0, 1, 2), (3, 4, 5));
+  return x[1][2] - 5;
+}

--- a/toolchain/semantics/fuzzer_corpus/31ef33085e7420998380c7dd66d8529ad975f7a4
+++ b/toolchain/semantics/fuzzer_corpus/31ef33085e7420998380c7dd66d8529ad975f7a4
@@ -1,0 +1,56 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: bool: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: string: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: int: 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareEqualValues[T:! EqWith(.Self)](format: String, a: T, b: T) {
+  Print(format, if a == b then 1 else 0);
+  Print(format, if a != b then 0 else 1);
+}
+
+fn CompareDifferentValues[U:! EqWith(.Self)](format: String, a: U, b: U) {
+  Print(format, if a == b then 0 else 1);
+  Print(format, if a != b then 1 else 0);
+}
+
+fn CompareAll[V:! EqWith(.Self)](format: String, a: V, b: V) {
+  CompareEqualValues(format, a, a);
+  CompareEqualValues(format, b, b);
+  CompareDifferentValues(format, a, b);
+  CompareDifferentValues(format, b, a);
+}
+
+fn Main() -> i32 {
+  CompareAll("bool: {0}", false, true);
+  CompareAll("string: {0}", "hello", "world");
+  CompareAll("int: {0}", 1, 2);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/3246530de7e46a174acd24fd87d38695fd5e36c9
+++ b/toolchain/semantics/fuzzer_corpus/3246530de7e46a174acd24fd87d38695fd5e36c9
@@ -1,0 +1,43 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR B 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: DESTRUCTOR A 4
+// CHECK:STDOUT: DESTRUCTOR A 5
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    fn Create(x: i32) -> A{
+        return {.n = x};
+    }
+    var n: i32;
+}
+
+class B{
+    destructor[self: Self]{
+        Print("DESTRUCTOR B {0}",self.n);
+    }
+    fn Create(x: i32) -> B{
+       return {.n = x, .a1 = A.Create(4),.a2 = A.Create(3) };
+    }
+    var a1: A;
+    var n: i32;
+    var a2: A;
+}
+
+
+fn Main() -> i32 {
+  var a: A = A.Create(5);
+  var b: B = B.Create(2);
+  var c: A = A.Create(1);
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/326f616ba0e75fe934290f59801ffeecb97fad51
+++ b/toolchain/semantics/fuzzer_corpus/326f616ba0e75fe934290f59801ffeecb97fad51
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class A {
+  fn F[self: Self]() -> i32;
+}
+
+fn Main() -> i32 {
+  var a: A = {};
+  // CHECK:STDERR: RUNTIME ERROR: fail_call_undefined_method.carbon:[[@LINE+1]]: attempt to call function `F` that has not been defined
+  return a.F();
+}

--- a/toolchain/semantics/fuzzer_corpus/328768bbd4cee309586c935aa27bedf19202ef39
+++ b/toolchain/semantics/fuzzer_corpus/328768bbd4cee309586c935aa27bedf19202ef39
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_octal.carbon:[[@LINE+1]]: Invalid escaping in string: "str\01"
+  Print("str\01");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/32ab1efa550be4f04cc3d07bf05a8804d09b754b
+++ b/toolchain/semantics/fuzzer_corpus/32ab1efa550be4f04cc3d07bf05a8804d09b754b
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: i32, y: i32);
+  // CHECK:STDERR: COMPILATION ERROR: fail_while_cond.carbon:[[@LINE+1]]: use of uninitialized variable x
+  while (x == 0) {
+    y = 1;
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/33346b680817ff4c2a003195a0a712daee297f8f
+++ b/toolchain/semantics/fuzzer_corpus/33346b680817ff4c2a003195a0a712daee297f8f
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package Foo api;
+fn F[self: i32]() {}
+fn Main() -> i32 {
+  // TODO: It's unclear whether this is valid per the current rules. See
+  // https://github.com/carbon-language/carbon-lang/pull/1122
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_non_member.carbon:[[@LINE+1]]: expected name of instance member or interface member in compound member access, found fn [self: i32]() -> ()
+  42.(F)();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/347494c3bd46b47f162b4abe214f5f71881dd126
+++ b/toolchain/semantics/fuzzer_corpus/347494c3bd46b47f162b4abe214f5f71881dd126
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  return p.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/34d5a979143e2dac42a721445d89d3681f13f4cd
+++ b/toolchain/semantics/fuzzer_corpus/34d5a979143e2dac42a721445d89d3681f13f4cd
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Container {
+  let Element:! type;
+  fn Front[self: Self]() -> Element;
+}
+
+fn A[T:! Container where .Element = i32](x: T) -> T.Element {
+  return x.Front();
+}
+
+fn B[T:! Container](x: T) -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_rewrite.carbon:[[@LINE+1]]: constraint requires that (T).(Container.Element) (with value (T).(Container.Element)) == i32, which is not known to be true
+  return A(x);
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/34ff001dd827e172826dd1a040df88b4f7d15a01
+++ b/toolchain/semantics/fuzzer_corpus/34ff001dd827e172826dd1a040df88b4f7d15a01
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Initialize c1 from initializing expression (returned var)
+// CHECK:STDOUT: Before nested init
+// CHECK:STDOUT: 0: Heap{}, 1: !Uninit<class C>
+// CHECK:STDOUT: Nested call return
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: First call return
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: Declaration scope
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("c destroyed");
+  }
+}
+
+fn CallWithReturnedVar2() -> C {
+  Print("Before nested init");
+  heap.PrintAllocs();
+  returned var c: C = {};
+  Print("Nested call return");
+  heap.PrintAllocs();
+  return var;
+}
+
+fn CallWithReturnedVar() -> C {
+  returned var c: C = CallWithReturnedVar2();
+  Print("First call return");
+  heap.PrintAllocs();
+  return var;
+}
+
+fn FromInitializingExpression_ReturnedVar() {
+  Print("Initialize c1 from initializing expression (returned var)");
+  let c: C = CallWithReturnedVar();
+  Print("Declaration scope");
+  heap.PrintAllocs();
+}
+
+fn Main() -> i32 {
+  FromInitializingExpression_ReturnedVar();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/35538f6224efb57c9edb0fa3da9f3679a1a1ceed
+++ b/toolchain/semantics/fuzzer_corpus/35538f6224efb57c9edb0fa3da9f3679a1a1ceed
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as DivWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n / rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 19};
+  a = a / 3;
+  Print("{0}", a.n);
+  a /= 2;
+  Print("{0}", a.n);
+  Print("{0}", (a / 2).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/36717d4dda9919479b60d7150b62df44499a51fd
+++ b/toolchain/semantics/fuzzer_corpus/36717d4dda9919479b60d7150b62df44499a51fd
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  var i: i32 = 0;
+  while( i < 2){
+    var a: A = {.n = 3};
+    var b: A = {.n = 2};
+    var c: A = {.n = 1};
+    i = i + 1;
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/36b957f732d3b3eb30b528c109683f3ff3e738f9
+++ b/toolchain/semantics/fuzzer_corpus/36b957f732d3b3eb30b528c109683f3ff3e738f9
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: (i32, i32) = (1, 2);
+  var p: (i32, i32)* = &a;
+
+  a[0] = 3;
+  Print("{0}", (*p)[0]);
+
+  (*p)[1] = 4;
+  Print("{0}", a[1]);
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/374e96ca0653e9f238dad0aa53e6d8243460302e
+++ b/toolchain/semantics/fuzzer_corpus/374e96ca0653e9f238dad0aa53e6d8243460302e
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32{
+  var x: Optional(String) = Optional(String).CreateEmpty();
+  if(x.HasValue()){
+    return -1;
+  }
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/3974726c6015a615360574cb1221200e183175c2
+++ b/toolchain/semantics/fuzzer_corpus/3974726c6015a615360574cb1221200e183175c2
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 12
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var cond: if true then bool else i32 = true;
+  if (if cond then true else false) {}
+  while (if cond then false else true) {}
+  return if if cond then true or false else false and true
+         then if not cond then 1 + 2 else 3 * 4
+         else if not cond then 5 + 6 else 7 * 8;
+}

--- a/toolchain/semantics/fuzzer_corpus/3a4ba37f94cf21edb7969ed61c1fea9a0f3eb56c
+++ b/toolchain/semantics/fuzzer_corpus/3a4ba37f94cf21edb7969ed61c1fea9a0f3eb56c
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var p: i32* = __intrinsic_new(0);
+  var y: i32 = *p;
+  __intrinsic_delete(p);
+  return y;
+}

--- a/toolchain/semantics/fuzzer_corpus/3bddb2be6780b792248656a086347171ecca2f1d
+++ b/toolchain/semantics/fuzzer_corpus/3bddb2be6780b792248656a086347171ecca2f1d
@@ -1,0 +1,66 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Allocate D
+// CHECK:STDOUT: DESTRUCTOR B
+// CHECK:STDOUT: DESTRUCTOR A
+// CHECK:STDOUT: DESTRUCTOR D
+// CHECK:STDOUT: DESTRUCTOR C
+// CHECK:STDOUT: Delete B from A*
+// CHECK:STDOUT: DESTRUCTOR B
+// CHECK:STDOUT: DESTRUCTOR A
+// CHECK:STDOUT: Delete D from C*
+// CHECK:STDOUT: DESTRUCTOR D
+// CHECK:STDOUT: DESTRUCTOR C
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class A {
+  virtual destructor[self: Self] {
+    Print("DESTRUCTOR A");
+  }
+}
+
+class B {
+  extend base: A;
+  fn Create() -> Self{
+    return {.base={}};
+  }
+  impl destructor[self: Self] {
+    Print("DESTRUCTOR B");
+  }
+}
+
+base class C {
+  virtual destructor[self: Self] {
+    Print("DESTRUCTOR C");
+  }
+}
+
+class D {
+  extend base: C;
+  fn Create() -> Self{
+    return {.base={}, .d_pa=heap.New(B.Create())};
+  }
+  impl destructor[self: Self] {
+    Print("DESTRUCTOR D");
+  }
+  var d_pa: A*;
+}
+
+fn Main() -> i32 {
+  Print("Allocate D");
+  var pd: D* = heap.New(D.Create());
+  var pc: C* = pd;
+
+  Print("Delete B from A*");
+  heap.Delete(pd->d_pa);
+
+  Print("Delete D from C*");
+  heap.Delete(pc);
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/3def80179ffa13dd5984676ace7c0d8e9cac2031
+++ b/toolchain/semantics/fuzzer_corpus/3def80179ffa13dd5984676ace7c0d8e9cac2031
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  fn Origin(zero: T) -> Point(T) {
+    return {.x = zero, .y = zero};
+  }
+
+  fn GetX[self: Point(T)]() -> T {
+    return self.x;
+  }
+
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = Point(i32).Origin(0);
+  return p.GetX();
+}

--- a/toolchain/semantics/fuzzer_corpus/3e51c009c54026d5e2cbbfe253b38765d4e71c63
+++ b/toolchain/semantics/fuzzer_corpus/3e51c009c54026d5e2cbbfe253b38765d4e71c63
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Check that even generic parameters are looked up in the namespace of an
+// entity.
+namespace N;
+
+interface N.Interface {}
+
+class N.A(T:! Interface) {}
+interface N.B(T:! Interface) {}
+constraint N.C(T:! Interface) {}
+__mixin N.D(T:! Interface) {}
+choice N.E(T:! Interface) {}
+fn N.F[T:! Interface](a: A(T)) {}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/3fa85a4f6a6e080e9c47b7de21848308a54fb12d
+++ b/toolchain/semantics/fuzzer_corpus/3fa85a4f6a6e080e9c47b7de21848308a54fb12d
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_multiply.carbon:[[@LINE+1]]: integer overflow
+  var a: auto = 1000000000 * 1000000000;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/40ec85973059ea2eb5ad4495a0e72412427eb429
+++ b/toolchain/semantics/fuzzer_corpus/40ec85973059ea2eb5ad4495a0e72412427eb429
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as ImplicitAs(i32) {
+  fn Convert[self: Self]() -> i32 { return self.n; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  return a as i32;
+}

--- a/toolchain/semantics/fuzzer_corpus/410e360fb25137ae34bb10ba8f43389970784769
+++ b/toolchain/semantics/fuzzer_corpus/410e360fb25137ae34bb10ba8f43389970784769
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1234
+
+package ExplorerTest api;
+
+interface A {
+  fn F() -> i32;
+}
+interface B {
+  fn F() -> i32;
+  fn G() -> i32;
+}
+interface C(T:! type) {
+  fn H() -> T;
+}
+
+impl i32 as A {
+  fn F() -> i32 { return 1; }
+}
+
+impl i32 as B & C(i32) where .Self impls A {
+  fn F() -> i32 { return 2; }
+  fn G() -> i32 { return 3; }
+  fn H() -> i32 { return 4; }
+}
+
+fn Main() -> i32 {
+  let n: i32 = 0;
+  return n.(A.F)() * 1000 + n.(B.F)() * 100 + n.(B.G)() * 10 + n.(C(i32).H)();
+}

--- a/toolchain/semantics/fuzzer_corpus/431046fc9aad6d960aac0e19b676292fb66cba26
+++ b/toolchain/semantics/fuzzer_corpus/431046fc9aad6d960aac0e19b676292fb66cba26
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// TODO: Should this work?
+
+package ExplorerTest api;
+
+interface Vector {
+  let Dim:! i32;
+}
+impl (i32, i32, i32) as Vector where .Dim = 3 {}
+
+class Point(Scalar:! type, Dim:! i32) {}
+
+fn F[Scalar:! type, V:! Vector where .Dim == 3](p: Point(Scalar, V.Dim), v: V) {}
+
+fn G[Scalar:! type](p: Point(Scalar, 3)) {}
+fn H[V:! Vector where .Dim == 3](v: V) {
+  var p: Point(i32, V.Dim) = {};
+  // CHECK:STDERR: COMPILATION ERROR: fail_match_in_deduction.carbon:[[@LINE+1]]: mismatch in non-deduced values, `(V).(Vector.Dim)` != `3`
+  G(p);
+}
+
+fn Main() -> i32 {
+  var p: Point(i32, 3) = {};
+  // Deduce Point(Scalar, V.Dim) from Point(i32, 3).
+  F(p, (0, 0, 0));
+  // Deduce Point(Scalar, 3) from Point(i32, V.Dim).
+  H((0, 0, 0));
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/4354d5620d966751cc545a5e9a7c55d263875c66
+++ b/toolchain/semantics/fuzzer_corpus/4354d5620d966751cc545a5e9a7c55d263875c66
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn F() {
+  return;
+}
+
+fn Main() -> i32 {
+  F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/4367b235dfdad01ab5652abfe5052b5b1a410d82
+++ b/toolchain/semantics/fuzzer_corpus/4367b235dfdad01ab5652abfe5052b5b1a410d82
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 10
+// CHECK:STDOUT: 30
+// CHECK:STDOUT: 210
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as MulWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n * rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  a = a * 2;
+  Print("{0}", a.n);
+  a *= 3;
+  Print("{0}", a.n);
+  Print("{0}", (a * 7).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/43921c8fea3dd42753e50ac91c5d83d87e1c3bea
+++ b/toolchain/semantics/fuzzer_corpus/43921c8fea3dd42753e50ac91c5d83d87e1c3bea
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  // CHECK:STDERR: COMPILATION ERROR: fail_circular_inheritance.carbon:[[@LINE+4]]: could not find `class C {
+  // CHECK:STDERR: extend base: C;
+  // CHECK:STDERR: }
+  // CHECK:STDERR: `
+  extend base: C;
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/4487e8bd672c03926d372d25aa108d6fa909c11a
+++ b/toolchain/semantics/fuzzer_corpus/4487e8bd672c03926d372d25aa108d6fa909c11a
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+class Cell(T:! type) {
+  fn Create(x: T) -> Cell(T) { return { .data = x }; }
+
+  fn Get[self: Self]() -> T {
+    return self.data;
+  }
+  fn Put[addr self: Self*](x: T) {
+    (*self).data = x;
+  }
+  fn Update[addr self: Self*, U:! ImplicitAs(T)](x: U) {
+    (*self).data = x;
+  }
+  fn CreateOther[self: Self, U:! type](x: U) -> Cell(U) {
+    return {.data = x};
+  }
+  var data: T;
+}
+
+class Integer {
+  var int: i32;
+}
+
+fn Main() -> i32 {
+  var i: Integer = {.int = 1};
+  var c: Cell(Integer) = Cell(Integer).Create(i); // c contains 1
+  i = {.int = 2};
+  var j: Integer = c.Get(); // j == 1
+  c.Put(i);    // c contains 2
+  c.Update(j); // c contains 1
+  var d: Cell(Integer) = c.CreateOther(i); // d contains 2
+  return c.data.int + d.data.int;
+}

--- a/toolchain/semantics/fuzzer_corpus/44b9bb4873ea7ed7eeddd3cd5af4bbb71507e31d
+++ b/toolchain/semantics/fuzzer_corpus/44b9bb4873ea7ed7eeddd3cd5af4bbb71507e31d
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface X(T:! type) {}
+
+interface Y(T:! type) {
+    let M:! X(T);
+}
+
+interface Z {
+  // The `i32 impls X(.Self)` constraint is indirectly required by
+  // specifying that `.M = i32`.
+  let N:! Y(.Self) where i32 impls X(.Self) and .M = i32;
+}
+
+impl i32 as X(i32) {}
+impl i32 as Y(i32) where .M = i32 {}
+impl i32 as Z where .N = i32 {}
+
+fn F[A:! Z](a: A) -> A { return a; }
+
+fn Main() -> i32 {
+  return F(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/45254859420f71824fe5123a1ce3fd71e25bc505
+++ b/toolchain/semantics/fuzzer_corpus/45254859420f71824fe5123a1ce3fd71e25bc505
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A {
+  class B {}
+  alias C = B;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/45579d56ffeffc9eb8926dc0cbcf5e86f34762a9
+++ b/toolchain/semantics/fuzzer_corpus/45579d56ffeffc9eb8926dc0cbcf5e86f34762a9
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Number {
+  fn Zero() -> Self;
+  fn Add[self: Self](other: Self) -> Self;
+}
+
+class Point(T:! Number) {
+  var x: T;
+  var y: T;
+}
+
+impl i32 as Number {
+  fn Zero() -> i32 { return 0; }
+  fn Add[self: i32](other: i32) -> i32 { return self + other; }
+}
+
+impl forall [U:! Number] Point(U) as Number {
+  fn Zero() -> Point(U) { return {.x = U.Zero(), .y = U.Zero() }; }
+  fn Add[self: Point(U)](other: Point(U)) -> Point(U) {
+    return {.x = self.x.Add(other.x), .y = self.y.Add(other.y)};
+  }
+}
+
+fn Sum[E:! Number](x: E, y: E) -> E {
+  var total: E = E.Zero();
+  total = total.Add(x);
+  total = total.Add(y);
+  return total;
+}
+
+fn SumPoints[E:! Number](p: Point(E), q: Point(E)) -> Point(E) {
+  return Sum(p, q);
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = {.x = 1, .y = 2};
+  var q: Point(i32) = {.x = 4, .y = 3};
+  var r: Point(i32) = SumPoints(p, q);
+  return r.x - r.y;
+}

--- a/toolchain/semantics/fuzzer_corpus/4577557849cfb38a618ee2da85894b9295c24506
+++ b/toolchain/semantics/fuzzer_corpus/4577557849cfb38a618ee2da85894b9295c24506
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p1: Point = {.x = 1, .y = 2};
+  var p2: auto = p1;
+  p2.x = 3;
+  return p1.x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/45de89d2347b547989589fb86ada1b4af7f9d556
+++ b/toolchain/semantics/fuzzer_corpus/45de89d2347b547989589fb86ada1b4af7f9d556
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn f(x: i32) -> i32 {
+  return x - 1;
+}
+
+fn Main() -> i32 {
+  return f(1);
+}

--- a/toolchain/semantics/fuzzer_corpus/46821819012bbf66e1018171eb9bdd984c20f353
+++ b/toolchain/semantics/fuzzer_corpus/46821819012bbf66e1018171eb9bdd984c20f353
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_unexpected_tuple.carbon:[[@LINE+1]]: didn't expect a tuple
+  var a: (auto,) = 1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/46a6da10d752a337c1d2639132658d885a75ee3b
+++ b/toolchain/semantics/fuzzer_corpus/46a6da10d752a337c1d2639132658d885a75ee3b
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  let n: i32 = 5;
+  return n as i32;
+}

--- a/toolchain/semantics/fuzzer_corpus/46c4faddda6395f30cf8690eb32cd453b255f015
+++ b/toolchain/semantics/fuzzer_corpus/46c4faddda6395f30cf8690eb32cd453b255f015
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test mutation of a global variable.
+
+var zero: i32 = 1;
+
+fn Main() -> i32 {
+  zero = 0;
+  return zero;
+}

--- a/toolchain/semantics/fuzzer_corpus/498b32b5cb688f465783e654f788300fd2636a19
+++ b/toolchain/semantics/fuzzer_corpus/498b32b5cb688f465783e654f788300fd2636a19
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 75
+// CHECK:STDOUT: 100
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Zero() -> Self;
+  fn Add[addr self: Self*](b: Self);
+  fn Scale[addr self: Self*](v: i32);
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Zero() -> Self {
+      return {.x = 1, .y = 1};
+    }
+    fn Add[addr self: Self*](b: Self) {
+      (*self).x = (*self).x + b.x;
+      (*self).y = (*self).y + b.y;
+    }
+    fn Scale[addr self: Self*](v: i32) {
+      (*self).x = (*self).x * v;
+      (*self).y = (*self).y * v;
+    }
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](p: T*, s: i32) {
+  (*p).Add(T.Zero());
+  (*p).(Vector.Scale)(s);
+  (*p).(T.(Vector.Scale))(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 2, .y = 3};
+  AddAndScaleGeneric(&a, 5);
+  Print("{0}", a.x);
+  Print("{0}", a.y);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/4b82dcd5072f57a2b04077c7e256b32c79410963
+++ b/toolchain/semantics/fuzzer_corpus/4b82dcd5072f57a2b04077c7e256b32c79410963
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_index_empty.carbon:[[@LINE+1]]: Invalid `{}` in `Print: {}`
+  Print("Print: {}");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/503f8d4fc4bb0e1f1e6cb23cd6b02751684bb242
+++ b/toolchain/semantics/fuzzer_corpus/503f8d4fc4bb0e1f1e6cb23cd6b02751684bb242
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  // Allowed: `Self` means `Point(T)` here.
+  fn Origin(zero: T) -> Self {
+    return {.x = zero, .y = zero};
+  }
+
+  fn GetX[self: Self]() -> T {
+    return self.x;
+  }
+
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = Point(i32).Origin(0);
+  return p.GetX();
+}

--- a/toolchain/semantics/fuzzer_corpus/5109f6e45e2667ab4a696441b235ab125d247ddb
+++ b/toolchain/semantics/fuzzer_corpus/5109f6e45e2667ab4a696441b235ab125d247ddb
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+interface A(T:! type) { let AResult:! type; }
+interface B(T:! type) { let BResult:! A(T); }
+interface I(T:! type) {
+  let X:! B(T);
+  // The constraints introduced by X should be in scope here.
+  let Y:! X.BResult.AResult;
+}
+
+class CA {
+  extend impl as A(i32) where .AResult = i32 {}
+}
+class CB {
+  extend impl as B(i32) where .BResult = CA {}
+}
+class CI {
+  extend impl as I(i32) where .X = CB and .Y = 5 {}
+}
+
+fn Main() -> i32 {
+  var v: CI = {};
+  return v.(I(i32).Y);
+}

--- a/toolchain/semantics/fuzzer_corpus/52092056bd9f5f8e5b73e07cf40278c70af4d078
+++ b/toolchain/semantics/fuzzer_corpus/52092056bd9f5f8e5b73e07cf40278c70af4d078
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector(Scalar:! type) {
+  fn Zero() -> Self;
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: Scalar) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector(i32) {
+    fn Zero() -> Point {
+      return {.x = 0, .y = 0};
+    }
+    fn Add[self: Point](b: Point) -> Point {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point](v: i32) -> Point {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+  }
+}
+
+fn AddAndScaleGeneric[T:! type, U:! Vector(T)](a: U, s: T) -> U {
+  return a.Add(U.Zero()).Scale(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 2, .y = 1};
+  var p: Point = AddAndScaleGeneric(a, 5);
+  return p.x - 10;
+}

--- a/toolchain/semantics/fuzzer_corpus/52d56f074421d8a0d70b7165db6df02000f35359
+++ b/toolchain/semantics/fuzzer_corpus/52d56f074421d8a0d70b7165db6df02000f35359
@@ -1,0 +1,42 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+choice Ints {
+  None,
+  One(i32),
+  Two(i32, i32)
+}
+
+// Test some alternate syntaxes
+choice MoreInts {
+  None(),
+  One(i32),
+  Two(i32, i32),
+}
+
+fn Main() -> i32 {
+  var x: Ints = Ints.None;
+  var y: Ints = Ints.One(42);
+  var z: MoreInts = MoreInts.None();
+  var n: i32 = 0;
+  match (y) {
+    case Ints.None => { n = n + 2; }
+    case Ints.One(x: auto) => { n = x + 1 - 42; }
+    case Ints.Two(a: auto, b: auto) => { n = 2; }
+  }
+  match (x) {
+    case Ints.One(x: auto) => { n = x + 2; }
+    case Ints.None => { n = n - 1; }
+    case Ints.Two(x: auto, y: auto) => { n = 5; }
+  }
+  match (z) {
+    case MoreInts.None() => { ++n; }
+  }
+  return n;
+}

--- a/toolchain/semantics/fuzzer_corpus/535b24afa4a13f10f1a4d60a54bc1e1274c2b59b
+++ b/toolchain/semantics/fuzzer_corpus/535b24afa4a13f10f1a4d60a54bc1e1274c2b59b
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point;
+  if (1 == 0) {
+    p = {.x = 0, .y = 0};
+  }
+  // CHECK:STDERR: RUNTIME ERROR: fail_store_to_uninitialized_class.carbon:[[@LINE+1]]: undefined behavior: store to subobject of uninitialized value Uninit<Placeholder<p>>
+  p.x = 1;
+  p.y = 2;
+  return p.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/53ac25de61ca8f6ef9ed06f4582063bdc8380c9a
+++ b/toolchain/semantics/fuzzer_corpus/53ac25de61ca8f6ef9ed06f4582063bdc8380c9a
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
+  var s: String = '''
+    error: closing ''' is not on its own line.
+  ''';
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/54bd36f9dc54f3a8ba2462aaf7203360c74c0eff
+++ b/toolchain/semantics/fuzzer_corpus/54bd36f9dc54f3a8ba2462aaf7203360c74c0eff
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+interface Frob {
+  let Result:! type;
+  fn F[self: Self]() -> Result;
+}
+
+fn Use[T:! Frob where .Result = .Self](x: T) -> T {
+  var v: T = x.F();
+  return v;
+}
+
+impl i32 as Frob where .Result = i32 {
+  fn F[self: Self]() -> i32 { return self + 1; }
+}
+
+fn Main() -> i32 {
+  return Use(2);
+}

--- a/toolchain/semantics/fuzzer_corpus/557e6261740982882c25ec653adb828d1fd636d9
+++ b/toolchain/semantics/fuzzer_corpus/557e6261740982882c25ec653adb828d1fd636d9
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+interface ConvertsFromInt {
+  require i32 impls ImplicitAs(Self);
+}
+
+fn ConvertIntTo(T:! ConvertsFromInt, n: i32) -> T {
+  return n;
+}
+
+class IntHolder {
+  var n: i32;
+}
+impl i32 as ImplicitAs(IntHolder) {
+  fn Convert[self: Self]() -> IntHolder { return {.n = self}; }
+}
+impl IntHolder as ConvertsFromInt {}
+
+fn Main() -> i32 {
+  return ConvertIntTo(IntHolder, 5).n;
+}

--- a/toolchain/semantics/fuzzer_corpus/55b33f1ae3ad484d9adbe539da4055e6e12e8737
+++ b/toolchain/semantics/fuzzer_corpus/55b33f1ae3ad484d9adbe539da4055e6e12e8737
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = '''
+    A "block" ""string"" literal
+      with indent.
+    ''';
+  if (s == "A \"block\" \"\"string\"\" literal\n  with indent.\n") {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/564500cfc2d733d6691063b77ec9685c1aca5326
+++ b/toolchain/semantics/fuzzer_corpus/564500cfc2d733d6691063b77ec9685c1aca5326
@@ -1,0 +1,77 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface I {
+  fn F() -> i32;
+  fn M[self: Self]() -> i32;
+}
+class A {
+  var n: i32;
+  extend impl as I {
+    fn F() -> i32 { return 1; }
+    fn M[self: Self]() -> i32 { return 2; }
+  }
+  fn G[self: Self]() -> i32 { return 3; }
+}
+impl i32 as I {
+  fn F() -> i32 { return 4; }
+  fn M[self: Self]() -> i32 { return 5; }
+}
+
+alias IF = I.F;
+alias IM = I.M;
+alias AIF = A.(IF);
+alias AIM = A.(IM);
+alias AG = A.G;
+alias i32IF = i32.(IF);
+alias i32IM = i32.(IM);
+
+fn Main() -> i32 {
+  var a: A = {.n = 0};
+  if (A.(IF)() != 1) {
+    return 1;
+  }
+  if (a.(IF)() != 1) {
+    return 2;
+  }
+  if (a.(IM)() != 2) {
+    return 3;
+  }
+  if (a.(A.(IM))() != 2) {
+    return 4;
+  }
+  if (AIF() != 1) {
+    return 5;
+  }
+  if (a.(AIM)() != 2) {
+    return 6;
+  }
+  if (a.(AG)() != 3) {
+    return 7;
+  }
+  if (i32.(IF)() != 4) {
+    return 8;
+  }
+  if (0.(IF)() != 4) {
+    return 9;
+  }
+  if (0.(IM)() != 5) {
+    return 10;
+  }
+  if (0.(i32.(IM))() != 5) {
+    return 11;
+  }
+  if (i32IF() != 4) {
+    return 12;
+  }
+  if (0.(i32IM)() != 5) {
+    return 13;
+  }
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/57b625d24d4e508e02fd4d013c5b8542b01925a2
+++ b/toolchain/semantics/fuzzer_corpus/57b625d24d4e508e02fd4d013c5b8542b01925a2
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  {
+    // CHECK:STDERR: SYNTAX ERROR: fail_block.carbon:[[@LINE+1]]: syntax error, unexpected RETURN, expecting PERIOD or RIGHT_CURLY_BRACE
+    return 0;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/585e5c74fac0d5cee731959d16d129154a776dd8
+++ b/toolchain/semantics/fuzzer_corpus/585e5c74fac0d5cee731959d16d129154a776dd8
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class ConvertTo(T:! type) {
+  var v: T;
+  extend impl as ImplicitAs(T) {
+    fn Convert[self: Self]() -> T { return self.v; }
+  }
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_no_convert.carbon:[[@LINE+3]]: type error in __intrinsic_assert argument 0
+  // CHECK:STDERR: expected: bool
+  // CHECK:STDERR: actual: class ConvertTo(T = bool)
+  __intrinsic_assert({.v = true} as ConvertTo(bool), {.v = "Pass"} as ConvertTo(String));
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/58f5a5b2c0b164ab3ab191696c790a041a5b14c1
+++ b/toolchain/semantics/fuzzer_corpus/58f5a5b2c0b164ab3ab191696c790a041a5b14c1
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: (*c).a: 1
+// CHECK:STDOUT: (*c).Foo(): 1
+// CHECK:STDOUT: (*c).Bar(): 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  var a: i32;
+  fn Foo[self: Self]() -> i32 {
+    return 1;
+  }
+  fn Bar() -> i32 {
+    return 1;
+  }
+}
+
+class D {
+  extend base: C;
+  var b: i32;
+  fn Foo[self: Self]() -> i32 {
+    return 2;
+  }
+  fn Bar() -> i32 {
+    return 2;
+  }
+}
+
+fn Main() -> i32 {
+  var d: D = { .base = {.a = 1}, .b = 2 };
+  var c: C* = &d;
+  Print("(*c).a: {0}", (*c).a);
+  Print("(*c).Foo(): {0}", (*c).Foo());
+  Print("(*c).Bar(): {0}", (*c).Bar());
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/595a50f41bad8481dd7dc4d2dde4691c48645254
+++ b/toolchain/semantics/fuzzer_corpus/595a50f41bad8481dd7dc4d2dde4691c48645254
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn f(x: i32) -> i32 {
+  if (x == 0) {
+    return x;
+  } else {
+    return f(x - 1);
+  }
+}
+
+fn Main() -> i32 {
+  return f(2);
+}

--- a/toolchain/semantics/fuzzer_corpus/5aedd13d71226154caf5100b513031d29105850b
+++ b/toolchain/semantics/fuzzer_corpus/5aedd13d71226154caf5100b513031d29105850b
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Foo() -> () {
+  returned var x: () = ();
+  return var;
+}
+
+fn Main() -> i32 {
+  Foo();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/5b649a15ff03bc16c5037f2e2019f5bbf953a6c9
+++ b/toolchain/semantics/fuzzer_corpus/5b649a15ff03bc16c5037f2e2019f5bbf953a6c9
@@ -1,0 +1,38 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Initialize c from initializing expression (return <expr>)
+// CHECK:STDOUT: 0: Heap{}, 1: !Uninit<class C>, 2: C{}
+// CHECK:STDOUT: Object created, returning
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: 0: Heap{}, 1: C{}, 2: !!C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("c destroyed");
+  }
+}
+
+fn CallWithReturnExpression() -> C {
+  var c: C = {};
+  heap.PrintAllocs();
+  Print("Object created, returning");
+  return c;
+}
+
+fn FromInitializingExpression_ReturnExpr() {
+  Print("Initialize c from initializing expression (return <expr>)");
+  let c: C = CallWithReturnExpression();
+  heap.PrintAllocs();
+}
+
+fn Main() -> i32 {
+  FromInitializingExpression_ReturnExpr();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/5c4072175e53c4fd0807395cb22c147179eed87b
+++ b/toolchain/semantics/fuzzer_corpus/5c4072175e53c4fd0807395cb22c147179eed87b
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class A {}
+
+fn Main() -> i32 {
+  var a: A = {};
+  var b: A* = &a;
+  // CHECK:STDERR: COMPILATION ERROR: fail_invalid_ptr_conversion1.carbon:[[@LINE+1]]: type error in initializer of variable: 'class A*' is not implicitly convertible to 'i32'
+  var c: i32 = b;
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/5d3e40b473f22a3492d91fa5ae3cdb49ba717c24
+++ b/toolchain/semantics/fuzzer_corpus/5d3e40b473f22a3492d91fa5ae3cdb49ba717c24
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn F() -> () {
+  // CHECK:STDERR: COMPILATION ERROR: fail_explicit_with_plain_return.carbon:[[@LINE+1]]: return; should provide a return value, to match the function's signature.
+  return;
+}
+
+fn Main() -> i32 {
+  F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/5dd74b1e5b931d243d08196dc0d1a4c7489d045a
+++ b/toolchain/semantics/fuzzer_corpus/5dd74b1e5b931d243d08196dc0d1a4c7489d045a
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Add[self: Point](b: Point) -> Point {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point](v: i32) -> Point {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](t: (T, T), s: i32) -> T {
+  var m: auto = t[0].Add;
+  var n: auto = m(t[1]).Scale;
+  return n(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 1, .y = 1};
+  var b: Point = {.x = 2, .y = 3};
+  var p: Point = AddAndScaleGeneric((a, b), 5);
+  return p.x - 15;
+}

--- a/toolchain/semantics/fuzzer_corpus/6271c667c707f9f332f8d672db458d12c99a85e6
+++ b/toolchain/semantics/fuzzer_corpus/6271c667c707f9f332f8d672db458d12c99a85e6
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+namespace A;
+namespace A.B;
+namespace A.B.C;
+fn A.B.C.
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_nested.carbon:[[@LINE+1]]: name 'D' has not been declared in namespace A.B.C
+  D
+  // Don't combine with the previous line. This test is verifying that the
+  // diagnostic points at the right token.
+  .E.F() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/62843918195183e17a993c061b9c88d636ca28f0
+++ b/toolchain/semantics/fuzzer_corpus/62843918195183e17a993c061b9c88d636ca28f0
@@ -1,0 +1,143 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This doesn't test trace ouptut because it's too slow.
+// AUTOUPDATE
+// CHECK:STDOUT: String list length is: 7
+// CHECK:STDOUT: This is a String Entry 4
+// CHECK:STDOUT: Value 1337
+// CHECK:STDOUT: result: 0
+package ExplorerTest api;
+
+class Node(T:! type) {
+  fn Create(value: T)-> Node(T) {
+    return {
+      .value = Optional(T).Create(value),
+      .next = Optional(Node(T)*).CreateEmpty(),
+      .prev = Optional(Node(T)*).CreateEmpty()
+    };
+  }
+  fn set_next[addr self: Self*](n: Optional(Node(T)*)) {
+    (*self).next = n;
+  }
+  fn set_prev[addr self: Self*](n: Optional(Node(T)*)) {
+    (*self).prev = n;
+  }
+  var value: Optional(T);
+  var next: Optional(Node(T)*);
+  var prev: Optional(Node(T)*);
+}
+
+class LinkedList(T:! type) {
+  fn Create() -> LinkedList(T) {
+    return {
+      .head = Optional(Node(T)*).CreateEmpty(),
+      .tail = Optional(Node(T)*).CreateEmpty(),
+      .len = 0
+    };
+  }
+  fn PushBack[addr self: Self*](value:T) {
+    (*self).len = (*self).len + 1;
+    if(not (*self).head.HasValue()) {
+      (*self).head = Optional(Node(T)*).Create(heap.New(Node(T).Create(value)));
+      (*self).tail = (*self).head;
+      return;
+    }
+    var last: Optional(Node(T)*) = (*self).tail;
+    var last_value:Node(T)* = last.Get();
+    var v_wrapped:Optional(Node(T)*) = Optional(Node(T)*).Create(heap.New(Node(T).Create(value)));
+    (*last_value).set_next(v_wrapped);
+    (*v_wrapped.Get()).set_prev(last);
+    (*self).tail = v_wrapped;
+  }
+  fn PushFront[addr self: Self*](value:T) {
+    (*self).len = (*self).len + 1;
+    if(not (*self).head.HasValue()) {
+      (*self).head = Optional(Node(T)*).Create(heap.New(Node(T).Create(value)));
+      (*self).tail = (*self).head;
+      return;
+    }
+    var v_wrapped:Optional(Node(T)*) = Optional(Node(T)*).Create(heap.New(Node(T).Create(value)));
+    var current_head: Optional(Node(T)*) = (*self).head;
+    var current_head_value: Node(T)* = current_head.Get();
+    (*v_wrapped.Get()).set_next(current_head);
+    (*current_head_value).set_prev(v_wrapped);
+    (*self).head = v_wrapped;
+  }
+  fn Clear[addr self: Self*]() {
+    if((*self).len == 0) {
+      return;
+    }
+    var iter: auto = (*self).head;
+    while(iter.HasValue()) {
+      var current: auto = iter;
+      iter = (*iter.Get()).next;
+      heap.Delete(current.Get());
+    }
+    (*self).head = Optional(Node(T)*).CreateEmpty();
+    (*self).tail = Optional(Node(T)*).CreateEmpty();
+    (*self).len = 0;
+  }
+  fn Length[self: Self]() -> i32 {
+    return self.len;
+  }
+  var head: Optional(Node(T)*);
+  var tail: Optional(Node(T)*);
+  var len: i32;
+}
+
+// This function exists as a helper the context of this test case specifically and does not represent
+// the common case for index based lookups in list like structures.
+fn GetListEntryByIndex[T:! type](list: LinkedList(T)*, target_index: i32) -> Optional(T) {
+  let list_length: i32 = (*list).Length();
+  if(target_index > list_length - 1 or target_index < 0) {
+    // Not in possible range
+    return Optional(T).CreateEmpty();
+  }
+  var search_backwards:bool = target_index > list_length / 2;
+  var iter:Optional(Node(T)*) = if search_backwards then (*list).tail else (*list).head;
+  var c:i32 = if search_backwards then list_length -1 else 0;
+  while(c != target_index) {
+    var node: Node(T) = *(iter.Get());
+    if(search_backwards) {
+      c = c - 1;
+      iter = node.prev;
+    } else {
+      iter = node.next;
+      c = c + 1;
+    }
+  }
+
+  return (*(iter.Get())).value;
+}
+
+fn Main() -> i32 {
+  var test_list:auto = LinkedList(String).Create();
+  test_list.PushBack("This is a String Entry 0");
+  test_list.PushBack("This is a String Entry 1");
+  test_list.PushBack("This is a String Entry 2");
+  test_list.PushBack("This is a String Entry 3");
+  test_list.PushBack("This is a String Entry 4");
+  test_list.PushBack("This is a String Entry 5");
+  test_list.PushFront("This is a prepended String -1");
+  Print("String list length is: {0}", test_list.Length());
+  var search_index:i32 = 5;
+  var retrieved_entry: auto = GetListEntryByIndex(&test_list,search_index);
+  if(retrieved_entry.HasValue()) {
+    var retrieved_value:String = retrieved_entry.Get();
+    Print(retrieved_value);
+  } else {
+    Print("No entry found in String list for index {0}!", search_index);
+  }
+  test_list.Clear();
+
+  var second_list: auto = LinkedList(i32*).Create();
+  var number: i32 = 1337;
+  var number_ptr: i32* = &number;
+  second_list.PushBack(number_ptr);
+  var retrieved_ptr:i32* = GetListEntryByIndex(&second_list, 0).Get();
+  var value: i32 = *retrieved_ptr;
+  Print("Value {0}", value);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/62dfbc885389ef6d5d68bf236c814ab1b50a830f
+++ b/toolchain/semantics/fuzzer_corpus/62dfbc885389ef6d5d68bf236c814ab1b50a830f
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface IFace {}
+
+impl {.IFace : (type where type == i32 and type == i32 and type == i32, )} as IFace {
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/6587b22ba1c43ce2feb22483a911799a4d0b4864
+++ b/toolchain/semantics/fuzzer_corpus/6587b22ba1c43ce2feb22483a911799a4d0b4864
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test that assignment performs a copy and does not create an alias.
+
+fn Main() -> i32 {
+  var x: i32 = -1;
+  if (true) {
+    var y: i32 = 0;
+    x = y;
+    // y dies here
+  }
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/66246b4676440f9d7e081eeba1db52967485be20
+++ b/toolchain/semantics/fuzzer_corpus/66246b4676440f9d7e081eeba1db52967485be20
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: auto = (1, 2);
+  var a: [i32; 2] = t;
+  return a[0] + a[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/668a14b9e1911baad9eb3b1029bce4fa4cb22c50
+++ b/toolchain/semantics/fuzzer_corpus/668a14b9e1911baad9eb3b1029bce4fa4cb22c50
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [i32; 2] = (0, 1);
+  // CHECK:STDERR: RUNTIME ERROR: fail_index.carbon:[[@LINE+1]]: index 2 out of range in (0, 1)
+  return x[2];
+}

--- a/toolchain/semantics/fuzzer_corpus/674b0a11f56cfc231154426154f979971f269f04
+++ b/toolchain/semantics/fuzzer_corpus/674b0a11f56cfc231154426154f979971f269f04
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+// The bodies of member functions are processed after all immediately enclosing
+// classes, impl declarations, and interfaces.
+class A {
+  fn F[self: Self]() -> i32 {
+    return G() + self.H();
+  }
+  fn G() -> i32 { return 1; }
+  fn H[self: Self]() -> i32 { return 2; }
+}
+
+fn Main() -> i32 {
+  var a: A = {};
+  return a.F();
+}

--- a/toolchain/semantics/fuzzer_corpus/676a9a2e7d85dd808d2d0ba40a0f73713ffb6836
+++ b/toolchain/semantics/fuzzer_corpus/676a9a2e7d85dd808d2d0ba40a0f73713ffb6836
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+fn AddInt(a: i32, b: i32) -> i32 {
+  returned var ret: i32 = a + b;
+  return var;
+}
+
+fn Main() -> i32 {
+  return AddInt(1, 2);
+}

--- a/toolchain/semantics/fuzzer_corpus/6967d4554a79d967765e2f4f4f4d9f660388ae35
+++ b/toolchain/semantics/fuzzer_corpus/6967d4554a79d967765e2f4f4f4d9f660388ae35
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_overflow_div.carbon:[[@LINE+1]]: integer overflow
+  var a: auto = (-2147483647 -1) /-1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/69c04a4e172b38ee2bd233cf2e16bc54e64f86c8
+++ b/toolchain/semantics/fuzzer_corpus/69c04a4e172b38ee2bd233cf2e16bc54e64f86c8
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: i32, y: i32);
+  x = 1;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/6bacf9e89d7d4ecc9d6fd27310cccdd491d03040
+++ b/toolchain/semantics/fuzzer_corpus/6bacf9e89d7d4ecc9d6fd27310cccdd491d03040
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Id(t: type) -> auto { return t; }
+
+// Test non-trivial type expression in variable declaration statement.
+
+fn Main() -> i32 {
+  var x: Id(i32) = 0;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/6bee596e11d3b23cb1b5a66320949a056ed670a7
+++ b/toolchain/semantics/fuzzer_corpus/6bee596e11d3b23cb1b5a66320949a056ed670a7
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Number {
+  fn Zero() -> Self;
+  fn Add[self: Self](other: Self) -> Self;
+}
+
+class Point(T:! Number) {
+  fn Origin() -> Point(T) {
+    return {.x = T.Zero(), .y = T.Zero()};
+  }
+  fn Clone[self: Point(T)]() -> Point(T) {
+    return {.x = self.x, .y = self.y};
+  }
+  fn SumXY[self: Point(T)]() -> T {
+    return self.x.Add(self.y);
+  }
+  var x: T;
+  var y: T;
+}
+
+impl i32 as Number {
+  fn Zero() -> i32 { return 0; }
+  fn Add[self: i32](other: i32) -> i32 { return self + other; }
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = Point(i32).Origin();
+  return p.Clone().SumXY();
+}

--- a/toolchain/semantics/fuzzer_corpus/6ca9f18aa125c49880d2596552e3faa81c63efb3
+++ b/toolchain/semantics/fuzzer_corpus/6ca9f18aa125c49880d2596552e3faa81c63efb3
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn BadSimpleMemberAccess[T:! type](a: T) -> T {
+  // CHECK:STDERR: COMPILATION ERROR: fail_field_access_on_generic.carbon:[[@LINE+1]]: member access in unconstrained type
+  return a.x;
+}
+
+fn Main() -> i32 {
+  return BadSimpleMemberAccess(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/6d1d2d78afae37c48771a7d9e1ebb943b4043d6e
+++ b/toolchain/semantics/fuzzer_corpus/6d1d2d78afae37c48771a7d9e1ebb943b4043d6e
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+var x: i32 = 0;
+
+fn Main() -> i32 {
+  var x: i32 = 0;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/6e17f17d5bfc65e44683079702a3ff6fb2eb5599
+++ b/toolchain/semantics/fuzzer_corpus/6e17f17d5bfc65e44683079702a3ff6fb2eb5599
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 << -1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/6ec937ca4086b447092cfc13d8d2e77c9536cf24
+++ b/toolchain/semantics/fuzzer_corpus/6ec937ca4086b447092cfc13d8d2e77c9536cf24
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = #'''
+    A block string literal
+    \#'''#
+    '''#;
+  if (s == "A block string literal\n'''#\n") {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/7210b63a30c6f2ca76270eeca909274971db9b36
+++ b/toolchain/semantics/fuzzer_corpus/7210b63a30c6f2ca76270eeca909274971db9b36
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: [i32;] = ();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/723771f1826c803bbd50afe6e703268a89d6edab
+++ b/toolchain/semantics/fuzzer_corpus/723771f1826c803bbd50afe6e703268a89d6edab
@@ -1,0 +1,8 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: SYNTAX ERROR: fail_invalid_char.carbon:[[@LINE+1]]: invalid character '\xEF' in source file.
+�

--- a/toolchain/semantics/fuzzer_corpus/7317dc5445182496edbdede5df5cc895f598dd2f
+++ b/toolchain/semantics/fuzzer_corpus/7317dc5445182496edbdede5df5cc895f598dd2f
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+__mixin Operations {
+  fn Square[self: Self](x:i32) -> i32{
+    return x * x;
+  }
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  fn DistanceSquare[self: Self](other:Self) -> i32 {
+    return self.Square(self.x - other.x) + self.Square(self.y - other.y);
+  }
+  __mix Operations;
+}
+
+class Complex {
+  var r: i32;
+  var i: i32;
+  __mix Operations;
+  fn AbsSquare[self: Self]() -> i32 {
+    return self.Square(self.r) + self.Square(self.i);
+  }
+}
+
+
+fn Main() -> i32 {
+  var p1: Point = {.x = 1, .y = 2 };
+  var p2: Point = {.x = 4, .y = 3 };
+  var c: Complex = {.r = 5, .i = 6 };
+  return c.AbsSquare() - p1.DistanceSquare(p2) - 51;
+}

--- a/toolchain/semantics/fuzzer_corpus/738455622faabb9ac57e4742ab9774f277769d1d
+++ b/toolchain/semantics/fuzzer_corpus/738455622faabb9ac57e4742ab9774f277769d1d
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface HasThreeTypes {
+  let A:! type;
+  let B:! type;
+  let C:! type;
+}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_incomplete_impl_2.carbon:[[@LINE+1]]: implementation doesn't provide a concrete value for interface HasThreeTypes.C
+impl i32 as HasThreeTypes where .A = i32 and .B = .C {}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/738e3314d89604cb56233d3d1d985b895264250f
+++ b/toolchain/semantics/fuzzer_corpus/738e3314d89604cb56233d3d1d985b895264250f
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+choice Opt {
+  None(),
+  Some(i32)
+}
+
+fn A(a: Opt, b: Opt) -> i32 {
+  match ((a, b)) {
+    case (Opt.Some(n: i32), _: auto) => { return n; }
+    case (_: auto, Opt.Some(n: i32)) => { return n; }
+    case (Opt.None(), Opt.None()) => { return 0; }
+  }
+}
+
+fn B(a: Opt, b: Opt) -> i32 {
+  match ((a, b)) {
+    case (Opt.None(), _: auto) => { return 0; }
+    case (Opt.Some(n: i32), Opt.None()) => { return n; }
+    case (Opt.Some(n: i32), Opt.Some(m: i32)) => { return n + m; }
+  }
+}
+
+fn Main() -> i32 {
+  return A(Opt.None(), Opt.Some(1)) + B(Opt.Some(2), Opt.None());
+}

--- a/toolchain/semantics/fuzzer_corpus/73b4d1aee1031af813cfe9efbf1427f3b2d10f6b
+++ b/toolchain/semantics/fuzzer_corpus/73b4d1aee1031af813cfe9efbf1427f3b2d10f6b
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+fn AddInt(a: i32, b: i32) -> i32 {
+  if (a == b) {
+    returned var ret: i32 = a + b;
+    return var;
+  } else {
+    return a + b;
+  }
+}
+
+fn Main() -> i32 {
+  return AddInt(1, 2);
+}

--- a/toolchain/semantics/fuzzer_corpus/73da4596259bfcfb0dc1a29e39f7c3b0944b1e32
+++ b/toolchain/semantics/fuzzer_corpus/73da4596259bfcfb0dc1a29e39f7c3b0944b1e32
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn DoNothing() {
+  // Empty block
+}
+
+fn Main() -> i32 {
+  var x: i32 = 0;
+  DoNothing();
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/741d81851f3d0d1ad8e1a1b2584d04390c1de134
+++ b/toolchain/semantics/fuzzer_corpus/741d81851f3d0d1ad8e1a1b2584d04390c1de134
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ab.a: 2
+// CHECK:STDOUT: ab.b: 1
+// CHECK:STDOUT: ba.a: 2
+// CHECK:STDOUT: ba.b: 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+alias AB = {.a: i32, .b: i32};
+alias BA = {.b: i32, .a: i32};
+
+fn Main() -> i32 {
+  var ab: AB = {.b = 1, .a = 2};
+  var ba: BA = ab;
+  Print("ab.a: {0}", ab.a);
+  Print("ab.b: {0}", ab.b);
+  Print("ba.a: {0}", ba.a);
+  Print("ba.b: {0}", ba.b);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/7439f0e12680c8328592155e4b3b38db983860ad
+++ b/toolchain/semantics/fuzzer_corpus/7439f0e12680c8328592155e4b3b38db983860ad
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: [i32; 2];
+  // CHECK:STDERR: COMPILATION ERROR: fail_array.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return v[0];
+}

--- a/toolchain/semantics/fuzzer_corpus/743bcc2582c9d359eb545c9c2234b31d20686ab1
+++ b/toolchain/semantics/fuzzer_corpus/743bcc2582c9d359eb545c9c2234b31d20686ab1
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+fn map[T:! type](f: __Fn (T) -> T, tuple: (T, T)) -> (T, T) {
+  return (f(tuple[0]), f(tuple[1]));
+}
+
+fn inc(x: i32) -> i32 { return x + 1; }
+
+fn Main() -> i32 {
+  return map(inc, (0, 2))[0];
+}

--- a/toolchain/semantics/fuzzer_corpus/74668979673c76a468906cbf4fb6c6807deb1ce7
+++ b/toolchain/semantics/fuzzer_corpus/74668979673c76a468906cbf4fb6c6807deb1ce7
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_size_mismatch.carbon:[[@LINE+1]]: type error in initializer of variable: '(i32, i32, i32)' is not implicitly convertible to '[i32; 2]'
+  var x: [i32; 2] = (0, 1, 2);
+  return x[0];
+}

--- a/toolchain/semantics/fuzzer_corpus/766f0c11773ae0fa80bdb4e441c61024fe08dbfa
+++ b/toolchain/semantics/fuzzer_corpus/766f0c11773ae0fa80bdb4e441c61024fe08dbfa
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C(T:! type) {}
+
+fn F(T:! type) -> type {
+  return C(T);
+}
+
+fn Main() -> i32 {
+  var v: F(i32) = {};
+  var w: C(i32) = v;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/76aa1704b7412be324a2fc194e4aaf03c0aae190
+++ b/toolchain/semantics/fuzzer_corpus/76aa1704b7412be324a2fc194e4aaf03c0aae190
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: RUNTIME ERROR: fail_mod_by_zero.carbon:[[@LINE+1]]: division by zero
+  var a: auto = 5 % 0;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/789722555be3fb72c649473531436974c36c0b99
+++ b/toolchain/semantics/fuzzer_corpus/789722555be3fb72c649473531436974c36c0b99
@@ -1,0 +1,51 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: c.Foo(): 1
+// CHECK:STDOUT: d.Foo(): 2
+// CHECK:STDOUT: e.Foo(): 3
+// CHECK:STDOUT: (*dp).Foo(): 3
+// CHECK:STDOUT: (*dc).Foo(): 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  var value_c: i32;
+  virtual fn Foo[self: Self]() -> i32 {
+    return self.value_c;
+  }
+}
+
+base class D {
+  extend base: C;
+  var value_d: i32;
+  impl fn Foo[self: Self]() -> i32 {
+    return self.value_d;
+  }
+}
+
+class E {
+  extend base: D;
+  var value_e: i32;
+  impl fn Foo[self: Self]() -> i32 {
+    return self.value_e;
+  }
+}
+
+fn Main() -> i32 {
+  var c: C = {.value_c = 1};
+  Print("c.Foo(): {0}", c.Foo());
+  var d: D = {.value_d = 2, .base = {.value_c = 1}};
+  Print("d.Foo(): {0}", d.Foo());
+  var e: E = {.value_e = 3, .base={.value_d = 2, .base = {.value_c = 1}}};
+  Print("e.Foo(): {0}", e.Foo());
+  var dp: D* = &e;
+  Print("(*dp).Foo(): {0}", (*dp).Foo());
+  var dc: C* = &e;
+  Print("(*dc).Foo(): {0}", (*dc).Foo());
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/78b31fa3b989055733f498c49e86a6211e1316bc
+++ b/toolchain/semantics/fuzzer_corpus/78b31fa3b989055733f498c49e86a6211e1316bc
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_quotes_not_on_own_line.carbon:[[@LINE+1]]: Invalid block string: Should end with triple quotes: error: closing '''
+  var s: String = #'''
+    error: closing '''# is not on its own line.
+  '''#;
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/795411f0b98335ca22f12b48b685bde1fc75bb61
+++ b/toolchain/semantics/fuzzer_corpus/795411f0b98335ca22f12b48b685bde1fc75bb61
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+choice AB {
+  A(),
+  B()
+}
+
+fn F() -> AB { return AB.A(); }
+
+fn Main() -> i32 {
+  // This is T9 from http://moscova.inria.fr/~maranget/papers/warn/warn014.html
+  // Note, this match is exhaustive, but it exceeds our depth limit.
+  match ((F(), F(), F(), F(), F(), F(), F(), F(), F())) {
+    case (AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 0; }
+    case (AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 1; }
+    case (_: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 2; }
+    case (_: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 3; }
+    case (_: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 4; }
+    case (_: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 5; }
+    case (_: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 6; }
+    case (_: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 7; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 8; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 9; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A()) => { return 10; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B()) => { return 11; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A()) => { return 12; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B()) => { return 13; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A()) => { return 14; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B()) => { return 15; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A()) => { return 16; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 17; }
+  }
+// CHECK:STDERR: COMPILATION ERROR: fail_exhaustive_exponential_series_t.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+}

--- a/toolchain/semantics/fuzzer_corpus/7a20636f05cc0619b0d09767f2f804541e9b1db7
+++ b/toolchain/semantics/fuzzer_corpus/7a20636f05cc0619b0d09767f2f804541e9b1db7
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: auto, y: [i32;]) = (42, (0, 1));
+  var index: i32 = 1;
+  y[index] = 0;
+  return y[0] + y[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/7b5a8347300b3181cd2cf471a26b4d1849cd736d
+++ b/toolchain/semantics/fuzzer_corpus/7b5a8347300b3181cd2cf471a26b4d1849cd736d
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// This tests the call-by-value aspect of parameter passing.
+// This makes sure that when the value in `x` dies,
+// it does not cause the value in `a` to also die.
+
+fn f(x: i32) -> i32 {
+  return 0;
+}
+
+fn Main() -> i32 {
+  var a: i32 = 0;
+  var b: i32 = 1;
+  f(a);
+  b = a;
+  return b;
+}

--- a/toolchain/semantics/fuzzer_corpus/7bb08a33952aae009b591d3cf1f9bb883fb0d552
+++ b/toolchain/semantics/fuzzer_corpus/7bb08a33952aae009b591d3cf1f9bb883fb0d552
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 12
+
+package Foo api;
+interface A {
+  fn F[self: Self]() -> i32;
+}
+interface B {
+  fn G(o: Self) -> i32;
+}
+alias C = A & B;
+class X {
+  extend impl as A {
+    fn F[self: Self]() -> i32 { return 10 * self.n; }
+  }
+  extend impl as B {
+    fn G(o: Self) -> i32 { return o.n; }
+  }
+  var n: i32;
+}
+fn Main() -> i32 {
+  var v: X = {.n = 1};
+  var w: X = {.n = 2};
+  return v.(C.F)() + X.(C.G)(w);
+}

--- a/toolchain/semantics/fuzzer_corpus/7c43b3e05d4290ec1321e4780fefb13ab78971df
+++ b/toolchain/semantics/fuzzer_corpus/7c43b3e05d4290ec1321e4780fefb13ab78971df
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_hex_lower.carbon:[[@LINE+1]]: Invalid escaping in string: "str\xaa"
+  Print("str\xaa");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/7cf48bc097227836f096053ec92498c72e03f61c
+++ b/toolchain/semantics/fuzzer_corpus/7cf48bc097227836f096053ec92498c72e03f61c
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32 = 0;
+  match (x) {
+    case 1 => {
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/7d517287eeb3fe4793d29afa7dbaea8ad67ac795
+++ b/toolchain/semantics/fuzzer_corpus/7d517287eeb3fe4793d29afa7dbaea8ad67ac795
@@ -1,0 +1,36 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR B 2
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A{
+    class B{
+        destructor[self: Self]{
+            Print("DESTRUCTOR B {0}",self.n);
+        }
+        fn Create(x: i32) -> B{
+           return {.n = x };
+        }
+        var n: i32;
+    }
+
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    fn Create(x: i32) -> A{
+        return {.n = x, .b = B.Create(2)};
+    }
+    var n: i32;
+    var b : B;
+}
+
+fn Main() -> i32 {
+  var a: A = A.Create(1);
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/7d621f229fa589942992db52f964d08c90debaf8
+++ b/toolchain/semantics/fuzzer_corpus/7d621f229fa589942992db52f964d08c90debaf8
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+namespace N;
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/7e458fdfd466476c1bbe4095f5d224a6ea4867d6
+++ b/toolchain/semantics/fuzzer_corpus/7e458fdfd466476c1bbe4095f5d224a6ea4867d6
@@ -1,0 +1,62 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface AddMul {
+  fn Add[self: Self](o: Self) -> Self;
+  fn Mul[self: Self](o: Self) -> Self;
+}
+
+impl i32 as AddMul {
+  fn Add[self: i32](o: i32) -> i32 {
+    return self + o;
+  }
+  fn Mul[self: i32](o: i32) -> i32 {
+    return self * o;
+  }
+}
+
+class Holder(T:! AddMul) {
+  var v: T;
+}
+
+interface Vector(Scalar:! AddMul) {
+  fn Zero() -> Self;
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: Scalar) -> Self;
+  fn Hold[self: Self](v: Scalar) -> Holder(Scalar);
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector(i32) {
+    fn Zero() -> Point {
+      return {.x = 0, .y = 0};
+    }
+    fn Add[self: Point](b: Point) -> Point {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point](v: i32) -> Point {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+    fn Hold[self: Point](v: i32) -> Holder(i32) {
+      return {.v = v};
+    }
+  }
+}
+
+fn AddAndScaleGeneric[T:! AddMul, U:! Vector(T)](a: U, s: T) -> U {
+  return a.Add(U.Zero()).Scale(a.Hold(s).v);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 2, .y = 1};
+  var p: Point = AddAndScaleGeneric(a, 5);
+  return p.x - 10;
+}

--- a/toolchain/semantics/fuzzer_corpus/7f48faf27fbcc85cce85d7d07d8557961e5ced8a
+++ b/toolchain/semantics/fuzzer_corpus/7f48faf27fbcc85cce85d7d07d8557961e5ced8a
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface IFace {
+  // CHECK:STDERR: COMPILATION ERROR: fail_use_assoc_const_before_decl.carbon:[[@LINE+1]]: 'C' has not been declared yet
+  let B:! C;
+  let C:! IFace;
+}
+
+fn Main() -> i32 {
+  // return T;
+}

--- a/toolchain/semantics/fuzzer_corpus/7fb61b792562af16e1daf033786f58c7a823a070
+++ b/toolchain/semantics/fuzzer_corpus/7fb61b792562af16e1daf033786f58c7a823a070
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest library "Foo" api;
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/7fb975bde1a7671c319af2ce9bb38f6aceba424a
+++ b/toolchain/semantics/fuzzer_corpus/7fb975bde1a7671c319af2ce9bb38f6aceba424a
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: [i32;0] = ();
+  var b: [i32;] = a;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/80d09b221ee7aa332626e27dd2a6a2bb32ce23f0
+++ b/toolchain/semantics/fuzzer_corpus/80d09b221ee7aa332626e27dd2a6a2bb32ce23f0
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_escape.carbon:[[@LINE+1]]: Invalid escaping in string: "str\e"
+  Print("str\e");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/8190cd3b83ab71746ab0bd56f6d20bcd5bd1eb25
+++ b/toolchain/semantics/fuzzer_corpus/8190cd3b83ab71746ab0bd56f6d20bcd5bd1eb25
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  fn GetSetX[addr self: Point*](x: i32) -> i32 {
+    var old: auto = (*self).x;
+    (*self).x = x;
+    return old;
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  var x: auto = p.GetSetX(42);
+  if (p.x == 42) {
+    return x;
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/81c388f907f56f9cdea48326b67d8a4fa201c2c4
+++ b/toolchain/semantics/fuzzer_corpus/81c388f907f56f9cdea48326b67d8a4fa201c2c4
@@ -1,0 +1,46 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: T as Iface
+// CHECK:STDOUT: T as Iface
+// CHECK:STDOUT: A as Iface
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface HasType {
+  let AssocType:! type;
+}
+
+interface Iface {
+  fn F();
+}
+
+impl forall [T:! HasType where .Self.AssocType impls Iface] T as Iface {
+  fn F() {
+    Print("T as Iface");
+    T.AssocType.(Iface.F)();
+  }
+}
+
+class A {
+  extend impl as Iface {
+    fn F() { Print("A as Iface"); }
+  }
+}
+
+class B {
+  extend impl as HasType where .AssocType = A {}
+}
+
+class C {
+  extend impl as HasType where .AssocType = B {}
+}
+
+fn Main() -> i32 {
+  let c: C = {};
+  c.(Iface.F)();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/828812494bef26c4fc1629e0d0312f7b5d89f589
+++ b/toolchain/semantics/fuzzer_corpus/828812494bef26c4fc1629e0d0312f7b5d89f589
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 0: Heap{}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  heap.PrintAllocs();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/82eae3149f6f3f9fed1ae96957948932a119d9f5
+++ b/toolchain/semantics/fuzzer_corpus/82eae3149f6f3f9fed1ae96957948932a119d9f5
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  // Allowed: `Self` here means `Point`.
+  fn Origin() -> Self {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  return p.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/83941bf67b0cd2e4d3f7502b2bb40a83889bf78b
+++ b/toolchain/semantics/fuzzer_corpus/83941bf67b0cd2e4d3f7502b2bb40a83889bf78b
@@ -1,0 +1,10 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: SYNTAX ERROR: fail_missing.carbon:[[@LINE+1]]: syntax error, unexpected FN, expecting PACKAGE
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/839c2b2c711830a8a7a042ea58cf14f2da090add
+++ b/toolchain/semantics/fuzzer_corpus/839c2b2c711830a8a7a042ea58cf14f2da090add
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+choice A {
+  Value(i32)
+}
+
+impl i32 as ImplicitAs(A) {
+  fn Convert[self: Self]() -> A { return A.Value(self + 1); }
+}
+
+fn Main() -> i32 {
+  let A.Value(n: i32) = 2;
+  return n;
+}

--- a/toolchain/semantics/fuzzer_corpus/851814a8347766e5ac44e7674deda604717043ca
+++ b/toolchain/semantics/fuzzer_corpus/851814a8347766e5ac44e7674deda604717043ca
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (0 == 0) {
+    if (0 == 1) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/852bf7ffb5136d7be49f858d8d73f8e2bb1936ce
+++ b/toolchain/semantics/fuzzer_corpus/852bf7ffb5136d7be49f858d8d73f8e2bb1936ce
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: 0
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as BitAndWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n & rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 13};
+  a = a & 7;
+  Print("{0}", a.n);
+  a &= -2;
+  Print("{0}", a.n);
+  Print("{0}", (a & 3).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/857f18630200f09d8fb028b8ccc4ce183a98c2cc
+++ b/toolchain/semantics/fuzzer_corpus/857f18630200f09d8fb028b8ccc4ce183a98c2cc
@@ -1,0 +1,43 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: (*c1).val: 1
+// CHECK:STDOUT: (*c2).val: 1
+// CHECK:STDOUT: (*d).val: 2
+// CHECK:STDOUT: e.val: 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  var val: i32;
+}
+
+base class D {
+  extend base: C;
+  var val: i32;
+}
+
+class E {
+  extend base: D;
+  var val: i32;
+}
+
+fn Foo(c: C*) -> i32 {
+  return (*c).val;
+}
+
+fn Main() -> i32 {
+  var e: E = { .val = 3, .base = {.val = 2,.base = {.val = 1}}};
+  var d: D* = &e;
+  var c1: C* = &e;
+  var c2: C* = d;
+  Print("(*c1).val: {0}", (*c1).val);
+  Print("(*c2).val: {0}", (*c2).val);
+  Print("(*d).val: {0}", (*d).val);
+  Print("e.val: {0}", e.val);
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/85c4bfadcd8471f961da3bd10b0b34e4c7d5009f
+++ b/toolchain/semantics/fuzzer_corpus/85c4bfadcd8471f961da3bd10b0b34e4c7d5009f
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+package ExplorerTest api;
+
+__mixin M1 {
+  fn F1[self: Self](x: Self) -> Self{
+     return x;
+  }
+  // CHECK:STDERR: COMPILATION ERROR: fail_circular_mixing.carbon:[[@LINE+1]]: 'M3' has not been declared yet
+  __mix M3;
+}
+
+__mixin M2 {
+  fn F2() {
+  }
+  __mix M1;
+}
+
+__mixin M3 {
+  __mix M2;
+  fn F3() {
+  }
+}
+
+class C {
+  __mix M2;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/86a7b652e94c15d3bd45835b379bdbed8202f26c
+++ b/toolchain/semantics/fuzzer_corpus/86a7b652e94c15d3bd45835b379bdbed8202f26c
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = #'''
+    A "block" ""string"" literal
+      with indent.
+    '''#;
+  if (s == #"A \#"block\#" \#"\#"string\#"\#" literal\#n  with indent.\#n"#) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/87371229f1dd5b8a059f57ab0f6fba55e1221074
+++ b/toolchain/semantics/fuzzer_corpus/87371229f1dd5b8a059f57ab0f6fba55e1221074
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Foo(n: i32) {
+  Print("{0}", n);
+}
+
+fn Main() -> i32 {
+  var v: {.a: i32, .b: i32} = {.a = 1, .b = 2};
+  let a: i32 = v.a;
+  v.b = 3;
+  Foo(a);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/87ea823113de8af3e349558955a773c57f383e6d
+++ b/toolchain/semantics/fuzzer_corpus/87ea823113de8af3e349558955a773c57f383e6d
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface A(T:! type) {}
+interface B {
+  fn F() -> i32;
+}
+
+class C(T:! type) {}
+
+impl forall [T:! type] C(T) as A(T) & B {
+  fn F() -> i32 { return 1; }
+}
+
+fn Main() -> i32 {
+  var v: C(i32) = {};
+  return v.(B.F)();
+}

--- a/toolchain/semantics/fuzzer_corpus/895bb8433ee2c3e9408e3d4f1979401d0bf4d064
+++ b/toolchain/semantics/fuzzer_corpus/895bb8433ee2c3e9408e3d4f1979401d0bf4d064
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 7
+
+package ExplorerTest api;
+
+alias TypeAlias = i32;
+
+fn Function(a: i32, b: TypeAlias) -> i32 { return a + b; }
+fn GenericFunction[T:! type](x: T) -> T { return x; }
+
+alias FunctionAlias = Function;
+alias GenericFunctionAlias = GenericFunction;
+
+fn Main() -> i32 {
+  return FunctionAlias(1, 2) + GenericFunctionAlias(4);
+}

--- a/toolchain/semantics/fuzzer_corpus/8bb43cfab7a6921135707ad94afb8df7f34485c4
+++ b/toolchain/semantics/fuzzer_corpus/8bb43cfab7a6921135707ad94afb8df7f34485c4
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_integer_type.carbon:[[@LINE+1]]: Invalid type literal: i11111111111111111111111111
+  var x: i11111111111111111111111111 = 1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/8e47cb329a5e2b86a17af1db4765dda7f4cb9522
+++ b/toolchain/semantics/fuzzer_corpus/8e47cb329a5e2b86a17af1db4765dda7f4cb9522
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  // CHECK:STDERR: SYNTAX ERROR: fail_method_self_misspelled.carbon:[[@LINE+1]]: illegal binding pattern in implicit parameter list
+  fn F[addr slef: Self*]() {}
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/8f084e14b32446d014b56c787cf20b5bcbcbf2b3
+++ b/toolchain/semantics/fuzzer_corpus/8f084e14b32446d014b56c787cf20b5bcbcbf2b3
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface FrobWith(T:! type) {}
+
+fn F[T:! FrobWith(.Self)]
+  // CHECK:STDERR: COMPILATION ERROR: fail_dot_self_after_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
+  (U: .Self) {
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/8f45cb7810622e3ea3355da118aa66bb05698c83
+++ b/toolchain/semantics/fuzzer_corpus/8f45cb7810622e3ea3355da118aa66bb05698c83
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (0 == 1) {
+    return 1;
+  } else if (0 == 2) {
+    return 2;
+  } else {
+    return 0;
+  }
+
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/8f5c05a54c77af530e9741b54ae4c04f578ce33f
+++ b/toolchain/semantics/fuzzer_corpus/8f5c05a54c77af530e9741b54ae4c04f578ce33f
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_invalid_fnty.carbon:[[@LINE+2]]: type error in `-`:
+// CHECK:STDERR: could not find implementation of interface Negate for bool
+fn f(g: __Fn(-true) -> true) {
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/8f965c76081ac01748708ba9fe81fef86fc6ea47
+++ b/toolchain/semantics/fuzzer_corpus/8f965c76081ac01748708ba9fe81fef86fc6ea47
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn swap[T:! type, U:! type](tuple: (T, U)) -> (U, T) {
+  return (tuple[1], tuple[0]);
+}
+
+fn Main() -> i32 {
+  return swap((0, true))[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/8fe0b93d3fb32b620a168e162cede0cc51f98a21
+++ b/toolchain/semantics/fuzzer_corpus/8fe0b93d3fb32b620a168e162cede0cc51f98a21
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface I {
+  fn G[self: Self]();
+}
+
+class C {
+  impl as I {
+    // CHECK:STDERR: COMPILATION ERROR: fail_impl_missing_self.carbon:[[@LINE+3]]: type error in member of implementation
+    // CHECK:STDERR: expected: fn [self: class C]() -> ()
+    // CHECK:STDERR: actual: fn () -> ()
+    fn G() { }
+  }
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/903677e98b215946f2feb75920c3f7f1bede77ff
+++ b/toolchain/semantics/fuzzer_corpus/903677e98b215946f2feb75920c3f7f1bede77ff
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_dot_self_not_in_scope.carbon:[[@LINE+1]]: could not resolve '.Self'
+fn Main() -> .Self {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/903eb115fd74cf5365d4a359caca9374cdd98d03
+++ b/toolchain/semantics/fuzzer_corpus/903eb115fd74cf5365d4a359caca9374cdd98d03
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Ensure that we can declare all different kinds of declarations as namespace
+// members.
+namespace N;
+
+__mixin N.Mixin {}
+
+base class N.BaseClass {
+  __mix Mixin;
+}
+
+class N.DerivedClass {
+  extend base: BaseClass;
+}
+
+namespace N.Inner;
+
+alias N.Inner.InnerClass = DerivedClass;
+
+choice N.Choice { A, B, C(DerivedClass) }
+
+interface N.Iface {
+  fn F() -> DerivedClass*;
+}
+
+constraint N.Constraint {
+  extend Iface;
+}
+
+var v: N.DerivedClass = {.base = {}};
+
+fn N.F[T:! Constraint]() {
+  var v: Inner.InnerClass = {.base = {}};
+}
+
+impl i32 as N.Constraint {
+  fn F() -> N.DerivedClass* { return &v; }
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/9291fb7d068a7b1191009b1f7225a7a6f1e4ad39
+++ b/toolchain/semantics/fuzzer_corpus/9291fb7d068a7b1191009b1f7225a7a6f1e4ad39
@@ -1,0 +1,88 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This doesn't check trace output because it's too slow with it.
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! type;
+  let T1:! type;
+  let T2:! type;
+  let T3:! type;
+  let T4:! type;
+  let T5:! type;
+  let T6:! type;
+  let T7:! type;
+}
+
+interface Splat { fn Op(n: i32) -> Self; }
+impl i32 as Splat {
+  fn Op(n: i32) -> Self { return n; }
+}
+impl forall [T:! Splat] (T, T, T) as Splat {
+  fn Op(n: i32) -> Self {
+    let v: T = T.Op(n);
+    return (v, v, v);
+  }
+}
+
+fn CallSplat(T:! Splat, n: i32) -> T { return T.Op(n); }
+
+fn DoSplat(
+    M:! ManyTypes where
+      .T0 = (.T1, .T1, .T1) and
+      .T1 = (.T2, .T2, .T2) and
+      .T2 = (.T3, .T3, .T3) and
+      .T3 = (.T4, .T4, .T4) and
+      .T4 = (.T5, .T5, .T5) and
+      .T5 = (.T6, .T6, .T6) and
+      .T6 = (.T7, .T7, .T7) and
+      .T7 = i32,
+    n: M.T7) -> M.T0 {
+  return CallSplat(M.T0, n);
+}
+
+interface First { fn Op[self: Self]() -> i32; }
+impl i32 as First {
+  fn Op[self: Self]() -> i32 { return self; }
+}
+impl forall [T:! First] (T, T, T) as First {
+  fn Op[self: Self]() -> i32 {
+    let (a: T, b: T, c: T) = self;
+    return a.Op();
+  }
+}
+
+fn DoFirst(
+    M:! ManyTypes where
+      .T7 = i32 and
+      .T6 = (.T7, .T7, .T7) and
+      .T5 = (.T6, .T6, .T6) and
+      .T4 = (.T5, .T5, .T5) and
+      .T3 = (.T4, .T4, .T4) and
+      .T2 = (.T3, .T3, .T3) and
+      .T1 = (.T2, .T2, .T2) and
+      .T0 = (.T1, .T1, .T1),
+    v: M.T0) -> M.T7 {
+  return v.(First.Op)();
+}
+
+class C {
+  extend impl as ManyTypes where
+      .T3 = (.T4, .T4, .T4) and
+      .T1 = (.T2, .T2, .T2) and
+      .T4 = (.T5, .T5, .T5) and
+      .T6 = (.T7, .T7, .T7) and
+      .T2 = (.T3, .T3, .T3) and
+      .T7 = i32 and
+      .T5 = (.T6, .T6, .T6) and
+      .T0 = (.T1, .T1, .T1) {}
+}
+
+fn Main() -> i32 {
+  return DoFirst(C, DoSplat(C, 1));
+}

--- a/toolchain/semantics/fuzzer_corpus/9376518e1dc8f99232774ebfed8bd2ec067c57bb
+++ b/toolchain/semantics/fuzzer_corpus/9376518e1dc8f99232774ebfed8bd2ec067c57bb
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface GetX {
+  fn DoIt[self: Self]() -> i32;
+}
+
+impl forall [template T:! type] T as GetX {
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_member.carbon:[[@LINE+1]]: member access, unexpected i32 in self.x
+  fn DoIt[self: Self]() -> i32 { return self.x; }
+}
+
+fn Main() -> i32 {
+  return 0.(GetX.DoIt)();
+}

--- a/toolchain/semantics/fuzzer_corpus/93fb896d84d3c28400848dd05e02196ca359693f
+++ b/toolchain/semantics/fuzzer_corpus/93fb896d84d3c28400848dd05e02196ca359693f
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn f(x: i32, y: i32) -> i32 { return x + y; }
+
+fn Main() -> i32 {
+  var xy: (i32, i32) = (1, 2);
+  // should fail to type-check
+  // CHECK:STDERR: COMPILATION ERROR: fail_call_with_tuple.carbon:[[@LINE+1]]: wrong number of arguments in function call, expected 2 but got 1
+  return f(xy);
+}

--- a/toolchain/semantics/fuzzer_corpus/93fb94869ce61d6f894145f00e041f6ba3bc4219
+++ b/toolchain/semantics/fuzzer_corpus/93fb94869ce61d6f894145f00e041f6ba3bc4219
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as SubWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n - rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  a = a - 1;
+  Print("{0}", a.n);
+  a -= 1;
+  Print("{0}", a.n);
+  Print("{0}", (a - 1).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/94042b6c90ab6c8991a69696ef27dd8360fc4a97
+++ b/toolchain/semantics/fuzzer_corpus/94042b6c90ab6c8991a69696ef27dd8360fc4a97
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var (x: auto, y: auto) = (2, 3);
+  return y - x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/94e81fee5787c7d7cbc11d9bb6d6a42f1fa1fd3f
+++ b/toolchain/semantics/fuzzer_corpus/94e81fee5787c7d7cbc11d9bb6d6a42f1fa1fd3f
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// TODO: This SHOULD fail but doesn't presently.
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+import ExplorerTest library "Nonexistent";
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9508a414e54a420c8f31afaba22d8894f8cbf5e3
+++ b/toolchain/semantics/fuzzer_corpus/9508a414e54a420c8f31afaba22d8894f8cbf5e3
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == ##"#"str"#"##) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("#\"str\"#");
+}

--- a/toolchain/semantics/fuzzer_corpus/954bef329801d815ea7fc44588cb5f6d741104d7
+++ b/toolchain/semantics/fuzzer_corpus/954bef329801d815ea7fc44588cb5f6d741104d7
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_instantiate_non_generic.carbon:[[@LINE+1]]: in call `Point(i32)`, expected callee to be a function, found `type`
+  var p: Point(i32) = Point.Origin();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/95eaba17106b051bb2ec04c8ce3a48373ed238c0
+++ b/toolchain/semantics/fuzzer_corpus/95eaba17106b051bb2ec04c8ce3a48373ed238c0
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package Foo api;
+interface A {
+  fn F[self: Self](o: Self) -> Self;
+}
+class X {
+  extend impl as A {
+    fn F[self: Self](o: Self) -> Self { return {.n = self.n + o.n}; }
+  }
+  var n: i32;
+}
+fn F[T:! A](v: T, w: T) -> T {
+  return v.(T.(A.F))(w);
+}
+fn Main() -> i32 {
+  var v: X = {.n = 1};
+  var w: X = {.n = 2};
+  return F(v, w).n;
+}

--- a/toolchain/semantics/fuzzer_corpus/9616f0607e0aa53f32551c7cf3fc08efa7e7fb86
+++ b/toolchain/semantics/fuzzer_corpus/9616f0607e0aa53f32551c7cf3fc08efa7e7fb86
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// This declaration is not allowed.
+// CHECK:STDERR: COMPILATION ERROR: fail_separate_decl.carbon:[[@LINE+1]]: Function declaration has deduced return type but no body
+fn ComputeSum(x: i32, y: i32) -> auto;
+
+fn Main() -> i32 {
+  return ComputeSum(1, 2) - 3;
+}

--- a/toolchain/semantics/fuzzer_corpus/97dd9ece505acb1475a24cff9ac3f30762854b56
+++ b/toolchain/semantics/fuzzer_corpus/97dd9ece505acb1475a24cff9ac3f30762854b56
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class S(T:! type) {}
+class Z {}
+
+class Tree(L:! type, R:! type) {}
+class Leaf {}
+
+interface Foo(T:! type) {}
+
+impl forall [U:! type, T:! Foo(Tree(U, U))] S(T) as Foo(U) {}
+
+alias Level1 = Tree(Leaf, Leaf);
+alias Level2 = Tree(Level1, Level1);
+alias Level3 = Tree(Level2, Level2);
+alias Level4 = Tree(Level3, Level3);
+alias Level5 = Tree(Level4, Level4);
+
+impl Z as Foo(Level5) {}
+
+fn F[T:! Foo(Leaf)](x: T) {}
+fn Main() -> i32 {
+  var n: S(S(S(S(S(Z))))) = {};
+  F(n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9898ec32a1d2cd6911f4815a43178aa358d49458
+++ b/toolchain/semantics/fuzzer_corpus/9898ec32a1d2cd6911f4815a43178aa358d49458
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: (auto, (i32, i32)) = ((1, 2), (3, 4));
+  return t[0][0] + t[1][1] - 5;
+}

--- a/toolchain/semantics/fuzzer_corpus/996146c52ec6d4b88e1a5c6f2ad1f8a8ed23a2a0
+++ b/toolchain/semantics/fuzzer_corpus/996146c52ec6d4b88e1a5c6f2ad1f8a8ed23a2a0
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  // Allowed: `Self` here means `Point`.
+  fn GetX[self: Self]() -> i32 {
+    return self.x;
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  return p.GetX();
+}

--- a/toolchain/semantics/fuzzer_corpus/99e29fe8751a2b381ff98f6a7f8fd5a39f47a089
+++ b/toolchain/semantics/fuzzer_corpus/99e29fe8751a2b381ff98f6a7f8fd5a39f47a089
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_length_mismatch_with_auto.carbon:[[@LINE+1]]: tuples of different length
+  var a: (auto,) = (1, 2);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9a93b28a17b3037de343c7627970a21ea9f36ad6
+++ b/toolchain/semantics/fuzzer_corpus/9a93b28a17b3037de343c7627970a21ea9f36ad6
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = {.x = 0, .y = 0};
+  // CHECK:STDERR: COMPILATION ERROR: fail_point_equal.carbon:[[@LINE+1]]: type error in initializer of variable: 'class Point(T = i32)' is not implicitly convertible to 'class Point(T = bool)'
+  var q: Point(bool) = p;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9be6536b748480b8d7046c4e360fefa33a996d59
+++ b/toolchain/semantics/fuzzer_corpus/9be6536b748480b8d7046c4e360fefa33a996d59
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Invalid {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9c8bddc13ecba23e290de63fec0c6ae8514e9ae4
+++ b/toolchain/semantics/fuzzer_corpus/9c8bddc13ecba23e290de63fec0c6ae8514e9ae4
@@ -1,0 +1,54 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: H 22
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+
+choice MyOptionalElement(T:! type) {
+  None(),
+  Element(T)
+}
+
+class MyOptional(T:! type){
+   fn CreateEmpty() -> MyOptional(T){
+       return { .element = MyOptionalElement(T).None() };
+   }
+   fn Create ( value: T ) -> MyOptional(T){
+       return { .element = MyOptionalElement(T).Element(value) };
+   }
+
+    fn has_value[self: Self] () -> bool{
+        var x: MyOptionalElement(T) = self.element;
+        match(x){
+            case MyOptionalElement(T).None() => { return false; }
+        }
+        return false;
+    }
+
+    fn get[self: Self] () -> T {
+        var x: MyOptionalElement(T) = self.element;
+        match(x){
+            case MyOptionalElement(T).Element( var x: T ) =>{
+                return x;
+            }
+        }
+        // TODO: Mark this as unreachable somehow.
+        return get();
+    }
+
+   var element: MyOptionalElement(T);
+}
+
+
+fn Main() -> i32 {
+  var f: MyOptional(i32) = MyOptional(i32).Create(22);
+  var x: i32 = f.get();
+  Print("H {0}",x);
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9d3ad28603113f1a195ef1ff6d7df7acb28fb605
+++ b/toolchain/semantics/fuzzer_corpus/9d3ad28603113f1a195ef1ff6d7df7acb28fb605
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR C 1
+// CHECK:STDOUT: DESTRUCTOR B 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+class B{
+    destructor[self: Self]{
+        Print("DESTRUCTOR B {0}",self.n);
+    }
+    var n: i32;
+}
+
+class C{
+    destructor[self: Self]{
+        Print("DESTRUCTOR C {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 3};
+  var b: B = {.n = 2};
+  var c: C = {.n = 1};
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/9e094e36792e0aaecca1ff9a71578e9d30acd809
+++ b/toolchain/semantics/fuzzer_corpus/9e094e36792e0aaecca1ff9a71578e9d30acd809
@@ -1,0 +1,36 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 25
+
+package ExplorerTest api;
+
+class List {
+  choice Node {
+    Nil,
+    Cons(i32, Self*)
+  }
+  var node: Node;
+
+  // Creates a list of `Cons(n, Cons(n - 1, ... Cons(1, Nil) ... ))`.
+  fn Make(n: i32) -> Self {
+    return {
+      .node = if n == 0 then Node.Nil else Node.Cons(n, heap.New(Make(n - 1)))
+    };
+  }
+
+  // Returns the sum of values in the list plus the value of `a`.
+  fn Sum[self: Self](a: i32) -> i32 {
+    match (self.node) {
+      case Node.Nil => { return a; }
+      case Node.Cons(b: i32, rest: Self*) => { return rest->Sum(a + b); }
+    }
+  }
+}
+
+fn Main() -> i32 {
+  var l: List = List.Make(5);
+  return l.Sum(10);
+}

--- a/toolchain/semantics/fuzzer_corpus/9ef0d30288fa7ec2d26c89a11fca1aafa1ffe7c9
+++ b/toolchain/semantics/fuzzer_corpus/9ef0d30288fa7ec2d26c89a11fca1aafa1ffe7c9
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32 = 0;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/9f448813378568e8b33edac8f46e3e419cc936cc
+++ b/toolchain/semantics/fuzzer_corpus/9f448813378568e8b33edac8f46e3e419cc936cc
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+  fn GetX[self: Point]() -> i32 {
+    return self.x;
+  }
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  var f: __Fn() -> i32 = p.GetX;
+  return f();
+}

--- a/toolchain/semantics/fuzzer_corpus/9f451f15c28166724e9389efbc97cd00c5f362a4
+++ b/toolchain/semantics/fuzzer_corpus/9f451f15c28166724e9389efbc97cd00c5f362a4
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32;
+  // CHECK:STDERR: COMPILATION ERROR: fail_increment.carbon:[[@LINE+1]]: use of uninitialized variable x
+  ++x;
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/9f5970dd9c7258c0b821fd5ae34567d74212ba97
+++ b/toolchain/semantics/fuzzer_corpus/9f5970dd9c7258c0b821fd5ae34567d74212ba97
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: Integer overflow
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: auto = 5 >> 75;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/9fb1f522bd3e58d4e328258b44317fb30a97fc1c
+++ b/toolchain/semantics/fuzzer_corpus/9fb1f522bd3e58d4e328258b44317fb30a97fc1c
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// The bodies of member functions are processed after all immediately enclosing
+// classes, impl declarations, and interfaces.
+class A {
+  fn F() -> type {
+    return i32;
+  }
+  // OK, resolves to `A.F`.
+  fn G() -> F() {
+    return 0;
+  }
+
+  // CHECK:STDERR: COMPILATION ERROR: fail_class_fn_use_before_declaration.carbon:[[@LINE+1]]: 'I' has not been declared yet
+  fn H() -> I() {
+    return 0;
+  }
+  fn I() -> type {
+    return i32;
+  }
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a011088c7e451b85fecd399382733c73f802f28a
+++ b/toolchain/semantics/fuzzer_corpus/a011088c7e451b85fecd399382733c73f802f28a
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: DESTRUCTOR A 4
+// CHECK:STDOUT: DESTRUCTOR A 5
+// CHECK:STDOUT: DESTRUCTOR A 6
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  var a: [A; 2] = ({.n = 6},{.n = 5});
+  var b: [[A; 2]; 2] = (({.n = 4},{.n = 3}), ({.n = 2},{.n = 1}));
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/a01c8bc05abec666a02db1ab14935e847cef45d6
+++ b/toolchain/semantics/fuzzer_corpus/a01c8bc05abec666a02db1ab14935e847cef45d6
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // -2147483648 is unsupported as a literal, but we can do it with a decrement.
+  var low: i32 = -2147483647;
+  low -= 1;
+  var high: i32 = 2147483647;
+  Rand(low, high);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a34128de7c6b4324037a1d26386e5712188b6598
+++ b/toolchain/semantics/fuzzer_corpus/a34128de7c6b4324037a1d26386e5712188b6598
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn identFn( x: i32 ) -> i32{
+    return x;
+}
+
+fn Main() -> i32 {
+  var x : i32 = 7 % 2;
+
+
+  if(  x != 1){
+      return 1;
+  }
+  x = (3*3) % 3;
+  if( x != 0){
+      return 2;
+  }
+
+  x = (4+4+4+4) % (2+1);
+  if(  x != 1){
+      return 3;
+  }
+
+  x = 15 % (identFn(2)+1);
+  if( x != 0){
+      return 4;
+  }
+
+  x = -15 % 7;
+  if( x != -1){
+      return 5;
+  }
+
+  x = 15 % -7;
+  if(  x != 1){
+      return 6;
+  }
+
+  x = -15 % -identFn(7);
+  if( x != -1){
+      return 7;
+  }
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a3a77b1b81f7a7ed4bfacadef7c9e26e94215d67
+++ b/toolchain/semantics/fuzzer_corpus/a3a77b1b81f7a7ed4bfacadef7c9e26e94215d67
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_tab.carbon:[[@LINE+1]]: Invalid escaping in string: "new	line"
+  Print("new	line");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a3bccd84f98029e5646785b746d7060e05b94a67
+++ b/toolchain/semantics/fuzzer_corpus/a3bccd84f98029e5646785b746d7060e05b94a67
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn CompareBools(a: bool, b: bool) -> bool {
+  // CHECK:STDERR: SYNTAX ERROR: fail_compare_precedence.carbon:[[@LINE+1]]: syntax error, unexpected EQUAL_EQUAL, expecting SEMICOLON
+  return not a == b;
+}

--- a/toolchain/semantics/fuzzer_corpus/a3c0fbd0181c8c492babc4d2f43c63c172c7ee9a
+++ b/toolchain/semantics/fuzzer_corpus/a3c0fbd0181c8c492babc4d2f43c63c172c7ee9a
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Interface: -3
+// CHECK:STDOUT: Op: -3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var val: i32 = 3;
+  // Make sure that both the interface and operator work with i32. These rely on
+  // builtin arithmetic more directly.
+  Print("Interface: {0}", val.(Negate.Op)());
+  Print("Op: {0}", -val);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a3e02430dc2657bec82d5c18ed4443701f8014d1
+++ b/toolchain/semantics/fuzzer_corpus/a3e02430dc2657bec82d5c18ed4443701f8014d1
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_unimplemented_example.carbon:[[@LINE+1]]: Unimplemented
+  return 1 __unimplemented_example_infix 2;
+}

--- a/toolchain/semantics/fuzzer_corpus/a418c18490f25bad7569608825bb2cfc65010510
+++ b/toolchain/semantics/fuzzer_corpus/a418c18490f25bad7569608825bb2cfc65010510
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: -2
+
+package ExplorerTest api;
+
+fn apply[T:! type, U:! type](f: __Fn (T) -> U, x: T) -> U {
+  return f(x);
+}
+
+fn positive(x: bool) -> i32 {
+  if (x) {
+    return 2;
+  } else {
+    return -2;
+  }
+}
+
+fn Main() -> i32 {
+  return apply(positive, false);
+}

--- a/toolchain/semantics/fuzzer_corpus/a46860eeff8a4a87f40c22b291dd4682ff578c79
+++ b/toolchain/semantics/fuzzer_corpus/a46860eeff8a4a87f40c22b291dd4682ff578c79
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: auto = {.x = 10, .y = 1};
+  var p: i32* = &x.x;
+  *p = 0;
+
+  return x.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/a470239a151b81273a143b8a350a3af05e527438
+++ b/toolchain/semantics/fuzzer_corpus/a470239a151b81273a143b8a350a3af05e527438
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var a: i32 = 1;
+  let a_pinned: i32 = a;
+  let a_pinned2: i32 = a;
+  // OK: Value unused after being mutated.
+  a = 2;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/a4e9de3300c2b7abcb4de7496fef8fe9c1b3c4e3
+++ b/toolchain/semantics/fuzzer_corpus/a4e9de3300c2b7abcb4de7496fef8fe9c1b3c4e3
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test multiple arguments
+fn f(x: i32, y: i32) -> i32 {
+  return x + y;
+}
+
+fn Main() -> i32 {
+  return f(2, 3) - 5;
+}

--- a/toolchain/semantics/fuzzer_corpus/a5a01595fd372c8eeb51411f91438e859a976275
+++ b/toolchain/semantics/fuzzer_corpus/a5a01595fd372c8eeb51411f91438e859a976275
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// Error: Can't use keyword `Self` as the name of a class.
+// CHECK:STDERR: SYNTAX ERROR: fail_class_named_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting identifier or LEFT_PARENTHESIS
+class Self {
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Self = {.x = 1, .y = 2};
+  return p.y - p.x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/a8a0c6ffc4cd6d63b08501b9166737fe0e02c79d
+++ b/toolchain/semantics/fuzzer_corpus/a8a0c6ffc4cd6d63b08501b9166737fe0e02c79d
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Number {
+  fn Zero() -> Self;
+  fn Add[self: Self](other: Self) -> Self;
+}
+
+class Point(T:! Number) {
+  fn Origin() -> Point(T) {
+    return {.x = T.Zero(), .y = T.Zero()};
+  }
+  var x: T;
+  var y: T;
+}
+
+impl i32 as Number {
+  fn Zero() -> i32 { return 0; }
+  fn Add[self: i32](other: i32) -> i32 { return self + other; }
+}
+
+fn SumXY[U:! Number](p: Point(U)) -> U {
+  return p.Origin().x.Add(p.y);
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = {.x = 0, .y = 0};
+  return SumXY(p);
+}

--- a/toolchain/semantics/fuzzer_corpus/a8dd59ebd4d67161627fc37cf42f56266eee84cc
+++ b/toolchain/semantics/fuzzer_corpus/a8dd59ebd4d67161627fc37cf42f56266eee84cc
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var arr: [i32; 2] = (0, 1);
+  var x: [i32;] = arr;
+  var index: i32 = 1;
+  x[index] = 0;
+  return x[0] + x[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/aa886554975dd8babdee871ba3a36cfdbf09adde
+++ b/toolchain/semantics/fuzzer_corpus/aa886554975dd8babdee871ba3a36cfdbf09adde
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Destructor
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("Destructor");
+  }
+}
+
+fn Main() -> i32 {
+  let c: C = {};
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/aa9139a5f1e7ae6867692e648fbfad717185399b
+++ b/toolchain/semantics/fuzzer_corpus/aa9139a5f1e7ae6867692e648fbfad717185399b
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Interface {}
+impl {} as Interface {}
+impl {.x: i32} as Interface {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/aabd223c584f5f94b59f397f0b60e428ef3467b4
+++ b/toolchain/semantics/fuzzer_corpus/aabd223c584f5f94b59f397f0b60e428ef3467b4
@@ -1,0 +1,74 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Struct OK
+// CHECK:STDOUT: Choice OK
+// CHECK:STDOUT: Class OK
+// CHECK:STDOUT: Interface OK
+// CHECK:STDOUT: Constraint OK
+// CHECK:STDOUT: result: 0
+
+package Foo api;
+
+choice Choice { Alternative() }
+class Class { fn F(n: i32) -> i32 { return n + 1; } }
+interface Interface { fn G[self: Self]() -> Self; }
+interface AnotherInterface {}
+
+impl i32 as Interface { fn G[self: i32]() -> i32 { return self + 1; } }
+impl i32 as AnotherInterface {}
+
+// TODO: These are intended to be called at compile time. Mark them as
+// constexpr once we have syntax for that.
+fn GetStruct() -> type { return {.n: i32}; }
+fn GetChoice() -> type { return Choice; }
+fn GetClass() -> type { return Class; }
+fn GetInterface() -> type { return Interface; }
+fn GetConstraint() -> type { return Interface & AnotherInterface; }
+
+fn TestStruct() {
+  var s: GetStruct() = {.n = 1};
+  if (s.(GetStruct().n) == 1) {
+    Print("Struct OK");
+  }
+}
+
+fn TestChoice() {
+  var c: GetChoice() = GetChoice().Alternative();
+  match (c) {
+    case GetChoice().Alternative() => {
+      Print("Choice OK");
+    }
+  }
+}
+
+fn TestClass() {
+  if (GetClass().F(1) == 2) {
+    Print("Class OK");
+  }
+}
+
+fn TestInterface() {
+  var n: i32 = 1;
+  if (n.(GetInterface().G)() == 2) {
+    Print("Interface OK");
+  }
+}
+
+fn TestConstraint() {
+  var n: i32 = 1;
+  if (n.(GetConstraint().G)() == 2) {
+    Print("Constraint OK");
+  }
+}
+
+fn Main() -> i32 {
+  TestStruct();
+  TestChoice();
+  TestClass();
+  TestInterface();
+  TestConstraint();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ab552ac377163a3e30372abf70dce002ad1e3504
+++ b/toolchain/semantics/fuzzer_corpus/ab552ac377163a3e30372abf70dce002ad1e3504
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 4
+  __intrinsic_print("", 1, 2, 3);
+}

--- a/toolchain/semantics/fuzzer_corpus/ac402eca16b8a60ca297a1c22e20896e4ac13d0c
+++ b/toolchain/semantics/fuzzer_corpus/ac402eca16b8a60ca297a1c22e20896e4ac13d0c
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: strings less: 1
+// CHECK:STDOUT: ints less: 0
+// CHECK:STDOUT: strings less eq: 1
+// CHECK:STDOUT: ints less eq: 1
+// CHECK:STDOUT: strings greater: 0
+// CHECK:STDOUT: ints greater: 0
+// CHECK:STDOUT: strings greater eq: 0
+// CHECK:STDOUT: ints greater eq: 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  Print("strings less: {0}", if "hello" < "world" then 1 else 0);
+  Print("ints less: {0}", if 1 < 1 then 1 else 0);
+  Print("strings less eq: {0}", if "hello" <= "world" then 1 else 0);
+  Print("ints less eq: {0}", if 1 <= 1 then 1 else 0);
+  Print("strings greater: {0}", if "hello" > "world" then 1 else 0);
+  Print("ints greater: {0}", if 1 > 1 then 1 else 0);
+  Print("strings greater eq: {0}", if "hello" >= "world" then 1 else 0);
+  Print("ints greater eq: {0}", if 1 >= 1 then 1 else 0);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/acc010e81f0b5de102362c90fb118a5b56e2c25e
+++ b/toolchain/semantics/fuzzer_corpus/acc010e81f0b5de102362c90fb118a5b56e2c25e
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 7
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 0
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as ModWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n % rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 15};
+  a = a % 8;
+  Print("{0}", a.n);
+  a %= 4;
+  Print("{0}", a.n);
+  Print("{0}", (a % 3).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ae4a3a0f6a16334564bf7c43ce7ff480597c2cdb
+++ b/toolchain/semantics/fuzzer_corpus/ae4a3a0f6a16334564bf7c43ce7ff480597c2cdb
@@ -1,0 +1,38 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! type;
+  let T1:! type;
+  let T2:! type;
+  let T3:! type;
+  let T4:! type;
+  let T5:! type;
+  let T6:! type;
+  let T7:! type;
+  let T8:! type;
+  let T9:! type;
+}
+
+fn F[
+  M:! ManyTypes where
+    .T0 = .T1 and
+    .T1 = .T2 and
+    .T2 = .T3 and
+    .T3 = .T4 and
+    .T4 = .T5 and
+    .T5 = .T6 and
+    .T6 = .T7 and
+    .T7 = .T8 and
+    .T8 = .T9 and
+    // CHECK:STDERR: COMPILATION ERROR: fail_rewrite_cycle.carbon:[[@LINE+1]]: rewrite of (M).(ManyTypes.T4) applies within its own resolved expansion of (M).(ManyTypes.T4)
+    .T9 = .T0]() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ae4f2943ada6a47e2d5beb1a11629d617af1f8ce
+++ b/toolchain/semantics/fuzzer_corpus/ae4f2943ada6a47e2d5beb1a11629d617af1f8ce
@@ -1,0 +1,34 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: Bind from c value expression
+// CHECK:STDOUT: Binding scope end
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: 0: Heap{}, 1: C{}, 2: !!C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("c destroyed");
+  }
+}
+
+fn CallWithReferenceExpressionBinding(var c: C) {
+  Print("Binding scope end");
+}
+
+fn Main() -> i32 {
+  let c_let: C = {};
+  heap.PrintAllocs();
+
+  Print("Bind from c value expression");
+  CallWithReferenceExpressionBinding(c_let);
+  heap.PrintAllocs();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/af335f3fb6fda3927b5a8be215b9ce90c7e40539
+++ b/toolchain/semantics/fuzzer_corpus/af335f3fb6fda3927b5a8be215b9ce90c7e40539
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn id[T:! type](x: T) -> T {
+  return x;
+}
+
+fn Main() -> i32 {
+  return id(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/b039b3b9343fd1c409690efa925a52c5e3cf9f3d
+++ b/toolchain/semantics/fuzzer_corpus/b039b3b9343fd1c409690efa925a52c5e3cf9f3d
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: auto = 5;
+  match (t) {
+    case x: i32 => {
+      return x - 5;
+    }
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/b091b7a85fd9dfb6e785a6ae16977ff1d2e20859
+++ b/toolchain/semantics/fuzzer_corpus/b091b7a85fd9dfb6e785a6ae16977ff1d2e20859
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: A(T) as B(i32)
+// CHECK:STDOUT: A(T) as B(U)
+// CHECK:STDOUT: A(i32) as B(T)
+// CHECK:STDOUT: A(i32) as B(T)
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A(T:! type) {}
+interface B(T:! type) {
+  fn F();
+}
+
+impl forall [T:! type] A(T) as B(i32) {
+  fn F() { Print("A(T) as B(i32)"); }
+}
+impl forall [T:! type] A(i32) as B(T) {
+  fn F() { Print("A(i32) as B(T)"); }
+}
+impl forall [T:! type, U:! type] A(T) as B(U) {
+  fn F() { Print("A(T) as B(U)"); }
+}
+
+fn F[T:! B(i32)](x: T) {
+  T.F();
+}
+fn G[T:! B(bool)](x: T) {
+  T.F();
+}
+
+fn Main() -> i32 {
+  let a: A(bool) = {};
+  let b: A(i32) = {};
+  F(a);
+  G(a);
+  F(b);
+  G(b);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b0f627cff7a9b69fbc6e7fee877e21eeb995fc94
+++ b/toolchain/semantics/fuzzer_corpus/b0f627cff7a9b69fbc6e7fee877e21eeb995fc94
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_more_hash_tags_on_right.carbon:[[@LINE+1]]: invalid character '\x23' in source file.
+  if (s == "str"#) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("str");
+}

--- a/toolchain/semantics/fuzzer_corpus/b2674ac0752c471c50d74e2fa23f67e29cfdae08
+++ b/toolchain/semantics/fuzzer_corpus/b2674ac0752c471c50d74e2fa23f67e29cfdae08
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn AddInt(a: i32, b: i32) -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_returned_var_type_mismatch.carbon:[[@LINE+1]]: type of returned var `bool` does not match return type `i32`
+  returned var ret: bool = true;
+  return var;
+}
+
+fn Main() -> i32 {
+  return AddInt(1, 2);
+}

--- a/toolchain/semantics/fuzzer_corpus/b2ffa84347526820d4fd74cc1e4b05245c8f3138
+++ b/toolchain/semantics/fuzzer_corpus/b2ffa84347526820d4fd74cc1e4b05245c8f3138
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// TODO: This SHOULD fail but doesn't presently.
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+import Nonexistent;
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b32770014a39c3d995257c8a4c9c7850720bc3b6
+++ b/toolchain/semantics/fuzzer_corpus/b32770014a39c3d995257c8a4c9c7850720bc3b6
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Carrot.G
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+interface Apple(T:! type) {
+  fn F[self: Self]() -> T;
+}
+
+interface Banana {
+  require Self impls Apple(i32);
+  fn G[self: Self]();
+}
+
+class Carrot {
+  var n: i32;
+}
+
+impl Carrot as Apple(i32) {
+  fn F[self: Self]() -> i32 { return self.n; }
+}
+
+impl Carrot as Banana {
+  fn G[self: Self]() { Print("Carrot.G"); }
+}
+
+fn H[T:! Banana](x: T) -> i32 {
+  x.G();
+  return x.(Apple(i32).F)();
+}
+
+fn Main() -> i32 {
+  var c: Carrot = {.n = 5};
+  return H(c);
+}

--- a/toolchain/semantics/fuzzer_corpus/b36b4cfd1f0f6b5a74973d8b925e26f98d5c4fa6
+++ b/toolchain/semantics/fuzzer_corpus/b36b4cfd1f0f6b5a74973d8b925e26f98d5c4fa6
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1133
+
+package ExplorerTest api;
+
+interface I(T:! type) {
+  fn F[self: Self](t: T, o: Self) -> Self;
+}
+
+class X(U:! type) {
+  extend impl as I(U) {
+    fn F[self: Self](u: U, o: Self) -> Self { return {.m = u, .n = self.n + o.n}; }
+  }
+  var m: U;
+  var n: i32;
+}
+
+fn Run[V:! type](x: V) -> (V, V, i32, i32) {
+  var v: X(V) = {.m = x, .n = 1};
+  var w: X(V) = {.m = x, .n = 2};
+  // OK, know that `X(V)` implements `I(V)` from the `impl` in the class.
+  var call: X(V) = v.(X(V).(I(V).F))(x, w);
+  return (call.(X(V).m), call.m, call.(X(V).n), call.n);
+}
+
+fn Main() -> i32 {
+  var (a: i32, b: i32, c: i32, d: i32) = Run(1);
+  return a * 1000 + b * 100 + c * 10 + d;
+}

--- a/toolchain/semantics/fuzzer_corpus/b3d7c16243e6d943b2a4e180d9151cecd4c08e64
+++ b/toolchain/semantics/fuzzer_corpus/b3d7c16243e6d943b2a4e180d9151cecd4c08e64
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface FrobWith(T:! type) {}
+
+fn F[T:! FrobWith(.Self),
+     // CHECK:STDERR: COMPILATION ERROR: fail_dot_self_after_scope_2.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `U`
+     U:! .Self]() {
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b444d666a312c8082f538078de9424a85fb83811
+++ b/toolchain/semantics/fuzzer_corpus/b444d666a312c8082f538078de9424a85fb83811
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Z {
+  fn Zero() -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  // `Self` not allowed after `extend impl`.
+  // CHECK:STDERR: SYNTAX ERROR: fail_extend_with_self.carbon:[[@LINE+1]]: syntax error, unexpected SELF, expecting AS
+  extend impl Self as Z {
+    fn Zero() -> Self {
+      return {.x = 0, .y = 0};
+    }
+  }
+}
+
+fn Main() -> i32 {
+  var a: Point = Point.Zero();
+  return p.x;
+}

--- a/toolchain/semantics/fuzzer_corpus/b4a3ef5dc70af7bf091693b5db3e5e20f946d990
+++ b/toolchain/semantics/fuzzer_corpus/b4a3ef5dc70af7bf091693b5db3e5e20f946d990
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+fn GetX(p: Point) -> i32 {
+  return p.x;
+}
+
+fn Main() -> i32 {
+  return GetX({.x = 1, .y = 2}) - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/b4fbe7fa53f07fd1c43f29638c96356ccbdd4d81
+++ b/toolchain/semantics/fuzzer_corpus/b4fbe7fa53f07fd1c43f29638c96356ccbdd4d81
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+impl Point as Vector {
+  fn Add[self: Point](b: Point) -> Point {
+    return {.x = self.x + b.x, .y = self.y + b.y};
+  }
+  fn Scale[self: Point](v: i32) -> Point {
+    return {.x = self.x * v, .y = self.y * v};
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {
+  var m: auto = a.Add;
+  var n: auto = m(b).Scale;
+  return n(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 1, .y = 4};
+  var b: Point = {.x = 2, .y = 3};
+  var p: Point = AddAndScaleGeneric(a, b, 5);
+  return p.x - 15;
+}

--- a/toolchain/semantics/fuzzer_corpus/b5e44948070a88388a336b5873eb35c6f19534bf
+++ b/toolchain/semantics/fuzzer_corpus/b5e44948070a88388a336b5873eb35c6f19534bf
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! type;
+}
+class X {
+  impl as HasAssoc where .Assoc = i32 {}
+}
+
+fn H[T:! HasAssoc where .Assoc = i32, U:! type where .Self == i32](a: T, b: U) -> i32 {
+  var a: T.((HasAssoc where .Assoc = U).Assoc) = 3;
+  return a;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  var y: i32 = 0;
+  return H(x, y);
+}

--- a/toolchain/semantics/fuzzer_corpus/b659fad4a34c3bff5cf5078a3d94215b8637ccae
+++ b/toolchain/semantics/fuzzer_corpus/b659fad4a34c3bff5cf5078a3d94215b8637ccae
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_parameter_type_only.carbon:[[@LINE+1]]: An irrefutable pattern is required, but `i32` is refutable.
+fn f(x: i32, i32) {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b712c4641839c062c5f581a67665f38ab9532665
+++ b/toolchain/semantics/fuzzer_corpus/b712c4641839c062c5f581a67665f38ab9532665
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_not_type.carbon:[[@LINE+1]]: type error in type expression: 'i32' is not implicitly convertible to 'type'
+fn F[a:! 42]();
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b7b4b3663513c4530e99086904fbb7108200bc77
+++ b/toolchain/semantics/fuzzer_corpus/b7b4b3663513c4530e99086904fbb7108200bc77
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Bad[T:! type](x: {.a: i32, .b: T}) {}
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_implicit_conversion_extra_field.carbon:[[@LINE+1]]: mismatch in field names, source field `c` not in destination type `{.a: i32, .b: T}`
+  Bad({.b = 5, .a = 7, .c = 2});
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b8c5b163cdd52c3dcbf7e22193574683199b623e
+++ b/toolchain/semantics/fuzzer_corpus/b8c5b163cdd52c3dcbf7e22193574683199b623e
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+__mixin Mixin {
+  // CHECK:STDERR: COMPILATION ERROR: fail_mix_invalid.carbon:[[@LINE+1]]: Not a valid mixin: `()`
+  __mix ();
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/b8d30bb681704e28b89a62f19a1c5846ff7b2b9d
+++ b/toolchain/semantics/fuzzer_corpus/b8d30bb681704e28b89a62f19a1c5846ff7b2b9d
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Iface {
+  let T:! type;
+  // CHECK:STDERR: COMPILATION ERROR: fail_redefined.carbon:[[@LINE+1]]: Duplicate name `T` also found at fail_redefined.carbon:[[@LINE-1]]
+  let T:! type;
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/b949eac08c4054892d0142d5bda771e1cb4ffa05
+++ b/toolchain/semantics/fuzzer_corpus/b949eac08c4054892d0142d5bda771e1cb4ffa05
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+// Error: need to specify which type implementing `Vector` for.
+// CHECK:STDERR: COMPILATION ERROR: fail_external_impl_omit_self.carbon:[[@LINE+1]]: could not resolve 'Self'
+impl as Vector {
+  fn Add[self: Point](b: Point) -> Point {
+    return {.x = self.x + b.x, .y = self.y + b.y};
+  }
+  fn Scale[self: Point](v: i32) -> Point {
+    return {.x = self.x * v, .y = self.y * v};
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {
+  var m: auto = a.Add;
+  var n: auto = m(b).Scale;
+  return n(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 1, .y = 4};
+  var b: Point = {.x = 2, .y = 3};
+  var p: Point = AddAndScaleGeneric(a, b, 5);
+  return p.x - 15;
+}

--- a/toolchain/semantics/fuzzer_corpus/b97f2101ca5e7b87bae66b45cd511a8f709496a9
+++ b/toolchain/semantics/fuzzer_corpus/b97f2101ca5e7b87bae66b45cd511a8f709496a9
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = {.x = 1, .y = 2};
+  return p.y - p.x - 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/ba1af5fb5ac955a0a4da3890243d68fd1ccddca0
+++ b/toolchain/semantics/fuzzer_corpus/ba1af5fb5ac955a0a4da3890243d68fd1ccddca0
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  // CHECK:STDERR: COMPILATION ERROR: fail_two_arg_lists.carbon:[[@LINE+1]]: in call `Point(T)(T)`, expected callee to be a function, found `type`
+  fn Origin(zero: T) -> Point(T)(T) {
+    return {.x = zero, .y = zero};
+  }
+
+  fn GetX[self: Point(T)(T)]() -> T {
+    return self.x;
+  }
+
+  var x: T;
+  var y: T;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = Point(i32).Origin(0);
+  return p.GetX();
+}

--- a/toolchain/semantics/fuzzer_corpus/bc00968d3030cf3aa5e2942dab6d5857a821c3c0
+++ b/toolchain/semantics/fuzzer_corpus/bc00968d3030cf3aa5e2942dab6d5857a821c3c0
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Demonstrate the aliasing behavior of pointers.
+
+fn Main() -> i32 {
+  var p: i32* = heap.New(5);
+  var q: i32* = p;
+  *q = 0;
+  return *p;
+}

--- a/toolchain/semantics/fuzzer_corpus/bc1b6d2505d65d64d6ca362158e2c2ec3dd83577
+++ b/toolchain/semantics/fuzzer_corpus/bc1b6d2505d65d64d6ca362158e2c2ec3dd83577
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class A {}
+
+fn Main() -> i32 {
+  var a: A = {};
+  // CHECK:STDERR: COMPILATION ERROR: fail_no_mul.carbon:[[@LINE+2]]: type error in `*`:
+  // CHECK:STDERR: could not find implementation of interface MulWith(U = i32) for class A
+  a * 1;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/bc3e368a7f2a1647772386571ac9efc52d0f6aff
+++ b/toolchain/semantics/fuzzer_corpus/bc3e368a7f2a1647772386571ac9efc52d0f6aff
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+fn A(b: bool) -> i32 {
+  match (b) {
+    case false => { return 1; }
+    case true => { return 2; }
+  }
+}
+
+fn Main() -> i32 {
+  return A(true);
+}

--- a/toolchain/semantics/fuzzer_corpus/bcb7fa4d022bd1099fce1eed15408ef42bd5346c
+++ b/toolchain/semantics/fuzzer_corpus/bcb7fa4d022bd1099fce1eed15408ef42bd5346c
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (0 == 1) {
+    return 1;
+  } else {
+    return 0;
+  }
+
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/bcc107beab4b61b4c0b497a909470ae56ece14cd
+++ b/toolchain/semantics/fuzzer_corpus/bcc107beab4b61b4c0b497a909470ae56ece14cd
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: d.a=1
+// CHECK:STDOUT: d.b=2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+abstract class C {
+  var a: i32;
+}
+
+class D {
+  extend base: C;
+  var b: i32;
+}
+
+fn Main() -> i32 {
+  var d: D = { .base = {.a = 1}, .b = 2 };
+  Print("d.a={0}", d.a);
+  Print("d.b={0}", d.b);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/bd4a8ee2367c6500f3a141093994d471f8c3f933
+++ b/toolchain/semantics/fuzzer_corpus/bd4a8ee2367c6500f3a141093994d471f8c3f933
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  fn SetX[self: Point](x: i32) {
+    // CHECK:STDERR: COMPILATION ERROR: fail_method_args.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `x`
+    x = 10;
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  p.SetX(42);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/bd5fb5758cb99b278455231a15b78acf6bd00857
+++ b/toolchain/semantics/fuzzer_corpus/bd5fb5758cb99b278455231a15b78acf6bd00857
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 7
+// CHECK:STDOUT: 15
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as BitOrWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n | rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 1};
+  a = a | 2;
+  Print("{0}", a.n);
+  a |= 5;
+  Print("{0}", a.n);
+  Print("{0}", (a | 12).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/bd849c0012a2caf88ddd85bca8984481c146b973
+++ b/toolchain/semantics/fuzzer_corpus/bd849c0012a2caf88ddd85bca8984481c146b973
@@ -1,0 +1,10 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDERR: RUNTIME ERROR: <Main()>:0: attempt to call function `Main` that has not been defined
+
+package ExplorerTest api;
+
+fn Main() -> i32;

--- a/toolchain/semantics/fuzzer_corpus/be582a24883e7352f2038210d5ec0bab85ef2964
+++ b/toolchain/semantics/fuzzer_corpus/be582a24883e7352f2038210d5ec0bab85ef2964
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  fn F() {}
+  fn G[self: Self]() {}
+}
+
+fn ReturnF() -> auto { return C.F; }
+// CHECK:STDERR: COMPILATION ERROR: fail_return_method.carbon:[[@LINE+1]]: member name G can only be used in a member access or alias
+fn ReturnG() -> auto { return C.G; }
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/bf0afbc4dfe5b6560b36212fd785221d72fe962b
+++ b/toolchain/semantics/fuzzer_corpus/bf0afbc4dfe5b6560b36212fd785221d72fe962b
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_invalid_integer.carbon:[[@LINE+1]]: Invalid integer literal: 11111111111111111111111111
+  return 11111111111111111111111111;
+}

--- a/toolchain/semantics/fuzzer_corpus/bff54e1386ecdc1e2d26258dd98bb24e45c8993f
+++ b/toolchain/semantics/fuzzer_corpus/bff54e1386ecdc1e2d26258dd98bb24e45c8993f
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32 = 2;
+  while (true) {
+    if (x == 0) {
+      break;
+    } else {
+      x = x - 1;
+    }
+  }
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/c06c7e4180fcc3902846677d5af1ce299ff04aaf
+++ b/toolchain/semantics/fuzzer_corpus/c06c7e4180fcc3902846677d5af1ce299ff04aaf
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Cell(T:! type) {
+  fn Create(x: T) -> Cell(T) { return { .data = x }; }
+
+  fn Get[self: Self]() -> T {
+    return self.data;
+  }
+  fn Put[addr self: Self*](x: T) {
+    (*self).data = x;
+  }
+  fn CreateOther[self: Self, U:! type](x: U) -> Cell(U) {
+    return {.data = x};
+  }
+  var data: T;
+}
+
+class Integer {
+  var int: i32;
+}
+
+fn Main() -> i32 {
+  var i: Integer = {.int = 1};
+  var c: Cell(Integer) = Cell(Integer).Create(i);
+  i = {.int = 0};
+  c.Put(i);
+  var j: Integer = c.Get();
+  var d: Cell(Integer) = c.CreateOther(j);
+  return c.data.int + d.data.int;
+}

--- a/toolchain/semantics/fuzzer_corpus/c1aaf1dd13a2d1ac0f10ccd627f5cf913b28e194
+++ b/toolchain/semantics/fuzzer_corpus/c1aaf1dd13a2d1ac0f10ccd627f5cf913b28e194
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: i32
+// CHECK:STDOUT: String
+// CHECK:STDOUT: result: 0
+
+package Testcase api;
+
+interface HasName {
+    let Name:! String;
+}
+
+impl i32 as HasName where .Name = "i32" {}
+impl String as HasName where .Name = "String" {}
+
+fn Main() -> i32 {
+    Print(i32.(HasName.Name));
+    Print(String.(HasName.Name));
+    return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c27e3f5e51cd3b8574375da26d66b5dab5574d82
+++ b/toolchain/semantics/fuzzer_corpus/c27e3f5e51cd3b8574375da26d66b5dab5574d82
@@ -1,0 +1,27 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 0
+// CHECK:STDOUT: -1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as BitXorWith(i32) where .Result = A {
+  fn Op[self: Self](rhs: i32) -> A { return {.n = self.n ^ rhs}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  a = a ^ 3;
+  Print("{0}", a.n);
+  a ^= 6;
+  Print("{0}", a.n);
+  Print("{0}", (a ^ -1).n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c2ccd8521e3272b84287c5beed50b16ea6f83328
+++ b/toolchain/semantics/fuzzer_corpus/c2ccd8521e3272b84287c5beed50b16ea6f83328
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: i32.F
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Base {
+  fn F();
+}
+
+interface Extension {
+  extend Base;
+}
+
+fn F[T:! type where .Self impls Extension](x: T) {
+  x.(Extension.F)();
+}
+
+impl i32 as Extension {
+  fn F() { Print("i32.F"); }
+}
+
+fn Main() -> i32 {
+  var n: i32 = 0;
+  F(n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c371479ed5d61900879832df3d14674b8bf586c4
+++ b/toolchain/semantics/fuzzer_corpus/c371479ed5d61900879832df3d14674b8bf586c4
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_block_more_hash_tags_on_left.carbon:[[@LINE+1]]: Unexpected end of file
+  var s: String = ##'''
+    error: there are more #s on the left than the right.
+  '''#;
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c53cde1fb7e3ae52dbc9bae3da52905047adb174
+++ b/toolchain/semantics/fuzzer_corpus/c53cde1fb7e3ae52dbc9bae3da52905047adb174
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn F() {
+}
+
+fn Main() -> i32 {
+  F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c62264ae938896c8ed1139a0fc215fb982e2fd69
+++ b/toolchain/semantics/fuzzer_corpus/c62264ae938896c8ed1139a0fc215fb982e2fd69
@@ -1,0 +1,54 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: DESTRUCTOR A 3
+// CHECK:STDOUT: DESTRUCTOR A 4
+// CHECK:STDOUT: DESTRUCTOR A 5
+// CHECK:STDOUT: DESTRUCTOR A 6
+// CHECK:STDOUT: DESTRUCTOR A 7
+// CHECK:STDOUT: DESTRUCTOR A 8
+// CHECK:STDOUT: DESTRUCTOR A 6
+// CHECK:STDOUT: DESTRUCTOR A 7
+// CHECK:STDOUT: DESTRUCTOR A 8
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  var i: i32 = 0;
+  while(true){
+      var a: A = {.n = 4};
+      var b: A = {.n = 3};
+      var c: A = {.n = 2};
+      if(true){
+        var a: A = {.n = 1};
+        break;
+      }
+  }
+
+  i = 0;
+  while(i < 2 ){
+    var a: A = {.n = 8};
+    var b: A = {.n = 7};
+    var c: A = {.n = 6};
+    if(i == 0){
+      var a: A = {.n = 5};
+      i = i+1;
+      continue;
+    }
+    i = i+1;
+  }
+
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/c64ac9d496e63e9f1b57dbbe870b16621d74ccd1
+++ b/toolchain/semantics/fuzzer_corpus/c64ac9d496e63e9f1b57dbbe870b16621d74ccd1
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 20
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var ar: [i32; 4] = (0, 1,2,3);
+   var count : i32 = 0;
+   for( x: i32 in ar){
+       count = count +1;
+        for( x: i32 in ar){
+            count = count +1;
+        }
+   }
+   return count;
+}

--- a/toolchain/semantics/fuzzer_corpus/c7b5d3d001bf7f0224140706e7d747a9fbed9e82
+++ b/toolchain/semantics/fuzzer_corpus/c7b5d3d001bf7f0224140706e7d747a9fbed9e82
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Before: 1
+// CHECK:STDOUT: Interface: 2
+// CHECK:STDOUT: Op: 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  var n: i32;
+}
+
+fn Main() -> i32 {
+  var c: C = {.n = 1};
+  Print("Before: {0}", c.n);
+  c.(AssignWith({.n: i32}).Op)({.n = 2});
+  Print("Interface: {0}", c.n);
+  c = {.n = 3};
+  Print("Op: {0}", c.n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/c7fd0880feb951aeeef92e782305cf89df1edcaa
+++ b/toolchain/semantics/fuzzer_corpus/c7fd0880feb951aeeef92e782305cf89df1edcaa
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+constraint X {
+  // CHECK:STDERR: COMPILATION ERROR: fail_associated_function.carbon:[[@LINE+1]]: associated function not permitted in named constraint
+  fn F();
+}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/ca9f42d81e2b4a9a940d82785dcd497837d0f8c7
+++ b/toolchain/semantics/fuzzer_corpus/ca9f42d81e2b4a9a940d82785dcd497837d0f8c7
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Hallo Welt
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32{
+  var x: Optional(String) = Optional(String).Create( "Hallo Welt" );
+  if(x.HasValue()){
+    Print(x.Get());
+    return 0;
+  }
+  return -1;
+}

--- a/toolchain/semantics/fuzzer_corpus/cb11afc40c6c53364bb4a113953adc9491e44eea
+++ b/toolchain/semantics/fuzzer_corpus/cb11afc40c6c53364bb4a113953adc9491e44eea
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Point {
+  // CHECK:STDERR: COMPILATION ERROR: fail_qualified_method.carbon:[[@LINE+1]]: qualified declaration names are not permitted in this context
+  fn Point.F[self: Self]() {}
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/cbf37765b92964dcab9df8d0d85992170399dd57
+++ b/toolchain/semantics/fuzzer_corpus/cbf37765b92964dcab9df8d0d85992170399dd57
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn F[T:! type & type](x: T) {}
+
+fn Main() -> i32 {
+  F(0);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/cc232597fcd132b1012a688015feff43620a22ef
+++ b/toolchain/semantics/fuzzer_corpus/cc232597fcd132b1012a688015feff43620a22ef
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_intrinsic_int_format.carbon:[[@LINE+3]]: type error in Print argument 0
+  // CHECK:STDERR: expected: String
+  // CHECK:STDERR: actual: i32
+  __intrinsic_print(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/cc862b044a179be2a5cde3ff9e2070fea2a7e2cc
+++ b/toolchain/semantics/fuzzer_corpus/cc862b044a179be2a5cde3ff9e2070fea2a7e2cc
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: i32 = (1);
+  var t2: (i32, i32) = (5, 2);
+  t2[0] = 3;
+  return t2[0] - t2[1] - x;
+}

--- a/toolchain/semantics/fuzzer_corpus/cce8949457022158df2d24b36f167db5f4acd9f7
+++ b/toolchain/semantics/fuzzer_corpus/cce8949457022158df2d24b36f167db5f4acd9f7
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 526
+
+package ExplorerTest api;
+
+interface A { fn F() -> i32; fn G() -> i32; }
+interface B { fn H() -> i32; }
+
+fn Get1[T:! A & B](n: T) -> i32 { return n.F() + n.H(); }
+fn Get2[T:! B & A](n: T) -> i32 { return n.G(); }
+fn Get3[T:! B & A & A & B & A](n: T) -> i32 { return n.G() + n.H(); }
+
+impl i32 as A {
+  fn F() -> i32 { return 1; }
+  fn G() -> i32 { return 2; }
+}
+impl i32 as B {
+  fn H() -> i32 { return 4; }
+}
+
+fn Main() -> i32 {
+  var z: i32 = 0;
+  return Get1(z) * 100 + Get2(z) * 10 + Get3(z);
+}

--- a/toolchain/semantics/fuzzer_corpus/cd45125269f01b6af10a764fdde04f35bab69ff8
+++ b/toolchain/semantics/fuzzer_corpus/cd45125269f01b6af10a764fdde04f35bab69ff8
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+namespace N;
+namespace N.M;
+fn N.F() {}
+fn N.M.FM() {}
+
+alias A = N;
+alias AM = N.M;
+alias N.A = N.M;
+alias N.A2 = N;
+
+fn Main() -> i32 {
+  A.F();
+  AM.FM();
+  N.A.FM();
+  A.A2.A2.A2.A2.A2.A2.A2.F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/cda355e8d76ac84f9c04ce81d4b10c43ede462fa
+++ b/toolchain/semantics/fuzzer_corpus/cda355e8d76ac84f9c04ce81d4b10c43ede462fa
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class C {
+  // CHECK:STDERR: COMPILATION ERROR: fail_member_of_self.carbon:[[@LINE+1]]: incomplete type `class C` used in type of variable
+  var m: Self;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ce4748f459444e0162224c3c7a549d2d233ae4a6
+++ b/toolchain/semantics/fuzzer_corpus/ce4748f459444e0162224c3c7a549d2d233ae4a6
@@ -1,0 +1,56 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+interface ManyTypes {
+  let T0:! type;
+  let T1:! type;
+  let T2:! type;
+  let T3:! type;
+  let T4:! type;
+  let T5:! type;
+  let T6:! type;
+  let T7:! type;
+  let T8:! type;
+  let T9:! type;
+}
+
+fn F[
+  M:! ManyTypes where
+    .T0 = .T1 and
+    .T1 = .T2 and
+    .T2 = .T3 and
+    .T3 = .T4 and
+    .T4 = .T5 and
+    .T5 = .T6 and
+    .T6 = .T7 and
+    .T7 = .T8 and
+    .T8 = .T9 and
+    .T9 = i32](m: M) -> i32 {
+  var v: M.T0 = 1;
+  return v;
+}
+
+class C {
+  extend impl as ManyTypes where
+    .T0 = i32 and
+    .T1 = .T0 and
+    .T2 = .T1 and
+    .T3 = .T2 and
+    .T4 = .T3 and
+    .T5 = .T4 and
+    .T6 = .T5 and
+    .T7 = .T6 and
+    .T8 = .T7 and
+    .T9 = .T8 {}
+}
+
+fn Main() -> i32 {
+  var c: C = {};
+  return F(c);
+}

--- a/toolchain/semantics/fuzzer_corpus/cf4f9df21de1a0aead957f6d4733369928bb6422
+++ b/toolchain/semantics/fuzzer_corpus/cf4f9df21de1a0aead957f6d4733369928bb6422
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// TODO: Implement this with some kind of reflection?
+impl {.x: i32, .y: i32} as EqWith(Self) {
+  fn Equal[self: Self](other: Self) -> bool {
+    return self.x == other.x and self.y == other.y;
+  }
+  fn NotEqual[self: Self](other: Self) -> bool {
+    return self.x != other.x or self.y != other.y;
+  }
+}
+
+fn Main() -> i32 {
+  var t1: {.x: i32, .y: i32} = {.x = 5, .y = 2};
+  var t2: {.x: i32, .y: i32} = {.x = 5, .y = 4};
+  if (t1 == t2) {
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/d024760cfb19a4a0634f0bc0ed0668b9526fb1d4
+++ b/toolchain/semantics/fuzzer_corpus/d024760cfb19a4a0634f0bc0ed0668b9526fb1d4
@@ -1,0 +1,92 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: i32.Hash
+// CHECK:STDOUT: 0
+// CHECK:STDOUT: Potato.(Hashable.Hash)
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: Potato.Hash
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: Potato.Hash
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Hashable {
+  fn Hash[self: Self]() -> i32;
+}
+
+class Potato {
+  impl as Hashable {
+    fn Hash[self: Self]() -> i32 {
+      Print("Potato.(Hashable.Hash)");
+      return 1;
+    }
+  }
+
+  fn Hash[self: Self]() -> i32 {
+    Print("Potato.Hash");
+    return 2;
+  }
+}
+
+interface Maker {
+  let Result:! Hashable;
+  fn Make() -> Result;
+}
+
+impl i32 as Hashable {
+  fn Hash[self: Self]() -> i32 {
+    Print("i32.Hash");
+    return self;
+  }
+}
+
+fn F[T:! Maker where .Result = i32](x: T) -> i32 {
+  // OK, can treat T.Make() as an i32.
+  return T.Make() + 1;
+}
+
+fn G[T:! Maker](x: T) -> i32 {
+  // OK, Potato.(Hashable.Hash), not Potato.Hash.
+  return T.Make().Hash();
+}
+
+fn H[T:! Maker where .Result = Potato](x: T) -> i32 {
+  // OK, Potato.Hash, not Potato.(Hashable.Hash).
+  return T.Make().Hash();
+}
+
+fn I[T:! Maker where .Result = Potato](x: T) -> i32 {
+  var p: Potato = {};
+  // OK, Potato.Hash, not Potato.(Hashable.Hash), even though we know Potato is
+  // Hashable here.
+  return p.Hash();
+}
+
+class IntFactory {
+  extend impl as Maker where .Result = i32 {
+    fn Make() -> i32 { return 0; }
+  }
+}
+
+class PotatoFactory {
+  extend impl as Maker where .Result = Potato {
+    fn Make() -> Potato { return {}; }
+  }
+}
+
+fn Main() -> i32 {
+  var f: IntFactory = {};
+  var g: PotatoFactory = {};
+  Print("{0}", F(f));
+  Print("{0}", G(f));
+  Print("{0}", G(g));
+  Print("{0}", H(g));
+  Print("{0}", I(g));
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d0accc7215bdb8744f4809bb73c082ded2779896
+++ b/toolchain/semantics/fuzzer_corpus/d0accc7215bdb8744f4809bb73c082ded2779896
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+interface HasAssoc {
+  let Assoc:! type;
+}
+class X {
+  impl as HasAssoc where .Assoc = i32 {}
+}
+
+alias WithoutRewrite = HasAssoc where .Assoc == i32;
+alias WithRewrite = HasAssoc where .Assoc = i32;
+
+fn G[T:! WithoutRewrite](x: T) -> i32 {
+  // TODO: We should reject this once `==` isn't applied automatically.
+  var a: T.(WithRewrite.Assoc) = 2;
+  return a;
+}
+
+fn Main() -> i32 {
+  var x: X = {};
+  return G(x);
+}

--- a/toolchain/semantics/fuzzer_corpus/d123ae0a5af4fc579954ea2a6791752f3cd0b6ec
+++ b/toolchain/semantics/fuzzer_corpus/d123ae0a5af4fc579954ea2a6791752f3cd0b6ec
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+interface Similar(T:! type) {}
+
+impl forall [T:! type] T as Similar(T) {}
+impl forall [T:! type] i32 as Similar(T) {}
+
+fn CheckSimilar[T:! type, U:! Similar(T)](a: T, b: U) {}
+
+fn Main() -> i32 {
+  let n: i32 = 0;
+  CheckSimilar(true, false);
+  CheckSimilar(true, n);
+  // CHECK:STDERR: COMPILATION ERROR: fail_param_interface_in_impl.carbon:[[@LINE+1]]: could not find implementation of interface Similar(T = i32) for bool
+  CheckSimilar(n, false);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d156bf026dca3e2ad0c6542dcfbc5adb2b92d984
+++ b/toolchain/semantics/fuzzer_corpus/d156bf026dca3e2ad0c6542dcfbc5adb2b92d984
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest impl;
+
+interface I {}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_call_at_compile_time.carbon:[[@LINE+1]]: Print called before run time
+impl forall [T:! String] Print(T) as I {}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/d1d59cb9c1123806753ceededad1e68260f28c02
+++ b/toolchain/semantics/fuzzer_corpus/d1d59cb9c1123806753ceededad1e68260f28c02
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 4
+
+package ExplorerTest api;
+
+fn F[T:! ImplicitAs(type)](x: T) -> type { return x; }
+
+fn Main() -> i32 {
+  var v: (i32, i32) as type = (1, 2);
+  var w: F((i32, i32)) = (3, 4);
+  v = w;
+  return v[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/d2080d3e83e7cd6bcf8502acc028ff081acfba37
+++ b/toolchain/semantics/fuzzer_corpus/d2080d3e83e7cd6bcf8502acc028ff081acfba37
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn F() -> () {
+  return ();
+}
+
+fn Main() -> i32 {
+  F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d2128bc393e5c6c0f97aa258700f37ade1d467ee
+++ b/toolchain/semantics/fuzzer_corpus/d2128bc393e5c6c0f97aa258700f37ade1d467ee
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Id(t: type) -> auto { return t; }
+
+// Test non-trivial type expression in parameter type.
+
+fn f(x: Id(i32)) -> i32 {
+  return x;
+}
+
+fn Main() -> i32 {
+  return f(0);
+}

--- a/toolchain/semantics/fuzzer_corpus/d24fb7aa6d76ab5a6e9095f88f1e6068791c2d93
+++ b/toolchain/semantics/fuzzer_corpus/d24fb7aa6d76ab5a6e9095f88f1e6068791c2d93
@@ -1,0 +1,42 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Initialize c from initializing expression (return <expr>)
+// CHECK:STDOUT: Entering call
+// CHECK:STDOUT: 0: Heap{}, 1: !Uninit<class C>
+// CHECK:STDOUT: Object created, returning
+// CHECK:STDOUT: 0: Heap{}, 1: !Uninit<class C>, 2: C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: 0: Heap{}, 1: C{}, 2: !!C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("c destroyed");
+  }
+}
+
+fn CallWithReturnExpression() -> C {
+  Print("Entering call");
+  heap.PrintAllocs();
+  var c: C = {};
+  Print("Object created, returning");
+  heap.PrintAllocs();
+  return c;
+}
+
+fn FromInitializingExpression_ReturnExpr() {
+  Print("Initialize c from initializing expression (return <expr>)");
+  var c: C = CallWithReturnExpression();
+  heap.PrintAllocs();
+}
+
+fn Main() -> i32 {
+  FromInitializingExpression_ReturnExpr();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d44923d4ad9d5e88759b7e8b73ba96656144547d
+++ b/toolchain/semantics/fuzzer_corpus/d44923d4ad9d5e88759b7e8b73ba96656144547d
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package ExplorerTest api;
+
+var call_count: i32 = 0;
+fn ReturnTrue() -> bool {
+  call_count = call_count + 1;
+  return true;
+}
+
+fn Main() -> i32 {
+  var result: bool = ReturnTrue() and ReturnTrue();
+  return if result then call_count else -1;
+}

--- a/toolchain/semantics/fuzzer_corpus/d5bf5d73d3d23dda8fcefdc6ee677656b43ebad8
+++ b/toolchain/semantics/fuzzer_corpus/d5bf5d73d3d23dda8fcefdc6ee677656b43ebad8
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Never actually called, so this only tests typechecking and semantic analysis.
+fn F(n: i32, p: i32*, q: i32***) -> i32* {
+  var a: i32 = n * *p;
+  var b: i32 = a*n;
+  *p = b*(*p);
+  **q = p;
+  return **q;
+}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d5dd762e4ac174102440e69ee85eaf4c0d8cf532
+++ b/toolchain/semantics/fuzzer_corpus/d5dd762e4ac174102440e69ee85eaf4c0d8cf532
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: auto = 2;
+  while (x != 0) {
+    x = x - 1;
+    continue;
+    x = x + 1;
+  }
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/d6c15493108686c94662f0b08ed99e626e16fab7
+++ b/toolchain/semantics/fuzzer_corpus/d6c15493108686c94662f0b08ed99e626e16fab7
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = #'''
+    A block string literal
+    \
+    '''#;
+  if (s == "A block string literal\n\\\n") {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/d6e613d75099261a4c26abf0efbf03f48084e913
+++ b/toolchain/semantics/fuzzer_corpus/d6e613d75099261a4c26abf0efbf03f48084e913
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1: 1
+// CHECK:STDOUT: 2: 2
+// CHECK:STDOUT: 3: 3
+// CHECK:STDOUT: 4: 4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A {
+  var n: i32;
+  impl as ImplicitAs(i32) {
+    fn Convert[self: Self]() -> i32 { return self.n; }
+  }
+}
+impl i32 as ImplicitAs(A) {
+  fn Convert[self: Self]() -> A { return {.n = self}; }
+}
+
+fn Main() -> i32 {
+  var arr1: [i32; 2] = (1, 2 as A);
+  Print("1: {0}", arr1[0]);
+  Print("2: {0}", arr1[1]);
+
+  var arr2: [A; 2] = (3, 4 as A);
+  Print("3: {0}", arr2[0].n);
+  Print("4: {0}", arr2[1].n);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d6ebebabaf129b9b53a10b3287236c126c4dd4c4
+++ b/toolchain/semantics/fuzzer_corpus/d6ebebabaf129b9b53a10b3287236c126c4dd4c4
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+choice AB {
+  A(),
+  B()
+}
+
+fn F() -> AB { return AB.A(); }
+
+fn Main() -> i32 {
+  match ((F(), F(), F(), F(), F(), F(), F(), F())) {
+    case (AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 0; }
+    case (AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 1; }
+    case (_: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 2; }
+    case (_: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 3; }
+    case (_: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 4; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A()) => { return 5; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A()) => { return 6; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A()) => { return 7; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 8; }
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/d6fd5d90b6e7549eaf183f533f12c616678538ae
+++ b/toolchain/semantics/fuzzer_corpus/d6fd5d90b6e7549eaf183f533f12c616678538ae
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_impl_as.carbon:[[@LINE+1]]: expected a constraint in impl declaration, found i32
+impl i32 as i32 {}
+
+fn Main() -> i32 {
+}

--- a/toolchain/semantics/fuzzer_corpus/d7d015ff09dfb67f0799dfeeeb735565887e4b50
+++ b/toolchain/semantics/fuzzer_corpus/d7d015ff09dfb67f0799dfeeeb735565887e4b50
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = '''
+    A block string literal
+    \'''
+    ''';
+  if (s == "A block string literal\n'''\n") {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/d89723c25665ed5021dd28e45776c750d82b0185
+++ b/toolchain/semantics/fuzzer_corpus/d89723c25665ed5021dd28e45776c750d82b0185
@@ -1,0 +1,92 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class ListElement{
+  fn Create(value: i32)->ListElement{
+    return {
+      .element = Optional(i32).Create(value),
+      .next = Optional(ListElement*).CreateEmpty()
+    };
+  }
+
+  fn set[addr self: Self*] (value: Optional(ListElement*)){
+    (*self).next = value;
+  }
+
+  var element: Optional(i32);
+  var next: Optional(ListElement*);
+}
+
+class List{
+  fn Create() -> List{
+    return {.next = Optional(ListElement*).CreateEmpty() };
+  }
+  fn insert[addr self: Self*] (value: i32){
+    if( not (*self).next.HasValue() ){
+      (*self).next = Optional(ListElement*).Create( heap.New(ListElement.Create(value)) );
+      return;
+    }
+    var iter: Optional(ListElement*) = (*self).next;
+    var node: auto = (iter.Get());
+    while((*node).next.HasValue()){
+      iter = (*node).next;
+      node = (iter.Get());
+    }
+    var v : ListElement* = iter.Get();
+    var x: Optional(ListElement*) = Optional(ListElement*).Create( heap.New(ListElement.Create(value) ));
+    (*v).set(x);
+  }
+
+  fn print[self: Self] (){
+    var iter: Optional(ListElement*) = self.next;
+    while(iter.HasValue()){
+      var node: auto = *(iter.Get());
+      Print("{0}",node.element.Get());
+      var node_ptr: auto = iter.Get();
+      iter = node.next;
+    }
+  }
+
+  fn clean[addr self: Self*] (){
+    var head: auto = (*self).next;
+    while(head.HasValue()){
+      var tmp: auto = head;
+      head = (*head.Get()).next;
+      heap.Delete(tmp.Get());
+    }
+    (*self).next= Optional(ListElement*).CreateEmpty();
+  }
+
+  var next: Optional(ListElement*);
+}
+
+fn Main() -> i32{
+  var list: List = List.Create();
+  list.insert(1);
+  list.insert(2);
+  list.insert(3);
+  list.insert(4);
+  list.print();
+  list.clean();
+  list.print();
+  list.insert(1);
+  list.insert(2);
+  list.insert(3);
+  list.insert(4);
+  list.print();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/d8e999fde93a63c561311ca9b1e68e6cc0a1d2f5
+++ b/toolchain/semantics/fuzzer_corpus/d8e999fde93a63c561311ca9b1e68e6cc0a1d2f5
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  fn GetX[self: Point]() -> i32 {
+    return self.x;
+  }
+
+  fn GetXY[self: Point]() -> (i32, i32) {
+    return (self.GetX(), self.y);
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  return p.GetXY()[0];
+}

--- a/toolchain/semantics/fuzzer_corpus/d8fab3ec1a5e5cc74cf915da2a182a47dde177ff
+++ b/toolchain/semantics/fuzzer_corpus/d8fab3ec1a5e5cc74cf915da2a182a47dde177ff
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: String = '''filetype
+    A "block" ""string"" literal
+      with file type indicator.
+    ''';
+  if (s == "A \"block\" \"\"string\"\" literal\n  with file type indicator.\n") {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/d982134d38f2ad7437e7faeba8a70c2d7c926b9a
+++ b/toolchain/semantics/fuzzer_corpus/d982134d38f2ad7437e7faeba8a70c2d7c926b9a
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface GetX {
+  fn DoIt[self: Self]() -> i32;
+}
+
+impl forall [template T:! type] T as GetX {
+  fn DoIt[self: Self]() -> i32 { return self.x; }
+}
+
+class C {
+  var x: i32;
+}
+
+fn Main() -> i32 {
+  var a: auto = {.x = 1, .y = 2};
+  var b: C = {.x = 3};
+  Print("{0}", a.(GetX.DoIt)());
+  Print("{0}", b.(GetX.DoIt)());
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/dacbcf23792118db3ab1ac01739fb1746f677991
+++ b/toolchain/semantics/fuzzer_corpus/dacbcf23792118db3ab1ac01739fb1746f677991
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 7
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  return (1 + 2) + 4;
+}

--- a/toolchain/semantics/fuzzer_corpus/db1e5ec70d15bbfc7afd16f53ab14b24032e6ab0
+++ b/toolchain/semantics/fuzzer_corpus/db1e5ec70d15bbfc7afd16f53ab14b24032e6ab0
@@ -1,0 +1,68 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: XYZ: 1
+// CHECK:STDOUT: XY: 1
+// CHECK:STDOUT: XZ: 1
+// CHECK:STDOUT: YZ: 2
+// CHECK:STDOUT: JustX: 1
+// CHECK:STDOUT: JustY: 2
+// CHECK:STDOUT: JustZ: 3
+// CHECK:STDOUT: None: 4
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface A {
+  fn Which() -> i32;
+}
+
+interface X {}
+interface Y {}
+interface Z {}
+
+__match_first {
+  impl forall [T:! X] T as A {
+    fn Which() -> i32 { return 1; }
+  }
+  impl forall [T:! Y] T as A {
+    fn Which() -> i32 { return 2; }
+  }
+  impl forall [T:! Z] T as A {
+    fn Which() -> i32 { return 3; }
+  }
+  impl forall [T:! type] T as A {
+    fn Which() -> i32 { return 4; }
+  }
+}
+
+class XYZ {}
+class XY {}
+class XZ {}
+class YZ {}
+class JustX {}
+class JustY {}
+class JustZ {}
+class None {}
+
+impl XYZ as X & Y & Z {}
+impl XY as X & Y {}
+impl XZ as X & Z {}
+impl YZ as Y & Z {}
+impl JustX as X {}
+impl JustY as Y {}
+impl JustZ as Z {}
+
+fn Main() -> i32 {
+  Print("XYZ: {0}", XYZ.(A.Which)());
+  Print("XY: {0}", XY.(A.Which)());
+  Print("XZ: {0}", XZ.(A.Which)());
+  Print("YZ: {0}", YZ.(A.Which)());
+  Print("JustX: {0}", JustX.(A.Which)());
+  Print("JustY: {0}", JustY.(A.Which)());
+  Print("JustZ: {0}", JustZ.(A.Which)());
+  Print("None: {0}", None.(A.Which)());
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/db794cf537ed613114f9612f9adc2218a8539120
+++ b/toolchain/semantics/fuzzer_corpus/db794cf537ed613114f9612f9adc2218a8539120
@@ -1,0 +1,28 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  if (^0 != -1) { return 11; }
+  if (^1 != -2) { return 12; }
+  if (^(-3) != 2) { return 13; }
+
+  if (3 & 6 != 2) { return 21; }
+  if (-1 & 4 != 4) { return 22; }
+  if (-1 & -2 != -2) { return 23; }
+
+  if (1 | 4 != 5) { return 31; }
+  if (5 | 3 != 7) { return 32; }
+  if (-2 | 1 != -1) { return 33; }
+
+  if (1 ^ 4 != 5) { return 41; }
+  if (5 ^ 3 != 6) { return 42; }
+  if (-2 ^ -3 != 3) { return 43; }
+
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/db8531a2205eba4d74aac481d01b5412148a8609
+++ b/toolchain/semantics/fuzzer_corpus/db8531a2205eba4d74aac481d01b5412148a8609
@@ -1,0 +1,43 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Allocate B
+// CHECK:STDOUT: DESTRUCTOR B
+// CHECK:STDOUT: DESTRUCTOR A
+// CHECK:STDOUT: Delete B
+// CHECK:STDOUT: DESTRUCTOR B
+// CHECK:STDOUT: DESTRUCTOR A
+// CHECK:STDOUT: Return
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+
+base class A{
+    destructor[self: Self] {
+        Print("DESTRUCTOR A");
+    }
+}
+
+class B {
+  extend base: A;
+    fn Create() -> Self{
+        return {.base={}};
+    }
+    destructor[self: Self] {
+        Print("DESTRUCTOR B");
+    }
+}
+
+fn Main() -> i32 {
+  Print("Allocate B");
+  var pb: B* = heap.New(B.Create());
+
+  Print("Delete B");
+  heap.Delete(pb);
+
+  Print("Return");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/dc7c445144f467eeb64983646e925ae07328bcba
+++ b/toolchain/semantics/fuzzer_corpus/dc7c445144f467eeb64983646e925ae07328bcba
@@ -1,0 +1,58 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 12345
+
+package ExplorerTest api;
+
+class Class { var a: i32; }
+class GenericClass(T:! type) { var a: T; }
+interface Interface { fn Make() -> Self; }
+interface GenericInterface(T:! type) { fn Make() -> (Self, T); }
+
+alias ClassAlias = Class;
+alias GenericClassAlias = GenericClass;
+alias ClassSpecializationAlias = GenericClassAlias(i32);
+alias InterfaceAlias = Interface;
+alias GenericInterfaceAlias = GenericInterface;
+alias InterfaceSpecializationAlias = GenericInterfaceAlias(i32);
+
+impl ClassAlias as InterfaceAlias {
+  fn Make() -> Self { return {.a = 1}; }
+}
+impl ClassSpecializationAlias as InterfaceSpecializationAlias {
+  fn Make() -> (Self, i32) { return ({.a = 2}, 3); }
+}
+alias S = {.a: i32};
+impl GenericClassAlias(S) as GenericInterfaceAlias(S) {
+  fn Make() -> (Self, {.a: i32}) { return ({.a = {.a = 4}}, {.a = 5}); }
+}
+
+fn CheckImplementsInterface[T:! Interface](x: T) -> T {
+  return T.Make();
+}
+fn CheckImplementsGenericInterface_i32
+    [T:! GenericInterface(i32)](x: T) -> (T, i32) {
+  return T.Make();
+}
+fn CheckImplementsGenericInterface_struct
+    [T:! GenericInterface(S)](x: T) -> (T, S) {
+  return T.Make();
+}
+
+fn Main() -> i32 {
+  var a: Class = {.a = 0};
+  a = CheckImplementsInterface(a);
+
+  var b: GenericClass(i32) = {.a = 0};
+  var (b2: GenericClass(i32), n: i32) =
+    CheckImplementsGenericInterface_i32(b);
+
+  var c: GenericClass({.a: i32}) = {.a = {.a = 0}};
+  var (c2: GenericClass({.a: i32}), s: S) =
+    CheckImplementsGenericInterface_struct(c);
+
+  return 10000 * a.a + 1000 * b2.a + 100 * n + 10 * c2.a.a + s.a;
+}

--- a/toolchain/semantics/fuzzer_corpus/dcf555e0afac952817e896d91358c612433ad2b2
+++ b/toolchain/semantics/fuzzer_corpus/dcf555e0afac952817e896d91358c612433ad2b2
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+class A {
+  var n: i32;
+}
+impl i32 as ImplicitAs(A) {
+  fn Convert[self: Self]() -> A { return {.n = self }; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 0};
+  a = 1;
+  return a.n;
+}

--- a/toolchain/semantics/fuzzer_corpus/de8fd526adf2973943a05700448469fece94f857
+++ b/toolchain/semantics/fuzzer_corpus/de8fd526adf2973943a05700448469fece94f857
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 122
+
+package ExplorerTest api;
+
+interface A { fn F() -> i32; }
+interface B { fn F() -> i32; }
+
+impl i32 as A { fn F() -> i32 { return 1; } }
+impl i32 as B { fn F() -> i32 { return 2; } }
+
+fn GetAB(T:! B where .Self impls A) -> i32 {
+  return 100 * T.(A.F)() + 10 * T.(B.F)() + T.F();
+}
+
+fn Main() -> i32 {
+  return GetAB(i32);
+}

--- a/toolchain/semantics/fuzzer_corpus/dea6e9dba0dfa54f07f7299afb5a8fff207fe36e
+++ b/toolchain/semantics/fuzzer_corpus/dea6e9dba0dfa54f07f7299afb5a8fff207fe36e
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class X(T:! type) {}
+
+// CHECK:STDERR: COMPILATION ERROR: fail_non_type_self.carbon:[[@LINE+1]]: `.Self` used in type of non-type generic binding `T`
+fn F[T:! X(.Self)](x: T) {}
+
+fn Main() -> i32 { return 0; }

--- a/toolchain/semantics/fuzzer_corpus/def696015dee4401e01d3f28ae43b4c142f8685f
+++ b/toolchain/semantics/fuzzer_corpus/def696015dee4401e01d3f28ae43b4c142f8685f
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_raw_more_hash_tags_on_left.carbon:[[@LINE+2]]: missing closing quote in single-line string: ##"str"#) {
+  // CHECK:STDERR:
+  if (s == ##"str"#) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("str");
+}

--- a/toolchain/semantics/fuzzer_corpus/dfc5226bc4e3ae2646b9ebc457e2d8b5c0af703f
+++ b/toolchain/semantics/fuzzer_corpus/dfc5226bc4e3ae2646b9ebc457e2d8b5c0af703f
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: DESTRUCTOR A 0
+// CHECK:STDOUT: DESTRUCTOR A 1
+// CHECK:STDOUT: DESTRUCTOR A 2
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+
+class A{
+    destructor[self: Self]{
+        Print("DESTRUCTOR A {0}",self.n);
+    }
+    var n: i32;
+}
+
+fn Main() -> i32 {
+  var a1: A = {.n = 2};
+  var a: [A; 2] = ({.n = 1},{.n = 0});
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/e03ed52b86e8c3c447feddc1c1c9c1e8a9d11a68
+++ b/toolchain/semantics/fuzzer_corpus/e03ed52b86e8c3c447feddc1c1c9c1e8a9d11a68
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_negative_size.carbon:[[@LINE+1]]: Array size cannot be negative
+  var x: [i32; -1] = ();
+  return x[0];
+}

--- a/toolchain/semantics/fuzzer_corpus/e0d6028299cf3768cc940ded9a62d55f552626cf
+++ b/toolchain/semantics/fuzzer_corpus/e0d6028299cf3768cc940ded9a62d55f552626cf
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_unknown_namespace.carbon:[[@LINE+1]]: name 'N' has not been declared in this scope
+fn N.F() {}
+
+fn Main() -> i32 {
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/e1138048729d4c9b1b655debd816e6f8fa5db3c5
+++ b/toolchain/semantics/fuzzer_corpus/e1138048729d4c9b1b655debd816e6f8fa5db3c5
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 42
+
+package ExplorerTest api;
+
+class A {
+  extend impl as ImplicitAs(i32) {
+    fn Convert[self: Self]() -> i32 { return 42; }
+  }
+}
+
+fn Main() -> i32 {
+  var a: A = {};
+  return a;
+}

--- a/toolchain/semantics/fuzzer_corpus/e19b661a0932282f448caf7d3fedd3b8c48fa551
+++ b/toolchain/semantics/fuzzer_corpus/e19b661a0932282f448caf7d3fedd3b8c48fa551
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var f: __Fn() -> Point = Point.Origin;
+  return f().x;
+}

--- a/toolchain/semantics/fuzzer_corpus/e25ab871af04cab76fa6c546132504aa96f3faaf
+++ b/toolchain/semantics/fuzzer_corpus/e25ab871af04cab76fa6c546132504aa96f3faaf
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package Foo api;
+class X {
+  fn F[self: Self](o: Self) -> Self { return {.n = self.n + o.n}; }
+  var n: i32;
+}
+fn Main() -> i32 {
+  var v: X = {.n = 1};
+  var w: X = {.n = 2};
+  return v.(X.F)(w).(X.n);
+}

--- a/toolchain/semantics/fuzzer_corpus/e2898735f5262d6c50f82f32ce5064b75a295a65
+++ b/toolchain/semantics/fuzzer_corpus/e2898735f5262d6c50f82f32ce5064b75a295a65
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var x: [i32;] = (0, 1);
+  var index: i32 = 1;
+  x[index] = 0;
+  return x[0] + x[1];
+}

--- a/toolchain/semantics/fuzzer_corpus/e2fab09c2abe74d199bcb899a087b265b1c3be60
+++ b/toolchain/semantics/fuzzer_corpus/e2fab09c2abe74d199bcb899a087b265b1c3be60
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 6
+
+package ExplorerTest api;
+
+// The constraint here resolves to:
+//
+//   MulWith(T) where <ConstraintSelf>.(MulWith(T).Result) == <ConstraintSelf>
+//
+// Note in particular that this involves a member of `MulWith(T)`, so we need
+// `T` to have a symbolic identity when checking its own type.
+fn DoMul[T:! MulWith(.Self) where .Result == .Self](x: T, y: T) -> T {
+  return x * y;
+}
+
+fn Main() -> i32 {
+  return DoMul(2, 3);
+}

--- a/toolchain/semantics/fuzzer_corpus/e43ad190c7a05b408d5b8f37b249188ad17d604e
+++ b/toolchain/semantics/fuzzer_corpus/e43ad190c7a05b408d5b8f37b249188ad17d604e
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_too_many_args.carbon:[[@LINE+1]]: Print takes 1 or 2 arguments, received 5
+  Print("too", "many", "args", "to", "print");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/e4423a3ef9ca66952fa4b4d7f5cbbca5adfd0f9c
+++ b/toolchain/semantics/fuzzer_corpus/e4423a3ef9ca66952fa4b4d7f5cbbca5adfd0f9c
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Nice!
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var i: i32 = Rand(0, 100);
+  var j: i32 = Rand(0, 100);
+  if (i == j) {
+    Print("HALLO WELT");
+  } else {
+    Print("Nice!");
+  }
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/e46d4e048f036d89c5cca5f3162868a8c5a6f117
+++ b/toolchain/semantics/fuzzer_corpus/e46d4e048f036d89c5cca5f3162868a8c5a6f117
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+
+fn Main() -> i32 {
+  var ar: [i32; 0] = () ;
+  var count : i32 = 0;
+  for( x: i32 in ar ){
+      count = 2;
+  }
+  return count;
+}

--- a/toolchain/semantics/fuzzer_corpus/e55351de4fa2d74ad5b31c7043567f06eecfa80d
+++ b/toolchain/semantics/fuzzer_corpus/e55351de4fa2d74ad5b31c7043567f06eecfa80d
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+choice AB {
+  A(),
+  B()
+}
+
+fn F() -> AB { return AB.A(); }
+
+fn Main() -> i32 {
+  // This is T8 from http://moscova.inria.fr/~maranget/papers/warn/warn014.html
+  match ((F(), F(), F(), F(), F(), F(), F(), F())) {
+    case (AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 0; }
+    case (AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 1; }
+    case (_: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 2; }
+    case (_: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 3; }
+    case (_: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 4; }
+    case (_: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 5; }
+    case (_: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 6; }
+    case (_: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B(), AB.B()) => { return 7; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A(), AB.A()) => { return 8; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B(), AB.B()) => { return 9; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A(), AB.A()) => { return 10; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B(), AB.B()) => { return 11; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A(), AB.A()) => { return 12; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.B()) => { return 13; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.A()) => { return 14; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 15; }
+  }
+}

--- a/toolchain/semantics/fuzzer_corpus/e63c8f2e9bfe81106c2ee20701edc9503166b5a0
+++ b/toolchain/semantics/fuzzer_corpus/e63c8f2e9bfe81106c2ee20701edc9503166b5a0
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+choice AB {
+  A(),
+  B()
+}
+
+fn F() -> AB { return AB.A(); }
+
+fn Main() -> i32 {
+  // Note, this match is exhaustive, but it exceeds our depth limit.
+  match ((F(), F(), F(), F(), F(), F(), F(), F(), F())) {
+    case (AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 0; }
+    case (AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 1; }
+    case (_: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 2; }
+    case (_: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 3; }
+    case (_: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 4; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A(), AB.A()) => { return 5; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A(), AB.A()) => { return 6; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A(), AB.A()) => { return 7; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B(), AB.A()) => { return 8; }
+    case (_: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  _: AB,  AB.B()) => { return 9; }
+  }
+// CHECK:STDERR: COMPILATION ERROR: fail_exhaustive_exponential_9x.carbon:[[@LINE+1]]: non-exhaustive match may allow control-flow to reach the end of a function that provides a `->` return type
+}

--- a/toolchain/semantics/fuzzer_corpus/e658fe116862210da87f0899577af9c2a39229c7
+++ b/toolchain/semantics/fuzzer_corpus/e658fe116862210da87f0899577af9c2a39229c7
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 12
+
+package ExplorerTest api;
+
+interface Runnable {
+  fn Run[self: Self]() -> i32;
+}
+
+interface Walkable {
+  fn Walk[self: Self]() -> i32;
+}
+
+constraint Traversible {
+  extend Runnable;
+  extend Walkable;
+}
+
+impl i32 as Traversible {
+  fn Run[self: i32]() -> i32 {
+    return 10 * self;
+  }
+  fn Walk[self: i32]() -> i32 {
+    return self + 1;
+  }
+}
+
+fn Main() -> i32 {
+  var n: i32 = 1;
+  return n.(Runnable.Run)() + n.(Walkable.Walk)();
+}

--- a/toolchain/semantics/fuzzer_corpus/e65f9f71488ae494dab2a1769c8f7aad2b2d2c0e
+++ b/toolchain/semantics/fuzzer_corpus/e65f9f71488ae494dab2a1769c8f7aad2b2d2c0e
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+var call_count: i32 = 0;
+fn ReturnTrue() -> bool {
+  call_count = call_count + 1;
+  return true;
+}
+
+fn Main() -> i32 {
+  var result: bool = ReturnTrue() or ReturnTrue();
+  return if result then call_count else -1;
+}

--- a/toolchain/semantics/fuzzer_corpus/e78a1c7691f0f1d0cfbb72f2769c496375dd04ba
+++ b/toolchain/semantics/fuzzer_corpus/e78a1c7691f0f1d0cfbb72f2769c496375dd04ba
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var v: bool;
+  // CHECK:STDERR: COMPILATION ERROR: fail_if_cond.carbon:[[@LINE+1]]: use of uninitialized variable v
+  return if v then 1 else 2;
+}

--- a/toolchain/semantics/fuzzer_corpus/e7ef2c2d8afe215740b56deaf30a4b4bfdf8d155
+++ b/toolchain/semantics/fuzzer_corpus/e7ef2c2d8afe215740b56deaf30a4b4bfdf8d155
@@ -1,0 +1,15 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Hello world!
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var s: auto = "Hello world!";
+  Print(s);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/e8c9f04411d114789432f5b5ee69a579154b1efc
+++ b/toolchain/semantics/fuzzer_corpus/e8c9f04411d114789432f5b5ee69a579154b1efc
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+class Point(T:! type) {
+  var x: T;
+  var y: T;
+}
+
+fn GetX[T:! type](pt: Point(T)) -> T {
+  return pt.x;
+}
+fn GetY(T:! type, pt: Point(T)) -> T {
+  return pt.y;
+}
+
+fn Main() -> i32 {
+  var p: Point(i32) = {.x = 1, .y = 2};
+  // TODO: Should `GetX({.x = 1, .y = 2})` work? See #1251.
+  return GetX(p) + GetY(i32, {.x = 3, .y = 4});
+}

--- a/toolchain/semantics/fuzzer_corpus/e8f83f0475b7aa7415e190c94ce1a42a0bdae647
+++ b/toolchain/semantics/fuzzer_corpus/e8f83f0475b7aa7415e190c94ce1a42a0bdae647
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package ExplorerTest api;
+
+
+
+
+fn Main() -> i32 {
+  var ar: [i32; 4] = (0, 1,2,3);
+  var count : i32 = 0;
+  for( x: i32 in ar){
+      count = count +x;
+      if( x == 2){
+        break;
+      }
+  }
+  return count;
+}

--- a/toolchain/semantics/fuzzer_corpus/e8f8d81bcb2d00b480af6a7e6b469642d79a301e
+++ b/toolchain/semantics/fuzzer_corpus/e8f8d81bcb2d00b480af6a7e6b469642d79a301e
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: COMPILATION ERROR: fail_assign_to_rval.carbon:[[@LINE+1]]: Only a reference expression can be assigned to, but got `1`
+  1 = 0;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/e9cbf6617e536aeba214c934e3bdaf0c078353ff
+++ b/toolchain/semantics/fuzzer_corpus/e9cbf6617e536aeba214c934e3bdaf0c078353ff
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Print: {0}
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  Print("Print: {{0}");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ea54be10885ecba80b88fbd97086a791b0717a88
+++ b/toolchain/semantics/fuzzer_corpus/ea54be10885ecba80b88fbd97086a791b0717a88
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 5
+
+package ExplorerTest api;
+
+interface HasTypeAndValue {
+  let T:! type;
+  let V:! T;
+}
+
+fn F(X:! HasTypeAndValue where .T = i32 and .V = 5) -> i32 { return X.V; }
+
+impl i32 as HasTypeAndValue where .T = i32 and .V = 5 {}
+
+fn Main() -> i32 {
+  return F(i32);
+}

--- a/toolchain/semantics/fuzzer_corpus/ea9a466902e7e5de89ab73b1fb426fc8b5a6d995
+++ b/toolchain/semantics/fuzzer_corpus/ea9a466902e7e5de89ab73b1fb426fc8b5a6d995
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package ExplorerTest api;
+
+var x: i32;
+
+fn Main() -> i32 {
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/eb86ced910a15a563fdf6b97b35561ad7a62634a
+++ b/toolchain/semantics/fuzzer_corpus/eb86ced910a15a563fdf6b97b35561ad7a62634a
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 1
+
+package Foo api;
+interface A { fn F() -> i32; }
+class X {
+  extend impl as A {
+    fn F() -> i32 { return 1; }
+  }
+}
+fn Main() -> i32 {
+  var a: X = {};
+  return a.(A.F)();
+}

--- a/toolchain/semantics/fuzzer_corpus/ebde8bbea6e7af4fb072907cfc9be00d971239ee
+++ b/toolchain/semantics/fuzzer_corpus/ebde8bbea6e7af4fb072907cfc9be00d971239ee
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "Attempted to unwrap empty Optional"
+
+package ExplorerTest api;
+
+fn Main() -> i32{
+  var x: Optional(i32) = Optional(i32).CreateEmpty();
+  return x.Get();
+}

--- a/toolchain/semantics/fuzzer_corpus/ed4b817bb59e605b98255e448092e811f6e82a1b
+++ b/toolchain/semantics/fuzzer_corpus/ed4b817bb59e605b98255e448092e811f6e82a1b
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+interface Vector {
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Point {
+  var x: i32;
+  var y: i32;
+  extend impl as Vector {
+    fn Add[self: Point](b: Point) -> Point {
+      return {.x = self.x + b.x, .y = self.y + b.y};
+    }
+    fn Scale[self: Point](v: i32) -> Point {
+      return {.x = self.x * v, .y = self.y * v};
+    }
+  }
+}
+
+fn AddAndScaleGeneric[T:! Vector](a: T, b: T, s: i32) -> T {
+  var m: __Fn(T)->T = a.Add;
+  var n: __Fn(i32)->T = m(b).Scale;
+  return n(s);
+}
+
+fn Main() -> i32 {
+  var a: Point = {.x = 1, .y = 1};
+  var b: Point = {.x = 2, .y = 3};
+  var p: Point = AddAndScaleGeneric(a, b, 5);
+  return p.x - 15;
+}

--- a/toolchain/semantics/fuzzer_corpus/ef2e0af90b23b181ff4232ff151921baabbd6279
+++ b/toolchain/semantics/fuzzer_corpus/ef2e0af90b23b181ff4232ff151921baabbd6279
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: test
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn F() { Print("test"); }
+
+fn Main() -> i32 {
+  var p: auto = heap.New(F);
+  var y: auto = *p;
+  y();
+  heap.Delete(p);
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/ef85503e869dddcd31e3fda607c157093dd58aaa
+++ b/toolchain/semantics/fuzzer_corpus/ef85503e869dddcd31e3fda607c157093dd58aaa
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+// CHECK:STDERR: COMPILATION ERROR: fail_fn_use_in_return_type.carbon:[[@LINE+1]]: 'F' is not usable until after it has been completely declared
+fn F() -> F() {
+  return type;
+}
+
+fn Main() -> i32 {
+  return x;
+}

--- a/toolchain/semantics/fuzzer_corpus/efca78c56911295c843344e70430e1f2a76ac3dd
+++ b/toolchain/semantics/fuzzer_corpus/efca78c56911295c843344e70430e1f2a76ac3dd
@@ -1,0 +1,33 @@
+
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class B {
+  var x: i32;
+
+  fn GetSetX[addr self: Self*](x: i32) -> i32 {
+    var oldX: auto = (*self).x;
+    (*self).x = x;
+    return oldX;
+  }
+}
+
+class A {
+  var b: B;
+}
+
+fn Main() -> i32 {
+  var b: B = {.x = 0};
+  var a: A = {.b = b};
+  var x: auto = a.b.GetSetX(42);
+  if (a.b.x == 42) {
+    return x;
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/f2a23da83d1decfbd0d6b632d4e3a7c0fe83229a
+++ b/toolchain/semantics/fuzzer_corpus/f2a23da83d1decfbd0d6b632d4e3a7c0fe83229a
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t1: {.x: i32,} = {.x = 5,};
+  var t2: {.x: i32, .y: i32} = {.x = 2, .y = 3,};
+  return t1.x - t2.x - t2.y;
+}

--- a/toolchain/semantics/fuzzer_corpus/f30e3a9ba4c393a1638833cb39b1af2fcf2c8f09
+++ b/toolchain/semantics/fuzzer_corpus/f30e3a9ba4c393a1638833cb39b1af2fcf2c8f09
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: -6
+
+package ExplorerTest api;
+
+class A { var n: i32; }
+
+impl A as BitComplement where .Result = A {
+  fn Op[self: Self]() -> A { return {.n = ^self.n}; }
+}
+
+fn Main() -> i32 {
+  var a: A = {.n = 5};
+  a = ^a;
+  return a.n;
+}

--- a/toolchain/semantics/fuzzer_corpus/f34cf0e7e074d139df2a5550a9cb7bb904947386
+++ b/toolchain/semantics/fuzzer_corpus/f34cf0e7e074d139df2a5550a9cb7bb904947386
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var t: auto = (1, 2, 3, 4);
+  match (t) {
+    case (_: i32, _: auto, x: i32, y: auto) => {
+      return y - x - 1;
+    }
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/f4644987ac7761e6269cc798952123a412d60579
+++ b/toolchain/semantics/fuzzer_corpus/f4644987ac7761e6269cc798952123a412d60579
@@ -1,0 +1,11 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 2
+
+package Foo api;
+fn Main() -> i32 {
+  return {.m = 1, .n = 2}.({.n: i32, .m: i32}.n);
+}

--- a/toolchain/semantics/fuzzer_corpus/f489479b6711f206c1674ab760a65ae1f611d23c
+++ b/toolchain/semantics/fuzzer_corpus/f489479b6711f206c1674ab760a65ae1f611d23c
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: result: 0
+
+package Foo api;
+class X {
+  fn F[self: Self]() -> i32 { return self.n; }
+  var n: i32;
+}
+fn Main() -> i32 {
+  var v: X = {.n = 1};
+  let p: X* = &v;
+  Print("{0}", p->n);
+  Print("{0}", p->(X.n));
+  Print("{0}", p->F());
+  Print("{0}", p->(X.F)());
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/f50ed08142a8c7abf9eb8a0fe9a1560172460772
+++ b/toolchain/semantics/fuzzer_corpus/f50ed08142a8c7abf9eb8a0fe9a1560172460772
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+__mixin Operations {
+  fn F[self: Self](x: Self) -> Self{
+     return x;
+  }
+}
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+  __mix Operations;
+}
+
+class Complex {
+  fn Zero() -> Complex {
+    return {.r = 0, .i = 0};
+  }
+
+  var r: i32;
+  var i: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  var c: Complex = {.r = 42, .i = 1};
+  // CHECK:STDERR: COMPILATION ERROR: fail_self_substitution.carbon:[[@LINE+1]]: mismatch in non-deduced types, `class Complex` is not implicitly convertible to `class Point`
+  var p1: Point = p.F(c);
+
+  return p1.x - 42;
+}

--- a/toolchain/semantics/fuzzer_corpus/f684767b7018726978f04cec28fc3505e830c280
+++ b/toolchain/semantics/fuzzer_corpus/f684767b7018726978f04cec28fc3505e830c280
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 4213
+
+package ExplorerTest api;
+
+interface IntLike {
+  fn Convert[self: Self]() -> i32;
+}
+impl i32 as IntLike {
+  fn Convert[self: i32]() -> i32 { return self; }
+}
+
+fn add[T:! IntLike](x: {.a: T, .b: ({.m: i32, .n: T}, i32)}) -> i32 {
+  return 1000 * x.a.Convert() + 100 * x.b[0].m + 10 * x.b[0].n.Convert() + x.b[1];
+}
+
+fn Main() -> i32 {
+  return add({.b = ({.n = 1, .m = 2}, 3), .a = 4});
+}

--- a/toolchain/semantics/fuzzer_corpus/f690876af2536fe2aa69e30d6b0ed44df3ab37cf
+++ b/toolchain/semantics/fuzzer_corpus/f690876af2536fe2aa69e30d6b0ed44df3ab37cf
@@ -1,0 +1,19 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == #"str"#) {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("str");
+}

--- a/toolchain/semantics/fuzzer_corpus/f7393ed8d9481808807434d4e757e0f8b11199f2
+++ b/toolchain/semantics/fuzzer_corpus/f7393ed8d9481808807434d4e757e0f8b11199f2
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: Destructor A 3
+// CHECK:STDOUT: Destructor A 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A {
+  var i: i32;
+  destructor[self: Self] {
+    Print("Destructor A {0}", self.i);
+  }
+}
+
+fn Main() -> i32 {
+  var a0: A;
+  var a1: A = {.i = 1};
+  var a2: A;
+  var a3: A = {.i = 3};
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/f76a0f5a984ac0ce2b83dfd9b9a0f98a23c10db8
+++ b/toolchain/semantics/fuzzer_corpus/f76a0f5a984ac0ce2b83dfd9b9a0f98a23c10db8
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Shape {
+  var x: i32;
+}
+
+class Point {
+
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  fn GetSetX[addr self: Shape*](x: i32) -> i32 {
+    var old: auto = (*self).x;
+    (*self).x = x;
+    return old;
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  // CHECK:STDERR: COMPILATION ERROR: fail_method_self_type.carbon:[[@LINE+3]]: type error in method access, receiver type
+  // CHECK:STDERR: expected: class Shape
+  // CHECK:STDERR: actual: class Point
+  var x: auto = p.GetSetX(42);
+  if (p.x == 42) {
+    return x;
+  }
+  return 1;
+}

--- a/toolchain/semantics/fuzzer_corpus/f7b635ace4157cf9aa35bf097ed316f49a1eeb4d
+++ b/toolchain/semantics/fuzzer_corpus/f7b635ace4157cf9aa35bf097ed316f49a1eeb4d
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDERR: RUNTIME ERROR: {{.*}}/explorer/data/prelude.carbon:{{.*}}: "HALLO WELT"
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  Assert(false, "HALLO WELT");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/f7e0b4168e589c4c297e0247cc3d5f18c7251880
+++ b/toolchain/semantics/fuzzer_corpus/f7e0b4168e589c4c297e0247cc3d5f18c7251880
@@ -1,0 +1,14 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  var p: {.x: i32, .y: i32};
+  // CHECK:STDERR: COMPILATION ERROR: fail_struct_member_access.carbon:[[@LINE+1]]: use of uninitialized variable p
+  p.x = p.y;
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/f842eee360ff15762e838268ea620397372e278f
+++ b/toolchain/semantics/fuzzer_corpus/f842eee360ff15762e838268ea620397372e278f
@@ -1,0 +1,31 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: Initialize c from reference expression
+// CHECK:STDOUT: 0: Heap{}, 1: C{}
+// CHECK:STDOUT: c destroyed
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class C {
+  destructor[self: Self] {
+    Print("c destroyed");
+  }
+}
+
+fn FromReferenceExpression() {
+  var c_var: C = {};
+  heap.PrintAllocs();
+  Print("Initialize c from reference expression");
+  let c: C = c_var;
+  heap.PrintAllocs();
+}
+
+fn Main() -> i32 {
+  FromReferenceExpression();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/f86b41031c5d4d3bdac24f679b6057470f3e47c7
+++ b/toolchain/semantics/fuzzer_corpus/f86b41031c5d4d3bdac24f679b6057470f3e47c7
@@ -1,0 +1,20 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+namespace N;
+fn N.F() {}
+
+alias A = N;
+alias B = A;
+alias C = B;
+
+fn Main() -> i32 {
+  C.F();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/faf03b2cec7b27856ad2faf2221466957630a6a5
+++ b/toolchain/semantics/fuzzer_corpus/faf03b2cec7b27856ad2faf2221466957630a6a5
@@ -1,0 +1,13 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+fn Main() -> i32 {
+  // CHECK:STDERR: SYNTAX ERROR: fail_hex_truncated.carbon:[[@LINE+1]]: Invalid escaping in string: "str\x"
+  Print("str\x");
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/fb9a1ebda410782881e93d1375d0199654fc3671
+++ b/toolchain/semantics/fuzzer_corpus/fb9a1ebda410782881e93d1375d0199654fc3671
@@ -1,0 +1,55 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: 1
+// CHECK:STDOUT: 2
+// CHECK:STDOUT: 3
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: 4
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: 5
+// CHECK:STDOUT: 6
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class A(T:! type, U:! type) {}
+interface B(T:! type, U:! type) { fn F(); }
+
+impl forall [T:! type] A(T, i32) as B(i32, i32) {
+  fn F() { Print("1"); }
+}
+impl forall [T:! type] A(i32, T) as B(i32, i32) {
+  fn F() { Print("2"); }
+}
+// Intentionally out of order so that explorer can't get the right answer by
+// chance, by just picking the first or last matching impl.
+impl forall [T:! type] A(i32, i32) as B(i32, T) {
+  fn F() { Print("4"); }
+}
+impl forall [T:! type] A(i32, i32) as B(T, i32) {
+  fn F() { Print("3"); }
+}
+
+impl forall [T:! type, U:! type] A(T, i32*) as B(i32*, U) {
+  fn F() { Print("5"); }
+}
+impl forall [T:! type, U:! type] A(i32*, T) as B(U, i32*) {
+  fn F() { Print("6"); }
+}
+
+fn Main() -> i32 {
+  A((), i32).(B(i32, i32).F)();
+  A(i32, ()).(B(i32, i32).F)();
+  A(i32, i32).(B((), i32).F)();
+  A(i32, i32).(B(i32, ()).F)();
+
+  A(i32, i32).(B(i32, i32).F)();
+
+  A(i32*, i32*).(B(i32, i32*).F)();
+  A(i32*, i32*).(B(i32*, i32).F)();
+  A(i32*, i32*).(B(i32*, i32*).F)();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/fc82ae870beedef35e5a93dbcc561de9224b2809
+++ b/toolchain/semantics/fuzzer_corpus/fc82ae870beedef35e5a93dbcc561de9224b2809
@@ -1,0 +1,22 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+class Point {
+  fn Origin() -> Point {
+    return {.x = 0, .y = 0};
+  }
+
+  var x: i32;
+  var y: i32;
+}
+
+fn Main() -> i32 {
+  var p: Point = Point.Origin();
+  return p.Origin().x;
+}

--- a/toolchain/semantics/fuzzer_corpus/feeca4b33699f31e73d11b425ebb9b3d0ceced81
+++ b/toolchain/semantics/fuzzer_corpus/feeca4b33699f31e73d11b425ebb9b3d0ceced81
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+// Test empty parameters and return type
+fn f() { }
+
+fn Main() -> i32 {
+  f();
+  return 0;
+}

--- a/toolchain/semantics/fuzzer_corpus/fef2019d504daf04cb84fea614dd22be3b112ab2
+++ b/toolchain/semantics/fuzzer_corpus/fef2019d504daf04cb84fea614dd22be3b112ab2
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: result: 3
+
+package Foo api;
+
+class X {
+  fn F[self: Self](o: Self) -> Self { return {.n = self.n + o.n}; }
+  var n: i32;
+}
+
+fn Main() -> i32 {
+  return {.n = 1}.(X.F)({.n = 2}).n;
+}

--- a/toolchain/semantics/fuzzer_corpus/ffeaa3f2403ef6e7b1654d437b2417d9913c332e
+++ b/toolchain/semantics/fuzzer_corpus/ffeaa3f2403ef6e7b1654d437b2417d9913c332e
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: (*c).a: 1
+// CHECK:STDOUT: Foo(&d): 1
+// CHECK:STDOUT: result: 0
+
+package ExplorerTest api;
+
+base class C {
+  var a: i32;
+}
+
+class D {
+  extend base: C;
+}
+
+fn Foo(c: C*) -> i32 {
+  return (*c).a;
+}
+
+fn Main() -> i32 {
+  var d: D = { .base = {.a = 1} };
+  var c: C* = &d;
+  Print("(*c).a: {0}", (*c).a);
+  Print("Foo(&d): {0}", Foo(&d));
+  return 0;
+}

--- a/toolchain/semantics/semantics_fuzzer.cpp
+++ b/toolchain/semantics/semantics_fuzzer.cpp
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/driver/driver.h"
+
+namespace Carbon::Testing {
+
+// NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
+                                      std::size_t size) {
+  // Ignore large inputs.
+  // TODO: See tokenized_buffer_fuzzer.cpp.
+  if (size > 100000) {
+    return 0;
+  }
+
+  static constexpr llvm::StringLiteral TestFileName = "test.carbon";
+  llvm::vfs::InMemoryFileSystem fs;
+  llvm::StringRef data_ref(reinterpret_cast<const char*>(data), size);
+  CARBON_CHECK(fs.addFile(
+      TestFileName, /*ModificationTime=*/0,
+      llvm::MemoryBuffer::getMemBuffer(data_ref, /*BufferName=*/TestFileName,
+                                       /*RequiresNullTerminator=*/false)));
+
+  llvm::raw_null_ostream null_ostream;
+  Driver driver(fs, null_ostream, null_ostream);
+
+  // TODO: Get semantics-ir to a point where it can handle invalid parse trees
+  // without crashing.
+  if (!driver.RunFullCommand({"dump", "parse-tree", TestFileName})) {
+    return 0;
+  }
+  driver.RunFullCommand({"dump", "semantics-ir", TestFileName});
+  return 0;
+}
+
+}  // namespace Carbon::Testing


### PR DESCRIPTION
Right now we expect crashes on invalid parses, we just don't try to handle it in general even though the long-term intent is we should handle semantics for bad parses. However, in theory, we should be correctly handling code that parses as valid and that's probably more interesting to fix bugs for. So this starts trying to fuzz that space of valid parses.

Fuzzer corpus is based on explorer tests, with one merge run.