### PR TITLE
Adjust handling of cases where conditions are missing.

### DIFF
--- a/toolchain/parser/parser_context.cpp
+++ b/toolchain/parser/parser_context.cpp
@@ -77,15 +77,18 @@ auto ParserContext::AddNode(ParseNodeKind kind, TokenizedBuffer::Token token,
 }
 
 auto ParserContext::ConsumeAndAddOpenParen(TokenizedBuffer::Token default_token,
-                                           ParseNodeKind start_kind) -> void {
+                                           ParseNodeKind start_kind)
+    -> std::optional<TokenizedBuffer::Token> {
   if (auto open_paren = ConsumeIf(TokenKind::OpenParen)) {
     AddLeafNode(start_kind, *open_paren, /*has_error=*/false);
+    return open_paren;
   } else {
     CARBON_DIAGNOSTIC(ExpectedParenAfter, Error, "Expected `(` after `{0}`.",
                       TokenKind);
     emitter_->Emit(*position_, ExpectedParenAfter,
                    tokens().GetKind(default_token));
     AddLeafNode(start_kind, default_token, /*has_error=*/true);
+    return std::nullopt;
   }
 }
 

--- a/toolchain/parser/parser_context.h
+++ b/toolchain/parser/parser_context.h
@@ -108,9 +108,10 @@ class ParserContext {
 
   // Parses an open paren token, possibly diagnosing if necessary. Creates a
   // leaf parse node of the specified start kind. The default_token is used when
-  // there's no open paren.
+  // there's no open paren. Returns the open paren token if it was found.
   auto ConsumeAndAddOpenParen(TokenizedBuffer::Token default_token,
-                              ParseNodeKind start_kind) -> void;
+                              ParseNodeKind start_kind)
+      -> std::optional<TokenizedBuffer::Token>;
 
   // Parses a closing symbol corresponding to the opening symbol
   // `expected_open`, possibly skipping forward and diagnosing if necessary.

--- a/toolchain/parser/parser_handle_statement.cpp
+++ b/toolchain/parser/parser_handle_statement.cpp
@@ -86,8 +86,12 @@ auto ParserHandleStatementContinueFinish(ParserContext& context) -> void {
 auto ParserHandleStatementForHeader(ParserContext& context) -> void {
   auto state = context.PopState();
 
-  context.ConsumeAndAddOpenParen(state.token, ParseNodeKind::ForHeaderStart);
-
+  std::optional<TokenizedBuffer::Token> open_paren =
+      context.ConsumeAndAddOpenParen(state.token,
+                                     ParseNodeKind::ForHeaderStart);
+  if (open_paren) {
+    state.token = *open_paren;
+  }
   state.state = ParserState::StatementForHeaderIn;
 
   if (context.PositionIs(TokenKind::Var)) {
@@ -118,9 +122,8 @@ auto ParserHandleStatementForHeaderIn(ParserContext& context) -> void {
 auto ParserHandleStatementForHeaderFinish(ParserContext& context) -> void {
   auto state = context.PopState();
 
-  context.ConsumeAndAddCloseSymbol(
-      *(TokenizedBuffer::TokenIterator(state.token) + 1), state,
-      ParseNodeKind::ForHeader);
+  context.ConsumeAndAddCloseSymbol(state.token, state,
+                                   ParseNodeKind::ForHeader);
 
   context.PushState(ParserState::CodeBlock);
 }

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -468,7 +468,9 @@ CARBON_PARSER_STATE_VARIANTS2(ParameterListFinish, Deduced, Regular)
 
 // Handles the processing of a `(condition)` up through the expression.
 //
-// Always:
+// If `OpenCurlyBrace`:
+//   1. ParenConditionAs(If|While)Finish
+// Else:
 //   1. Expression
 //   2. ParenConditionAs(If|While)Finish
 CARBON_PARSER_STATE_VARIANTS2(ParenCondition, If, While)

--- a/toolchain/parser/testdata/for/fail_missing_cond.carbon
+++ b/toolchain/parser/testdata/for/fail_missing_cond.carbon
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F() {
+  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+6]]:7: Expected `(` after `for`.
+  // CHECK:STDERR:   for {
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+3]]:7: Expected `var` declaration.
+  // CHECK:STDERR:   for {
+  // CHECK:STDERR:       ^
+  for {
+  }
+// CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+6]]:1: Expected braced code block.
+// CHECK:STDERR: }
+// CHECK:STDERR: ^
+// CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+3]]:1: Expected expression.
+// CHECK:STDERR: }
+// CHECK:STDERR: ^
+}
+
+// CHECK:STDOUT: [
+// CHECK:STDOUT:     {kind: 'FunctionIntroducer', text: 'fn'},
+// CHECK:STDOUT:     {kind: 'Name', text: 'F'},
+// CHECK:STDOUT:       {kind: 'ParameterListStart', text: '('},
+// CHECK:STDOUT:     {kind: 'ParameterList', text: ')', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'FunctionDefinitionStart', text: '{', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'ForHeaderStart', text: 'for', has_error: yes},
+// CHECK:STDOUT:         {kind: 'StructLiteralOrStructTypeLiteralStart', text: '{'},
+// CHECK:STDOUT:       {kind: 'StructLiteral', text: '}', subtree_size: 2},
+// CHECK:STDOUT:     {kind: 'ForHeader', text: 'for', has_error: yes, subtree_size: 4},
+// CHECK:STDOUT:       {kind: 'CodeBlockStart', text: '}', has_error: yes},
+// CHECK:STDOUT:       {kind: 'InvalidParse', text: '}', has_error: yes},
+// CHECK:STDOUT:     {kind: 'CodeBlock', text: '}', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:   {kind: 'ForStatement', text: 'for', subtree_size: 8},
+// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 14},
+// CHECK:STDOUT: {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT: ]

