### PR TITLE
Optimize the outer lexer loop.

### DIFF
--- a/toolchain/lexer/token_kind.cpp
+++ b/toolchain/lexer/token_kind.cpp
@@ -79,6 +79,15 @@ auto TokenKind::opening_symbol() const -> TokenKind {
   return result;
 }
 
+auto TokenKind::is_one_char_symbol() const -> bool {
+  static constexpr bool Table[] = {
+#define CARBON_TOKEN(TokenName) false,
+#define CARBON_ONE_CHAR_SYMBOL_TOKEN(TokenName, Spelling) true,
+#include "toolchain/lexer/token_kind.def"
+  };
+  return Table[AsInt()];
+}
+
 auto TokenKind::is_keyword() const -> bool {
   static constexpr bool Table[] = {
 #define CARBON_TOKEN(TokenName) false,

--- a/toolchain/lexer/token_kind.def
+++ b/toolchain/lexer/token_kind.def
@@ -36,6 +36,11 @@
 #define CARBON_SYMBOL_TOKEN(Name, Spelling) CARBON_TOKEN(Name)
 #endif
 
+#ifndef CARBON_ONE_CHAR_SYMBOL_TOKEN
+#define CARBON_ONE_CHAR_SYMBOL_TOKEN(Name, Spelling) \
+  CARBON_SYMBOL_TOKEN(Name, Spelling)
+#endif
+
 #ifndef CARBON_TOKEN_WITH_VIRTUAL_NODE
 #define CARBON_TOKEN_WITH_VIRTUAL_NODE(Name) Name
 #endif
@@ -78,7 +83,6 @@ CARBON_SYMBOL_TOKEN(At,                  "@")
 CARBON_SYMBOL_TOKEN(Backslash,           "\\")
 CARBON_SYMBOL_TOKEN(Caret,               "^")
 CARBON_SYMBOL_TOKEN(Colon,               ":")
-CARBON_SYMBOL_TOKEN(Comma,               ",")
 CARBON_SYMBOL_TOKEN(Equal,               "=")
 CARBON_SYMBOL_TOKEN(Exclaim,             "!")
 CARBON_SYMBOL_TOKEN(Greater,             ">")
@@ -89,16 +93,25 @@ CARBON_SYMBOL_TOKEN(Period,              ".")
 CARBON_SYMBOL_TOKEN(Pipe,                "|")
 CARBON_SYMBOL_TOKEN(Plus,                "+")
 CARBON_SYMBOL_TOKEN(Question,            "?")
-CARBON_SYMBOL_TOKEN(Semi,                ";")
 CARBON_SYMBOL_TOKEN(Slash,               "/")
 CARBON_SYMBOL_TOKEN(Star,                "*")
 CARBON_SYMBOL_TOKEN(Tilde,               "~")
+
+// Some Carbon symbols are constructively exactly one character and cannot be
+// combined with any other characters to form new symbols. We can lex these
+// without needing to max-munch any other characters. These are typically
+// expected to be terminators or separators that need to compose with all other
+// parts of the grammar. Group symbols are also currently one-character symbols,
+// although we may choose to remove that if we need to add composite grouping
+// symbols in the future.
+CARBON_ONE_CHAR_SYMBOL_TOKEN(Comma,      ",")
+CARBON_ONE_CHAR_SYMBOL_TOKEN(Semi,       ";")
 
 // clang-format on
 
 #ifndef CARBON_OPENING_GROUP_SYMBOL_TOKEN
 #define CARBON_OPENING_GROUP_SYMBOL_TOKEN(Name, Spelling, ClosingName) \
-  CARBON_SYMBOL_TOKEN(Name, Spelling)
+  CARBON_ONE_CHAR_SYMBOL_TOKEN(Name, Spelling)
 #endif
 CARBON_OPENING_GROUP_SYMBOL_TOKEN(OpenParen, "(", CloseParen)
 CARBON_OPENING_GROUP_SYMBOL_TOKEN(OpenCurlyBrace, "{", CloseCurlyBrace)
@@ -107,13 +120,14 @@ CARBON_OPENING_GROUP_SYMBOL_TOKEN(OpenSquareBracket, "[", CloseSquareBracket)
 
 #ifndef CARBON_CLOSING_GROUP_SYMBOL_TOKEN
 #define CARBON_CLOSING_GROUP_SYMBOL_TOKEN(Name, Spelling, OpeningName) \
-  CARBON_SYMBOL_TOKEN(Name, Spelling)
+  CARBON_ONE_CHAR_SYMBOL_TOKEN(Name, Spelling)
 #endif
 CARBON_CLOSING_GROUP_SYMBOL_TOKEN(CloseParen, ")", OpenParen)
 CARBON_CLOSING_GROUP_SYMBOL_TOKEN(CloseCurlyBrace, "}", OpenCurlyBrace)
 CARBON_CLOSING_GROUP_SYMBOL_TOKEN(CloseSquareBracket, "]", OpenSquareBracket)
 #undef CARBON_CLOSING_GROUP_SYMBOL_TOKEN
 
+#undef CARBON_ONE_CHAR_SYMBOL_TOKEN
 #undef CARBON_SYMBOL_TOKEN
 
 #ifndef CARBON_KEYWORD_TOKEN

--- a/toolchain/lexer/token_kind.h
+++ b/toolchain/lexer/token_kind.h
@@ -54,6 +54,10 @@ class TokenKind : public CARBON_ENUM_BASE(TokenKind) {
   // The token kind must be a closing symbol.
   [[nodiscard]] auto opening_symbol() const -> TokenKind;
 
+  // Test whether this kind of token is a one-character symbol whose character
+  // is not part of any other symbol.
+  [[nodiscard]] auto is_one_char_symbol() const -> bool;
+
   // Test whether this kind of token is a keyword.
   [[nodiscard]] auto is_keyword() const -> bool;
 

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -248,8 +248,8 @@ class TokenizedBuffer::Lexer {
     bool formed_token_;
   };
 
-  using DispatchFunctionT = auto (Lexer& lexer,
-                                  llvm::StringRef& source_text) -> LexResult;
+  using DispatchFunctionT = auto(Lexer& lexer, llvm::StringRef& source_text)
+      -> LexResult;
   using DispatchTableT = std::array<DispatchFunctionT*, 256>;
 
   Lexer(TokenizedBuffer& buffer, DiagnosticConsumer& consumer)
@@ -463,7 +463,7 @@ class TokenizedBuffer::Lexer {
     auto compute_symbol_kind = [](llvm::StringRef source_text) {
       return llvm::StringSwitch<TokenKind>(source_text)
 #define CARBON_SYMBOL_TOKEN(Name, Spelling) \
-    .StartsWith(Spelling, TokenKind::Name)
+  .StartsWith(Spelling, TokenKind::Name)
 #include "toolchain/lexer/token_kind.def"
           .Default(TokenKind::Error);
     };
@@ -811,27 +811,27 @@ auto TokenizedBuffer::Lex(SourceBuffer& source, DiagnosticConsumer& consumer)
 
   // Build a table of function pointers that we can use to dispatch to the
   // correct lexer routine based on the first byte of source text.
-  // 
+  //
   // While it is tempting to simply use a `switch` on the first byte and
   // dispatch with cases into this, in practice that doesn't produce great code.
   // There seem to be two issues that are the root cause.
-  // 
+  //
   // First, there are lots of different values of bytes that dispatch to a
   // fairly small set of routines, and then some byte values that dispatch
   // differently for each byte. This pattern isn't one that the compiler-based
   // lowering of switches works well with -- it tries to balance all the cases,
   // and in doing so emits several compares and other control flow rather than a
   // simple jump table.
-  // 
+  //
   // Second, with a `case`, it isn't as obvious how to create a single, uniform
   // interface that is effective for *every* byte value, and thus makes for a
   // single consistent table-based dispatch. By forcing these to be function
   // pointers, we also coerce the code to use a strictly homogenous structure
   // that can form a single dispatch table.
-  // 
+  //
   // These two actually interact -- the second issue is part of what makes the
   // non-table lowering in the first one desirable for many switches and cases.
-  // 
+  //
   // Ultimately, when table-based dispatch is such an important technique, we
   // get better results by taking full control and manually creating the
   // dispatch structures.

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -458,47 +458,31 @@ class TokenizedBuffer::Lexer {
     }
   }
 
-  auto LexSymbolToken(llvm::StringRef& source_text, TokenKind kind)
-      -> LexResult {
-    // We use the `period` token as a place-holder for cases where one
-    // character isn't enough to pick a definitive symbol token. Recompute the
-    // kind using the full symbol set.
-    if (LLVM_UNLIKELY(kind == TokenKind::Period)) {
-      kind = llvm::StringSwitch<TokenKind>(source_text)
+  auto LexSymbolToken(llvm::StringRef& source_text,
+                      TokenKind kind = TokenKind::Error) -> LexResult {
+    auto compute_symbol_kind = [](llvm::StringRef source_text) {
+      return llvm::StringSwitch<TokenKind>(source_text)
 #define CARBON_SYMBOL_TOKEN(Name, Spelling) \
-  .StartsWith(Spelling, TokenKind::Name)
+    .StartsWith(Spelling, TokenKind::Name)
 #include "toolchain/lexer/token_kind.def"
-                 .Default(TokenKind::Error);
+          .Default(TokenKind::Error);
+    };
+
+    // We use the `error` token as a place-holder for cases where one character
+    // isn't enough to pick a definitive symbol token. Recompute the kind using
+    // the full symbol set.
+    if (LLVM_UNLIKELY(kind == TokenKind::Error)) {
+      kind = compute_symbol_kind(source_text);
       if (kind == TokenKind::Error) {
         return LexError(source_text);
       }
     } else {
-      auto compute_kind = [] (llvm::StringRef source_text) {
-        return llvm::StringSwitch<TokenKind>(source_text)
-#define CARBON_SYMBOL_TOKEN(Name, Spelling) \
-    .StartsWith(Spelling, TokenKind::Name)
-#include "toolchain/lexer/token_kind.def"
-                                   .Default(TokenKind::Error);
-      };
-
       // Verify in a debug build that the incoming token kind is correct.
-      CARBON_DCHECK(kind == compute_kind(source_text))
+      CARBON_DCHECK(kind == compute_symbol_kind(source_text))
           << "Incoming token kind '" << kind
-          << "' does not match computed kind '" << compute_kind(source_text) << "'!";
+          << "' does not match computed kind '"
+          << compute_symbol_kind(source_text) << "'!";
     }
-
-    // In debug builds, re-check the kind after our optimizations to make sure
-    // we get the same result.
-#ifndef NDEBUG
-    TokenKind debug_kind = llvm::StringSwitch<TokenKind>(source_text)
-#define CARBON_SYMBOL_TOKEN(Name, Spelling) \
-  .StartsWith(Spelling, TokenKind::Name)
-#include "toolchain/lexer/token_kind.def"
-                               .Default(TokenKind::Error);
-    CARBON_CHECK(debug_kind == kind)
-        << "Optimized code computed kind '" << kind
-        << "' but it should have been '" << debug_kind << "'";
-#endif
 
     if (!set_indent_) {
       current_line_info_->indent = current_column_;
@@ -740,13 +724,12 @@ class TokenizedBuffer::Lexer {
       table[i] = dispatch_lex_error;
     }
 
-    // First, set the first character of each symbol token spelling to dispatch
-    // to the symbol lexer. We use a `Period` placeholder for the token as there
-    // may be several different tokens that start with the same spelling. When
-    // that placeholder token kind is used, the symbol lexer will compute the
+    // Symbols have some special dispatching. First, set the first character of
+    // each symbol token spelling to dispatch to the symbol lexer. We don't
+    // provide a pre-computed token here, so the symbol lexer will compute the
     // exact symbol token kind.
     auto dispatch_lex_symbol = +[](Lexer& lexer, llvm::StringRef& source_text) {
-      return lexer.LexSymbolToken(source_text, TokenKind::Period);
+      return lexer.LexSymbolToken(source_text);
     };
 #define CARBON_SYMBOL_TOKEN(TokenName, Spelling) \
   table[(Spelling)[0]] = dispatch_lex_symbol;
@@ -756,15 +739,14 @@ class TokenizedBuffer::Lexer {
     // join with another symbol. These are grouping symbols, terminators,
     // or separators in the grammar and have a good reason to be
     // orthogonal to any other punctuation. We do this separately because this
-    // needs to override soe of the generic handling above.
+    // needs to override some of the generic handling above, and provide a
+    // custom token.
 #define CARBON_ONE_CHAR_SYMBOL_TOKEN(TokenName, Spelling)                  \
   table[(Spelling)[0]] = +[](Lexer& lexer, llvm::StringRef& source_text) { \
     return lexer.LexSymbolToken(source_text, TokenKind::TokenName);        \
   };
 #include "toolchain/lexer/token_kind.def"
 
-    // For identifiers, keywords, and numeric type literals, we use the
-    // `Identifier` placeholder token kind.
     auto dispatch_lex_word = +[](Lexer& lexer, llvm::StringRef& source_text) {
       return lexer.LexKeywordOrIdentifier(source_text);
     };
@@ -785,8 +767,6 @@ class TokenizedBuffer::Lexer {
       table[i] = dispatch_lex_word;
     }
 
-    // For numeric literals of all kinds, we use the `IntegerLiteral`
-    // placeholder token kind.
     auto dispatch_lex_numeric =
         +[](Lexer& lexer, llvm::StringRef& source_text) {
           return lexer.LexNumericLiteral(source_text);
@@ -795,8 +775,6 @@ class TokenizedBuffer::Lexer {
       table[c] = dispatch_lex_numeric;
     }
 
-    // We can immediately tell when starting to lex a string literal and
-    // dispatch directly.
     auto dispatch_lex_string = +[](Lexer& lexer, llvm::StringRef& source_text) {
       return lexer.LexStringLiteral(source_text);
     };
@@ -833,6 +811,30 @@ auto TokenizedBuffer::Lex(SourceBuffer& source, DiagnosticConsumer& consumer)
 
   // Build a table of function pointers that we can use to dispatch to the
   // correct lexer routine based on the first byte of source text.
+  // 
+  // While it is tempting to simply use a `switch` on the first byte and
+  // dispatch with cases into this, in practice that doesn't produce great code.
+  // There seem to be two issues that are the root cause.
+  // 
+  // First, there are lots of different values of bytes that dispatch to a
+  // fairly small set of routines, and then some byte values that dispatch
+  // differently for each byte. This pattern isn't one that the compiler-based
+  // lowering of switches works well with -- it tries to balance all the cases,
+  // and in doing so emits several compares and other control flow rather than a
+  // simple jump table.
+  // 
+  // Second, with a `case`, it isn't as obvious how to create a single, uniform
+  // interface that is effective for *every* byte value, and thus makes for a
+  // single consistent table-based dispatch. By forcing these to be function
+  // pointers, we also coerce the code to use a strictly homogenous structure
+  // that can form a single dispatch table.
+  // 
+  // These two actually interact -- the second issue is part of what makes the
+  // non-table lowering in the first one desirable for many switches and cases.
+  // 
+  // Ultimately, when table-based dispatch is such an important technique, we
+  // get better results by taking full control and manually creating the
+  // dispatch structures.
   constexpr Lexer::DispatchTableT DispatchTable = Lexer::MakeDispatchTable();
 
   llvm::StringRef source_text = source.text();

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -826,7 +826,7 @@ auto TokenizedBuffer::Lex(SourceBuffer& source, DiagnosticConsumer& consumer)
   // Second, with a `case`, it isn't as obvious how to create a single, uniform
   // interface that is effective for *every* byte value, and thus makes for a
   // single consistent table-based dispatch. By forcing these to be function
-  // pointers, we also coerce the code to use a strictly homogenous structure
+  // pointers, we also coerce the code to use a strictly homogeneous structure
   // that can form a single dispatch table.
   //
   // These two actually interact -- the second issue is part of what makes the

--- a/toolchain/lexer/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lexer/tokenized_buffer_benchmark.cpp
@@ -15,6 +15,117 @@
 namespace Carbon::Testing {
 namespace {
 
+auto IdentifierStartChars() -> llvm::ArrayRef<char> {
+  static llvm::SmallVector<char> chars = [] {
+    llvm::SmallVector<char> chars;
+    chars.push_back('_');
+    for (char c : llvm::seq_inclusive('A', 'Z')) {
+      chars.push_back(c);
+    }
+    for (char c : llvm::seq_inclusive('a', 'z')) {
+      chars.push_back(c);
+    }
+    return chars;
+  }();
+  return chars;
+}
+
+auto IdentifierChars() -> llvm::ArrayRef<char> {
+  static llvm::SmallVector<char> chars = [] {
+    llvm::ArrayRef<char> start_chars = IdentifierStartChars();
+    llvm::SmallVector<char> chars(start_chars.begin(), start_chars.end());
+    for (char c : llvm::seq_inclusive('0', '9')) {
+      chars.push_back(c);
+    }
+    return chars;
+  }();
+  return chars;
+}
+
+// Generates a random identifier string using the provided RNG BitGen.
+//
+// Optionally, can specify a min and max length for the generated identifier.
+//
+// Optionally, can request a uniform distribution of lengths. When this is false
+// (the default) the routine tries to generate a distribution that roughly
+// matches what we observe in C++ code.
+auto GenerateRandomIdentifier(absl::BitGen& gen, int min_length = 1,
+                              int max_length = 64, bool uniform_lengths = false)
+    -> std::string {
+  llvm::ArrayRef<char> start_chars = IdentifierStartChars();
+  llvm::ArrayRef<char> chars = IdentifierChars();
+
+  int length =
+      uniform_lengths
+          ? absl::Uniform<int>(gen, min_length, max_length)
+          // None of the Abseil distributions are *great* fits for observed data
+          // on identifier length, but log-uniform is vaguely close. A better
+          // distribution would have two peaks -- one at 1 and the other at 4,
+          // with a minor dip between and a fairly slow log-uniform falloff into
+          // the long tail. Lacking more nuanced distribution functions, we work
+          // with a basic log-uniform.
+          : absl::LogUniform<int>(gen, min_length, max_length);
+
+  std::string id_result;
+  llvm::raw_string_ostream os(id_result);
+  llvm::StringRef id;
+  do {
+    // Erase any prior attempts to find an identifier.
+    id_result.clear();
+    os << start_chars[absl::Uniform<int>(gen, 0, start_chars.size())];
+    for (int j : llvm::seq(0, length)) {
+      static_cast<void>(j);
+      os << chars[absl::Uniform<int>(gen, 0, chars.size())];
+    }
+    // Check if we ended up forming an integer type literal or a keyword, and
+    // try again.
+    id = llvm::StringRef(id_result);
+  } while (
+      llvm::any_of(TokenKind::KeywordTokens,
+                   [id](auto token) { return id == token.fixed_spelling(); }) ||
+      ((id.consume_front("i") || id.consume_front("u") ||
+        id.consume_front("f")) &&
+       llvm::all_of(id, [](const char c) { return llvm::isDigit(c); })));
+  return id_result;
+}
+
+// Build our own table of symbols so we can use repetitions to skew the
+// distribution.
+auto GetSymbolTokenTableImpl() -> llvm::SmallVector<TokenKind> {
+  llvm::SmallVector<TokenKind> table;
+#define CARBON_SYMBOL_TOKEN(TokenName, Spelling) \
+  table.push_back(TokenKind::TokenName);
+#define CARBON_OPENING_GROUP_SYMBOL_TOKEN(TokenName, Spelling, ClosingName)
+#define CARBON_CLOSING_GROUP_SYMBOL_TOKEN(TokenName, Spelling, OpeningName)
+#include "toolchain/lexer/token_kind.def"
+  table.insert(table.end(), 32, TokenKind::Semi);
+  table.insert(table.end(), 16, TokenKind::Comma);
+  table.insert(table.end(), 12, TokenKind::Period);
+  table.insert(table.end(), 8, TokenKind::Colon);
+  table.insert(table.end(), 8, TokenKind::Equal);
+  table.insert(table.end(), 4, TokenKind::Amp);
+  table.insert(table.end(), 4, TokenKind::ColonExclaim);
+  table.insert(table.end(), 4, TokenKind::EqualEqual);
+  table.insert(table.end(), 4, TokenKind::ExclaimEqual);
+  table.insert(table.end(), 4, TokenKind::MinusGreater);
+  table.insert(table.end(), 4, TokenKind::Star);
+  return table;
+}
+
+auto GetSymbolTokenTable() -> llvm::ArrayRef<TokenKind> {
+  static auto symbol_token_table_storage = GetSymbolTokenTableImpl();
+  return symbol_token_table_storage;
+}
+
+// Generate random symbols. This skews the distribution as best it can towards
+// what we expect in real world source code, but doesn't include grouping
+// symbols for simplicity.
+auto GenerateRandomSymbol(absl::BitGen& gen) -> llvm::StringRef {
+  llvm::ArrayRef<TokenKind> table = GetSymbolTokenTable();
+  auto index = absl::Uniform<int>(gen, 0, table.size());
+  return table[index].fixed_spelling();
+}
+
 class LexerBenchHelper {
  public:
   explicit LexerBenchHelper(llvm::StringRef text)
@@ -73,66 +184,60 @@ void BM_ValidKeywords(benchmark::State& state) {
 }
 BENCHMARK(BM_ValidKeywords);
 
-auto IdentifierStartChars() -> llvm::ArrayRef<char> {
-  static llvm::SmallVector<char> chars = [] {
-    llvm::SmallVector<char> chars;
-    chars.push_back('_');
-    for (char c : llvm::seq_inclusive('A', 'Z')) {
-      chars.push_back(c);
-    }
-    for (char c : llvm::seq_inclusive('a', 'z')) {
-      chars.push_back(c);
-    }
-    return chars;
-  }();
-  return chars;
-}
-
-auto IdentifierChars() -> llvm::ArrayRef<char> {
-  static llvm::SmallVector<char> chars = [] {
-    llvm::ArrayRef<char> start_chars = IdentifierStartChars();
-    llvm::SmallVector<char> chars(start_chars.begin(), start_chars.end());
-    for (char c : llvm::seq_inclusive('0', '9')) {
-      chars.push_back(c);
-    }
-    return chars;
-  }();
-  return chars;
-}
-
-void BM_ValidIdentifiers(benchmark::State& state) {
+void BM_ValidIdentifiers(benchmark::State& state, bool uniform_lengths) {
   int min_length = state.range(0);
   int max_length = state.range(1);
   absl::BitGen gen;
   std::string source;
   llvm::raw_string_ostream os(source);
   llvm::ListSeparator sep(" ");
-  for (int i : llvm::seq(0, NumTokens)) {
-    static_cast<void>(i);
-    int length = absl::Uniform<int>(absl::IntervalClosedClosed, gen, min_length,
-                                    max_length);
+  for (int i = 0; i < NumTokens; ++i) {
+    os << sep
+       << GenerateRandomIdentifier(gen, min_length, max_length,
+                                   uniform_lengths);
+  }
+
+  LexerBenchHelper helper(source);
+  for (auto _ : state) {
+    TokenizedBuffer buffer = helper.Lex();
+    CARBON_CHECK(!buffer.has_errors()) << helper.DiagnoseErrors();
+  }
+
+  state.counters["TokenRate"] = benchmark::Counter(
+      NumTokens, benchmark::Counter::kIsIterationInvariantRate);
+}
+// Benchmark the non-uniform distribution we observe in C++ code.
+BENCHMARK_CAPTURE(BM_ValidIdentifiers, Representative,
+                  /*uniform_lengths=*/false)
+    ->Args({1, 64});
+
+// Also benchmark a few uniform distribution ranges of identifier widths to
+// cover different patterns that emerge with small, medium, and longer
+// identifiers.
+BENCHMARK_CAPTURE(BM_ValidIdentifiers, Uniform,
+                  /*uniform_lengths=*/true)
+    ->Args({3, 5})
+    ->Args({3, 16})
+    ->Args({12, 64});
+
+void BM_ValidMix(benchmark::State& state) {
+  int symbol_percent = state.range(0);
+  int keyword_percent = state.range(1);
+  absl::BitGen gen;
+  std::string source;
+  llvm::raw_string_ostream os(source);
+  llvm::ListSeparator sep(" ");
+  for (int i = 0; i < NumTokens; ++i) {
     os << sep;
-    int id_start = source.size();
-    llvm::StringRef id;
-    do {
-      // Erase any prior attempts to find an identifier.
-      source.resize(id_start);
-      llvm::ArrayRef<char> start_chars = IdentifierStartChars();
-      os << start_chars[absl::Uniform<int>(gen, 0, start_chars.size())];
-      llvm::ArrayRef<char> chars = IdentifierChars();
-      for (int j : llvm::seq(0, length)) {
-        static_cast<void>(j);
-        os << chars[absl::Uniform<int>(gen, 0, chars.size())];
-      }
-      // Check if we ended up forming an integer type literal or a keyword, and
-      // try again.
-      id = llvm::StringRef(source).substr(id_start);
-    } while (llvm::any_of(
-                 TokenKind::KeywordTokens,
-                 [id](auto token) { return id == token.fixed_spelling(); }) ||
-             ((id.consume_front("i") || id.consume_front("u") ||
-               id.consume_front("f")) &&
-              llvm::all_of(id, [](const char c) { return llvm::isDigit(c); })));
+    int percent_bucket = absl::Uniform<int>(gen, 0, 100);
+    if (percent_bucket < symbol_percent) {
+      os << GenerateRandomSymbol(gen);
+    } else if (percent_bucket < symbol_percent + keyword_percent) {
+      int index = absl::Uniform<int>(gen, 0, TokenKind::KeywordTokens.size());
+      os << TokenKind::KeywordTokens[index].fixed_spelling();
+    } else {
+      os << GenerateRandomIdentifier(gen);
+    }
   }
 
   LexerBenchHelper helper(source);
@@ -147,13 +252,15 @@ void BM_ValidIdentifiers(benchmark::State& state) {
   state.counters["TokenRate"] = benchmark::Counter(
       NumTokens, benchmark::Counter::kIsIterationInvariantRate);
 }
-BENCHMARK(BM_ValidIdentifiers)
-    // Benchmark a few ranges of identifier widths to cover different patterns
-    // that emerge with small, medium, and longer identifiers.
-    ->Args({1, 3})
-    ->Args({3, 5})
-    ->Args({3, 16})
-    ->Args({12, 64});
+// The distributions between symbols, keywords, and identifiers here are
+// guesses. Eventually, we should collect more data to help tune these, but
+// hopefully the performance isn't too sensitive and we can just cover a wide
+// range here.
+BENCHMARK(BM_ValidMix)
+    ->Args({10, 40})
+    ->Args({25, 30})
+    ->Args({50, 20})
+    ->Args({75, 10});
 
 }  // namespace
 }  // namespace Carbon::Testing


### PR DESCRIPTION
Previously, the code would try each form of lexing and let that
sub-lexing routine reject the code. This was very branch heavy and also
hard to optimize -- lots of hard to inline function calls, etc.

However, it's really nice to keep the different categories of lexing
broken out into their own functions rather than flattening this into
a huge state machine.

So this creates a miniature explicit state machine by building a table
of function pointers that wrap the methods on the lexer. The main lexing
loop simply indexes this table with the first byte of the source code,
and calls the dispatch function pointer returned.

The result is that the main lex loop is *incredibly* tight code, and the
only time spent appears to be stalls waiting on memory for the next
byte. =]

As part of this, optimize symbol lexing specifically by recognizing all
the symbols that are exactly one character -- IE, we don't even need to
look at the *next* character, there is no max-munch or anything else.
For these, we pre-detect the exact token kind and hand that into the
symbol lexing routine to avoid re-computing it. The symbols in this
category are really frequent symbols in practice like `,` and `;`, so
this seems likely worthwhile in practice.

The one-byte-dispatch should also be reasonably extendable in the
future. For example, I suspect this is the likely hot-path for non-ASCII
lexing, where we see the UTF-8 marker at the start of a token and most
(if not all) of the token is non-ASCII. We can use this table to
dispatch immediately to an optimized routine dedicated to UTF-8
processing, without any slowdown for other inputs.

The benchmark results are best for keyword lexing because that is the
fastest thing to lex -- it goes form 25 mt/s to 30 mt/s. Other
improvements are less dramatic, but I think this is still worthwhile
because it gives a really strong basis for both expanded functionality
without performance hit and further optimizations.
