### PR TITLE
Update contribution tools with bazel versioning details

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -130,7 +130,7 @@ These tools are essential for work on Carbon.
             outdated, and not be upgraded.
 -   Main tools
     -   [Bazel](https://www.bazel.build/)
-        -   At least bazel version 6.0.0.
+        -   NOTE: See [the bazelisk config](/.bazeliskrc) for a supported version.
     -   [Bazelisk](https://docs.bazel.build/versions/master/install-bazelisk.html)
         (for macOS, Linux, Windows): Handles Bazel versions.
     -   [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/)

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -130,8 +130,9 @@ These tools are essential for work on Carbon.
             outdated, and not be upgraded.
 -   Main tools
     -   [Bazel](https://www.bazel.build/)
+        -   At least bazel version 6.0.0.
     -   [Bazelisk](https://docs.bazel.build/versions/master/install-bazelisk.html)
-        (for macOS): Handles Bazel versions.
+        (for macOS, Linux, Windows): Handles Bazel versions.
     -   [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/)
         -   NOTE: Most LLVM 14+ installs should build Carbon. If you're having
             issues, see

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -132,7 +132,7 @@ These tools are essential for work on Carbon.
     -   [Bazel](https://www.bazel.build/)
         -   NOTE: See [the bazelisk config](/.bazeliskrc) for a supported version.
     -   [Bazelisk](https://docs.bazel.build/versions/master/install-bazelisk.html)
-        (for macOS, Linux, Windows): Handles Bazel versions.
+        (for macOS): Handles Bazel versions.
     -   [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/)
         -   NOTE: Most LLVM 14+ installs should build Carbon. If you're having
             issues, see

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -130,7 +130,8 @@ These tools are essential for work on Carbon.
             outdated, and not be upgraded.
 -   Main tools
     -   [Bazel](https://www.bazel.build/)
-        -   NOTE: See [the bazelisk config](/.bazeliskrc) for a supported version.
+        -   NOTE: See [the bazelisk config](/.bazeliskrc) for a supported
+            version.
     -   [Bazelisk](https://docs.bazel.build/versions/master/install-bazelisk.html)
         (for macOS): Handles Bazel versions.
     -   [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/)


### PR DESCRIPTION
You need bazel version 6.0.0 (with --host_per_file_copt) to build carbon. This adds versioning info and adds that Linux, Mac and Windows can use bazelisk.

