### PR TITLE
Run clang-tidy over toolchain code.

### DIFF
--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -67,7 +67,7 @@ struct DiagnosticMessage {
       llvm::StringLiteral format, llvm::SmallVector<llvm::Any> format_args,
       std::function<std::string(const DiagnosticMessage&)> format_fn)
       : kind(kind),
-        location(std::move(location)),
+        location(location),
         format(format),
         format_args(std::move(format_args)),
         format_fn(std::move(format_fn)) {}

--- a/toolchain/lexer/token_kind.cpp
+++ b/toolchain/lexer/token_kind.cpp
@@ -107,13 +107,7 @@ auto TokenKind::fixed_spelling() const -> llvm::StringRef {
 auto TokenKind::expected_parse_tree_size() const -> int {
   static constexpr int8_t Table[] = {
 #define CARBON_TOKEN(Name) 1,
-// CARBON_TOKEN_WITH_VIRTUAL_NODE wraps CARBON_TOKEN, so needs to be written
-// as-is.
-// TODO: Consider changing the macro setup to avoid the lint issue, e.g. so that
-// CARBON_KEYWORD_TOKEN would be called by a macro that could be replaced,
-// instead of wrapped.
-// NOLINTNEXTLINE(bugprone-macro-parentheses)
-#define CARBON_TOKEN_WITH_VIRTUAL_NODE(size) 1 + size
+#define CARBON_TOKEN_WITH_VIRTUAL_NODE(size) 2,
 #include "toolchain/lexer/token_kind.def"
   };
   return Table[AsInt()];

--- a/toolchain/lexer/token_kind.cpp
+++ b/toolchain/lexer/token_kind.cpp
@@ -107,6 +107,12 @@ auto TokenKind::fixed_spelling() const -> llvm::StringRef {
 auto TokenKind::expected_parse_tree_size() const -> int {
   static constexpr int8_t Table[] = {
 #define CARBON_TOKEN(Name) 1,
+// CARBON_TOKEN_WITH_VIRTUAL_NODE wraps CARBON_TOKEN, so needs to be written
+// as-is.
+// TODO: Consider changing the macro setup to avoid the lint issue, e.g. so that
+// CARBON_KEYWORD_TOKEN would be called by a macro that could be replaced,
+// instead of wrapped.
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define CARBON_TOKEN_WITH_VIRTUAL_NODE(size) 1 + size
 #include "toolchain/lexer/token_kind.def"
   };

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -28,7 +28,6 @@ using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
-using ::testing::StrEq;
 
 class LexerTest : public ::testing::Test {
  protected:

--- a/toolchain/semantics/semantics_context.cpp
+++ b/toolchain/semantics/semantics_context.cpp
@@ -640,8 +640,9 @@ auto SemanticsContext::GetUnqualifiedType(SemanticsTypeId type_id)
     -> SemanticsTypeId {
   SemanticsNode type_node =
       semantics_ir_->GetNode(semantics_ir_->GetTypeAllowBuiltinTypes(type_id));
-  if (type_node.kind() == SemanticsNodeKind::ConstType)
+  if (type_node.kind() == SemanticsNodeKind::ConstType) {
     return type_node.GetAsConstType();
+  }
   return type_id;
 }
 

--- a/toolchain/semantics/semantics_context.h
+++ b/toolchain/semantics/semantics_context.h
@@ -92,7 +92,7 @@ class SemanticsContext {
   // reconvergence of control flow, and pushes the new block onto the node
   // block stack.
   auto AddConvergenceBlockAndPush(
-      ParseTree::Node parse_tree,
+      ParseTree::Node parse_node,
       std::initializer_list<SemanticsNodeBlockId> blocks) -> void;
 
   // Adds branches from the given list of blocks and values to a new block, for

--- a/toolchain/semantics/semantics_ir_formatter.cpp
+++ b/toolchain/semantics/semantics_ir_formatter.cpp
@@ -22,10 +22,13 @@ namespace {
 //   type to distinguish.
 class NodeNamer {
  public:
-  enum class ScopeIndex : int {
+  // int32_t matches the input value size.
+  // NOLINTNEXTLINE(performance-enum-size)
+  enum class ScopeIndex : int32_t {
     None = -1,
     Package = 0,
   };
+  static_assert(sizeof(ScopeIndex) == sizeof(SemanticsFunctionId));
 
   NodeNamer(const TokenizedBuffer& tokenized_buffer,
             const ParseTree& parse_tree, const SemanticsIR& semantics_ir)
@@ -68,7 +71,7 @@ class NodeNamer {
 
   // Returns the scope index corresponding to a function.
   auto GetScopeFor(SemanticsFunctionId fn_id) -> ScopeIndex {
-    return ScopeIndex(fn_id.index + 1);
+    return static_cast<ScopeIndex>(fn_id.index + 1);
   }
 
   // Returns the IR name to use for a function.
@@ -76,7 +79,7 @@ class NodeNamer {
     if (!fn_id.is_valid()) {
       return "invalid";
     }
-    return GetScopeInfo(GetScopeFor(fn_id)).name;
+    return GetScopeInfo(GetScopeFor(fn_id)).name.str();
   }
 
   // Returns the IR name to use for a node, when referenced from a given scope.
@@ -144,8 +147,6 @@ class NodeNamer {
         }
         return value->first();
       }
-
-      operator llvm::StringRef() const { return str(); }
 
       auto SetFallback(Name name) -> void { value_->second.fallback = name; }
 
@@ -239,7 +240,7 @@ class NodeNamer {
   };
 
   auto GetScopeInfo(ScopeIndex scope_idx) -> Scope& {
-    return scopes[(int)scope_idx];
+    return scopes[static_cast<int>(scope_idx)];
   }
 
   auto AddBlockLabel(ScopeIndex scope_idx, SemanticsNodeBlockId block_id,
@@ -251,7 +252,8 @@ class NodeNamer {
     }
 
     if (parse_node == ParseTree::Node::Invalid) {
-      if (auto& block = semantics_ir_.GetNodeBlock(block_id); !block.empty()) {
+      if (const auto& block = semantics_ir_.GetNodeBlock(block_id);
+          !block.empty()) {
         parse_node = semantics_ir_.GetNode(block.front()).parse_node();
       }
     }
@@ -524,8 +526,9 @@ class SemanticsIRFormatter {
   // are never referenced themselves.
   // TODO: Include BindName nodes in the output if we start referring to them.
   template <>
-  auto FormatInstruction<SemanticsNode::BindName>(SemanticsNodeId,
-                                                  SemanticsNode) -> void {}
+  auto FormatInstruction<SemanticsNode::BindName>(SemanticsNodeId /*node_id*/,
+                                                  SemanticsNode /*node*/)
+      -> void {}
 
   template <>
   auto FormatInstructionRHS<SemanticsNode::BlockArg>(SemanticsNode node)
@@ -535,7 +538,7 @@ class SemanticsIRFormatter {
   }
 
   template <>
-  auto FormatInstruction<SemanticsNode::BranchIf>(SemanticsNodeId,
+  auto FormatInstruction<SemanticsNode::BranchIf>(SemanticsNodeId /*node_id*/,
                                                   SemanticsNode node) -> void {
     if (!in_terminator_sequence) {
       out_ << "  ";
@@ -550,9 +553,8 @@ class SemanticsIRFormatter {
   }
 
   template <>
-  auto FormatInstruction<SemanticsNode::BranchWithArg>(SemanticsNodeId,
-                                                       SemanticsNode node)
-      -> void {
+  auto FormatInstruction<SemanticsNode::BranchWithArg>(
+      SemanticsNodeId /*node_id*/, SemanticsNode node) -> void {
     if (!in_terminator_sequence) {
       out_ << "  ";
     }
@@ -566,7 +568,7 @@ class SemanticsIRFormatter {
   }
 
   template <>
-  auto FormatInstruction<SemanticsNode::Branch>(SemanticsNodeId,
+  auto FormatInstruction<SemanticsNode::Branch>(SemanticsNodeId /*node_id*/,
                                                 SemanticsNode node) -> void {
     if (!in_terminator_sequence) {
       out_ << "  ";
@@ -596,9 +598,8 @@ class SemanticsIRFormatter {
 
   // StructTypeFields are formatted as part of their StructType.
   template <>
-  auto FormatInstruction<SemanticsNode::StructTypeField>(SemanticsNodeId,
-                                                         SemanticsNode)
-      -> void {}
+  auto FormatInstruction<SemanticsNode::StructTypeField>(
+      SemanticsNodeId /*node_id*/, SemanticsNode /*node*/) -> void {}
 
   template <>
   auto FormatInstructionRHS<SemanticsNode::StructType>(SemanticsNode node)
@@ -616,7 +617,7 @@ class SemanticsIRFormatter {
     out_ << "}";
   }
 
-  auto FormatArgs(SemanticsNode::NoArgs) -> void {}
+  auto FormatArgs(SemanticsNode::NoArgs /*unused*/) -> void {}
 
   template <typename Arg1>
   auto FormatArgs(Arg1 arg) -> void {


### PR DESCRIPTION
Amongst other changes, this removes the implicit StringRef cast in formatter code due to google-explicit-constructor. Only one line of code relied on the implicit cast, and style says "Do not define implicit conversions." (https://google.github.io/styleguide/cppguide.html#Implicit_Conversions).