### PR TITLE
Remove automatic flushing in the SortingDiagnosticConsumer destructor.

### DIFF
--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -17,7 +17,14 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
   explicit SortingDiagnosticConsumer(DiagnosticConsumer& next_consumer)
       : next_consumer_(&next_consumer) {}
 
-  ~SortingDiagnosticConsumer() override { Flush(); }
+  ~SortingDiagnosticConsumer() override {
+    // We choose not to automatically flush diagnostics here, because they are
+    // likely to refer to data that gets destroyed before the diagnostics
+    // consumer is destroyed, because the diagnostics consumer is typically
+    // created before the objects that diagnostics refer into are created.
+    CARBON_CHECK(diagnostics_.empty())
+        << "Must flush diagnostics consumer before destroying it";
+  }
 
   // Buffers the diagnostic.
   auto HandleDiagnostic(Diagnostic diagnostic) -> void override {


### PR DESCRIPTION
We already needed to manually flush diagnostics along every path out of the driver, so switch to a CHECK-failure if we get this wrong rather than a potential use-after-lifetime bug.

Switch the driver to flush explicitly rather than using a bunch of cleanup lambdas, now that we have checking that we get this right.

This is a follow-up after #3126.