### PR TITLE
Take value representation into account when lowering functions and calls.

### DIFF
--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -59,6 +59,7 @@ auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
     -> llvm::Function* {
   const auto& function = semantics_ir().GetFunction(function_id);
   const bool has_return_slot = function.return_slot_id.is_valid();
+  auto& param_refs = semantics_ir().GetNodeBlock(function.param_refs_id);
 
   SemIR::InitializingRepresentation return_rep =
       function.return_type_id.is_valid()
@@ -68,18 +69,20 @@ auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
                 .kind = SemIR::InitializingRepresentation::None};
   CARBON_CHECK(return_rep.has_return_slot() == has_return_slot);
 
-  // TODO: Lower type information for the arguments prior to building args.
-  auto param_refs = semantics_ir().GetNodeBlock(function.param_refs_id);
-  llvm::SmallVector<llvm::Type*> args;
-  llvm::SmallVector<SemIR::NodeId> param_nodes;
-  args.reserve(has_return_slot + param_refs.size());
-  param_nodes.reserve(has_return_slot + param_refs.size());
+  llvm::SmallVector<llvm::Type*> param_types;
+  // TODO: Consider either storing `param_node_ids` somewhere so that we can
+  // reuse it from `BuildFunctionDefinition` and when building calls, or factor
+  // out a mechanism to compute the mapping between parameters and arguments on
+  // demand.
+  llvm::SmallVector<SemIR::NodeId> param_node_ids;
+  param_types.reserve(has_return_slot + param_refs.size());
+  param_node_ids.reserve(has_return_slot + param_refs.size());
   if (has_return_slot) {
-    args.push_back(GetType(function.return_type_id)->getPointerTo());
-    param_nodes.push_back(function.return_slot_id);
+    param_types.push_back(GetType(function.return_type_id)->getPointerTo());
+    param_node_ids.push_back(function.return_slot_id);
   }
