### PR TITLE
Clean up handling of incomplete line locations.

### DIFF
--- a/toolchain/lexer/testdata/fail_block_string_second_line.carbon
+++ b/toolchain/lexer/testdata/fail_block_string_second_line.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// NOAUTOUPDATE
+
+// CHECK:STDOUT: [
+// CHECK:STDOUT: { index: 0, kind:               'Var', line: {{ *}}[[@LINE+12]], column:  1, indent:  1, spelling: 'var', has_trailing_space: true },
+// CHECK:STDOUT: { index: 1, kind:        'Identifier', line: {{ *}}[[@LINE+11]], column:  5, indent:  1, spelling: 's', identifier: 0 },
+// CHECK:STDOUT: { index: 2, kind:             'Colon', line: {{ *}}[[@LINE+10]], column:  6, indent:  1, spelling: ':', has_trailing_space: true },
+// CHECK:STDOUT: { index: 3, kind: 'StringTypeLiteral', line: {{ *}}[[@LINE+9]], column:  8, indent:  1, spelling: 'String', has_trailing_space: true },
+// CHECK:STDOUT: { index: 4, kind:             'Equal', line: {{ *}}[[@LINE+8]], column: 15, indent:  1, spelling: '=', has_trailing_space: true },
+// CHECK:STDOUT: { index: 5, kind:     'StringLiteral', line: {{ *}}[[@LINE+7]], column: 17, indent:  1, spelling: ''''
+// CHECK:STDOUT:   error here: '''', value: `error here: `, has_trailing_space: true },
+// CHECK:STDOUT: { index: 6, kind:         'EndOfFile', line: {{ *}}[[@LINE+6]], column: {{[0-9]+}}, indent: 17, spelling: '' },
+// CHECK:STDOUT: ]
+// CHECK:STDERR: fail_block_string_second_line.carbon:[[@LINE+4]]:3: Only whitespace is permitted before the closing `'''` of a multi-line string.
+// CHECK:STDERR:   error here: '''
+// CHECK:STDERR:   ^
+var s: String = '''
+  error here: '''

--- a/toolchain/lexer/testdata/fail_block_string_second_line.carbon
+++ b/toolchain/lexer/testdata/fail_block_string_second_line.carbon
@@ -2,6 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// An autoupdate wants to put the CHECK in the middle of the block string.
 // NOAUTOUPDATE
 
 // CHECK:STDOUT: [

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -905,9 +905,9 @@ auto TokenizedBuffer::SourceBufferLocationTranslator::GetLocation(
   int line_number = line_it - buffer_->line_infos_.begin();
   int column_number = offset - line_it->start;
 
-  // Start by grabbing the buffer. If the line isn't fully lexed, the length
-  // will be npos and the buffer will be grabbed from the start; we'll then
-  // adjust the length.
+  // Start by grabbing the line from the buffer. If the line isn't fully lexed,
+  // the length will be npos and the line will be grabbed from the known start
+  // to the end of the buffer; we'll then adjust the length.
   llvm::StringRef line =
       buffer_->source_->text().substr(line_it->start, line_it->length);
   if (line_it->length == static_cast<int32_t>(llvm::StringRef::npos)) {

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -360,7 +360,10 @@ class TokenizedBuffer {
   struct LineInfo {
     // The length will always be assigned later. Indent may be assigned if
     // non-zero.
-    explicit LineInfo(int64_t start) : start(start), length(-1), indent(0) {}
+    explicit LineInfo(int64_t start)
+        : start(start),
+          length(static_cast<int32_t>(llvm::StringRef::npos)),
+          indent(0) {}
 
     // Zero-based byte offset of the start of the line within the source buffer
     // provided.

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -170,18 +170,14 @@ class TokenizedBuffer {
   // buffer locations.
   class TokenLocationTranslator : public DiagnosticLocationTranslator<Token> {
    public:
-    explicit TokenLocationTranslator(const TokenizedBuffer* buffer,
-                                     int* last_line_lexed_to_column)
-        : buffer_(buffer),
-          last_line_lexed_to_column_(last_line_lexed_to_column) {}
+    explicit TokenLocationTranslator(const TokenizedBuffer* buffer)
+        : buffer_(buffer) {}
 
     // Map the given token into a diagnostic location.
     auto GetLocation(Token token) -> DiagnosticLocation override;
 
    private:
     const TokenizedBuffer* buffer_;
-    // Passed to SourceBufferLocationTranslator.
-    int* last_line_lexed_to_column_;
   };
 
   // Lexes a buffer of source code into a tokenized buffer.
@@ -298,10 +294,8 @@ class TokenizedBuffer {
   class SourceBufferLocationTranslator
       : public DiagnosticLocationTranslator<const char*> {
    public:
-    explicit SourceBufferLocationTranslator(const TokenizedBuffer* buffer,
-                                            int* last_line_lexed_to_column)
-        : buffer_(buffer),
-          last_line_lexed_to_column_(last_line_lexed_to_column) {}
+    explicit SourceBufferLocationTranslator(const TokenizedBuffer* buffer)
+        : buffer_(buffer) {}
 
     // Map the given position within the source buffer into a diagnostic
     // location.
@@ -309,9 +303,6 @@ class TokenizedBuffer {
 
    private:
     const TokenizedBuffer* buffer_;
-    // The last lexed column, for determining whether the last line should be
-    // checked for unlexed newlines. May be null after lexing is complete.
-    int* last_line_lexed_to_column_;
   };
 
   // Specifies minimum widths to use when printing a token's fields via

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -20,8 +20,7 @@ namespace Carbon {
 
 auto ParseTree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                       llvm::raw_ostream* vlog_stream) -> ParseTree {
-  TokenizedBuffer::TokenLocationTranslator translator(
-      &tokens, /*last_line_lexed_to_column=*/nullptr);
+  TokenizedBuffer::TokenLocationTranslator translator(&tokens);
   TokenDiagnosticEmitter emitter(translator, consumer);
 
   // Delegate to the parser.

--- a/toolchain/parser/parse_tree_node_location_translator.h
+++ b/toolchain/parser/parse_tree_node_location_translator.h
@@ -14,7 +14,7 @@ class ParseTreeNodeLocationTranslator
  public:
   explicit ParseTreeNodeLocationTranslator(const TokenizedBuffer* tokens,
                                            const ParseTree* parse_tree)
-      : token_translator_(tokens, nullptr), parse_tree_(parse_tree) {}
+      : token_translator_(tokens), parse_tree_(parse_tree) {}
 
   // Map the given token into a diagnostic location.
   auto GetLocation(ParseTree::Node node) -> DiagnosticLocation override {


### PR DESCRIPTION
Building on #3010, the handling of incomplete lines seems like it can be straightened out. Doing this separately because it seemed better to demonstrate tests aren't affected by the change.