### PR TITLE
Adds LLVM hardening flag for cc_toolchain libc++ for LLVM >= 17

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -512,9 +512,6 @@ def _impl(ctx):
     # With clang 14 and lower, we expect it to be built with libc++ debug
     # support. In later LLVM versions, we expect the assertions define to work.
     # clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of HARDENED_MODE.
-    # TODO(samkhn): Once LLVM makes ENABLE_ASSERTIONS equivalent to
-    # ENABLE_HARDENING, remove the HARDENED_MODE check
-    # https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config
     if clang_version and clang_version <= 14:
         libcpp_debug_flags = ["-D_LIBCPP_DEBUG=1"]
     elif clang_version and clang_version <= 16:

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -511,8 +511,14 @@ def _impl(ctx):
 
     # With clang 14 and lower, we expect it to be built with libc++ debug
     # support. In later LLVM versions, we expect the assertions define to work.
+    # clang 17 deprecates LIBCPP_ENABLE_ASSERTIONS in favor of HARDENED_MODE.
+    # TODO(samkhn): Once LLVM makes ENABLE_ASSERTIONS equivalent to
+    # ENABLE_HARDENING, remove the HARDENED_MODE check
+    # https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config
     if clang_version and clang_version <= 14:
         libcpp_debug_flags = ["-D_LIBCPP_DEBUG=1"]
+    elif clang_version and clang_version <= 17:
+        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
     else:
         libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
 

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -517,10 +517,10 @@ def _impl(ctx):
     # https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config
     if clang_version and clang_version <= 14:
         libcpp_debug_flags = ["-D_LIBCPP_DEBUG=1"]
-    elif clang_version and clang_version <= 17:
-        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
-    else:
+    elif clang_version and clang_version <= 16:
         libcpp_debug_flags = ["-D_LIBCPP_ENABLE_ASSERTIONS=1"]
+    else:
+        libcpp_debug_flags = ["-D_LIBCPP_ENABLE_HARDENED_MODE=1"]
 
     linux_flags_feature = feature(
         name = "linux_flags",


### PR DESCRIPTION
LLVM 17 replaces ENABLE_ASSERTIONS with ENABLE_HARDEDNING. LLVM 18 is temporarily warning that ENABLE_ASSERTIONS is deprecated. Since we treat warnings as errors, this causes build failures for LLVM 18.

This commit can probably be safely removed/undone once LLVM hardening removes the check [here](https://github.com/llvm/llvmproject/blob/667602793bef72e64367ac46cbaf96e3afaea22e/libcxx/include/__config#L211). 