-  for (auto [i, param_ref] : llvm::enumerate(param_refs)) {
-    auto param_type_id = semantics_ir().GetNode(param_ref).type_id();
+  for (auto param_ref_id : param_refs) {
+    auto param_type_id = semantics_ir().GetNode(param_ref_id).type_id();
     switch (auto value_rep =
                 SemIR::GetValueRepresentation(semantics_ir(), param_type_id);
             value_rep.kind) {
@@ -87,12 +90,12 @@ auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
         break;
       case SemIR::ValueRepresentation::Copy:
       case SemIR::ValueRepresentation::Custom:
-        args.push_back(GetType(value_rep.type));
-        param_nodes.push_back(param_ref);
+        param_types.push_back(GetType(value_rep.type));
+        param_node_ids.push_back(param_ref_id);
         break;
       case SemIR::ValueRepresentation::Pointer:
-        args.push_back(GetType(value_rep.type)->getPointerTo());
-        param_nodes.push_back(param_ref);
+        param_types.push_back(GetType(value_rep.type)->getPointerTo());
+        param_node_ids.push_back(param_ref_id);
         break;
     }
   }
@@ -105,22 +108,21 @@ auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
           : llvm::Type::getVoidTy(llvm_context());
 
   llvm::FunctionType* function_type =
-      llvm::FunctionType::get(return_type, args, /*isVarArg=*/false);
+      llvm::FunctionType::get(return_type, param_types, /*isVarArg=*/false);
   auto* llvm_function = llvm::Function::Create(
       function_type, llvm::Function::ExternalLinkage,
       semantics_ir().GetString(function.name_id), llvm_module());
 
-  // Set up parameters.
-  for (auto [i, node_id, arg] : llvm::enumerate(
-           param_nodes,
-           map_range(llvm_function->args(), [](auto& arg) { return &arg; }))) {
-    auto node = semantics_ir().GetNode(node_id);
-    if (node.kind() == SemIR::NodeKind::Parameter) {
-      arg->setName(semantics_ir().GetString(node.GetAsParameter()));
-    } else if (node_id == function.return_slot_id) {
-      arg->setName("return");
-      arg->addAttr(llvm::Attribute::getWithStructRetType(
+  // Set up parameters and the return slot.
+  for (auto [node_id, arg] :
+       llvm::zip_equal(param_node_ids, llvm_function->args())) {
+    if (node_id == function.return_slot_id) {
+      arg.setName("return");
+      arg.addAttr(llvm::Attribute::getWithStructRetType(
           llvm_context(), GetType(function.return_type_id)));
+    } else {
+      arg.setName(semantics_ir().GetString(
+          semantics_ir().GetNode(node_id).GetAsParameter()));
     }
   }
 
@@ -145,21 +147,23 @@ auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   // TODO: This duplicates the mapping between semantics nodes and LLVM
   // function parameters that was already computed in BuildFunctionDeclaration.
   // We should only do that once.
-  auto param_refs = semantics_ir().GetNodeBlock(function.param_refs_id);
+  auto& param_refs = semantics_ir().GetNodeBlock(function.param_refs_id);
   int param_index = 0;
   if (has_return_slot) {
     function_lowering.SetLocal(function.return_slot_id,
-                               llvm_function->getArg(param_index++));
+                               llvm_function->getArg(param_index));
+    ++param_index;
   }
-  for (auto [i, param_ref] : llvm::enumerate(param_refs)) {
-    auto param_type_id = semantics_ir().GetNode(param_ref).type_id();
+  for (auto param_ref_id : param_refs) {
+    auto param_type_id = semantics_ir().GetNode(param_ref_id).type_id();
     if (SemIR::GetValueRepresentation(semantics_ir(), param_type_id).kind ==
         SemIR::ValueRepresentation::None) {
       function_lowering.SetLocal(
-          param_ref, llvm::PoisonValue::get(GetType(param_type_id)));
+          param_ref_id, llvm::PoisonValue::get(GetType(param_type_id)));
     } else {
-      function_lowering.SetLocal(param_ref,
-                                 llvm_function->getArg(param_index++));
+      function_lowering.SetLocal(param_ref_id,
+                                 llvm_function->getArg(param_index));
+      ++param_index;
     }
   }
 
@@ -210,7 +214,7 @@ auto LoweringContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
     case SemIR::NodeKind::PointerType:
       return llvm::PointerType::get(*llvm_context_, /*AddressSpace=*/0);
     case SemIR::NodeKind::StructType: {
-      auto refs = semantics_ir_->GetNodeBlock(node.GetAsStructType());
+      auto& refs = semantics_ir_->GetNodeBlock(node.GetAsStructType());
       llvm::SmallVector<llvm::Type*> subtypes;
       subtypes.reserve(refs.size());
       for (auto ref_id : refs) {
@@ -229,7 +233,7 @@ auto LoweringContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
       // can be collectively replaced with LLVM's void, particularly around
       // function returns. LLVM doesn't allow declaring variables with a void
       // type, so that may require significant special casing.
-      auto refs = semantics_ir_->GetTypeBlock(node.GetAsTupleType());
+      auto& refs = semantics_ir_->GetTypeBlock(node.GetAsTupleType());
       llvm::SmallVector<llvm::Type*> subtypes;
       subtypes.reserve(refs.size());
       for (auto ref_id : refs) {

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -215,7 +215,19 @@ auto LoweringHandleCall(LoweringFunctionContext& context, SemIR::NodeId node_id,
   }
 
   for (auto ref_id : arg_ids) {
-    args.push_back(context.GetLocalLoaded(ref_id));
+    auto arg_type_id = context.semantics_ir().GetNode(ref_id).type_id();
+    switch (SemIR::GetValueRepresentation(context.semantics_ir(), arg_type_id)
+                .kind) {
+      case SemIR::ValueRepresentation::None:
+        break;
+      case SemIR::ValueRepresentation::Copy:
+      case SemIR::ValueRepresentation::Custom:
+        args.push_back(context.GetLocalLoaded(ref_id));
+        break;
+      case SemIR::ValueRepresentation::Pointer:
+        args.push_back(context.GetLocal(ref_id));
+        break;
+    }
   }
 
   if (llvm_function->getReturnType()->isVoidTy()) {

--- a/toolchain/lowering/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lowering/testdata/function/call/empty_struct.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo({} %a) {
+// CHECK:STDOUT: define void @Echo() {
 // CHECK:STDOUT:   %struct = alloca {}, align 8
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -24,7 +24,6 @@ fn Main() {
 // CHECK:STDOUT:   %struct = alloca {}, align 8
 // CHECK:STDOUT:   %b = alloca {}, align 8
 // CHECK:STDOUT:   %struct1 = alloca {}, align 8
-// CHECK:STDOUT:   %1 = load {}, ptr %struct1, align 1
-// CHECK:STDOUT:   call void @Echo({} %1)
+// CHECK:STDOUT:   call void @Echo()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lowering/testdata/function/call/empty_tuple.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'empty_tuple.carbon'
 // CHECK:STDOUT: source_filename = "empty_tuple.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo({} %a) {
+// CHECK:STDOUT: define void @Echo() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -23,7 +23,6 @@ fn Main() {
 // CHECK:STDOUT:   %tuple = alloca {}, align 8
 // CHECK:STDOUT:   %b = alloca {}, align 8
 // CHECK:STDOUT:   %tuple1 = alloca {}, align 8
-// CHECK:STDOUT:   %1 = load {}, ptr %tuple1, align 1
-// CHECK:STDOUT:   call void @Echo({} %1)
+// CHECK:STDOUT:   call void @Echo()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/function/call/implicit_empty_tuple_as_arg.carbon
+++ b/toolchain/lowering/testdata/function/call/implicit_empty_tuple_as_arg.carbon
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Bar({} %a) {
+// CHECK:STDOUT: define void @Bar() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -30,6 +30,6 @@ fn Main() {
 // CHECK:STDOUT:   call void @Foo()
 // CHECK:STDOUT:   %temp = alloca {}, align 8
 // CHECK:STDOUT:   %1 = load {}, ptr %temp, align 1
-// CHECK:STDOUT:   call void @Bar({} %1)
+// CHECK:STDOUT:   call void @Bar()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/function/call/struct_param.carbon
+++ b/toolchain/lowering/testdata/function/call/struct_param.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F(a: {}, b: {.a: i32}, c: {.a: i32, .b: i32}) {}
+
+fn Main() {
+  F({}, {.a = 1}, {.a = 2, .b = 3});
+}
+
+// CHECK:STDOUT: ; ModuleID = 'struct_param.carbon'
+// CHECK:STDOUT: source_filename = "struct_param.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT:   %struct = alloca {}, align 8
+// CHECK:STDOUT:   %struct1 = alloca { i32 }, align 8
+// CHECK:STDOUT:   %a = getelementptr inbounds { i32 }, ptr %struct1, i32 0, i32 0
+// CHECK:STDOUT:   store i32 1, ptr %a, align 4
+// CHECK:STDOUT:   %struct2 = alloca { i32, i32 }, align 8
+// CHECK:STDOUT:   %a3 = getelementptr inbounds { i32, i32 }, ptr %struct2, i32 0, i32 0
+// CHECK:STDOUT:   store i32 2, ptr %a3, align 4
+// CHECK:STDOUT:   %b = getelementptr inbounds { i32, i32 }, ptr %struct2, i32 0, i32 1
+// CHECK:STDOUT:   store i32 3, ptr %b, align 4
+// CHECK:STDOUT:   %1 = load { i32 }, ptr %struct1, align 4
+// CHECK:STDOUT:   call void @F({ i32 } %1, ptr %struct2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/function/call/tuple_param.carbon
+++ b/toolchain/lowering/testdata/function/call/tuple_param.carbon
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F(a: (), b: (i32,), c: (i32, i32)) {}
+
+fn Main() {
+  F((), (1,), (2, 3));
+}
+
+// CHECK:STDOUT: ; ModuleID = 'tuple_param.carbon'
+// CHECK:STDOUT: source_filename = "tuple_param.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT:   %tuple = alloca {}, align 8
+// CHECK:STDOUT:   %tuple1 = alloca { i32 }, align 8
+// CHECK:STDOUT:   %1 = getelementptr inbounds { i32 }, ptr %tuple1, i32 0, i32 0
+// CHECK:STDOUT:   store i32 1, ptr %1, align 4
+// CHECK:STDOUT:   %tuple2 = alloca { i32, i32 }, align 8
+// CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32 }, ptr %tuple2, i32 0, i32 0
+// CHECK:STDOUT:   store i32 2, ptr %2, align 4
+// CHECK:STDOUT:   %3 = getelementptr inbounds { i32, i32 }, ptr %tuple2, i32 0, i32 1
+// CHECK:STDOUT:   store i32 3, ptr %3, align 4
+// CHECK:STDOUT:   %4 = load { i32 }, ptr %tuple1, align 4
+// CHECK:STDOUT:   call void @F({ i32 } %4, ptr %tuple2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }

--- a/toolchain/lowering/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lowering/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F(a: (), b: (i32,), c: (i32, i32)) -> (i32, i32, i32) {
+  return (b[0], c[0], c[1]);
+}
+
+fn Main() {
+  F((), (1,), (2, 3));
+}
+
+// CHECK:STDOUT: ; ModuleID = 'tuple_param_with_return_slot.carbon'
+// CHECK:STDOUT: source_filename = "tuple_param_with_return_slot.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @F(ptr sret({ i32, i32, i32 }) %return, { i32 } %b, ptr %c) {
+// CHECK:STDOUT:   %tuple.index = extractvalue { i32 } %b, 0
+// CHECK:STDOUT:   %tuple.index1 = getelementptr inbounds { i32, i32 }, ptr %c, i32 0, i32 0
+// CHECK:STDOUT:   %tuple.index2 = getelementptr inbounds { i32, i32 }, ptr %c, i32 0, i32 1
+// CHECK:STDOUT:   %tuple = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %1 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %tuple.index, ptr %1, align 4
+// CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 1
+// CHECK:STDOUT:   store ptr %tuple.index1, ptr %2, align 8
+// CHECK:STDOUT:   %3 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 2
+// CHECK:STDOUT:   store ptr %tuple.index2, ptr %3, align 8
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 %tuple, i64 12, i1 false)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @Main() {
+// CHECK:STDOUT:   %tuple = alloca {}, align 8
+// CHECK:STDOUT:   %tuple1 = alloca { i32 }, align 8
+// CHECK:STDOUT:   %1 = getelementptr inbounds { i32 }, ptr %tuple1, i32 0, i32 0
+// CHECK:STDOUT:   store i32 1, ptr %1, align 4
+// CHECK:STDOUT:   %tuple2 = alloca { i32, i32 }, align 8
+// CHECK:STDOUT:   %2 = getelementptr inbounds { i32, i32 }, ptr %tuple2, i32 0, i32 0
+// CHECK:STDOUT:   store i32 2, ptr %2, align 4
+// CHECK:STDOUT:   %3 = getelementptr inbounds { i32, i32 }, ptr %tuple2, i32 0, i32 1
+// CHECK:STDOUT:   store i32 3, ptr %3, align 4
+// CHECK:STDOUT:   %temp = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %4 = load { i32 }, ptr %tuple1, align 4
+// CHECK:STDOUT:   call void @F(ptr %temp, { i32 } %4, ptr %tuple2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #0
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lowering/testdata/function/definition/empty_struct.carbon
+++ b/toolchain/lowering/testdata/function/definition/empty_struct.carbon
@@ -10,6 +10,6 @@ fn Echo(a: {}) {
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: define void @Echo({} %a) {
+// CHECK:STDOUT: define void @Echo() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }


### PR DESCRIPTION
Pass function parameters directly or indirectly, depending on their value representation. For types such as empty tuples with an empty value representation, don't pass them at all.