### PR TITLE
Fix spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ contribute.
 
 You can also directly:
 
--   [Contribute the language design](CONTRIBUTING.md#contributing-to-the-language-design):
+-   [Contribute to the language design](CONTRIBUTING.md#contributing-to-the-language-design):
     feedback on design, new design proposal
 -   [Contribute to the language implementation](CONTRIBUTING.md#contributing-to-the-language-implementation)
     -   [Carbon Explorer](/explorer/): bug report, bug fix, language feature


### PR DESCRIPTION
This PR resolves the spelling error in the "Contributing" section of the README. The sentence "Contribute the language design: feedback on design, new design proposal" has been corrected to "Contribute to the language design: feedback on design, new design proposal". This change enhances the clarity and accuracy of the contribution guidelines.

Closes #3068
