### PR TITLE
Remove `MemberName::Print`.

### DIFF
--- a/explorer/ast/value.cpp
+++ b/explorer/ast/value.cpp
@@ -761,7 +761,7 @@ void Value::Print(llvm::raw_ostream& out) const {
       if (member_name.interface().has_value()) {
         out << *member_name.interface().value();
       }
-      out << "." << member_name;
+      out << "." << member_name.member();
       if (member_name.base_type().has_value() &&
           member_name.interface().has_value()) {
         out << ")";

--- a/explorer/ast/value.h
+++ b/explorer/ast/value.h
@@ -1488,9 +1488,6 @@ class MemberName : public Value {
     return f(base_type_, interface_, member_);
   }
 
-  // Prints the member name or identifier.
-  void Print(llvm::raw_ostream& out) const { member_->Print(out); }
-
   // The type for which `name` is a member or a member of an `impl`.
   auto base_type() const -> std::optional<Nonnull<const Value*>> {
     return base_type_;


### PR DESCRIPTION
This function hid the `Value::Print` function from the base class, and provided different output. As far as I can tell, the only caller is the implementation of `Value::Print`.