### PR TITLE
Manual cleanup of toolchain clang-tidy/clangd warnings.

### DIFF
--- a/toolchain/base/yaml_test_helpers.cpp
+++ b/toolchain/base/yaml_test_helpers.cpp
@@ -14,7 +14,8 @@ static auto Parse(llvm::yaml::Node* node) -> Value {
     return Value{ErrorValue()};
   }
 
-  switch (node->getType()) {
+  // getType returns an unsigned int which should map to the enum.
+  switch (static_cast<llvm::yaml::Node::NodeKind>(node->getType())) {
     case llvm::yaml::Node::NK_Null:
       return Value{NullValue()};
 
@@ -53,7 +54,6 @@ static auto Parse(llvm::yaml::Node* node) -> Value {
     case llvm::yaml::Node::NK_KeyValue:
       llvm_unreachable("should only exist as child of mapping");
   }
-
   llvm_unreachable("unknown yaml node kind");
 }
 

--- a/toolchain/base/yaml_test_helpers.h
+++ b/toolchain/base/yaml_test_helpers.h
@@ -50,12 +50,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <variant>
 
-#include "common/ostream.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace Carbon::Testing::Yaml {
 

--- a/toolchain/codegen/codegen.cpp
+++ b/toolchain/codegen/codegen.cpp
@@ -4,7 +4,6 @@
 
 #include "toolchain/codegen/codegen.h"
 
-#include <cstdio>
 #include <memory>
 
 #include "llvm/IR/LegacyPassManager.h"

--- a/toolchain/codegen/codegen.h
+++ b/toolchain/codegen/codegen.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_CODEGEN_CODEGEN_H_
 #define CARBON_TOOLCHAIN_CODEGEN_CODEGEN_H_
 
-#include <cstdint>
-
 #include "llvm/IR/Module.h"
 #include "llvm/Target/TargetMachine.h"
 

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -8,7 +8,6 @@
 #include <gtest/gtest.h>
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/diagnostics/mocks.h"
 
 namespace Carbon::Testing {

--- a/toolchain/diagnostics/diagnostic_kind.h
+++ b/toolchain/diagnostics/diagnostic_kind.h
@@ -11,6 +11,9 @@
 
 namespace Carbon {
 
+// Although this currently fits into int8_t, it shouldn't be expected to
+// long-term.
+// NOLINTNEXTLINE(performance-enum-size)
 CARBON_DEFINE_RAW_ENUM_CLASS(DiagnosticKind, uint16_t) {
 #define CARBON_DIAGNOSTIC_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/diagnostics/diagnostic_kind.def"

--- a/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
@@ -8,7 +8,6 @@
 #include <gtest/gtest.h>
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/mocks.h"
 

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -7,12 +7,9 @@
 #include "common/command_line.h"
 #include "common/vlog.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/Support/Format.h"
 #include "llvm/Support/Path.h"
 #include "llvm/TargetParser/Host.h"
 #include "toolchain/codegen/codegen.h"
@@ -43,7 +40,7 @@ can be written to standard output as these phases progress.
 )""",
   };
 
-  enum class Phase {
+  enum class Phase : int8_t {
     Lex,
     Parse,
     Check,
@@ -287,7 +284,7 @@ For questions, issues, or bug reports, please use our GitHub project:
 )""",
   };
 
-  enum class Subcommand {
+  enum class Subcommand : int8_t {
     Compile,
   };
 

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -5,15 +5,11 @@
 #ifndef CARBON_TOOLCHAIN_DRIVER_DRIVER_H_
 #define CARBON_TOOLCHAIN_DRIVER_DRIVER_H_
 
-#include <cstdint>
-
 #include "common/command_line.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 
 namespace Carbon {
 

--- a/toolchain/driver/driver_file_test_base.h
+++ b/toolchain/driver/driver_file_test_base.h
@@ -6,7 +6,6 @@
 #define CARBON_TOOLCHAIN_DRIVER_DRIVER_FILE_TEST_BASE_H_
 
 #include <cstdio>
-#include <fstream>
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -2,9 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cstdint>
 #include <cstring>
-#include <numeric>
 #include <string>
 
 #include "llvm/ADT/SmallVector.h"

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -12,13 +12,10 @@
 #include <utility>
 
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Object/Binary.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "testing/base/test_raw_ostream.h"
 #include "toolchain/base/yaml_test_helpers.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 
 namespace Carbon::Testing {
 namespace {

--- a/toolchain/lexer/character_set.h
+++ b/toolchain/lexer/character_set.h
@@ -6,7 +6,6 @@
 #define CARBON_TOOLCHAIN_LEXER_CHARACTER_SET_H_
 
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace Carbon {
 

--- a/toolchain/lexer/lex_helpers.cpp
+++ b/toolchain/lexer/lex_helpers.cpp
@@ -4,8 +4,6 @@
 
 #include "toolchain/lexer/lex_helpers.h"
 
-#include "llvm/Support/FormatVariadic.h"
-
 namespace Carbon {
 
 auto CanLexInteger(DiagnosticEmitter<const char*>& emitter,

--- a/toolchain/lexer/numeric_literal.cpp
+++ b/toolchain/lexer/numeric_literal.cpp
@@ -8,13 +8,15 @@
 
 #include "common/check.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/lexer/character_set.h"
 #include "toolchain/lexer/lex_helpers.h"
 
 namespace Carbon {
 
 // Adapts Radix for use with formatv.
+// NOTE: clangd may see this as unused, but it will be invoked by diagnostics.
+// We don't do anything to disable the warning because clang compile invocations
+// should warn if it's actually unused.
 static auto operator<<(llvm::raw_ostream& out, LexedNumericLiteral::Radix radix)
     -> llvm::raw_ostream& {
   switch (radix) {

--- a/toolchain/lexer/numeric_literal.h
+++ b/toolchain/lexer/numeric_literal.h
@@ -6,7 +6,6 @@
 #define CARBON_TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_
 
 #include <optional>
-#include <utility>
 #include <variant>
 
 #include "llvm/ADT/APInt.h"

--- a/toolchain/lexer/numeric_literal_fuzzer.cpp
+++ b/toolchain/lexer/numeric_literal_fuzzer.cpp
@@ -2,11 +2,9 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cstdint>
 #include <cstring>
 
 #include "llvm/ADT/StringRef.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/numeric_literal.h"
 

--- a/toolchain/lexer/numeric_literal_test.cpp
+++ b/toolchain/lexer/numeric_literal_test.cpp
@@ -7,12 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <iterator>
-#include <memory>
-#include <vector>
-
 #include "common/check.h"
-#include "common/ostream.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lexer/test_helpers.h"
 

--- a/toolchain/lexer/string_literal.cpp
+++ b/toolchain/lexer/string_literal.cpp
@@ -9,7 +9,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/lexer/character_set.h"
 #include "toolchain/lexer/lex_helpers.h"
 
@@ -162,6 +161,9 @@ auto LexedStringLiteral::Lex(llvm::StringRef source_text)
           return LexedStringLiteral(text, content, hash_level, introducer->kind,
                                     /*is_terminated=*/true);
         }
+        break;
+      default:
+        // No action for non-terminators.
         break;
     }
   }

--- a/toolchain/lexer/string_literal.h
+++ b/toolchain/lexer/string_literal.h
@@ -38,7 +38,11 @@ class LexedStringLiteral {
   [[nodiscard]] auto is_terminated() const -> bool { return is_terminated_; }
 
  private:
-  enum MultiLineKind { NotMultiLine, MultiLine, MultiLineWithDoubleQuotes };
+  enum MultiLineKind : int8_t {
+    NotMultiLine,
+    MultiLine,
+    MultiLineWithDoubleQuotes
+  };
 
   struct Introducer;
 

--- a/toolchain/lexer/string_literal_fuzzer.cpp
+++ b/toolchain/lexer/string_literal_fuzzer.cpp
@@ -2,12 +2,10 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cstdint>
 #include <cstring>
 
 #include "common/check.h"
 #include "llvm/ADT/StringRef.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/string_literal.h"
 

--- a/toolchain/lexer/string_literal_test.cpp
+++ b/toolchain/lexer/string_literal_test.cpp
@@ -8,7 +8,6 @@
 #include <gtest/gtest.h>
 
 #include "common/check.h"
-#include "common/ostream.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lexer/test_helpers.h"
 

--- a/toolchain/lexer/test_helpers.h
+++ b/toolchain/lexer/test_helpers.h
@@ -8,12 +8,9 @@
 #include <gmock/gmock.h>
 
 #include <array>
-#include <string>
 
 #include "common/check.h"
 #include "common/string_helpers.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
 namespace Carbon::Testing {

--- a/toolchain/lexer/token_kind_test.cpp
+++ b/toolchain/lexer/token_kind_test.cpp
@@ -7,8 +7,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstring>
-
 #include "llvm/ADT/StringRef.h"
 
 namespace Carbon::Testing {

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -536,7 +536,7 @@ class TokenizedBuffer::Lexer {
       // Too short to form one of these tokens.
       return LexResult::NoMatch();
     }
-    if (word[1] < '1' || '9' < word[1]) {
+    if (word[1] < '1' || word[1] > '9') {
       // Doesn't start with a valid initial digit.
       return LexResult::NoMatch();
     }

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -7,13 +7,9 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <iterator>
-#include <string>
 
 #include "common/check.h"
 #include "common/string_helpers.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -540,7 +536,7 @@ class TokenizedBuffer::Lexer {
       // Too short to form one of these tokens.
       return LexResult::NoMatch();
     }
-    if (!('1' <= word[1] && word[1] <= '9')) {
+    if (word[1] < '1' || '9' < word[1]) {
       // Doesn't start with a valid initial digit.
       return LexResult::NoMatch();
     }
@@ -683,6 +679,8 @@ class TokenizedBuffer::Lexer {
         case '\t':
         case '\n':
           return false;
+        default:
+          break;
       }
       return llvm::StringSwitch<bool>(llvm::StringRef(&c, 1))
 #define CARBON_SYMBOL_TOKEN(Name, Spelling) .StartsWith(Spelling, false)

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <iterator>
-#include <optional>
 
 #include "common/ostream.h"
 #include "llvm/ADT/APInt.h"

--- a/toolchain/lexer/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lexer/tokenized_buffer_fuzzer.cpp
@@ -2,12 +2,10 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cstdint>
 #include <cstring>
 
 #include "common/check.h"
 #include "llvm/ADT/StringRef.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -11,10 +11,6 @@
 #include <iterator>
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Sequence.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/raw_ostream.h"
 #include "testing/base/test_raw_ostream.h"
 #include "toolchain/base/yaml_test_helpers.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"

--- a/toolchain/lexer/tokenized_buffer_test_helpers.h
+++ b/toolchain/lexer/tokenized_buffer_test_helpers.h
@@ -8,8 +8,6 @@
 #include <gmock/gmock.h>
 
 #include "common/check.h"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/YAMLParser.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 

--- a/toolchain/lowering/lowering_context.cpp
+++ b/toolchain/lowering/lowering_context.cpp
@@ -177,6 +177,8 @@ auto LoweringContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     for (const auto& node_id : semantics_ir().GetNodeBlock(block_id)) {
       auto node = semantics_ir().GetNode(node_id);
       CARBON_VLOG() << "Lowering " << node_id << ": " << node << "\n";
+      // clang warns on unhandled enum values; clang-tidy is incorrect here.
+      // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
       switch (node.kind()) {
 #define CARBON_SEMANTICS_NODE_KIND(Name)                    \
   case SemIR::NodeKind::Name:                               \
@@ -200,6 +202,9 @@ auto LoweringContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
       // TODO: We may want to have different representations for `bool` storage
       // (`i8`) versus for `bool` values (`i1`).
       return llvm::Type::getInt1Ty(*llvm_context_);
+    default:
+      // Handled below.
+      break;
   }
 
   auto node = semantics_ir_->GetNode(node_id);

--- a/toolchain/lowering/lowering_function_context.h
+++ b/toolchain/lowering/lowering_function_context.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_LOWERING_LOWERING_FUNCTION_CONTEXT_H_
 #define CARBON_TOOLCHAIN_LOWERING_LOWERING_FUNCTION_CONTEXT_H_
 
-#include <optional>
-
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/toolchain/lowering/lowering_handle.cpp
+++ b/toolchain/lowering/lowering_handle.cpp
@@ -95,7 +95,7 @@ auto LoweringHandleAssign(LoweringFunctionContext& context,
                                     context.GetLocal(storage_id));
       break;
     case SemIR::ValueRepresentation::Pointer: {
-      auto& layout = context.llvm_module().getDataLayout();
+      const auto& layout = context.llvm_module().getDataLayout();
       auto* type = context.GetType(storage_type_id);
       // TODO: Compute known alignment of the source and destination, which may
       // be greater than the alignment computed by LLVM.

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -35,6 +35,8 @@ auto ParseTree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
   }
 
   while (!context.state_stack().empty()) {
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (context.state_stack().back().state) {
 #define CARBON_PARSER_STATE(Name) \
   case ParserState::Name:         \

--- a/toolchain/parser/parse_tree_fuzzer.cpp
+++ b/toolchain/parser/parse_tree_fuzzer.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cstddef>
-#include <cstdint>
 #include <cstring>
 
 #include "llvm/ADT/StringRef.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/parser/parse_tree.h"

--- a/toolchain/parser/parser_context.h
+++ b/toolchain/parser/parser_context.h
@@ -23,16 +23,16 @@ namespace Carbon {
 class ParserContext {
  public:
   // Possible operator fixities for errors.
-  enum class OperatorFixity { Prefix, Infix, Postfix };
+  enum class OperatorFixity : int8_t { Prefix, Infix, Postfix };
 
   // Possible return values for FindListToken.
-  enum class ListTokenKind { Comma, Close, CommaClose };
+  enum class ListTokenKind : int8_t { Comma, Close, CommaClose };
 
   // Supported kinds for HandlePattern.
-  enum class PatternKind { DeducedParameter, Parameter, Variable };
+  enum class PatternKind : int8_t { DeducedParameter, Parameter, Variable };
 
   // Supported return values for GetDeclarationContext.
-  enum class DeclarationContext {
+  enum class DeclarationContext : int8_t {
     File,  // Top-level context.
     Class,
     Interface,

--- a/toolchain/parser/parser_handle_declaration_name_and_params.cpp
+++ b/toolchain/parser/parser_handle_declaration_name_and_params.cpp
@@ -56,7 +56,7 @@ auto ParserHandleDeclarationNameAndParamsAsRequired(ParserContext& context)
       context, ParserState::DeclarationNameAndParamsAfterNameAsRequired);
 }
 
-enum class Params {
+enum class Params : int8_t {
   None,
   Optional,
   Required,

--- a/toolchain/parser/precedence.cpp
+++ b/toolchain/parser/precedence.cpp
@@ -4,8 +4,6 @@
 
 #include "toolchain/parser/precedence.h"
 
-#include <utility>
-
 #include "common/check.h"
 
 namespace Carbon {

--- a/toolchain/semantics/semantics_context.h
+++ b/toolchain/semantics/semantics_context.h
@@ -255,7 +255,7 @@ class Context {
 
  private:
   // For CanImplicitAs, the detected conversion to apply.
-  enum ImplicitAsKind {
+  enum ImplicitAsKind : int8_t {
     // Incompatible types.
     Incompatible,
     // No conversion required.
@@ -295,7 +295,7 @@ class Context {
       -> SemIR::NodeId;
 
   // Marks the initializer `init_id` as initializing `target_id`.
-  auto MarkInitializerFor(SemIR::NodeId target_id, SemIR::NodeId init_id)
+  auto MarkInitializerFor(SemIR::NodeId init_id, SemIR::NodeId target_id)
       -> void;
 
   // Runs ImplicitAs behavior to convert `value` to `as_type`, returning the

--- a/toolchain/semantics/semantics_declaration_name_stack.h
+++ b/toolchain/semantics/semantics_declaration_name_stack.h
@@ -52,7 +52,7 @@ class DeclarationNameStack {
  public:
   // Context for declaration name construction.
   struct NameContext {
-    enum class State {
+    enum class State : int8_t {
       // A new context which has not processed any parts of the qualifier.
       New,
 

--- a/toolchain/semantics/semantics_handle_if_expression.cpp
+++ b/toolchain/semantics/semantics_handle_if_expression.cpp
@@ -8,15 +8,18 @@ namespace Carbon::Check {
 
 auto HandleIfExpressionIf(Context& context, ParseTree::Node parse_node)
     -> bool {
+  // Alias parse_node for if/then/else consistency.
+  auto if_node = parse_node;
+
   auto cond_value_id = context.node_stack().PopExpression();
 
-  context.node_stack().Push(parse_node);
+  context.node_stack().Push(if_node);
 
   // Convert the condition to `bool`, and branch on it.
-  cond_value_id = context.ConvertToBoolValue(parse_node, cond_value_id);
+  cond_value_id = context.ConvertToBoolValue(if_node, cond_value_id);
   auto then_block_id =
-      context.AddDominatedBlockAndBranchIf(parse_node, cond_value_id);
-  auto else_block_id = context.AddDominatedBlockAndBranch(parse_node);
+      context.AddDominatedBlockAndBranchIf(if_node, cond_value_id);
+  auto else_block_id = context.AddDominatedBlockAndBranch(if_node);
 
   // Push the `else` block and `then` block, and start emitting the `then`.
   context.node_block_stack().Pop();
@@ -28,19 +31,25 @@ auto HandleIfExpressionIf(Context& context, ParseTree::Node parse_node)
 
 auto HandleIfExpressionThen(Context& context, ParseTree::Node parse_node)
     -> bool {
+  // Alias parse_node for if/then/else consistency.
+  auto then_node = parse_node;
+
   // Convert the first operand to a value.
   auto [then_value_node, then_value_id] =
       context.node_stack().PopExpressionWithParseNode();
   context.node_stack().Push(then_value_node,
                             context.ConvertToValueExpression(then_value_id));
 
-  context.node_stack().Push(parse_node, context.node_block_stack().Pop());
+  context.node_stack().Push(then_node, context.node_block_stack().Pop());
   context.AddCurrentCodeBlockToFunction();
   return true;
 }
 
 auto HandleIfExpressionElse(Context& context, ParseTree::Node parse_node)
     -> bool {
+  // Alias parse_node for if/then/else consistency.
+  auto else_node = parse_node;
+
   auto else_value_id = context.node_stack().PopExpression();
   auto [then_node, then_end_block_id] =
       context.node_stack().PopWithParseNode<ParseNodeKind::IfExpressionThen>();
@@ -53,7 +62,7 @@ auto HandleIfExpressionElse(Context& context, ParseTree::Node parse_node)
   // TODO: Find a common type, and convert both operands to it instead.
   auto result_type_id = context.semantics_ir().GetNode(then_value_id).type_id();
   else_value_id =
-      context.ConvertToValueOfType(parse_node, else_value_id, result_type_id);
+      context.ConvertToValueOfType(else_node, else_value_id, result_type_id);
   auto else_end_block_id = context.node_block_stack().Pop();
 
   // Create a resumption block and branches to it.
@@ -63,7 +72,7 @@ auto HandleIfExpressionElse(Context& context, ParseTree::Node parse_node)
   context.AddCurrentCodeBlockToFunction();
 
   // Push the result value.
-  context.node_stack().Push(parse_node, chosen_value_id);
+  context.node_stack().Push(else_node, chosen_value_id);
   return true;
 }
 

--- a/toolchain/semantics/semantics_handle_if_expression.cpp
+++ b/toolchain/semantics/semantics_handle_if_expression.cpp
@@ -9,7 +9,7 @@ namespace Carbon::Check {
 auto HandleIfExpressionIf(Context& context, ParseTree::Node parse_node)
     -> bool {
   // Alias parse_node for if/then/else consistency.
-  auto if_node = parse_node;
+  auto& if_node = parse_node;
 
   auto cond_value_id = context.node_stack().PopExpression();
 
@@ -32,7 +32,7 @@ auto HandleIfExpressionIf(Context& context, ParseTree::Node parse_node)
 auto HandleIfExpressionThen(Context& context, ParseTree::Node parse_node)
     -> bool {
   // Alias parse_node for if/then/else consistency.
-  auto then_node = parse_node;
+  auto& then_node = parse_node;
 
   // Convert the first operand to a value.
   auto [then_value_node, then_value_id] =
@@ -48,7 +48,7 @@ auto HandleIfExpressionThen(Context& context, ParseTree::Node parse_node)
 auto HandleIfExpressionElse(Context& context, ParseTree::Node parse_node)
     -> bool {
   // Alias parse_node for if/then/else consistency.
-  auto else_node = parse_node;
+  auto& else_node = parse_node;
 
   auto else_value_id = context.node_stack().PopExpression();
   auto [then_node, then_end_block_id] =

--- a/toolchain/semantics/semantics_handle_loop_statement.cpp
+++ b/toolchain/semantics/semantics_handle_loop_statement.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/semantics/semantics_context.h"
-#include "toolchain/semantics/semantics_node.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/semantics/semantics_handle_named_constraint.cpp
+++ b/toolchain/semantics/semantics_handle_named_constraint.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/semantics/semantics_context.h"
-#include "toolchain/semantics/semantics_node.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/semantics/semantics_ir.cpp
+++ b/toolchain/semantics/semantics_ir.cpp
@@ -73,6 +73,8 @@ auto File::MakeFromParseTree(const File& builtin_ir,
   // Loops over all nodes in the tree. On some errors, this may return early,
   // for example if an unrecoverable state is encountered.
   for (auto parse_node : parse_tree.postorder()) {
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (auto parse_kind = parse_tree.node_kind(parse_node)) {
 #define CARBON_PARSE_NODE_KIND(Name)                 \
   case ParseNodeKind::Name: {                        \
@@ -198,6 +200,8 @@ auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
 // precedence of that type's syntax. Higher numbers correspond to higher
 // precedence.
 static auto GetTypePrecedence(NodeKind kind) -> int {
+  // clang warns on unhandled enum values; clang-tidy is incorrect here.
+  // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (kind) {
     case NodeKind::ArrayType:
     case NodeKind::Builtin:
@@ -285,6 +289,8 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
     }
 
     auto node = GetNode(step.node_id);
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
       case NodeKind::ArrayType: {
         auto [bound_id, type_id] = node.GetAsArrayType();
@@ -434,6 +440,8 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
   const File* ir = &file;
   while (true) {
     auto node = ir->GetNode(node_id);
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
       case NodeKind::Invalid:
       case NodeKind::Assign:
@@ -524,6 +532,8 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
   NodeId node_id = ir->GetTypeAllowBuiltinTypes(type_id);
   while (true) {
     auto node = ir->GetNode(node_id);
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
       case NodeKind::AddressOf:
       case NodeKind::ArrayIndex:
@@ -577,7 +587,7 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
         return {.kind = ValueRepresentation::Pointer, .type = type_id};
 
       case NodeKind::StructType: {
-        auto& fields = ir->GetNodeBlock(node.GetAsStructType());
+        const auto& fields = ir->GetNodeBlock(node.GetAsStructType());
         if (fields.empty()) {
           // An empty struct has an empty representation.
           return {.kind = ValueRepresentation::None, .type = TypeId::Invalid};
@@ -594,7 +604,7 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
       }
 
       case NodeKind::TupleType: {
-        auto& elements = ir->GetTypeBlock(node.GetAsTupleType());
+        const auto& elements = ir->GetTypeBlock(node.GetAsTupleType());
         if (elements.empty()) {
           // An empty tuple has an empty representation.
           return {.kind = ValueRepresentation::None, .type = TypeId::Invalid};
@@ -609,6 +619,8 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
       }
 
       case NodeKind::Builtin:
+        // clang warns on unhandled enum values; clang-tidy is incorrect here.
+        // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
         switch (node.GetAsBuiltin()) {
           case BuiltinKind::TypeType:
           case BuiltinKind::Error:

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -343,7 +343,7 @@ class File {
 
 // The expression category of a semantics node. See /docs/design/values.md for
 // details.
-enum class ExpressionCategory {
+enum class ExpressionCategory : int8_t {
   // This node does not correspond to an expression, and as such has no
   // category.
   NotExpression,
@@ -366,7 +366,7 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
 
 // The value representation to use when passing by value.
 struct ValueRepresentation {
-  enum Kind {
+  enum Kind : int8_t {
     // The type has no value representation. This is used for empty types, such
     // as `()`, where there is no value.
     None,
@@ -396,7 +396,7 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
 
 // The initializing representation to use when returning by value.
 struct InitializingRepresentation {
-  enum Kind {
+  enum Kind : int8_t {
     // The type has no initializing representation. This is used for empty
     // types, where no initialization is necessary.
     None,
@@ -414,7 +414,7 @@ struct InitializingRepresentation {
   Kind kind;
 
   // Returns whether a return slot is used when returning this type.
-  bool has_return_slot() const { return kind == InPlace; }
+  auto has_return_slot() const -> bool { return kind == InPlace; }
 };
 
 // Returns information about the initializing representation to use for a type.

--- a/toolchain/semantics/semantics_ir_formatter.cpp
+++ b/toolchain/semantics/semantics_ir_formatter.cpp
@@ -492,6 +492,8 @@ class Formatter {
   }
 
   auto FormatInstruction(NodeId node_id, Node node) -> void {
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
 #define CARBON_SEMANTICS_NODE_KIND(Name)          \
   case NodeKind::Name:                            \

--- a/toolchain/semantics/semantics_ir_test.cpp
+++ b/toolchain/semantics/semantics_ir_test.cpp
@@ -5,8 +5,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <string>
-
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"

--- a/toolchain/semantics/semantics_node.cpp
+++ b/toolchain/semantics/semantics_node.cpp
@@ -23,6 +23,8 @@ static auto PrintArgs(llvm::raw_ostream& out, std::pair<T0, T1> args) -> void {
 auto operator<<(llvm::raw_ostream& out, const Node& node)
     -> llvm::raw_ostream& {
   out << "{kind: " << node.kind_;
+  // clang warns on unhandled enum values; clang-tidy is incorrect here.
+  // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (node.kind_) {
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
   case NodeKind::Name:                   \

--- a/toolchain/semantics/semantics_node_block_stack.h
+++ b/toolchain/semantics/semantics_node_block_stack.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_BLOCK_STACK_H_
 #define CARBON_TOOLCHAIN_SEMANTICS_SEMANTICS_NODE_BLOCK_STACK_H_
 
-#include <type_traits>
-
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/semantics/semantics_ir.h"
 #include "toolchain/semantics/semantics_node.h"

--- a/toolchain/semantics/semantics_node_kind.h
+++ b/toolchain/semantics/semantics_node_kind.h
@@ -13,7 +13,7 @@
 namespace Carbon::SemIR {
 
 // Whether a node produces or represents a value, and if so, what kind of value.
-enum class NodeValueKind {
+enum class NodeValueKind : int8_t {
   // This node doesn't produce a value, and shouldn't be referenced by other
   // nodes.
   None,
@@ -28,7 +28,7 @@ enum class NodeValueKind {
 // Whether a node is a terminator or part of the terminator sequence. The nodes
 // in a block appear in the order NotTerminator, then TerminatorSequence, then
 // Terminator, which is also the numerical order of these values.
-enum class TerminatorKind {
+enum class TerminatorKind : int8_t {
   // This node is not a terminator.
   NotTerminator,
   // This node is not itself a terminator, but forms part of a terminator

--- a/toolchain/semantics/semantics_node_stack.h
+++ b/toolchain/semantics/semantics_node_stack.h
@@ -174,7 +174,7 @@ class NodeStack {
 
  private:
   // Possible associated ID types.
-  enum class IdKind {
+  enum class IdKind : int8_t {
     NodeId,
     NodeBlockId,
     FunctionId,

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -6,7 +6,7 @@
 
 #include <limits>
 
-#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FormatVariadic.h"
 
 namespace Carbon {

--- a/toolchain/source/source_buffer_test.cpp
+++ b/toolchain/source/source_buffer_test.cpp
@@ -6,9 +6,7 @@
 
 #include <gtest/gtest.h>
 
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace Carbon::Testing {
 namespace {


### PR DESCRIPTION
A lot of this is more boring "remove unused header", plus some other minor cleanups. I think the most significant changes were:

- yaml_test_helpers.cpp is doing a switch on an unsigned int, comparing to enum values.
  - [bugprone-switch-missing-default-case](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/switch-missing-default-case.html) is unhappy with EnumBase, but correctly identified yaml_test_helpers.cpp, so I'm opting to address it rather than disabling it even though it needs NOLINT in several locations as a result, in addition to what I think are some low-value `default` cases. I'd be fine going the other way with this too and disabling it globally (I could see it being noisier in the explorer).
- MarkInitializerFor swaps the argument names between the .h and .cpp. I think the .cpp had the order as intended.
- There's a new-ish [performance-enum-size](https://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html) which I'm basically treating as "add int8_t to enums".

My main motivation here is to just clean up as many of these as I can so that I stop seeing them in vscode.