### PR TITLE
Split Semantics into Check and SemIR namespaces

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -45,6 +45,7 @@ cc_library(
     ],
     hdrs = ["check.h"],
     deps = [
+        ":ostream",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -7,7 +7,7 @@
 
 #include <cstdlib>
 
-#include "llvm/Support/raw_ostream.h"
+#include "common/ostream.h"
 
 namespace Carbon::Internal {
 

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -438,9 +438,9 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
     return !has_errors;
   }
 
-  const SemanticsIR builtin_ir = SemanticsIR::MakeBuiltinIR();
+  const SemIR::File builtin_ir = SemIR::File::MakeBuiltinIR();
   CARBON_VLOG() << "*** SemanticsIR::MakeFromParseTree ***\n";
-  const SemanticsIR semantics_ir = SemanticsIR::MakeFromParseTree(
+  const SemIR::File semantics_ir = SemIR::File::MakeFromParseTree(
       builtin_ir, tokenized_source, parse_tree, *consumer, vlog_stream_);
 
   // We've finished all steps that can produce diagnostics. Emit the
@@ -449,7 +449,7 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
   consumer->Flush();
 
   has_errors |= semantics_ir.has_errors();
-  CARBON_VLOG() << "*** SemanticsIR::MakeFromParseTree done ***\n";
+  CARBON_VLOG() << "*** SemIR::File::MakeFromParseTree done ***\n";
   if (options.dump_raw_semantics_ir) {
     semantics_ir.Print(output_stream_, options.builtin_semantics_ir);
     if (options.dump_semantics_ir) {
@@ -458,7 +458,7 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
   }
   if (options.dump_semantics_ir) {
     consumer->Flush();
-    FormatSemanticsIR(tokenized_source, parse_tree, semantics_ir,
+    SemIR::FormatFile(tokenized_source, parse_tree, semantics_ir,
                       output_stream_);
   }
   CARBON_VLOG() << "semantics_ir: " << semantics_ir;

--- a/toolchain/lowering/lower_to_llvm.cpp
+++ b/toolchain/lowering/lower_to_llvm.cpp
@@ -9,7 +9,7 @@
 namespace Carbon {
 
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
-                 const SemanticsIR& semantics_ir,
+                 const SemIR::File& semantics_ir,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module> {
   LoweringContext context(llvm_context, module_name, semantics_ir, vlog_stream);

--- a/toolchain/lowering/lower_to_llvm.h
+++ b/toolchain/lowering/lower_to_llvm.h
@@ -11,7 +11,7 @@
 
 namespace Carbon {
 
-// Lowers SemIR:: IR to LLVM IR.
+// Lowers SemIR to LLVM IR.
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
                  const SemIR::File& semantics_ir,
                  llvm::raw_ostream* vlog_stream)

--- a/toolchain/lowering/lower_to_llvm.h
+++ b/toolchain/lowering/lower_to_llvm.h
@@ -11,9 +11,9 @@
 
 namespace Carbon {
 
-// Lowers Semantics IR to LLVM IR.
+// Lowers SemIR:: IR to LLVM IR.
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
-                 const SemanticsIR& semantics_ir,
+                 const SemIR::File& semantics_ir,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module>;
 

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -18,23 +18,23 @@ class LoweringContext {
  public:
   explicit LoweringContext(llvm::LLVMContext& llvm_context,
                            llvm::StringRef module_name,
-                           const SemanticsIR& semantics_ir,
+                           const SemIR::File& semantics_ir,
                            llvm::raw_ostream* vlog_stream);
 
-  // Lowers the SemanticsIR to LLVM IR. Should only be called once, and handles
+  // Lowers the SemIR::File to LLVM IR. Should only be called once, and handles
   // the main execution loop.
   auto Run() -> std::unique_ptr<llvm::Module>;
 
   // Gets a callable's function.
-  auto GetFunction(SemanticsFunctionId function_id) -> llvm::Function* {
+  auto GetFunction(SemIR::FunctionId function_id) -> llvm::Function* {
     CARBON_CHECK(functions_[function_id.index] != nullptr) << function_id;
     return functions_[function_id.index];
   }
 
   // Returns a lowered type for the given type_id.
-  auto GetType(SemanticsTypeId type_id) -> llvm::Type* {
+  auto GetType(SemIR::TypeId type_id) -> llvm::Type* {
     // InvalidType should not be passed in.
-    if (type_id == SemanticsTypeId::TypeType) {
+    if (type_id == SemIR::TypeId::TypeType) {
       return GetTypeType();
     }
     CARBON_CHECK(type_id.index >= 0) << type_id;
@@ -48,21 +48,21 @@ class LoweringContext {
 
   auto llvm_context() -> llvm::LLVMContext& { return *llvm_context_; }
   auto llvm_module() -> llvm::Module& { return *llvm_module_; }
-  auto semantics_ir() -> const SemanticsIR& { return *semantics_ir_; }
+  auto semantics_ir() -> const SemIR::File& { return *semantics_ir_; }
 
  private:
   // Builds the declaration for the given function, which should then be cached
   // by the caller.
-  auto BuildFunctionDeclaration(SemanticsFunctionId function_id)
+  auto BuildFunctionDeclaration(SemIR::FunctionId function_id)
       -> llvm::Function*;
 
   // Builds the definition for the given function. If the function is only a
   // declaration with no definition, does nothing.
-  auto BuildFunctionDefinition(SemanticsFunctionId function_id) -> void;
+  auto BuildFunctionDefinition(SemIR::FunctionId function_id) -> void;
 
   // Builds the type for the given node, which should then be cached by the
   // caller.
-  auto BuildType(SemanticsNodeId node_id) -> llvm::Type*;
+  auto BuildType(SemIR::NodeId node_id) -> llvm::Type*;
 
   // Returns the empty LLVM struct type used to represent the type `type`.
   auto GetTypeType() -> llvm::StructType* {
@@ -77,13 +77,13 @@ class LoweringContext {
   llvm::LLVMContext* llvm_context_;
   std::unique_ptr<llvm::Module> llvm_module_;
 
-  // The input Semantics IR.
-  const SemanticsIR* const semantics_ir_;
+  // The input SemIR:: IR.
+  const SemIR::File* const semantics_ir_;
 
   // The optional vlog stream.
   llvm::raw_ostream* vlog_stream_;
 
-  // Maps callables to lowered functions. Semantics treats callables as the
+  // Maps callables to lowered functions. SemIR:: treats callables as the
   // canonical form of a function, so lowering needs to do the same.
   llvm::SmallVector<llvm::Function*> functions_;
 

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -77,13 +77,13 @@ class LoweringContext {
   llvm::LLVMContext* llvm_context_;
   std::unique_ptr<llvm::Module> llvm_module_;
 
-  // The input SemIR:: IR.
+  // The input SemIR.
   const SemIR::File* const semantics_ir_;
 
   // The optional vlog stream.
   llvm::raw_ostream* vlog_stream_;
 
-  // Maps callables to lowered functions. SemIR:: treats callables as the
+  // Maps callables to lowered functions. SemIR treats callables as the
   // canonical form of a function, so lowering needs to do the same.
   llvm::SmallVector<llvm::Function*> functions_;
 

--- a/toolchain/lowering/lowering_function_context.cpp
+++ b/toolchain/lowering/lowering_function_context.cpp
@@ -14,7 +14,7 @@ LoweringFunctionContext::LoweringFunctionContext(
       function_(function),
       builder_(lowering_context.llvm_context()) {}
 
-auto LoweringFunctionContext::GetBlock(SemanticsNodeBlockId block_id)
+auto LoweringFunctionContext::GetBlock(SemIR::NodeBlockId block_id)
     -> llvm::BasicBlock* {
   llvm::BasicBlock*& entry = blocks_[block_id];
   if (!entry) {
@@ -23,7 +23,7 @@ auto LoweringFunctionContext::GetBlock(SemanticsNodeBlockId block_id)
   return entry;
 }
 
-auto LoweringFunctionContext::TryToReuseBlock(SemanticsNodeBlockId block_id,
+auto LoweringFunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
                                               llvm::BasicBlock* block) -> bool {
   if (!blocks_.insert({block_id, block}).second) {
     return false;
@@ -34,8 +34,8 @@ auto LoweringFunctionContext::TryToReuseBlock(SemanticsNodeBlockId block_id,
   return true;
 }
 
-auto LoweringFunctionContext::GetBlockArg(SemanticsNodeBlockId block_id,
-                                          SemanticsTypeId type_id)
+auto LoweringFunctionContext::GetBlockArg(SemIR::NodeBlockId block_id,
+                                          SemIR::TypeId type_id)
     -> llvm::PHINode* {
   llvm::BasicBlock* block = GetBlock(block_id);
 
@@ -60,7 +60,7 @@ auto LoweringFunctionContext::CreateSyntheticBlock() -> llvm::BasicBlock* {
   return synthetic_block_;
 }
 
-auto LoweringFunctionContext::GetLocalLoaded(SemanticsNodeId node_id)
+auto LoweringFunctionContext::GetLocalLoaded(SemIR::NodeId node_id)
     -> llvm::Value* {
   auto* value = GetLocal(node_id);
   if (llvm::isa<llvm::AllocaInst, llvm::GetElementPtrInst>(value)) {

--- a/toolchain/lowering/lowering_function_context.h
+++ b/toolchain/lowering/lowering_function_context.h
@@ -25,23 +25,23 @@ class LoweringFunctionContext {
 
   // Returns a basic block corresponding to the start of the given semantics
   // block, and enqueues it for emission.
-  auto GetBlock(SemanticsNodeBlockId block_id) -> llvm::BasicBlock*;
+  auto GetBlock(SemIR::NodeBlockId block_id) -> llvm::BasicBlock*;
 
   // If we have not yet allocated a `BasicBlock` for this `block_id`, set it to
   // `block`, and enqueue `block_id` for emission. Returns whether we set the
   // block.
-  auto TryToReuseBlock(SemanticsNodeBlockId block_id, llvm::BasicBlock* block)
+  auto TryToReuseBlock(SemIR::NodeBlockId block_id, llvm::BasicBlock* block)
       -> bool;
 
   // Returns a phi node corresponding to the block argument of the given basic
   // block.
-  auto GetBlockArg(SemanticsNodeBlockId block_id, SemanticsTypeId type_id)
+  auto GetBlockArg(SemIR::NodeBlockId block_id, SemIR::TypeId type_id)
       -> llvm::PHINode*;
 
   // Returns a local (versus global) value for the given node.
-  auto GetLocal(SemanticsNodeId node_id) -> llvm::Value* {
+  auto GetLocal(SemIR::NodeId node_id) -> llvm::Value* {
     // All builtins are types, with the same empty lowered value.
-    if (node_id.index < SemanticsBuiltinKind::ValidCount) {
+    if (node_id.index < SemIR::BuiltinKind::ValidCount) {
       return GetTypeAsValue();
     }
 
@@ -52,10 +52,10 @@ class LoweringFunctionContext {
 
   // Returns a local (versus global) value for the given node in loaded state.
   // Loads will only be inserted on an as-needed basis.
-  auto GetLocalLoaded(SemanticsNodeId node_id) -> llvm::Value*;
+  auto GetLocalLoaded(SemIR::NodeId node_id) -> llvm::Value*;
 
   // Sets the value for the given node.
-  auto SetLocal(SemanticsNodeId node_id, llvm::Value* value) {
+  auto SetLocal(SemIR::NodeId node_id, llvm::Value* value) {
     bool added = locals_.insert({node_id, value}).second;
     CARBON_CHECK(added) << "Duplicate local insert: " << node_id;
   }
@@ -71,12 +71,12 @@ class LoweringFunctionContext {
   }
 
   // Gets a callable's function.
-  auto GetFunction(SemanticsFunctionId function_id) -> llvm::Function* {
+  auto GetFunction(SemIR::FunctionId function_id) -> llvm::Function* {
     return lowering_context_->GetFunction(function_id);
   }
 
   // Returns a lowered type for the given type_id.
-  auto GetType(SemanticsTypeId type_id) -> llvm::Type* {
+  auto GetType(SemIR::TypeId type_id) -> llvm::Type* {
     return lowering_context_->GetType(type_id);
   }
 
@@ -85,10 +85,10 @@ class LoweringFunctionContext {
     return lowering_context_->GetTypeAsValue();
   }
 
-  // Create a synthetic block that corresponds to no SemanticsNodeBlockId. Such
+  // Create a synthetic block that corresponds to no SemIR::NodeBlockId. Such
   // a block should only ever have a single predecessor, and is used when we
   // need multiple `llvm::BasicBlock`s to model the linear control flow in a
-  // single SemanticsIR block.
+  // single SemIR::File block.
   auto CreateSyntheticBlock() -> llvm::BasicBlock*;
 
   // Determine whether block is the most recently created synthetic block.
@@ -103,7 +103,7 @@ class LoweringFunctionContext {
     return lowering_context_->llvm_module();
   }
   auto builder() -> llvm::IRBuilder<>& { return builder_; }
-  auto semantics_ir() -> const SemanticsIR& {
+  auto semantics_ir() -> const SemIR::File& {
     return lowering_context_->semantics_ir();
   }
 
@@ -116,23 +116,23 @@ class LoweringFunctionContext {
 
   llvm::IRBuilder<> builder_;
 
-  // Maps a function's SemanticsIR blocks to lowered blocks.
-  llvm::DenseMap<SemanticsNodeBlockId, llvm::BasicBlock*> blocks_;
+  // Maps a function's SemIR::File blocks to lowered blocks.
+  llvm::DenseMap<SemIR::NodeBlockId, llvm::BasicBlock*> blocks_;
 
   // The synthetic block we most recently created. May be null if there is no
   // such block.
   llvm::BasicBlock* synthetic_block_ = nullptr;
 
-  // Maps a function's SemanticsIR nodes to lowered values.
+  // Maps a function's SemIR::File nodes to lowered values.
   // TODO: Handle nested scopes. Right now this is just cleared at the end of
   // every block.
-  llvm::DenseMap<SemanticsNodeId, llvm::Value*> locals_;
+  llvm::DenseMap<SemIR::NodeId, llvm::Value*> locals_;
 };
 
-// Declare handlers for each SemanticsIR node.
-#define CARBON_SEMANTICS_NODE_KIND(Name)                                 \
-  auto LoweringHandle##Name(LoweringFunctionContext& context,            \
-                            SemanticsNodeId node_id, SemanticsNode node) \
+// Declare handlers for each SemIR::File node.
+#define CARBON_SEMANTICS_NODE_KIND(Name)                             \
+  auto LoweringHandle##Name(LoweringFunctionContext& context,        \
+                            SemIR::NodeId node_id, SemIR::Node node) \
       ->void;
 #include "toolchain/semantics/semantics_node_kind.def"
 

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -10,26 +10,24 @@
 namespace Carbon {
 
 auto LoweringHandleInvalid(LoweringFunctionContext& /*context*/,
-                           SemanticsNodeId /*node_id*/, SemanticsNode /*node*/)
+                           SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
     -> void {
   llvm_unreachable("never in actual IR");
 }
 
 auto LoweringHandleCrossReference(LoweringFunctionContext& /*context*/,
-                                  SemanticsNodeId /*node_id*/,
-                                  SemanticsNode node) -> void {
+                                  SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
 auto LoweringHandleAddressOf(LoweringFunctionContext& context,
-                             SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                             SemIR::NodeId node_id, SemIR::Node node) -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsAddressOf()));
 }
 
 auto LoweringHandleArrayIndex(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                              SemIR::NodeId node_id, SemIR::Node node) -> void {
   auto [array_node_id, index_node_id] = node.GetAsArrayIndex();
   auto* array_value = context.GetLocal(array_node_id);
   auto* llvm_type =
@@ -37,7 +35,7 @@ auto LoweringHandleArrayIndex(LoweringFunctionContext& context,
   auto index_node = context.semantics_ir().GetNode(index_node_id);
   llvm::Value* array_element_value;
 
-  if (index_node.kind() == SemanticsNodeKind::IntegerLiteral) {
+  if (index_node.kind() == SemIR::NodeKind::IntegerLiteral) {
     const auto index = context.semantics_ir()
                            .GetIntegerLiteral(index_node.GetAsIntegerLiteral())
                            .getZExtValue();
@@ -54,8 +52,7 @@ auto LoweringHandleArrayIndex(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleArrayValue(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                              SemIR::NodeId node_id, SemIR::Node node) -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca =
       context.builder().CreateAlloca(llvm_type, /*ArraySize=*/nullptr, "array");
@@ -80,34 +77,32 @@ auto LoweringHandleArrayValue(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleAssign(LoweringFunctionContext& context,
-                          SemanticsNodeId /*node_id*/, SemanticsNode node)
-    -> void {
+                          SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
   auto [storage_id, value_id] = node.GetAsAssign();
   context.builder().CreateStore(context.GetLocalLoaded(value_id),
                                 context.GetLocal(storage_id));
 }
 
 auto LoweringHandleBinaryOperatorAdd(LoweringFunctionContext& /*context*/,
-                                     SemanticsNodeId /*node_id*/,
-                                     SemanticsNode node) -> void {
+                                     SemIR::NodeId /*node_id*/,
+                                     SemIR::Node node) -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
 auto LoweringHandleBindName(LoweringFunctionContext& /*context*/,
-                            SemanticsNodeId /*node_id*/, SemanticsNode /*node*/)
+                            SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
     -> void {
   // Probably need to do something here, but not necessary for now.
 }
 
 auto LoweringHandleBlockArg(LoweringFunctionContext& context,
-                            SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
-  SemanticsNodeBlockId block_id = node.GetAsBlockArg();
+                            SemIR::NodeId node_id, SemIR::Node node) -> void {
+  SemIR::NodeBlockId block_id = node.GetAsBlockArg();
   context.SetLocal(node_id, context.GetBlockArg(block_id, node.type_id()));
 }
 
 auto LoweringHandleBoolLiteral(LoweringFunctionContext& context,
-                               SemanticsNodeId node_id, SemanticsNode node)
+                               SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   llvm::Value* v = llvm::ConstantInt::get(context.builder().getInt1Ty(),
                                           node.GetAsBoolLiteral().index);
@@ -115,9 +110,8 @@ auto LoweringHandleBoolLiteral(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleBranch(LoweringFunctionContext& context,
-                          SemanticsNodeId /*node_id*/, SemanticsNode node)
-    -> void {
-  SemanticsNodeBlockId target_block_id = node.GetAsBranch();
+                          SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
+  SemIR::NodeBlockId target_block_id = node.GetAsBranch();
 
   // Opportunistically avoid creating a BasicBlock that contains just a branch.
   llvm::BasicBlock* block = context.builder().GetInsertBlock();
@@ -131,7 +125,7 @@ auto LoweringHandleBranch(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleBranchIf(LoweringFunctionContext& context,
-                            SemanticsNodeId /*node_id*/, SemanticsNode node)
+                            SemIR::NodeId /*node_id*/, SemIR::Node node)
     -> void {
   auto [target_block_id, cond_id] = node.GetAsBranchIf();
   llvm::Value* cond = context.GetLocalLoaded(cond_id);
@@ -142,12 +136,11 @@ auto LoweringHandleBranchIf(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleBranchWithArg(LoweringFunctionContext& context,
-                                 SemanticsNodeId /*node_id*/,
-                                 SemanticsNode node) -> void {
+                                 SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
   auto [target_block_id, arg_id] = node.GetAsBranchWithArg();
   llvm::Value* arg = context.GetLocalLoaded(arg_id);
-  SemanticsTypeId arg_type_id =
-      context.semantics_ir().GetNode(arg_id).type_id();
+  SemIR::TypeId arg_type_id = context.semantics_ir().GetNode(arg_id).type_id();
 
   // Opportunistically avoid creating a BasicBlock that contains just a branch.
   // We only do this for a block that we know will only have a single
@@ -171,13 +164,13 @@ auto LoweringHandleBranchWithArg(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleBuiltin(LoweringFunctionContext& /*context*/,
-                           SemanticsNodeId /*node_id*/, SemanticsNode node)
+                           SemIR::NodeId /*node_id*/, SemIR::Node node)
     -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
-auto LoweringHandleCall(LoweringFunctionContext& context,
-                        SemanticsNodeId node_id, SemanticsNode node) -> void {
+auto LoweringHandleCall(LoweringFunctionContext& context, SemIR::NodeId node_id,
+                        SemIR::Node node) -> void {
   auto [refs_id, function_id] = node.GetAsCall();
   auto* function = context.GetFunction(function_id);
   std::vector<llvm::Value*> args;
@@ -198,14 +191,14 @@ auto LoweringHandleCall(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleDereference(LoweringFunctionContext& context,
-                               SemanticsNodeId node_id, SemanticsNode node)
+                               SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsDereference()));
 }
 
 auto LoweringHandleFunctionDeclaration(LoweringFunctionContext& /*context*/,
-                                       SemanticsNodeId /*node_id*/,
-                                       SemanticsNode node) -> void {
+                                       SemIR::NodeId /*node_id*/,
+                                       SemIR::Node node) -> void {
   CARBON_FATAL()
       << "Should not be encountered. If that changes, we may want to change "
          "higher-level logic to skip them rather than calling this. "
@@ -213,7 +206,7 @@ auto LoweringHandleFunctionDeclaration(LoweringFunctionContext& /*context*/,
 }
 
 auto LoweringHandleIntegerLiteral(LoweringFunctionContext& context,
-                                  SemanticsNodeId node_id, SemanticsNode node)
+                                  SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   llvm::APInt i =
       context.semantics_ir().GetIntegerLiteral(node.GetAsIntegerLiteral());
@@ -224,21 +217,21 @@ auto LoweringHandleIntegerLiteral(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleNamespace(LoweringFunctionContext& /*context*/,
-                             SemanticsNodeId /*node_id*/,
-                             SemanticsNode /*node*/) -> void {
+                             SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
+    -> void {
   // No action to take.
 }
 
 auto LoweringHandleParameter(LoweringFunctionContext& /*context*/,
-                             SemanticsNodeId /*node_id*/,
-                             SemanticsNode /*node*/) -> void {
+                             SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
+    -> void {
   CARBON_FATAL() << "Parameters should be lowered by `BuildFunctionDefinition`";
 }
 
 auto LoweringHandleRealLiteral(LoweringFunctionContext& context,
-                               SemanticsNodeId node_id, SemanticsNode node)
+                               SemIR::NodeId node_id, SemIR::Node node)
     -> void {
-  SemanticsRealLiteral real =
+  SemIR::RealLiteral real =
       context.semantics_ir().GetRealLiteral(node.GetAsRealLiteral());
   // TODO: This will probably have overflow issues, and should be fixed.
   double val =
@@ -250,26 +243,26 @@ auto LoweringHandleRealLiteral(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleReturn(LoweringFunctionContext& context,
-                          SemanticsNodeId /*node_id*/, SemanticsNode /*node*/)
+                          SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
     -> void {
   context.builder().CreateRetVoid();
 }
 
 auto LoweringHandleReturnExpression(LoweringFunctionContext& context,
-                                    SemanticsNodeId /*node_id*/,
-                                    SemanticsNode node) -> void {
-  SemanticsNodeId expr_id = node.GetAsReturnExpression();
+                                    SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
+  SemIR::NodeId expr_id = node.GetAsReturnExpression();
   context.builder().CreateRet(context.GetLocalLoaded(expr_id));
 }
 
 auto LoweringHandleStringLiteral(LoweringFunctionContext& /*context*/,
-                                 SemanticsNodeId /*node_id*/,
-                                 SemanticsNode node) -> void {
+                                 SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
 auto LoweringHandleStructAccess(LoweringFunctionContext& context,
-                                SemanticsNodeId node_id, SemanticsNode node)
+                                SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   auto [struct_id, member_index] = node.GetAsStructAccess();
   auto struct_type_id = context.semantics_ir().GetNode(struct_id).type_id();
@@ -292,8 +285,7 @@ auto LoweringHandleStructAccess(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleTupleIndex(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                              SemIR::NodeId node_id, SemIR::Node node) -> void {
   auto [tuple_node_id, index_node_id] = node.GetAsTupleIndex();
   auto* tuple_value = context.GetLocal(tuple_node_id);
   auto index_node = context.semantics_ir().GetNode(index_node_id);
@@ -307,8 +299,7 @@ auto LoweringHandleTupleIndex(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleTupleValue(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                              SemIR::NodeId node_id, SemIR::Node node) -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca =
       context.builder().CreateAlloca(llvm_type, /*ArraySize=*/nullptr, "tuple");
@@ -321,13 +312,13 @@ auto LoweringHandleTupleValue(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleStructTypeField(LoweringFunctionContext& /*context*/,
-                                   SemanticsNodeId /*node_id*/,
-                                   SemanticsNode /*node*/) -> void {
+                                   SemIR::NodeId /*node_id*/,
+                                   SemIR::Node /*node*/) -> void {
   // No action to take.
 }
 
 auto LoweringHandleStructValue(LoweringFunctionContext& context,
-                               SemanticsNodeId node_id, SemanticsNode node)
+                               SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca = context.builder().CreateAlloca(
@@ -351,21 +342,20 @@ auto LoweringHandleStructValue(LoweringFunctionContext& context,
 }
 
 auto LoweringHandleStubReference(LoweringFunctionContext& context,
-                                 SemanticsNodeId node_id, SemanticsNode node)
+                                 SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsStubReference()));
 }
 
 auto LoweringHandleUnaryOperatorNot(LoweringFunctionContext& context,
-                                    SemanticsNodeId node_id, SemanticsNode node)
+                                    SemIR::NodeId node_id, SemIR::Node node)
     -> void {
   context.SetLocal(node_id, context.builder().CreateNot(context.GetLocal(
                                 node.GetAsUnaryOperatorNot())));
 }
 
 auto LoweringHandleVarStorage(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode node)
-    -> void {
+                              SemIR::NodeId node_id, SemIR::Node node) -> void {
   // TODO: Eventually this name will be optional, and we'll want to provide
   // something like `var` as a default. However, that's not possible right now
   // so cannot be tested.

--- a/toolchain/lowering/lowering_handle_type.cpp
+++ b/toolchain/lowering/lowering_handle_type.cpp
@@ -7,31 +7,31 @@
 namespace Carbon {
 
 auto LoweringHandleArrayType(LoweringFunctionContext& context,
-                             SemanticsNodeId node_id, SemanticsNode /*node*/)
+                             SemIR::NodeId node_id, SemIR::Node /*node*/)
     -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto LoweringHandleConstType(LoweringFunctionContext& context,
-                             SemanticsNodeId node_id, SemanticsNode /*node*/)
+                             SemIR::NodeId node_id, SemIR::Node /*node*/)
     -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto LoweringHandlePointerType(LoweringFunctionContext& context,
-                               SemanticsNodeId node_id, SemanticsNode /*node*/)
+                               SemIR::NodeId node_id, SemIR::Node /*node*/)
     -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto LoweringHandleStructType(LoweringFunctionContext& context,
-                              SemanticsNodeId node_id, SemanticsNode /*node*/)
+                              SemIR::NodeId node_id, SemIR::Node /*node*/)
     -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto LoweringHandleTupleType(LoweringFunctionContext& context,
-                             SemanticsNodeId node_id, SemanticsNode /*node*/)
+                             SemIR::NodeId node_id, SemIR::Node /*node*/)
     -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }

--- a/toolchain/semantics/semantics_builtin_kind.h
+++ b/toolchain/semantics/semantics_builtin_kind.h
@@ -52,6 +52,11 @@ static_assert(
 static_assert(sizeof(SemanticsBuiltinKind) == 1,
               "Kind objects include padding!");
 
+// TODO: Refactor EnumBase to remove the need for this alias.
+namespace SemIR {
+using BuiltinKind = SemanticsBuiltinKind;
+}  // namespace SemIR
+
 }  // namespace Carbon
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_BUILTIN_KIND_H_

--- a/toolchain/semantics/semantics_context.cpp
+++ b/toolchain/semantics/semantics_context.cpp
@@ -18,13 +18,12 @@
 #include "toolchain/semantics/semantics_node_block_stack.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-SemanticsContext::SemanticsContext(const TokenizedBuffer& tokens,
-                                   DiagnosticEmitter<ParseTree::Node>& emitter,
-                                   const ParseTree& parse_tree,
-                                   SemanticsIR& semantics_ir,
-                                   llvm::raw_ostream* vlog_stream)
+Context::Context(const TokenizedBuffer& tokens,
+                 DiagnosticEmitter<ParseTree::Node>& emitter,
+                 const ParseTree& parse_tree, SemIR::File& semantics_ir,
+                 llvm::raw_ostream* vlog_stream)
     : tokens_(&tokens),
       emitter_(&emitter),
       parse_tree_(&parse_tree),
@@ -37,21 +36,19 @@ SemanticsContext::SemanticsContext(const TokenizedBuffer& tokens,
       declaration_name_stack_(this) {
   // Inserts the "Error" and "Type" types as "used types" so that
   // canonicalization can skip them. We don't emit either for lowering.
+  canonical_types_.insert({SemIR::NodeId::BuiltinError, SemIR::TypeId::Error});
   canonical_types_.insert(
-      {SemanticsNodeId::BuiltinError, SemanticsTypeId::Error});
-  canonical_types_.insert(
-      {SemanticsNodeId::BuiltinTypeType, SemanticsTypeId::TypeType});
+      {SemIR::NodeId::BuiltinTypeType, SemIR::TypeId::TypeType});
 }
 
-auto SemanticsContext::TODO(ParseTree::Node parse_node, std::string label)
-    -> bool {
+auto Context::TODO(ParseTree::Node parse_node, std::string label) -> bool {
   CARBON_DIAGNOSTIC(SemanticsTodo, Error, "Semantics TODO: `{0}`.",
                     std::string);
   emitter_->Emit(parse_node, SemanticsTodo, std::move(label));
   return false;
 }
 
-auto SemanticsContext::VerifyOnFinish() -> void {
+auto Context::VerifyOnFinish() -> void {
   // Information in all the various context objects should be cleaned up as
   // various pieces of context go out of scope. At this point, nothing should
   // remain.
@@ -62,25 +59,24 @@ auto SemanticsContext::VerifyOnFinish() -> void {
   CARBON_CHECK(params_or_args_stack_.empty()) << params_or_args_stack_.size();
 }
 
-auto SemanticsContext::AddNode(SemanticsNode node) -> SemanticsNodeId {
+auto Context::AddNode(SemIR::Node node) -> SemIR::NodeId {
   return AddNodeToBlock(node_block_stack_.PeekForAdd(), node);
 }
 
-auto SemanticsContext::AddNodeToBlock(SemanticsNodeBlockId block,
-                                      SemanticsNode node) -> SemanticsNodeId {
+auto Context::AddNodeToBlock(SemIR::NodeBlockId block, SemIR::Node node)
+    -> SemIR::NodeId {
   CARBON_VLOG() << "AddNode " << block << ": " << node << "\n";
   return semantics_ir_->AddNode(block, node);
 }
 
-auto SemanticsContext::AddNodeAndPush(ParseTree::Node parse_node,
-                                      SemanticsNode node) -> void {
+auto Context::AddNodeAndPush(ParseTree::Node parse_node, SemIR::Node node)
+    -> void {
   auto node_id = AddNode(node);
   node_stack_.Push(parse_node, node_id);
 }
 
-auto SemanticsContext::DiagnoseDuplicateName(ParseTree::Node parse_node,
-                                             SemanticsNodeId prev_def_id)
-    -> void {
+auto Context::DiagnoseDuplicateName(ParseTree::Node parse_node,
+                                    SemIR::NodeId prev_def_id) -> void {
   CARBON_DIAGNOSTIC(NameDeclarationDuplicate, Error,
                     "Duplicate name being declared in the same scope.");
   CARBON_DIAGNOSTIC(NameDeclarationPrevious, Note,
@@ -91,16 +87,16 @@ auto SemanticsContext::DiagnoseDuplicateName(ParseTree::Node parse_node,
       .Emit();
 }
 
-auto SemanticsContext::DiagnoseNameNotFound(ParseTree::Node parse_node,
-                                            SemanticsStringId name_id) -> void {
+auto Context::DiagnoseNameNotFound(ParseTree::Node parse_node,
+                                   SemIR::StringId name_id) -> void {
   CARBON_DIAGNOSTIC(NameNotFound, Error, "Name `{0}` not found.",
                     llvm::StringRef);
   emitter_->Emit(parse_node, NameNotFound, semantics_ir_->GetString(name_id));
 }
 
-auto SemanticsContext::AddNameToLookup(ParseTree::Node name_node,
-                                       SemanticsStringId name_id,
-                                       SemanticsNodeId target_id) -> void {
+auto Context::AddNameToLookup(ParseTree::Node name_node,
+                              SemIR::StringId name_id, SemIR::NodeId target_id)
+    -> void {
   if (current_scope().names.insert(name_id).second) {
     name_lookup_[name_id].push_back(target_id);
   } else {
@@ -108,17 +104,16 @@ auto SemanticsContext::AddNameToLookup(ParseTree::Node name_node,
   }
 }
 
-auto SemanticsContext::LookupName(ParseTree::Node parse_node,
-                                  SemanticsStringId name_id,
-                                  SemanticsNameScopeId scope_id,
-                                  bool print_diagnostics) -> SemanticsNodeId {
-  if (scope_id == SemanticsNameScopeId::Invalid) {
+auto Context::LookupName(ParseTree::Node parse_node, SemIR::StringId name_id,
+                         SemIR::NameScopeId scope_id, bool print_diagnostics)
+    -> SemIR::NodeId {
+  if (scope_id == SemIR::NameScopeId::Invalid) {
     auto it = name_lookup_.find(name_id);
     if (it == name_lookup_.end()) {
       if (print_diagnostics) {
         DiagnoseNameNotFound(parse_node, name_id);
       }
-      return SemanticsNodeId::BuiltinError;
+      return SemIR::NodeId::BuiltinError;
     }
     CARBON_CHECK(!it->second.empty())
         << "Should have been erased: " << semantics_ir_->GetString(name_id);
@@ -132,16 +127,16 @@ auto SemanticsContext::LookupName(ParseTree::Node parse_node,
       if (print_diagnostics) {
         DiagnoseNameNotFound(parse_node, name_id);
       }
-      return SemanticsNodeId::BuiltinError;
+      return SemIR::NodeId::BuiltinError;
     }
 
     return it->second;
   }
 }
 
-auto SemanticsContext::PushScope() -> void { scope_stack_.push_back({}); }
+auto Context::PushScope() -> void { scope_stack_.push_back({}); }
 
-auto SemanticsContext::PopScope() -> void {
+auto Context::PopScope() -> void {
   auto scope = scope_stack_.pop_back_val();
   for (const auto& str_id : scope.names) {
     auto it = name_lookup_.find(str_id);
@@ -155,83 +150,81 @@ auto SemanticsContext::PopScope() -> void {
 }
 
 template <typename BranchNode, typename... Args>
-static auto AddDominatedBlockAndBranchImpl(SemanticsContext& context,
+static auto AddDominatedBlockAndBranchImpl(Context& context,
                                            ParseTree::Node parse_node,
-                                           Args... args)
-    -> SemanticsNodeBlockId {
+                                           Args... args) -> SemIR::NodeBlockId {
   if (!context.node_block_stack().is_current_block_reachable()) {
-    return SemanticsNodeBlockId::Unreachable;
+    return SemIR::NodeBlockId::Unreachable;
   }
   auto block_id = context.semantics_ir().AddNodeBlock();
   context.AddNode(BranchNode::Make(parse_node, block_id, args...));
   return block_id;
 }
 
-auto SemanticsContext::AddDominatedBlockAndBranch(ParseTree::Node parse_node)
-    -> SemanticsNodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemanticsNode::Branch>(*this,
-                                                               parse_node);
+auto Context::AddDominatedBlockAndBranch(ParseTree::Node parse_node)
+    -> SemIR::NodeBlockId {
+  return AddDominatedBlockAndBranchImpl<SemIR::Node::Branch>(*this, parse_node);
 }
 
-auto SemanticsContext::AddDominatedBlockAndBranchWithArg(
-    ParseTree::Node parse_node, SemanticsNodeId arg_id)
-    -> SemanticsNodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemanticsNode::BranchWithArg>(
+auto Context::AddDominatedBlockAndBranchWithArg(ParseTree::Node parse_node,
+                                                SemIR::NodeId arg_id)
+    -> SemIR::NodeBlockId {
+  return AddDominatedBlockAndBranchImpl<SemIR::Node::BranchWithArg>(
       *this, parse_node, arg_id);
 }
 
-auto SemanticsContext::AddDominatedBlockAndBranchIf(ParseTree::Node parse_node,
-                                                    SemanticsNodeId cond_id)
-    -> SemanticsNodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemanticsNode::BranchIf>(
+auto Context::AddDominatedBlockAndBranchIf(ParseTree::Node parse_node,
+                                           SemIR::NodeId cond_id)
+    -> SemIR::NodeBlockId {
+  return AddDominatedBlockAndBranchImpl<SemIR::Node::BranchIf>(
       *this, parse_node, cond_id);
 }
 
-auto SemanticsContext::AddConvergenceBlockAndPush(
+auto Context::AddConvergenceBlockAndPush(
     ParseTree::Node parse_node,
-    std::initializer_list<SemanticsNodeBlockId> blocks) -> void {
+    std::initializer_list<SemIR::NodeBlockId> blocks) -> void {
   CARBON_CHECK(blocks.size() >= 2) << "no convergence";
 
-  SemanticsNodeBlockId new_block_id = SemanticsNodeBlockId::Unreachable;
-  for (SemanticsNodeBlockId block_id : blocks) {
-    if (block_id != SemanticsNodeBlockId::Unreachable) {
-      if (new_block_id == SemanticsNodeBlockId::Unreachable) {
+  SemIR::NodeBlockId new_block_id = SemIR::NodeBlockId::Unreachable;
+  for (SemIR::NodeBlockId block_id : blocks) {
+    if (block_id != SemIR::NodeBlockId::Unreachable) {
+      if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlock();
       }
       AddNodeToBlock(block_id,
-                     SemanticsNode::Branch::Make(parse_node, new_block_id));
+                     SemIR::Node::Branch::Make(parse_node, new_block_id));
     }
   }
   node_block_stack().Push(new_block_id);
 }
 
-auto SemanticsContext::AddConvergenceBlockWithArgAndPush(
+auto Context::AddConvergenceBlockWithArgAndPush(
     ParseTree::Node parse_node,
-    std::initializer_list<std::pair<SemanticsNodeBlockId, SemanticsNodeId>>
-        blocks_and_args) -> SemanticsNodeId {
+    std::initializer_list<std::pair<SemIR::NodeBlockId, SemIR::NodeId>>
+        blocks_and_args) -> SemIR::NodeId {
   CARBON_CHECK(blocks_and_args.size() >= 2) << "no convergence";
 
-  SemanticsNodeBlockId new_block_id = SemanticsNodeBlockId::Unreachable;
+  SemIR::NodeBlockId new_block_id = SemIR::NodeBlockId::Unreachable;
   for (auto [block_id, arg_id] : blocks_and_args) {
-    if (block_id != SemanticsNodeBlockId::Unreachable) {
-      if (new_block_id == SemanticsNodeBlockId::Unreachable) {
+    if (block_id != SemIR::NodeBlockId::Unreachable) {
+      if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlock();
       }
-      AddNodeToBlock(block_id, SemanticsNode::BranchWithArg::Make(
+      AddNodeToBlock(block_id, SemIR::Node::BranchWithArg::Make(
                                    parse_node, new_block_id, arg_id));
     }
   }
   node_block_stack().Push(new_block_id);
 
   // Acquire the result value.
-  SemanticsTypeId result_type_id =
+  SemIR::TypeId result_type_id =
       semantics_ir().GetNode(blocks_and_args.begin()->second).type_id();
   return AddNode(
-      SemanticsNode::BlockArg::Make(parse_node, result_type_id, new_block_id));
+      SemIR::Node::BlockArg::Make(parse_node, result_type_id, new_block_id));
 }
 
 // Add the current code block to the enclosing function.
-auto SemanticsContext::AddCurrentCodeBlockToFunction() -> void {
+auto Context::AddCurrentCodeBlockToFunction() -> void {
   CARBON_CHECK(!node_block_stack().empty()) << "no current code block";
   CARBON_CHECK(!return_scope_stack().empty()) << "no current function";
 
@@ -248,12 +241,12 @@ auto SemanticsContext::AddCurrentCodeBlockToFunction() -> void {
       .body_block_ids.push_back(node_block_stack().PeekForAdd());
 }
 
-auto SemanticsContext::is_current_position_reachable() -> bool {
+auto Context::is_current_position_reachable() -> bool {
   switch (auto block_id = node_block_stack().Peek(); block_id.index) {
-    case SemanticsNodeBlockId::Unreachable.index: {
+    case SemIR::NodeBlockId::Unreachable.index: {
       return false;
     }
-    case SemanticsNodeBlockId::Invalid.index: {
+    case SemIR::NodeBlockId::Invalid.index: {
       return true;
     }
     default: {
@@ -265,19 +258,19 @@ auto SemanticsContext::is_current_position_reachable() -> bool {
       }
       const auto& last_node = semantics_ir().GetNode(block_contents.back());
       return last_node.kind().terminator_kind() !=
-             SemanticsTerminatorKind::Terminator;
+             SemIR::TerminatorKind::Terminator;
     }
   }
 }
 
-auto SemanticsContext::ImplicitAsForArgs(
-    SemanticsNodeBlockId arg_refs_id, ParseTree::Node param_parse_node,
-    SemanticsNodeBlockId param_refs_id,
+auto Context::ImplicitAsForArgs(
+    SemIR::NodeBlockId arg_refs_id, ParseTree::Node param_parse_node,
+    SemIR::NodeBlockId param_refs_id,
     DiagnosticEmitter<ParseTree::Node>::DiagnosticBuilder* diagnostic) -> bool {
   // If both arguments and parameters are empty, return quickly. Otherwise,
   // we'll fetch both so that errors are consistent.
-  if (arg_refs_id == SemanticsNodeBlockId::Empty &&
-      param_refs_id == SemanticsNodeBlockId::Empty) {
+  if (arg_refs_id == SemIR::NodeBlockId::Empty &&
+      param_refs_id == SemIR::NodeBlockId::Empty) {
     return true;
   }
 
@@ -320,11 +313,10 @@ auto SemanticsContext::ImplicitAsForArgs(
   return true;
 }
 
-auto SemanticsContext::ImplicitAsRequired(ParseTree::Node parse_node,
-                                          SemanticsNodeId value_id,
-                                          SemanticsTypeId as_type_id)
-    -> SemanticsNodeId {
-  SemanticsNodeId output_value_id = value_id;
+auto Context::ImplicitAsRequired(ParseTree::Node parse_node,
+                                 SemIR::NodeId value_id,
+                                 SemIR::TypeId as_type_id) -> SemIR::NodeId {
+  SemIR::NodeId output_value_id = value_id;
   if (ImplicitAsImpl(value_id, as_type_id, &output_value_id) ==
       ImplicitAsKind::Incompatible) {
     // Only error when the system is trying to use the result.
@@ -341,37 +333,34 @@ auto SemanticsContext::ImplicitAsRequired(ParseTree::Node parse_node,
   return output_value_id;
 }
 
-auto SemanticsContext::ImplicitAsBool(ParseTree::Node parse_node,
-                                      SemanticsNodeId value_id)
-    -> SemanticsNodeId {
+auto Context::ImplicitAsBool(ParseTree::Node parse_node, SemIR::NodeId value_id)
+    -> SemIR::NodeId {
   return ImplicitAsRequired(parse_node, value_id,
-                            CanonicalizeType(SemanticsNodeId::BuiltinBoolType));
+                            CanonicalizeType(SemIR::NodeId::BuiltinBoolType));
 }
 
-auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
-                                      SemanticsTypeId as_type_id,
-                                      SemanticsNodeId* output_value_id)
-    -> ImplicitAsKind {
+auto Context::ImplicitAsImpl(SemIR::NodeId value_id, SemIR::TypeId as_type_id,
+                             SemIR::NodeId* output_value_id) -> ImplicitAsKind {
   // Start by making sure both sides are valid. If any part is invalid, the
   // result is invalid and we shouldn't error.
-  if (value_id == SemanticsNodeId::BuiltinError) {
+  if (value_id == SemIR::NodeId::BuiltinError) {
     // If the value is invalid, we can't do much, but do "succeed".
     return ImplicitAsKind::Identical;
   }
   auto value = semantics_ir_->GetNode(value_id);
   auto value_type_id = value.type_id();
-  if (value_type_id == SemanticsTypeId::Error) {
+  if (value_type_id == SemIR::TypeId::Error) {
     // Although the source type is invalid, this still changes the value.
     if (output_value_id != nullptr) {
-      *output_value_id = SemanticsNodeId::BuiltinError;
+      *output_value_id = SemIR::NodeId::BuiltinError;
     }
     return ImplicitAsKind::Compatible;
   }
 
-  if (as_type_id == SemanticsTypeId::Error) {
+  if (as_type_id == SemIR::TypeId::Error) {
     // Although the target type is invalid, this still changes the value.
     if (output_value_id != nullptr) {
-      *output_value_id = SemanticsNodeId::BuiltinError;
+      *output_value_id = SemIR::NodeId::BuiltinError;
     }
     return ImplicitAsKind::Compatible;
   }
@@ -383,13 +372,13 @@ auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
 
   auto as_type = semantics_ir_->GetTypeAllowBuiltinTypes(as_type_id);
   auto as_type_node = semantics_ir_->GetNode(as_type);
-  if (as_type_node.kind() == SemanticsNodeKind::ArrayType) {
+  if (as_type_node.kind() == SemIR::NodeKind::ArrayType) {
     auto [bound_node_id, element_type_id] = as_type_node.GetAsArrayType();
     // To resolve lambda issue.
     auto element_type = element_type_id;
     auto value_type_node = semantics_ir_->GetNode(
         semantics_ir_->GetTypeAllowBuiltinTypes(value_type_id));
-    if (value_type_node.kind() == SemanticsNodeKind::TupleType) {
+    if (value_type_node.kind() == SemIR::NodeKind::TupleType) {
       auto tuple_type_block_id = value_type_node.GetAsTupleType();
       const auto& type_block = semantics_ir_->GetTypeBlock(tuple_type_block_id);
       if (type_block.size() ==
@@ -397,7 +386,7 @@ auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
           std::all_of(type_block.begin(), type_block.end(),
                       [&](auto type) { return type == element_type; })) {
         if (output_value_id != nullptr) {
-          *output_value_id = AddNode(SemanticsNode::ArrayValue::Make(
+          *output_value_id = AddNode(SemIR::Node::ArrayValue::Make(
               value.parse_node(), as_type_id, value_id));
         }
         return ImplicitAsKind::Compatible;
@@ -405,12 +394,12 @@ auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
     }
   }
 
-  if (as_type_id == SemanticsTypeId::TypeType) {
-    if (value.kind() == SemanticsNodeKind::TupleValue) {
+  if (as_type_id == SemIR::TypeId::TypeType) {
+    if (value.kind() == SemIR::NodeKind::TupleValue) {
       auto tuple_block_id = value.GetAsTupleValue();
-      llvm::SmallVector<SemanticsTypeId> type_ids;
+      llvm::SmallVector<SemIR::TypeId> type_ids;
       // If it is empty tuple type, we don't fetch anything.
-      if (tuple_block_id != SemanticsNodeBlockId::Empty) {
+      if (tuple_block_id != SemIR::NodeBlockId::Empty) {
         const auto& tuple_block = semantics_ir_->GetNodeBlock(tuple_block_id);
         for (auto tuple_node_id : tuple_block) {
           // TODO: Eventually ExpressionAsType will insert implicit cast
@@ -429,8 +418,8 @@ auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
       return ImplicitAsKind::Compatible;
     }
     // When converting `{}` to a type, the result is `{} as Type`.
-    if (value.kind() == SemanticsNodeKind::StructValue &&
-        value.GetAsStructValue() == SemanticsNodeBlockId::Empty) {
+    if (value.kind() == SemIR::NodeKind::StructValue &&
+        value.GetAsStructValue() == SemIR::NodeBlockId::Empty) {
       if (output_value_id != nullptr) {
         *output_value_id = semantics_ir_->GetType(value_type_id);
       }
@@ -441,34 +430,32 @@ auto SemanticsContext::ImplicitAsImpl(SemanticsNodeId value_id,
   // TODO: Handle ImplicitAs for compatible structs and tuples.
 
   if (output_value_id != nullptr) {
-    *output_value_id = SemanticsNodeId::BuiltinError;
+    *output_value_id = SemIR::NodeId::BuiltinError;
   }
   return ImplicitAsKind::Incompatible;
 }
 
-auto SemanticsContext::ParamOrArgStart() -> void {
-  params_or_args_stack_.Push();
-}
+auto Context::ParamOrArgStart() -> void { params_or_args_stack_.Push(); }
 
-auto SemanticsContext::ParamOrArgComma(bool for_args) -> void {
+auto Context::ParamOrArgComma(bool for_args) -> void {
   ParamOrArgSave(for_args);
 }
 
-auto SemanticsContext::ParamOrArgEnd(bool for_args, ParseNodeKind start_kind)
-    -> SemanticsNodeBlockId {
+auto Context::ParamOrArgEnd(bool for_args, ParseNodeKind start_kind)
+    -> SemIR::NodeBlockId {
   if (parse_tree_->node_kind(node_stack_.PeekParseNode()) != start_kind) {
     ParamOrArgSave(for_args);
   }
   return params_or_args_stack_.Pop();
 }
 
-auto SemanticsContext::ParamOrArgSave(bool for_args) -> void {
+auto Context::ParamOrArgSave(bool for_args) -> void {
   auto [entry_parse_node, entry_node_id] =
       node_stack_.PopExpressionWithParseNode();
   if (for_args) {
     // For an argument, we add a stub reference to the expression on the top of
     // the stack. There may not be anything on the IR prior to this.
-    entry_node_id = AddNode(SemanticsNode::StubReference::Make(
+    entry_node_id = AddNode(SemIR::Node::StubReference::Make(
         entry_parse_node, semantics_ir_->GetNode(entry_node_id).type_id(),
         entry_node_id));
   }
@@ -479,10 +466,10 @@ auto SemanticsContext::ParamOrArgSave(bool for_args) -> void {
   params_or_args.push_back(entry_node_id);
 }
 
-auto SemanticsContext::CanonicalizeTypeImpl(
-    SemanticsNodeKind kind,
+auto Context::CanonicalizeTypeImpl(
+    SemIR::NodeKind kind,
     llvm::function_ref<void(llvm::FoldingSetNodeID& canonical_id)> profile_type,
-    llvm::function_ref<SemanticsNodeId()> make_node) -> SemanticsTypeId {
+    llvm::function_ref<SemIR::NodeId()> make_node) -> SemIR::TypeId {
   llvm::FoldingSetNodeID canonical_id;
   kind.Profile(canonical_id);
   profile_type(canonical_id);
@@ -514,7 +501,7 @@ auto SemanticsContext::CanonicalizeTypeImpl(
 }
 
 // Compute a fingerprint for a tuple type, for use as a key in a folding set.
-static auto ProfileTupleType(const llvm::SmallVector<SemanticsTypeId>& type_ids,
+static auto ProfileTupleType(const llvm::SmallVector<SemIR::TypeId>& type_ids,
                              llvm::FoldingSetNodeID& canonical_id) -> void {
   for (const auto& type_id : type_ids) {
     canonical_id.AddInteger(type_id.index);
@@ -522,20 +509,20 @@ static auto ProfileTupleType(const llvm::SmallVector<SemanticsTypeId>& type_ids,
 }
 
 // Compute a fingerprint for a type, for use as a key in a folding set.
-static auto ProfileType(SemanticsContext& semantics_context, SemanticsNode node,
+static auto ProfileType(Context& semantics_context, SemIR::Node node,
                         llvm::FoldingSetNodeID& canonical_id) -> void {
   switch (node.kind()) {
-    case SemanticsNodeKind::ArrayType: {
+    case SemIR::NodeKind::ArrayType: {
       auto [bound_id, element_type_id] = node.GetAsArrayType();
       canonical_id.AddInteger(
           semantics_context.semantics_ir().GetArrayBoundValue(bound_id));
       canonical_id.AddInteger(element_type_id.index);
       break;
     }
-    case SemanticsNodeKind::Builtin:
+    case SemIR::NodeKind::Builtin:
       canonical_id.AddInteger(node.GetAsBuiltin().AsInt());
       break;
-    case SemanticsNodeKind::CrossReference: {
+    case SemIR::NodeKind::CrossReference: {
       // TODO: Cross-references should be canonicalized by looking at their
       // target rather than treating them as new unique types.
       auto [xref_id, node_id] = node.GetAsCrossReference();
@@ -543,14 +530,14 @@ static auto ProfileType(SemanticsContext& semantics_context, SemanticsNode node,
       canonical_id.AddInteger(node_id.index);
       break;
     }
-    case SemanticsNodeKind::ConstType:
+    case SemIR::NodeKind::ConstType:
       canonical_id.AddInteger(
           semantics_context.GetUnqualifiedType(node.GetAsConstType()).index);
       break;
-    case SemanticsNodeKind::PointerType:
+    case SemIR::NodeKind::PointerType:
       canonical_id.AddInteger(node.GetAsPointerType().index);
       break;
-    case SemanticsNodeKind::StructType: {
+    case SemIR::NodeKind::StructType: {
       auto refs =
           semantics_context.semantics_ir().GetNodeBlock(node.GetAsStructType());
       for (const auto& ref_id : refs) {
@@ -561,17 +548,17 @@ static auto ProfileType(SemanticsContext& semantics_context, SemanticsNode node,
       }
       break;
     }
-    case SemanticsNodeKind::StubReference: {
+    case SemIR::NodeKind::StubReference: {
       // We rely on stub references not referring to each other to ensure we
       // only recurse once here.
       auto inner =
           semantics_context.semantics_ir().GetNode(node.GetAsStubReference());
-      CARBON_CHECK(inner.kind() != SemanticsNodeKind::StubReference)
+      CARBON_CHECK(inner.kind() != SemIR::NodeKind::StubReference)
           << "A stub reference should never refer to another stub reference.";
       ProfileType(semantics_context, inner, canonical_id);
       break;
     }
-    case SemanticsNodeKind::TupleType:
+    case SemIR::NodeKind::TupleType:
       ProfileTupleType(
           semantics_context.semantics_ir().GetTypeBlock(node.GetAsTupleType()),
           canonical_id);
@@ -581,8 +568,8 @@ static auto ProfileType(SemanticsContext& semantics_context, SemanticsNode node,
   }
 }
 
-auto SemanticsContext::CanonicalizeTypeAndAddNodeIfNew(SemanticsNode node)
-    -> SemanticsTypeId {
+auto Context::CanonicalizeTypeAndAddNodeIfNew(SemIR::Node node)
+    -> SemIR::TypeId {
   auto profile_node = [&](llvm::FoldingSetNodeID& canonical_id) {
     ProfileType(*this, node, canonical_id);
   };
@@ -590,8 +577,7 @@ auto SemanticsContext::CanonicalizeTypeAndAddNodeIfNew(SemanticsNode node)
   return CanonicalizeTypeImpl(node.kind(), profile_node, make_node);
 }
 
-auto SemanticsContext::CanonicalizeType(SemanticsNodeId node_id)
-    -> SemanticsTypeId {
+auto Context::CanonicalizeType(SemIR::NodeId node_id) -> SemIR::TypeId {
   auto it = canonical_types_.find(node_id);
   if (it != canonical_types_.end()) {
     return it->second;
@@ -605,17 +591,17 @@ auto SemanticsContext::CanonicalizeType(SemanticsNodeId node_id)
   return CanonicalizeTypeImpl(node.kind(), profile_node, make_node);
 }
 
-auto SemanticsContext::CanonicalizeStructType(ParseTree::Node parse_node,
-                                              SemanticsNodeBlockId refs_id)
-    -> SemanticsTypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemanticsNode::StructType::Make(
-      parse_node, SemanticsTypeId::TypeType, refs_id));
+auto Context::CanonicalizeStructType(ParseTree::Node parse_node,
+                                     SemIR::NodeBlockId refs_id)
+    -> SemIR::TypeId {
+  return CanonicalizeTypeAndAddNodeIfNew(SemIR::Node::StructType::Make(
+      parse_node, SemIR::TypeId::TypeType, refs_id));
 }
 
-auto SemanticsContext::CanonicalizeTupleType(
-    ParseTree::Node parse_node, llvm::SmallVector<SemanticsTypeId>&& type_ids)
-    -> SemanticsTypeId {
-  // Defer allocating a SemanticsTypeBlockId until we know this is a new type.
+auto Context::CanonicalizeTupleType(ParseTree::Node parse_node,
+                                    llvm::SmallVector<SemIR::TypeId>&& type_ids)
+    -> SemIR::TypeId {
+  // Defer allocating a SemIR::TypeBlockId until we know this is a new type.
   auto profile_tuple = [&](llvm::FoldingSetNodeID& canonical_id) {
     ProfileTupleType(type_ids, canonical_id);
   };
@@ -623,36 +609,33 @@ auto SemanticsContext::CanonicalizeTupleType(
     auto type_block_id = semantics_ir_->AddTypeBlock();
     auto& type_block = semantics_ir_->GetTypeBlock(type_block_id);
     type_block = std::move(type_ids);
-    return AddNode(SemanticsNode::TupleType::Make(
-        parse_node, SemanticsTypeId::TypeType, type_block_id));
+    return AddNode(SemIR::Node::TupleType::Make(
+        parse_node, SemIR::TypeId::TypeType, type_block_id));
   };
-  return CanonicalizeTypeImpl(SemanticsNodeKind::TupleType, profile_tuple,
+  return CanonicalizeTypeImpl(SemIR::NodeKind::TupleType, profile_tuple,
                               make_tuple_node);
 }
 
-auto SemanticsContext::GetPointerType(ParseTree::Node parse_node,
-                                      SemanticsTypeId pointee_type_id)
-    -> SemanticsTypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemanticsNode::PointerType::Make(
-      parse_node, SemanticsTypeId::TypeType, pointee_type_id));
+auto Context::GetPointerType(ParseTree::Node parse_node,
+                             SemIR::TypeId pointee_type_id) -> SemIR::TypeId {
+  return CanonicalizeTypeAndAddNodeIfNew(SemIR::Node::PointerType::Make(
+      parse_node, SemIR::TypeId::TypeType, pointee_type_id));
 }
 
-auto SemanticsContext::GetUnqualifiedType(SemanticsTypeId type_id)
-    -> SemanticsTypeId {
-  SemanticsNode type_node =
+auto Context::GetUnqualifiedType(SemIR::TypeId type_id) -> SemIR::TypeId {
+  SemIR::Node type_node =
       semantics_ir_->GetNode(semantics_ir_->GetTypeAllowBuiltinTypes(type_id));
-  if (type_node.kind() == SemanticsNodeKind::ConstType) {
+  if (type_node.kind() == SemIR::NodeKind::ConstType) {
     return type_node.GetAsConstType();
   }
   return type_id;
 }
 
-auto SemanticsContext::PrintForStackDump(llvm::raw_ostream& output) const
-    -> void {
+auto Context::PrintForStackDump(llvm::raw_ostream& output) const -> void {
   node_stack_.PrintForStackDump(output);
   node_block_stack_.PrintForStackDump(output);
   params_or_args_stack_.PrintForStackDump(output);
   args_type_info_stack_.PrintForStackDump(output);
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_context.h
+++ b/toolchain/semantics/semantics_context.h
@@ -16,16 +16,16 @@
 #include "toolchain/semantics/semantics_node_block_stack.h"
 #include "toolchain/semantics/semantics_node_stack.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
 // Context and shared functionality for semantics handlers.
-class SemanticsContext {
+class Context {
  public:
   // Stores references for work.
-  explicit SemanticsContext(const TokenizedBuffer& tokens,
-                            DiagnosticEmitter<ParseTree::Node>& emitter,
-                            const ParseTree& parse_tree, SemanticsIR& semantics,
-                            llvm::raw_ostream* vlog_stream);
+  explicit Context(const TokenizedBuffer& tokens,
+                   DiagnosticEmitter<ParseTree::Node>& emitter,
+                   const ParseTree& parse_tree, SemIR::File& semantics,
+                   llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
   auto TODO(ParseTree::Node parse_node, std::string label) -> bool;
@@ -34,33 +34,33 @@ class SemanticsContext {
   auto VerifyOnFinish() -> void;
 
   // Adds a node to the current block, returning the produced ID.
-  auto AddNode(SemanticsNode node) -> SemanticsNodeId;
+  auto AddNode(SemIR::Node node) -> SemIR::NodeId;
 
   // Adds a node to the given block, returning the produced ID.
-  auto AddNodeToBlock(SemanticsNodeBlockId block, SemanticsNode node)
-      -> SemanticsNodeId;
+  auto AddNodeToBlock(SemIR::NodeBlockId block, SemIR::Node node)
+      -> SemIR::NodeId;
 
-  // Pushes a parse tree node onto the stack, storing the SemanticsNode as the
+  // Pushes a parse tree node onto the stack, storing the SemIR::Node as the
   // result.
-  auto AddNodeAndPush(ParseTree::Node parse_node, SemanticsNode node) -> void;
+  auto AddNodeAndPush(ParseTree::Node parse_node, SemIR::Node node) -> void;
 
   // Adds a name to name lookup. Prints a diagnostic for name conflicts.
-  auto AddNameToLookup(ParseTree::Node name_node, SemanticsStringId name_id,
-                       SemanticsNodeId target_id) -> void;
+  auto AddNameToLookup(ParseTree::Node name_node, SemIR::StringId name_id,
+                       SemIR::NodeId target_id) -> void;
 
   // Performs name lookup in a specified scope, returning the referenced node.
   // If scope_id is invalid, uses the current contextual scope.
-  auto LookupName(ParseTree::Node parse_node, SemanticsStringId name_id,
-                  SemanticsNameScopeId scope_id, bool print_diagnostics)
-      -> SemanticsNodeId;
+  auto LookupName(ParseTree::Node parse_node, SemIR::StringId name_id,
+                  SemIR::NameScopeId scope_id, bool print_diagnostics)
+      -> SemIR::NodeId;
 
   // Prints a diagnostic for a duplicate name.
   auto DiagnoseDuplicateName(ParseTree::Node parse_node,
-                             SemanticsNodeId prev_def_id) -> void;
+                             SemIR::NodeId prev_def_id) -> void;
 
   // Prints a diagnostic for a missing name.
-  auto DiagnoseNameNotFound(ParseTree::Node parse_node,
-                            SemanticsStringId name_id) -> void;
+  auto DiagnoseNameNotFound(ParseTree::Node parse_node, SemIR::StringId name_id)
+      -> void;
 
   // Pushes a new scope onto scope_stack_.
   auto PushScope() -> void;
@@ -72,28 +72,28 @@ class SemanticsContext {
   // the new block. All paths to the branch target must go through the current
   // block, though not necessarily through this branch.
   auto AddDominatedBlockAndBranch(ParseTree::Node parse_node)
-      -> SemanticsNodeBlockId;
+      -> SemIR::NodeBlockId;
 
   // Adds a `Branch` node branching to a new node block with a value, and
   // returns the ID of the new block. All paths to the branch target must go
   // through the current block.
   auto AddDominatedBlockAndBranchWithArg(ParseTree::Node parse_node,
-                                         SemanticsNodeId arg_id)
-      -> SemanticsNodeBlockId;
+                                         SemIR::NodeId arg_id)
+      -> SemIR::NodeBlockId;
 
   // Adds a `BranchIf` node branching to a new node block, and returns the ID
   // of the new block. All paths to the branch target must go through the
   // current block.
   auto AddDominatedBlockAndBranchIf(ParseTree::Node parse_node,
-                                    SemanticsNodeId cond_id)
-      -> SemanticsNodeBlockId;
+                                    SemIR::NodeId cond_id)
+      -> SemIR::NodeBlockId;
 
   // Adds branches from the given list of blocks to a new block, for
   // reconvergence of control flow, and pushes the new block onto the node
   // block stack.
   auto AddConvergenceBlockAndPush(
       ParseTree::Node parse_node,
-      std::initializer_list<SemanticsNodeBlockId> blocks) -> void;
+      std::initializer_list<SemIR::NodeBlockId> blocks) -> void;
 
   // Adds branches from the given list of blocks and values to a new block, for
   // reconvergence of control flow with a result value, and pushes the new
@@ -101,8 +101,8 @@ class SemanticsContext {
   // value.
   auto AddConvergenceBlockWithArgAndPush(
       ParseTree::Node parse_node,
-      std::initializer_list<std::pair<SemanticsNodeBlockId, SemanticsNodeId>>
-          blocks_and_args) -> SemanticsNodeId;
+      std::initializer_list<std::pair<SemIR::NodeBlockId, SemIR::NodeId>>
+          blocks_and_args) -> SemIR::NodeId;
 
   // Add the current code block to the enclosing function.
   auto AddCurrentCodeBlockToFunction() -> void;
@@ -118,24 +118,24 @@ class SemanticsContext {
   // future we may want to remember the right implicit conversions to do for
   // valid cases in order to efficiently handle generics.
   auto ImplicitAsForArgs(
-      SemanticsNodeBlockId arg_refs_id, ParseTree::Node param_parse_node,
-      SemanticsNodeBlockId param_refs_id,
+      SemIR::NodeBlockId arg_refs_id, ParseTree::Node param_parse_node,
+      SemIR::NodeBlockId param_refs_id,
       DiagnosticEmitter<ParseTree::Node>::DiagnosticBuilder* diagnostic)
       -> bool;
 
   // Runs ImplicitAsImpl for a situation where a cast is required, returning the
   // updated `value_id`. Prints a diagnostic and returns an Error if
   // unsupported.
-  auto ImplicitAsRequired(ParseTree::Node parse_node, SemanticsNodeId value_id,
-                          SemanticsTypeId as_type_id) -> SemanticsNodeId;
+  auto ImplicitAsRequired(ParseTree::Node parse_node, SemIR::NodeId value_id,
+                          SemIR::TypeId as_type_id) -> SemIR::NodeId;
 
   // Runs ImplicitAsRequired for a conversion to `bool`.
-  auto ImplicitAsBool(ParseTree::Node parse_node, SemanticsNodeId value_id)
-      -> SemanticsNodeId;
+  auto ImplicitAsBool(ParseTree::Node parse_node, SemIR::NodeId value_id)
+      -> SemIR::NodeId;
 
   // Canonicalizes a type which is tracked as a single node.
   // TODO: This should eventually return a type ID.
-  auto CanonicalizeType(SemanticsNodeId node_id) -> SemanticsTypeId;
+  auto CanonicalizeType(SemIR::NodeId node_id) -> SemIR::TypeId;
 
   // Handles canonicalization of struct types. This may create a new struct type
   // when it has a new structure, or reference an existing struct type when it
@@ -145,36 +145,36 @@ class SemanticsContext {
   // name conflicts or other diagnostics during creation, which can use the
   // parse node.
   auto CanonicalizeStructType(ParseTree::Node parse_node,
-                              SemanticsNodeBlockId refs_id) -> SemanticsTypeId;
+                              SemIR::NodeBlockId refs_id) -> SemIR::TypeId;
 
   // Handles canonicalization of tuple types. This may create a new tuple type
   // if the `type_ids` doesn't match an existing tuple type.
   auto CanonicalizeTupleType(ParseTree::Node parse_node,
-                             llvm::SmallVector<SemanticsTypeId>&& type_ids)
-      -> SemanticsTypeId;
+                             llvm::SmallVector<SemIR::TypeId>&& type_ids)
+      -> SemIR::TypeId;
 
   // Returns a pointer type whose pointee type is `pointee_type_id`.
-  auto GetPointerType(ParseTree::Node parse_node,
-                      SemanticsTypeId pointee_type_id) -> SemanticsTypeId;
+  auto GetPointerType(ParseTree::Node parse_node, SemIR::TypeId pointee_type_id)
+      -> SemIR::TypeId;
 
   // Converts an expression for use as a type.
   // TODO: This should eventually return a type ID.
-  auto ExpressionAsType(ParseTree::Node parse_node, SemanticsNodeId value_id)
-      -> SemanticsTypeId {
+  auto ExpressionAsType(ParseTree::Node parse_node, SemIR::NodeId value_id)
+      -> SemIR::TypeId {
     auto node = semantics_ir_->GetNode(value_id);
-    if (node.kind() == SemanticsNodeKind::StubReference) {
+    if (node.kind() == SemIR::NodeKind::StubReference) {
       value_id = node.GetAsStubReference();
       CARBON_CHECK(semantics_ir_->GetNode(value_id).kind() !=
-                   SemanticsNodeKind::StubReference)
+                   SemIR::NodeKind::StubReference)
           << "Stub reference should not point to another stub reference";
     }
 
     return CanonicalizeType(
-        ImplicitAsRequired(parse_node, value_id, SemanticsTypeId::TypeType));
+        ImplicitAsRequired(parse_node, value_id, SemIR::TypeId::TypeType));
   }
 
   // Removes any top-level `const` qualifiers from a type.
-  auto GetUnqualifiedType(SemanticsTypeId type_id) -> SemanticsTypeId;
+  auto GetUnqualifiedType(SemIR::TypeId type_id) -> SemIR::TypeId;
 
   // Starts handling parameters or arguments.
   auto ParamOrArgStart() -> void;
@@ -187,7 +187,7 @@ class SemanticsContext {
   // node_stack_ will be start_kind, and the caller should do type-specific
   // processing. Returns refs_id.
   auto ParamOrArgEnd(bool for_args, ParseNodeKind start_kind)
-      -> SemanticsNodeBlockId;
+      -> SemIR::NodeBlockId;
 
   // Saves a parameter from the top block in node_stack_ to the top block in
   // params_or_args_stack_. If for_args, adds a StubReference of the previous
@@ -205,23 +205,21 @@ class SemanticsContext {
 
   auto parse_tree() -> const ParseTree& { return *parse_tree_; }
 
-  auto semantics_ir() -> SemanticsIR& { return *semantics_ir_; }
+  auto semantics_ir() -> SemIR::File& { return *semantics_ir_; }
 
-  auto node_stack() -> SemanticsNodeStack& { return node_stack_; }
+  auto node_stack() -> NodeStack& { return node_stack_; }
 
-  auto node_block_stack() -> SemanticsNodeBlockStack& {
-    return node_block_stack_;
-  }
+  auto node_block_stack() -> NodeBlockStack& { return node_block_stack_; }
 
-  auto args_type_info_stack() -> SemanticsNodeBlockStack& {
+  auto args_type_info_stack() -> NodeBlockStack& {
     return args_type_info_stack_;
   }
 
-  auto return_scope_stack() -> llvm::SmallVector<SemanticsNodeId>& {
+  auto return_scope_stack() -> llvm::SmallVector<SemIR::NodeId>& {
     return return_scope_stack_;
   }
 
-  auto declaration_name_stack() -> SemanticsDeclarationNameStack& {
+  auto declaration_name_stack() -> DeclarationNameStack& {
     return declaration_name_stack_;
   }
 
@@ -240,20 +238,20 @@ class SemanticsContext {
   class TypeNode : public llvm::FastFoldingSetNode {
    public:
     explicit TypeNode(const llvm::FoldingSetNodeID& node_id,
-                      SemanticsTypeId type_id)
+                      SemIR::TypeId type_id)
         : llvm::FastFoldingSetNode(node_id), type_id_(type_id) {}
 
-    auto type_id() -> SemanticsTypeId { return type_id_; }
+    auto type_id() -> SemIR::TypeId { return type_id_; }
 
    private:
-    SemanticsTypeId type_id_;
+    SemIR::TypeId type_id_;
   };
 
   // An entry in scope_stack_.
   struct ScopeStackEntry {
     // Names which are registered with name_lookup_, and will need to be
     // deregistered when the scope ends.
-    llvm::DenseSet<SemanticsStringId> names;
+    llvm::DenseSet<SemIR::StringId> names;
 
     // TODO: This likely needs to track things which need to be destructed.
   };
@@ -266,8 +264,8 @@ class SemanticsContext {
   //
   // If `output_value_id` is not null, then it will be set if there is a need to
   // cast.
-  auto ImplicitAsImpl(SemanticsNodeId value_id, SemanticsTypeId as_type_id,
-                      SemanticsNodeId* output_value_id) -> ImplicitAsKind;
+  auto ImplicitAsImpl(SemIR::NodeId value_id, SemIR::TypeId as_type_id,
+                      SemIR::NodeId* output_value_id) -> ImplicitAsKind;
 
   // Forms a canonical type ID for a type. This function is given two
   // callbacks:
@@ -276,19 +274,19 @@ class SemanticsContext {
   // type. The ID should be distinct for all distinct type values with the same
   // `kind`.
   //
-  // `make_node()` is called to obtain a `SemanticsNodeId` that describes the
+  // `make_node()` is called to obtain a `SemIR::NodeId` that describes the
   // type. It is only called if the type does not already exist, so can be used
-  // to lazily build the `SemanticsNode`. `make_node()` is not permitted to
+  // to lazily build the `SemIR::Node`. `make_node()` is not permitted to
   // directly or indirectly canonicalize any types.
   auto CanonicalizeTypeImpl(
-      SemanticsNodeKind kind,
+      SemIR::NodeKind kind,
       llvm::function_ref<void(llvm::FoldingSetNodeID& canonical_id)>
           profile_type,
-      llvm::function_ref<SemanticsNodeId()> make_node) -> SemanticsTypeId;
+      llvm::function_ref<SemIR::NodeId()> make_node) -> SemIR::TypeId;
 
   // Forms a canonical type ID for a type. If the type is new, adds the node to
   // the current block.
-  auto CanonicalizeTypeAndAddNodeIfNew(SemanticsNode node) -> SemanticsTypeId;
+  auto CanonicalizeTypeAndAddNodeIfNew(SemIR::Node node) -> SemIR::TypeId;
 
   auto current_scope() -> ScopeStackEntry& { return scope_stack_.back(); }
 
@@ -301,39 +299,39 @@ class SemanticsContext {
   // The file's parse tree.
   const ParseTree* parse_tree_;
 
-  // The SemanticsIR being added to.
-  SemanticsIR* semantics_ir_;
+  // The SemIR::File being added to.
+  SemIR::File* semantics_ir_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;
 
   // The stack during Build. Will contain file-level parse nodes on return.
-  SemanticsNodeStack node_stack_;
+  NodeStack node_stack_;
 
   // The stack of node blocks being used for general IR generation.
-  SemanticsNodeBlockStack node_block_stack_;
+  NodeBlockStack node_block_stack_;
 
   // The stack of node blocks being used for per-element tracking of nodes in
   // parameter and argument node blocks. Versus node_block_stack_, an element
   // will have 1 or more nodes in blocks in node_block_stack_, but only ever 1
   // node in blocks here.
-  SemanticsNodeBlockStack params_or_args_stack_;
+  NodeBlockStack params_or_args_stack_;
 
   // The stack of node blocks being used for type information while processing
   // arguments. This is used in parallel with params_or_args_stack_. It's
   // currently only used for struct literals, where we need to track names
   // for a type separate from the literal arguments.
-  SemanticsNodeBlockStack args_type_info_stack_;
+  NodeBlockStack args_type_info_stack_;
 
   // A stack of return scopes; i.e., targets for `return`. Inside a function,
   // this will be a FunctionDeclaration.
-  llvm::SmallVector<SemanticsNodeId> return_scope_stack_;
+  llvm::SmallVector<SemIR::NodeId> return_scope_stack_;
 
   // A stack for scope context.
   llvm::SmallVector<ScopeStackEntry> scope_stack_;
 
   // The stack used for qualified declaration name construction.
-  SemanticsDeclarationNameStack declaration_name_stack_;
+  DeclarationNameStack declaration_name_stack_;
 
   // Maps identifiers to name lookup results. Values are a stack of name lookup
   // results in the ancestor scopes. This offers constant-time lookup of names,
@@ -341,12 +339,12 @@ class SemanticsContext {
   // reference.
   //
   // Names which no longer have lookup results are erased.
-  llvm::DenseMap<SemanticsStringId, llvm::SmallVector<SemanticsNodeId>>
+  llvm::DenseMap<SemIR::StringId, llvm::SmallVector<SemIR::NodeId>>
       name_lookup_;
 
   // Cache of the mapping from nodes to types, to avoid recomputing the folding
   // set ID.
-  llvm::DenseMap<SemanticsNodeId, SemanticsTypeId> canonical_types_;
+  llvm::DenseMap<SemIR::NodeId, SemIR::TypeId> canonical_types_;
 
   // Tracks the canonical representation of types that have been defined.
   llvm::FoldingSet<TypeNode> canonical_type_nodes_;
@@ -357,12 +355,10 @@ class SemanticsContext {
 };
 
 // Parse node handlers. Returns false for unrecoverable errors.
-#define CARBON_PARSE_NODE_KIND(Name)                     \
-  auto SemanticsHandle##Name(SemanticsContext& context,  \
-                             ParseTree::Node parse_node) \
-      ->bool;
+#define CARBON_PARSE_NODE_KIND(Name) \
+  auto Handle##Name(Context& context, ParseTree::Node parse_node)->bool;
 #include "toolchain/parser/parse_node_kind.def"
 
-}  // namespace Carbon
+}  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_CONTEXT_H_

--- a/toolchain/semantics/semantics_file_test.cpp
+++ b/toolchain/semantics/semantics_file_test.cpp
@@ -10,7 +10,7 @@
 namespace Carbon::Testing {
 namespace {
 
-class SemanticsFileTest : public DriverFileTestBase {
+class CheckFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
@@ -24,6 +24,6 @@ class SemanticsFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-CARBON_FILE_TEST_FACTORY(SemanticsFileTest);
+CARBON_FILE_TEST_FACTORY(CheckFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/semantics/semantics_handle_array.cpp
+++ b/toolchain/semantics/semantics_handle_array.cpp
@@ -7,22 +7,21 @@
 #include "toolchain/semantics/semantics_node.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleArrayExpressionStart(SemanticsContext& /*context*/,
-                                         ParseTree::Node /*parse_node*/)
-    -> bool {
+auto HandleArrayExpressionStart(Context& /*context*/,
+                                ParseTree::Node /*parse_node*/) -> bool {
   return true;
 }
 
-auto SemanticsHandleArrayExpressionSemi(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleArrayExpressionSemi(Context& context, ParseTree::Node parse_node)
+    -> bool {
   context.node_stack().Push(parse_node);
   return true;
 }
 
-auto SemanticsHandleArrayExpression(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleArrayExpression(Context& context, ParseTree::Node parse_node)
+    -> bool {
   // TODO: Handle array type with undefined bound.
   if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==
       ParseNodeKind::ArrayExpressionSemi) {
@@ -36,22 +35,22 @@ auto SemanticsHandleArrayExpression(SemanticsContext& context,
       .PopAndDiscardSoloParseNode<ParseNodeKind::ArrayExpressionSemi>();
   auto element_type_node_id = context.node_stack().PopExpression();
   auto bound_node = context.semantics_ir().GetNode(bound_node_id);
-  if (bound_node.kind() == SemanticsNodeKind::IntegerLiteral) {
+  if (bound_node.kind() == SemIR::NodeKind::IntegerLiteral) {
     auto bound_value = context.semantics_ir().GetIntegerLiteral(
         bound_node.GetAsIntegerLiteral());
     if (!bound_value.isNegative()) {
       context.AddNodeAndPush(
           parse_node,
-          SemanticsNode::ArrayType::Make(
-              parse_node, SemanticsTypeId::TypeType, bound_node_id,
+          SemIR::Node::ArrayType::Make(
+              parse_node, SemIR::TypeId::TypeType, bound_node_id,
               context.ExpressionAsType(parse_node, element_type_node_id)));
       return true;
     }
   }
   CARBON_DIAGNOSTIC(InvalidArrayExpression, Error, "Invalid array expression.");
   context.emitter().Emit(parse_node, InvalidArrayExpression);
-  context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinError);
+  context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinError);
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_call_expression.cpp
+++ b/toolchain/semantics/semantics_handle_call_expression.cpp
@@ -5,10 +5,10 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleCallExpression(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleCallExpression(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto refs_id = context.ParamOrArgEnd(
       /*for_args=*/true, ParseNodeKind::CallExpressionStart);
 
@@ -17,7 +17,7 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
       context.node_stack()
           .PopWithParseNode<ParseNodeKind::CallExpressionStart>();
   auto name_node = context.semantics_ir().GetNode(name_id);
-  if (name_node.kind() != SemanticsNodeKind::FunctionDeclaration) {
+  if (name_node.kind() != SemIR::NodeKind::FunctionDeclaration) {
     // TODO: Work on error.
     context.TODO(parse_node, "Not a callable name");
     context.node_stack().Push(parse_node, name_id);
@@ -33,7 +33,7 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
   if (!context.ImplicitAsForArgs(refs_id, name_node.parse_node(),
                                  callable.param_refs_id, &diagnostic)) {
     diagnostic.Emit();
-    context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinError);
+    context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinError);
     return true;
   }
 
@@ -42,32 +42,31 @@ auto SemanticsHandleCallExpression(SemanticsContext& context,
                                          /*diagnostic=*/nullptr));
 
   // TODO: Propagate return types from callable.
-  SemanticsTypeId type_id = callable.return_type_id;
+  SemIR::TypeId type_id = callable.return_type_id;
   // For functions with an implicit return type, set the return type to empty
   // tuple type.
-  if (type_id == SemanticsTypeId::Invalid) {
+  if (type_id == SemIR::TypeId::Invalid) {
     type_id = context.CanonicalizeTupleType(call_expr_parse_node, {});
   }
-  auto call_node_id = context.AddNode(SemanticsNode::Call::Make(
+  auto call_node_id = context.AddNode(SemIR::Node::Call::Make(
       call_expr_parse_node, type_id, refs_id, function_id));
 
   context.node_stack().Push(parse_node, call_node_id);
   return true;
 }
 
-auto SemanticsHandleCallExpressionComma(SemanticsContext& context,
-                                        ParseTree::Node /*parse_node*/)
+auto HandleCallExpressionComma(Context& context, ParseTree::Node /*parse_node*/)
     -> bool {
   context.ParamOrArgComma(/*for_args=*/true);
   return true;
 }
 
-auto SemanticsHandleCallExpressionStart(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleCallExpressionStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto name_id = context.node_stack().PopExpression();
   context.node_stack().Push(parse_node, name_id);
   context.ParamOrArgStart();
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_class.cpp
+++ b/toolchain/semantics/semantics_handle_class.cpp
@@ -4,26 +4,26 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleClassDeclaration(SemanticsContext& context,
-                                     ParseTree::Node parse_node) -> bool {
+auto HandleClassDeclaration(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleClassDeclaration");
 }
 
-auto SemanticsHandleClassDefinition(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleClassDefinition(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleClassDefinition");
 }
 
-auto SemanticsHandleClassDefinitionStart(SemanticsContext& context,
-                                         ParseTree::Node parse_node) -> bool {
+auto HandleClassDefinitionStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleClassDefinitionStart");
 }
 
-auto SemanticsHandleClassIntroducer(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleClassIntroducer(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleClassIntroducer");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_codeblock.cpp
+++ b/toolchain/semantics/semantics_handle_codeblock.cpp
@@ -4,20 +4,19 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleCodeBlockStart(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleCodeBlockStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   context.node_stack().Push(parse_node);
   context.PushScope();
   return true;
 }
 
-auto SemanticsHandleCodeBlock(SemanticsContext& context,
-                              ParseTree::Node /*parse_node*/) -> bool {
+auto HandleCodeBlock(Context& context, ParseTree::Node /*parse_node*/) -> bool {
   context.PopScope();
   context.node_stack().PopForSoloParseNode<ParseNodeKind::CodeBlockStart>();
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_if_expression.cpp
+++ b/toolchain/semantics/semantics_handle_if_expression.cpp
@@ -4,10 +4,9 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleIfExpressionIf(SemanticsContext& context,
-                                   ParseTree::Node if_node) -> bool {
+auto HandleIfExpressionIf(Context& context, ParseTree::Node if_node) -> bool {
   auto cond_value_id = context.node_stack().PopExpression();
 
   context.node_stack().Push(if_node);
@@ -26,15 +25,15 @@ auto SemanticsHandleIfExpressionIf(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleIfExpressionThen(SemanticsContext& context,
-                                     ParseTree::Node then_node) -> bool {
+auto HandleIfExpressionThen(Context& context, ParseTree::Node then_node)
+    -> bool {
   context.node_stack().Push(then_node, context.node_block_stack().Pop());
   context.AddCurrentCodeBlockToFunction();
   return true;
 }
 
-auto SemanticsHandleIfExpressionElse(SemanticsContext& context,
-                                     ParseTree::Node else_node) -> bool {
+auto HandleIfExpressionElse(Context& context, ParseTree::Node else_node)
+    -> bool {
   auto else_value_id = context.node_stack().PopExpression();
   auto [then_node, then_end_block_id] =
       context.node_stack().PopWithParseNode<ParseNodeKind::IfExpressionThen>();
@@ -61,4 +60,4 @@ auto SemanticsHandleIfExpressionElse(SemanticsContext& context,
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_if_statement.cpp
+++ b/toolchain/semantics/semantics_handle_if_statement.cpp
@@ -5,15 +5,14 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleIfConditionStart(SemanticsContext& /*context*/,
-                                     ParseTree::Node /*parse_node*/) -> bool {
+auto HandleIfConditionStart(Context& /*context*/,
+                            ParseTree::Node /*parse_node*/) -> bool {
   return true;
 }
 
-auto SemanticsHandleIfCondition(SemanticsContext& context,
-                                ParseTree::Node parse_node) -> bool {
+auto HandleIfCondition(Context& context, ParseTree::Node parse_node) -> bool {
   // Convert the condition to `bool`.
   auto cond_value_id = context.node_stack().PopExpression();
   cond_value_id = context.ImplicitAsBool(parse_node, cond_value_id);
@@ -35,8 +34,8 @@ auto SemanticsHandleIfCondition(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleIfStatementElse(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleIfStatementElse(Context& context, ParseTree::Node parse_node)
+    -> bool {
   context.node_stack().PopAndDiscardSoloParseNode<ParseNodeKind::IfCondition>();
 
   // Switch to emitting the else block.
@@ -46,8 +45,7 @@ auto SemanticsHandleIfStatementElse(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleIfStatement(SemanticsContext& context,
-                                ParseTree::Node parse_node) -> bool {
+auto HandleIfStatement(Context& context, ParseTree::Node parse_node) -> bool {
   // Either the then or else block, depending on whether there's an `else` node
   // on the top of the node stack.
   auto sub_block_id = context.node_block_stack().PopForAdd();
@@ -60,14 +58,14 @@ auto SemanticsHandleIfStatement(SemanticsContext& context,
           .PopAndDiscardSoloParseNode<ParseNodeKind::IfCondition>();
       context.AddNodeToBlock(
           sub_block_id,
-          SemanticsNode::Branch::Make(parse_node,
-                                      context.node_block_stack().PeekForAdd()));
+          SemIR::Node::Branch::Make(parse_node,
+                                    context.node_block_stack().PeekForAdd()));
       break;
     }
 
     case ParseNodeKind::IfStatementElse: {
       // Branch from the then and else blocks to a new resumption block.
-      SemanticsNodeBlockId then_block_id =
+      SemIR::NodeBlockId then_block_id =
           context.node_stack().Pop<ParseNodeKind::IfStatementElse>();
       context.AddConvergenceBlockAndPush(parse_node,
                                          {then_block_id, sub_block_id});
@@ -83,4 +81,4 @@ auto SemanticsHandleIfStatement(SemanticsContext& context,
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_interface.cpp
+++ b/toolchain/semantics/semantics_handle_interface.cpp
@@ -4,27 +4,26 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleInterfaceDeclaration(SemanticsContext& context,
-                                         ParseTree::Node parse_node) -> bool {
+auto HandleInterfaceDeclaration(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleInterfaceDeclaration");
 }
 
-auto SemanticsHandleInterfaceDefinition(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleInterfaceDefinition(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleInterfaceDefinition");
 }
 
-auto SemanticsHandleInterfaceDefinitionStart(SemanticsContext& context,
-                                             ParseTree::Node parse_node)
-    -> bool {
+auto HandleInterfaceDefinitionStart(Context& context,
+                                    ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleInterfaceDefinitionStart");
 }
 
-auto SemanticsHandleInterfaceIntroducer(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleInterfaceIntroducer(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleInterfaceIntroducer");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_literal.cpp
+++ b/toolchain/semantics/semantics_handle_literal.cpp
@@ -4,21 +4,20 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleLiteral(SemanticsContext& context,
-                            ParseTree::Node parse_node) -> bool {
+auto HandleLiteral(Context& context, ParseTree::Node parse_node) -> bool {
   auto token = context.parse_tree().node_token(parse_node);
   switch (auto token_kind = context.tokens().GetKind(token)) {
     case TokenKind::False:
     case TokenKind::True: {
       context.AddNodeAndPush(
           parse_node,
-          SemanticsNode::BoolLiteral::Make(
+          SemIR::Node::BoolLiteral::Make(
               parse_node,
-              context.CanonicalizeType(SemanticsNodeId::BuiltinBoolType),
-              token_kind == TokenKind::True ? SemanticsBoolValue::True
-                                            : SemanticsBoolValue::False));
+              context.CanonicalizeType(SemIR::NodeId::BuiltinBoolType),
+              token_kind == TokenKind::True ? SemIR::BoolValue::True
+                                            : SemIR::BoolValue::False));
       break;
     }
     case TokenKind::IntegerLiteral: {
@@ -26,10 +25,9 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
           parse_node,
-          SemanticsNode::IntegerLiteral::Make(
+          SemIR::Node::IntegerLiteral::Make(
               parse_node,
-              context.CanonicalizeType(SemanticsNodeId::BuiltinIntegerType),
-              id));
+              context.CanonicalizeType(SemIR::NodeId::BuiltinIntegerType), id));
       break;
     }
     case TokenKind::RealLiteral: {
@@ -38,12 +36,12 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
           {.mantissa = token_value.Mantissa(),
            .exponent = token_value.Exponent(),
            .is_decimal = token_value.IsDecimal()});
-      context.AddNodeAndPush(parse_node,
-                             SemanticsNode::RealLiteral::Make(
-                                 parse_node,
-                                 context.CanonicalizeType(
-                                     SemanticsNodeId::BuiltinFloatingPointType),
-                                 id));
+      context.AddNodeAndPush(
+          parse_node,
+          SemIR::Node::RealLiteral::Make(
+              parse_node,
+              context.CanonicalizeType(SemIR::NodeId::BuiltinFloatingPointType),
+              id));
       break;
     }
     case TokenKind::StringLiteral: {
@@ -51,18 +49,17 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
           context.tokens().GetStringLiteral(token));
       context.AddNodeAndPush(
           parse_node,
-          SemanticsNode::StringLiteral::Make(
+          SemIR::Node::StringLiteral::Make(
               parse_node,
-              context.CanonicalizeType(SemanticsNodeId::BuiltinStringType),
-              id));
+              context.CanonicalizeType(SemIR::NodeId::BuiltinStringType), id));
       break;
     }
     case TokenKind::Type: {
-      context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinTypeType);
+      context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinTypeType);
       break;
     }
     case TokenKind::Bool: {
-      context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinBoolType);
+      context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinBoolType);
       break;
     }
     case TokenKind::IntegerTypeLiteral: {
@@ -70,8 +67,7 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
       if (text != "i32") {
         return context.TODO(parse_node, "Currently only i32 is allowed");
       }
-      context.node_stack().Push(parse_node,
-                                SemanticsNodeId::BuiltinIntegerType);
+      context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinIntegerType);
       break;
     }
     case TokenKind::FloatingPointTypeLiteral: {
@@ -80,11 +76,11 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
         return context.TODO(parse_node, "Currently only f64 is allowed");
       }
       context.node_stack().Push(parse_node,
-                                SemanticsNodeId::BuiltinFloatingPointType);
+                                SemIR::NodeId::BuiltinFloatingPointType);
       break;
     }
     case TokenKind::StringTypeLiteral: {
-      context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinStringType);
+      context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinStringType);
       break;
     }
     default: {
@@ -95,4 +91,4 @@ auto SemanticsHandleLiteral(SemanticsContext& context,
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_loop_statement.cpp
+++ b/toolchain/semantics/semantics_handle_loop_statement.cpp
@@ -5,61 +5,58 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleBreakStatement(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleBreakStatement(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleBreakStatement");
 }
 
-auto SemanticsHandleBreakStatementStart(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleBreakStatementStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleBreakStatementStart");
 }
 
-auto SemanticsHandleContinueStatement(SemanticsContext& context,
-                                      ParseTree::Node parse_node) -> bool {
+auto HandleContinueStatement(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleContinueStatement");
 }
 
-auto SemanticsHandleContinueStatementStart(SemanticsContext& context,
-                                           ParseTree::Node parse_node) -> bool {
+auto HandleContinueStatementStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleContinueStatementStart");
 }
 
-auto SemanticsHandleForHeader(SemanticsContext& context,
-                              ParseTree::Node parse_node) -> bool {
+auto HandleForHeader(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleForHeader");
 }
 
-auto SemanticsHandleForHeaderStart(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleForHeaderStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleForHeaderStart");
 }
 
-auto SemanticsHandleForIn(SemanticsContext& context, ParseTree::Node parse_node)
-    -> bool {
+auto HandleForIn(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleForIn");
 }
 
-auto SemanticsHandleForStatement(SemanticsContext& context,
-                                 ParseTree::Node parse_node) -> bool {
+auto HandleForStatement(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleForStatement");
 }
 
-auto SemanticsHandleWhileCondition(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleWhileCondition(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleWhileCondition");
 }
 
-auto SemanticsHandleWhileConditionStart(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleWhileConditionStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleWhileConditionStart");
 }
 
-auto SemanticsHandleWhileStatement(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleWhileStatement(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleWhileStatement");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_name.cpp
+++ b/toolchain/semantics/semantics_handle_name.cpp
@@ -6,15 +6,15 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
-                                           ParseTree::Node parse_node) -> bool {
-  SemanticsStringId name_id = context.node_stack().Pop<ParseNodeKind::Name>();
+auto HandleMemberAccessExpression(Context& context, ParseTree::Node parse_node)
+    -> bool {
+  SemIR::StringId name_id = context.node_stack().Pop<ParseNodeKind::Name>();
 
   auto base_id = context.node_stack().PopExpression();
   auto base = context.semantics_ir().GetNode(base_id);
-  if (base.kind() == SemanticsNodeKind::Namespace) {
+  if (base.kind() == SemIR::NodeKind::Namespace) {
     // For a namespace, just resolve the name.
     auto node_id =
         context.LookupName(parse_node, name_id, base.GetAsNamespace(),
@@ -27,7 +27,7 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
       context.semantics_ir().GetTypeAllowBuiltinTypes(base.type_id()));
 
   switch (base_type.kind()) {
-    case SemanticsNodeKind::StructType: {
+    case SemIR::NodeKind::StructType: {
       auto refs =
           context.semantics_ir().GetNodeBlock(base_type.GetAsStructType());
       // TODO: Do we need to optimize this with a lookup table for O(1)?
@@ -37,8 +37,8 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
             name_id == field_name_id) {
           context.AddNodeAndPush(
               parse_node,
-              SemanticsNode::StructAccess::Make(
-                  parse_node, field_type_id, base_id, SemanticsMemberIndex(i)));
+              SemIR::Node::StructAccess::Make(parse_node, field_type_id,
+                                              base_id, SemIR::MemberIndex(i)));
           return true;
         }
       }
@@ -52,7 +52,7 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
       break;
     }
     default: {
-      if (base.type_id() != SemanticsTypeId::Error) {
+      if (base.type_id() != SemIR::TypeId::Error) {
         CARBON_DIAGNOSTIC(QualifiedExpressionUnsupported, Error,
                           "Type `{0}` does not support qualified expressions.",
                           std::string);
@@ -65,18 +65,16 @@ auto SemanticsHandleMemberAccessExpression(SemanticsContext& context,
   }
 
   // Should only be reached on error.
-  context.node_stack().Push(parse_node, SemanticsNodeId::BuiltinError);
+  context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinError);
   return true;
 }
 
-auto SemanticsHandlePointerMemberAccessExpression(SemanticsContext& context,
-                                                  ParseTree::Node parse_node)
-    -> bool {
+auto HandlePointerMemberAccessExpression(Context& context,
+                                         ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandlePointerMemberAccessExpression");
 }
 
-auto SemanticsHandleName(SemanticsContext& context, ParseTree::Node parse_node)
-    -> bool {
+auto HandleName(Context& context, ParseTree::Node parse_node) -> bool {
   auto name_str = context.parse_tree().GetNodeText(parse_node);
   auto name_id = context.semantics_ir().AddString(name_str);
   // The parent is responsible for binding the name.
@@ -84,19 +82,19 @@ auto SemanticsHandleName(SemanticsContext& context, ParseTree::Node parse_node)
   return true;
 }
 
-auto SemanticsHandleNameExpression(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandleNameExpression(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto name_str = context.parse_tree().GetNodeText(parse_node);
   auto name_id = context.semantics_ir().AddString(name_str);
   context.node_stack().Push(
       parse_node,
-      context.LookupName(parse_node, name_id, SemanticsNameScopeId::Invalid,
+      context.LookupName(parse_node, name_id, SemIR::NameScopeId::Invalid,
                          /*print_diagnostics=*/true));
   return true;
 }
 
-auto SemanticsHandleQualifiedDeclaration(SemanticsContext& context,
-                                         ParseTree::Node parse_node) -> bool {
+auto HandleQualifiedDeclaration(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto pop_and_apply_first_child = [&]() {
     if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) !=
         ParseNodeKind::QualifiedDeclaration) {
@@ -115,12 +113,11 @@ auto SemanticsHandleQualifiedDeclaration(SemanticsContext& context,
 
   ParseTree::Node parse_node2 = context.node_stack().PeekParseNode();
   if (context.parse_tree().node_kind(parse_node2) == ParseNodeKind::Name) {
-    SemanticsStringId name_id2 =
-        context.node_stack().Pop<ParseNodeKind::Name>();
+    SemIR::StringId name_id2 = context.node_stack().Pop<ParseNodeKind::Name>();
     pop_and_apply_first_child();
     context.declaration_name_stack().ApplyNameQualifier(parse_node2, name_id2);
   } else {
-    SemanticsNodeId node_id2 = context.node_stack().PopExpression();
+    SemIR::NodeId node_id2 = context.node_stack().PopExpression();
     pop_and_apply_first_child();
     context.declaration_name_stack().ApplyExpressionQualifier(parse_node2,
                                                               node_id2);
@@ -129,14 +126,13 @@ auto SemanticsHandleQualifiedDeclaration(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleSelfTypeNameExpression(SemanticsContext& context,
-                                           ParseTree::Node parse_node) -> bool {
+auto HandleSelfTypeNameExpression(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleSelfTypeNameExpression");
 }
 
-auto SemanticsHandleSelfValueName(SemanticsContext& context,
-                                  ParseTree::Node parse_node) -> bool {
+auto HandleSelfValueName(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleSelfValueName");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_named_constraint.cpp
+++ b/toolchain/semantics/semantics_handle_named_constraint.cpp
@@ -5,30 +5,26 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleNamedConstraintDeclaration(SemanticsContext& context,
-                                               ParseTree::Node parse_node)
-    -> bool {
+auto HandleNamedConstraintDeclaration(Context& context,
+                                      ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleNamedConstraintDeclaration");
 }
 
-auto SemanticsHandleNamedConstraintDefinition(SemanticsContext& context,
-                                              ParseTree::Node parse_node)
-    -> bool {
+auto HandleNamedConstraintDefinition(Context& context,
+                                     ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleNamedConstraintDefinition");
 }
 
-auto SemanticsHandleNamedConstraintDefinitionStart(SemanticsContext& context,
-                                                   ParseTree::Node parse_node)
-    -> bool {
+auto HandleNamedConstraintDefinitionStart(Context& context,
+                                          ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleNamedConstraintDefinitionStart");
 }
 
-auto SemanticsHandleNamedConstraintIntroducer(SemanticsContext& context,
-                                              ParseTree::Node parse_node)
-    -> bool {
+auto HandleNamedConstraintIntroducer(Context& context,
+                                     ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleNamedConstraintIntroducer");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_namespace.cpp
+++ b/toolchain/semantics/semantics_handle_namespace.cpp
@@ -5,21 +5,20 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleNamespaceStart(SemanticsContext& context,
-                                   ParseTree::Node /*parse_node*/) -> bool {
+auto HandleNamespaceStart(Context& context, ParseTree::Node /*parse_node*/)
+    -> bool {
   context.declaration_name_stack().Push();
   return true;
 }
 
-auto SemanticsHandleNamespace(SemanticsContext& context,
-                              ParseTree::Node parse_node) -> bool {
+auto HandleNamespace(Context& context, ParseTree::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
-  auto namespace_id = context.AddNode(SemanticsNode::Namespace::Make(
+  auto namespace_id = context.AddNode(SemIR::Node::Namespace::Make(
       parse_node, context.semantics_ir().AddNameScope()));
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_noop.cpp
+++ b/toolchain/semantics/semantics_handle_noop.cpp
@@ -4,23 +4,22 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleEmptyDeclaration(SemanticsContext& /*context*/,
-                                     ParseTree::Node /*parse_node*/) -> bool {
+auto HandleEmptyDeclaration(Context& /*context*/,
+                            ParseTree::Node /*parse_node*/) -> bool {
   // Empty declarations have no actions associated.
   return true;
 }
 
-auto SemanticsHandleFileEnd(SemanticsContext& /*context*/,
-                            ParseTree::Node /*parse_node*/) -> bool {
+auto HandleFileEnd(Context& /*context*/, ParseTree::Node /*parse_node*/)
+    -> bool {
   // Do nothing, no need to balance this node.
   return true;
 }
 
-auto SemanticsHandleInvalidParse(SemanticsContext& context,
-                                 ParseTree::Node parse_node) -> bool {
+auto HandleInvalidParse(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleInvalidParse");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_package.cpp
+++ b/toolchain/semantics/semantics_handle_package.cpp
@@ -4,31 +4,29 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandlePackageApi(SemanticsContext& context,
-                               ParseTree::Node parse_node) -> bool {
+auto HandlePackageApi(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandlePackageApi");
 }
 
-auto SemanticsHandlePackageDirective(SemanticsContext& context,
-                                     ParseTree::Node parse_node) -> bool {
+auto HandlePackageDirective(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandlePackageDirective");
 }
 
-auto SemanticsHandlePackageImpl(SemanticsContext& context,
-                                ParseTree::Node parse_node) -> bool {
+auto HandlePackageImpl(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandlePackageImpl");
 }
 
-auto SemanticsHandlePackageIntroducer(SemanticsContext& context,
-                                      ParseTree::Node parse_node) -> bool {
+auto HandlePackageIntroducer(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandlePackageIntroducer");
 }
 
-auto SemanticsHandlePackageLibrary(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandlePackageLibrary(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandlePackageLibrary");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_parameter_list.cpp
+++ b/toolchain/semantics/semantics_handle_parameter_list.cpp
@@ -4,21 +4,19 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleDeducedParameterList(SemanticsContext& context,
-                                         ParseTree::Node parse_node) -> bool {
+auto HandleDeducedParameterList(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleDeducedParameterList");
 }
 
-auto SemanticsHandleDeducedParameterListStart(SemanticsContext& context,
-                                              ParseTree::Node parse_node)
-    -> bool {
+auto HandleDeducedParameterListStart(Context& context,
+                                     ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleDeducedParameterListStart");
 }
 
-auto SemanticsHandleParameterList(SemanticsContext& context,
-                                  ParseTree::Node parse_node) -> bool {
+auto HandleParameterList(Context& context, ParseTree::Node parse_node) -> bool {
   auto refs_id = context.ParamOrArgEnd(
       /*for_args=*/false, ParseNodeKind::ParameterListStart);
   // TODO: This contains the IR block for parameters. At present, it's just
@@ -36,14 +34,14 @@ auto SemanticsHandleParameterList(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleParameterListComma(SemanticsContext& context,
-                                       ParseTree::Node /*parse_node*/) -> bool {
+auto HandleParameterListComma(Context& context, ParseTree::Node /*parse_node*/)
+    -> bool {
   context.ParamOrArgComma(/*for_args=*/false);
   return true;
 }
 
-auto SemanticsHandleParameterListStart(SemanticsContext& context,
-                                       ParseTree::Node parse_node) -> bool {
+auto HandleParameterListStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   context.PushScope();
   context.node_stack().Push(parse_node);
   context.node_block_stack().Push();
@@ -51,4 +49,4 @@ auto SemanticsHandleParameterListStart(SemanticsContext& context,
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_pattern_binding.cpp
+++ b/toolchain/semantics/semantics_handle_pattern_binding.cpp
@@ -5,20 +5,19 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleAddress(SemanticsContext& context,
-                            ParseTree::Node parse_node) -> bool {
+auto HandleAddress(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleAddress");
 }
 
-auto SemanticsHandleGenericPatternBinding(SemanticsContext& context,
-                                          ParseTree::Node parse_node) -> bool {
+auto HandleGenericPatternBinding(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "GenericPatternBinding");
 }
 
-auto SemanticsHandlePatternBinding(SemanticsContext& context,
-                                   ParseTree::Node parse_node) -> bool {
+auto HandlePatternBinding(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto [type_node, parsed_type_id] =
       context.node_stack().PopExpressionWithParseNode();
   auto cast_type_id = context.ExpressionAsType(type_node, parsed_type_id);
@@ -32,11 +31,11 @@ auto SemanticsHandlePatternBinding(SemanticsContext& context,
   switch (auto context_parse_node_kind = context.parse_tree().node_kind(
               context.node_stack().PeekParseNode())) {
     case ParseNodeKind::VariableIntroducer:
-      context.AddNodeAndPush(parse_node, SemanticsNode::VarStorage::Make(
+      context.AddNodeAndPush(parse_node, SemIR::Node::VarStorage::Make(
                                              name_node, cast_type_id, name_id));
       break;
     case ParseNodeKind::ParameterListStart:
-      context.AddNodeAndPush(parse_node, SemanticsNode::Parameter::Make(
+      context.AddNodeAndPush(parse_node, SemIR::Node::Parameter::Make(
                                              name_node, cast_type_id, name_id));
       break;
     default:
@@ -46,9 +45,8 @@ auto SemanticsHandlePatternBinding(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleTemplate(SemanticsContext& context,
-                             ParseTree::Node parse_node) -> bool {
+auto HandleTemplate(Context& context, ParseTree::Node parse_node) -> bool {
   return context.TODO(parse_node, "HandleTemplate");
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_statement.cpp
+++ b/toolchain/semantics/semantics_handle_statement.cpp
@@ -5,10 +5,9 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleExpressionStatement(SemanticsContext& context,
-                                        ParseTree::Node /*parse_node*/)
+auto HandleExpressionStatement(Context& context, ParseTree::Node /*parse_node*/)
     -> bool {
   // Pop the expression without investigating its contents.
   // TODO: This will probably eventually need to do some "do not discard"
@@ -17,8 +16,8 @@ auto SemanticsHandleExpressionStatement(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleReturnStatement(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleReturnStatement(Context& context, ParseTree::Node parse_node)
+    -> bool {
   CARBON_CHECK(!context.return_scope_stack().empty());
   const auto& fn_node =
       context.semantics_ir().GetNode(context.return_scope_stack().back());
@@ -40,7 +39,7 @@ auto SemanticsHandleReturnStatement(SemanticsContext& context,
           .Emit();
     }
 
-    context.AddNode(SemanticsNode::Return::Make(parse_node));
+    context.AddNode(SemIR::Node::Return::Make(parse_node));
   } else {
     auto arg = context.node_stack().PopExpression();
     context.node_stack()
@@ -61,7 +60,7 @@ auto SemanticsHandleReturnStatement(SemanticsContext& context,
           context.ImplicitAsRequired(parse_node, arg, callable.return_type_id);
     }
 
-    context.AddNode(SemanticsNode::ReturnExpression::Make(parse_node, arg));
+    context.AddNode(SemIR::Node::ReturnExpression::Make(parse_node, arg));
   }
 
   // Switch to a new, unreachable, empty node block. This typically won't
@@ -72,11 +71,11 @@ auto SemanticsHandleReturnStatement(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleReturnStatementStart(SemanticsContext& context,
-                                         ParseTree::Node parse_node) -> bool {
+auto HandleReturnStatementStart(Context& context, ParseTree::Node parse_node)
+    -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(parse_node);
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_struct.cpp
+++ b/toolchain/semantics/semantics_handle_struct.cpp
@@ -4,10 +4,10 @@
 
 #include "toolchain/semantics/semantics_context.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleStructComma(SemanticsContext& context,
-                                ParseTree::Node /*parse_node*/) -> bool {
+auto HandleStructComma(Context& context, ParseTree::Node /*parse_node*/)
+    -> bool {
   context.ParamOrArgComma(
       /*for_args=*/context.parse_tree().node_kind(
           context.node_stack().PeekParseNode()) !=
@@ -15,9 +15,8 @@ auto SemanticsHandleStructComma(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleStructFieldDesignator(SemanticsContext& context,
-                                          ParseTree::Node /*parse_node*/)
-    -> bool {
+auto HandleStructFieldDesignator(Context& context,
+                                 ParseTree::Node /*parse_node*/) -> bool {
   // This leaves the designated name on top because the `.` isn't interesting.
   CARBON_CHECK(
       context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==
@@ -25,35 +24,35 @@ auto SemanticsHandleStructFieldDesignator(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleStructFieldType(SemanticsContext& context,
-                                    ParseTree::Node parse_node) -> bool {
+auto HandleStructFieldType(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto [type_node, type_id] = context.node_stack().PopExpressionWithParseNode();
-  SemanticsTypeId cast_type_id = context.ExpressionAsType(type_node, type_id);
+  SemIR::TypeId cast_type_id = context.ExpressionAsType(type_node, type_id);
 
   auto [name_node, name_id] =
       context.node_stack().PopWithParseNode<ParseNodeKind::Name>();
 
-  context.AddNodeAndPush(parse_node, SemanticsNode::StructTypeField::Make(
+  context.AddNodeAndPush(parse_node, SemIR::Node::StructTypeField::Make(
                                          name_node, name_id, cast_type_id));
   return true;
 }
 
-auto SemanticsHandleStructFieldUnknown(SemanticsContext& context,
-                                       ParseTree::Node parse_node) -> bool {
+auto HandleStructFieldUnknown(Context& context, ParseTree::Node parse_node)
+    -> bool {
   return context.TODO(parse_node, "HandleStructFieldUnknown");
 }
 
-auto SemanticsHandleStructFieldValue(SemanticsContext& context,
-                                     ParseTree::Node parse_node) -> bool {
+auto HandleStructFieldValue(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto [value_parse_node, value_node_id] =
       context.node_stack().PopExpressionWithParseNode();
-  SemanticsStringId name_id = context.node_stack().Pop<ParseNodeKind::Name>();
+  SemIR::StringId name_id = context.node_stack().Pop<ParseNodeKind::Name>();
 
   // Store the name for the type.
   auto type_block_id = context.args_type_info_stack().PeekForAdd();
   context.semantics_ir().AddNode(
       type_block_id,
-      SemanticsNode::StructTypeField::Make(
+      SemIR::Node::StructTypeField::Make(
           parse_node, name_id,
           context.semantics_ir().GetNode(value_node_id).type_id()));
 
@@ -62,8 +61,7 @@ auto SemanticsHandleStructFieldValue(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleStructLiteral(SemanticsContext& context,
-                                  ParseTree::Node parse_node) -> bool {
+auto HandleStructLiteral(Context& context, ParseTree::Node parse_node) -> bool {
   auto refs_id = context.ParamOrArgEnd(
       /*for_args=*/true, ParseNodeKind::StructLiteralOrStructTypeLiteralStart);
 
@@ -76,13 +74,14 @@ auto SemanticsHandleStructLiteral(SemanticsContext& context,
   auto type_id = context.CanonicalizeStructType(parse_node, type_block_id);
 
   auto value_id = context.AddNode(
-      SemanticsNode::StructValue::Make(parse_node, type_id, refs_id));
+      SemIR::Node::StructValue::Make(parse_node, type_id, refs_id));
   context.node_stack().Push(parse_node, value_id);
   return true;
 }
 
-auto SemanticsHandleStructLiteralOrStructTypeLiteralStart(
-    SemanticsContext& context, ParseTree::Node parse_node) -> bool {
+auto HandleStructLiteralOrStructTypeLiteralStart(Context& context,
+                                                 ParseTree::Node parse_node)
+    -> bool {
   context.PushScope();
   context.node_stack().Push(parse_node);
   // At this point we aren't sure whether this will be a value or type literal,
@@ -93,8 +92,8 @@ auto SemanticsHandleStructLiteralOrStructTypeLiteralStart(
   return true;
 }
 
-auto SemanticsHandleStructTypeLiteral(SemanticsContext& context,
-                                      ParseTree::Node parse_node) -> bool {
+auto HandleStructTypeLiteral(Context& context, ParseTree::Node parse_node)
+    -> bool {
   auto refs_id = context.ParamOrArgEnd(
       /*for_args=*/false, ParseNodeKind::StructLiteralOrStructTypeLiteralStart);
 
@@ -105,13 +104,13 @@ auto SemanticsHandleStructTypeLiteral(SemanticsContext& context,
   // This is only used for value literals.
   context.args_type_info_stack().Pop();
 
-  CARBON_CHECK(refs_id != SemanticsNodeBlockId::Empty)
+  CARBON_CHECK(refs_id != SemIR::NodeBlockId::Empty)
       << "{} is handled by StructLiteral.";
 
   context.AddNodeAndPush(parse_node,
-                         SemanticsNode::StructType::Make(
-                             parse_node, SemanticsTypeId::TypeType, refs_id));
+                         SemIR::Node::StructType::Make(
+                             parse_node, SemIR::TypeId::TypeType, refs_id));
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_handle_variable.cpp
+++ b/toolchain/semantics/semantics_handle_variable.cpp
@@ -5,12 +5,12 @@
 #include "toolchain/semantics/semantics_context.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsHandleVariableDeclaration(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleVariableDeclaration(Context& context, ParseTree::Node parse_node)
+    -> bool {
   // Handle the optional initializer.
-  auto expr_node_id = SemanticsNodeId::Invalid;
+  auto expr_node_id = SemIR::NodeId::Invalid;
   bool has_init =
       context.parse_tree().node_kind(context.node_stack().PeekParseNode()) !=
       ParseNodeKind::PatternBinding;
@@ -21,7 +21,7 @@ auto SemanticsHandleVariableDeclaration(SemanticsContext& context,
   }
 
   // Get the storage and add it to name lookup.
-  SemanticsNodeId var_id =
+  SemIR::NodeId var_id =
       context.node_stack().Pop<ParseNodeKind::PatternBinding>();
   auto var = context.semantics_ir().GetNode(var_id);
   auto name_id = var.GetAsVarStorage();
@@ -31,7 +31,7 @@ auto SemanticsHandleVariableDeclaration(SemanticsContext& context,
     auto cast_value_id =
         context.ImplicitAsRequired(parse_node, expr_node_id, var.type_id());
     context.AddNode(
-        SemanticsNode::Assign::Make(parse_node, var_id, cast_value_id));
+        SemIR::Node::Assign::Make(parse_node, var_id, cast_value_id));
   }
 
   context.node_stack()
@@ -40,18 +40,18 @@ auto SemanticsHandleVariableDeclaration(SemanticsContext& context,
   return true;
 }
 
-auto SemanticsHandleVariableIntroducer(SemanticsContext& context,
-                                       ParseTree::Node parse_node) -> bool {
+auto HandleVariableIntroducer(Context& context, ParseTree::Node parse_node)
+    -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(parse_node);
   return true;
 }
 
-auto SemanticsHandleVariableInitializer(SemanticsContext& context,
-                                        ParseTree::Node parse_node) -> bool {
+auto HandleVariableInitializer(Context& context, ParseTree::Node parse_node)
+    -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(parse_node);
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -14,57 +14,55 @@
 #include "toolchain/semantics/semantics_node.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::SemIR {
 
-auto SemanticsIR::MakeBuiltinIR() -> SemanticsIR {
-  SemanticsIR semantics_ir(/*builtin_ir=*/nullptr);
-  semantics_ir.nodes_.reserve(SemanticsBuiltinKind::ValidCount);
+auto File::MakeBuiltinIR() -> File {
+  File semantics_ir(/*builtin_ir=*/nullptr);
+  semantics_ir.nodes_.reserve(BuiltinKind::ValidCount);
 
   // Error uses a self-referential type so that it's not accidentally treated as
   // a normal type. Every other builtin is a type, including the
   // self-referential TypeType.
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                \
-  semantics_ir.nodes_.push_back(SemanticsNode::Builtin::Make(   \
-      SemanticsBuiltinKind::Name,                               \
-      SemanticsBuiltinKind::Name == SemanticsBuiltinKind::Error \
-          ? SemanticsTypeId::Error                              \
-          : SemanticsTypeId::TypeType));
+#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                 \
+  semantics_ir.nodes_.push_back(Node::Builtin::Make(             \
+      BuiltinKind::Name, BuiltinKind::Name == BuiltinKind::Error \
+                             ? TypeId::Error                     \
+                             : TypeId::TypeType));
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
   CARBON_CHECK(semantics_ir.node_blocks_.size() == 1)
       << "BuildBuiltins should only have the empty block, actual: "
       << semantics_ir.node_blocks_.size();
-  CARBON_CHECK(semantics_ir.nodes_.size() == SemanticsBuiltinKind::ValidCount)
-      << "BuildBuiltins should produce " << SemanticsBuiltinKind::ValidCount
+  CARBON_CHECK(semantics_ir.nodes_.size() == BuiltinKind::ValidCount)
+      << "BuildBuiltins should produce " << BuiltinKind::ValidCount
       << " nodes, actual: " << semantics_ir.nodes_.size();
   return semantics_ir;
 }
 
-auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
-                                    const TokenizedBuffer& tokens,
-                                    const ParseTree& parse_tree,
-                                    DiagnosticConsumer& consumer,
-                                    llvm::raw_ostream* vlog_stream)
-    -> SemanticsIR {
-  SemanticsIR semantics_ir(&builtin_ir);
+auto File::MakeFromParseTree(const File& builtin_ir,
+                             const TokenizedBuffer& tokens,
+                             const ParseTree& parse_tree,
+                             DiagnosticConsumer& consumer,
+                             llvm::raw_ostream* vlog_stream) -> File {
+  File semantics_ir(&builtin_ir);
 
   // Copy builtins over.
-  semantics_ir.nodes_.resize_for_overwrite(SemanticsBuiltinKind::ValidCount);
-  static constexpr auto BuiltinIR = SemanticsCrossReferenceIRId(0);
-  for (int i : llvm::seq(SemanticsBuiltinKind::ValidCount)) {
+  semantics_ir.nodes_.resize_for_overwrite(BuiltinKind::ValidCount);
+  static constexpr auto BuiltinIR = CrossReferenceIRId(0);
+  for (int i : llvm::seq(BuiltinKind::ValidCount)) {
     // We can reuse the type node ID because the offsets of cross-references
     // will be the same in this IR.
     auto type = builtin_ir.nodes_[i].type_id();
-    semantics_ir.nodes_[i] = SemanticsNode::CrossReference::Make(
-        type, BuiltinIR, SemanticsNodeId(i));
+    semantics_ir.nodes_[i] =
+        Node::CrossReference::Make(type, BuiltinIR, NodeId(i));
   }
 
   ParseTreeNodeLocationTranslator translator(&tokens, &parse_tree);
   ErrorTrackingDiagnosticConsumer err_tracker(consumer);
   DiagnosticEmitter<ParseTree::Node> emitter(translator, err_tracker);
 
-  SemanticsContext context(tokens, emitter, parse_tree, semantics_ir,
-                           vlog_stream);
+  Check::Context context(tokens, emitter, parse_tree, semantics_ir,
+                         vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -76,13 +74,13 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
   // for example if an unrecoverable state is encountered.
   for (auto parse_node : parse_tree.postorder()) {
     switch (auto parse_kind = parse_tree.node_kind(parse_node)) {
-#define CARBON_PARSE_NODE_KIND(Name)                   \
-  case ParseNodeKind::Name: {                          \
-    if (!SemanticsHandle##Name(context, parse_node)) { \
-      semantics_ir.has_errors_ = true;                 \
-      return semantics_ir;                             \
-    }                                                  \
-    break;                                             \
+#define CARBON_PARSE_NODE_KIND(Name)                 \
+  case ParseNodeKind::Name: {                        \
+    if (!Check::Handle##Name(context, parse_node)) { \
+      semantics_ir.has_errors_ = true;               \
+      return semantics_ir;                           \
+    }                                                \
+    break;                                           \
   }
 #include "toolchain/parser/parse_node_kind.def"
     }
@@ -106,7 +104,7 @@ auto SemanticsIR::MakeFromParseTree(const SemanticsIR& builtin_ir,
   return semantics_ir;
 }
 
-auto SemanticsIR::Verify() const -> ErrorOr<Success> {
+auto File::Verify() const -> ErrorOr<Success> {
   // Invariants don't necessarily hold for invalid IR.
   if (has_errors_) {
     return Success();
@@ -114,14 +112,12 @@ auto SemanticsIR::Verify() const -> ErrorOr<Success> {
 
   // Check that every code block has a terminator sequence that appears at the
   // end of the block.
-  for (const SemanticsFunction& function : functions_) {
-    for (SemanticsNodeBlockId block_id : function.body_block_ids) {
-      SemanticsTerminatorKind prior_kind =
-          SemanticsTerminatorKind::NotTerminator;
-      for (SemanticsNodeId node_id : GetNodeBlock(block_id)) {
-        SemanticsTerminatorKind node_kind =
-            GetNode(node_id).kind().terminator_kind();
-        if (prior_kind == SemanticsTerminatorKind::Terminator) {
+  for (const Function& function : functions_) {
+    for (NodeBlockId block_id : function.body_block_ids) {
+      TerminatorKind prior_kind = TerminatorKind::NotTerminator;
+      for (NodeId node_id : GetNodeBlock(block_id)) {
+        TerminatorKind node_kind = GetNode(node_id).kind().terminator_kind();
+        if (prior_kind == TerminatorKind::Terminator) {
           return Error(llvm::formatv("Node {0} in block {1} follows terminator",
                                      node_id, block_id));
         }
@@ -133,7 +129,7 @@ auto SemanticsIR::Verify() const -> ErrorOr<Success> {
         }
         prior_kind = node_kind;
       }
-      if (prior_kind != SemanticsTerminatorKind::Terminator) {
+      if (prior_kind != TerminatorKind::Terminator) {
         return Error(llvm::formatv("No terminator in block {0}", block_id));
       }
     }
@@ -175,8 +171,7 @@ static auto PrintBlock(llvm::raw_ostream& out, llvm::StringLiteral block_name,
   out << "]\n";
 }
 
-auto SemanticsIR::Print(llvm::raw_ostream& out, bool include_builtins) const
-    -> void {
+auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
   out << "cross_reference_irs_size: " << cross_reference_irs_.size() << "\n";
 
   PrintList(out, "functions", functions_);
@@ -188,7 +183,7 @@ auto SemanticsIR::Print(llvm::raw_ostream& out, bool include_builtins) const
   PrintBlock(out, "type_blocks", type_blocks_);
 
   out << "nodes: [\n";
-  for (int i = include_builtins ? 0 : SemanticsBuiltinKind::ValidCount;
+  for (int i = include_builtins ? 0 : BuiltinKind::ValidCount;
        i < static_cast<int>(nodes_.size()); ++i) {
     const auto& element = nodes_[i];
     out.indent(Indent);
@@ -202,65 +197,65 @@ auto SemanticsIR::Print(llvm::raw_ostream& out, bool include_builtins) const
 // Map a node kind representing a type into an integer describing the
 // precedence of that type's syntax. Higher numbers correspond to higher
 // precedence.
-static auto GetTypePrecedence(SemanticsNodeKind kind) -> int {
+static auto GetTypePrecedence(NodeKind kind) -> int {
   switch (kind) {
-    case SemanticsNodeKind::ArrayType:
-    case SemanticsNodeKind::Builtin:
-    case SemanticsNodeKind::StructType:
-    case SemanticsNodeKind::TupleType:
+    case NodeKind::ArrayType:
+    case NodeKind::Builtin:
+    case NodeKind::StructType:
+    case NodeKind::TupleType:
       return 0;
-    case SemanticsNodeKind::ConstType:
+    case NodeKind::ConstType:
       return -1;
-    case SemanticsNodeKind::PointerType:
+    case NodeKind::PointerType:
       return -2;
 
-    case SemanticsNodeKind::CrossReference:
+    case NodeKind::CrossReference:
       // TODO: Once we support stringification of cross-references, we'll need
       // to determine the precedence of the target of the cross-reference. For
       // now, all cross-references refer to builtin types from the prelude.
       return 0;
 
-    case SemanticsNodeKind::AddressOf:
-    case SemanticsNodeKind::ArrayIndex:
-    case SemanticsNodeKind::ArrayValue:
-    case SemanticsNodeKind::Assign:
-    case SemanticsNodeKind::BinaryOperatorAdd:
-    case SemanticsNodeKind::BlockArg:
-    case SemanticsNodeKind::BoolLiteral:
-    case SemanticsNodeKind::Branch:
-    case SemanticsNodeKind::BranchIf:
-    case SemanticsNodeKind::BranchWithArg:
-    case SemanticsNodeKind::Call:
-    case SemanticsNodeKind::Dereference:
-    case SemanticsNodeKind::FunctionDeclaration:
-    case SemanticsNodeKind::IntegerLiteral:
-    case SemanticsNodeKind::Invalid:
-    case SemanticsNodeKind::Namespace:
-    case SemanticsNodeKind::Parameter:
-    case SemanticsNodeKind::RealLiteral:
-    case SemanticsNodeKind::Return:
-    case SemanticsNodeKind::ReturnExpression:
-    case SemanticsNodeKind::StringLiteral:
-    case SemanticsNodeKind::StructAccess:
-    case SemanticsNodeKind::StructTypeField:
-    case SemanticsNodeKind::StructValue:
-    case SemanticsNodeKind::StubReference:
-    case SemanticsNodeKind::TupleIndex:
-    case SemanticsNodeKind::TupleValue:
-    case SemanticsNodeKind::UnaryOperatorNot:
-    case SemanticsNodeKind::VarStorage:
+    case NodeKind::AddressOf:
+    case NodeKind::ArrayIndex:
+    case NodeKind::ArrayValue:
+    case NodeKind::Assign:
+    case NodeKind::BinaryOperatorAdd:
+    case NodeKind::BlockArg:
+    case NodeKind::BoolLiteral:
+    case NodeKind::Branch:
+    case NodeKind::BranchIf:
+    case NodeKind::BranchWithArg:
+    case NodeKind::Call:
+    case NodeKind::Dereference:
+    case NodeKind::FunctionDeclaration:
+    case NodeKind::IntegerLiteral:
+    case NodeKind::Invalid:
+    case NodeKind::Namespace:
+    case NodeKind::Parameter:
+    case NodeKind::RealLiteral:
+    case NodeKind::Return:
+    case NodeKind::ReturnExpression:
+    case NodeKind::StringLiteral:
+    case NodeKind::StructAccess:
+    case NodeKind::StructTypeField:
+    case NodeKind::StructValue:
+    case NodeKind::StubReference:
+    case NodeKind::TupleIndex:
+    case NodeKind::TupleValue:
+    case NodeKind::UnaryOperatorNot:
+    case NodeKind::VarStorage:
       CARBON_FATAL() << "GetTypePrecedence for non-type node kind " << kind;
   }
 }
 
-auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
-                                bool in_type_context) const -> std::string {
+auto File::StringifyType(TypeId type_id, bool in_type_context) const
+    -> std::string {
   std::string str;
   llvm::raw_string_ostream out(str);
 
   struct Step {
     // The node to print.
-    SemanticsNodeId node_id;
+    NodeId node_id;
     // The index into node_id to print. Not used by all types.
     int index = 0;
 
@@ -281,14 +276,14 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
     }
 
     // Builtins have designated labels.
-    if (step.node_id.index < SemanticsBuiltinKind::ValidCount) {
-      out << SemanticsBuiltinKind::FromInt(step.node_id.index).label();
+    if (step.node_id.index < BuiltinKind::ValidCount) {
+      out << BuiltinKind::FromInt(step.node_id.index).label();
       continue;
     }
 
     auto node = GetNode(step.node_id);
     switch (node.kind()) {
-      case SemanticsNodeKind::ArrayType: {
+      case NodeKind::ArrayType: {
         auto [bound_id, type_id] = node.GetAsArrayType();
         if (step.index == 0) {
           out << "[";
@@ -299,7 +294,7 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
         }
         break;
       }
-      case SemanticsNodeKind::ConstType: {
+      case NodeKind::ConstType: {
         if (step.index == 0) {
           out << "const ";
 
@@ -318,7 +313,7 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
         }
         break;
       }
-      case SemanticsNodeKind::PointerType: {
+      case NodeKind::PointerType: {
         if (step.index == 0) {
           steps.push_back(step.Next());
           steps.push_back(
@@ -328,7 +323,7 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
         }
         break;
       }
-      case SemanticsNodeKind::StructType: {
+      case NodeKind::StructType: {
         auto refs = GetNodeBlock(node.GetAsStructType());
         if (refs.empty()) {
           out << "{}";
@@ -346,13 +341,13 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
         steps.push_back({.node_id = refs[step.index]});
         break;
       }
-      case SemanticsNodeKind::StructTypeField: {
+      case NodeKind::StructTypeField: {
         auto [name_id, type_id] = node.GetAsStructTypeField();
         out << "." << GetString(name_id) << ": ";
         steps.push_back({.node_id = GetTypeAllowBuiltinTypes(type_id)});
         break;
       }
-      case SemanticsNodeKind::TupleType: {
+      case NodeKind::TupleType: {
         auto refs = GetTypeBlock(node.GetAsTupleType());
         if (refs.empty()) {
           out << "()";
@@ -375,42 +370,42 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
             {.node_id = GetTypeAllowBuiltinTypes(refs[step.index])});
         break;
       }
-      case SemanticsNodeKind::AddressOf:
-      case SemanticsNodeKind::ArrayIndex:
-      case SemanticsNodeKind::ArrayValue:
-      case SemanticsNodeKind::Assign:
-      case SemanticsNodeKind::BinaryOperatorAdd:
-      case SemanticsNodeKind::BlockArg:
-      case SemanticsNodeKind::BoolLiteral:
-      case SemanticsNodeKind::Branch:
-      case SemanticsNodeKind::BranchIf:
-      case SemanticsNodeKind::BranchWithArg:
-      case SemanticsNodeKind::Builtin:
-      case SemanticsNodeKind::Call:
-      case SemanticsNodeKind::Dereference:
-      case SemanticsNodeKind::CrossReference:
-      case SemanticsNodeKind::FunctionDeclaration:
-      case SemanticsNodeKind::IntegerLiteral:
-      case SemanticsNodeKind::Namespace:
-      case SemanticsNodeKind::Parameter:
-      case SemanticsNodeKind::RealLiteral:
-      case SemanticsNodeKind::Return:
-      case SemanticsNodeKind::ReturnExpression:
-      case SemanticsNodeKind::StringLiteral:
-      case SemanticsNodeKind::StructAccess:
-      case SemanticsNodeKind::StructValue:
-      case SemanticsNodeKind::StubReference:
-      case SemanticsNodeKind::TupleIndex:
-      case SemanticsNodeKind::TupleValue:
-      case SemanticsNodeKind::UnaryOperatorNot:
-      case SemanticsNodeKind::VarStorage:
+      case NodeKind::AddressOf:
+      case NodeKind::ArrayIndex:
+      case NodeKind::ArrayValue:
+      case NodeKind::Assign:
+      case NodeKind::BinaryOperatorAdd:
+      case NodeKind::BlockArg:
+      case NodeKind::BoolLiteral:
+      case NodeKind::Branch:
+      case NodeKind::BranchIf:
+      case NodeKind::BranchWithArg:
+      case NodeKind::Builtin:
+      case NodeKind::Call:
+      case NodeKind::Dereference:
+      case NodeKind::CrossReference:
+      case NodeKind::FunctionDeclaration:
+      case NodeKind::IntegerLiteral:
+      case NodeKind::Namespace:
+      case NodeKind::Parameter:
+      case NodeKind::RealLiteral:
+      case NodeKind::Return:
+      case NodeKind::ReturnExpression:
+      case NodeKind::StringLiteral:
+      case NodeKind::StructAccess:
+      case NodeKind::StructValue:
+      case NodeKind::StubReference:
+      case NodeKind::TupleIndex:
+      case NodeKind::TupleValue:
+      case NodeKind::UnaryOperatorNot:
+      case NodeKind::VarStorage:
         // We don't need to handle stringification for nodes that don't show up
         // in errors, but make it clear what's going on so that it's clearer
         // when stringification is needed.
         out << "<cannot stringify " << step.node_id << ">";
         break;
-      case SemanticsNodeKind::Invalid:
-        llvm_unreachable("SemanticsNodeKind::Invalid is never used.");
+      case NodeKind::Invalid:
+        llvm_unreachable("NodeKind::Invalid is never used.");
     }
   }
 
@@ -418,8 +413,8 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
   // conversion to type `type` if it's not implied by the context.
   if (!in_type_context) {
     auto outer_node = GetNode(outer_node_id);
-    if (outer_node.kind() == SemanticsNodeKind::TupleType ||
-        (outer_node.kind() == SemanticsNodeKind::StructType &&
+    if (outer_node.kind() == NodeKind::TupleType ||
+        (outer_node.kind() == NodeKind::StructType &&
          GetNodeBlock(outer_node.GetAsStructType()).empty())) {
       out << " as type";
     }
@@ -428,90 +423,89 @@ auto SemanticsIR::StringifyType(SemanticsTypeId type_id,
   return str;
 }
 
-auto GetSemanticsExpressionCategory(const SemanticsIR& semantics_ir,
-                                    SemanticsNodeId node_id)
-    -> SemanticsExpressionCategory {
-  const SemanticsIR* ir = &semantics_ir;
+auto GetExpressionCategory(const File& semantics_ir, NodeId node_id)
+    -> ExpressionCategory {
+  const File* ir = &semantics_ir;
   while (true) {
     auto node = ir->GetNode(node_id);
     switch (node.kind()) {
-      case SemanticsNodeKind::Invalid:
-      case SemanticsNodeKind::Assign:
-      case SemanticsNodeKind::Branch:
-      case SemanticsNodeKind::BranchIf:
-      case SemanticsNodeKind::BranchWithArg:
-      case SemanticsNodeKind::FunctionDeclaration:
-      case SemanticsNodeKind::Namespace:
-      case SemanticsNodeKind::Return:
-      case SemanticsNodeKind::ReturnExpression:
-      case SemanticsNodeKind::StructTypeField:
-        return SemanticsExpressionCategory::NotExpression;
+      case NodeKind::Invalid:
+      case NodeKind::Assign:
+      case NodeKind::Branch:
+      case NodeKind::BranchIf:
+      case NodeKind::BranchWithArg:
+      case NodeKind::FunctionDeclaration:
+      case NodeKind::Namespace:
+      case NodeKind::Return:
+      case NodeKind::ReturnExpression:
+      case NodeKind::StructTypeField:
+        return ExpressionCategory::NotExpression;
 
-      case SemanticsNodeKind::CrossReference: {
+      case NodeKind::CrossReference: {
         auto [xref_id, xref_node_id] = node.GetAsCrossReference();
         ir = &semantics_ir.GetCrossReferenceIR(xref_id);
         node_id = xref_node_id;
         continue;
       }
 
-      case SemanticsNodeKind::Call:
+      case NodeKind::Call:
         // TODO: This should eventually be Initializing.
-        return SemanticsExpressionCategory::Value;
+        return ExpressionCategory::Value;
 
-      case SemanticsNodeKind::AddressOf:
-      case SemanticsNodeKind::ArrayType:
-      case SemanticsNodeKind::BinaryOperatorAdd:
-      case SemanticsNodeKind::BlockArg:
-      case SemanticsNodeKind::BoolLiteral:
-      case SemanticsNodeKind::Builtin:
-      case SemanticsNodeKind::ConstType:
-      case SemanticsNodeKind::IntegerLiteral:
-      case SemanticsNodeKind::Parameter:
-      case SemanticsNodeKind::PointerType:
-      case SemanticsNodeKind::RealLiteral:
-      case SemanticsNodeKind::StringLiteral:
-      case SemanticsNodeKind::StructType:
-      case SemanticsNodeKind::TupleType:
-      case SemanticsNodeKind::UnaryOperatorNot:
-        return SemanticsExpressionCategory::Value;
+      case NodeKind::AddressOf:
+      case NodeKind::ArrayType:
+      case NodeKind::BinaryOperatorAdd:
+      case NodeKind::BlockArg:
+      case NodeKind::BoolLiteral:
+      case NodeKind::Builtin:
+      case NodeKind::ConstType:
+      case NodeKind::IntegerLiteral:
+      case NodeKind::Parameter:
+      case NodeKind::PointerType:
+      case NodeKind::RealLiteral:
+      case NodeKind::StringLiteral:
+      case NodeKind::StructType:
+      case NodeKind::TupleType:
+      case NodeKind::UnaryOperatorNot:
+        return ExpressionCategory::Value;
 
-      case SemanticsNodeKind::ArrayIndex: {
+      case NodeKind::ArrayIndex: {
         auto [base_id, index_id] = node.GetAsArrayIndex();
         node_id = base_id;
         continue;
       }
 
-      case SemanticsNodeKind::StructAccess: {
+      case NodeKind::StructAccess: {
         auto [base_id, member_index] = node.GetAsStructAccess();
         node_id = base_id;
         continue;
       }
 
-      case SemanticsNodeKind::TupleIndex: {
+      case NodeKind::TupleIndex: {
         auto [base_id, index_id] = node.GetAsTupleIndex();
         node_id = base_id;
         continue;
       }
 
-      case SemanticsNodeKind::StubReference: {
+      case NodeKind::StubReference: {
         node_id = node.GetAsStubReference();
         continue;
       }
 
-      case SemanticsNodeKind::ArrayValue:
-      case SemanticsNodeKind::StructValue:
-      case SemanticsNodeKind::TupleValue:
+      case NodeKind::ArrayValue:
+      case NodeKind::StructValue:
+      case NodeKind::TupleValue:
         // TODO: Eventually these will depend on the context in which the value
         // is used, and could be either Value or Initializing. We may want
         // different node kinds for a struct/tuple initializer versus a
         // struct/tuple value construction.
-        return SemanticsExpressionCategory::Value;
+        return ExpressionCategory::Value;
 
-      case SemanticsNodeKind::Dereference:
-      case SemanticsNodeKind::VarStorage:
-        return SemanticsExpressionCategory::DurableReference;
+      case NodeKind::Dereference:
+      case NodeKind::VarStorage:
+        return ExpressionCategory::DurableReference;
     }
   }
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::SemIR

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -12,40 +12,44 @@
 #include "toolchain/parser/parse_tree.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::SemIR {
 
 // A function.
-struct SemanticsFunction {
-  auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{name: " << name_id << ", "
-        << "param_refs: " << param_refs_id;
-    if (return_type_id.is_valid()) {
-      out << ", return_type: " << return_type_id;
+struct Function {
+  friend auto operator<<(llvm::raw_ostream& out, const Function& fn)
+      -> llvm::raw_ostream& {
+    out << "{name: " << fn.name_id << ", "
+        << "param_refs: " << fn.param_refs_id;
+    if (fn.return_type_id.is_valid()) {
+      out << ", return_type: " << fn.return_type_id;
     }
-    if (!body_block_ids.empty()) {
+    if (!fn.body_block_ids.empty()) {
       out << llvm::formatv(
           ", body: [{0}]",
-          llvm::make_range(body_block_ids.begin(), body_block_ids.end()));
+          llvm::make_range(fn.body_block_ids.begin(), fn.body_block_ids.end()));
     }
     out << "}";
+    return out;
   }
 
   // The function name.
-  SemanticsStringId name_id;
+  StringId name_id;
   // A block containing a single reference node per parameter.
-  SemanticsNodeBlockId param_refs_id;
+  NodeBlockId param_refs_id;
   // The return type. This will be invalid if the return type wasn't specified.
-  SemanticsTypeId return_type_id;
+  TypeId return_type_id;
   // A list of the statically reachable code blocks in the body of the
   // function, in lexical order. The first block is the entry block. This will
   // be empty for declarations that don't have a visible definition.
-  llvm::SmallVector<SemanticsNodeBlockId> body_block_ids;
+  llvm::SmallVector<NodeBlockId> body_block_ids;
 };
 
-struct SemanticsRealLiteral {
-  auto Print(llvm::raw_ostream& out) const -> void {
-    out << "{mantissa: " << mantissa << ", exponent: " << exponent
-        << ", is_decimal: " << is_decimal << "}";
+struct RealLiteral {
+  friend auto operator<<(llvm::raw_ostream& out, const RealLiteral& val)
+      -> llvm::raw_ostream& {
+    out << "{mantissa: " << val.mantissa << ", exponent: " << val.exponent
+        << ", is_decimal: " << val.is_decimal << "}";
+    return out;
   }
 
   llvm::APInt mantissa;
@@ -57,17 +61,17 @@ struct SemanticsRealLiteral {
 };
 
 // Provides semantic analysis on a ParseTree.
-class SemanticsIR {
+class File {
  public:
   // Produces the builtins.
-  static auto MakeBuiltinIR() -> SemanticsIR;
+  static auto MakeBuiltinIR() -> File;
 
   // Adds the IR for the provided ParseTree.
-  static auto MakeFromParseTree(const SemanticsIR& builtin_ir,
+  static auto MakeFromParseTree(const File& builtin_ir,
                                 const TokenizedBuffer& tokens,
                                 const ParseTree& parse_tree,
                                 DiagnosticConsumer& consumer,
-                                llvm::raw_ostream* vlog_stream) -> SemanticsIR;
+                                llvm::raw_ostream* vlog_stream) -> File;
 
   // Verifies that invariants of the semantics IR hold.
   auto Verify() const -> ErrorOr<Success>;
@@ -77,131 +81,122 @@ class SemanticsIR {
   // TODO: In the future, the things to print may change, for example by adding
   // preludes. We may then want the ability to omit other things similar to
   // builtins.
-  auto Print(llvm::raw_ostream& out) const -> void {
-    Print(out, /*include_builtins=*/false);
+  friend auto operator<<(llvm::raw_ostream& out, const File& file)
+      -> llvm::raw_ostream& {
+    file.Print(out, /*include_builtins=*/false);
+    return out;
   }
   auto Print(llvm::raw_ostream& out, bool include_builtins) const -> void;
 
   // Returns array bound value from the bound node.
-  auto GetArrayBoundValue(SemanticsNodeId bound_id) const -> uint64_t {
+  auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
     return GetIntegerLiteral(GetNode(bound_id).GetAsIntegerLiteral())
         .getZExtValue();
   }
 
   // Returns the requested IR.
-  auto GetCrossReferenceIR(SemanticsCrossReferenceIRId xref_id) const
-      -> const SemanticsIR& {
+  auto GetCrossReferenceIR(CrossReferenceIRId xref_id) const -> const File& {
     return *cross_reference_irs_[xref_id.index];
   }
 
   // Adds a callable, returning an ID to reference it.
-  auto AddFunction(SemanticsFunction function) -> SemanticsFunctionId {
-    SemanticsFunctionId id(functions_.size());
+  auto AddFunction(Function function) -> FunctionId {
+    FunctionId id(functions_.size());
     functions_.push_back(function);
     return id;
   }
 
   // Returns the requested callable.
-  auto GetFunction(SemanticsFunctionId function_id) const
-      -> const SemanticsFunction& {
+  auto GetFunction(FunctionId function_id) const -> const Function& {
     return functions_[function_id.index];
   }
 
   // Returns the requested callable.
-  auto GetFunction(SemanticsFunctionId function_id) -> SemanticsFunction& {
+  auto GetFunction(FunctionId function_id) -> Function& {
     return functions_[function_id.index];
   }
 
   // Adds an integer literal, returning an ID to reference it.
-  auto AddIntegerLiteral(llvm::APInt integer_literal)
-      -> SemanticsIntegerLiteralId {
-    SemanticsIntegerLiteralId id(integer_literals_.size());
+  auto AddIntegerLiteral(llvm::APInt integer_literal) -> IntegerLiteralId {
+    IntegerLiteralId id(integer_literals_.size());
     integer_literals_.push_back(integer_literal);
     return id;
   }
 
   // Returns the requested integer literal.
-  auto GetIntegerLiteral(SemanticsIntegerLiteralId int_id) const
-      -> const llvm::APInt& {
+  auto GetIntegerLiteral(IntegerLiteralId int_id) const -> const llvm::APInt& {
     return integer_literals_[int_id.index];
   }
 
   // Adds a name scope, returning an ID to reference it.
-  auto AddNameScope() -> SemanticsNameScopeId {
-    SemanticsNameScopeId name_scopes_id(name_scopes_.size());
+  auto AddNameScope() -> NameScopeId {
+    NameScopeId name_scopes_id(name_scopes_.size());
     name_scopes_.resize(name_scopes_id.index + 1);
     return name_scopes_id;
   }
 
   // Adds an entry to a name scope. Returns true on success, false on
   // duplicates.
-  auto AddNameScopeEntry(SemanticsNameScopeId scope_id,
-                         SemanticsStringId name_id, SemanticsNodeId target_id)
-      -> bool {
+  auto AddNameScopeEntry(NameScopeId scope_id, StringId name_id,
+                         NodeId target_id) -> bool {
     return name_scopes_[scope_id.index].insert({name_id, target_id}).second;
   }
 
   // Returns the requested name scope.
-  auto GetNameScope(SemanticsNameScopeId scope_id) const
-      -> const llvm::DenseMap<SemanticsStringId, SemanticsNodeId>& {
+  auto GetNameScope(NameScopeId scope_id) const
+      -> const llvm::DenseMap<StringId, NodeId>& {
     return name_scopes_[scope_id.index];
   }
 
   // Adds a node to a specified block, returning an ID to reference the node.
-  auto AddNode(SemanticsNodeBlockId block_id, SemanticsNode node)
-      -> SemanticsNodeId {
-    SemanticsNodeId node_id(nodes_.size());
+  auto AddNode(NodeBlockId block_id, Node node) -> NodeId {
+    NodeId node_id(nodes_.size());
     nodes_.push_back(node);
-    if (block_id != SemanticsNodeBlockId::Unreachable) {
+    if (block_id != NodeBlockId::Unreachable) {
       node_blocks_[block_id.index].push_back(node_id);
     }
     return node_id;
   }
 
   // Returns the requested node.
-  auto GetNode(SemanticsNodeId node_id) const -> SemanticsNode {
-    return nodes_[node_id.index];
-  }
+  auto GetNode(NodeId node_id) const -> Node { return nodes_[node_id.index]; }
 
   // Adds an empty node block, returning an ID to reference it.
-  auto AddNodeBlock() -> SemanticsNodeBlockId {
-    SemanticsNodeBlockId id(node_blocks_.size());
+  auto AddNodeBlock() -> NodeBlockId {
+    NodeBlockId id(node_blocks_.size());
     node_blocks_.push_back({});
     return id;
   }
 
   // Returns the requested node block.
-  auto GetNodeBlock(SemanticsNodeBlockId block_id) const
-      -> const llvm::SmallVector<SemanticsNodeId>& {
-    CARBON_CHECK(block_id != SemanticsNodeBlockId::Unreachable);
+  auto GetNodeBlock(NodeBlockId block_id) const
+      -> const llvm::SmallVector<NodeId>& {
+    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
     return node_blocks_[block_id.index];
   }
 
   // Returns the requested node block.
-  auto GetNodeBlock(SemanticsNodeBlockId block_id)
-      -> llvm::SmallVector<SemanticsNodeId>& {
-    CARBON_CHECK(block_id != SemanticsNodeBlockId::Unreachable);
+  auto GetNodeBlock(NodeBlockId block_id) -> llvm::SmallVector<NodeId>& {
+    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
     return node_blocks_[block_id.index];
   }
 
   // Adds a real literal, returning an ID to reference it.
-  auto AddRealLiteral(SemanticsRealLiteral real_literal)
-      -> SemanticsRealLiteralId {
-    SemanticsRealLiteralId id(real_literals_.size());
+  auto AddRealLiteral(RealLiteral real_literal) -> RealLiteralId {
+    RealLiteralId id(real_literals_.size());
     real_literals_.push_back(real_literal);
     return id;
   }
 
   // Returns the requested real literal.
-  auto GetRealLiteral(SemanticsRealLiteralId int_id) const
-      -> const SemanticsRealLiteral& {
+  auto GetRealLiteral(RealLiteralId int_id) const -> const RealLiteral& {
     return real_literals_[int_id.index];
   }
 
   // Adds an string, returning an ID to reference it.
-  auto AddString(llvm::StringRef str) -> SemanticsStringId {
+  auto AddString(llvm::StringRef str) -> StringId {
     // Look up the string, or add it if it's new.
-    SemanticsStringId next_id(strings_.size());
+    StringId next_id(strings_.size());
     auto [it, added] = string_to_id_.insert({str, next_id});
 
     if (added) {
@@ -214,13 +209,13 @@ class SemanticsIR {
   }
 
   // Returns the requested string.
-  auto GetString(SemanticsStringId string_id) const -> llvm::StringRef {
+  auto GetString(StringId string_id) const -> llvm::StringRef {
     return strings_[string_id.index];
   }
 
   // Adds a type, returning an ID to reference it.
-  auto AddType(SemanticsNodeId node_id) -> SemanticsTypeId {
-    SemanticsTypeId type_id(types_.size());
+  auto AddType(NodeId node_id) -> TypeId {
+    TypeId type_id(types_.size());
     types_.push_back(node_id);
     return type_id;
   }
@@ -228,40 +223,38 @@ class SemanticsIR {
   // Gets the node ID for a type. This doesn't handle TypeType or InvalidType in
   // order to avoid a check; callers that need that should use
   // GetTypeAllowBuiltinTypes.
-  auto GetType(SemanticsTypeId type_id) const -> SemanticsNodeId {
+  auto GetType(TypeId type_id) const -> NodeId {
     // Double-check it's not called with TypeType or InvalidType.
     CARBON_CHECK(type_id.index >= 0)
         << "Invalid argument for GetType: " << type_id;
     return types_[type_id.index];
   }
 
-  auto GetTypeAllowBuiltinTypes(SemanticsTypeId type_id) const
-      -> SemanticsNodeId {
-    if (type_id == SemanticsTypeId::TypeType) {
-      return SemanticsNodeId::BuiltinTypeType;
-    } else if (type_id == SemanticsTypeId::Error) {
-      return SemanticsNodeId::BuiltinError;
+  auto GetTypeAllowBuiltinTypes(TypeId type_id) const -> NodeId {
+    if (type_id == TypeId::TypeType) {
+      return NodeId::BuiltinTypeType;
+    } else if (type_id == TypeId::Error) {
+      return NodeId::BuiltinError;
     } else {
       return GetType(type_id);
     }
   }
 
   // Adds an empty type block, returning an ID to reference it.
-  auto AddTypeBlock() -> SemanticsTypeBlockId {
-    SemanticsTypeBlockId id(type_blocks_.size());
+  auto AddTypeBlock() -> TypeBlockId {
+    TypeBlockId id(type_blocks_.size());
     type_blocks_.push_back({});
     return id;
   }
 
   // Returns the requested type block.
-  auto GetTypeBlock(SemanticsTypeBlockId block_id) const
-      -> const llvm::SmallVector<SemanticsTypeId>& {
+  auto GetTypeBlock(TypeBlockId block_id) const
+      -> const llvm::SmallVector<TypeId>& {
     return type_blocks_[block_id.index];
   }
 
   // Returns the requested type block.
-  auto GetTypeBlock(SemanticsTypeBlockId block_id)
-      -> llvm::SmallVector<SemanticsTypeId>& {
+  auto GetTypeBlock(TypeBlockId block_id) -> llvm::SmallVector<TypeId>& {
     return type_blocks_[block_id.index];
   }
 
@@ -269,82 +262,77 @@ class SemanticsIR {
   // explicit conversion to type `type` will be added in cases where the type
   // expression would otherwise have a different type, such as a tuple or
   // struct type.
-  auto StringifyType(SemanticsTypeId type_id,
-                     bool in_type_context = false) const -> std::string;
+  auto StringifyType(TypeId type_id, bool in_type_context = false) const
+      -> std::string;
 
   auto functions_size() const -> int { return functions_.size(); }
   auto nodes_size() const -> int { return nodes_.size(); }
   auto node_blocks_size() const -> int { return node_blocks_.size(); }
 
-  auto types() const -> const llvm::SmallVector<SemanticsNodeId>& {
-    return types_;
-  }
+  auto types() const -> const llvm::SmallVector<NodeId>& { return types_; }
 
   // The node blocks, for direct mutation.
-  auto node_blocks() -> llvm::SmallVector<llvm::SmallVector<SemanticsNodeId>>& {
+  auto node_blocks() -> llvm::SmallVector<llvm::SmallVector<NodeId>>& {
     return node_blocks_;
   }
 
-  auto top_node_block_id() const -> SemanticsNodeBlockId {
-    return top_node_block_id_;
-  }
+  auto top_node_block_id() const -> NodeBlockId { return top_node_block_id_; }
 
   // Returns true if there were errors creating the semantics IR.
   auto has_errors() const -> bool { return has_errors_; }
 
  private:
-  explicit SemanticsIR(const SemanticsIR* builtin_ir)
+  explicit File(const File* builtin_ir)
       : cross_reference_irs_({builtin_ir == nullptr ? this : builtin_ir}) {
-    // For SemanticsNodeBlockId::Empty.
+    // For NodeBlockId::Empty.
     node_blocks_.resize(1);
   }
 
   bool has_errors_ = false;
 
   // Storage for callable objects.
-  llvm::SmallVector<SemanticsFunction> functions_;
+  llvm::SmallVector<Function> functions_;
 
   // Related IRs. There will always be at least 2 entries, the builtin IR (used
   // for references of builtins) followed by the current IR (used for references
   // crossing node blocks).
-  llvm::SmallVector<const SemanticsIR*> cross_reference_irs_;
+  llvm::SmallVector<const File*> cross_reference_irs_;
 
   // Storage for integer literals.
   llvm::SmallVector<llvm::APInt> integer_literals_;
 
   // Storage for name scopes.
-  llvm::SmallVector<llvm::DenseMap<SemanticsStringId, SemanticsNodeId>>
-      name_scopes_;
+  llvm::SmallVector<llvm::DenseMap<StringId, NodeId>> name_scopes_;
 
   // Storage for real literals.
-  llvm::SmallVector<SemanticsRealLiteral> real_literals_;
+  llvm::SmallVector<RealLiteral> real_literals_;
 
   // Storage for strings. strings_ provides a list of allocated strings, while
   // string_to_id_ provides a mapping to identify strings.
-  llvm::StringMap<SemanticsStringId> string_to_id_;
+  llvm::StringMap<StringId> string_to_id_;
   llvm::SmallVector<llvm::StringRef> strings_;
 
   // Nodes which correspond to in-use types. Stored separately for easy access
   // by lowering.
-  llvm::SmallVector<SemanticsNodeId> types_;
+  llvm::SmallVector<NodeId> types_;
 
   // Storage for blocks within the IR. These reference entries in types_.
-  llvm::SmallVector<llvm::SmallVector<SemanticsTypeId>> type_blocks_;
+  llvm::SmallVector<llvm::SmallVector<TypeId>> type_blocks_;
 
   // All nodes. The first entries will always be cross-references to builtins,
-  // at indices matching SemanticsBuiltinKind ordering.
-  llvm::SmallVector<SemanticsNode> nodes_;
+  // at indices matching BuiltinKind ordering.
+  llvm::SmallVector<Node> nodes_;
 
   // Storage for blocks within the IR. These reference entries in nodes_.
-  llvm::SmallVector<llvm::SmallVector<SemanticsNodeId>> node_blocks_;
+  llvm::SmallVector<llvm::SmallVector<NodeId>> node_blocks_;
 
   // The top node block ID.
-  SemanticsNodeBlockId top_node_block_id_ = SemanticsNodeBlockId::Invalid;
+  NodeBlockId top_node_block_id_ = NodeBlockId::Invalid;
 };
 
 // The expression category of a semantics node. See /docs/design/values.md for
 // details.
-enum class SemanticsExpressionCategory {
+enum class ExpressionCategory {
   // This node does not correspond to an expression, and as such has no
   // category.
   NotExpression,
@@ -362,10 +350,9 @@ enum class SemanticsExpressionCategory {
 };
 
 // Returns the expression category for a node.
-auto GetSemanticsExpressionCategory(const SemanticsIR& semantics_ir,
-                                    SemanticsNodeId node_id)
-    -> SemanticsExpressionCategory;
+auto GetExpressionCategory(const File& semantics_ir, NodeId node_id)
+    -> ExpressionCategory;
 
-}  // namespace Carbon
+}  // namespace Carbon::SemIR
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_H_

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -16,20 +16,18 @@ namespace Carbon::SemIR {
 
 // A function.
 struct Function {
-  friend auto operator<<(llvm::raw_ostream& out, const Function& fn)
-      -> llvm::raw_ostream& {
-    out << "{name: " << fn.name_id << ", "
-        << "param_refs: " << fn.param_refs_id;
-    if (fn.return_type_id.is_valid()) {
-      out << ", return_type: " << fn.return_type_id;
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{name: " << name_id << ", "
+        << "param_refs: " << param_refs_id;
+    if (return_type_id.is_valid()) {
+      out << ", return_type: " << return_type_id;
     }
-    if (!fn.body_block_ids.empty()) {
+    if (!body_block_ids.empty()) {
       out << llvm::formatv(
           ", body: [{0}]",
-          llvm::make_range(fn.body_block_ids.begin(), fn.body_block_ids.end()));
+          llvm::make_range(body_block_ids.begin(), body_block_ids.end()));
     }
     out << "}";
-    return out;
   }
   LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
@@ -46,11 +44,9 @@ struct Function {
 };
 
 struct RealLiteral {
-  friend auto operator<<(llvm::raw_ostream& out, const RealLiteral& val)
-      -> llvm::raw_ostream& {
-    out << "{mantissa: " << val.mantissa << ", exponent: " << val.exponent
-        << ", is_decimal: " << val.is_decimal << "}";
-    return out;
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "{mantissa: " << mantissa << ", exponent: " << exponent
+        << ", is_decimal: " << is_decimal << "}";
   }
   LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
@@ -85,12 +81,9 @@ class File {
   // builtins.
   auto Print(llvm::raw_ostream& out, bool include_builtins) const -> void;
 
-  friend auto operator<<(llvm::raw_ostream& out, const File& file)
-      -> llvm::raw_ostream& {
-    file.Print(out, /*include_builtins=*/false);
-    return out;
+  auto Print(llvm::raw_ostream& out) const -> void {
+    Print(out, /*include_builtins=*/false);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -31,6 +31,7 @@ struct Function {
     out << "}";
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
   // The function name.
   StringId name_id;
@@ -51,6 +52,7 @@ struct RealLiteral {
         << ", is_decimal: " << val.is_decimal << "}";
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
   llvm::APInt mantissa;
   llvm::APInt exponent;
@@ -81,12 +83,14 @@ class File {
   // TODO: In the future, the things to print may change, for example by adding
   // preludes. We may then want the ability to omit other things similar to
   // builtins.
+  auto Print(llvm::raw_ostream& out, bool include_builtins) const -> void;
+
   friend auto operator<<(llvm::raw_ostream& out, const File& file)
       -> llvm::raw_ostream& {
     file.Print(out, /*include_builtins=*/false);
     return out;
   }
-  auto Print(llvm::raw_ostream& out, bool include_builtins) const -> void;
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {

--- a/toolchain/semantics/semantics_ir_formatter.h
+++ b/toolchain/semantics/semantics_ir_formatter.h
@@ -8,13 +8,12 @@
 #include "llvm/Support/raw_ostream.h"
 #include "toolchain/semantics/semantics_ir.h"
 
-namespace Carbon {
+namespace Carbon::SemIR {
 
-auto FormatSemanticsIR(const TokenizedBuffer& tokenized_buffer,
-                       const ParseTree& parse_tree,
-                       const SemanticsIR& semantics_ir, llvm::raw_ostream& out)
-    -> void;
+auto FormatFile(const TokenizedBuffer& tokenized_buffer,
+                const ParseTree& parse_tree, const File& semantics_ir,
+                llvm::raw_ostream& out) -> void;
 
-}  // namespace Carbon
+}  // namespace Carbon::SemIR
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_IR_FORMATTER_H_

--- a/toolchain/semantics/semantics_ir_test.cpp
+++ b/toolchain/semantics/semantics_ir_test.cpp
@@ -27,7 +27,7 @@ using ::testing::MatchesRegex;
 using ::testing::Pair;
 using ::testing::SizeIs;
 
-TEST(SemanticsIRTest, YAML) {
+TEST(SemIRTest, YAML) {
   llvm::vfs::InMemoryFileSystem fs;
   CARBON_CHECK(fs.addFile(
       "test.carbon", /*ModificationTime=*/0,

--- a/toolchain/semantics/semantics_node.cpp
+++ b/toolchain/semantics/semantics_node.cpp
@@ -4,10 +4,10 @@
 
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::SemIR {
 
 static auto PrintArgs(llvm::raw_ostream& /*out*/,
-                      const SemanticsNode::NoArgs /*no_args*/) -> void {}
+                      const Node::NoArgs /*no_args*/) -> void {}
 
 template <typename T>
 static auto PrintArgs(llvm::raw_ostream& out, T arg) -> void {
@@ -20,19 +20,21 @@ static auto PrintArgs(llvm::raw_ostream& out, std::pair<T0, T1> args) -> void {
   out << ", arg1: " << args.second;
 }
 
-auto SemanticsNode::Print(llvm::raw_ostream& out) const -> void {
-  out << "{kind: " << kind_;
-  switch (kind_) {
+auto operator<<(llvm::raw_ostream& out, const Node& node)
+    -> llvm::raw_ostream& {
+  out << "{kind: " << node.kind_;
+  switch (node.kind_) {
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
-  case SemanticsNodeKind::Name:          \
-    PrintArgs(out, GetAs##Name());       \
+  case NodeKind::Name:                   \
+    PrintArgs(out, node.GetAs##Name());  \
     break;
 #include "toolchain/semantics/semantics_node_kind.def"
   }
-  if (type_id_.is_valid()) {
-    out << ", type: " << type_id_;
+  if (node.type_id_.is_valid()) {
+    out << ", type: " << node.type_id_;
   }
   out << "}";
+  return out;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::SemIR

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -27,21 +27,18 @@ struct NodeId : public IndexBase {
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const NodeId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "node";
-    if (!id.is_valid()) {
-      id.Print(out);
-    } else if (id.index < BuiltinKind::ValidCount) {
-      out << BuiltinKind::FromInt(id.index);
+    if (!is_valid()) {
+      IndexBase::Print(out);
+    } else if (index < BuiltinKind::ValidCount) {
+      out << BuiltinKind::FromInt(index);
     } else {
       // Use the `+` as a small reminder that this is a delta, rather than an
       // absolute index.
-      out << "+" << id.index - BuiltinKind::ValidCount;
+      out << "+" << index - BuiltinKind::ValidCount;
     }
-    return out;
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NodeId NodeId::Invalid = NodeId(NodeId::InvalidIndex);
@@ -55,25 +52,19 @@ constexpr NodeId NodeId::Invalid = NodeId(NodeId::InvalidIndex);
 // The ID of a function.
 struct FunctionId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const FunctionId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "function";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a cross-referenced IR.
 struct CrossReferenceIRId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const CrossReferenceIRId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "ir";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // A boolean value.
@@ -82,9 +73,8 @@ struct BoolValue : public IndexBase {
   static const BoolValue True;
 
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const BoolValue& val)
-      -> llvm::raw_ostream& {
-    switch (val.index) {
+  auto Print(llvm::raw_ostream& out) const -> void {
+    switch (index) {
       case 0:
         out << "false";
         break;
@@ -92,11 +82,9 @@ struct BoolValue : public IndexBase {
         out << "true";
         break;
       default:
-        CARBON_FATAL() << "Invalid bool value " << val.index;
+        CARBON_FATAL() << "Invalid bool value " << index;
     }
-    return out;
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr BoolValue BoolValue::False = BoolValue(0);
@@ -105,13 +93,10 @@ constexpr BoolValue BoolValue::True = BoolValue(1);
 // The ID of an integer literal.
 struct IntegerLiteralId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const IntegerLiteralId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "int";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a name scope.
@@ -120,13 +105,10 @@ struct NameScopeId : public IndexBase {
   static const NameScopeId Invalid;
 
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const NameScopeId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "name_scope";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NameScopeId NameScopeId::Invalid =
@@ -144,17 +126,14 @@ struct NodeBlockId : public IndexBase {
   static const NodeBlockId Unreachable;
 
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const NodeBlockId& id)
-      -> llvm::raw_ostream& {
-    if (id.index == Unreachable.index) {
+  auto Print(llvm::raw_ostream& out) const -> void {
+    if (index == Unreachable.index) {
       out << "unreachable";
     } else {
       out << "block";
-      id.Print(out);
+      IndexBase::Print(out);
     }
-    return out;
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NodeBlockId NodeBlockId::Empty = NodeBlockId(0);
@@ -166,25 +145,19 @@ constexpr NodeBlockId NodeBlockId::Unreachable =
 // The ID of a real literal.
 struct RealLiteralId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const RealLiteralId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "real";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a string.
 struct StringId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const StringId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "str";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a node block.
@@ -199,19 +172,16 @@ struct TypeId : public IndexBase {
   static const TypeId Invalid;
 
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const TypeId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "type";
-    if (id.index == TypeType.index) {
+    if (index == TypeType.index) {
       out << "TypeType";
-    } else if (id.index == Error.index) {
+    } else if (index == Error.index) {
       out << "Error";
     } else {
-      id.Print(out);
+      IndexBase::Print(out);
     }
-    return out;
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr TypeId TypeId::TypeType = TypeId(TypeId::InvalidIndex - 2);
@@ -221,25 +191,19 @@ constexpr TypeId TypeId::Invalid = TypeId(TypeId::InvalidIndex);
 // The ID of a type block.
 struct TypeBlockId : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const TypeBlockId& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "typeBlock";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // An index for member access.
 struct MemberIndex : public IndexBase {
   using IndexBase::IndexBase;
-  friend auto operator<<(llvm::raw_ostream& out, const MemberIndex& id)
-      -> llvm::raw_ostream& {
+  auto Print(llvm::raw_ostream& out) const -> void {
     out << "member";
-    id.Print(out);
-    return out;
+    IndexBase::Print(out);
   }
-  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The standard structure for Node. This is trying to provide a minimal

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -14,69 +14,74 @@
 #include "toolchain/semantics/semantics_builtin_kind.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::SemIR {
 
 // The ID of a node.
-struct SemanticsNodeId : public IndexBase {
+struct NodeId : public IndexBase {
   // An explicitly invalid node ID.
-  static const SemanticsNodeId Invalid;
+  static const NodeId Invalid;
 
 // Builtin node IDs.
 #define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
-  static const SemanticsNodeId Builtin##Name;
+  static const NodeId Builtin##Name;
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const NodeId& id)
+      -> llvm::raw_ostream& {
     out << "node";
-    if (!is_valid()) {
-      IndexBase::Print(out);
-    } else if (index < SemanticsBuiltinKind::ValidCount) {
-      out << SemanticsBuiltinKind::FromInt(index);
+    if (!id.is_valid()) {
+      id.Print(out);
+    } else if (id.index < BuiltinKind::ValidCount) {
+      out << BuiltinKind::FromInt(id.index);
     } else {
       // Use the `+` as a small reminder that this is a delta, rather than an
       // absolute index.
-      out << "+" << index - SemanticsBuiltinKind::ValidCount;
+      out << "+" << id.index - BuiltinKind::ValidCount;
     }
+    return out;
   }
 };
 
-constexpr SemanticsNodeId SemanticsNodeId::Invalid =
-    SemanticsNodeId(SemanticsNodeId::InvalidIndex);
+constexpr NodeId NodeId::Invalid = NodeId(NodeId::InvalidIndex);
 
-// Uses the cross-reference node ID for a builtin. This relies on SemanticsIR
+// Uses the cross-reference node ID for a builtin. This relies on File
 // guarantees for builtin cross-reference placement.
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)             \
-  constexpr SemanticsNodeId SemanticsNodeId::Builtin##Name = \
-      SemanticsNodeId(SemanticsBuiltinKind::Name.AsInt());
+#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
+  constexpr NodeId NodeId::Builtin##Name = NodeId(BuiltinKind::Name.AsInt());
 #include "toolchain/semantics/semantics_builtin_kind.def"
 
 // The ID of a function.
-struct SemanticsFunctionId : public IndexBase {
+struct FunctionId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const FunctionId& id)
+      -> llvm::raw_ostream& {
     out << "function";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // The ID of a cross-referenced IR.
-struct SemanticsCrossReferenceIRId : public IndexBase {
+struct CrossReferenceIRId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const CrossReferenceIRId& id)
+      -> llvm::raw_ostream& {
     out << "ir";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // A boolean value.
-struct SemanticsBoolValue : public IndexBase {
-  static const SemanticsBoolValue False;
-  static const SemanticsBoolValue True;
+struct BoolValue : public IndexBase {
+  static const BoolValue False;
+  static const BoolValue True;
 
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
-    switch (index) {
+  friend auto operator<<(llvm::raw_ostream& out, const BoolValue& val)
+      -> llvm::raw_ostream& {
+    switch (val.index) {
       case 0:
         out << "false";
         break;
@@ -84,135 +89,148 @@ struct SemanticsBoolValue : public IndexBase {
         out << "true";
         break;
       default:
-        CARBON_FATAL() << "Invalid bool value " << index;
+        CARBON_FATAL() << "Invalid bool value " << val.index;
     }
+    return out;
   }
 };
 
-constexpr SemanticsBoolValue SemanticsBoolValue::False = SemanticsBoolValue(0);
-constexpr SemanticsBoolValue SemanticsBoolValue::True = SemanticsBoolValue(1);
+constexpr BoolValue BoolValue::False = BoolValue(0);
+constexpr BoolValue BoolValue::True = BoolValue(1);
 
 // The ID of an integer literal.
-struct SemanticsIntegerLiteralId : public IndexBase {
+struct IntegerLiteralId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const IntegerLiteralId& id)
+      -> llvm::raw_ostream& {
     out << "int";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // The ID of a name scope.
-struct SemanticsNameScopeId : public IndexBase {
+struct NameScopeId : public IndexBase {
   // An explicitly invalid ID.
-  static const SemanticsNameScopeId Invalid;
+  static const NameScopeId Invalid;
 
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const NameScopeId& id)
+      -> llvm::raw_ostream& {
     out << "name_scope";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
-constexpr SemanticsNameScopeId SemanticsNameScopeId::Invalid =
-    SemanticsNameScopeId(SemanticsNameScopeId::InvalidIndex);
+constexpr NameScopeId NameScopeId::Invalid =
+    NameScopeId(NameScopeId::InvalidIndex);
 
 // The ID of a node block.
-struct SemanticsNodeBlockId : public IndexBase {
-  // All SemanticsIR instances must provide the 0th node block as empty.
-  static const SemanticsNodeBlockId Empty;
+struct NodeBlockId : public IndexBase {
+  // All File instances must provide the 0th node block as empty.
+  static const NodeBlockId Empty;
 
   // An explicitly invalid ID.
-  static const SemanticsNodeBlockId Invalid;
+  static const NodeBlockId Invalid;
 
   // An ID for unreachable code.
-  static const SemanticsNodeBlockId Unreachable;
+  static const NodeBlockId Unreachable;
 
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
-    if (index == Unreachable.index) {
+  friend auto operator<<(llvm::raw_ostream& out, const NodeBlockId& id)
+      -> llvm::raw_ostream& {
+    if (id.index == Unreachable.index) {
       out << "unreachable";
     } else {
       out << "block";
-      IndexBase::Print(out);
+      id.Print(out);
     }
+    return out;
   }
 };
 
-constexpr SemanticsNodeBlockId SemanticsNodeBlockId::Empty =
-    SemanticsNodeBlockId(0);
-constexpr SemanticsNodeBlockId SemanticsNodeBlockId::Invalid =
-    SemanticsNodeBlockId(SemanticsNodeBlockId::InvalidIndex);
-constexpr SemanticsNodeBlockId SemanticsNodeBlockId::Unreachable =
-    SemanticsNodeBlockId(SemanticsNodeBlockId::InvalidIndex - 1);
+constexpr NodeBlockId NodeBlockId::Empty = NodeBlockId(0);
+constexpr NodeBlockId NodeBlockId::Invalid =
+    NodeBlockId(NodeBlockId::InvalidIndex);
+constexpr NodeBlockId NodeBlockId::Unreachable =
+    NodeBlockId(NodeBlockId::InvalidIndex - 1);
 
 // The ID of a real literal.
-struct SemanticsRealLiteralId : public IndexBase {
+struct RealLiteralId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const RealLiteralId& id)
+      -> llvm::raw_ostream& {
     out << "real";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // The ID of a string.
-struct SemanticsStringId : public IndexBase {
+struct StringId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const StringId& id)
+      -> llvm::raw_ostream& {
     out << "str";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // The ID of a node block.
-struct SemanticsTypeId : public IndexBase {
+struct TypeId : public IndexBase {
   // The builtin TypeType.
-  static const SemanticsTypeId TypeType;
+  static const TypeId TypeType;
 
   // The builtin Error.
-  static const SemanticsTypeId Error;
+  static const TypeId Error;
 
   // An explicitly invalid ID.
-  static const SemanticsTypeId Invalid;
+  static const TypeId Invalid;
 
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const TypeId& id)
+      -> llvm::raw_ostream& {
     out << "type";
-    if (index == TypeType.index) {
+    if (id.index == TypeType.index) {
       out << "TypeType";
-    } else if (index == Error.index) {
+    } else if (id.index == Error.index) {
       out << "Error";
     } else {
-      IndexBase::Print(out);
+      id.Print(out);
     }
+    return out;
   }
 };
 
-constexpr SemanticsTypeId SemanticsTypeId::TypeType =
-    SemanticsTypeId(SemanticsTypeId::InvalidIndex - 2);
-constexpr SemanticsTypeId SemanticsTypeId::Error =
-    SemanticsTypeId(SemanticsTypeId::InvalidIndex - 1);
-constexpr SemanticsTypeId SemanticsTypeId::Invalid =
-    SemanticsTypeId(SemanticsTypeId::InvalidIndex);
+constexpr TypeId TypeId::TypeType = TypeId(TypeId::InvalidIndex - 2);
+constexpr TypeId TypeId::Error = TypeId(TypeId::InvalidIndex - 1);
+constexpr TypeId TypeId::Invalid = TypeId(TypeId::InvalidIndex);
 
 // The ID of a type block.
-struct SemanticsTypeBlockId : public IndexBase {
+struct TypeBlockId : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const TypeBlockId& id)
+      -> llvm::raw_ostream& {
     out << "typeBlock";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
 // An index for member access.
-struct SemanticsMemberIndex : public IndexBase {
+struct MemberIndex : public IndexBase {
   using IndexBase::IndexBase;
-  auto Print(llvm::raw_ostream& out) const -> void {
+  friend auto operator<<(llvm::raw_ostream& out, const MemberIndex& id)
+      -> llvm::raw_ostream& {
     out << "member";
-    IndexBase::Print(out);
+    id.Print(out);
+    return out;
   }
 };
 
-// The standard structure for SemanticsNode. This is trying to provide a minimal
+// The standard structure for Node. This is trying to provide a minimal
 // amount of information for a node:
 //
 // - parse_node for error placement.
@@ -220,9 +238,9 @@ struct SemanticsMemberIndex : public IndexBase {
 // - type_id for quick type checking.
 // - Up to two Kind-specific members.
 //
-// For each Kind in SemanticsNodeKind, a typical flow looks like:
+// For each Kind in NodeKind, a typical flow looks like:
 //
-// - Create a `SemanticsNode` using `SemanticsNode::Kind::Make()`
+// - Create a `Node` using `Node::Kind::Make()`
 // - Access cross-Kind members using `node.type_id()` and similar.
 // - Access Kind-specific members using `node.GetAsKind()`, which depending on
 //   the number of members will return one of NoArgs, a single value, or a
@@ -232,7 +250,7 @@ struct SemanticsMemberIndex : public IndexBase {
 //
 // Internally, each Kind uses the `Factory*` types to provide a boilerplate
 // `Make` and `Get` methods.
-class SemanticsNode {
+class Node {
  public:
   struct NoArgs {};
 
@@ -242,19 +260,19 @@ class SemanticsNode {
   // Factory templates need to use the raw enum instead of the class wrapper.
   using KindTemplateEnum = Internal::SemanticsNodeKindRawEnum;
 
-  // Provides Make and Get to support 0, 1, or 2 arguments for a SemanticsNode.
+  // Provides Make and Get to support 0, 1, or 2 arguments for a Node.
   // These are protected so that child factories can opt in to what pieces they
   // want to use.
   template <KindTemplateEnum Kind, typename... ArgTypes>
   class FactoryBase {
    protected:
-    static auto Make(ParseTree::Node parse_node, SemanticsTypeId type_id,
-                     ArgTypes... arg_ids) -> SemanticsNode {
-      return SemanticsNode(parse_node, SemanticsNodeKind::Create(Kind), type_id,
-                           arg_ids.index...);
+    static auto Make(ParseTree::Node parse_node, TypeId type_id,
+                     ArgTypes... arg_ids) -> Node {
+      return Node(parse_node, NodeKind::Create(Kind), type_id,
+                  arg_ids.index...);
     }
 
-    static auto Get(SemanticsNode node) {
+    static auto Get(Node node) {
       struct Unused {};
       return GetImpl<ArgTypes..., Unused>(node);
     }
@@ -262,17 +280,17 @@ class SemanticsNode {
    private:
     // GetImpl handles the different return types based on ArgTypes.
     template <typename Arg0Type, typename Arg1Type, typename>
-    static auto GetImpl(SemanticsNode node) -> std::pair<Arg0Type, Arg1Type> {
+    static auto GetImpl(Node node) -> std::pair<Arg0Type, Arg1Type> {
       CARBON_CHECK(node.kind() == Kind);
       return {Arg0Type(node.arg0_), Arg1Type(node.arg1_)};
     }
     template <typename Arg0Type, typename>
-    static auto GetImpl(SemanticsNode node) -> Arg0Type {
+    static auto GetImpl(Node node) -> Arg0Type {
       CARBON_CHECK(node.kind() == Kind);
       return Arg0Type(node.arg0_);
     }
     template <typename>
-    static auto GetImpl(SemanticsNode node) -> NoArgs {
+    static auto GetImpl(Node node) -> NoArgs {
       CARBON_CHECK(node.kind() == Kind);
       return NoArgs();
     }
@@ -292,92 +310,76 @@ class SemanticsNode {
   class FactoryNoType : public FactoryBase<Kind, ArgTypes...> {
    public:
     static auto Make(ParseTree::Node parse_node, ArgTypes... args) {
-      return FactoryBase<Kind, ArgTypes...>::Make(
-          parse_node, SemanticsTypeId::Invalid, args...);
+      return FactoryBase<Kind, ArgTypes...>::Make(parse_node, TypeId::Invalid,
+                                                  args...);
     }
     using FactoryBase<Kind, ArgTypes...>::Get;
   };
 
  public:
-  // Invalid is in the SemanticsNodeKind enum, but should never be used.
+  // Invalid is in the NodeKind enum, but should never be used.
   class Invalid {
    public:
-    static auto Get(SemanticsNode /*node*/) -> SemanticsNode::NoArgs {
+    static auto Get(Node /*node*/) -> Node::NoArgs {
       CARBON_FATAL() << "Invalid access";
     }
   };
 
-  using AddressOf = SemanticsNode::Factory<SemanticsNodeKind::AddressOf,
-                                           SemanticsNodeId /*lvalue_id*/>;
+  using AddressOf = Node::Factory<NodeKind::AddressOf, NodeId /*lvalue_id*/>;
 
   using ArrayIndex =
-      Factory<SemanticsNodeKind::ArrayIndex, SemanticsNodeId /*array_id*/,
-              SemanticsNodeId /*index*/>;
+      Factory<NodeKind::ArrayIndex, NodeId /*array_id*/, NodeId /*index*/>;
 
-  using ArrayType =
-      SemanticsNode::Factory<SemanticsNodeKind::ArrayType,
-                             SemanticsNodeId /*bound_node_id*/,
-                             SemanticsTypeId /*array_element_type_id*/>;
+  using ArrayType = Node::Factory<NodeKind::ArrayType, NodeId /*bound_node_id*/,
+                                  TypeId /*array_element_type_id*/>;
 
-  using ArrayValue = Factory<SemanticsNodeKind::ArrayValue,
-                             SemanticsNodeId /*tuple_value_id*/>;
+  using ArrayValue = Factory<NodeKind::ArrayValue, NodeId /*tuple_value_id*/>;
 
-  using Assign = SemanticsNode::FactoryNoType<SemanticsNodeKind::Assign,
-                                              SemanticsNodeId /*lhs_id*/,
-                                              SemanticsNodeId /*rhs_id*/>;
+  using Assign = Node::FactoryNoType<NodeKind::Assign, NodeId /*lhs_id*/,
+                                     NodeId /*rhs_id*/>;
 
-  using BinaryOperatorAdd =
-      SemanticsNode::Factory<SemanticsNodeKind::BinaryOperatorAdd,
-                             SemanticsNodeId /*lhs_id*/,
-                             SemanticsNodeId /*rhs_id*/>;
+  using BinaryOperatorAdd = Node::Factory<NodeKind::BinaryOperatorAdd,
+                                          NodeId /*lhs_id*/, NodeId /*rhs_id*/>;
 
-  using BlockArg =
-      Factory<SemanticsNodeKind::BlockArg, SemanticsNodeBlockId /*block_id*/>;
+  using BlockArg = Factory<NodeKind::BlockArg, NodeBlockId /*block_id*/>;
 
-  using BoolLiteral =
-      Factory<SemanticsNodeKind::BoolLiteral, SemanticsBoolValue /*value*/>;
+  using BoolLiteral = Factory<NodeKind::BoolLiteral, BoolValue /*value*/>;
 
-  using Branch = FactoryNoType<SemanticsNodeKind::Branch,
-                               SemanticsNodeBlockId /*target_id*/>;
+  using Branch = FactoryNoType<NodeKind::Branch, NodeBlockId /*target_id*/>;
 
-  using BranchIf = FactoryNoType<SemanticsNodeKind::BranchIf,
-                                 SemanticsNodeBlockId /*target_id*/,
-                                 SemanticsNodeId /*cond_id*/>;
+  using BranchIf = FactoryNoType<NodeKind::BranchIf, NodeBlockId /*target_id*/,
+                                 NodeId /*cond_id*/>;
 
-  using BranchWithArg = FactoryNoType<SemanticsNodeKind::BranchWithArg,
-                                      SemanticsNodeBlockId /*target_id*/,
-                                      SemanticsNodeId /*arg*/>;
+  using BranchWithArg =
+      FactoryNoType<NodeKind::BranchWithArg, NodeBlockId /*target_id*/,
+                    NodeId /*arg*/>;
 
   class Builtin {
    public:
-    static auto Make(SemanticsBuiltinKind builtin_kind, SemanticsTypeId type_id)
-        -> SemanticsNode {
+    static auto Make(BuiltinKind builtin_kind, TypeId type_id) -> Node {
       // Builtins won't have a ParseTree node associated, so we provide the
       // default invalid one.
       // This can't use the standard Make function because of the `AsInt()` cast
       // instead of `.index`.
-      return SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Builtin,
-                           type_id, builtin_kind.AsInt());
+      return Node(ParseTree::Node::Invalid, NodeKind::Builtin, type_id,
+                  builtin_kind.AsInt());
     }
-    static auto Get(SemanticsNode node) -> SemanticsBuiltinKind {
-      return SemanticsBuiltinKind::FromInt(node.arg0_);
+    static auto Get(Node node) -> BuiltinKind {
+      return BuiltinKind::FromInt(node.arg0_);
     }
   };
 
-  using Call =
-      Factory<SemanticsNodeKind::Call, SemanticsNodeBlockId /*refs_id*/,
-              SemanticsFunctionId /*function_id*/>;
+  using Call = Factory<NodeKind::Call, NodeBlockId /*refs_id*/,
+                       FunctionId /*function_id*/>;
 
-  using ConstType =
-      Factory<SemanticsNodeKind::ConstType, SemanticsTypeId /*inner_id*/>;
+  using ConstType = Factory<NodeKind::ConstType, TypeId /*inner_id*/>;
 
   class CrossReference
-      : public FactoryBase<SemanticsNodeKind::CrossReference,
-                           SemanticsCrossReferenceIRId /*ir_id*/,
-                           SemanticsNodeId /*node_id*/> {
+      : public FactoryBase<NodeKind::CrossReference,
+                           CrossReferenceIRId /*ir_id*/, NodeId /*node_id*/> {
    public:
-    static auto Make(SemanticsTypeId type_id, SemanticsCrossReferenceIRId ir_id,
-                     SemanticsNodeId node_id) -> SemanticsNode {
+    static auto Make(TypeId type_id, CrossReferenceIRId ir_id, NodeId node_id)
+        -> Node {
       // A node's parse tree node must refer to a node in the current parse
       // tree. This cannot use the cross-referenced node's parse tree node
       // because it will be in a different parse tree.
@@ -387,96 +389,82 @@ class SemanticsNode {
     using FactoryBase::Get;
   };
 
-  using Dereference =
-      Factory<SemanticsNodeKind::Dereference, SemanticsNodeId /*pointer_id*/>;
+  using Dereference = Factory<NodeKind::Dereference, NodeId /*pointer_id*/>;
 
   using FunctionDeclaration =
-      FactoryNoType<SemanticsNodeKind::FunctionDeclaration,
-                    SemanticsFunctionId /*function_id*/>;
+      FactoryNoType<NodeKind::FunctionDeclaration, FunctionId /*function_id*/>;
 
-  using IntegerLiteral = Factory<SemanticsNodeKind::IntegerLiteral,
-                                 SemanticsIntegerLiteralId /*integer_id*/>;
+  using IntegerLiteral =
+      Factory<NodeKind::IntegerLiteral, IntegerLiteralId /*integer_id*/>;
 
-  using Namespace = FactoryNoType<SemanticsNodeKind::Namespace,
-                                  SemanticsNameScopeId /*name_scope_id*/>;
+  using Namespace =
+      FactoryNoType<NodeKind::Namespace, NameScopeId /*name_scope_id*/>;
 
-  using Parameter =
-      Factory<SemanticsNodeKind::Parameter, SemanticsStringId /*name_id*/>;
+  using Parameter = Factory<NodeKind::Parameter, StringId /*name_id*/>;
 
-  using PointerType =
-      Factory<SemanticsNodeKind::PointerType, SemanticsTypeId /*pointee_id*/>;
+  using PointerType = Factory<NodeKind::PointerType, TypeId /*pointee_id*/>;
 
-  using RealLiteral = Factory<SemanticsNodeKind::RealLiteral,
-                              SemanticsRealLiteralId /*real_id*/>;
+  using RealLiteral = Factory<NodeKind::RealLiteral, RealLiteralId /*real_id*/>;
 
-  using Return = FactoryNoType<SemanticsNodeKind::Return>;
+  using Return = FactoryNoType<NodeKind::Return>;
 
-  using ReturnExpression = FactoryNoType<SemanticsNodeKind::ReturnExpression,
-                                         SemanticsNodeId /*expr_id*/>;
+  using ReturnExpression =
+      FactoryNoType<NodeKind::ReturnExpression, NodeId /*expr_id*/>;
 
-  using StringLiteral = Factory<SemanticsNodeKind::StringLiteral,
-                                SemanticsStringId /*string_id*/>;
+  using StringLiteral =
+      Factory<NodeKind::StringLiteral, StringId /*string_id*/>;
 
-  using StructAccess =
-      Factory<SemanticsNodeKind::StructAccess, SemanticsNodeId /*struct_id*/,
-              SemanticsMemberIndex /*ref_index*/>;
+  using StructAccess = Factory<NodeKind::StructAccess, NodeId /*struct_id*/,
+                               MemberIndex /*ref_index*/>;
 
-  using StructType =
-      Factory<SemanticsNodeKind::StructType, SemanticsNodeBlockId /*refs_id*/>;
+  using StructType = Factory<NodeKind::StructType, NodeBlockId /*refs_id*/>;
 
   using StructTypeField =
-      FactoryNoType<SemanticsNodeKind::StructTypeField,
-                    SemanticsStringId /*name_id*/, SemanticsTypeId /*type_id*/>;
+      FactoryNoType<NodeKind::StructTypeField, StringId /*name_id*/,
+                    TypeId /*type_id*/>;
 
-  using StructValue =
-      Factory<SemanticsNodeKind::StructValue, SemanticsNodeBlockId /*refs_id*/>;
+  using StructValue = Factory<NodeKind::StructValue, NodeBlockId /*refs_id*/>;
 
-  using StubReference =
-      Factory<SemanticsNodeKind::StubReference, SemanticsNodeId /*node_id*/>;
+  using StubReference = Factory<NodeKind::StubReference, NodeId /*node_id*/>;
 
   using TupleIndex =
-      Factory<SemanticsNodeKind::TupleIndex, SemanticsNodeId /*tuple_id*/,
-              SemanticsNodeId /*index*/>;
+      Factory<NodeKind::TupleIndex, NodeId /*tuple_id*/, NodeId /*index*/>;
 
-  using TupleType =
-      Factory<SemanticsNodeKind::TupleType, SemanticsTypeBlockId /*refs_id*/>;
+  using TupleType = Factory<NodeKind::TupleType, TypeBlockId /*refs_id*/>;
 
-  using TupleValue =
-      Factory<SemanticsNodeKind::TupleValue, SemanticsNodeBlockId /*refs_id*/>;
+  using TupleValue = Factory<NodeKind::TupleValue, NodeBlockId /*refs_id*/>;
 
-  using UnaryOperatorNot = Factory<SemanticsNodeKind::UnaryOperatorNot,
-                                   SemanticsNodeId /*operand_id*/>;
+  using UnaryOperatorNot =
+      Factory<NodeKind::UnaryOperatorNot, NodeId /*operand_id*/>;
 
-  using VarStorage =
-      Factory<SemanticsNodeKind::VarStorage, SemanticsStringId /*name_id*/>;
+  using VarStorage = Factory<NodeKind::VarStorage, StringId /*name_id*/>;
 
-  explicit SemanticsNode()
-      : SemanticsNode(ParseTree::Node::Invalid, SemanticsNodeKind::Invalid,
-                      SemanticsTypeId::Invalid) {}
+  explicit Node()
+      : Node(ParseTree::Node::Invalid, NodeKind::Invalid, TypeId::Invalid) {}
 
   // Provide `node.GetAsKind()` as an instance method for all kinds, essentially
-  // an alias for`SemanticsNode::Kind::Get(node)`.
+  // an alias for`Node::Kind::Get(node)`.
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
   auto GetAs##Name() const { return Name::Get(*this); }
 #include "toolchain/semantics/semantics_node_kind.def"
 
   auto parse_node() const -> ParseTree::Node { return parse_node_; }
-  auto kind() const -> SemanticsNodeKind { return kind_; }
+  auto kind() const -> NodeKind { return kind_; }
 
   // Gets the type of the value produced by evaluating this node.
-  auto type_id() const -> SemanticsTypeId { return type_id_; }
+  auto type_id() const -> TypeId { return type_id_; }
 
-  auto Print(llvm::raw_ostream& out) const -> void;
+  friend auto operator<<(llvm::raw_ostream& out, const Node& node)
+      -> llvm::raw_ostream&;
 
  private:
   // Builtins have peculiar construction, so they are a friend rather than using
   // a factory base class.
-  friend struct SemanticsNodeForBuiltin;
+  friend struct NodeForBuiltin;
 
-  explicit SemanticsNode(ParseTree::Node parse_node, SemanticsNodeKind kind,
-                         SemanticsTypeId type_id,
-                         int32_t arg0 = SemanticsNodeId::InvalidIndex,
-                         int32_t arg1 = SemanticsNodeId::InvalidIndex)
+  explicit Node(ParseTree::Node parse_node, NodeKind kind, TypeId type_id,
+                int32_t arg0 = NodeId::InvalidIndex,
+                int32_t arg1 = NodeId::InvalidIndex)
       : parse_node_(parse_node),
         kind_(kind),
         type_id_(type_id),
@@ -484,8 +472,8 @@ class SemanticsNode {
         arg1_(arg1) {}
 
   ParseTree::Node parse_node_;
-  SemanticsNodeKind kind_;
-  SemanticsTypeId type_id_;
+  NodeKind kind_;
+  TypeId type_id_;
 
   // Use GetAsKind to access arg0 and arg1.
   int32_t arg0_;
@@ -493,15 +481,15 @@ class SemanticsNode {
 };
 
 // TODO: This is currently 20 bytes because we sometimes have 2 arguments for a
-// pair of SemanticsNodes. However, SemanticsNodeKind is 1 byte; if args
-// were 3.5 bytes, we could potentially shrink SemanticsNode by 4 bytes. This
+// pair of Nodes. However, NodeKind is 1 byte; if args
+// were 3.5 bytes, we could potentially shrink Node by 4 bytes. This
 // may be worth investigating further.
-static_assert(sizeof(SemanticsNode) == 20, "Unexpected SemanticsNode size");
+static_assert(sizeof(Node) == 20, "Unexpected Node size");
 
 // Provides base support for use of Id types as DenseMap/DenseSet keys.
 // Instantiated below.
 template <typename Id>
-struct SemanticsIdMapInfo {
+struct IdMapInfo {
   static inline auto getEmptyKey() -> Id {
     return Id(llvm::DenseMapInfo<int32_t>::getEmptyKey());
   }
@@ -519,17 +507,17 @@ struct SemanticsIdMapInfo {
   }
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::SemIR
 
 // Support use of Id types as DenseMap/DenseSet keys.
 template <>
-struct llvm::DenseMapInfo<Carbon::SemanticsNodeBlockId>
-    : public Carbon::SemanticsIdMapInfo<Carbon::SemanticsNodeBlockId> {};
+struct llvm::DenseMapInfo<Carbon::SemIR::NodeBlockId>
+    : public Carbon::SemIR::IdMapInfo<Carbon::SemIR::NodeBlockId> {};
 template <>
-struct llvm::DenseMapInfo<Carbon::SemanticsNodeId>
-    : public Carbon::SemanticsIdMapInfo<Carbon::SemanticsNodeId> {};
+struct llvm::DenseMapInfo<Carbon::SemIR::NodeId>
+    : public Carbon::SemIR::IdMapInfo<Carbon::SemIR::NodeId> {};
 template <>
-struct llvm::DenseMapInfo<Carbon::SemanticsStringId>
-    : public Carbon::SemanticsIdMapInfo<Carbon::SemanticsStringId> {};
+struct llvm::DenseMapInfo<Carbon::SemIR::StringId>
+    : public Carbon::SemIR::IdMapInfo<Carbon::SemIR::StringId> {};
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_H_

--- a/toolchain/semantics/semantics_node.h
+++ b/toolchain/semantics/semantics_node.h
@@ -41,6 +41,7 @@ struct NodeId : public IndexBase {
     }
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NodeId NodeId::Invalid = NodeId(NodeId::InvalidIndex);
@@ -60,6 +61,7 @@ struct FunctionId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a cross-referenced IR.
@@ -71,6 +73,7 @@ struct CrossReferenceIRId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // A boolean value.
@@ -93,6 +96,7 @@ struct BoolValue : public IndexBase {
     }
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr BoolValue BoolValue::False = BoolValue(0);
@@ -107,6 +111,7 @@ struct IntegerLiteralId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a name scope.
@@ -121,6 +126,7 @@ struct NameScopeId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NameScopeId NameScopeId::Invalid =
@@ -148,6 +154,7 @@ struct NodeBlockId : public IndexBase {
     }
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr NodeBlockId NodeBlockId::Empty = NodeBlockId(0);
@@ -165,6 +172,7 @@ struct RealLiteralId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a string.
@@ -176,6 +184,7 @@ struct StringId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The ID of a node block.
@@ -202,6 +211,7 @@ struct TypeId : public IndexBase {
     }
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 constexpr TypeId TypeId::TypeType = TypeId(TypeId::InvalidIndex - 2);
@@ -217,6 +227,7 @@ struct TypeBlockId : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // An index for member access.
@@ -228,6 +239,7 @@ struct MemberIndex : public IndexBase {
     id.Print(out);
     return out;
   }
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 };
 
 // The standard structure for Node. This is trying to provide a minimal
@@ -456,6 +468,7 @@ class Node {
 
   friend auto operator<<(llvm::raw_ostream& out, const Node& node)
       -> llvm::raw_ostream&;
+  LLVM_DUMP_METHOD void Dump() const { llvm::errs() << *this; }
 
  private:
   // Builtins have peculiar construction, so they are a friend rather than using

--- a/toolchain/semantics/semantics_node_block_stack.cpp
+++ b/toolchain/semantics/semantics_node_block_stack.cpp
@@ -8,16 +8,16 @@
 #include "llvm/ADT/STLExtras.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsNodeBlockStack::Push(SemanticsNodeBlockId id) -> void {
+auto NodeBlockStack::Push(SemIR::NodeBlockId id) -> void {
   CARBON_VLOG() << name_ << " Push " << stack_.size() << "\n";
   CARBON_CHECK(stack_.size() < (1 << 20))
       << "Excessive stack size: likely infinite loop";
   stack_.push_back(id);
 }
 
-auto SemanticsNodeBlockStack::PeekForAdd() -> SemanticsNodeBlockId {
+auto NodeBlockStack::PeekForAdd() -> SemIR::NodeBlockId {
   CARBON_CHECK(!stack_.empty()) << "no current block";
   auto& back = stack_.back();
   if (!back.is_valid()) {
@@ -28,17 +28,17 @@ auto SemanticsNodeBlockStack::PeekForAdd() -> SemanticsNodeBlockId {
   return back;
 }
 
-auto SemanticsNodeBlockStack::Pop() -> SemanticsNodeBlockId {
+auto NodeBlockStack::Pop() -> SemIR::NodeBlockId {
   CARBON_CHECK(!stack_.empty()) << "no current block";
   auto back = stack_.pop_back_val();
   CARBON_VLOG() << name_ << " Pop " << stack_.size() << ": " << back << "\n";
   if (!back.is_valid()) {
-    return SemanticsNodeBlockId::Empty;
+    return SemIR::NodeBlockId::Empty;
   }
   return back;
 }
 
-auto SemanticsNodeBlockStack::PrintForStackDump(llvm::raw_ostream& output) const
+auto NodeBlockStack::PrintForStackDump(llvm::raw_ostream& output) const
     -> void {
   output << name_ << ":\n";
   for (auto [i, entry] : llvm::enumerate(stack_)) {
@@ -46,4 +46,4 @@ auto SemanticsNodeBlockStack::PrintForStackDump(llvm::raw_ostream& output) const
   }
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_node_kind.cpp
+++ b/toolchain/semantics/semantics_node_kind.cpp
@@ -20,19 +20,19 @@ CARBON_DEFINE_ENUM_CLASS_NAMES(SemanticsNodeKind) = {
   return Table[AsInt()];
 }
 
-auto SemanticsNodeKind::value_kind() const -> SemanticsNodeValueKind {
-  static constexpr SemanticsNodeValueKind Table[] = {
-#define CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND(Name, ValueKind) \
-  SemanticsNodeValueKind::ValueKind,
+auto SemanticsNodeKind::value_kind() const -> SemIR::NodeValueKind {
+  static constexpr SemIR::NodeValueKind Table[] = {
+#define CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND(Name, Kind) \
+  SemIR::NodeValueKind::Kind,
 #include "toolchain/semantics/semantics_node_kind.def"
   };
   return Table[AsInt()];
 }
 
-auto SemanticsNodeKind::terminator_kind() const -> SemanticsTerminatorKind {
-  static constexpr SemanticsTerminatorKind Table[] = {
-#define CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND(Name, TerminatorKind) \
-  SemanticsTerminatorKind::TerminatorKind,
+auto SemanticsNodeKind::terminator_kind() const -> SemIR::TerminatorKind {
+  static constexpr SemIR::TerminatorKind Table[] = {
+#define CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND(Name, Kind) \
+  SemIR::TerminatorKind::Kind,
 #include "toolchain/semantics/semantics_node_kind.def"
   };
   return Table[AsInt()];

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -10,15 +10,10 @@
 #include "common/enum_base.h"
 #include "llvm/ADT/FoldingSet.h"
 
-namespace Carbon {
-
-CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsNodeKind, uint8_t) {
-#define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
-#include "toolchain/semantics/semantics_node_kind.def"
-};
+namespace Carbon::SemIR {
 
 // Whether a node produces or represents a value, and if so, what kind of value.
-enum class SemanticsNodeValueKind {
+enum class NodeValueKind {
   // This node doesn't produce a value, and shouldn't be referenced by other
   // nodes.
   None,
@@ -33,7 +28,7 @@ enum class SemanticsNodeValueKind {
 // Whether a node is a terminator or part of the terminator sequence. The nodes
 // in a block appear in the order NotTerminator, then TerminatorSequence, then
 // Terminator, which is also the numerical order of these values.
-enum class SemanticsTerminatorKind {
+enum class TerminatorKind {
   // This node is not a terminator.
   NotTerminator,
   // This node is not itself a terminator, but forms part of a terminator
@@ -41,6 +36,15 @@ enum class SemanticsTerminatorKind {
   TerminatorSequence,
   // This node is a terminator.
   Terminator,
+};
+
+}  // namespace Carbon::SemIR
+
+namespace Carbon {
+
+CARBON_DEFINE_RAW_ENUM_CLASS(SemanticsNodeKind, uint8_t) {
+#define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
+#include "toolchain/semantics/semantics_node_kind.def"
 };
 
 class SemanticsNodeKind : public CARBON_ENUM_BASE(SemanticsNodeKind) {
@@ -54,14 +58,14 @@ class SemanticsNodeKind : public CARBON_ENUM_BASE(SemanticsNodeKind) {
   [[nodiscard]] auto ir_name() const -> llvm::StringRef;
 
   // Returns whether this kind of node is expected to produce a value.
-  [[nodiscard]] auto value_kind() const -> SemanticsNodeValueKind;
+  [[nodiscard]] auto value_kind() const -> SemIR::NodeValueKind;
 
   // Returns whether this node kind is a code block terminator, such as an
   // unconditional branch instruction, or part of the termination sequence,
   // such as a conditional branch instruction. The termination sequence of a
   // code block appears after all other instructions, and ends with a
   // terminator instruction.
-  [[nodiscard]] auto terminator_kind() const -> SemanticsTerminatorKind;
+  [[nodiscard]] auto terminator_kind() const -> SemIR::TerminatorKind;
 
   // Compute a fingerprint for this node kind, allowing its use as part of the
   // key in a `FoldingSet`.
@@ -74,6 +78,11 @@ class SemanticsNodeKind : public CARBON_ENUM_BASE(SemanticsNodeKind) {
 
 // We expect the node kind to fit compactly into 8 bits.
 static_assert(sizeof(SemanticsNodeKind) == 1, "Kind objects include padding!");
+
+// TODO: Refactor EnumBase to remove the need for this alias.
+namespace SemIR {
+using NodeKind = SemanticsNodeKind;
+}  // namespace SemIR
 
 }  // namespace Carbon
 

--- a/toolchain/semantics/semantics_node_stack.cpp
+++ b/toolchain/semantics/semantics_node_stack.cpp
@@ -7,11 +7,10 @@
 #include "llvm/ADT/STLExtras.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-auto SemanticsNodeStack::PrintForStackDump(llvm::raw_ostream& output) const
-    -> void {
-  output << "SemanticsNodeStack:\n";
+auto NodeStack::PrintForStackDump(llvm::raw_ostream& output) const -> void {
+  output << "NodeStack:\n";
   for (auto [i, entry] : llvm::enumerate(stack_)) {
     auto parse_node_kind = parse_tree_->node_kind(entry.parse_node);
     output << "\t" << i << ".\t" << parse_node_kind;
@@ -26,4 +25,4 @@ auto SemanticsNodeStack::PrintForStackDump(llvm::raw_ostream& output) const
   }
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Check

--- a/toolchain/semantics/semantics_node_stack.h
+++ b/toolchain/semantics/semantics_node_stack.h
@@ -13,9 +13,9 @@
 #include "toolchain/parser/parse_tree.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Check {
 
-// Wraps the stack of nodes for SemanticsParseTreeHandler.
+// Wraps the stack of nodes for Context.
 //
 // All pushes and pops will be vlogged.
 //
@@ -28,10 +28,10 @@ namespace Carbon {
 //
 // These should be assumed API constraints unless otherwise mentioned on a
 // method. The main exception is PopAndIgnore, which doesn't do verification.
-class SemanticsNodeStack {
+class NodeStack {
  public:
-  explicit SemanticsNodeStack(const ParseTree& parse_tree,
-                              llvm::raw_ostream* vlog_stream)
+  explicit NodeStack(const ParseTree& parse_tree,
+                     llvm::raw_ostream* vlog_stream)
       : parse_tree_(&parse_tree), vlog_stream_(vlog_stream) {}
 
   // Pushes a solo parse tree node onto the stack. Used when there is no
@@ -44,7 +44,7 @@ class SemanticsNodeStack {
                   << parse_tree_->node_kind(parse_node) << " -> <none>\n";
     CARBON_CHECK(stack_.size() < (1 << 20))
         << "Excessive stack size: likely infinite loop";
-    stack_.push_back(Entry(parse_node, SemanticsNodeId::Invalid));
+    stack_.push_back(Entry(parse_node, SemIR::NodeId::Invalid));
   }
 
   // Pushes a parse tree node onto the stack with an ID.
@@ -64,12 +64,12 @@ class SemanticsNodeStack {
   }
 
   // Pops the top of the stack without any verification.
-  auto PopAndIgnore() -> void { PopEntry<SemanticsNodeId>(); }
+  auto PopAndIgnore() -> void { PopEntry<SemIR::NodeId>(); }
 
   // Pops the top of the stack and returns the parse_node.
   template <ParseNodeKind::RawEnumType RequiredParseKind>
   auto PopForSoloParseNode() -> ParseTree::Node {
-    Entry back = PopEntry<SemanticsNodeId>();
+    Entry back = PopEntry<SemIR::NodeId>();
     RequireIdKind(ParseNodeKind::Create(RequiredParseKind),
                   IdKind::SoloParseNode);
     RequireParseKind<RequiredParseKind>(back.parse_node);
@@ -85,8 +85,8 @@ class SemanticsNodeStack {
   // Pops an expression from the top of the stack and returns the parse_node and
   // the ID.
   auto PopExpressionWithParseNode()
-      -> std::pair<ParseTree::Node, SemanticsNodeId> {
-    return PopWithParseNode<SemanticsNodeId>();
+      -> std::pair<ParseTree::Node, SemIR::NodeId> {
+    return PopWithParseNode<SemIR::NodeId>();
   }
 
   // Pops the top of the stack and returns the parse_node and the ID.
@@ -94,28 +94,28 @@ class SemanticsNodeStack {
   auto PopWithParseNode() -> auto {
     constexpr IdKind RequiredIdKind =
         ParseNodeKindToIdKind(ParseNodeKind::Create(RequiredParseKind));
-    if constexpr (RequiredIdKind == IdKind::SemanticsNodeId) {
-      auto back = PopWithParseNode<SemanticsNodeId>();
+    if constexpr (RequiredIdKind == IdKind::NodeId) {
+      auto back = PopWithParseNode<SemIR::NodeId>();
       RequireParseKind<RequiredParseKind>(back.first);
       return back;
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsNodeBlockId) {
-      auto back = PopWithParseNode<SemanticsNodeBlockId>();
+    if constexpr (RequiredIdKind == IdKind::NodeBlockId) {
+      auto back = PopWithParseNode<SemIR::NodeBlockId>();
       RequireParseKind<RequiredParseKind>(back.first);
       return back;
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsFunctionId) {
-      auto back = PopWithParseNode<SemanticsFunctionId>();
+    if constexpr (RequiredIdKind == IdKind::FunctionId) {
+      auto back = PopWithParseNode<SemIR::FunctionId>();
       RequireParseKind<RequiredParseKind>(back.first);
       return back;
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsStringId) {
-      auto back = PopWithParseNode<SemanticsStringId>();
+    if constexpr (RequiredIdKind == IdKind::StringId) {
+      auto back = PopWithParseNode<SemIR::StringId>();
       RequireParseKind<RequiredParseKind>(back.first);
       return back;
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsTypeId) {
-      auto back = PopWithParseNode<SemanticsTypeId>();
+    if constexpr (RequiredIdKind == IdKind::TypeId) {
+      auto back = PopWithParseNode<SemIR::TypeId>();
       RequireParseKind<RequiredParseKind>(back.first);
       return back;
     }
@@ -125,8 +125,8 @@ class SemanticsNodeStack {
   }
 
   // Pops an expression from the top of the stack and returns the ID.
-  // Expressions map multiple ParseNodeKinds to SemanticsNodeId always.
-  auto PopExpression() -> SemanticsNodeId {
+  // Expressions map multiple ParseNodeKinds to SemIR::NodeId always.
+  auto PopExpression() -> SemIR::NodeId {
     return PopExpressionWithParseNode().second;
   }
 
@@ -146,20 +146,20 @@ class SemanticsNodeStack {
     RequireParseKind<RequiredParseKind>(back.parse_node);
     constexpr IdKind RequiredIdKind =
         ParseNodeKindToIdKind(ParseNodeKind::Create(RequiredParseKind));
-    if constexpr (RequiredIdKind == IdKind::SemanticsNodeId) {
-      return back.id<SemanticsNodeId>();
+    if constexpr (RequiredIdKind == IdKind::NodeId) {
+      return back.id<SemIR::NodeId>();
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsNodeBlockId) {
-      return back.id<SemanticsNodeBlockId>();
+    if constexpr (RequiredIdKind == IdKind::NodeBlockId) {
+      return back.id<SemIR::NodeBlockId>();
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsFunctionId) {
-      return back.id<SemanticsFunctionId>();
+    if constexpr (RequiredIdKind == IdKind::FunctionId) {
+      return back.id<SemIR::FunctionId>();
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsStringId) {
-      return back.id<SemanticsStringId>();
+    if constexpr (RequiredIdKind == IdKind::StringId) {
+      return back.id<SemIR::StringId>();
     }
-    if constexpr (RequiredIdKind == IdKind::SemanticsTypeId) {
-      return back.id<SemanticsTypeId>();
+    if constexpr (RequiredIdKind == IdKind::TypeId) {
+      return back.id<SemIR::TypeId>();
     }
     CARBON_FATAL() << "Unpeekable IdKind for parse kind: "
                    << ParseNodeKind::Create(RequiredParseKind)
@@ -175,11 +175,11 @@ class SemanticsNodeStack {
  private:
   // Possible associated ID types.
   enum class IdKind {
-    SemanticsNodeId,
-    SemanticsNodeBlockId,
-    SemanticsFunctionId,
-    SemanticsStringId,
-    SemanticsTypeId,
+    NodeId,
+    NodeBlockId,
+    FunctionId,
+    StringId,
+    TypeId,
     // No associated ID type.
     SoloParseNode,
     // Not expected in the node stack.
@@ -188,34 +188,33 @@ class SemanticsNodeStack {
 
   // An entry in stack_.
   struct Entry {
-    explicit Entry(ParseTree::Node parse_node, SemanticsNodeId node_id)
+    explicit Entry(ParseTree::Node parse_node, SemIR::NodeId node_id)
         : parse_node(parse_node), node_id(node_id) {}
-    explicit Entry(ParseTree::Node parse_node,
-                   SemanticsNodeBlockId node_block_id)
+    explicit Entry(ParseTree::Node parse_node, SemIR::NodeBlockId node_block_id)
         : parse_node(parse_node), node_block_id(node_block_id) {}
-    explicit Entry(ParseTree::Node parse_node, SemanticsFunctionId function_id)
+    explicit Entry(ParseTree::Node parse_node, SemIR::FunctionId function_id)
         : parse_node(parse_node), function_id(function_id) {}
-    explicit Entry(ParseTree::Node parse_node, SemanticsStringId name_id)
+    explicit Entry(ParseTree::Node parse_node, SemIR::StringId name_id)
         : parse_node(parse_node), name_id(name_id) {}
-    explicit Entry(ParseTree::Node parse_node, SemanticsTypeId type_id)
+    explicit Entry(ParseTree::Node parse_node, SemIR::TypeId type_id)
         : parse_node(parse_node), type_id(type_id) {}
 
     // Returns the appropriate ID basaed on type.
     template <typename T>
     auto id() -> T& {
-      if constexpr (std::is_same<T, SemanticsNodeId>()) {
+      if constexpr (std::is_same<T, SemIR::NodeId>()) {
         return node_id;
       }
-      if constexpr (std::is_same<T, SemanticsNodeBlockId>()) {
+      if constexpr (std::is_same<T, SemIR::NodeBlockId>()) {
         return node_block_id;
       }
-      if constexpr (std::is_same<T, SemanticsFunctionId>()) {
+      if constexpr (std::is_same<T, SemIR::FunctionId>()) {
         return function_id;
       }
-      if constexpr (std::is_same<T, SemanticsStringId>()) {
+      if constexpr (std::is_same<T, SemIR::StringId>()) {
         return name_id;
       }
-      if constexpr (std::is_same<T, SemanticsTypeId>()) {
+      if constexpr (std::is_same<T, SemIR::TypeId>()) {
         return type_id;
       }
     }
@@ -229,11 +228,11 @@ class SemanticsNodeStack {
     // A discriminator isn't needed because the caller can determine which field
     // is used based on the ParseNodeKind.
     union {
-      SemanticsNodeId node_id;
-      SemanticsNodeBlockId node_block_id;
-      SemanticsFunctionId function_id;
-      SemanticsStringId name_id;
-      SemanticsTypeId type_id;
+      SemIR::NodeId node_id;
+      SemIR::NodeBlockId node_block_id;
+      SemIR::FunctionId function_id;
+      SemIR::StringId name_id;
+      SemIR::TypeId type_id;
     };
   };
   static_assert(sizeof(Entry) == 8, "Unexpected Entry size");
@@ -260,17 +259,17 @@ class SemanticsNodeStack {
       case ParseNodeKind::StructFieldType:
       case ParseNodeKind::StructTypeLiteral:
       case ParseNodeKind::TupleLiteral:
-        return IdKind::SemanticsNodeId;
+        return IdKind::NodeId;
       case ParseNodeKind::IfExpressionThen:
       case ParseNodeKind::IfStatementElse:
       case ParseNodeKind::ParameterList:
-        return IdKind::SemanticsNodeBlockId;
+        return IdKind::NodeBlockId;
       case ParseNodeKind::FunctionDefinitionStart:
-        return IdKind::SemanticsFunctionId;
+        return IdKind::FunctionId;
       case ParseNodeKind::Name:
-        return IdKind::SemanticsStringId;
+        return IdKind::StringId;
       case ParseNodeKind::ReturnType:
-        return IdKind::SemanticsTypeId;
+        return IdKind::TypeId;
       case ParseNodeKind::ArrayExpressionSemi:
       case ParseNodeKind::CodeBlockStart:
       case ParseNodeKind::FunctionIntroducer:
@@ -293,20 +292,20 @@ class SemanticsNodeStack {
   // ParseNodeKindToIdKind.
   template <typename IdT>
   static constexpr auto IdTypeToIdKind() -> IdKind {
-    if constexpr (std::is_same_v<IdT, SemanticsNodeId>) {
-      return IdKind::SemanticsNodeId;
+    if constexpr (std::is_same_v<IdT, SemIR::NodeId>) {
+      return IdKind::NodeId;
     }
-    if constexpr (std::is_same_v<IdT, SemanticsNodeBlockId>) {
-      return IdKind::SemanticsNodeBlockId;
+    if constexpr (std::is_same_v<IdT, SemIR::NodeBlockId>) {
+      return IdKind::NodeBlockId;
     }
-    if constexpr (std::is_same_v<IdT, SemanticsFunctionId>) {
-      return IdKind::SemanticsFunctionId;
+    if constexpr (std::is_same_v<IdT, SemIR::FunctionId>) {
+      return IdKind::FunctionId;
     }
-    if constexpr (std::is_same_v<IdT, SemanticsStringId>) {
-      return IdKind::SemanticsStringId;
+    if constexpr (std::is_same_v<IdT, SemIR::StringId>) {
+      return IdKind::StringId;
     }
-    if constexpr (std::is_same_v<IdT, SemanticsTypeId>) {
-      return IdKind::SemanticsTypeId;
+    if constexpr (std::is_same_v<IdT, SemIR::TypeId>) {
+      return IdKind::TypeId;
     }
   }
 
@@ -356,6 +355,6 @@ class SemanticsNodeStack {
   llvm::SmallVector<Entry> stack_;
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_STACK_H_


### PR DESCRIPTION
Splits IR files into SemIR, and logic files into Check. These will be split into separate directories as part of a later move; the namespaces are being done first in order to vet the switch, and hopefully make conflicts a little easier to manage due to the substantial renames.

A lot of this is just automated removal of Semantics prefixes from names, adding namespace references where needed. A few special-cases are:

- SemanticsIR -> SemIR::File
  - A few things were discussed, like Unit, CompileUnit, or CompiledUnit. Unit was too vague for chandlerc, and I thought CompileUnit might lead to incorrect inferences (CompilationUnit would be more precise, but typically written as SemIR::CompilationUnit which is pretty long). File seemed to be a short name that we could agree on.
- SemanticsIRFormatter -> SemIR::Formatter
- FormatSemanticsIR -> SemIR::FormatFile
- SemanticsFileTest -> CheckFileTest
  - It remains in the Testing namespace, where just "FileTest" might be too broad a name.
- SemanticsDeclarationNameStack::Context -> Check::DeclarationNameStack::NameContext
  - This avoids a Check::Context name shadowing.

Changes check_internal.h to include ostream.h to improve finding of Print/operator<< (otherwise it didn't compile).

This is part of #3070 