### PR TITLE
Explorer: Add heading and sub-heading methods to trace

### DIFF
--- a/explorer/common/trace_stream.h
+++ b/explorer/common/trace_stream.h
@@ -7,6 +7,7 @@
 
 #include <bitset>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -127,6 +128,25 @@ class TraceStream {
   auto Not() const -> llvm::raw_ostream& { return *this << "-!- "; }
   auto Skip() const -> llvm::raw_ostream& { return *this << ">>> "; }
   auto Source() const -> llvm::raw_ostream& { return *this << "*** "; }
+
+  // Format utility methods
+  void Heading(llvm::StringRef heading) const {
+    CARBON_CHECK(is_enabled() && stream_);
+    std::stringstream stream;
+    const std::string stars = "* * * * * * * * * *";
+    const std::string dashed_line(stars.size() * 2 + heading.size() + 4, '-');
+    **stream_ << stars << "  " << heading << "  " << stars << "\n"
+              << dashed_line << "\n";
+  }
+
+  void SubHeading(llvm::StringRef heading) const {
+    CARBON_CHECK(is_enabled() && stream_);
+    std::stringstream stream;
+    const std::string stars = "- - - - -";
+    const std::string dashed_line(stars.size() * 2 + heading.size() + 4, '-');
+    **stream_ << stars << "  " << heading << "  " << stars << "\n"
+              << dashed_line << "\n";
+  }
 
  private:
   bool in_prelude_ = false;

