### PR TITLE
Implement canonicalization of Value and Element

### DIFF
--- a/explorer/ast/BUILD
+++ b/explorer/ast/BUILD
@@ -52,6 +52,7 @@ cc_library(
         "//common:indirect_value",
         "//common:ostream",
         "//explorer/common:arena",
+        "//explorer/common:decompose",
         "//explorer/common:error_builders",
         "//explorer/common:nonnull",
         "//explorer/common:source_location",

--- a/explorer/ast/address.h
+++ b/explorer/ast/address.h
@@ -24,6 +24,13 @@ class AllocationId {
   AllocationId(const AllocationId&) = default;
   auto operator=(const AllocationId&) -> AllocationId& = default;
 
+  inline friend auto operator==(AllocationId lhs, AllocationId rhs) -> bool {
+    return lhs.index_ == rhs.index_;
+  }
+  inline friend auto hash_value(AllocationId id) {
+    return llvm::hash_combine(id.index_);
+  }
+
   // Prints a human-readable representation of *this to `out`.
   //
   // Currently that representation consists of an integer index.
@@ -79,6 +86,15 @@ class Address {
     Address address = *this;
     address.element_path_.RemoveTrailingBaseElements();
     return address;
+  }
+
+  inline friend auto operator==(const Address& lhs, const Address& rhs)
+      -> bool {
+    return lhs.allocation_ == rhs.allocation_ &&
+           lhs.element_path_ == rhs.element_path_;
+  }
+  inline friend auto hash_value(const Address& a) -> llvm::hash_code {
+    return llvm::hash_combine(a.allocation_, a.element_path_);
   }
 
  private:

--- a/explorer/ast/bindings.cpp
+++ b/explorer/ast/bindings.cpp
@@ -8,6 +8,7 @@
 #include "explorer/ast/impl_binding.h"
 #include "explorer/ast/pattern.h"
 #include "explorer/ast/value.h"
+#include "llvm/ADT/StringExtras.h"
 
 namespace Carbon {
 
@@ -39,6 +40,18 @@ void Bindings::Add(Nonnull<const GenericBinding*> binding,
 auto Bindings::None() -> Nonnull<const Bindings*> {
   static Nonnull<const Bindings*> bindings = new Bindings;
   return bindings;
+}
+
+void Bindings::Print(llvm::raw_ostream& out) const {
+  out << "{";
+  llvm::ListSeparator sep;
+  for (const auto& [name, value] : args_) {
+    out << sep << *name << " -> " << *value;
+  }
+  for (const auto& [name, value] : witnesses_) {
+    out << sep << *name << " -> " << *value;
+  }
+  out << "}";
 }
 
 auto Bindings::SymbolicIdentity(

--- a/explorer/ast/bindings.h
+++ b/explorer/ast/bindings.h
@@ -63,6 +63,9 @@ class Bindings {
     return f(args_, witnesses_);
   }
 
+  void Print(llvm::raw_ostream& out) const;
+  LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }
+
   // Add a value, and perhaps a witness, for a generic binding.
   void Add(Nonnull<const GenericBinding*> binding, Nonnull<const Value*> value,
            std::optional<Nonnull<const Value*>> witness);

--- a/explorer/ast/element.h
+++ b/explorer/ast/element.h
@@ -29,6 +29,14 @@ struct NamedValue {
     return f(name, value);
   }
 
+  inline friend auto operator==(const NamedValue& lhs, const NamedValue& rhs)
+      -> bool {
+    return lhs.name == rhs.name && lhs.value == rhs.value;
+  }
+  inline friend auto hash_value(const NamedValue& value) -> llvm::hash_code {
+    return llvm::hash_combine(value.name, value.value);
+  }
+
   // The field name.
   std::string name;
 
@@ -36,14 +44,19 @@ struct NamedValue {
   Nonnull<const Value*> value;
 };
 
-// A generic member of a type.
+// A generic member of a type. This is can be a named, positional or other type
+// of member.
 //
-// This is can be a named, positional or other type of member.
+// Arena's canonicalization support is enabled for Element and all derived
+// types. As a result, all Elements must be immutable, and all their constructor
+// arguments must be copyable, equality-comparable, and hashable. See
+// Arena's documentation for details.
 class Element {
  protected:
   explicit Element(ElementKind kind) : kind_(kind) {}
 
  public:
+  using EnableCanonicalizedAllocation = void;
   virtual ~Element() = default;
 
   // Call `f` on this value, cast to its most-derived type. `R` specifies the

--- a/explorer/ast/element.h
+++ b/explorer/ast/element.h
@@ -29,6 +29,14 @@ struct NamedValue {
     return f(name, value);
   }
 
+  inline friend auto operator==(const NamedValue& lhs, const NamedValue& rhs)
+      -> bool {
+    return lhs.name == rhs.name && lhs.value == rhs.value;
+  }
+  inline friend auto hash_value(const NamedValue& value) -> llvm::hash_code {
+    return llvm::hash_combine(value.name, value.value);
+  }
+
   // The field name.
   std::string name;
 

--- a/explorer/ast/element.h
+++ b/explorer/ast/element.h
@@ -11,6 +11,7 @@
 
 #include "common/ostream.h"
 #include "explorer/ast/ast_rtti.h"
+#include "explorer/common/decompose.h"
 #include "explorer/common/nonnull.h"
 #include "llvm/ADT/PointerUnion.h"
 
@@ -20,21 +21,13 @@ class Declaration;
 class Value;
 
 // A NamedValue represents a value with a name, such as a single struct field.
-struct NamedValue {
+struct NamedValue : HashFromDecompose<NamedValue> {
   NamedValue(std::string name, Nonnull<const Value*> value)
       : name(std::move(name)), value(value) {}
 
   template <typename F>
   auto Decompose(F f) const {
     return f(name, value);
-  }
-
-  inline friend auto operator==(const NamedValue& lhs, const NamedValue& rhs)
-      -> bool {
-    return lhs.name == rhs.name && lhs.value == rhs.value;
-  }
-  inline friend auto hash_value(const NamedValue& value) -> llvm::hash_code {
-    return llvm::hash_combine(value.name, value.value);
   }
 
   // The field name.

--- a/explorer/ast/element.h
+++ b/explorer/ast/element.h
@@ -29,14 +29,6 @@ struct NamedValue {
     return f(name, value);
   }
 
-  inline friend auto operator==(const NamedValue& lhs, const NamedValue& rhs)
-      -> bool {
-    return lhs.name == rhs.name && lhs.value == rhs.value;
-  }
-  inline friend auto hash_value(const NamedValue& value) -> llvm::hash_code {
-    return llvm::hash_combine(value.name, value.value);
-  }
-
   // The field name.
   std::string name;
 

--- a/explorer/ast/element_path.h
+++ b/explorer/ast/element_path.h
@@ -50,6 +50,17 @@ class ElementPath {
               std::optional<Nonnull<const Witness*>> witness)
         : element_(element), interface_(interface), witness_(witness) {}
 
+    inline friend auto operator==(const Component& lhs, const Component& rhs)
+        -> bool {
+      return lhs.element_ == rhs.element_ && lhs.interface_ == rhs.interface_ &&
+             lhs.witness_ == rhs.witness_;
+    }
+    inline friend auto hash_value(const Component& component)
+        -> llvm::hash_code {
+      return llvm::hash_combine(component.element_, component.interface_,
+                                component.witness_);
+    }
+
     auto element() const -> Nonnull<const Element*> { return element_; }
 
     auto IsNamed(std::string_view name) const -> bool {
@@ -81,6 +92,15 @@ class ElementPath {
   ElementPath(ElementPath&&) = default;
   auto operator=(const ElementPath&) -> ElementPath& = default;
   auto operator=(ElementPath&&) -> ElementPath& = default;
+
+  inline friend auto operator==(const ElementPath& lhs, const ElementPath& rhs)
+      -> bool {
+    return lhs.components_ == rhs.components_;
+  }
+  inline friend auto hash_value(const ElementPath& path) -> llvm::hash_code {
+    return llvm::hash_combine_range(path.components_.begin(),
+                                    path.components_.end());
+  }
 
   // Returns whether *this is empty.
   auto IsEmpty() const -> bool { return components_.empty(); }

--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -98,7 +98,7 @@ struct NestedValueVisitor {
     // which is not "within" this value, so we shouldn't visit it.
     return true;
   }
-  auto Visit(const VTable&) -> bool { return true; }
+  auto Visit(const VTable*) -> bool { return true; }
 
   llvm::function_ref<bool(const Value*)> callback;
 };

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -739,11 +739,8 @@ class FunctionType : public Value {
         impl_bindings_(std::move(impl_bindings)),
         is_initializing_(is_initializing) {}
 
-  struct ExceptSelf {
-    friend auto operator==(ExceptSelf, ExceptSelf) -> bool { return true; }
-    friend auto hash_value(ExceptSelf) -> llvm::hash_code {
-      return llvm::hash_combine(0);
-    }
+  struct ExceptSelf : public HashFromDecompose<ExceptSelf> {
+    template <typename F> auto Decompose(F f) const { return f(); }
   };
   FunctionType(ExceptSelf, const FunctionType* clone)
       : FunctionType(std::nullopt, clone->parameters_,

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -740,8 +740,12 @@ class FunctionType : public Value {
         is_initializing_(is_initializing) {}
 
   struct ExceptSelf : public HashFromDecompose<ExceptSelf> {
-    template <typename F> auto Decompose(F f) const { return f(); }
+    template <typename F>
+    auto Decompose(F f) const {
+      return f();
+    }
   };
+
   FunctionType(ExceptSelf, const FunctionType* clone)
       : FunctionType(std::nullopt, clone->parameters_,
                      clone->generic_parameters_, clone->return_type_,

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -694,19 +694,10 @@ class FunctionType : public Value {
   // An explicit function parameter that is a `:!` binding:
   //
   //     fn MakeEmptyVector(T:! type) -> Vector(T);
-  struct GenericParameter {
+  struct GenericParameter : public HashFromDecompose<GenericParameter> {
     template <typename F>
     auto Decompose(F f) const {
       return f(index, binding);
-    }
-
-    inline friend auto operator==(const GenericParameter& lhs,
-                                  const GenericParameter& rhs) -> bool {
-      return lhs.index == rhs.index && lhs.binding == rhs.binding;
-    }
-    inline friend auto hash_value(const GenericParameter& parameter)
-        -> llvm::hash_code {
-      return llvm::hash_combine(parameter.index, parameter.binding);
     }
 
     size_t index;
@@ -714,18 +705,10 @@ class FunctionType : public Value {
   };
 
   // For methods with unbound `self` parameters.
-  struct MethodSelf {
+  struct MethodSelf : public HashFromDecompose<MethodSelf> {
     template <typename F>
     auto Decompose(F f) const {
       return f(addr_self, self_type);
-    }
-
-    inline friend auto operator==(const MethodSelf& lhs, const MethodSelf& rhs)
-        -> bool {
-      return lhs.addr_self == rhs.addr_self && lhs.self_type == rhs.self_type;
-    }
-    inline friend auto hash_value(const MethodSelf& self) -> llvm::hash_code {
-      return llvm::hash_combine(self.addr_self, self.self_type);
     }
 
     // True if `self` parameter uses an `addr` pattern.
@@ -1064,19 +1047,10 @@ class NamedConstraintType : public Value {
 };
 
 // A constraint that requires implementation of an interface.
-struct ImplsConstraint {
+struct ImplsConstraint : public HashFromDecompose<ImplsConstraint> {
   template <typename F>
   auto Decompose(F f) const {
     return f(type, interface);
-  }
-
-  inline friend auto operator==(const ImplsConstraint& lhs,
-                                const ImplsConstraint& rhs) -> bool {
-    return lhs.type == rhs.type && lhs.interface == rhs.interface;
-  }
-  inline friend auto hash_value(const ImplsConstraint& constraint)
-      -> llvm::hash_code {
-    return llvm::hash_combine(constraint.type, constraint.interface);
   }
 
   // The type that is required to implement the interface.
@@ -1086,23 +1060,10 @@ struct ImplsConstraint {
 };
 
 // A constraint that requires an intrinsic property of a type.
-struct IntrinsicConstraint {
+struct IntrinsicConstraint : public HashFromDecompose<IntrinsicConstraint> {
   template <typename F>
   auto Decompose(F f) const {
     return f(type, kind, arguments);
-  }
-
-  inline friend auto operator==(const IntrinsicConstraint& lhs,
-                                const IntrinsicConstraint& rhs) -> bool {
-    return lhs.type == rhs.type && lhs.kind == rhs.kind &&
-           lhs.arguments == rhs.arguments;
-  }
-  inline friend auto hash_value(const IntrinsicConstraint& constraint)
-      -> llvm::hash_code {
-    return llvm::hash_combine(
-        constraint.type, constraint.kind,
-        llvm::hash_combine_range(constraint.arguments.begin(),
-                                 constraint.arguments.end()));
   }
 
   // Print the intrinsic constraint.
@@ -1124,20 +1085,10 @@ struct IntrinsicConstraint {
 };
 
 // A constraint that a collection of values are known to be the same.
-struct EqualityConstraint {
+struct EqualityConstraint : public HashFromDecompose<EqualityConstraint> {
   template <typename F>
   auto Decompose(F f) const {
     return f(values);
-  }
-
-  inline friend auto operator==(const EqualityConstraint& lhs,
-                                const EqualityConstraint& rhs) -> bool {
-    return lhs.values == rhs.values;
-  }
-  inline friend auto hash_value(const EqualityConstraint& constraint)
-      -> llvm::hash_code {
-    return llvm::hash_combine_range(constraint.values.begin(),
-                                    constraint.values.end());
   }
 
   // Visit the values in this equality constraint that are a single step away
@@ -1157,27 +1108,11 @@ struct EqualityConstraint {
 
 // A constraint indicating that access to an associated constant should be
 // replaced by another value.
-struct RewriteConstraint {
+struct RewriteConstraint : public HashFromDecompose<RewriteConstraint> {
   template <typename F>
   auto Decompose(F f) const {
     return f(constant, unconverted_replacement, unconverted_replacement_type,
              converted_replacement);
-  }
-
-  inline friend auto operator==(const RewriteConstraint& lhs,
-                                const RewriteConstraint& rhs) -> bool {
-    return lhs.constant == rhs.constant &&
-           lhs.unconverted_replacement == rhs.unconverted_replacement &&
-           lhs.unconverted_replacement_type ==
-               rhs.unconverted_replacement_type &&
-           lhs.converted_replacement == rhs.converted_replacement;
-  }
-  inline friend auto hash_value(const RewriteConstraint& constraint)
-      -> llvm::hash_code {
-    return llvm::hash_combine(constraint.constant,
-                              constraint.unconverted_replacement,
-                              constraint.unconverted_replacement_type,
-                              constraint.converted_replacement);
   }
 
   // The associated constant value that is rewritten.
@@ -1191,17 +1126,10 @@ struct RewriteConstraint {
 };
 
 // A context in which we might look up a name.
-struct LookupContext {
+struct LookupContext : public HashFromDecompose<LookupContext> {
   template <typename F>
   auto Decompose(F f) const {
     return f(context);
-  }
-
-  inline friend auto operator==(LookupContext lhs, LookupContext rhs) -> bool {
-    return lhs.context == rhs.context;
-  }
-  inline friend auto hash_value(LookupContext context) -> llvm::hash_code {
-    return llvm::hash_combine(context.context);
   }
 
   Nonnull<const Value*> context;

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -700,6 +700,15 @@ class FunctionType : public Value {
       return f(index, binding);
     }
 
+    inline friend auto operator==(const GenericParameter& lhs,
+                                  const GenericParameter& rhs) -> bool {
+      return lhs.index == rhs.index && lhs.binding == rhs.binding;
+    }
+    inline friend auto hash_value(const GenericParameter& parameter)
+        -> llvm::hash_code {
+      return llvm::hash_combine(parameter.index, parameter.binding);
+    }
+
     size_t index;
     Nonnull<const GenericBinding*> binding;
   };
@@ -709,6 +718,14 @@ class FunctionType : public Value {
     template <typename F>
     auto Decompose(F f) const {
       return f(addr_self, self_type);
+    }
+
+    inline friend auto operator==(const MethodSelf& lhs, const MethodSelf& rhs)
+        -> bool {
+      return lhs.addr_self == rhs.addr_self && lhs.self_type == rhs.self_type;
+    }
+    inline friend auto hash_value(const MethodSelf& self) -> llvm::hash_code {
+      return llvm::hash_combine(self.addr_self, self.self_type);
     }
 
     // True if `self` parameter uses an `addr` pattern.
@@ -740,9 +757,9 @@ class FunctionType : public Value {
         is_initializing_(is_initializing) {}
 
   struct ExceptSelf {
-    template <typename F>
-    auto Decompose(F f) const {
-      return f();
+    friend auto operator==(ExceptSelf, ExceptSelf) -> bool { return true; }
+    friend auto hash_value(ExceptSelf) -> llvm::hash_code {
+      return llvm::hash_combine(0);
     }
   };
   FunctionType(ExceptSelf, const FunctionType* clone)
@@ -1053,6 +1070,15 @@ struct ImplsConstraint {
     return f(type, interface);
   }
 
+  inline friend auto operator==(const ImplsConstraint& lhs,
+                                const ImplsConstraint& rhs) -> bool {
+    return lhs.type == rhs.type && lhs.interface == rhs.interface;
+  }
+  inline friend auto hash_value(const ImplsConstraint& constraint)
+      -> llvm::hash_code {
+    return llvm::hash_combine(constraint.type, constraint.interface);
+  }
+
   // The type that is required to implement the interface.
   Nonnull<const Value*> type;
   // The interface that is required to be implemented.
@@ -1064,6 +1090,19 @@ struct IntrinsicConstraint {
   template <typename F>
   auto Decompose(F f) const {
     return f(type, kind, arguments);
+  }
+
+  inline friend auto operator==(const IntrinsicConstraint& lhs,
+                                const IntrinsicConstraint& rhs) -> bool {
+    return lhs.type == rhs.type && lhs.kind == rhs.kind &&
+           lhs.arguments == rhs.arguments;
+  }
+  inline friend auto hash_value(const IntrinsicConstraint& constraint)
+      -> llvm::hash_code {
+    return llvm::hash_combine(
+        constraint.type, constraint.kind,
+        llvm::hash_combine_range(constraint.arguments.begin(),
+                                 constraint.arguments.end()));
   }
 
   // Print the intrinsic constraint.
@@ -1091,6 +1130,16 @@ struct EqualityConstraint {
     return f(values);
   }
 
+  inline friend auto operator==(const EqualityConstraint& lhs,
+                                const EqualityConstraint& rhs) -> bool {
+    return lhs.values == rhs.values;
+  }
+  inline friend auto hash_value(const EqualityConstraint& constraint)
+      -> llvm::hash_code {
+    return llvm::hash_combine_range(constraint.values.begin(),
+                                    constraint.values.end());
+  }
+
   // Visit the values in this equality constraint that are a single step away
   // from the given value according to this equality constraint. That is: if
   // `value` is identical to a value in `values`, then call the visitor on all
@@ -1115,6 +1164,22 @@ struct RewriteConstraint {
              converted_replacement);
   }
 
+  inline friend auto operator==(const RewriteConstraint& lhs,
+                                const RewriteConstraint& rhs) -> bool {
+    return lhs.constant == rhs.constant &&
+           lhs.unconverted_replacement == rhs.unconverted_replacement &&
+           lhs.unconverted_replacement_type ==
+               rhs.unconverted_replacement_type &&
+           lhs.converted_replacement == rhs.converted_replacement;
+  }
+  inline friend auto hash_value(const RewriteConstraint& constraint)
+      -> llvm::hash_code {
+    return llvm::hash_combine(constraint.constant,
+                              constraint.unconverted_replacement,
+                              constraint.unconverted_replacement_type,
+                              constraint.converted_replacement);
+  }
+
   // The associated constant value that is rewritten.
   Nonnull<const AssociatedConstant*> constant;
   // The replacement in its original type.
@@ -1130,6 +1195,13 @@ struct LookupContext {
   template <typename F>
   auto Decompose(F f) const {
     return f(context);
+  }
+
+  inline friend auto operator==(LookupContext lhs, LookupContext rhs) -> bool {
+    return lhs.context == rhs.context;
+  }
+  inline friend auto hash_value(LookupContext context) -> llvm::hash_code {
+    return llvm::hash_combine(context.context);
   }
 
   Nonnull<const Value*> context;

--- a/explorer/ast/value_node.h
+++ b/explorer/ast/value_node.h
@@ -137,6 +137,11 @@ class ValueNodeView {
     return std::less<>()(lhs.base_, rhs.base_);
   }
 
+  friend auto hash_value(const ValueNodeView& view) -> llvm::hash_code {
+    using llvm::hash_value;
+    return hash_value(view.base_);
+  }
+
  private:
   Nonnull<const AstNode*> base_;
   std::function<std::optional<Nonnull<const Value*>>(const AstNode&)>

--- a/explorer/common/BUILD
+++ b/explorer/common/BUILD
@@ -24,6 +24,24 @@ cc_test(
 )
 
 cc_library(
+    name = "decompose",
+    hdrs = ["decompose.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "decompose_test",
+    srcs = ["decompose_test.cpp"],
+    deps = [
+        ":decompose",
+        "//testing/util:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "error_builders",
     hdrs = ["error_builders.h"],
     deps = [

--- a/explorer/common/BUILD
+++ b/explorer/common/BUILD
@@ -9,6 +9,7 @@ cc_library(
     hdrs = ["arena.h"],
     deps = [
         ":nonnull",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/explorer/common/BUILD
+++ b/explorer/common/BUILD
@@ -13,6 +13,16 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "arena_test",
+    srcs = ["arena_test.cpp"],
+    deps = [
+        ":arena",
+        "//testing/util:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 cc_library(
     name = "error_builders",
     hdrs = ["error_builders.h"],

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -136,9 +136,7 @@ class Arena {
 
   // Allocates an object in the arena. Unlike New, this will always allocate
   // and construct a new object.
-  template <
-      typename T, typename... Args,
-      typename std::enable_if_t<std::is_constructible_v<T, Args...>>* = nullptr>
+  template <typename T, typename... Args>
   auto UniqueNew(Args&&... args) -> Nonnull<T*>;
 
   // Returns a pointer to the canonical instance of T constructed from
@@ -219,8 +217,7 @@ void Arena::New(WriteAddressTo<U> addr, Args&&... args) {
   allocated_ += sizeof(T);
 }
 
-template <typename T, typename... Args,
-          typename std::enable_if_t<std::is_constructible_v<T, Args...>>*>
+template <typename T, typename... Args>
 auto Arena::UniqueNew(Args&&... args) -> Nonnull<T*> {
   auto smart_ptr =
       std::make_unique<ArenaEntryTyped<T>>(std::forward<Args>(args)...);

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -125,7 +125,7 @@ class Arena {
   std::vector<std::unique_ptr<ArenaEntry>> arena_;
   int64_t allocated_ = 0;
 
-  // Hash functor implemented in terms of hash_value (see llvm/ADT/Hashing.h)
+  // Hash functor implemented in terms of hash_value (see llvm/ADT/Hashing.h).
   struct LlvmHasher {
     template <typename T>
     auto operator()(const T& t) const -> size_t {
@@ -140,6 +140,7 @@ class Arena {
   // Inspired by llvm::Any::TypeId.
   template <typename T>
   struct TypeId {
+    // This is only used for an address to compare; the value is unimportant.
     static char id;
   };
 
@@ -156,7 +157,9 @@ class Arena {
   std::map<char*, std::any> canonical_tables_;
 };
 
-// Implementation details only below here -------------------------------------
+// ---------------------------------------
+// Implementation details only below here.
+// ---------------------------------------
 
 template <>
 struct ArgKey<std::nullopt_t> {

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -200,7 +200,7 @@ template <typename T, typename... Args,
           typename std::enable_if_t<std::is_constructible_v<T, Args...> &&
                                     Arena::CanonicalizeAllocation<T>::value>*>
 auto Arena::New(Args&&... args) -> Nonnull<const T*> {
-  const T*& canonical_instance = CanonicalInstance<T>(this, args...);
+  const T*& canonical_instance = CanonicalInstance<T>(args...);
   if (canonical_instance == nullptr) {
     canonical_instance = UniqueNew<T>(std::forward<Args>(args)...);
   }

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -18,6 +18,21 @@
 
 namespace Carbon {
 
+// Adapter metafunction that converts T to a form that is usable as part of
+// a key in a hash map.
+//
+// ArgKey<T>::type must be implicitly convertible from T, equality-comparable,
+// and have a hash_value overload as defined in llvm/ADT/Hashing.h. This
+// should only be customized in cases where we cannot modify T itself to
+// satisfy those requirements.
+template <typename T, typename = void>
+struct ArgKey {
+  using type = T;
+};
+
+template <typename T>
+using ArgKeyType = typename ArgKey<T>::type;
+
 // Allocates and maintains ownership of arbitrary objects, so that their
 // lifetimes all end at the same time. It can also canonicalize the allocated
 // objects (see the documentation of New).
@@ -46,19 +61,17 @@ class Arena {
   // will canonicalize the allocated objects, meaning that two calls to this
   // method with the same T and equal arguments will return pointers to the same
   // object. If canonicalization is enabled, all types in Args... must be
-  // canonicalizable, meaning that they are copyable, and either are
-  // equality-comparable and have a hash_value overload as defined in
-  // llvm/ADT/Hashing.h, or are `Decompose`able into canonicalizable values.
-  // Canonicalization also supports certain standard library types; in
-  // particular, std::vector<T> and std::optional<T> are canonicalizable if T
-  // is.
+  // copyable, equality-comparable, and have a hash_value overload as defined in
+  // llvm/ADT/Hashing.h. If it's not possible to modify an argument type A to
+  // satisfy those requirements, the ArgKey<A> customization point can be used
+  // instead.
   //
   // Canonically-allocated objects must not be mutated, because those mutations
-  // would be visible to all users that happened to allocate a T object with the
-  // same constructor arguments. To help enforce this, the returned pointer will
-  // be const when canonicalization is enabled. Since that means there is no way
-  // to allocate a mutable instance of T, canonicalization should only be
-  // enabled for types that are inherently immutable.
+  // would be visible to all users that happened to allocate a T object with
+  // the same constructor arguments. To help enforce this, the returned pointer
+  // will be const when canonicalization is enabled. Since that means there
+  // is no way to allocate a mutable instance of T, canonicalization should
+  // only be enabled for types that are inherently immutable.
   //
   // Canonicalization does not guarantee that equal objects will be identical,
   // but it can substantially reduce the incidence of equal-but-not-identical
@@ -95,200 +108,13 @@ class Arena {
   template <typename T>
   class ArenaEntryTyped;
 
-  // FIXME clean up and document implementation details of canonicalization.
-
-  struct DummyCallback {
-    template <typename... Ts>
-    void operator()(const Ts&...);
-  };
-
-  template <typename T, typename = void>
-  struct IsDecomposable : public std::false_type {};
-
-  template <typename T>
-  struct IsDecomposable<
-      T,
-      std::void_t<decltype(std::declval<const T>().Decompose(DummyCallback{}))>>
-      : public std::true_type {};
-
-  static constexpr int MaxPriority = 10;
-  template <int N>
-  struct Priority : Priority<N + 1> {
-    static_assert(N < MaxPriority);
-  };
-
-  template <>
-  struct Priority<MaxPriority> {};
-
-  // Hash functor for tuples of canonicalizable types.
-  struct ArgsHash {
-    template <typename... Ts>
-    auto operator()(const std::tuple<Ts...>& t) const -> size_t {
-      return std::apply(
-          [](const auto&... elements) {
-            return CustomHashCombine(elements...);
-          },
-          t);
-    }
-
-    template <typename... Ts>
-    static auto CustomHashCombine(const Ts&... ts) -> llvm::hash_code {
-      return llvm::hash_combine(CustomHashValue(Priority<0>{}, ts)...);
-    }
-
-    template <typename Iterator>
-    static auto CustomHashCombineRange(Iterator begin, Iterator end)
-        -> llvm::hash_code {
-      llvm::hash_code result = llvm::hash_combine();
-      while (begin != end) {
-        result = CustomHashCombine(result, *begin);
-        ++begin;
-      }
-      return result;
-    }
-
+  // Hash functor implemented in terms of hash_value (see llvm/ADT/Hashing.h).
+  struct LlvmHasher {
     template <typename T>
-    static constexpr auto IsLlvmHashable() -> bool {
-      using llvm::hash_value;
-      auto probe = [](const auto& t) -> decltype(hash_value(t)) {};
-      return std::is_invocable_r_v<llvm::hash_code, decltype(probe), const T&>;
-    }
-
-    template <typename T, typename = void>
-    struct IsCustomHashable;
-
-    // We have to exclude implicit conversions to avoid ambiguity, because
-    // hash_code is implicitly convertible from size_t.
-    template <typename T,
-              typename = std::enable_if_t<std::is_same_v<T, llvm::hash_code>>>
-    static auto CustomHashValue(Priority<0>, T code) -> llvm::hash_code {
-      return code;
-    }
-
-    template <typename T,
-              typename = std::enable_if_t<IsCustomHashable<T>::value>>
-    static auto CustomHashValue(Priority<0>, const std::vector<T>& v)
-        -> llvm::hash_code {
-      return CustomHashCombineRange(v.begin(), v.end());
-    }
-
-    // We need this because of optional<Decomposable> ctor parameters.
-    template <typename T,
-              typename = std::enable_if_t<IsCustomHashable<T>::value>>
-    static auto CustomHashValue(Priority<0>, const std::optional<T>& opt)
-        -> llvm::hash_code {
-      if (opt.has_value()) {
-        return CustomHashCombine(*opt);
-      } else {
-        return CustomHashCombine(std::nullopt);
-      }
-    }
-
-    static auto CustomHashValue(Priority<0>, std::nullopt_t)
-        -> llvm::hash_code {
-      return llvm::hash_combine();
-    }
-
-    template <typename T, typename = std::enable_if_t<IsLlvmHashable<T>()>>
-    static auto CustomHashValue(Priority<1>, const T& t) -> llvm::hash_code {
+    auto operator()(const T& t) const -> size_t {
       using llvm::hash_value;
       return hash_value(t);
     }
-
-    template <typename T,
-              typename = std::enable_if_t<IsDecomposable<T>::value &&
-                                          std::is_copy_constructible_v<T>>>
-    static auto CustomHashValue(Priority<2>, const T& t) -> llvm::hash_code {
-      return t.Decompose([](auto&&... us) { return CustomHashCombine(us...); });
-    }
-
-    template <typename T, typename>
-    struct IsCustomHashable : public std::false_type {};
-
-    template <typename T>
-    struct IsCustomHashable<T, std::void_t<decltype(CustomHashValue(
-                                   Priority<0>{}, std::declval<const T>()))>>
-        : public std::true_type {};
-  };
-
-  struct ArgsEqual {
-    template <typename... Ts>
-    auto operator()(const std::tuple<Ts...>& lhs,
-                    const std::tuple<Ts...>& rhs) const -> bool {
-      return std::apply(
-          [&](const auto&... lhs_elements) {
-            return std::apply(
-                [&](const auto&... rhs_elements) {
-                  return (Equals(Priority<0>{}, lhs_elements, rhs_elements) &&
-                          ...);
-                },
-                rhs);
-          },
-          lhs);
-    }
-
-    template <typename T, typename = void>
-    struct SupportsEquals;
-
-    template <typename T, typename = std::enable_if_t<SupportsEquals<T>::value>>
-    static auto Equals(Priority<0>, const std::vector<T>& lhs,
-                       const std::vector<T>& rhs) -> bool {
-      if (lhs.size() != rhs.size()) {
-        return false;
-      }
-      auto lhs_it = lhs.begin();
-      auto rhs_it = rhs.begin();
-      while (lhs_it != lhs.end()) {
-        if (!Equals(Priority<0>{}, *lhs_it, *rhs_it)) {
-          return false;
-        }
-        ++lhs_it;
-        ++rhs_it;
-      }
-      return true;
-    }
-
-    template <typename T, typename = std::enable_if_t<SupportsEquals<T>::value>>
-    static auto Equals(Priority<0>, const std::optional<T>& lhs,
-                       const std::optional<T>& rhs) -> bool {
-      if (lhs.has_value() && rhs.has_value()) {
-        return Equals(Priority<0>{}, *lhs, *rhs);
-      } else {
-        return lhs.has_value() == rhs.has_value();
-      }
-    }
-
-    static auto Equals(Priority<0>, std::nullopt_t, std::nullopt_t) -> bool {
-      return true;
-    }
-
-    template <typename T,
-              typename = std::enable_if_t<std::is_convertible_v<
-                  decltype(std::declval<const T>() == std::declval<const T>()),
-                  bool>>>
-    static auto Equals(Priority<1>, const T& lhs, const T& rhs) -> bool {
-      return lhs == rhs;
-    }
-
-    template <typename T,
-              typename = std::enable_if_t<IsDecomposable<T>::value &&
-                                          std::is_copy_constructible_v<T>>>
-    static auto Equals(Priority<2>, const T& lhs, const T& rhs) -> bool {
-      return lhs.Decompose([&](auto&&... lhs_elements) {
-        return rhs.Decompose([&](auto&&... rhs_elements) {
-          return (Equals(Priority<0>{}, lhs_elements, rhs_elements) && ...);
-        });
-      });
-    }
-
-    template <typename T, typename>
-    struct SupportsEquals : public std::false_type {};
-
-    template <typename T>
-    struct SupportsEquals<
-        T, std::void_t<decltype(Equals(Priority<0>{}, std::declval<const T>(),
-                                       std::declval<const T>()))>>
-        : public std::true_type {};
   };
 
   // Factory metafunction for globally unique type IDs.
@@ -305,8 +131,8 @@ class Arena {
   // a non-null pointer to a T object constructed with those arguments.
   template <typename T, typename... Args>
   using CanonicalizationTable =
-      std::unordered_map<std::tuple<Args...>, Nonnull<const T*>, ArgsHash,
-                         ArgsEqual>;
+      std::unordered_map<std::tuple<ArgKeyType<Args>...>, Nonnull<const T*>,
+                         LlvmHasher>;
 
   // Allocates an object in the arena. Unlike New, this will always allocate
   // and construct a new object.
@@ -332,6 +158,36 @@ class Arena {
 // ---------------------------------------
 // Implementation details only below here.
 // ---------------------------------------
+
+template <>
+struct ArgKey<std::nullopt_t> {
+  using type = struct NulloptProxy {
+    NulloptProxy(std::nullopt_t) {}
+    friend auto operator==(NulloptProxy, NulloptProxy) -> bool { return true; }
+    friend auto hash_value(NulloptProxy) -> llvm::hash_code {
+      return llvm::hash_combine();
+    }
+  };
+};
+
+template <typename T>
+struct ArgKey<std::vector<T>> {
+  using type = class VectorProxy {
+   public:
+    VectorProxy(std::vector<T> vec) : vec_(std::move(vec)) {}
+    friend auto operator==(const VectorProxy& lhs, const VectorProxy& rhs) {
+      return lhs.vec_ == rhs.vec_;
+    }
+    friend auto hash_value(const VectorProxy& v) {
+      return llvm::hash_combine(
+          llvm::hash_combine_range(v.vec_.begin(), v.vec_.end()),
+          v.vec_.size());
+    }
+
+   private:
+    std::vector<T> vec_;
+  };
+};
 
 template <typename T, typename... Args,
           typename std::enable_if_t<std::is_constructible_v<T, Args...> &&

--- a/explorer/common/arena.h
+++ b/explorer/common/arena.h
@@ -5,15 +5,42 @@
 #ifndef CARBON_EXPLORER_COMMON_ARENA_H_
 #define CARBON_EXPLORER_COMMON_ARENA_H_
 
+#include <any>
+#include <map>
 #include <memory>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "explorer/common/nonnull.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace std {
+// FIXME what should we do about these?
+template <typename T>
+auto hash_value(const std::vector<T>& vector) -> llvm::hash_code {
+  return llvm::hash_combine(
+      llvm::hash_combine_range(vector.begin(), vector.end()), vector.size());
+}
+
+inline auto hash_value(nullopt_t) -> llvm::hash_code {
+  return llvm::hash_combine();
+}
+inline auto operator==(nullopt_t, nullopt_t) -> bool { return true; }
+}  // namespace std
 
 namespace Carbon {
 
+// Allocates and maintains ownership of arbitrary objects, so that their
+// lifetimes all end at the same time. It can also canonicalize the allocated
+// objects (see the documentation of New).
 class Arena {
+  // CanonicalizeAllocation<T>::value is true if canonicalization is enabled
+  // for T, and false otherwise.
+  template <typename T, typename = void>
+  struct CanonicalizeAllocation;
+
  public:
   // Values of this type can be passed as the first argument to New in order to
   // have the address of the created object written to the given pointer before
@@ -26,32 +53,60 @@ class Arena {
   template <typename T>
   WriteAddressTo(T** target) -> WriteAddressTo<T>;
 
-  // Allocates an object in the arena, returning a pointer to it.
+  // Returns a pointer to an object constructed as if by `T(args...)`, owned
+  // by this Arena.
+  //
+  // If T::EnableCanonicalizedAllocation exists and names a type, this method
+  // will canonicalize the allocated objects, meaning that two calls to this
+  // method with the same T and equal arguments will return pointers to the same
+  // object. If canonicalization is enabled, Args... must all be copyable,
+  // equality-comparable, and have a hash_value overload as defined in
+  // llvm/ADT/Hashing.h.
+  //
+  // Canonically-allocated objects must not be mutated, because those mutations
+  // would be visible to all users that happened to allocate a T object with
+  // the same constructor arguments. To help enforce this, the returned pointer
+  // will be const when canonicalization is enabled. Since that means there
+  // is no way to allocate a mutable instance of T, canonicalization should
+  // only be enabled for types that are inherently immutable.
+  //
+  // Canonicalization does not guarantee that equal objects will be identical,
+  // but it can substantially reduce the incidence of equal-but-not-identical
+  // objects, which can facilitate various optimizations.
   template <
       typename T, typename... Args,
-      typename std::enable_if_t<std::is_constructible_v<T, Args...>>* = nullptr>
-  auto New(Args&&... args) -> Nonnull<T*> {
-    auto smart_ptr =
-        std::make_unique<ArenaEntryTyped<T>>(std::forward<Args>(args)...);
-    Nonnull<T*> ptr = smart_ptr->Instance();
-    arena_.push_back(std::move(smart_ptr));
-    allocated_ += sizeof(T);
-    return ptr;
-  }
+      typename std::enable_if_t<std::is_constructible_v<T, Args...> &&
+                                !CanonicalizeAllocation<T>::value>* = nullptr>
+  auto New(Args&&... args) -> Nonnull<T*>;
+
+  template <
+      typename T, typename... Args,
+      typename std::enable_if_t<std::is_constructible_v<T, Args...> &&
+                                CanonicalizeAllocation<T>::value>* = nullptr>
+  auto New(Args&&... args) -> Nonnull<const T*>;
 
   // Allocates an object in the arena, writing its address to the given pointer.
   template <
       typename T, typename U, typename... Args,
       typename std::enable_if_t<std::is_constructible_v<T, Args...>>* = nullptr>
-  void New(WriteAddressTo<U> addr, Args&&... args) {
-    arena_.push_back(std::make_unique<ArenaEntryTyped<T>>(
-        addr, std::forward<Args>(args)...));
-    allocated_ += sizeof(T);
-  }
+  void New(WriteAddressTo<U> addr, Args&&... args);
 
   auto allocated() -> int64_t { return allocated_; }
 
  private:
+  // Allocates an object in the arena. Unlike New, this will always allocate
+  // and construct a new object.
+  template <
+      typename T, typename... Args,
+      typename std::enable_if_t<std::is_constructible_v<T, Args...>>* = nullptr>
+  auto UniqueNew(Args&&... args) -> Nonnull<T*>;
+
+  // Returns a pointer to the canonical instance of T constructed from
+  // `args...`, or null if there is no such instance yet. Returns a mutable
+  // reference so that a null entry can be updated.
+  template <typename T, typename... Args>
+  auto CanonicalInstance(const Args&... args) -> const T*&;
+
   // Virtualizes arena entries so that a single vector can contain many types,
   // avoiding templated statics.
   class ArenaEntry {
@@ -61,34 +116,130 @@ class Arena {
 
   // Templated destruction of a pointer.
   template <typename T>
-  class ArenaEntryTyped : public ArenaEntry {
-   public:
-    struct WriteAddressHelper {};
-
-    template <typename... Args>
-    explicit ArenaEntryTyped(Args&&... args)
-        : instance_(std::forward<Args>(args)...) {}
-
-    template <typename... Args>
-    explicit ArenaEntryTyped(WriteAddressHelper, Args&&... args)
-        : ArenaEntryTyped(std::forward<Args>(args)...) {}
-
-    template <typename U, typename... Args>
-    explicit ArenaEntryTyped(WriteAddressTo<U> write_address, Args&&... args)
-        : ArenaEntryTyped(
-              (*write_address.target = &instance_, WriteAddressHelper{}),
-              std::forward<Args>(args)...) {}
-
-    auto Instance() -> Nonnull<T*> { return Nonnull<T*>(&instance_); }
-
-   private:
-    T instance_;
-  };
+  class ArenaEntryTyped;
 
   // Manages allocations in an arena for destruction at shutdown.
   std::vector<std::unique_ptr<ArenaEntry>> arena_;
   int64_t allocated_ = 0;
+
+  // Hash functor implemented in terms of hash_value (see llvm/ADT/Hashing.h)
+  struct LlvmHasher {
+    template <typename T>
+    auto operator()(const T& t) const -> size_t {
+      using llvm::hash_value;
+      return hash_value(t);
+    }
+  };
+
+  // Factory metafunction for globally unique type IDs.
+  // &TypeId<T>::id == &TypeId<U>::id if and only if std::is_same_v<T,U>.
+  //
+  // Inspired by llvm::Any::TypeId.
+  template <typename T>
+  struct TypeId {
+    static char id;
+  };
+
+  // A canonicalization table maps a tuple of constructor argument values to
+  // a non-null pointer to a T object constructed with those arguments.
+  template <typename T, typename... Args>
+  using CanonicalizationTable =
+      std::unordered_map<std::tuple<Args...>, Nonnull<const T*>, LlvmHasher>;
+
+  // Maps a CanonicalizationTable type to a unique instance of that type for
+  // this arena. For a key equal to &TypeId<T>::id for some T, the corresponding
+  // value contains a T*.
+  std::map<char*, std::any> canonical_tables_;
 };
+
+// Implementation details only below here -------------------------------------
+
+template <typename T, typename... Args,
+          typename std::enable_if_t<std::is_constructible_v<T, Args...> &&
+                                    !Arena::CanonicalizeAllocation<T>::value>*>
+auto Arena::New(Args&&... args) -> Nonnull<T*> {
+  return UniqueNew<T>(std::forward<Args>(args)...);
+}
+
+template <typename T, typename... Args,
+          typename std::enable_if_t<std::is_constructible_v<T, Args...> &&
+                                    Arena::CanonicalizeAllocation<T>::value>*>
+auto Arena::New(Args&&... args) -> Nonnull<const T*> {
+  const T*& canonical_instance = CanonicalInstance<T>(this, args...);
+  if (canonical_instance == nullptr) {
+    canonical_instance = UniqueNew<T>(std::forward<Args>(args)...);
+  }
+  return canonical_instance;
+}
+
+template <typename T, typename U, typename... Args,
+          typename std::enable_if_t<std::is_constructible_v<T, Args...>>*>
+void Arena::New(WriteAddressTo<U> addr, Args&&... args) {
+  static_assert(!CanonicalizeAllocation<T>::value,
+                "This form of New does not support canonicalization yet");
+  arena_.push_back(
+      std::make_unique<ArenaEntryTyped<T>>(addr, std::forward<Args>(args)...));
+  allocated_ += sizeof(T);
+}
+
+template <typename T, typename... Args,
+          typename std::enable_if_t<std::is_constructible_v<T, Args...>>*>
+auto Arena::UniqueNew(Args&&... args) -> Nonnull<T*> {
+  auto smart_ptr =
+      std::make_unique<ArenaEntryTyped<T>>(std::forward<Args>(args)...);
+  Nonnull<T*> ptr = smart_ptr->Instance();
+  arena_.push_back(std::move(smart_ptr));
+  allocated_ += sizeof(T);
+  return ptr;
+}
+
+template <typename T, typename>
+struct Arena::CanonicalizeAllocation : public std::false_type {};
+
+template <typename T>
+struct Arena::CanonicalizeAllocation<
+    T, std::void_t<typename T::EnableCanonicalizedAllocation>>
+    : public std::true_type {};
+
+template <typename T, typename... Args>
+auto Arena::CanonicalInstance(const Args&... args) -> const T*& {
+  using MapType = CanonicalizationTable<T, Args...>;
+  std::any& wrapped_table = canonical_tables_[&TypeId<MapType>::id];
+  if (!wrapped_table.has_value()) {
+    wrapped_table.emplace<MapType>();
+  }
+  MapType& table = std::any_cast<MapType&>(wrapped_table);
+  return table[std::tuple<Args...>(args...)];
+}
+
+// Templated destruction of a pointer.
+template <typename T>
+class Arena::ArenaEntryTyped : public ArenaEntry {
+ public:
+  struct WriteAddressHelper {};
+
+  template <typename... Args>
+  explicit ArenaEntryTyped(Args&&... args)
+      : instance_(std::forward<Args>(args)...) {}
+
+  template <typename... Args>
+  explicit ArenaEntryTyped(WriteAddressHelper, Args&&... args)
+      : ArenaEntryTyped(std::forward<Args>(args)...) {}
+
+  template <typename U, typename... Args>
+  explicit ArenaEntryTyped(WriteAddressTo<U> write_address, Args&&... args)
+      : ArenaEntryTyped(
+            (*write_address.target = &instance_, WriteAddressHelper{}),
+            std::forward<Args>(args)...) {}
+
+  auto Instance() -> Nonnull<T*> { return Nonnull<T*>(&instance_); }
+
+ private:
+  T instance_;
+};
+
+template <typename T>
+char Arena::TypeId<T>::id = 1;
 
 }  // namespace Carbon
 

--- a/explorer/common/arena_test.cpp
+++ b/explorer/common/arena_test.cpp
@@ -1,0 +1,78 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "explorer/common/arena.h"
+
+#include <gtest/gtest.h>
+
+namespace Carbon {
+
+class ReportDestruction {
+ public:
+  explicit ReportDestruction(bool* destroyed) : destroyed_(destroyed) {}
+
+  ~ReportDestruction() { *destroyed_ = true; }
+
+ private:
+  bool* destroyed_;
+};
+
+TEST(ArenaTest, BasicAllocation) {
+  bool destroyed = false;
+  {
+    Arena arena;
+    (void)arena.New<ReportDestruction>(&destroyed);
+  }
+  EXPECT_TRUE(destroyed);
+}
+
+struct CanonicalizedDummy {
+  explicit CanonicalizedDummy(int) {}
+  explicit CanonicalizedDummy(int*) {}
+  explicit CanonicalizedDummy(int, int*) {}
+  using EnableCanonicalizedAllocation = void;
+};
+
+TEST(ArenaTest, Canonicalization) {
+  Arena arena;
+  auto* dummy1 = arena.New<CanonicalizedDummy>(1);
+  EXPECT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(dummy1)>>);
+  auto* dummy2 = arena.New<CanonicalizedDummy>(1);
+  EXPECT_TRUE(dummy1 == dummy2);
+}
+
+TEST(ArenaTest, CanonicalizationArgMismatch) {
+  Arena arena;
+  auto* dummy1 = arena.New<CanonicalizedDummy>(1);
+  auto* dummy2 = arena.New<CanonicalizedDummy>(2);
+  EXPECT_TRUE(dummy1 != dummy2);
+}
+
+TEST(ArenaTest, CanonicalizationDifferentArenas) {
+  Arena arena1;
+  Arena arena2;
+  auto* dummy1 = arena1.New<CanonicalizedDummy>(1);
+  auto* dummy2 = arena2.New<CanonicalizedDummy>(1);
+
+  EXPECT_TRUE(dummy1 != dummy2);
+}
+
+TEST(ArenaTest, CanonicalizationShallow) {
+  Arena arena;
+  int i1 = 1;
+  int i2 = 1;
+  auto* dummy1 = arena.New<CanonicalizedDummy>(&i1);
+  auto* dummy2 = arena.New<CanonicalizedDummy>(&i2);
+  EXPECT_TRUE(dummy1 != dummy2);
+}
+
+TEST(ArenaTest, CanonicalizationMultipleArgs) {
+  Arena arena;
+  int i;
+  auto* dummy1 = arena.New<CanonicalizedDummy>(1, &i);
+  auto* dummy2 = arena.New<CanonicalizedDummy>(1, &i);
+  EXPECT_TRUE(dummy1 == dummy2);
+}
+
+}  // namespace Carbon

--- a/explorer/common/decompose.h
+++ b/explorer/common/decompose.h
@@ -1,0 +1,54 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Utilities for types that support the `Decompose` API.
+
+#ifndef CARBON_EXPLORER_COMMON_DECOMPOSE_H_
+#define CARBON_EXPLORER_COMMON_DECOMPOSE_H_
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace Carbon {
+
+// CRTP base class which extends `Base` to support hashing and equality
+// comparison. `Base` must support the `Decompose` API.
+template <typename Base>
+class HashFromDecompose {
+ public:
+  friend auto operator==(const HashFromDecompose& lhs,
+                         const HashFromDecompose& rhs) -> bool {
+    return static_cast<const Base*>(&lhs)->Decompose(
+        [&](auto&&... lhs_elements) {
+          return static_cast<const Base*>(&rhs)->Decompose(
+              [&](auto&&... rhs_elements) {
+                return ((lhs_elements == rhs_elements) && ...);
+              });
+        });
+  }
+
+  friend auto hash_value(const HashFromDecompose& self) -> llvm::hash_code {
+    return static_cast<const Base*>(&self)->Decompose(
+        [&](auto&&... lhs_elements) {
+          return llvm::hash_combine(WrapForHash(lhs_elements)...);
+        });
+  }
+
+ private:
+  // Wraps T in a form that supports `hash_value`. Used for adapting types that
+  // we can't extend directly.
+  template <typename T>
+  static auto WrapForHash(const T& t) -> const T& {
+    return t;
+  }
+
+  template <typename T>
+  static auto WrapForHash(const std::vector<T>& vec) -> llvm::ArrayRef<T> {
+    return vec;
+  }
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_EXPLORER_COMMON_DECOMPOSE_H_

--- a/explorer/common/decompose_test.cpp
+++ b/explorer/common/decompose_test.cpp
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "explorer/common/decompose.h"
+
+#include <gtest/gtest.h>
+
+namespace Carbon {
+namespace {
+
+struct Decomposeable : public HashFromDecompose<Decomposeable> {
+  template <typename F>
+  auto Decompose(F f) const {
+    return f(i, s);
+  }
+
+  int i = 0;
+  std::string s;
+};
+
+TEST(HashFromDecomposeTest, EqualValues) {
+  Decomposeable d1 = {.i = 42, .s = "foo"};
+  Decomposeable d2 = {.i = 42, .s = "foo"};
+
+  EXPECT_TRUE(d1 == d2);
+  EXPECT_TRUE(hash_value(d1) == hash_value(d2));
+}
+
+TEST(HashFromDecomposeTest, NonEqualValues) {
+  Decomposeable d1 = {.i = 42, .s = "foo"};
+  Decomposeable d2 = {.i = 42, .s = "bar"};
+
+  EXPECT_FALSE(d1 == d2);
+  EXPECT_FALSE(hash_value(d1) == hash_value(d2));
+}
+
+}  // namespace
+}  // namespace Carbon

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -3854,7 +3854,7 @@ auto TypeChecker::TypeCheckExpImpl(Nonnull<Expression*> e,
           for (size_t i = 0; i != params.size(); ++i) {
             // TODO: Should we disallow all other kinds of top-level params?
             if (const auto* binding = dyn_cast<GenericBinding>(params[i])) {
-              generic_parameters.push_back({i, binding});
+              generic_parameters.push_back({{}, i, binding});
             }
           }
 
@@ -5129,8 +5129,8 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
     CollectAndNumberGenericBindingsInPattern(&f->self_pattern(), all_bindings);
     CollectImplBindingsInPattern(&f->self_pattern(), impl_bindings);
     FunctionType::MethodSelf method_self_present = {
-        (f->self_pattern().kind() == PatternKind::AddrPattern),
-        &f->self_pattern().static_type()};
+        .addr_self = (f->self_pattern().kind() == PatternKind::AddrPattern),
+        .self_type = &f->self_pattern().static_type()};
     method_self = method_self_present;
   }
   // Type check the parameter pattern.
@@ -5153,7 +5153,7 @@ auto TypeChecker::DeclareCallableDeclaration(Nonnull<CallableDeclaration*> f,
     CollectAndNumberGenericBindingsInPattern(param_pattern, all_bindings);
 
     if (const auto* binding = dyn_cast<GenericBinding>(param_pattern)) {
-      generic_parameters.push_back({i, binding});
+      generic_parameters.push_back({.index = i, .binding = binding});
     } else {
       deduced_bindings.insert(deduced_bindings.end(),
                               all_bindings.begin() + old_size,

--- a/explorer/interpreter/type_structure.cpp
+++ b/explorer/interpreter/type_structure.cpp
@@ -81,10 +81,10 @@ struct TypeStructureBuilder {
   void Visit(Nonnull<const AstNode*>) {}
   void Visit(const ValueNodeView&) {}
   void Visit(const Address&) {}
-  void Visit(const VTable&) {}
+  void Visit(const VTable*) {}
   void Visit(const FunctionType::GenericParameter&) {}
   void Visit(const FunctionType::MethodSelf&) {}
-  void Visit(const NamedElement&) {}
+  void Visit(const NamedElement*) {}
 
   // Constraint types can contain mentions of VariableTypes, but they aren't
   // deducible so it's not important to look for them.


### PR DESCRIPTION
See arena.h for discussion of what canonicalization means in this context. This is primarily intended to support implementing a memo table of template instantiations to resolve #2951, but could be useful for other purposes as well.

Additional changes:
- Pass `VTable` constructor parameters by pointer, to avoid the need to define `operator==` and `hash_value` for it.
- Clean up the recurring pattern of allocating identical `NamedElement`s on the stack and heap. Instead we always allocate it on the heap and pass it by pointer.
- Add `Print()` and `Dump()` to `Bindings` as a debugging convenience.
