### PR TITLE
Use `memcpy` for memory-to-memory assignment.

### DIFF
--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -79,8 +79,38 @@ auto LoweringHandleArrayValue(LoweringFunctionContext& context,
 auto LoweringHandleAssign(LoweringFunctionContext& context,
                           SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
   auto [storage_id, value_id] = node.GetAsAssign();
-  context.builder().CreateStore(context.GetLocalLoaded(value_id),
-                                context.GetLocal(storage_id));
+  auto storage_type_id = context.semantics_ir().GetNode(storage_id).type_id();
+
+  // We can assign from either a value expression or a by-copy initializing
+  // expression. In either case, the value of the source is the value
+  // representation of the target.
+  // TODO: Should we use different semantic nodes for those operations?
+  switch (auto rep = SemIR::GetValueRepresentation(context.semantics_ir(),
+                                                   storage_type_id);
+          rep.kind) {
+    case SemIR::ValueRepresentation::None:
+      break;
+    case SemIR::ValueRepresentation::Copy:
+      context.builder().CreateStore(context.GetLocalLoaded(value_id),
+                                    context.GetLocal(storage_id));
+      break;
+    case SemIR::ValueRepresentation::Pointer: {
+      auto& layout = context.llvm_module().getDataLayout();
+      auto* type = context.GetType(storage_type_id);
+      auto size = layout.getTypeAllocSize(type);
+      // TODO: Compute known alignment of the source and destination, which may
+      // be greater than the alignment computed by LLVM.
+      auto align = layout.getABITypeAlign(type);
+
+      // TODO: Attach !tbaa.struct metadata indicating which portions of the
+      // type we actually need to copy and which are padding.
+      context.builder().CreateMemCpy(context.GetLocal(storage_id), align,
+                                     context.GetLocal(value_id), align, size);
+      break;
+    }
+    case SemIR::ValueRepresentation::Custom:
+      CARBON_FATAL() << "TODO: Add support for Assign with custom value rep";
+  }
 }
 
 auto LoweringHandleBinaryOperatorAdd(LoweringFunctionContext& /*context*/,

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -97,7 +97,6 @@ auto LoweringHandleAssign(LoweringFunctionContext& context,
     case SemIR::ValueRepresentation::Pointer: {
       auto& layout = context.llvm_module().getDataLayout();
       auto* type = context.GetType(storage_type_id);
-      auto size = layout.getTypeAllocSize(type);
       // TODO: Compute known alignment of the source and destination, which may
       // be greater than the alignment computed by LLVM.
       auto align = layout.getABITypeAlign(type);
@@ -105,7 +104,8 @@ auto LoweringHandleAssign(LoweringFunctionContext& context,
       // TODO: Attach !tbaa.struct metadata indicating which portions of the
       // type we actually need to copy and which are padding.
       context.builder().CreateMemCpy(context.GetLocal(storage_id), align,
-                                     context.GetLocal(value_id), align, size);
+                                     context.GetLocal(value_id), align,
+                                     layout.getTypeAllocSize(type));
       break;
     }
     case SemIR::ValueRepresentation::Custom:

--- a/toolchain/lowering/testdata/array/assign_return_value.carbon
+++ b/toolchain/lowering/testdata/array/assign_return_value.carbon
@@ -19,8 +19,7 @@ fn Run() {
 // CHECK:STDOUT:   store i32 12, ptr %1, align 4
 // CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32 }, ptr %tuple, i32 0, i32 1
 // CHECK:STDOUT:   store i32 24, ptr %2, align 4
-// CHECK:STDOUT:   %3 = load { i32, i32 }, ptr %tuple, align 4
-// CHECK:STDOUT:   store { i32, i32 } %3, ptr %return, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 %tuple, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -36,7 +35,14 @@ fn Run() {
 // CHECK:STDOUT:   %array.element1 = extractvalue { i32, i32 } %1, 1
 // CHECK:STDOUT:   %3 = getelementptr inbounds [2 x i32], ptr %array, i32 0, i32 1
 // CHECK:STDOUT:   store i32 %array.element1, ptr %3, align 4
-// CHECK:STDOUT:   %4 = load [2 x i32], ptr %array, align 4
-// CHECK:STDOUT:   store [2 x i32] %4, ptr %t, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %t, ptr align 4 %array, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/array/base.carbon
+++ b/toolchain/lowering/testdata/array/base.carbon
@@ -27,25 +27,23 @@ fn Run() {
 // CHECK:STDOUT:   %2 = load i32, ptr %array.element, align 4
 // CHECK:STDOUT:   %3 = getelementptr inbounds [1 x i32], ptr %array, i32 0, i32 0
 // CHECK:STDOUT:   store i32 %2, ptr %3, align 4
-// CHECK:STDOUT:   %4 = load [1 x i32], ptr %array, align 4
-// CHECK:STDOUT:   store [1 x i32] %4, ptr %a, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %array, i64 4, i1 false)
 // CHECK:STDOUT:   %b = alloca [2 x double], align 8
 // CHECK:STDOUT:   %tuple1 = alloca { double, double }, align 8
-// CHECK:STDOUT:   %5 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 0
-// CHECK:STDOUT:   store double 0x4026333333333334, ptr %5, align 8
-// CHECK:STDOUT:   %6 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 1
-// CHECK:STDOUT:   store double 2.200000e+00, ptr %6, align 8
+// CHECK:STDOUT:   %4 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 0
+// CHECK:STDOUT:   store double 0x4026333333333334, ptr %4, align 8
+// CHECK:STDOUT:   %5 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 1
+// CHECK:STDOUT:   store double 2.200000e+00, ptr %5, align 8
 // CHECK:STDOUT:   %array2 = alloca [2 x double], align 8
 // CHECK:STDOUT:   %array.element3 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 0
-// CHECK:STDOUT:   %7 = load double, ptr %array.element3, align 8
-// CHECK:STDOUT:   %8 = getelementptr inbounds [2 x double], ptr %array2, i32 0, i32 0
-// CHECK:STDOUT:   store double %7, ptr %8, align 8
+// CHECK:STDOUT:   %6 = load double, ptr %array.element3, align 8
+// CHECK:STDOUT:   %7 = getelementptr inbounds [2 x double], ptr %array2, i32 0, i32 0
+// CHECK:STDOUT:   store double %6, ptr %7, align 8
 // CHECK:STDOUT:   %array.element4 = getelementptr inbounds { double, double }, ptr %tuple1, i32 0, i32 1
-// CHECK:STDOUT:   %9 = load double, ptr %array.element4, align 8
-// CHECK:STDOUT:   %10 = getelementptr inbounds [2 x double], ptr %array2, i32 0, i32 1
-// CHECK:STDOUT:   store double %9, ptr %10, align 8
-// CHECK:STDOUT:   %11 = load [2 x double], ptr %array2, align 8
-// CHECK:STDOUT:   store [2 x double] %11, ptr %b, align 8
+// CHECK:STDOUT:   %8 = load double, ptr %array.element4, align 8
+// CHECK:STDOUT:   %9 = getelementptr inbounds [2 x double], ptr %array2, i32 0, i32 1
+// CHECK:STDOUT:   store double %8, ptr %9, align 8
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b, ptr align 8 %array2, i64 16, i1 false)
 // CHECK:STDOUT:   %tuple5 = alloca {}, align 8
 // CHECK:STDOUT:   %c = alloca [5 x {}], align 8
 // CHECK:STDOUT:   %tuple6 = alloca {}, align 8
@@ -54,69 +52,74 @@ fn Run() {
 // CHECK:STDOUT:   %tuple9 = alloca {}, align 8
 // CHECK:STDOUT:   %tuple10 = alloca {}, align 8
 // CHECK:STDOUT:   %tuple11 = alloca { {}, {}, {}, {}, {} }, align 8
-// CHECK:STDOUT:   %12 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 0
-// CHECK:STDOUT:   store ptr %tuple6, ptr %12, align 8
-// CHECK:STDOUT:   %13 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 1
-// CHECK:STDOUT:   store ptr %tuple7, ptr %13, align 8
-// CHECK:STDOUT:   %14 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 2
-// CHECK:STDOUT:   store ptr %tuple8, ptr %14, align 8
-// CHECK:STDOUT:   %15 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 3
-// CHECK:STDOUT:   store ptr %tuple9, ptr %15, align 8
-// CHECK:STDOUT:   %16 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 4
-// CHECK:STDOUT:   store ptr %tuple10, ptr %16, align 8
+// CHECK:STDOUT:   %10 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 0
+// CHECK:STDOUT:   store ptr %tuple6, ptr %10, align 8
+// CHECK:STDOUT:   %11 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 1
+// CHECK:STDOUT:   store ptr %tuple7, ptr %11, align 8
+// CHECK:STDOUT:   %12 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 2
+// CHECK:STDOUT:   store ptr %tuple8, ptr %12, align 8
+// CHECK:STDOUT:   %13 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 3
+// CHECK:STDOUT:   store ptr %tuple9, ptr %13, align 8
+// CHECK:STDOUT:   %14 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 4
+// CHECK:STDOUT:   store ptr %tuple10, ptr %14, align 8
 // CHECK:STDOUT:   %array12 = alloca [5 x {}], align 8
 // CHECK:STDOUT:   %array.element13 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 0
-// CHECK:STDOUT:   %17 = load {}, ptr %array.element13, align 1
-// CHECK:STDOUT:   %18 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 0
-// CHECK:STDOUT:   store {} %17, ptr %18, align 1
+// CHECK:STDOUT:   %15 = load {}, ptr %array.element13, align 1
+// CHECK:STDOUT:   %16 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 0
+// CHECK:STDOUT:   store {} %15, ptr %16, align 1
 // CHECK:STDOUT:   %array.element14 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 1
-// CHECK:STDOUT:   %19 = load {}, ptr %array.element14, align 1
-// CHECK:STDOUT:   %20 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 1
-// CHECK:STDOUT:   store {} %19, ptr %20, align 1
+// CHECK:STDOUT:   %17 = load {}, ptr %array.element14, align 1
+// CHECK:STDOUT:   %18 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 1
+// CHECK:STDOUT:   store {} %17, ptr %18, align 1
 // CHECK:STDOUT:   %array.element15 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 2
-// CHECK:STDOUT:   %21 = load {}, ptr %array.element15, align 1
-// CHECK:STDOUT:   %22 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 2
-// CHECK:STDOUT:   store {} %21, ptr %22, align 1
+// CHECK:STDOUT:   %19 = load {}, ptr %array.element15, align 1
+// CHECK:STDOUT:   %20 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 2
+// CHECK:STDOUT:   store {} %19, ptr %20, align 1
 // CHECK:STDOUT:   %array.element16 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 3
-// CHECK:STDOUT:   %23 = load {}, ptr %array.element16, align 1
-// CHECK:STDOUT:   %24 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 3
-// CHECK:STDOUT:   store {} %23, ptr %24, align 1
+// CHECK:STDOUT:   %21 = load {}, ptr %array.element16, align 1
+// CHECK:STDOUT:   %22 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 3
+// CHECK:STDOUT:   store {} %21, ptr %22, align 1
 // CHECK:STDOUT:   %array.element17 = getelementptr inbounds { {}, {}, {}, {}, {} }, ptr %tuple11, i32 0, i32 4
-// CHECK:STDOUT:   %25 = load {}, ptr %array.element17, align 1
-// CHECK:STDOUT:   %26 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 4
-// CHECK:STDOUT:   store {} %25, ptr %26, align 1
-// CHECK:STDOUT:   %27 = load [5 x {}], ptr %array12, align 1
-// CHECK:STDOUT:   store [5 x {}] %27, ptr %c, align 1
+// CHECK:STDOUT:   %23 = load {}, ptr %array.element17, align 1
+// CHECK:STDOUT:   %24 = getelementptr inbounds [5 x {}], ptr %array12, i32 0, i32 4
+// CHECK:STDOUT:   store {} %23, ptr %24, align 1
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c, ptr align 1 %array12, i64 0, i1 false)
 // CHECK:STDOUT:   %tuple18 = alloca { %type, %type, %type }, align 8
-// CHECK:STDOUT:   %28 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 0
-// CHECK:STDOUT:   store %type zeroinitializer, ptr %28, align 1
-// CHECK:STDOUT:   %29 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 1
-// CHECK:STDOUT:   store %type zeroinitializer, ptr %29, align 1
-// CHECK:STDOUT:   %30 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 2
-// CHECK:STDOUT:   store %type zeroinitializer, ptr %30, align 1
+// CHECK:STDOUT:   %25 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 0
+// CHECK:STDOUT:   store %type zeroinitializer, ptr %25, align 1
+// CHECK:STDOUT:   %26 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 1
+// CHECK:STDOUT:   store %type zeroinitializer, ptr %26, align 1
+// CHECK:STDOUT:   %27 = getelementptr inbounds { %type, %type, %type }, ptr %tuple18, i32 0, i32 2
+// CHECK:STDOUT:   store %type zeroinitializer, ptr %27, align 1
 // CHECK:STDOUT:   %d = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   %tuple19 = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   %31 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 0
-// CHECK:STDOUT:   store i32 1, ptr %31, align 4
-// CHECK:STDOUT:   %32 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 1
-// CHECK:STDOUT:   store i32 2, ptr %32, align 4
-// CHECK:STDOUT:   %33 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 2
-// CHECK:STDOUT:   store i32 3, ptr %33, align 4
-// CHECK:STDOUT:   %34 = load { i32, i32, i32 }, ptr %tuple19, align 4
-// CHECK:STDOUT:   store { i32, i32, i32 } %34, ptr %d, align 4
+// CHECK:STDOUT:   %28 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 0
+// CHECK:STDOUT:   store i32 1, ptr %28, align 4
+// CHECK:STDOUT:   %29 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 1
+// CHECK:STDOUT:   store i32 2, ptr %29, align 4
+// CHECK:STDOUT:   %30 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple19, i32 0, i32 2
+// CHECK:STDOUT:   store i32 3, ptr %30, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d, ptr align 4 %tuple19, i64 12, i1 false)
 // CHECK:STDOUT:   %e = alloca [3 x i32], align 4
-// CHECK:STDOUT:   %35 = load { i32, i32, i32 }, ptr %d, align 4
+// CHECK:STDOUT:   %31 = load { i32, i32, i32 }, ptr %d, align 4
 // CHECK:STDOUT:   %array20 = alloca [3 x i32], align 4
-// CHECK:STDOUT:   %array.element21 = extractvalue { i32, i32, i32 } %35, 0
-// CHECK:STDOUT:   %36 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %array.element21, ptr %36, align 4
-// CHECK:STDOUT:   %array.element22 = extractvalue { i32, i32, i32 } %35, 1
-// CHECK:STDOUT:   %37 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %array.element22, ptr %37, align 4
-// CHECK:STDOUT:   %array.element23 = extractvalue { i32, i32, i32 } %35, 2
-// CHECK:STDOUT:   %38 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 2
-// CHECK:STDOUT:   store i32 %array.element23, ptr %38, align 4
-// CHECK:STDOUT:   %39 = load [3 x i32], ptr %array20, align 4
-// CHECK:STDOUT:   store [3 x i32] %39, ptr %e, align 4
+// CHECK:STDOUT:   %array.element21 = extractvalue { i32, i32, i32 } %31, 0
+// CHECK:STDOUT:   %32 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %array.element21, ptr %32, align 4
+// CHECK:STDOUT:   %array.element22 = extractvalue { i32, i32, i32 } %31, 1
+// CHECK:STDOUT:   %33 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %array.element22, ptr %33, align 4
+// CHECK:STDOUT:   %array.element23 = extractvalue { i32, i32, i32 } %31, 2
+// CHECK:STDOUT:   %34 = getelementptr inbounds [3 x i32], ptr %array20, i32 0, i32 2
+// CHECK:STDOUT:   store i32 %array.element23, ptr %34, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %e, ptr align 4 %array20, i64 12, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 4, 3, 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/index/array_element_access.carbon
+++ b/toolchain/lowering/testdata/index/array_element_access.carbon
@@ -23,8 +23,7 @@ fn Run() {
 // CHECK:STDOUT:   store i32 1, ptr %1, align 4
 // CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32 }, ptr %tuple, i32 0, i32 1
 // CHECK:STDOUT:   store i32 2, ptr %2, align 4
-// CHECK:STDOUT:   %3 = load { i32, i32 }, ptr %tuple, align 4
-// CHECK:STDOUT:   store { i32, i32 } %3, ptr %return, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 %tuple, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -43,8 +42,7 @@ fn Run() {
 // CHECK:STDOUT:   %5 = load i32, ptr %array.element1, align 4
 // CHECK:STDOUT:   %6 = getelementptr inbounds [2 x i32], ptr %array, i32 0, i32 1
 // CHECK:STDOUT:   store i32 %5, ptr %6, align 4
-// CHECK:STDOUT:   %7 = load [2 x i32], ptr %array, align 4
-// CHECK:STDOUT:   store [2 x i32] %7, ptr %return, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 %array, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -60,24 +58,31 @@ fn Run() {
 // CHECK:STDOUT:   %array.element1 = extractvalue { i32, i32 } %1, 1
 // CHECK:STDOUT:   %3 = getelementptr inbounds [2 x i32], ptr %array, i32 0, i32 1
 // CHECK:STDOUT:   store i32 %array.element1, ptr %3, align 4
-// CHECK:STDOUT:   %4 = load [2 x i32], ptr %array, align 4
-// CHECK:STDOUT:   store [2 x i32] %4, ptr %a, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %array, i64 8, i1 false)
 // CHECK:STDOUT:   %b = alloca i32, align 4
 // CHECK:STDOUT:   %temp2 = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   call void @A(ptr %temp2)
 // CHECK:STDOUT:   %tuple.index = getelementptr inbounds { i32, i32 }, ptr %temp2, i32 0, i32 0
-// CHECK:STDOUT:   %5 = load i32, ptr %tuple.index, align 4
-// CHECK:STDOUT:   store i32 %5, ptr %b, align 4
+// CHECK:STDOUT:   %4 = load i32, ptr %tuple.index, align 4
+// CHECK:STDOUT:   store i32 %4, ptr %b, align 4
 // CHECK:STDOUT:   %c = alloca i32, align 4
-// CHECK:STDOUT:   %6 = load i32, ptr %b, align 4
-// CHECK:STDOUT:   %array.index = getelementptr inbounds [2 x i32], ptr %a, i32 %6
-// CHECK:STDOUT:   %7 = load i32, ptr %array.index, align 4
-// CHECK:STDOUT:   store i32 %7, ptr %c, align 4
+// CHECK:STDOUT:   %5 = load i32, ptr %b, align 4
+// CHECK:STDOUT:   %array.index = getelementptr inbounds [2 x i32], ptr %a, i32 %5
+// CHECK:STDOUT:   %6 = load i32, ptr %array.index, align 4
+// CHECK:STDOUT:   store i32 %6, ptr %c, align 4
 // CHECK:STDOUT:   %d = alloca i32, align 4
 // CHECK:STDOUT:   %temp3 = alloca [2 x i32], align 4
 // CHECK:STDOUT:   call void @B(ptr %temp3)
 // CHECK:STDOUT:   %array.index4 = getelementptr inbounds [2 x i32], ptr %temp3, i32 0, i32 1
-// CHECK:STDOUT:   %8 = load i32, ptr %array.index4, align 4
-// CHECK:STDOUT:   store i32 %8, ptr %d, align 4
+// CHECK:STDOUT:   %7 = load i32, ptr %array.index4, align 4
+// CHECK:STDOUT:   store i32 %7, ptr %d, align 4
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/index/tuple_element_access.carbon
+++ b/toolchain/lowering/testdata/index/tuple_element_access.carbon
@@ -32,15 +32,19 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   store i32 1, ptr %5, align 4
 // CHECK:STDOUT:   %6 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple1, i32 0, i32 2
 // CHECK:STDOUT:   store i32 2, ptr %6, align 4
-// CHECK:STDOUT:   %7 = load { i32, i32, i32 }, ptr %tuple1, align 4
-// CHECK:STDOUT:   store { i32, i32, i32 } %7, ptr %a, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %tuple1, i64 12, i1 false)
 // CHECK:STDOUT:   %b = alloca i32, align 4
 // CHECK:STDOUT:   %tuple.index = getelementptr inbounds { i32, i32, i32 }, ptr %a, i32 0, i32 0
-// CHECK:STDOUT:   %8 = load i32, ptr %tuple.index, align 4
-// CHECK:STDOUT:   store i32 %8, ptr %b, align 4
+// CHECK:STDOUT:   %7 = load i32, ptr %tuple.index, align 4
+// CHECK:STDOUT:   store i32 %7, ptr %b, align 4
 // CHECK:STDOUT:   %c = alloca i32, align 4
 // CHECK:STDOUT:   %tuple.index2 = getelementptr inbounds { i32, i32, i32 }, ptr %a, i32 0, i32 2
-// CHECK:STDOUT:   %9 = load i32, ptr %tuple.index2, align 4
-// CHECK:STDOUT:   store i32 %9, ptr %c, align 4
+// CHECK:STDOUT:   %8 = load i32, ptr %tuple.index2, align 4
+// CHECK:STDOUT:   store i32 %8, ptr %c, align 4
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/lowering/testdata/index/tuple_return_value_access.carbon
@@ -19,8 +19,7 @@ fn Run() {
 // CHECK:STDOUT:   store i32 12, ptr %1, align 4
 // CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32 }, ptr %tuple, i32 0, i32 1
 // CHECK:STDOUT:   store i32 24, ptr %2, align 4
-// CHECK:STDOUT:   %3 = load { i32, i32 }, ptr %tuple, align 4
-// CHECK:STDOUT:   store { i32, i32 } %3, ptr %return, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 %tuple, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -33,3 +32,8 @@ fn Run() {
 // CHECK:STDOUT:   store i32 %1, ptr %t, align 4
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/operators/assignment.carbon
+++ b/toolchain/lowering/testdata/operators/assignment.carbon
@@ -31,7 +31,11 @@ fn Main() {
 // CHECK:STDOUT:   store i32 1, ptr %3, align 4
 // CHECK:STDOUT:   %4 = getelementptr inbounds { i32, i32 }, ptr %tuple1, i32 0, i32 1
 // CHECK:STDOUT:   store i32 2, ptr %4, align 4
-// CHECK:STDOUT:   %5 = load { i32, i32 }, ptr %tuple1, align 4
-// CHECK:STDOUT:   store { i32, i32 } %5, ptr %b, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b, ptr align 4 %tuple1, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/pointer/address_of_field.carbon
+++ b/toolchain/lowering/testdata/pointer/address_of_field.carbon
@@ -24,10 +24,14 @@ fn F() {
 // CHECK:STDOUT:   store i32 1, ptr %a, align 4
 // CHECK:STDOUT:   %b = getelementptr inbounds { i32, i32 }, ptr %struct, i32 0, i32 1
 // CHECK:STDOUT:   store i32 2, ptr %b, align 4
-// CHECK:STDOUT:   %1 = load { i32, i32 }, ptr %struct, align 4
-// CHECK:STDOUT:   store { i32, i32 } %1, ptr %s, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %s, ptr align 4 %struct, i64 8, i1 false)
 // CHECK:STDOUT:   %b1 = getelementptr inbounds { i32, i32 }, ptr %s, i32 0, i32 1
-// CHECK:STDOUT:   %2 = load ptr, ptr %b1, align 8
-// CHECK:STDOUT:   call void @G(ptr %2)
+// CHECK:STDOUT:   %1 = load ptr, ptr %b1, align 8
+// CHECK:STDOUT:   call void @G(ptr %1)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/struct/empty.carbon
+++ b/toolchain/lowering/testdata/struct/empty.carbon
@@ -17,11 +17,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %struct = alloca {}, align 8
 // CHECK:STDOUT:   %x = alloca {}, align 8
 // CHECK:STDOUT:   %struct1 = alloca {}, align 8
-// CHECK:STDOUT:   %1 = load {}, ptr %struct1, align 1
-// CHECK:STDOUT:   store {} %1, ptr %x, align 1
 // CHECK:STDOUT:   %struct2 = alloca {}, align 8
 // CHECK:STDOUT:   %y = alloca {}, align 8
-// CHECK:STDOUT:   %2 = load {}, ptr %x, align 1
-// CHECK:STDOUT:   store {} %2, ptr %y, align 1
+// CHECK:STDOUT:   %1 = load {}, ptr %x, align 1
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/struct/member_access.carbon
+++ b/toolchain/lowering/testdata/struct/member_access.carbon
@@ -21,14 +21,18 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   store double 0.000000e+00, ptr %a, align 8
 // CHECK:STDOUT:   %b = getelementptr inbounds { double, i32 }, ptr %struct, i32 0, i32 1
 // CHECK:STDOUT:   store i32 1, ptr %b, align 4
-// CHECK:STDOUT:   %1 = load { double, i32 }, ptr %struct, align 8
-// CHECK:STDOUT:   store { double, i32 } %1, ptr %x, align 8
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %x, ptr align 8 %struct, i64 16, i1 false)
 // CHECK:STDOUT:   %y = alloca i32, align 4
 // CHECK:STDOUT:   %b1 = getelementptr inbounds { double, i32 }, ptr %x, i32 0, i32 1
-// CHECK:STDOUT:   %2 = load i32, ptr %b1, align 4
-// CHECK:STDOUT:   store i32 %2, ptr %y, align 4
+// CHECK:STDOUT:   %1 = load i32, ptr %b1, align 4
+// CHECK:STDOUT:   store i32 %1, ptr %y, align 4
 // CHECK:STDOUT:   %z = alloca i32, align 4
-// CHECK:STDOUT:   %3 = load i32, ptr %y, align 4
-// CHECK:STDOUT:   store i32 %3, ptr %z, align 4
+// CHECK:STDOUT:   %2 = load i32, ptr %y, align 4
+// CHECK:STDOUT:   store i32 %2, ptr %z, align 4
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/struct/two_entries.carbon
+++ b/toolchain/lowering/testdata/struct/two_entries.carbon
@@ -20,10 +20,17 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   store i32 1, ptr %a, align 4
 // CHECK:STDOUT:   %b = getelementptr inbounds { i32, i32 }, ptr %struct, i32 0, i32 1
 // CHECK:STDOUT:   store i32 2, ptr %b, align 4
-// CHECK:STDOUT:   %1 = load { i32, i32 }, ptr %struct, align 4
-// CHECK:STDOUT:   store { i32, i32 } %1, ptr %x, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x, ptr align 4 %struct, i64 8, i1 false)
 // CHECK:STDOUT:   %y = alloca { i32, i32 }, align 8
-// CHECK:STDOUT:   %2 = load { i32, i32 }, ptr %x, align 4
-// CHECK:STDOUT:   store { i32, i32 } %2, ptr %y, align 4
+// CHECK:STDOUT:   %1 = load { i32, i32 }, ptr %x, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.sl_i32i32s.i64(ptr align 4 %y, { i32, i32 } align 4 %1, i64 8, i1 false)
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.sl_i32i32s.i64(ptr noalias nocapture writeonly, { i32, i32 } noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/tuple/empty.carbon
+++ b/toolchain/lowering/testdata/tuple/empty.carbon
@@ -17,11 +17,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %tuple = alloca {}, align 8
 // CHECK:STDOUT:   %x = alloca {}, align 8
 // CHECK:STDOUT:   %tuple1 = alloca {}, align 8
-// CHECK:STDOUT:   %1 = load {}, ptr %tuple1, align 1
-// CHECK:STDOUT:   store {} %1, ptr %x, align 1
 // CHECK:STDOUT:   %tuple2 = alloca {}, align 8
 // CHECK:STDOUT:   %y = alloca {}, align 8
-// CHECK:STDOUT:   %2 = load {}, ptr %x, align 1
-// CHECK:STDOUT:   store {} %2, ptr %y, align 1
+// CHECK:STDOUT:   %1 = load {}, ptr %x, align 1
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/tuple/two_entries.carbon
+++ b/toolchain/lowering/testdata/tuple/two_entries.carbon
@@ -27,15 +27,22 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   store i32 12, ptr %3, align 4
 // CHECK:STDOUT:   %4 = getelementptr inbounds { i32, i32 }, ptr %tuple1, i32 0, i32 1
 // CHECK:STDOUT:   store i32 7, ptr %4, align 4
-// CHECK:STDOUT:   %5 = load { i32, i32 }, ptr %tuple1, align 4
-// CHECK:STDOUT:   store { i32, i32 } %5, ptr %x, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x, ptr align 4 %tuple1, i64 8, i1 false)
 // CHECK:STDOUT:   %tuple2 = alloca { %type, %type }, align 8
-// CHECK:STDOUT:   %6 = getelementptr inbounds { %type, %type }, ptr %tuple2, i32 0, i32 0
+// CHECK:STDOUT:   %5 = getelementptr inbounds { %type, %type }, ptr %tuple2, i32 0, i32 0
+// CHECK:STDOUT:   store %type zeroinitializer, ptr %5, align 1
+// CHECK:STDOUT:   %6 = getelementptr inbounds { %type, %type }, ptr %tuple2, i32 0, i32 1
 // CHECK:STDOUT:   store %type zeroinitializer, ptr %6, align 1
-// CHECK:STDOUT:   %7 = getelementptr inbounds { %type, %type }, ptr %tuple2, i32 0, i32 1
-// CHECK:STDOUT:   store %type zeroinitializer, ptr %7, align 1
 // CHECK:STDOUT:   %y = alloca { i32, i32 }, align 8
-// CHECK:STDOUT:   %8 = load { i32, i32 }, ptr %x, align 4
-// CHECK:STDOUT:   store { i32, i32 } %8, ptr %y, align 4
+// CHECK:STDOUT:   %7 = load { i32, i32 }, ptr %x, align 4
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.sl_i32i32s.i64(ptr align 4 %y, { i32, i32 } align 4 %7, i64 8, i1 false)
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.sl_i32i32s.i64(ptr noalias nocapture writeonly, { i32, i32 } noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }


### PR DESCRIPTION
For types using a pointer value representation, emit an `llvm.memcpy` call to perform assignment rather performing a first-class aggregate load and store.