--- a/toolchain/parser/testdata/for/fail_square_brackets.carbon
+++ b/toolchain/parser/testdata/for/fail_square_brackets.carbon
@@ -1,0 +1,41 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F() {
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+12]]:7: Expected `(` after `for`.
+  // CHECK:STDERR:   for [] {
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+9]]:7: Expected `var` declaration.
+  // CHECK:STDERR:   for [] {
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+6]]:8: Expected expression.
+  // CHECK:STDERR:   for [] {
+  // CHECK:STDERR:        ^
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+3]]:8: Expected `;` in array type.
+  // CHECK:STDERR:   for [] {
+  // CHECK:STDERR:        ^
+  for [] {
+  }
+}
+
+// CHECK:STDOUT: [
+// CHECK:STDOUT:     {kind: 'FunctionIntroducer', text: 'fn'},
+// CHECK:STDOUT:     {kind: 'Name', text: 'F'},
+// CHECK:STDOUT:       {kind: 'ParameterListStart', text: '('},
+// CHECK:STDOUT:     {kind: 'ParameterList', text: ')', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'FunctionDefinitionStart', text: '{', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'ForHeaderStart', text: 'for', has_error: yes},
+// CHECK:STDOUT:           {kind: 'ArrayExpressionStart', text: '['},
+// CHECK:STDOUT:           {kind: 'InvalidParse', text: ']', has_error: yes},
+// CHECK:STDOUT:         {kind: 'ArrayExpressionSemi', text: ']', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:       {kind: 'ArrayExpression', text: ']', has_error: yes, subtree_size: 4},
+// CHECK:STDOUT:     {kind: 'ForHeader', text: 'for', has_error: yes, subtree_size: 6},
+// CHECK:STDOUT:       {kind: 'CodeBlockStart', text: '{'},
+// CHECK:STDOUT:     {kind: 'CodeBlock', text: '}', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'ForStatement', text: 'for', subtree_size: 9},
+// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 15},
+// CHECK:STDOUT: {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT: ]

