### PR TITLE
Fix bug in the VFS construction.

### DIFF
--- a/explorer/file_test.cpp
+++ b/explorer/file_test.cpp
@@ -31,7 +31,7 @@ class ExplorerFileTest : public FileTestBase {
            llvm::raw_pwrite_stream& stdout, llvm::raw_pwrite_stream& stderr)
       -> ErrorOr<bool> override {
     // Create the files in-memory.
-    llvm::vfs::InMemoryFileSystem fs(new llvm::vfs::InMemoryFileSystem());
+    llvm::vfs::InMemoryFileSystem fs;
     for (const auto& test_file : test_files) {
       if (!fs.addFile(test_file.filename, /*ModificationTime=*/0,
                       llvm::MemoryBuffer::getMemBuffer(test_file.content))) {


### PR DESCRIPTION
The constructor accepts a `bool` which we were setting to `true` by converting from a heap allocated, and thus non-null, pointer. But that heap allocation was dead and leaked, somewhat obviously. Leak checking is disabled on our CI at the moment, but this was failing for me locally with our default build on Linux where it uses ASan.

The `true` value also had no effect because the default argument to the bool parameter is itself, `true`. :sigh:

It's really sad that this compiled. But it's the same thing as using a non-null pointer in an `if`. There doesn't seem to be any `clang-tidy` check for a `new` expression that is implicitly converted to a `bool` type either. I've filled
https://github.com/llvm/llvm-project/issues/64461 requesting a check or warning to catch this in the future.