### PR TITLE
Update C++Now talks with video links

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,15 +305,12 @@ Past Carbon focused talks from the community:
 
 ### 2023
 
-Press `S` when viewing slides to see speaker notes.
-
--   [Carbon’s Successor Strategy: From C++ interop to memory safety (Slides)](https://chandlerc.blog/slides/2023-cppnow-carbon-strategy/index.html#/),
+-   [Carbon’s Successor Strategy: From C++ interop to memory safety](https://www.youtube.com/watch?v=1ZTJ9omXOQ0),
     C++Now
 -   Definition-Checked Generics
-    [(Part 1, Slides)](https://chandlerc.blog/slides/2023-cppnow-generics-1/#/),
-    [(Part 2, Slides)](https://chandlerc.blog/slides/2023-cppnow-generics-2/#/),
-    C++Now
--   [Modernizing Compiler Design for Carbon’s Toolchain (Slides)](https://chandlerc.blog/slides/2023-cppnow-compiler/index.html#/),
+    ([Part 1](https://www.youtube.com/watch?v=FKC8WACSMP0),
+    [Part 2](https://www.youtube.com/watch?v=VxQ3PwxiSzk)), C++Now
+-   [Modernizing Compiler Design for Carbon’s Toolchain](https://www.youtube.com/watch?v=ZI198eFghJk),
     C++Now
 
 ## Join us


### PR DESCRIPTION
The successor strategy talk isn't up yet, but will be on Sep 8 -- just trying to get them all in one pass.

Slides were previously linked, which I could keep, although it's weird to have a long link with just `(Slides)` at the end because it implies the whole linked text is slides (rather than a video). So if that's desired, I might switch instead to something like:

```
- Talk name, con ([video](youtube link), [slides](slides link))
```

But, this current format (video-only full-name link) felt consistent with the 2022 links.