--- a/toolchain/parser/testdata/if/fail_missing_cond.carbon
+++ b/toolchain/parser/testdata/if/fail_missing_cond.carbon
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F() {
+  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+3]]:6: Expected `(` after `if`.
+  // CHECK:STDERR:   if {
+  // CHECK:STDERR:      ^
+  if {
+  }
+}
+
+// CHECK:STDOUT: [
+// CHECK:STDOUT:     {kind: 'FunctionIntroducer', text: 'fn'},
+// CHECK:STDOUT:     {kind: 'Name', text: 'F'},
+// CHECK:STDOUT:       {kind: 'ParameterListStart', text: '('},
+// CHECK:STDOUT:     {kind: 'ParameterList', text: ')', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'FunctionDefinitionStart', text: '{', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'IfConditionStart', text: 'if', has_error: yes},
+// CHECK:STDOUT:       {kind: 'InvalidParse', text: '{', has_error: yes},
+// CHECK:STDOUT:     {kind: 'IfCondition', text: 'if', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:       {kind: 'CodeBlockStart', text: '{'},
+// CHECK:STDOUT:     {kind: 'CodeBlock', text: '}', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'IfStatement', text: 'if', subtree_size: 6},
+// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 12},
+// CHECK:STDOUT: {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT: ]

--- a/toolchain/parser/testdata/if/fail_square_brackets.carbon
+++ b/toolchain/parser/testdata/if/fail_square_brackets.carbon
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F() {
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+9]]:6: Expected `(` after `if`.
+  // CHECK:STDERR:   if [] {}
+  // CHECK:STDERR:      ^
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+6]]:7: Expected expression.
+  // CHECK:STDERR:   if [] {}
+  // CHECK:STDERR:       ^
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+3]]:7: Expected `;` in array type.
+  // CHECK:STDERR:   if [] {}
+  // CHECK:STDERR:       ^
+  if [] {}
+}
+
+// CHECK:STDOUT: [
+// CHECK:STDOUT:     {kind: 'FunctionIntroducer', text: 'fn'},
+// CHECK:STDOUT:     {kind: 'Name', text: 'F'},
+// CHECK:STDOUT:       {kind: 'ParameterListStart', text: '('},
+// CHECK:STDOUT:     {kind: 'ParameterList', text: ')', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'FunctionDefinitionStart', text: '{', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'IfConditionStart', text: 'if', has_error: yes},
+// CHECK:STDOUT:           {kind: 'ArrayExpressionStart', text: '['},
+// CHECK:STDOUT:           {kind: 'InvalidParse', text: ']', has_error: yes},
+// CHECK:STDOUT:         {kind: 'ArrayExpressionSemi', text: ']', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:       {kind: 'ArrayExpression', text: ']', has_error: yes, subtree_size: 4},
+// CHECK:STDOUT:     {kind: 'IfCondition', text: 'if', has_error: yes, subtree_size: 6},
+// CHECK:STDOUT:       {kind: 'CodeBlockStart', text: '{'},
+// CHECK:STDOUT:     {kind: 'CodeBlock', text: '}', subtree_size: 2},
+// CHECK:STDOUT:   {kind: 'IfStatement', text: 'if', subtree_size: 9},
+// CHECK:STDOUT: {kind: 'FunctionDefinition', text: '}', subtree_size: 15},
+// CHECK:STDOUT: {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT: ]


### PR DESCRIPTION
In #3064, code was changed to look at a future token. This is an issue because the parser is set up to enforce that tokens aren't used without being consumed. That's part of #3118; related validation fails. Also, since it's not necessarily the open paren that was consumed, it could be a different opening symbol, which the closing symbol handling doesn't check.

Under this approach, it's tracked whether an open paren was consumed, and the open paren is associated with the state. That's more aligned with how the parser expects to be fed information.

In paren condition handling for if and while, I'm also adding some special casing for `if {` in particular to not assume the `{` is a struct. I just think that this will come up somewhat often and the resulting output is better this way (an error either way).  I'm not doing similar with `for` because there's already some `var` handling there, and I'd need a little more time to think about structure -- whereas right now I'm just trying to fix the crashes (`if {}`, `if []`, etc).

Fixes #3118