### PR TITLE
Clean up uncommented SmallVector size parameters.

### DIFF
--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -62,7 +62,7 @@ struct DiagnosticLocation {
 struct DiagnosticMessage {
   explicit DiagnosticMessage(
       DiagnosticKind kind, DiagnosticLocation location,
-      llvm::StringLiteral format, llvm::SmallVector<llvm::Any, 0> format_args,
+      llvm::StringLiteral format, llvm::SmallVector<llvm::Any> format_args,
       std::function<std::string(const DiagnosticMessage&)> format_fn)
       : kind(kind),
         location(std::move(location)),
@@ -86,7 +86,7 @@ struct DiagnosticMessage {
   // without needing to parse the formatted string; however, it should be
   // understood that diagnostic formats are subject to change and the llvm::Any
   // offers limited compile-time type safety. Integration tests are required.
-  llvm::SmallVector<llvm::Any, 0> format_args;
+  llvm::SmallVector<llvm::Any> format_args;
 
   // Returns the formatted string. By default, this uses llvm::formatv.
   std::function<std::string(const DiagnosticMessage&)> format_fn;

--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -40,7 +40,10 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
   }
 
  private:
+  // A Diagnostic is undesirably large for inline storage by SmallVector, so we
+  // specify 0.
   llvm::SmallVector<Diagnostic, 0> diagnostics_;
+
   DiagnosticConsumer* next_consumer_;
 };
 

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -41,7 +41,7 @@ extern "C" auto LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
   // exhaust all memory, so bound the search space to using 2^17 bytes of
   // memory for the argument text itself.
   size_t arg_length_sum = 0;
-  llvm::SmallVector<int, 16> arg_lengths(num_args);
+  llvm::SmallVector<int> arg_lengths(num_args);
   for (int& arg_length : arg_lengths) {
     if (!Read(data, size, arg_length) || arg_length < 0) {
       return 0;
@@ -58,7 +58,7 @@ extern "C" auto LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
   }
 
   // Lastly, read the contents of each argument out of the data.
-  llvm::SmallVector<llvm::StringRef, 16> args;
+  llvm::SmallVector<llvm::StringRef> args;
   args.reserve(num_args);
   for (int arg_length : arg_lengths) {
     args.push_back(

--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -27,7 +27,7 @@ auto main(int argc, char** argv) -> int {
   // is piped to stdout.
   llvm::errs().tie(&llvm::outs());
 
-  llvm::SmallVector<llvm::StringRef, 16> args(argv + 1, argv + argc);
+  llvm::SmallVector<llvm::StringRef> args(argv + 1, argv + argc);
   auto fs = llvm::vfs::getRealFileSystem();
   Carbon::Driver driver(*fs, llvm::outs(), llvm::errs());
   bool success = driver.RunFullCommand(args);

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -543,7 +543,7 @@ class TokenizedBuffer::Lexer {
   int current_column_ = 0;
   bool set_indent_ = false;
 
-  llvm::SmallVector<Token, 8> open_groups_;
+  llvm::SmallVector<Token> open_groups_;
 };
 
 auto TokenizedBuffer::Lex(SourceBuffer& source, DiagnosticConsumer& consumer)

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -393,17 +393,17 @@ class TokenizedBuffer {
 
   SourceBuffer* source_;
 
-  llvm::SmallVector<TokenInfo, 16> token_infos_;
+  llvm::SmallVector<TokenInfo> token_infos_;
 
-  llvm::SmallVector<LineInfo, 16> line_infos_;
+  llvm::SmallVector<LineInfo> line_infos_;
 
-  llvm::SmallVector<IdentifierInfo, 16> identifier_infos_;
+  llvm::SmallVector<IdentifierInfo> identifier_infos_;
 
   // Storage for integers that form part of the value of a numeric or type
   // literal.
-  llvm::SmallVector<llvm::APInt, 16> literal_int_storage_;
+  llvm::SmallVector<llvm::APInt> literal_int_storage_;
 
-  llvm::SmallVector<std::string, 16> literal_string_storage_;
+  llvm::SmallVector<std::string> literal_string_storage_;
 
   llvm::DenseMap<llvm::StringRef, Identifier> identifier_map_;
 

--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -218,7 +218,7 @@ class ParseTree {
                  bool preorder) const -> bool;
 
   // Depth-first postorder sequence of node implementation data.
-  llvm::SmallVector<NodeImpl, 0> node_impls_;
+  llvm::SmallVector<NodeImpl> node_impls_;
 
   TokenizedBuffer* tokens_;
 


### PR DESCRIPTION
The lack of comments makes it difficult to be sure, but if any of these are necessary, I'd like to make sure there are comments to explain why a specific value was shown (which I do add for diagnostics_ in this change).