### PR TITLE
Fix missing APSInt include.

### DIFF
--- a/toolchain/semantics/semantics_handle_index.cpp
+++ b/toolchain/semantics/semantics_handle_index.cpp
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/semantics/semantics_builtin_kind.h"
+#include "llvm/ADT/APSInt.h"
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 #include "toolchain/semantics/semantics_node_kind.h"


### PR DESCRIPTION
Works by chance right now, but should be expected to break in future LLVM versions.

The builtin kind include is removed as unused.