### PR TITLE
Explorer: Reduce prelude path when printing source location

### DIFF
--- a/explorer/common/source_location.h
+++ b/explorer/common/source_location.h
@@ -48,14 +48,20 @@ class SourceLocation {
   auto file_kind() const -> FileKind { return file_kind_; }
 
   void Print(llvm::raw_ostream& out) const {
-    out << filename_ << ":" << line_num_;
+    if (file_kind_ == FileKind::Prelude) {
+      out << llvm::StringRef(filename_).rsplit("/").second << ":" << line_num_;
+    } else {
+      out << filename_ << ":" << line_num_;
+    }
   }
+
   auto ToString() const -> std::string {
     std::string result;
     llvm::raw_string_ostream out(result);
     Print(out);
     return result;
   }
+
   LLVM_DUMP_METHOD void Dump() const { Print(llvm::errs()); }
 
  private:

--- a/explorer/testdata/assert/fail_assert.carbon
+++ b/explorer/testdata/assert/fail_assert.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: "HALLO WELT"
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: "HALLO WELT"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/assert/fail_convert.carbon
+++ b/explorer/testdata/assert/fail_convert.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: "Fail"
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: "Fail"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/destructor/fail_delete_base_without_virtual_destructor.carbon
+++ b/explorer/testdata/destructor/fail_delete_base_without_virtual_destructor.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Deallocating a derived class from base class pointer requires a virtual destructor
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Deallocating a derived class from base class pointer requires a virtual destructor
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_large_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_left_shift_negative_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_large_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
+++ b/explorer/testdata/operators/fail_right_shift_negative_rhs.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Integer overflow
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Integer overflow
 
 package ExplorerTest api;
 

--- a/explorer/testdata/optional/fail_optional_get_empty.carbon
+++ b/explorer/testdata/optional/fail_optional_get_empty.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: "Attempted to unwrap empty Optional"
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: "Attempted to unwrap empty Optional"
 
 package ExplorerTest api;
 

--- a/explorer/testdata/random/fail_empty_range.carbon
+++ b/explorer/testdata/random/fail_empty_range.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Rand inputs must be ordered for a non-empty range: 0 must be less than 0
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Rand inputs must be ordered for a non-empty range: 0 must be less than 0
 
 package ExplorerTest api;
 

--- a/explorer/testdata/random/fail_reverse_range.carbon
+++ b/explorer/testdata/random/fail_reverse_range.carbon
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: RUNTIME ERROR: /explorer/data/prelude.carbon:{{\d+}}: Rand inputs must be ordered for a non-empty range: 1 must be less than -1
+// CHECK:STDERR: RUNTIME ERROR: prelude.carbon:{{\d+}}: Rand inputs must be ordered for a non-empty range: 1 must be less than -1
 
 package ExplorerTest api;
 

--- a/explorer/testdata/trace/context_all.carbon
+++ b/explorer/testdata/trace/context_all.carbon
@@ -15,7 +15,7 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=all --trace_file_context=all %s
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
-// CHECK:STDOUT: *** declaring `interface As` ({{.*}}/explorer/data/prelude.carbon:14)
+// CHECK:STDOUT: *** declaring `interface As` (prelude.carbon:14)
 // CHECK:STDOUT: *** declaring function `Main` (context_all.carbon:11)
 // CHECK:STDOUT: interface As {
 // CHECK:STDOUT: fn Main ()-> i32 {

--- a/explorer/testdata/trace/context_prelude.carbon
+++ b/explorer/testdata/trace/context_prelude.carbon
@@ -15,5 +15,5 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=all --trace_file_context=prelude %s
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
-// CHECK:STDOUT: *** declaring `interface As` ({{.*}}/explorer/data/prelude.carbon:14)
+// CHECK:STDOUT: *** declaring `interface As` (prelude.carbon:14)
 // CHECK:STDOUT: interface As {


### PR DESCRIPTION
The Prelude path can be very long, which can make the `SourceLocation`'s `Print(...)` method output unnecessarily verbose. This PR modifies the `SourceLocation`'s `Print()` method to just print the **filename** and **line number** for prelude. 