### PR TITLE
Introduce flag handling into file_test.

### DIFF
--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -40,21 +40,49 @@ cc_binary(
     ],
 )
 
-file_test(
-    name = "file_test",
+cc_library(
+    name = "file_test_common",
+    testonly = 1,
     srcs = ["file_test.cpp"],
-    # Bazel limits sharding to 50. We have lots of tests, so this should
-    # maximize parallelism.
-    shard_count = 50,
-    tests = glob([
-        "testdata/**/*.carbon",
-        "trace_testdata/**/*.carbon",
-    ]),
     deps = [
         "//explorer/parse_and_execute",
         "//testing/file_test:file_test_base",
         "//testing/util:test_raw_ostream",
+        "@com_google_absl//absl/flags:flag",
     ],
+)
+
+file_test(
+    name = "file_test",
+    size = "small",
+    shard_count = 20,
+    tests = glob([
+        "testdata/**/*.carbon",
+        "trace_testdata/**/*.carbon",
+    ]),
+    deps = [":file_test_common"],
+)
+
+file_test(
+    name = "file_test.trace",
+    size = "small",
+    args = ["--trace"],
+    shard_count = 30,
+    tests = glob(
+        # This omits trace_testdata because that's run with trace in the
+        # default mode.
+        ["testdata/**/*.carbon"],
+        exclude = [
+            # `limits` tests check for various limit conditions (such as an
+            # infinite loop). The tests collectively don't test tracing
+            # because it creates substantial additional overhead.
+            "testdata/limits/**",
+            # Expensive tests to trace.
+            "testdata/assoc_const/rewrite_large_type.carbon",
+            "testdata/linked_list/typed_linked_list.carbon",
+        ],
+    ),
+    deps = [":file_test_common"],
 )
 
 glob_sh_run(

--- a/scripts/fix_cc_deps.py
+++ b/scripts/fix_cc_deps.py
@@ -54,6 +54,10 @@ EXTERNAL_REPOS: Dict[str, ExternalRepo] = {
     ),
     # tools/cpp/runfiles:runfiles.h -> tools/cpp/runfiles/runfiles.h
     "@bazel_tools": ExternalRepo(lambda x: re.sub(":", "/", x), "...", None),
+    # absl/flags:flag.h -> absl/flags/flag.h
+    "@com_google_absl": ExternalRepo(
+        lambda x: re.sub(":", "/", x), "...", None
+    ),
 }
 
 # TODO: proto rules are aspect-based and their generated files don't show up in

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -14,6 +14,8 @@ cc_library(
     deps = [
         "//common:check",
         "//testing/util:test_raw_ostream",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
         "@com_google_googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],

--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -4,9 +4,7 @@
 
 """Rules for building fuzz tests."""
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_test")
-
-def file_test(name, srcs, deps, tests, shard_count = 1):
+def file_test(name, tests, data = [], args = [], **kwargs):
     """Generates tests using the file_test base.
 
     There will be one main test using `name` that can be sharded, and includes
@@ -15,26 +13,17 @@ def file_test(name, srcs, deps, tests, shard_count = 1):
 
     Args:
       name: The base name of the tests.
-      srcs: cc_test srcs.
-      deps: cc_test deps.
-      tests: The list of test files to use as data.
-      shard_count: The number of shards to use; defaults to 1.
+      tests: The list of test files to use as data, typically a glob.
+      data: Passed to cc_test.
+      args: Passed to cc_test.
+      **kwargs: Passed to cc_test.
     """
-    subset_name = "{0}.subset".format(name)
-
     native.cc_test(
         name = name,
-        srcs = srcs,
-        deps = deps,
-        data = tests,
-        args = ["$(location {0})".format(x) for x in tests],
-        shard_count = shard_count,
-    )
-
-    native_test(
-        name = subset_name,
-        src = name,
-        out = subset_name,
-        data = tests,
-        tags = ["manual"],
+        data = tests + data,
+        args = ["--file_tests=" + ",".join([
+            "$(location {0})".format(x)
+            for x in tests
+        ])] + args,
+        **kwargs
     )


### PR DESCRIPTION
I'm integrating absl flag support with a few thoughts here...

1. It simplifies the handling of files in file_test.
    - Removes the need for a separate subset target.
3. Looking forward, I'm planning to add a flag to allow for autoupdate of golden files.
4. In explorer, there's been confusion about having file_test run tests "twice" so hopefully it's clearer when it's a separate target with a different flag on the target.