### PR TITLE
Fix crash type-checking member access into an invalid expression.

### DIFF
--- a/toolchain/semantics/semantics_handle_name.cpp
+++ b/toolchain/semantics/semantics_handle_name.cpp
@@ -23,7 +23,7 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
   }
 
   auto base_type = context.semantics_ir().GetNode(
-      context.semantics_ir().GetType(base.type_id()));
+      context.semantics_ir().GetTypeAllowBuiltinTypes(base.type_id()));
 
   switch (base_type.kind()) {
     case SemanticsNodeKind::StructType: {
@@ -50,12 +50,14 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
       break;
     }
     default: {
-      CARBON_DIAGNOSTIC(QualifiedExpressionUnsupported, Error,
-                        "Type `{0}` does not support qualified expressions.",
-                        std::string);
-      context.emitter().Emit(
-          parse_node, QualifiedExpressionUnsupported,
-          context.semantics_ir().StringifyType(base.type_id()));
+      if (base.type_id() != SemanticsTypeId::Error) {
+        CARBON_DIAGNOSTIC(QualifiedExpressionUnsupported, Error,
+                          "Type `{0}` does not support qualified expressions.",
+                          std::string);
+        context.emitter().Emit(
+            parse_node, QualifiedExpressionUnsupported,
+            context.semantics_ir().StringifyType(base.type_id()));
+      }
       break;
     }
   }

--- a/toolchain/semantics/testdata/struct/fail_access_into_invalid.carbon
+++ b/toolchain/semantics/testdata/struct/fail_access_into_invalid.carbon
@@ -1,0 +1,42 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+// CHECK:STDOUT: cross_reference_irs_size: 1
+// CHECK:STDOUT: functions: [
+// CHECK:STDOUT:   {name: str0, param_refs: block0, body: {block2}}},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: integer_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: real_literals: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: strings: [
+// CHECK:STDOUT:   F,
+// CHECK:STDOUT:   a,
+// CHECK:STDOUT:   b,
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: types: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: type_blocks: [
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: nodes: [
+// CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:   {kind: Return},
+// CHECK:STDOUT: ]
+// CHECK:STDOUT: node_blocks: [
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node+0,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT:   [
+// CHECK:STDOUT:     node+1,
+// CHECK:STDOUT:   ],
+// CHECK:STDOUT: ]
+
+
+// CHECK:STDERR: fail_access_into_invalid.carbon:[[@LINE+3]]:10: Name a not found
+// CHECK:STDERR: fn F() { a.b; }
+// CHECK:STDERR:          ^
+fn F() { a.b; }


### PR DESCRIPTION
Found by fuzzer.