### PR TITLE
Refactor FileTest construction so that the test class is directly available.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,11 +45,11 @@ repos:
 
   # Formatters should be run late so that they can re-format any prior changes.
   - repo: https://github.com/psf/black
-    rev: bf7a16254ec96b084a6caf3d435ec18f0f245cc7 # frozen: 23.3.0
+    rev: 193ee766ca496871f93621d6b58d57a6564ff81b # frozen: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: v3.0.0-alpha.9-for-vscode
+    rev: efd8b1e16f05132acf6edcf2827eeab21e0e00db # frozen: v3.0.0
     hooks:
       - id: prettier
   - repo: local
@@ -71,14 +71,14 @@ repos:
         types_or: [c++, proto]
         language: python
         args: ['-i']
-        additional_dependencies: ['clang-format==16.0.0']
+        additional_dependencies: ['clang-format==16.0.6']
       - id: explorer-format-grammar
         name: Format the explorer grammar file
         entry: explorer/syntax/format_grammar.py
         language: python
         files: ^explorer/syntax/(lexer.lpp|parser.ypp)$
         pass_filenames: false
-        additional_dependencies: ['clang-format==16.0.0']
+        additional_dependencies: ['clang-format==16.0.6']
 
   - repo: local
     hooks:
@@ -122,7 +122,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'bd424e49d4f0181d4c8b8909a8cd5ce9eb058044' # frozen: v1.3.0
+    rev: '6e63c9e9c65e1df04465cdcda0f2490e89291f58' # frozen: v1.4.1
     hooks:
       - id: mypy
         # Use setup.cfg to match the command line.

--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "absl/flags/flag.h"
-#include "common/check.h"
 #include "explorer/main.h"
 #include "testing/file_test/file_test_base.h"
 #include "testing/util/test_raw_ostream.h"
@@ -16,10 +15,9 @@ ABSL_FLAG(bool, trace, false,
 namespace Carbon::Testing {
 namespace {
 
-class ParseAndExecuteTestFile : public FileTestBase {
+class ExplorerFileTest : public FileTestBase {
  public:
-  explicit ParseAndExecuteTestFile(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using FileTestBase::FileTestBase;
 
   auto RunWithFiles(const llvm::SmallVector<llvm::StringRef>& test_args,
                     const llvm::SmallVector<TestFile>& test_files,
@@ -89,12 +87,6 @@ class ParseAndExecuteTestFile : public FileTestBase {
 
 }  // namespace
 
-extern auto RegisterFileTests(
-    const llvm::SmallVector<std::filesystem::path>& paths) -> void {
-  ParseAndExecuteTestFile::RegisterTests(
-      "ParseAndExecuteTestFile", paths, [](const std::filesystem::path& path) {
-        return new ParseAndExecuteTestFile(path);
-      });
-}
+CARBON_FILE_TEST_FACTORY(ExplorerFileTest);
 
 }  // namespace Carbon::Testing

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -147,6 +147,9 @@ struct FileTestFactory {
 // We can't use INSTANTIATE_TEST_CASE_P because of ordering issues between
 // container initialization and test instantiation by InitGoogleTest, but this
 // also allows us more flexibility in execution.
+//
+// We provide a `CARBON_FILE_TEST_FACTOR` macro below that provides a common,
+// convenient way to implement this function.
 extern auto GetFileTestFactory() -> FileTestFactory;
 
 // Provides a standard way to implement GetFileTestFactory.

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -134,7 +134,7 @@ class FileTestBase : public testing::Test {
 
   const std::filesystem::path path_;
 };
-
+// A plain struct to aggregate a name and factory function for tests using this framework.
 struct FileTestFactory {
   // The test fixture name.
   const char* name;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -138,6 +138,7 @@ class FileTestBase : public testing::Test {
 struct FileTestFactory {
   // The test fixture name.
   const char* name;
+
   // A factory function for tests.
   std::function<FileTestBase*(const std::filesystem::path& path)> factory_fn;
 };

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -24,8 +24,7 @@ using ::testing::Matcher;
 
 class FileTestBaseTest : public FileTestBase {
  public:
-  explicit FileTestBaseTest(const std::filesystem::path& path)
-      : FileTestBase(path) {}
+  using FileTestBase::FileTestBase;
 
   static auto HasFilename(std::string filename) -> Matcher<TestFile> {
     return Field("filename", &TestFile::filename, Eq(filename));
@@ -92,9 +91,6 @@ class FileTestBaseTest : public FileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  FileTestBaseTest::RegisterTests<FileTestBaseTest>("FileTestBaseTest", paths);
-}
+CARBON_FILE_TEST_FACTORY(FileTestBaseTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/codegen/codegen_file_test.cpp
+++ b/toolchain/codegen/codegen_file_test.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
@@ -23,9 +21,6 @@ class CodeGenFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  CodeGenFileTest::RegisterTests<CodeGenFileTest>("CodeGenFileTest", paths);
-}
+CARBON_FILE_TEST_FACTORY(CodeGenFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/driver/driver_file_test.cpp
+++ b/toolchain/driver/driver_file_test.cpp
@@ -2,7 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
@@ -22,9 +21,6 @@ class DriverFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  DriverFileTest::RegisterTests<DriverFileTest>("DriverFileTest", paths);
-}
+CARBON_FILE_TEST_FACTORY(DriverFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/lexer/lexer_file_test.cpp
+++ b/toolchain/lexer/lexer_file_test.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
@@ -23,9 +21,6 @@ class LexerFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  LexerFileTest::RegisterTests<LexerFileTest>("LexerFileTest", paths);
-}
+CARBON_FILE_TEST_FACTORY(LexerFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
@@ -23,9 +21,6 @@ class LoweringFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  LoweringFileTest::RegisterTests<LoweringFileTest>("LoweringFileTest", paths);
-}
+CARBON_FILE_TEST_FACTORY(LoweringFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/parser/parse_tree_file_test.cpp
+++ b/toolchain/parser/parse_tree_file_test.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
@@ -23,10 +21,6 @@ class ParseTreeFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  ParseTreeFileTest::RegisterTests<ParseTreeFileTest>("ParseTreeFileTest",
-                                                      paths);
-}
+CARBON_FILE_TEST_FACTORY(ParseTreeFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "toolchain/driver/driver_file_test_base.h"
 
 namespace Carbon::Testing {
@@ -23,10 +21,6 @@ class SemanticsFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-auto RegisterFileTests(const llvm::SmallVector<std::filesystem::path>& paths)
-    -> void {
-  SemanticsFileTest::RegisterTests<SemanticsFileTest>("SemanticsFileTest",
-                                                      paths);
-}
+CARBON_FILE_TEST_FACTORY(SemanticsFileTest);
 
 }  // namespace Carbon::Testing


### PR DESCRIPTION
This is a simplification of the construction, although somewhat limiting (it means that the caller can't register the same file multiple times, though I stopped doing that anyways since it was causing confusion). What this more importantly _allows_ is logic on the FileTestBase child itself that's not test-specific -- in particular, autoupdate functionality which wouldn't use RUN_ALL_TESTS.