### PR TITLE
Move lowering into a 'Lower' namespace

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -469,11 +469,11 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
     return false;
   }
 
-  CARBON_VLOG() << "*** LowerToLLVM ***\n";
+  CARBON_VLOG() << "*** Lower::LowerToLLVM ***\n";
   llvm::LLVMContext llvm_context;
-  const std::unique_ptr<llvm::Module> module = LowerToLLVM(
+  const std::unique_ptr<llvm::Module> module = Lower::LowerToLLVM(
       llvm_context, options.input_file_name, semantics_ir, vlog_stream_);
-  CARBON_VLOG() << "*** LowerToLLVM done ***\n";
+  CARBON_VLOG() << "*** Lower::LowerToLLVM done ***\n";
   if (options.dump_llvm_ir) {
     module->print(output_stream_, /*AAW=*/nullptr,
                   /*ShouldPreserveUseListOrder=*/true);

--- a/toolchain/lowering/lower_to_llvm.cpp
+++ b/toolchain/lowering/lower_to_llvm.cpp
@@ -6,14 +6,14 @@
 
 #include "toolchain/lowering/lowering_context.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
                  const SemIR::File& semantics_ir,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module> {
-  LoweringContext context(llvm_context, module_name, semantics_ir, vlog_stream);
+  FileContext context(llvm_context, module_name, semantics_ir, vlog_stream);
   return context.Run();
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower

--- a/toolchain/lowering/lower_to_llvm.h
+++ b/toolchain/lowering/lower_to_llvm.h
@@ -9,7 +9,7 @@
 #include "llvm/IR/Module.h"
 #include "toolchain/semantics/semantics_ir.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
 // Lowers SemIR to LLVM IR.
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
@@ -17,6 +17,6 @@ auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
                  llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module>;
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower
 
 #endif  // CARBON_TOOLCHAIN_LOWERING_LOWER_TO_LLVM_H_

--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -12,12 +12,12 @@
 #include "toolchain/semantics/semantics_node.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
-LoweringContext::LoweringContext(llvm::LLVMContext& llvm_context,
-                                 llvm::StringRef module_name,
-                                 const SemIR::File& semantics_ir,
-                                 llvm::raw_ostream* vlog_stream)
+FileContext::FileContext(llvm::LLVMContext& llvm_context,
+                         llvm::StringRef module_name,
+                         const SemIR::File& semantics_ir,
+                         llvm::raw_ostream* vlog_stream)
     : llvm_context_(&llvm_context),
       llvm_module_(std::make_unique<llvm::Module>(module_name, llvm_context)),
       semantics_ir_(&semantics_ir),
@@ -27,7 +27,7 @@ LoweringContext::LoweringContext(llvm::LLVMContext& llvm_context,
 }
 
 // TODO: Move this to lower_to_llvm.cpp.
-auto LoweringContext::Run() -> std::unique_ptr<llvm::Module> {
+auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
   CARBON_CHECK(llvm_module_) << "Run can only be called once.";
 
   // Lower types.
@@ -55,7 +55,7 @@ auto LoweringContext::Run() -> std::unique_ptr<llvm::Module> {
   return std::move(llvm_module_);
 }
 
-auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
+auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
     -> llvm::Function* {
   const auto& function = semantics_ir().GetFunction(function_id);
   const bool has_return_slot = function.return_slot_id.is_valid();
@@ -129,7 +129,7 @@ auto LoweringContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
   return llvm_function;
 }
 
-auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
+auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     -> void {
   const auto& function = semantics_ir().GetFunction(function_id);
   const auto& body_block_ids = function.body_block_ids;
@@ -139,7 +139,7 @@ auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 
   llvm::Function* llvm_function = GetFunction(function_id);
-  LoweringFunctionContext function_lowering(*this, llvm_function);
+  FunctionContext function_lowering(*this, llvm_function);
 
   const bool has_return_slot = function.return_slot_id.is_valid();
 
@@ -180,9 +180,9 @@ auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
       // clang warns on unhandled enum values; clang-tidy is incorrect here.
       // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
       switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(Name)                    \
-  case SemIR::NodeKind::Name:                               \
-    LoweringHandle##Name(function_lowering, node_id, node); \
+#define CARBON_SEMANTICS_NODE_KIND(Name)            \
+  case SemIR::NodeKind::Name:                       \
+    Handle##Name(function_lowering, node_id, node); \
     break;
 #include "toolchain/semantics/semantics_node_kind.def"
       }
@@ -190,7 +190,7 @@ auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
   }
 }
 
-auto LoweringContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
+auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
   switch (node_id.index) {
     case SemIR::BuiltinKind::FloatingPointType.AsInt():
       // TODO: Handle different sizes.
@@ -252,4 +252,4 @@ auto LoweringContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
   }
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower

--- a/toolchain/lowering/lowering_context.h
+++ b/toolchain/lowering/lowering_context.h
@@ -11,15 +11,15 @@
 #include "toolchain/semantics/semantics_ir.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
 // Context and shared functionality for lowering handlers.
-class LoweringContext {
+class FileContext {
  public:
-  explicit LoweringContext(llvm::LLVMContext& llvm_context,
-                           llvm::StringRef module_name,
-                           const SemIR::File& semantics_ir,
-                           llvm::raw_ostream* vlog_stream);
+  explicit FileContext(llvm::LLVMContext& llvm_context,
+                       llvm::StringRef module_name,
+                       const SemIR::File& semantics_ir,
+                       llvm::raw_ostream* vlog_stream);
 
   // Lowers the SemIR::File to LLVM IR. Should only be called once, and handles
   // the main execution loop.
@@ -94,6 +94,6 @@ class LoweringContext {
   llvm::StructType* type_type_ = nullptr;
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower
 
 #endif  // CARBON_TOOLCHAIN_LOWERING_LOWERING_CONTEXT_H_

--- a/toolchain/lowering/lowering_file_test.cpp
+++ b/toolchain/lowering/lowering_file_test.cpp
@@ -10,7 +10,7 @@
 namespace Carbon::Testing {
 namespace {
 
-class LoweringFileTest : public DriverFileTestBase {
+class LowerFileTest : public DriverFileTestBase {
  public:
   using DriverFileTestBase::DriverFileTestBase;
 
@@ -21,6 +21,6 @@ class LoweringFileTest : public DriverFileTestBase {
 
 }  // namespace
 
-CARBON_FILE_TEST_FACTORY(LoweringFileTest);
+CARBON_FILE_TEST_FACTORY(LowerFileTest);
 
 }  // namespace Carbon::Testing

--- a/toolchain/lowering/lowering_function_context.cpp
+++ b/toolchain/lowering/lowering_function_context.cpp
@@ -6,15 +6,15 @@
 
 #include "toolchain/semantics/semantics_ir.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
-LoweringFunctionContext::LoweringFunctionContext(
-    LoweringContext& lowering_context, llvm::Function* function)
-    : lowering_context_(&lowering_context),
+FunctionContext::FunctionContext(FileContext& file_context,
+                                 llvm::Function* function)
+    : file_context_(&file_context),
       function_(function),
-      builder_(lowering_context.llvm_context()) {}
+      builder_(file_context.llvm_context()) {}
 
-auto LoweringFunctionContext::GetBlock(SemIR::NodeBlockId block_id)
+auto FunctionContext::GetBlock(SemIR::NodeBlockId block_id)
     -> llvm::BasicBlock* {
   llvm::BasicBlock*& entry = blocks_[block_id];
   if (!entry) {
@@ -23,8 +23,8 @@ auto LoweringFunctionContext::GetBlock(SemIR::NodeBlockId block_id)
   return entry;
 }
 
-auto LoweringFunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
-                                              llvm::BasicBlock* block) -> bool {
+auto FunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
+                                      llvm::BasicBlock* block) -> bool {
   if (!blocks_.insert({block_id, block}).second) {
     return false;
   }
@@ -34,9 +34,8 @@ auto LoweringFunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
   return true;
 }
 
-auto LoweringFunctionContext::GetBlockArg(SemIR::NodeBlockId block_id,
-                                          SemIR::TypeId type_id)
-    -> llvm::PHINode* {
+auto FunctionContext::GetBlockArg(SemIR::NodeBlockId block_id,
+                                  SemIR::TypeId type_id) -> llvm::PHINode* {
   llvm::BasicBlock* block = GetBlock(block_id);
 
   // Find the existing phi, if any.
@@ -55,13 +54,12 @@ auto LoweringFunctionContext::GetBlockArg(SemIR::NodeBlockId block_id,
   return phi;
 }
 
-auto LoweringFunctionContext::CreateSyntheticBlock() -> llvm::BasicBlock* {
+auto FunctionContext::CreateSyntheticBlock() -> llvm::BasicBlock* {
   synthetic_block_ = llvm::BasicBlock::Create(llvm_context(), "", function_);
   return synthetic_block_;
 }
 
-auto LoweringFunctionContext::GetLocalLoaded(SemIR::NodeId node_id)
-    -> llvm::Value* {
+auto FunctionContext::GetLocalLoaded(SemIR::NodeId node_id) -> llvm::Value* {
   auto* value = GetLocal(node_id);
   if (llvm::isa<llvm::AllocaInst, llvm::GetElementPtrInst>(value)) {
     auto* load_type = GetType(semantics_ir().GetNode(node_id).type_id());
@@ -72,4 +70,4 @@ auto LoweringFunctionContext::GetLocalLoaded(SemIR::NodeId node_id)
   }
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower

--- a/toolchain/lowering/lowering_function_context.h
+++ b/toolchain/lowering/lowering_function_context.h
@@ -12,14 +12,13 @@
 #include "toolchain/semantics/semantics_ir.h"
 #include "toolchain/semantics/semantics_node.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
 // Context and shared functionality for lowering handlers that produce an
 // `llvm::Function` definition.
-class LoweringFunctionContext {
+class FunctionContext {
  public:
-  explicit LoweringFunctionContext(LoweringContext& lowering_context,
-                                   llvm::Function* function);
+  explicit FunctionContext(FileContext& file_context, llvm::Function* function);
 
   // Returns a basic block corresponding to the start of the given semantics
   // block, and enqueues it for emission.
@@ -70,17 +69,17 @@ class LoweringFunctionContext {
 
   // Gets a callable's function.
   auto GetFunction(SemIR::FunctionId function_id) -> llvm::Function* {
-    return lowering_context_->GetFunction(function_id);
+    return file_context_->GetFunction(function_id);
   }
 
   // Returns a lowered type for the given type_id.
   auto GetType(SemIR::TypeId type_id) -> llvm::Type* {
-    return lowering_context_->GetType(type_id);
+    return file_context_->GetType(type_id);
   }
 
   // Returns a lowered value to use for a value of type `type`.
   auto GetTypeAsValue() -> llvm::Value* {
-    return lowering_context_->GetTypeAsValue();
+    return file_context_->GetTypeAsValue();
   }
 
   // Create a synthetic block that corresponds to no SemIR::NodeBlockId. Such
@@ -95,19 +94,17 @@ class LoweringFunctionContext {
   }
 
   auto llvm_context() -> llvm::LLVMContext& {
-    return lowering_context_->llvm_context();
+    return file_context_->llvm_context();
   }
-  auto llvm_module() -> llvm::Module& {
-    return lowering_context_->llvm_module();
-  }
+  auto llvm_module() -> llvm::Module& { return file_context_->llvm_module(); }
   auto builder() -> llvm::IRBuilder<>& { return builder_; }
   auto semantics_ir() -> const SemIR::File& {
-    return lowering_context_->semantics_ir();
+    return file_context_->semantics_ir();
   }
 
  private:
   // Context for the overall lowering process.
-  LoweringContext* lowering_context_;
+  FileContext* file_context_;
 
   // The IR function we're generating.
   llvm::Function* function_;
@@ -129,11 +126,11 @@ class LoweringFunctionContext {
 
 // Declare handlers for each SemIR::File node.
 #define CARBON_SEMANTICS_NODE_KIND(Name)                             \
-  auto LoweringHandle##Name(LoweringFunctionContext& context,        \
-                            SemIR::NodeId node_id, SemIR::Node node) \
+  auto Handle##Name(FunctionContext& context, SemIR::NodeId node_id, \
+                    SemIR::Node node)                                \
       ->void;
 #include "toolchain/semantics/semantics_node_kind.def"
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower
 
 #endif  // CARBON_TOOLCHAIN_LOWERING_LOWERING_FUNCTION_CONTEXT_H_

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -7,27 +7,25 @@
 #include "toolchain/lowering/lowering_function_context.h"
 #include "toolchain/semantics/semantics_node_kind.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
-auto LoweringHandleInvalid(LoweringFunctionContext& /*context*/,
-                           SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleInvalid(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                   SemIR::Node /*node*/) -> void {
   llvm_unreachable("never in actual IR");
 }
 
-auto LoweringHandleCrossReference(LoweringFunctionContext& /*context*/,
-                                  SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleCrossReference(FunctionContext& /*context*/,
+                          SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
-auto LoweringHandleAddressOf(LoweringFunctionContext& context,
-                             SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleAddressOf(FunctionContext& context, SemIR::NodeId node_id,
+                     SemIR::Node node) -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsAddressOf()));
 }
 
-auto LoweringHandleArrayIndex(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleArrayIndex(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node node) -> void {
   auto [array_node_id, index_node_id] = node.GetAsArrayIndex();
   auto* array_value = context.GetLocal(array_node_id);
   auto* llvm_type =
@@ -51,8 +49,8 @@ auto LoweringHandleArrayIndex(LoweringFunctionContext& context,
   context.SetLocal(node_id, array_element_value);
 }
 
-auto LoweringHandleArrayValue(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleArrayValue(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node node) -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca =
       context.builder().CreateAlloca(llvm_type, /*ArraySize=*/nullptr, "array");
@@ -76,8 +74,8 @@ auto LoweringHandleArrayValue(LoweringFunctionContext& context,
   }
 }
 
-auto LoweringHandleAssign(LoweringFunctionContext& context,
-                          SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
+auto HandleAssign(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                  SemIR::Node node) -> void {
   auto [storage_id, value_id] = node.GetAsAssign();
   auto storage_type_id = context.semantics_ir().GetNode(storage_id).type_id();
 
@@ -113,34 +111,32 @@ auto LoweringHandleAssign(LoweringFunctionContext& context,
   }
 }
 
-auto LoweringHandleBinaryOperatorAdd(LoweringFunctionContext& /*context*/,
-                                     SemIR::NodeId /*node_id*/,
-                                     SemIR::Node node) -> void {
+auto HandleBinaryOperatorAdd(FunctionContext& /*context*/,
+                             SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
-auto LoweringHandleBindName(LoweringFunctionContext& /*context*/,
-                            SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleBindName(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                    SemIR::Node /*node*/) -> void {
   // Probably need to do something here, but not necessary for now.
 }
 
-auto LoweringHandleBlockArg(LoweringFunctionContext& context,
-                            SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleBlockArg(FunctionContext& context, SemIR::NodeId node_id,
+                    SemIR::Node node) -> void {
   SemIR::NodeBlockId block_id = node.GetAsBlockArg();
   context.SetLocal(node_id, context.GetBlockArg(block_id, node.type_id()));
 }
 
-auto LoweringHandleBoolLiteral(LoweringFunctionContext& context,
-                               SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleBoolLiteral(FunctionContext& context, SemIR::NodeId node_id,
+                       SemIR::Node node) -> void {
   llvm::Value* v = llvm::ConstantInt::get(context.builder().getInt1Ty(),
                                           node.GetAsBoolLiteral().index);
   context.SetLocal(node_id, v);
 }
 
-auto LoweringHandleBranch(LoweringFunctionContext& context,
-                          SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
+auto HandleBranch(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                  SemIR::Node node) -> void {
   SemIR::NodeBlockId target_block_id = node.GetAsBranch();
 
   // Opportunistically avoid creating a BasicBlock that contains just a branch.
@@ -154,9 +150,8 @@ auto LoweringHandleBranch(LoweringFunctionContext& context,
   context.builder().ClearInsertionPoint();
 }
 
-auto LoweringHandleBranchIf(LoweringFunctionContext& context,
-                            SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleBranchIf(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                    SemIR::Node node) -> void {
   auto [target_block_id, cond_id] = node.GetAsBranchIf();
   llvm::Value* cond = context.GetLocalLoaded(cond_id);
   llvm::BasicBlock* then_block = context.GetBlock(target_block_id);
@@ -165,9 +160,8 @@ auto LoweringHandleBranchIf(LoweringFunctionContext& context,
   context.builder().SetInsertPoint(else_block);
 }
 
-auto LoweringHandleBranchWithArg(LoweringFunctionContext& context,
-                                 SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleBranchWithArg(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                         SemIR::Node node) -> void {
   auto [target_block_id, arg_id] = node.GetAsBranchWithArg();
   llvm::Value* arg = context.GetLocalLoaded(arg_id);
   SemIR::TypeId arg_type_id = context.semantics_ir().GetNode(arg_id).type_id();
@@ -193,14 +187,13 @@ auto LoweringHandleBranchWithArg(LoweringFunctionContext& context,
   context.builder().ClearInsertionPoint();
 }
 
-auto LoweringHandleBuiltin(LoweringFunctionContext& /*context*/,
-                           SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleBuiltin(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                   SemIR::Node node) -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
-auto LoweringHandleCall(LoweringFunctionContext& context, SemIR::NodeId node_id,
-                        SemIR::Node node) -> void {
+auto HandleCall(FunctionContext& context, SemIR::NodeId node_id,
+                SemIR::Node node) -> void {
   auto [refs_id, function_id] = node.GetAsCall();
   auto* llvm_function = context.GetFunction(function_id);
   const auto& function = context.semantics_ir().GetFunction(function_id);
@@ -243,24 +236,22 @@ auto LoweringHandleCall(LoweringFunctionContext& context, SemIR::NodeId node_id,
   }
 }
 
-auto LoweringHandleDereference(LoweringFunctionContext& context,
-                               SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleDereference(FunctionContext& context, SemIR::NodeId node_id,
+                       SemIR::Node node) -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsDereference()));
 }
 
-auto LoweringHandleFunctionDeclaration(LoweringFunctionContext& /*context*/,
-                                       SemIR::NodeId /*node_id*/,
-                                       SemIR::Node node) -> void {
+auto HandleFunctionDeclaration(FunctionContext& /*context*/,
+                               SemIR::NodeId /*node_id*/, SemIR::Node node)
+    -> void {
   CARBON_FATAL()
       << "Should not be encountered. If that changes, we may want to change "
          "higher-level logic to skip them rather than calling this. "
       << node;
 }
 
-auto LoweringHandleIntegerLiteral(LoweringFunctionContext& context,
-                                  SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
+                          SemIR::Node node) -> void {
   llvm::APInt i =
       context.semantics_ir().GetIntegerLiteral(node.GetAsIntegerLiteral());
   // TODO: This won't offer correct semantics, but seems close enough for now.
@@ -269,27 +260,23 @@ auto LoweringHandleIntegerLiteral(LoweringFunctionContext& context,
   context.SetLocal(node_id, v);
 }
 
-auto LoweringHandleNamespace(LoweringFunctionContext& /*context*/,
-                             SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleNamespace(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                     SemIR::Node /*node*/) -> void {
   // No action to take.
 }
 
-auto LoweringHandleNoOp(LoweringFunctionContext& /*context*/,
-                        SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleNoOp(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                SemIR::Node /*node*/) -> void {
   // No action to take.
 }
 
-auto LoweringHandleParameter(LoweringFunctionContext& /*context*/,
-                             SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleParameter(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
+                     SemIR::Node /*node*/) -> void {
   CARBON_FATAL() << "Parameters should be lowered by `BuildFunctionDefinition`";
 }
 
-auto LoweringHandleRealLiteral(LoweringFunctionContext& context,
-                               SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleRealLiteral(FunctionContext& context, SemIR::NodeId node_id,
+                       SemIR::Node node) -> void {
   SemIR::RealLiteral real =
       context.semantics_ir().GetRealLiteral(node.GetAsRealLiteral());
   // TODO: This will probably have overflow issues, and should be fixed.
@@ -301,28 +288,24 @@ auto LoweringHandleRealLiteral(LoweringFunctionContext& context,
                                 context.builder().getDoubleTy(), llvm_val));
 }
 
-auto LoweringHandleReturn(LoweringFunctionContext& context,
-                          SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
-    -> void {
+auto HandleReturn(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                  SemIR::Node /*node*/) -> void {
   context.builder().CreateRetVoid();
 }
 
-auto LoweringHandleReturnExpression(LoweringFunctionContext& context,
-                                    SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleReturnExpression(FunctionContext& context, SemIR::NodeId /*node_id*/,
+                            SemIR::Node node) -> void {
   SemIR::NodeId expr_id = node.GetAsReturnExpression();
   context.builder().CreateRet(context.GetLocalLoaded(expr_id));
 }
 
-auto LoweringHandleStringLiteral(LoweringFunctionContext& /*context*/,
-                                 SemIR::NodeId /*node_id*/, SemIR::Node node)
-    -> void {
+auto HandleStringLiteral(FunctionContext& /*context*/,
+                         SemIR::NodeId /*node_id*/, SemIR::Node node) -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 
-auto LoweringHandleStructAccess(LoweringFunctionContext& context,
-                                SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleStructAccess(FunctionContext& context, SemIR::NodeId node_id,
+                        SemIR::Node node) -> void {
   auto [struct_id, member_index] = node.GetAsStructAccess();
   auto struct_type_id = context.semantics_ir().GetNode(struct_id).type_id();
   auto* llvm_type = context.GetType(struct_type_id);
@@ -343,8 +326,8 @@ auto LoweringHandleStructAccess(LoweringFunctionContext& context,
   context.SetLocal(node_id, gep);
 }
 
-auto LoweringHandleTupleIndex(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleTupleIndex(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node node) -> void {
   auto [tuple_node_id, index_node_id] = node.GetAsTupleIndex();
   auto* tuple_value = context.GetLocal(tuple_node_id);
   auto index_node = context.semantics_ir().GetNode(index_node_id);
@@ -357,8 +340,8 @@ auto LoweringHandleTupleIndex(LoweringFunctionContext& context,
                                 llvm_type, tuple_value, index, "tuple.index"));
 }
 
-auto LoweringHandleTupleValue(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleTupleValue(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node node) -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca =
       context.builder().CreateAlloca(llvm_type, /*ArraySize=*/nullptr, "tuple");
@@ -370,15 +353,14 @@ auto LoweringHandleTupleValue(LoweringFunctionContext& context,
   }
 }
 
-auto LoweringHandleStructTypeField(LoweringFunctionContext& /*context*/,
-                                   SemIR::NodeId /*node_id*/,
-                                   SemIR::Node /*node*/) -> void {
+auto HandleStructTypeField(FunctionContext& /*context*/,
+                           SemIR::NodeId /*node_id*/, SemIR::Node /*node*/)
+    -> void {
   // No action to take.
 }
 
-auto LoweringHandleStructValue(LoweringFunctionContext& context,
-                               SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleStructValue(FunctionContext& context, SemIR::NodeId node_id,
+                       SemIR::Node node) -> void {
   auto* llvm_type = context.GetType(node.type_id());
   auto* alloca = context.builder().CreateAlloca(
       llvm_type, /*ArraySize=*/nullptr, "struct");
@@ -400,21 +382,19 @@ auto LoweringHandleStructValue(LoweringFunctionContext& context,
   }
 }
 
-auto LoweringHandleStubReference(LoweringFunctionContext& context,
-                                 SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleStubReference(FunctionContext& context, SemIR::NodeId node_id,
+                         SemIR::Node node) -> void {
   context.SetLocal(node_id, context.GetLocal(node.GetAsStubReference()));
 }
 
-auto LoweringHandleUnaryOperatorNot(LoweringFunctionContext& context,
-                                    SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleUnaryOperatorNot(FunctionContext& context, SemIR::NodeId node_id,
+                            SemIR::Node node) -> void {
   context.SetLocal(node_id, context.builder().CreateNot(context.GetLocal(
                                 node.GetAsUnaryOperatorNot())));
 }
 
-auto LoweringHandleVarStorage(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleVarStorage(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node node) -> void {
   // TODO: Eventually this name will be optional, and we'll want to provide
   // something like `var` as a default. However, that's not possible right now
   // so cannot be tested.
@@ -424,4 +404,4 @@ auto LoweringHandleVarStorage(LoweringFunctionContext& context,
   context.SetLocal(node_id, alloca);
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower

--- a/toolchain/lowering/lowering_handle_expression_category.cpp
+++ b/toolchain/lowering/lowering_handle_expression_category.cpp
@@ -4,10 +4,10 @@
 
 #include "toolchain/lowering/lowering_function_context.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
-auto LoweringHandleBindValue(LoweringFunctionContext& context,
-                             SemIR::NodeId node_id, SemIR::Node node) -> void {
+auto HandleBindValue(FunctionContext& context, SemIR::NodeId node_id,
+                     SemIR::Node node) -> void {
   switch (auto rep = SemIR::GetValueRepresentation(context.semantics_ir(),
                                                    node.type_id());
           rep.kind) {
@@ -30,12 +30,11 @@ auto LoweringHandleBindValue(LoweringFunctionContext& context,
   }
 }
 
-auto LoweringHandleMaterializeTemporary(LoweringFunctionContext& context,
-                                        SemIR::NodeId node_id, SemIR::Node node)
-    -> void {
+auto HandleMaterializeTemporary(FunctionContext& context, SemIR::NodeId node_id,
+                                SemIR::Node node) -> void {
   context.SetLocal(
       node_id, context.builder().CreateAlloca(context.GetType(node.type_id()),
                                               nullptr, "temp"));
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower

--- a/toolchain/lowering/lowering_handle_type.cpp
+++ b/toolchain/lowering/lowering_handle_type.cpp
@@ -4,36 +4,31 @@
 
 #include "toolchain/lowering/lowering_function_context.h"
 
-namespace Carbon {
+namespace Carbon::Lower {
 
-auto LoweringHandleArrayType(LoweringFunctionContext& context,
-                             SemIR::NodeId node_id, SemIR::Node /*node*/)
-    -> void {
+auto HandleArrayType(FunctionContext& context, SemIR::NodeId node_id,
+                     SemIR::Node /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
-auto LoweringHandleConstType(LoweringFunctionContext& context,
-                             SemIR::NodeId node_id, SemIR::Node /*node*/)
-    -> void {
+auto HandleConstType(FunctionContext& context, SemIR::NodeId node_id,
+                     SemIR::Node /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
-auto LoweringHandlePointerType(LoweringFunctionContext& context,
-                               SemIR::NodeId node_id, SemIR::Node /*node*/)
-    -> void {
+auto HandlePointerType(FunctionContext& context, SemIR::NodeId node_id,
+                       SemIR::Node /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
-auto LoweringHandleStructType(LoweringFunctionContext& context,
-                              SemIR::NodeId node_id, SemIR::Node /*node*/)
-    -> void {
+auto HandleStructType(FunctionContext& context, SemIR::NodeId node_id,
+                      SemIR::Node /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
-auto LoweringHandleTupleType(LoweringFunctionContext& context,
-                             SemIR::NodeId node_id, SemIR::Node /*node*/)
-    -> void {
+auto HandleTupleType(FunctionContext& context, SemIR::NodeId node_id,
+                     SemIR::Node /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lower


### PR DESCRIPTION
Splitting namespace changes from file renames with the thought that it'll be more likely to work with git's merge logic.

Renamed LoweringContext to FileContext to disambiguate more clearly from FunctionContext.

This is part of #3070 