### PR TITLE
Move explorer timing matching out of the shared script.

### DIFF
--- a/explorer/autoupdate_trace_testdata.py
+++ b/explorer/autoupdate_trace_testdata.py
@@ -27,6 +27,10 @@ def main() -> None:
         "--testdata=explorer/trace_testdata",
         "--autoupdate_arg=--trace_file=-",
         "--autoupdate_arg=-trace_phase=all",
+        "--extra_check_replacement",
+        r".+Time elapsed in (\S+): (\d+)ms",
+        r"Time elapsed in (\S+): (\d+)ms",
+        r"Time elapsed in \1: {{[0-9]+}}ms",
     ] + sys.argv[1:]
     exit(subprocess.call(args))
 

--- a/testing/scripts/autoupdate_testdata_base.py
+++ b/testing/scripts/autoupdate_testdata_base.py
@@ -201,9 +201,6 @@ class CheckLine(Line):
         self.out_line = out_line
         self.line_number_delta_prefix = line_number_delta_prefix
         self.line_number_pattern = line_number_pattern
-        self.time_elapsed_pattern = re.compile(
-            r"Time elapsed in (\S+): (\d+)ms"
-        )
         self.trailing_whitespace_pattern = re.compile(r"(\s+$)")
 
         # If any match is specific to this file, use the first matched line for
@@ -221,7 +218,6 @@ class CheckLine(Line):
         result = self.out_line
         while True:
             line_match = self.line_number_pattern.search(result)
-            time_match = self.time_elapsed_pattern.search(result)
             trailing_match = self.trailing_whitespace_pattern.search(result)
             if line_match:
                 if self._matches_filename(line_match):
@@ -241,10 +237,6 @@ class CheckLine(Line):
                         result,
                         count=1,
                     )
-            elif time_match:
-                result = self.time_elapsed_pattern.sub(
-                    r"Time elapsed in \1: {{[0-9]+}}ms", result, count=1
-                )
             elif trailing_match:
                 result = self.trailing_whitespace_pattern.sub(r"{{\1}}", result)
             else:


### PR DESCRIPTION
This goes back to my comment at the end of #2934. Rather than implementing support in the shared script, this only affects one explorer test so would be better to have in the respective invocation. It's coming up now because #3018 has me thinking about autoupdate behaviors again.