### PR TITLE
Semantics and lowering for `type` keyword and type values.

### DIFF
--- a/toolchain/lowering/BUILD
+++ b/toolchain/lowering/BUILD
@@ -24,8 +24,11 @@ cc_library(
     srcs = [
         "lowering_context.cpp",
         "lowering_function_context.cpp",
-        "lowering_handle.cpp",
-    ],
+    ] +
+    # Glob handler files to avoid missing anyway.
+    glob([
+        "lowering_handle*.cpp",
+    ]),
     hdrs = [
         "lowering_context.h",
         "lowering_function_context.h",

--- a/toolchain/lowering/BUILD
+++ b/toolchain/lowering/BUILD
@@ -25,7 +25,7 @@ cc_library(
         "lowering_context.cpp",
         "lowering_function_context.cpp",
     ] +
-    # Glob handler files to avoid missing anyway.
+    # Glob handler files to avoid missing any.
     glob([
         "lowering_handle*.cpp",
     ]),

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -5,6 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_LOWERING_LOWERING_CONTEXT_H_
 #define CARBON_TOOLCHAIN_LOWERING_LOWERING_CONTEXT_H_
 
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "toolchain/semantics/semantics_ir.h"
@@ -34,12 +35,16 @@ class LoweringContext {
   auto GetType(SemanticsTypeId type_id) -> llvm::Type* {
     // InvalidType should not be passed in.
     if (type_id == SemanticsTypeId::TypeType) {
-      // TODO: Handle TypeType. Currently using a place holder
-      // as a workaround.
-      return llvm::Type::getInt1Ty(llvm_context());
+      // `type` is represented as `{}`.
+      return llvm::StructType::get(llvm_context());
     }
     CARBON_CHECK(type_id.index >= 0) << type_id;
     return types_[type_id.index];
+  }
+
+  // Returns a lowered value to use for a value of type `type`.
+  auto GetTypeValue() -> llvm::Value* {
+    return llvm::ConstantStruct::getAnon(llvm_context(), {});
   }
 
   auto llvm_context() -> llvm::LLVMContext& { return *llvm_context_; }

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -35,7 +35,7 @@ class LoweringContext {
   auto GetType(SemanticsTypeId type_id) -> llvm::Type* {
     // InvalidType should not be passed in.
     if (type_id == SemanticsTypeId::TypeType) {
-      // `type` is represented as `{}`.
+      // `type` is lowered to an empty LLVM StructType.
       return llvm::StructType::get(llvm_context());
     }
     CARBON_CHECK(type_id.index >= 0) << type_id;
@@ -43,7 +43,7 @@ class LoweringContext {
   }
 
   // Returns a lowered value to use for a value of type `type`.
-  auto GetTypeValue() -> llvm::Value* {
+  auto GetTypeAsValue() -> llvm::Value* {
     return llvm::ConstantStruct::getAnon(llvm_context(), {});
   }
 

--- a/toolchain/lowering/lowering_function_context.h
+++ b/toolchain/lowering/lowering_function_context.h
@@ -40,6 +40,11 @@ class LoweringFunctionContext {
 
   // Returns a local (versus global) value for the given node.
   auto GetLocal(SemanticsNodeId node_id) -> llvm::Value* {
+    // All builtins are types, with the same empty lowered value.
+    if (node_id.index < SemanticsBuiltinKind::ValidCount) {
+      return GetTypeValue();
+    }
+
     auto it = locals_.find(node_id);
     CARBON_CHECK(it != locals_.end()) << "Missing local: " << node_id;
     return it->second;
@@ -63,6 +68,11 @@ class LoweringFunctionContext {
   // Returns a lowered type for the given type_id.
   auto GetType(SemanticsTypeId type_id) -> llvm::Type* {
     return lowering_context_->GetType(type_id);
+  }
+
+  // Returns a lowered value to use for a value of type `type`.
+  auto GetTypeValue() -> llvm::Value* {
+    return lowering_context_->GetTypeValue();
   }
 
   // Create a synthetic block that corresponds to no SemanticsNodeBlockId. Such

--- a/toolchain/lowering/lowering_function_context.h
+++ b/toolchain/lowering/lowering_function_context.h
@@ -42,7 +42,7 @@ class LoweringFunctionContext {
   auto GetLocal(SemanticsNodeId node_id) -> llvm::Value* {
     // All builtins are types, with the same empty lowered value.
     if (node_id.index < SemanticsBuiltinKind::ValidCount) {
-      return GetTypeValue();
+      return GetTypeAsValue();
     }
 
     auto it = locals_.find(node_id);
@@ -71,8 +71,8 @@ class LoweringFunctionContext {
   }
 
   // Returns a lowered value to use for a value of type `type`.
-  auto GetTypeValue() -> llvm::Value* {
-    return lowering_context_->GetTypeValue();
+  auto GetTypeAsValue() -> llvm::Value* {
+    return lowering_context_->GetTypeAsValue();
   }
 
   // Create a synthetic block that corresponds to no SemanticsNodeBlockId. Such

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -209,12 +209,6 @@ auto LoweringHandleStructMemberAccess(LoweringFunctionContext& context,
   context.SetLocal(node_id, gep);
 }
 
-auto LoweringHandleStructType(LoweringFunctionContext& /*context*/,
-                              SemanticsNodeId /*node_id*/,
-                              SemanticsNode /*node*/) -> void {
-  // No action to take.
-}
-
 auto LoweringHandleTupleValue(LoweringFunctionContext& context,
                               SemanticsNodeId node_id, SemanticsNode node)
     -> void {
@@ -233,12 +227,6 @@ auto LoweringHandleTupleValue(LoweringFunctionContext& context,
     auto* gep = context.builder().CreateStructGEP(llvm_type, alloca, i);
     context.builder().CreateStore(context.GetLocal(refs[i]), gep);
   }
-}
-
-auto LoweringHandleTupleType(LoweringFunctionContext& /*context*/,
-                             SemanticsNodeId /*node_id*/,
-                             SemanticsNode /*node*/) -> void {
-  // No action to take.
 }
 
 auto LoweringHandleStructTypeField(LoweringFunctionContext& /*context*/,
@@ -273,14 +261,7 @@ auto LoweringHandleStructValue(LoweringFunctionContext& context,
 auto LoweringHandleStubReference(LoweringFunctionContext& context,
                                  SemanticsNodeId node_id, SemanticsNode node)
     -> void {
-  // TODO: Handle TypeType. Currently using a place holder
-  // but this is just a workaround.
-  if (node.type_id() == SemanticsTypeId::TypeType) {
-    llvm::Value* v = llvm::ConstantInt::get(context.builder().getInt1Ty(), 0);
-    context.SetLocal(node_id, v);
-  } else {
-    context.SetLocal(node_id, context.GetLocal(node.GetAsStubReference()));
-  }
+  context.SetLocal(node_id, context.GetLocal(node.GetAsStubReference()));
 }
 
 auto LoweringHandleUnaryOperatorNot(LoweringFunctionContext& context,

--- a/toolchain/lowering/lowering_handle_type.cpp
+++ b/toolchain/lowering/lowering_handle_type.cpp
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/lowering/lowering_function_context.h"
+
+namespace Carbon {
+
+auto LoweringHandleStructType(LoweringFunctionContext& context,
+                              SemanticsNodeId node_id, SemanticsNode /*node*/)
+    -> void {
+  context.SetLocal(node_id, context.GetTypeValue());
+}
+
+auto LoweringHandleTupleType(LoweringFunctionContext& context,
+                             SemanticsNodeId node_id, SemanticsNode /*node*/)
+    -> void {
+  context.SetLocal(node_id, context.GetTypeValue());
+}
+
+}  // namespace Carbon

--- a/toolchain/lowering/lowering_handle_type.cpp
+++ b/toolchain/lowering/lowering_handle_type.cpp
@@ -9,13 +9,13 @@ namespace Carbon {
 auto LoweringHandleStructType(LoweringFunctionContext& context,
                               SemanticsNodeId node_id, SemanticsNode /*node*/)
     -> void {
-  context.SetLocal(node_id, context.GetTypeValue());
+  context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto LoweringHandleTupleType(LoweringFunctionContext& context,
                              SemanticsNodeId node_id, SemanticsNode /*node*/)
     -> void {
-  context.SetLocal(node_id, context.GetTypeValue());
+  context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 }  // namespace Carbon

--- a/toolchain/lowering/testdata/basics/type_values.carbon
+++ b/toolchain/lowering/testdata/basics/type_values.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: ; ModuleID = 'type_values.carbon'
+// CHECK:STDOUT: source_filename = "type_values.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define {} @I32() {
+// CHECK:STDOUT:   ret {} zeroinitializer
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define {} @F64() {
+// CHECK:STDOUT:   ret {} zeroinitializer
+// CHECK:STDOUT: }
+
+fn I32() -> type {
+  return i32;
+}
+
+fn F64() -> type {
+  return f64;
+}

--- a/toolchain/lowering/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lowering/testdata/function/call/empty_tuple.carbon
@@ -12,7 +12,6 @@
 // CHECK:STDOUT: define %TupleLiteralType @Echo(%TupleLiteralType %a) {
 // CHECK:STDOUT:   ret %TupleLiteralType %a
 // CHECK:STDOUT: }
-
 // CHECK:STDOUT:
 // CHECK:STDOUT: define %EmptyTupleType @Main() {
 // CHECK:STDOUT:   %TupleLiteralValue = alloca %TupleLiteralType, align 8
@@ -23,6 +22,7 @@
 // CHECK:STDOUT:   store %TupleLiteralType %Echo, ptr %var, align 1
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+
 
 fn Echo(a: ()) -> () {
   return a;

--- a/toolchain/lowering/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lowering/testdata/function/call/empty_tuple.carbon
@@ -23,7 +23,6 @@
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 
-
 fn Echo(a: ()) -> () {
   return a;
 }

--- a/toolchain/lowering/testdata/struct/nested_struct.carbon
+++ b/toolchain/lowering/testdata/struct/nested_struct.carbon
@@ -6,12 +6,12 @@
 // CHECK:STDOUT: ; ModuleID = 'nested_struct.carbon'
 // CHECK:STDOUT: source_filename = "nested_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %StructLiteralType.0 = type { i1 }
+// CHECK:STDOUT: %StructLiteralType.0 = type { {} }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Run() {
 // CHECK:STDOUT:   %StructLiteralValue = alloca %StructLiteralType.0, align 8
 // CHECK:STDOUT:   %b = getelementptr inbounds %StructLiteralType.0, ptr %StructLiteralValue, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %b, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %b, align 1
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
 

--- a/toolchain/lowering/testdata/tuple/nested_tuple.carbon
+++ b/toolchain/lowering/testdata/tuple/nested_tuple.carbon
@@ -6,13 +6,13 @@
 // CHECK:STDOUT: ; ModuleID = 'nested_tuple.carbon'
 // CHECK:STDOUT: source_filename = "nested_tuple.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %TupleLiteralType = type { i1 }
+// CHECK:STDOUT: %TupleLiteralType = type { {} }
 // CHECK:STDOUT: %TupleLiteralType.0 = type { %TupleLiteralType }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Run() {
 // CHECK:STDOUT:   %TupleLiteralValue = alloca %TupleLiteralType, align 8
 // CHECK:STDOUT:   %1 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %1, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %1, align 1
 // CHECK:STDOUT:   %TupleLiteralValue1 = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %2 = getelementptr inbounds %TupleLiteralType.0, ptr %TupleLiteralValue1, i32 0, i32 0
 // CHECK:STDOUT:   store ptr %TupleLiteralValue, ptr %2, align 8

--- a/toolchain/lowering/testdata/tuple/one_entry.carbon
+++ b/toolchain/lowering/testdata/tuple/one_entry.carbon
@@ -6,13 +6,13 @@
 // CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
 // CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %TupleLiteralType = type { i1 }
+// CHECK:STDOUT: %TupleLiteralType = type { {} }
 // CHECK:STDOUT: %TupleLiteralType.0 = type { i32 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Run() {
 // CHECK:STDOUT:   %TupleLiteralValue = alloca %TupleLiteralType, align 8
 // CHECK:STDOUT:   %1 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %1, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %1, align 1
 // CHECK:STDOUT:   %var = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %TupleLiteralValue1 = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %2 = getelementptr inbounds %TupleLiteralType.0, ptr %TupleLiteralValue1, i32 0, i32 0
@@ -21,7 +21,7 @@
 // CHECK:STDOUT:   store %TupleLiteralType.0 %3, ptr %var, align 4
 // CHECK:STDOUT:   %TupleLiteralValue2 = alloca %TupleLiteralType, align 8
 // CHECK:STDOUT:   %4 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue2, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %4, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %4, align 1
 // CHECK:STDOUT:   %var3 = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %5 = load %TupleLiteralType.0, ptr %var, align 4
 // CHECK:STDOUT:   store %TupleLiteralType.0 %5, ptr %var3, align 4

--- a/toolchain/lowering/testdata/tuple/two_entries.carbon
+++ b/toolchain/lowering/testdata/tuple/two_entries.carbon
@@ -6,15 +6,15 @@
 // CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
 // CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %TupleLiteralType = type { i1, i1 }
+// CHECK:STDOUT: %TupleLiteralType = type { {}, {} }
 // CHECK:STDOUT: %TupleLiteralType.0 = type { i32, i32 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Run() {
 // CHECK:STDOUT:   %TupleLiteralValue = alloca %TupleLiteralType, align 8
 // CHECK:STDOUT:   %1 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %1, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %1, align 1
 // CHECK:STDOUT:   %2 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue, i32 0, i32 1
-// CHECK:STDOUT:   store i1 false, ptr %2, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %2, align 1
 // CHECK:STDOUT:   %var = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %TupleLiteralValue1 = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %3 = getelementptr inbounds %TupleLiteralType.0, ptr %TupleLiteralValue1, i32 0, i32 0
@@ -25,9 +25,9 @@
 // CHECK:STDOUT:   store %TupleLiteralType.0 %5, ptr %var, align 4
 // CHECK:STDOUT:   %TupleLiteralValue2 = alloca %TupleLiteralType, align 8
 // CHECK:STDOUT:   %6 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue2, i32 0, i32 0
-// CHECK:STDOUT:   store i1 false, ptr %6, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %6, align 1
 // CHECK:STDOUT:   %7 = getelementptr inbounds %TupleLiteralType, ptr %TupleLiteralValue2, i32 0, i32 1
-// CHECK:STDOUT:   store i1 false, ptr %7, align 1
+// CHECK:STDOUT:   store {} zeroinitializer, ptr %7, align 1
 // CHECK:STDOUT:   %var3 = alloca %TupleLiteralType.0, align 8
 // CHECK:STDOUT:   %8 = load %TupleLiteralType.0, ptr %var, align 4
 // CHECK:STDOUT:   store %TupleLiteralType.0 %8, ptr %var3, align 4

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -34,7 +34,7 @@ cc_library(
         "parser_context.cpp",
         "parser_context.h",
     ] +
-    # Glob handler files to avoid missing anyway.
+    # Glob handler files to avoid missing any.
     glob([
         "parser_handle_*.cpp",
     ]),

--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -62,7 +62,7 @@ cc_library(
         "semantics_node_block_stack.cpp",
         "semantics_declaration_name_stack.cpp",
     ] +
-    # Glob handler files to avoid missing anyway.
+    # Glob handler files to avoid missing any.
     glob([
         "semantics_handle*.cpp",
     ]),

--- a/toolchain/semantics/semantics_builtin_kind.def
+++ b/toolchain/semantics/semantics_builtin_kind.def
@@ -38,7 +38,7 @@
 
 // Tracks expressions which are valid as types.
 // This has a deliberately self-referential type.
-CARBON_SEMANTICS_BUILTIN_KIND(TypeType, "Type")
+CARBON_SEMANTICS_BUILTIN_KIND(TypeType, "type")
 
 // Used when a semantic error has been detected, and a SemanticNodeId is still
 // required. For example, when there is a type checking issue, this will be used
@@ -65,7 +65,7 @@ CARBON_SEMANTICS_BUILTIN_KIND(FloatingPointType, "f64")
 CARBON_SEMANTICS_BUILTIN_KIND(StringType, "String")
 
 // The canonical empty tuple type.
-CARBON_SEMANTICS_BUILTIN_KIND(EmptyTupleType, "() as Type")
+CARBON_SEMANTICS_BUILTIN_KIND(EmptyTupleType, "() as type")
 
 // Keep invalid last, so that we can use values as array indices without needing
 // an invalid entry.

--- a/toolchain/semantics/semantics_handle_literal.cpp
+++ b/toolchain/semantics/semantics_handle_literal.cpp
@@ -57,6 +57,10 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
               id));
       break;
     }
+    case TokenKind::Type: {
+      context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinTypeType);
+      break;
+    }
     case TokenKind::Bool: {
       context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinBoolType);
       break;

--- a/toolchain/semantics/testdata/basics/builtin_types.carbon
+++ b/toolchain/semantics/testdata/basics/builtin_types.carbon
@@ -17,6 +17,7 @@
 // CHECK:STDOUT:   test_f64,
 // CHECK:STDOUT:   test_str,
 // CHECK:STDOUT:   Test,
+// CHECK:STDOUT:   test_type,
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: types: [
 // CHECK:STDOUT:   nodeIntegerType,
@@ -38,6 +39,9 @@
 // CHECK:STDOUT:   {kind: BindName, arg0: str2, arg1: node+8, type: type2},
 // CHECK:STDOUT:   {kind: StringLiteral, arg0: str3, type: type2},
 // CHECK:STDOUT:   {kind: Assign, arg0: node+8, arg1: node+10, type: type2},
+// CHECK:STDOUT:   {kind: VarStorage, type: typeTypeType},
+// CHECK:STDOUT:   {kind: BindName, arg0: str4, arg1: node+12, type: typeTypeType},
+// CHECK:STDOUT:   {kind: Assign, arg0: node+12, arg1: nodeIntegerType, type: typeTypeType},
 // CHECK:STDOUT: ]
 // CHECK:STDOUT: node_blocks: [
 // CHECK:STDOUT:   [
@@ -55,9 +59,13 @@
 // CHECK:STDOUT:     node+9,
 // CHECK:STDOUT:     node+10,
 // CHECK:STDOUT:     node+11,
+// CHECK:STDOUT:     node+12,
+// CHECK:STDOUT:     node+13,
+// CHECK:STDOUT:     node+14,
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
 var test_i32: i32 = 0;
 var test_f64: f64 = 0.1;
 var test_str: String = "Test";
+var test_type: type = i32;

--- a/toolchain/semantics/testdata/basics/fail_non_type_as_type.carbon
+++ b/toolchain/semantics/testdata/basics/fail_non_type_as_type.carbon
@@ -1,0 +1,42 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: functions: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT:   42,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: real_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   x,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT:   nodeIntegerType,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: type_blocks: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: VarStorage, type: typeTypeType},
+// CHECK:STDOUT:   {kind: BindName, arg0: str0, arg1: node+0, type: typeTypeType},
+// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: type0},
+// CHECK:STDOUT:   {kind: Assign, arg0: node+0, arg1: nodeError, type: typeError},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node+0,
+// CHECK:STDOUT:     node+1,
+// CHECK:STDOUT:     node+2,
+// CHECK:STDOUT:     node+3,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
+
+// CHECK:STDERR: fail_non_type_as_type.carbon:[[@LINE+3]]:17: Cannot implicitly convert from `i32` to `type`.
+// CHECK:STDERR: var x: type = 42;
+// CHECK:STDERR:                 ^
+var x: type = 42;

--- a/toolchain/semantics/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/semantics/testdata/struct/fail_type_assign.carbon
@@ -47,7 +47,7 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: fail_type_assign.carbon:[[@LINE+3]]:29: Cannot implicitly convert from `Type` to `{.a: i32}`.
+// CHECK:STDERR: fail_type_assign.carbon:[[@LINE+3]]:29: Cannot implicitly convert from `type` to `{.a: i32}`.
 // CHECK:STDERR: var x: {.a: i32} = {.a: i32};
 // CHECK:STDERR:                             ^
 var x: {.a: i32} = {.a: i32};

--- a/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/semantics/testdata/struct/fail_value_as_type.carbon
@@ -49,7 +49,7 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: fail_value_as_type.carbon:[[@LINE+3]]:15: Cannot implicitly convert from `{.a: i32}` to `Type`.
+// CHECK:STDERR: fail_value_as_type.carbon:[[@LINE+3]]:15: Cannot implicitly convert from `{.a: i32}` to `type`.
 // CHECK:STDERR: var x: {.a = 1};
 // CHECK:STDERR:               ^
 var x: {.a = 1};

--- a/toolchain/semantics/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/semantics/testdata/tuples/fail_type_assign.carbon
@@ -59,7 +59,7 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: fail_type_assign.carbon:[[@LINE+3]]:25: Cannot implicitly convert from `(Type,) as type` to `(i32,) as type`.
+// CHECK:STDERR: fail_type_assign.carbon:[[@LINE+3]]:25: Cannot implicitly convert from `(type,) as type` to `(i32,) as type`.
 // CHECK:STDERR: var x: (i32, ) = (i32, );
 // CHECK:STDERR:                         ^
 var x: (i32, ) = (i32, );

--- a/toolchain/semantics/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/semantics/testdata/tuples/fail_value_as_type.carbon
@@ -53,7 +53,7 @@
 // CHECK:STDOUT:   ],
 // CHECK:STDOUT: ]
 
-// CHECK:STDERR: fail_value_as_type.carbon:[[@LINE+3]]:12: Cannot implicitly convert from `i32` to `Type`.
+// CHECK:STDERR: fail_value_as_type.carbon:[[@LINE+3]]:12: Cannot implicitly convert from `i32` to `type`.
 // CHECK:STDERR: var x: (1, );
 // CHECK:STDERR:            ^
 var x: (1, );

--- a/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/semantics/testdata/var/fail_storage_is_literal.carbon
@@ -49,7 +49,7 @@
 // CHECK:STDOUT: ]
 
 fn Main() {
-  // CHECK:STDERR: fail_storage_is_literal.carbon:[[@LINE+3]]:10: Cannot implicitly convert from `i32` to `Type`.
+  // CHECK:STDERR: fail_storage_is_literal.carbon:[[@LINE+3]]:10: Cannot implicitly convert from `i32` to `type`.
   // CHECK:STDERR:   var x: 1 = 1;
   // CHECK:STDERR:          ^
   var x: 1 = 1;


### PR DESCRIPTION
Also switch from modeling type values as `i1` to modeling them as an empty struct. We don't need any runtime representation for types, as there are no runtime operations on them, so an empty struct seems like a good representation.