### PR TITLE
Add lint fixes to the buildifier setup.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,8 @@ repos:
       - id: buildifier
         name: Bazel buildifier
         entry: scripts/run_buildifier.py
-        args: ['-r', '.']
+        # Beyond just formatting, explicitly fix lint warnings.
+        args: ['--lint=fix', '--warnings=all', '-r', '.']
         language: python
         files: |
           (?x)^(

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -4,6 +4,7 @@
 
 """A Starlark cc_toolchain configuration rule"""
 
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "action_config",
@@ -16,7 +17,6 @@ load(
     "variable_with_value",
     "with_feature_set",
 )
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     ":clang_detected_variables.bzl",
     "clang_bindir",
@@ -856,7 +856,7 @@ def _impl(ctx):
     # Next, add the features based on the target platform. Here too the
     # features are order sensitive. We also setup the sysroot here.
     if ctx.attr.target_cpu == "k8":
-        features += [linux_flags_feature]
+        features.append(linux_flags_feature)
         sysroot = None
     elif ctx.attr.target_cpu == "x64_windows":
         # TODO: Need to figure out if we need to add windows specific features
@@ -864,19 +864,19 @@ def _impl(ctx):
         # so that might be an example where a feature must be added.
         sysroot = None
     elif ctx.attr.target_cpu in ["darwin", "darwin_arm64"]:
-        features += [macos_flags_feature]
+        features.append(macos_flags_feature)
         sysroot = sysroot_dir
     elif ctx.attr.target_cpu == "freebsd":
-        features += [freebsd_flags_feature]
+        features.append(freebsd_flags_feature)
         sysroot = sysroot_dir
     else:
         fail("Unsupported target platform!")
 
     # TODO: Need to support non-macOS ARM platforms here.
     if ctx.attr.target_cpu == "darwin_arm64":
-        features += [aarch64_cpu_flags]
+        features.append(aarch64_cpu_flags)
     else:
-        features += [x86_64_cpu_flags]
+        features.append(x86_64_cpu_flags)
 
     # Finally append the libraries to link and any final flags.
     features += [

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -212,15 +212,15 @@ def _configure_clang_toolchain_impl(repository_ctx):
         "clang_detected_variables.bzl",
         repository_ctx.attr._clang_detected_variables_template,
         substitutions = {
-            "{LLVM_BINDIR}": str(ar_path.dirname),
-            "{LLVM_SYMBOLIZER}": str(ar_path.dirname.get_child("llvm-symbolizer")),
             "{CLANG_BINDIR}": str(clang.dirname),
-            "{CLANG_VERSION}": str(clang_version),
-            "{CLANG_VERSION_FOR_CACHE}": clang_version_for_cache.replace('"', "_").replace("\\", "_"),
-            "{CLANG_RESOURCE_DIR}": resource_dir,
             "{CLANG_INCLUDE_DIRS_LIST}": str(
                 [str(path) for path in include_dirs],
             ),
+            "{CLANG_RESOURCE_DIR}": resource_dir,
+            "{CLANG_VERSION_FOR_CACHE}": clang_version_for_cache.replace('"', "_").replace("\\", "_"),
+            "{CLANG_VERSION}": str(clang_version),
+            "{LLVM_BINDIR}": str(ar_path.dirname),
+            "{LLVM_SYMBOLIZER}": str(ar_path.dirname.get_child("llvm-symbolizer")),
             "{SYSROOT}": str(sysroot_dir),
         },
         executable = False,
@@ -231,10 +231,6 @@ configure_clang_toolchain = repository_rule(
     configure = True,
     local = True,
     attrs = {
-        "_clang_toolchain_build": attr.label(
-            default = Label("//bazel/cc_toolchains:clang_toolchain.BUILD"),
-            allow_single_file = True,
-        ),
         "_clang_cc_toolchain_config": attr.label(
             default = Label(
                 "//bazel/cc_toolchains:clang_cc_toolchain_config.bzl",
@@ -245,6 +241,10 @@ configure_clang_toolchain = repository_rule(
             default = Label(
                 "//bazel/cc_toolchains:clang_detected_variables.tpl.bzl",
             ),
+            allow_single_file = True,
+        ),
+        "_clang_toolchain_build": attr.label(
+            default = Label("//bazel/cc_toolchains:clang_toolchain.BUILD"),
             allow_single_file = True,
         ),
     },

--- a/bazel/check_deps/BUILD
+++ b/bazel/check_deps/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_python//python:defs.bzl", "py_test")
+
 # The filegroups establishing root rules for `genquery` invocations can be
 # updated by running:
 #

--- a/common/BUILD
+++ b/common/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")

--- a/explorer/ast/BUILD
+++ b/explorer/ast/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//explorer:__subpackages__"])
 
 cc_library(

--- a/explorer/base/BUILD
+++ b/explorer/base/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//explorer:__subpackages__"])
 
 cc_library(

--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 cc_library(

--- a/explorer/interpreter/BUILD
+++ b/explorer/interpreter/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//explorer/parse_and_execute:__pkg__"])
 
 cc_library(

--- a/explorer/parse_and_execute/BUILD
+++ b/explorer/parse_and_execute/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = [
     "//explorer:__pkg__",
     "//explorer/fuzzing:__pkg__",

--- a/explorer/syntax/BUILD
+++ b/explorer/syntax/BUILD
@@ -2,6 +2,9 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 package(default_visibility = ["//explorer/parse_and_execute:__pkg__"])
 
 cc_library(

--- a/github_tools/BUILD
+++ b/github_tools/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@py_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_library(
     name = "github_helpers",

--- a/installers/local/BUILD
+++ b/installers/local/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("install.bzl", "install_path_rule")
 
 # Turns `--//installers/local:install_path=arg` into `$(INSTALL_PATH)`.

--- a/language_server/BUILD
+++ b/language_server/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(default_visibility = [
     "//language_server:__subpackages__",
 ])

--- a/migrate_cpp/BUILD
+++ b/migrate_cpp/BUILD
@@ -2,6 +2,9 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "migrate_cpp",
     srcs = ["migrate_cpp.py"],

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/proposals/scripts/BUILD
+++ b/proposals/scripts/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+
 py_binary(
     name = "new_proposal",
     srcs = ["new_proposal.py"],

--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -5,6 +5,8 @@
 # Trivial, single-file testing libraries. More complex libraries should get
 # their own directory.
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 # This does extra initialization on top of googletest's gtest_main in order to

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("rules.bzl", "file_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
 """Rules for building fuzz tests."""
 
 def file_test(name, tests, data = [], args = [], **kwargs):
@@ -18,7 +20,7 @@ def file_test(name, tests, data = [], args = [], **kwargs):
       args: Passed to cc_test.
       **kwargs: Passed to cc_test.
     """
-    native.cc_test(
+    cc_test(
         name = name,
         data = tests + data,
         args = ["--file_tests=" + ",".join([

--- a/testing/fuzzing/BUILD
+++ b/testing/fuzzing/BUILD
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/examples/woff2/BUILD.original
+++ b/third_party/examples/woff2/BUILD.original
@@ -4,6 +4,8 @@
 
 # Rules are adapted from CMakeLists.txt.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/third_party/examples/woff2/carbon/BUILD
+++ b/third_party/examples/woff2/carbon/BUILD
@@ -4,6 +4,8 @@
 
 # Rules are adapted from CMakeLists.txt.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/third_party/libprotobuf_mutator/BUILD.txt
+++ b/third_party/libprotobuf_mutator/BUILD.txt
@@ -5,6 +5,8 @@
 # libprotobuf_mutator uses cmake and doesn't provide a bazel BUILD file.
 # See https://github.com/google/libprotobuf-mutator/issues/91.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 exports_files(["LICENSE"])
 
 cc_library(

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/toolchain/codegen/BUILD
+++ b/toolchain/codegen/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//testing/file_test:rules.bzl", "file_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//testing/file_test:rules.bzl", "file_test")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")

--- a/toolchain/lexer/BUILD
+++ b/toolchain/lexer/BUILD
@@ -2,9 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")
+load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchain/lowering/BUILD
+++ b/toolchain/lowering/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")
 

--- a/toolchain/parser/BUILD
+++ b/toolchain/parser/BUILD
@@ -2,9 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")
+load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -2,9 +2,10 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel/sh_run:rules.bzl", "glob_sh_run")
 load("//testing/file_test:rules.bzl", "file_test")
+load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/utils/treesitter/BUILD
+++ b/utils/treesitter/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_tree_sitter//tree_sitter:tree_sitter.bzl", "tree_sitter_cc_library")
 
 tree_sitter_cc_library(


### PR DESCRIPTION
The main motivation for this is to get python loads in using the `native-py` lint fix. However, enabling that made me wonder, maybe we should fix in general?

`native-cc` is delayed, but not wholly cancelled (and `native-py` picking up might indicate `native-cc` won't be too far behind). There's also some automated fixes for `.append` and dict sorting -- this felt okay to me, maybe not something to eagerly add but probably not worth stopping buildifier from fixing (I've noticed the warnings in the past and had been ignoring them).

Running everything does mean that load orders are sorted automatically now, which I think is a positive. Most generally, I think these fixes aren't _harmful_, and having them done automatically seems beneficial: my biggest concern about `native-py` and `native-cc` was actually that regressions wouldn't be caught, but this addresses that issue automatically.