### PR TITLE
add documentation about debugging on macOS

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -13,18 +13,21 @@ contributions.
 
 ## Table of contents
 
--   [Setup commands](#setup-commands)
-    -   [Debian or Ubuntu](#debian-or-ubuntu)
-    -   [macOS](#macos)
--   [Tools](#tools)
-    -   [Main tools](#main-tools)
-        -   [Running pre-commit](#running-pre-commit)
-    -   [Optional tools](#optional-tools)
-    -   [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
--   [Troubleshooting build issues](#troubleshooting-build-issues)
-    -   [Old LLVM versions](#old-llvm-versions)
-    -   [Asking for help](#asking-for-help)
--   [Troubleshooting debug issues](#troubleshooting-debug-issues)
+- [Contribution tools](#contribution-tools)
+  - [Table of contents](#table-of-contents)
+  - [Setup commands](#setup-commands)
+    - [Debian or Ubuntu](#debian-or-ubuntu)
+    - [macOS](#macos)
+  - [Tools](#tools)
+    - [Main tools](#main-tools)
+      - [Running pre-commit](#running-pre-commit)
+    - [Optional tools](#optional-tools)
+    - [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
+  - [Troubleshooting build issues](#troubleshooting-build-issues)
+    - [Old LLVM versions](#old-llvm-versions)
+    - [Asking for help](#asking-for-help)
+  - [Troubleshooting debug issues](#troubleshooting-debug-issues)
+    - [Debugging on MacOS](#debugging-on-macos)
 
 <!-- tocstop -->
 
@@ -268,3 +271,46 @@ Dwarf Error: DW_FORM_strx1 found in non-DWO CU
 
 It means that the version of GDB used is too old, and does not support the DWARF
 v5 format.
+
+### Debugging on MacOS
+
+Getting Bazel to build debuggable binaries on MacOS requires passing a few extra
+flags while building:
+
+```shell
+bazel build --spawn_strategy=local -c dbg //explorer --apple_generate_dsym
+```
+
+You should then be able to debug with `lldb`.
+
+If this build command doesn't seem to produce a debuggable binary you might
+need to both clear the build disk cache and clean the build. Running
+`scripts/clean_disk_cache.sh` may not be enough, you might try deleting all the
+files within the disk cache, typically located at
+`~/.cache/carbon-lang-build-cache`. Deleting the disk cache, followed by a
+`bazel clean` should allow your next rebuild, with the recommended flags, to
+supply the symbols for debugging.
+
+For debugging on MacOS using VSCode, I've had good luck using the CodeLLDB
+extension. In order for LLDB to connect the project source files with the
+symbols you will need to add a `"sourceMap": { ".": "${workspaceRoot}" }` line
+to the `launch.json` configuration, for example:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "explorer",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceRoot}/bazel-bin/explorer/explorer",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "sourceMap": {
+        ".": "${workspaceRoot}"
+      }
+    }
+  ]
+}
+```

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -289,7 +289,7 @@ files within the disk cache, typically located at
 `bazel clean` should allow your next rebuild, with the recommended options, to
 supply the symbols for debugging.
 
-For debugging on MacOS using VSCode, I've had good luck using the CodeLLDB
+For debugging on MacOS using VSCode, some have had success using the CodeLLDB
 extension. In order for LLDB to connect the project source files with the
 symbols you will need to add a `"sourceMap": { ".": "${workspaceRoot}" }` line
 to the `launch.json` configuration, for example:

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -13,21 +13,19 @@ contributions.
 
 ## Table of contents
 
-- [Contribution tools](#contribution-tools)
-  - [Table of contents](#table-of-contents)
-  - [Setup commands](#setup-commands)
-    - [Debian or Ubuntu](#debian-or-ubuntu)
-    - [macOS](#macos)
-  - [Tools](#tools)
-    - [Main tools](#main-tools)
-      - [Running pre-commit](#running-pre-commit)
-    - [Optional tools](#optional-tools)
-    - [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
-  - [Troubleshooting build issues](#troubleshooting-build-issues)
-    - [Old LLVM versions](#old-llvm-versions)
-    - [Asking for help](#asking-for-help)
-  - [Troubleshooting debug issues](#troubleshooting-debug-issues)
-    - [Debugging on MacOS](#debugging-on-macos)
+-   [Setup commands](#setup-commands)
+    -   [Debian or Ubuntu](#debian-or-ubuntu)
+    -   [macOS](#macos)
+-   [Tools](#tools)
+    -   [Main tools](#main-tools)
+        -   [Running pre-commit](#running-pre-commit)
+    -   [Optional tools](#optional-tools)
+    -   [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
+-   [Troubleshooting build issues](#troubleshooting-build-issues)
+    -   [Old LLVM versions](#old-llvm-versions)
+    -   [Asking for help](#asking-for-help)
+-   [Troubleshooting debug issues](#troubleshooting-debug-issues)
+    -   [Debugging on MacOS](#debugging-on-macos)
 
 <!-- tocstop -->
 
@@ -275,7 +273,7 @@ v5 format.
 ### Debugging on MacOS
 
 Getting Bazel to build debuggable binaries on MacOS requires passing a few extra
-flags while building:
+options while building:
 
 ```shell
 bazel build --spawn_strategy=local -c dbg //explorer --apple_generate_dsym
@@ -283,12 +281,12 @@ bazel build --spawn_strategy=local -c dbg //explorer --apple_generate_dsym
 
 You should then be able to debug with `lldb`.
 
-If this build command doesn't seem to produce a debuggable binary you might
-need to both clear the build disk cache and clean the build. Running
+If this build command doesn't seem to produce a debuggable binary you might need
+to both clear the build disk cache and clean the build. Running
 `scripts/clean_disk_cache.sh` may not be enough, you might try deleting all the
 files within the disk cache, typically located at
 `~/.cache/carbon-lang-build-cache`. Deleting the disk cache, followed by a
-`bazel clean` should allow your next rebuild, with the recommended flags, to
+`bazel clean` should allow your next rebuild, with the recommended options, to
 supply the symbols for debugging.
 
 For debugging on MacOS using VSCode, I've had good luck using the CodeLLDB
@@ -298,19 +296,19 @@ to the `launch.json` configuration, for example:
 
 ```json
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "explorer",
-      "type": "lldb",
-      "request": "launch",
-      "program": "${workspaceRoot}/bazel-bin/explorer/explorer",
-      "args": [],
-      "cwd": "${workspaceRoot}",
-      "sourceMap": {
-        ".": "${workspaceRoot}"
-      }
-    }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "explorer",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceRoot}/bazel-bin/explorer/explorer",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "sourceMap": {
+                ".": "${workspaceRoot}"
+            }
+        }
+    ]
 }
 ```

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -272,11 +272,14 @@ v5 format.
 
 ### Debugging on MacOS
 
-Getting Bazel to build debuggable binaries on MacOS requires passing a few extra
-options while building:
+Bazel sandboxes builds, which makes it hard for the debugger to locate symbols
+on linked binaries when debugging. See this
+[Bazel issue](https://github.com/bazelbuild/bazel/issues/2537#issuecomment-449089673)
+for more information. To workaround, provide the `--spawn_strategy=local` option
+to Bazel for the debug build, like:
 
 ```shell
-bazel build --spawn_strategy=local -c dbg //explorer --apple_generate_dsym
+bazel build --spawn_strategy=local -c dbg //explorer
 ```
 
 You should then be able to debug with `lldb`.

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -289,10 +289,10 @@ files within the disk cache, typically located at
 `bazel clean` should allow your next rebuild, with the recommended options, to
 supply the symbols for debugging.
 
-For debugging on MacOS using VSCode, some have had success using the CodeLLDB
-extension. In order for LLDB to connect the project source files with the
-symbols you will need to add a `"sourceMap": { ".": "${workspaceRoot}" }` line
-to the `launch.json` configuration, for example:
+For debugging on MacOS using VSCode, some people have had success using the
+CodeLLDB extension. In order for LLDB to connect the project source files with
+the symbols you will need to add a `"sourceMap": { ".": "${workspaceRoot}" }`
+line to the `launch.json` configuration, for example:
 
 ```json
 {

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -292,7 +292,7 @@ supply the symbols for debugging.
 For debugging on MacOS using VSCode, some people have had success using the
 CodeLLDB extension. In order for LLDB to connect the project source files with
 the symbols you will need to add a `"sourceMap": { ".": "${workspaceRoot}" }`
-line to the `launch.json` configuration, for example:
+line to the CodeLLDB `launch.json` configuration, for example:
 
 ```json
 {

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -272,8 +272,8 @@ v5 format.
 
 ### Debugging on MacOS
 
-Bazel sandboxes builds, which makes it hard for the debugger to locate symbols
-on linked binaries when debugging. See this
+Bazel sandboxes builds, which on MacOS makes it hard for the debugger to locate
+symbols on linked binaries when debugging. See this
 [Bazel issue](https://github.com/bazelbuild/bazel/issues/2537#issuecomment-449089673)
 for more information. To workaround, provide the `--spawn_strategy=local` option
 to Bazel for the debug build, like:


### PR DESCRIPTION
Adds some notes about the required build flags for lldb to successfully find the symbols on macOS debug builds. Also adds a recommended debugger configuration for interactive debugging in VSCode on macOS.