--- a/explorer/common/trace_stream.h
+++ b/explorer/common/trace_stream.h
@@ -7,7 +7,6 @@
 
 #include <bitset>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -132,7 +131,6 @@ class TraceStream {
   // Format utility methods
   void Heading(llvm::StringRef heading) const {
     CARBON_CHECK(is_enabled() && stream_);
-    std::stringstream stream;
     const std::string stars = "* * * * * * * * * *";
     const std::string dashed_line(stars.size() * 2 + heading.size() + 4, '-');
     **stream_ << stars << "  " << heading << "  " << stars << "\n"
@@ -141,7 +139,6 @@ class TraceStream {
 
   void SubHeading(llvm::StringRef heading) const {
     CARBON_CHECK(is_enabled() && stream_);
-    std::stringstream stream;
     const std::string stars = "- - - - -";
     const std::string dashed_line(stars.size() * 2 + heading.size() + 4, '-');
     **stream_ << stars << "  " << heading << "  " << stars << "\n"

--- a/explorer/interpreter/interpreter.cpp
+++ b/explorer/interpreter/interpreter.cpp
@@ -2568,7 +2568,7 @@ auto InterpProgram(const AST& ast, Nonnull<Arena*> arena,
                    Nonnull<llvm::raw_ostream*> print_stream) -> ErrorOr<int> {
   Interpreter interpreter(Phase::RunTime, arena, trace_stream, print_stream);
   if (trace_stream->is_enabled()) {
-    *trace_stream << "********** initializing globals **********\n";
+    trace_stream->SubHeading("initializing globals");
   }
 
   SetFileContext set_file_ctx(*trace_stream,
@@ -2580,7 +2580,7 @@ auto InterpProgram(const AST& ast, Nonnull<Arena*> arena,
   }
 
   if (trace_stream->is_enabled()) {
-    *trace_stream << "********** calling main function **********\n";
+    trace_stream->SubHeading("calling main function");
   }
 
   CARBON_CHECK(ast.main_call);

--- a/explorer/interpreter/type_checker.cpp
+++ b/explorer/interpreter/type_checker.cpp
@@ -2378,7 +2378,8 @@ auto TypeChecker::MatchImpl(const InterfaceType& iface,
   MatchingImplSet::Match match(&matching_impl_set_, &impl, impl_type, &iface);
 
   if (trace_stream_->is_enabled()) {
-    *trace_stream_ << "\n========\tMatch Impl\t========\n";
+    *trace_stream_ << "\n";
+    trace_stream_->SubHeading("match impl");
     trace_stream_->Start() << "looking for `" << *impl_type << "` as `" << iface
                            << "`\n";
     trace_stream_->Start() << "checking `" << *impl.type << "` as `"

--- a/explorer/parse_and_execute/parse_and_execute.cpp
+++ b/explorer/parse_and_execute/parse_and_execute.cpp
@@ -78,7 +78,7 @@ auto ParseAndExecute(llvm::vfs::FileSystem& fs, std::string_view prelude_path,
     auto print_trace_timing_heading = llvm::make_scope_exit([=]() {
       SetProgramPhase set_prog_phase(*trace_stream, ProgramPhase::Timing);
       if (trace_stream->is_enabled()) {
-        *trace_stream << "********** printing timing **********\n";
+        trace_stream->Heading("printing timing");
       }
     });
 

--- a/explorer/testdata/trace/context_main.carbon
+++ b/explorer/testdata/trace/context_main.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=all --trace_file_context=main %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** source program **********
+// CHECK:STDOUT: * * * * * * * * * *  source program  * * * * * * * * * *
+// CHECK:STDOUT: --------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: fn Main ()-> i32 {
@@ -24,7 +25,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: }
-// CHECK:STDOUT: ********** resolving names **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving names  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: ==> declared `TestInterface` as `interface TestInterface` in `package` (context_main.carbon:7)
 // CHECK:STDOUT: ==> declared `Main` as `fn Main` in `package` (context_main.carbon:11)
 // CHECK:STDOUT: ->> resolving decl `interface TestInterface` (context_main.carbon:7)
@@ -41,9 +43,11 @@ fn Main() -> i32 {
 // CHECK:STDOUT: <<- finished resolving stmt `{return 0;}` (context_main.carbon:11)
 // CHECK:STDOUT: <<- finished resolving decl `fn Main` (context_main.carbon:11)
 // CHECK:STDOUT: ==> resolved `Main` as `fn Main` in `package` (<Main()>:0)
-// CHECK:STDOUT: ********** resolving control flow **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving control flow  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------
 // CHECK:STDOUT: ==> flow-resolved return statement `return 0;` in `fn Main` (context_main.carbon:10)
-// CHECK:STDOUT: ********** type checking **********
+// CHECK:STDOUT: * * * * * * * * * *  type checking  * * * * * * * * * *
+// CHECK:STDOUT: -------------------------------------------------------
 // CHECK:STDOUT: *** declaration at (context_main.carbon:7)
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: interface TestInterface {
@@ -213,12 +217,14 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ->> checking call to function of type `fn () -> i32` with arguments of type `()` (<Main()>:0)
 // CHECK:STDOUT: ->> performing argument deduction for bindings: []
 // CHECK:STDOUT: ==> deduction succeeded with results: []
-// CHECK:STDOUT: ********** resolving unformed variables **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving unformed variables  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------------
 // CHECK:STDOUT: ->> resolving-unformed in decl `interface TestInterface` (context_main.carbon:7)
 // CHECK:STDOUT: ->> resolving-unformed in decl `fn Main` (context_main.carbon:11)
 // CHECK:STDOUT: ->> resolving-unformed in stmt `{return 0;}` (context_main.carbon:11)
 // CHECK:STDOUT: ->> resolving-unformed in stmt `return 0;` (context_main.carbon:10)
-// CHECK:STDOUT: ********** printing declarations **********
+// CHECK:STDOUT: * * * * * * * * * *  printing declarations  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: fn Main ()-> i32 {
@@ -227,8 +233,10 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: }
-// CHECK:STDOUT: ********** starting execution **********
-// CHECK:STDOUT: ********** initializing globals **********
+// CHECK:STDOUT: * * * * * * * * * *  starting execution  * * * * * * * * * *
+// CHECK:STDOUT: ------------------------------------------------------------
+// CHECK:STDOUT: - - - - -  initializing globals  - - - - -
+// CHECK:STDOUT: ------------------------------------------
 // CHECK:STDOUT: >[] stack-push: DeclarationAction pos: 0 `interface TestInterface` (context_main.carbon:7)
 // CHECK:STDOUT: ->> step DeclarationAction pos: 0 `interface TestInterface` (context_main.carbon:7) --->
 // CHECK:STDOUT: *** declaration at (context_main.carbon:7)
@@ -249,7 +257,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: <[] stack-pop:  DeclarationAction pos: 0 `fn Main` (context_main.carbon:11)
-// CHECK:STDOUT: ********** calling main function **********
+// CHECK:STDOUT: - - - - -  calling main function  - - - - -
+// CHECK:STDOUT: -------------------------------------------
 // CHECK:STDOUT: >[] stack-push: ValueExpressionAction pos: 0 `Main()` (<Main()>:0)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 0 `Main()` (<Main()>:0) --->
 // CHECK:STDOUT: >[] stack-push: ExpressionAction pos: 0 `Main()` (<Main()>:0)
@@ -309,8 +318,9 @@ fn Main() -> i32 {
 // CHECK:STDOUT: <[] stack-pop:  CleanUpAction pos: 0  scope: [] (stack cleanup:1)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 1 `Main()` results: [`0`]  (<Main()>:0) --->
 // CHECK:STDOUT: <[] stack-pop:  ValueExpressionAction pos: 1 `Main()` results: [`0`]  (<Main()>:0)
-// CHECK:STDOUT: interpreter result: 0
-// CHECK:STDOUT: ********** printing timing **********
+// CHECK:STDOUT: ==> interpreter result: 0
+// CHECK:STDOUT: * * * * * * * * * *  printing timing  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: Time elapsed in ExecProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AnalyzeProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AddPrelude: {{\d+}}ms

--- a/explorer/testdata/trace/phase_all.carbon
+++ b/explorer/testdata/trace/phase_all.carbon
@@ -22,7 +22,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=all %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** source program **********
+// CHECK:STDOUT: * * * * * * * * * *  source program  * * * * * * * * * *
+// CHECK:STDOUT: --------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: namespace N;fn Foo (n: i32)-> i32 {
@@ -38,7 +39,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: }
-// CHECK:STDOUT: ********** resolving names **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving names  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: ==> declared `TestInterface` as `interface TestInterface` in `package` (phase_all.carbon:7)
 // CHECK:STDOUT: ==> declared `N` as `namespace N` in `package` (phase_all.carbon:9)
 // CHECK:STDOUT: ==> resolved `N` as `namespace N` in `package` (phase_all.carbon:11)
@@ -78,10 +80,12 @@ fn Main() -> i32 {
 // CHECK:STDOUT: <<- finished resolving stmt `{var x: i32 = N.Foo(0);return x;}` (phase_all.carbon:18)
 // CHECK:STDOUT: <<- finished resolving decl `fn Main` (phase_all.carbon:18)
 // CHECK:STDOUT: ==> resolved `Main` as `fn Main` in `package` (<Main()>:0)
-// CHECK:STDOUT: ********** resolving control flow **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving control flow  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------
 // CHECK:STDOUT: ==> flow-resolved return statement `return (n + 1);` in `fn N.Foo` (phase_all.carbon:12)
 // CHECK:STDOUT: ==> flow-resolved return statement `return x;` in `fn Main` (phase_all.carbon:17)
-// CHECK:STDOUT: ********** type checking **********
+// CHECK:STDOUT: * * * * * * * * * *  type checking  * * * * * * * * * *
+// CHECK:STDOUT: -------------------------------------------------------
 // CHECK:STDOUT: *** declaration at (phase_all.carbon:7)
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: interface TestInterface {
@@ -397,7 +401,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ->> checking call to function of type `fn () -> i32` with arguments of type `()` (<Main()>:0)
 // CHECK:STDOUT: ->> performing argument deduction for bindings: []
 // CHECK:STDOUT: ==> deduction succeeded with results: []
-// CHECK:STDOUT: ********** resolving unformed variables **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving unformed variables  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------------
 // CHECK:STDOUT: ->> resolving-unformed in decl `interface TestInterface` (phase_all.carbon:7)
 // CHECK:STDOUT: ->> resolving-unformed in decl `namespace N` (phase_all.carbon:9)
 // CHECK:STDOUT: ->> resolving-unformed in decl `fn N.Foo` (phase_all.carbon:13)
@@ -410,7 +415,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: ==> add init `x` (phase_all.carbon:16)
 // CHECK:STDOUT: ->> resolving-unformed in stmt `return x;` (phase_all.carbon:17)
 // CHECK:STDOUT: ==> check `x` (phase_all.carbon:17)
-// CHECK:STDOUT: ********** printing declarations **********
+// CHECK:STDOUT: * * * * * * * * * *  printing declarations  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: namespace N;fn Foo (n: i32)-> i32 {
@@ -426,8 +432,10 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: }
-// CHECK:STDOUT: ********** starting execution **********
-// CHECK:STDOUT: ********** initializing globals **********
+// CHECK:STDOUT: * * * * * * * * * *  starting execution  * * * * * * * * * *
+// CHECK:STDOUT: ------------------------------------------------------------
+// CHECK:STDOUT: - - - - -  initializing globals  - - - - -
+// CHECK:STDOUT: ------------------------------------------
 // CHECK:STDOUT: >[] stack-push: DeclarationAction pos: 0 `interface TestInterface` (phase_all.carbon:7)
 // CHECK:STDOUT: ->> step DeclarationAction pos: 0 `interface TestInterface` (phase_all.carbon:7) --->
 // CHECK:STDOUT: *** declaration at (phase_all.carbon:7)
@@ -467,7 +475,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: <[] stack-pop:  DeclarationAction pos: 0 `fn Main` (phase_all.carbon:18)
-// CHECK:STDOUT: ********** calling main function **********
+// CHECK:STDOUT: - - - - -  calling main function  - - - - -
+// CHECK:STDOUT: -------------------------------------------
 // CHECK:STDOUT: >[] stack-push: ValueExpressionAction pos: 0 `Main()` (<Main()>:0)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 0 `Main()` (<Main()>:0) --->
 // CHECK:STDOUT: >[] stack-push: ExpressionAction pos: 0 `Main()` (<Main()>:0)
@@ -642,8 +651,9 @@ fn Main() -> i32 {
 // CHECK:STDOUT: <[] stack-pop:  CleanUpAction pos: 0  scope: [] (stack cleanup:1)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 1 `Main()` results: [`1`]  (<Main()>:0) --->
 // CHECK:STDOUT: <[] stack-pop:  ValueExpressionAction pos: 1 `Main()` results: [`1`]  (<Main()>:0)
-// CHECK:STDOUT: interpreter result: 1
-// CHECK:STDOUT: ********** printing timing **********
+// CHECK:STDOUT: ==> interpreter result: 1
+// CHECK:STDOUT: * * * * * * * * * *  printing timing  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: Time elapsed in ExecProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AnalyzeProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AddPrelude: {{\d+}}ms

--- a/explorer/testdata/trace/phase_control_flow_resolution.carbon
+++ b/explorer/testdata/trace/phase_control_flow_resolution.carbon
@@ -15,6 +15,7 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=control_flow_resolution %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** resolving control flow **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving control flow  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------
 // CHECK:STDOUT: ==> flow-resolved return statement `return 0;` in `fn Main` (phase_control_flow_resolution.carbon:10)
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/trace/phase_declarations.carbon
+++ b/explorer/testdata/trace/phase_declarations.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=declarations %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** printing declarations **********
+// CHECK:STDOUT: * * * * * * * * * *  printing declarations  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: fn Main ()-> i32 {

--- a/explorer/testdata/trace/phase_execution.carbon
+++ b/explorer/testdata/trace/phase_execution.carbon
@@ -15,8 +15,10 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=execution %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** starting execution **********
-// CHECK:STDOUT: ********** initializing globals **********
+// CHECK:STDOUT: * * * * * * * * * *  starting execution  * * * * * * * * * *
+// CHECK:STDOUT: ------------------------------------------------------------
+// CHECK:STDOUT: - - - - -  initializing globals  - - - - -
+// CHECK:STDOUT: ------------------------------------------
 // CHECK:STDOUT: >[] stack-push: DeclarationAction pos: 0 `interface TestInterface` (phase_execution.carbon:7)
 // CHECK:STDOUT: ->> step DeclarationAction pos: 0 `interface TestInterface` (phase_execution.carbon:7) --->
 // CHECK:STDOUT: *** declaration at (phase_execution.carbon:7)
@@ -37,7 +39,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: <[] stack-pop:  DeclarationAction pos: 0 `fn Main` (phase_execution.carbon:11)
-// CHECK:STDOUT: ********** calling main function **********
+// CHECK:STDOUT: - - - - -  calling main function  - - - - -
+// CHECK:STDOUT: -------------------------------------------
 // CHECK:STDOUT: >[] stack-push: ValueExpressionAction pos: 0 `Main()` (<Main()>:0)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 0 `Main()` (<Main()>:0) --->
 // CHECK:STDOUT: >[] stack-push: ExpressionAction pos: 0 `Main()` (<Main()>:0)
@@ -97,5 +100,5 @@ fn Main() -> i32 {
 // CHECK:STDOUT: <[] stack-pop:  CleanUpAction pos: 0  scope: [] (stack cleanup:1)
 // CHECK:STDOUT: ->> step ValueExpressionAction pos: 1 `Main()` results: [`0`]  (<Main()>:0) --->
 // CHECK:STDOUT: <[] stack-pop:  ValueExpressionAction pos: 1 `Main()` results: [`0`]  (<Main()>:0)
-// CHECK:STDOUT: interpreter result: 0
+// CHECK:STDOUT: ==> interpreter result: 0
 // CHECK:STDOUT: result: 0

--- a/explorer/testdata/trace/phase_name_resolution.carbon
+++ b/explorer/testdata/trace/phase_name_resolution.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=name_resolution %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** resolving names **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving names  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: ==> declared `TestInterface` as `interface TestInterface` in `package` (phase_name_resolution.carbon:7)
 // CHECK:STDOUT: ==> declared `Main` as `fn Main` in `package` (phase_name_resolution.carbon:11)
 // CHECK:STDOUT: ->> resolving decl `interface TestInterface` (phase_name_resolution.carbon:7)

--- a/explorer/testdata/trace/phase_source_program.carbon
+++ b/explorer/testdata/trace/phase_source_program.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=source_program %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** source program **********
+// CHECK:STDOUT: * * * * * * * * * *  source program  * * * * * * * * * *
+// CHECK:STDOUT: --------------------------------------------------------
 // CHECK:STDOUT: interface TestInterface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: fn Main ()-> i32 {

--- a/explorer/testdata/trace/phase_timing.carbon
+++ b/explorer/testdata/trace/phase_timing.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=timing %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** printing timing **********
+// CHECK:STDOUT: * * * * * * * * * *  printing timing  * * * * * * * * * *
+// CHECK:STDOUT: ---------------------------------------------------------
 // CHECK:STDOUT: Time elapsed in ExecProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AnalyzeProgram: {{\d+}}ms
 // CHECK:STDOUT: Time elapsed in AddPrelude: {{\d+}}ms

--- a/explorer/testdata/trace/phase_type_checking.carbon
+++ b/explorer/testdata/trace/phase_type_checking.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=type_checking %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** type checking **********
+// CHECK:STDOUT: * * * * * * * * * *  type checking  * * * * * * * * * *
+// CHECK:STDOUT: -------------------------------------------------------
 // CHECK:STDOUT: *** declaration at (phase_type_checking.carbon:7)
 // CHECK:STDOUT: ```
 // CHECK:STDOUT: interface TestInterface {

--- a/explorer/testdata/trace/phase_unformed_variables_resolution.carbon
+++ b/explorer/testdata/trace/phase_unformed_variables_resolution.carbon
@@ -15,7 +15,8 @@ fn Main() -> i32 {
 // ARGS: --trace_file=- --trace_phase=unformed_variables_resolution %s
 // AUTOUPDATE
 
-// CHECK:STDOUT: ********** resolving unformed variables **********
+// CHECK:STDOUT: * * * * * * * * * *  resolving unformed variables  * * * * * * * * * *
+// CHECK:STDOUT: ----------------------------------------------------------------------
 // CHECK:STDOUT: ->> resolving-unformed in decl `interface TestInterface` (phase_unformed_variables_resolution.carbon:7)
 // CHECK:STDOUT: ->> resolving-unformed in decl `fn Main` (phase_unformed_variables_resolution.carbon:11)
 // CHECK:STDOUT: ->> resolving-unformed in stmt `{return 0;}` (phase_unformed_variables_resolution.carbon:11)


### PR DESCRIPTION
Instead of manually putting symbols before and after heading, this introduces two methods `Heading` and `SubHeading` inside `TraceStream`.

Both methods take `llvm::StringRef` as parameter, formats the given text as follows and adds it into the output stream.

**Heading**
```
* * * * * * * * * *  heading  * * * * * * * * * *
-------------------------------------------------
```
**Sub heading**
```
- - - - -  sub heading  - - - - -
---------------------------------
```

Note: both methods assert that tracing should be enabled.
