### PR TITLE
Flush diagnostics before printing semantics IR rather than after.

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -449,6 +449,7 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
     }
   }
   if (options.dump_semantics_ir) {
+    consumer->Flush();
     FormatSemanticsIR(tokenized_source, parse_tree, semantics_ir,
                       output_stream_);
   }


### PR DESCRIPTION
This matches what we do for all other dump output.

No test: this is just changing the behavior of a dump mode, and is really awkward to exercise without adding back in something like a lit test to observe the behavior when stdout and stderr go to the same place.