### PR TITLE
Fix missing assignment to me_value found by msan.

### DIFF
--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -173,7 +173,7 @@ static auto GetPositionalElement(Nonnull<const TupleValue*> tuple,
 static auto GetNamedElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
                             const ElementPath::Component& field,
                             SourceLocation source_loc,
-                            Nonnull<const Value*> me_value)
+                            std::optional<Nonnull<const Value*>> me_value)
     -> ErrorOr<Nonnull<const Value*>> {
   CARBON_CHECK(field.element()->kind() == ElementKind::NamedElement)
       << "Invalid element, expecting NamedElement";
@@ -199,7 +199,7 @@ static auto GetNamedElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
           mem_decl.has_value()) {
         const auto& fun_decl = cast<FunctionDeclaration>(**mem_decl);
         if (fun_decl.is_method()) {
-          return arena->New<BoundMethodValue>(&fun_decl, me_value,
+          return arena->New<BoundMethodValue>(&fun_decl, *me_value,
                                               &impl_witness->bindings());
         } else {
           // Class function.
@@ -243,7 +243,7 @@ static auto GetNamedElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
           // Found a method. Turn it into a bound method.
           const auto& m = cast<FunctionValue>(**func);
           if (m.declaration().virt_override() == VirtualOverride::None) {
-            return arena->New<BoundMethodValue>(&m.declaration(), me_value,
+            return arena->New<BoundMethodValue>(&m.declaration(), *me_value,
                                                 &class_type.bindings());
           }
           // Method is virtual, get child-most class value and perform vtable
@@ -306,7 +306,7 @@ static auto GetNamedElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
 static auto GetElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
                        const ElementPath::Component& path_comp,
                        SourceLocation source_loc,
-                       Nonnull<const Value*> me_value)
+                       std::optional<Nonnull<const Value*>> me_value)
     -> ErrorOr<Nonnull<const Value*>> {
   switch (path_comp.element()->kind()) {
     case ElementKind::NamedElement:
@@ -335,7 +335,7 @@ static auto GetElement(Nonnull<Arena*> arena, Nonnull<const Value*> v,
 
 auto Value::GetElement(Nonnull<Arena*> arena, const ElementPath& path,
                        SourceLocation source_loc,
-                       Nonnull<const Value*> me_value) const
+                       std::optional<Nonnull<const Value*>> me_value) const
     -> ErrorOr<Nonnull<const Value*>> {
   Nonnull<const Value*> value(this);
   for (const ElementPath::Component& field : path.components_) {

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -73,7 +73,7 @@ class Value {
   // `me_value`, otherwise pass `*this`.
   auto GetElement(Nonnull<Arena*> arena, const ElementPath& path,
                   SourceLocation source_loc,
-                  Nonnull<const Value*> me_value) const
+                  std::optional<Nonnull<const Value*>> me_value) const
       -> ErrorOr<Nonnull<const Value*>>;
 
   // Returns a copy of *this, but with the sub-Value specified by `path`

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1486,26 +1486,23 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
             ElementPath::Component member(&access.member(), found_in_interface,
                                           witness);
             const Value* aggregate;
-            const Value* me_value;
+            Nonnull<const Value*> me_value = act.results()[0];
             std::optional<Address> lhs_address;
             if (access.is_type_access()) {
               aggregate = act.results().back();
             } else if (const auto* location =
-                           dyn_cast<LocationValue>(act.results()[0])) {
+                           dyn_cast<LocationValue>(me_value)) {
               lhs_address = location->address();
-              me_value = act.results()[0];
               CARBON_ASSIGN_OR_RETURN(
                   aggregate,
                   this->heap_.Read(location->address(), exp.source_loc()));
             } else if (const auto* expr_value =
-                           dyn_cast<ReferenceExpressionValue>(
-                               act.results()[0])) {
+                           dyn_cast<ReferenceExpressionValue>(me_value)) {
               lhs_address = expr_value->address();
-              aggregate = expr_value->value();
-              me_value = aggregate;
+              me_value = expr_value->value();
+              aggregate = me_value;
             } else {
-              aggregate = act.results()[0];
-              me_value = aggregate;
+              aggregate = me_value;
             }
             CARBON_ASSIGN_OR_RETURN(
                 Nonnull<const Value*> member_value,

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -1486,23 +1486,26 @@ auto Interpreter::StepExp() -> ErrorOr<Success> {
             ElementPath::Component member(&access.member(), found_in_interface,
                                           witness);
             const Value* aggregate;
-            Nonnull<const Value*> me_value = act.results()[0];
+            std::optional<Nonnull<const Value*>> me_value;
             std::optional<Address> lhs_address;
             if (access.is_type_access()) {
               aggregate = act.results().back();
             } else if (const auto* location =
-                           dyn_cast<LocationValue>(me_value)) {
+                           dyn_cast<LocationValue>(act.results()[0])) {
               lhs_address = location->address();
+              me_value = act.results()[0];
               CARBON_ASSIGN_OR_RETURN(
                   aggregate,
                   this->heap_.Read(location->address(), exp.source_loc()));
             } else if (const auto* expr_value =
-                           dyn_cast<ReferenceExpressionValue>(me_value)) {
+                           dyn_cast<ReferenceExpressionValue>(
+                               act.results()[0])) {
               lhs_address = expr_value->address();
-              me_value = expr_value->value();
-              aggregate = me_value;
+              aggregate = expr_value->value();
+              me_value = aggregate;
             } else {
-              aggregate = me_value;
+              aggregate = act.results()[0];
+              me_value = aggregate;
             }
             CARBON_ASSIGN_OR_RETURN(
                 Nonnull<const Value*> member_value,


### PR DESCRIPTION
Looks like a small oversight in #2946. Probably missed because type access shouldn't really access the me_value.