### PR TITLE
Fix newline formatting in stale-issue message

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,20 +18,28 @@ jobs:
             active work. If this issue should remain active or becomes active
             again, please comment or remove the `inactive` label. The `long
             term` label can also be added for issues which are expected to take
-            time. \n\n\n This issue is labeled `inactive` because the last
-            activity was over 90 days ago.
+            time.
+
+
+            This issue is labeled `inactive` because the last activity was over
+            90 days ago.
           stale-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active, please comment or
-            remove the `inactive` label. \n\n\n This PR is labeled `inactive`
-            because the last activity was over 90 days ago. This PR will be
-            closed and archived after 14 additional days without activity.
+            remove the `inactive` label.
+
+
+            This PR is labeled `inactive` because the last activity was over 90
+            days ago. This PR will be closed and archived after 14 additional
+            days without activity.
           close-pr-message: >
             We triage inactive PRs and issues in order to make it easier to find
             active work. If this PR should remain active or becomes active
-            again, please reopen it. \n\n\n This PR was closed and archived
-            because there has been no new activity in the 14 days since the
-            `inactive` label was added.
+            again, please reopen it.
+
+
+            This PR was closed and archived because there has been no new
+            activity in the 14 days since the `inactive` label was added.
           stale-issue-label: 'inactive'
           stale-pr-label: 'inactive'
           exempt-issue-labels:


### PR DESCRIPTION
YAML string literals don't seem to support escape sequences like `\n`, so `\n\n\n` was showing up literally in the issue messages.
