### PR TITLE
Moving lexer into a 'Lex' namespace.

### DIFF
--- a/language_server/language_server.cpp
+++ b/language_server/language_server.cpp
@@ -95,7 +95,7 @@ void LanguageServer::OnDocumentSymbol(
               llvm::MemoryBuffer::getMemBufferCopy(files_.at(file)));
 
   auto buf = SourceBuffer::CreateFromFile(vfs, file);
-  auto lexed = TokenizedBuffer::Lex(*buf, NullDiagnosticConsumer());
+  auto lexed = Lex::TokenizedBuffer::Lex(*buf, NullDiagnosticConsumer());
   auto parsed = Parse::Tree::Parse(lexed, NullDiagnosticConsumer(), nullptr);
   std::vector<clang::clangd::DocumentSymbol> result;
   for (const auto& node : parsed.postorder()) {

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -406,10 +406,10 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
   }
   CARBON_VLOG() << "*** file:\n```\n" << source->text() << "\n```\n";
 
-  CARBON_VLOG() << "*** TokenizedBuffer::Lex ***\n";
-  auto tokenized_source = TokenizedBuffer::Lex(*source, *consumer);
+  CARBON_VLOG() << "*** Lex::TokenizedBuffer::Lex ***\n";
+  auto tokenized_source = Lex::TokenizedBuffer::Lex(*source, *consumer);
   bool has_errors = tokenized_source.has_errors();
-  CARBON_VLOG() << "*** TokenizedBuffer::Lex done ***\n";
+  CARBON_VLOG() << "*** Lex::TokenizedBuffer::Lex done ***\n";
   if (options.dump_tokens) {
     CARBON_VLOG() << "Finishing output.";
     consumer->Flush();

--- a/toolchain/lexer/character_set.h
+++ b/toolchain/lexer/character_set.h
@@ -7,7 +7,7 @@
 
 #include "llvm/ADT/StringExtras.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 // TODO: These definitions need to be updated to match whatever Unicode lexical
 // rules we pick. The function interfaces will need to change to accommodate
@@ -71,6 +71,6 @@ inline auto IsSpace(char c) -> bool {
   return IsHorizontalWhitespace(c) || IsVerticalWhitespace(c);
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 #endif  // CARBON_TOOLCHAIN_LEXER_CHARACTER_SET_H_

--- a/toolchain/lexer/lex_helpers.cpp
+++ b/toolchain/lexer/lex_helpers.cpp
@@ -4,7 +4,7 @@
 
 #include "toolchain/lexer/lex_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 auto CanLexInteger(DiagnosticEmitter<const char*>& emitter,
                    llvm::StringRef text) -> bool {
@@ -29,4 +29,4 @@ auto CanLexInteger(DiagnosticEmitter<const char*>& emitter,
   return true;
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex

--- a/toolchain/lexer/lex_helpers.h
+++ b/toolchain/lexer/lex_helpers.h
@@ -7,13 +7,13 @@
 
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 // Should guard calls to getAsInteger due to performance issues with large
 // integers. Emits an error if the text cannot be lexed.
 auto CanLexInteger(DiagnosticEmitter<const char*>& emitter,
                    llvm::StringRef text) -> bool;
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 #endif  // CARBON_TOOLCHAIN_LEXER_LEX_HELPERS_H_

--- a/toolchain/lexer/numeric_literal.cpp
+++ b/toolchain/lexer/numeric_literal.cpp
@@ -11,7 +11,7 @@
 #include "toolchain/lexer/character_set.h"
 #include "toolchain/lexer/lex_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 // Adapts Radix for use with formatv.
 // NOTE: clangd may see this as unused, but it will be invoked by diagnostics.
@@ -461,4 +461,4 @@ auto LexedNumericLiteral::ComputeValue(
       .exponent = parser.GetExponent()};
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex

--- a/toolchain/lexer/numeric_literal.h
+++ b/toolchain/lexer/numeric_literal.h
@@ -12,7 +12,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 // A numeric literal token that has been extracted from a source buffer.
 class LexedNumericLiteral {
@@ -71,6 +71,6 @@ class LexedNumericLiteral {
   int exponent_;
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 #endif  // CARBON_TOOLCHAIN_LEXER_NUMERIC_LITERAL_H_

--- a/toolchain/lexer/numeric_literal_benchmark.cpp
+++ b/toolchain/lexer/numeric_literal_benchmark.cpp
@@ -11,6 +11,8 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::LexedNumericLiteral;
+
 static void BM_Lex_Float(benchmark::State& state) {
   for (auto _ : state) {
     CARBON_CHECK(LexedNumericLiteral::Lex("0.000001"));

--- a/toolchain/lexer/numeric_literal_fuzzer.cpp
+++ b/toolchain/lexer/numeric_literal_fuzzer.cpp
@@ -13,7 +13,7 @@ namespace Carbon::Testing {
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                       std::size_t size) {
-  auto token = LexedNumericLiteral::Lex(
+  auto token = Lex::LexedNumericLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {
     // Lexically not a numeric literal.

--- a/toolchain/lexer/numeric_literal_test.cpp
+++ b/toolchain/lexer/numeric_literal_test.cpp
@@ -14,6 +14,7 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::LexedNumericLiteral;
 using ::testing::_;
 using ::testing::Field;
 using ::testing::Matcher;

--- a/toolchain/lexer/string_literal.cpp
+++ b/toolchain/lexer/string_literal.cpp
@@ -12,7 +12,7 @@
 #include "toolchain/lexer/character_set.h"
 #include "toolchain/lexer/lex_helpers.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 using LexerDiagnosticEmitter = DiagnosticEmitter<const char*>;
 
@@ -455,4 +455,4 @@ auto LexedStringLiteral::ComputeValue(LexerDiagnosticEmitter& emitter) const
                                               indent);
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex

--- a/toolchain/lexer/string_literal.h
+++ b/toolchain/lexer/string_literal.h
@@ -11,7 +11,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 class LexedStringLiteral {
  public:
@@ -70,6 +70,6 @@ class LexedStringLiteral {
   bool is_terminated_;
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 #endif  // CARBON_TOOLCHAIN_LEXER_STRING_LITERAL_H_

--- a/toolchain/lexer/string_literal_benchmark.cpp
+++ b/toolchain/lexer/string_literal_benchmark.cpp
@@ -10,6 +10,8 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::LexedStringLiteral;
+
 static void BM_ValidString(benchmark::State& state, std::string_view introducer,
                            std::string_view terminator) {
   std::string x(introducer);

--- a/toolchain/lexer/string_literal_fuzzer.cpp
+++ b/toolchain/lexer/string_literal_fuzzer.cpp
@@ -14,7 +14,7 @@ namespace Carbon::Testing {
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                       std::size_t size) {
-  auto token = LexedStringLiteral::Lex(
+  auto token = Lex::LexedStringLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {
     // Lexically not a string literal.

--- a/toolchain/lexer/string_literal_test.cpp
+++ b/toolchain/lexer/string_literal_test.cpp
@@ -14,6 +14,8 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::LexedStringLiteral;
+
 class StringLiteralTest : public ::testing::Test {
  protected:
   StringLiteralTest() : error_tracker(ConsoleDiagnosticConsumer()) {}

--- a/toolchain/lexer/token_kind.cpp
+++ b/toolchain/lexer/token_kind.cpp
@@ -4,7 +4,7 @@
 
 #include "toolchain/lexer/token_kind.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(TokenKind) = {
 #define CARBON_TOKEN(TokenName) CARBON_ENUM_CLASS_NAME_STRING(TokenName)
@@ -79,4 +79,4 @@ constexpr int8_t TokenKind::ExpectedParseTreeSize[] = {
 #include "toolchain/lexer/token_kind.def"
 };
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex

--- a/toolchain/lexer/token_kind.h
+++ b/toolchain/lexer/token_kind.h
@@ -13,7 +13,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadicDetails.h"
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 CARBON_DEFINE_RAW_ENUM_CLASS(TokenKind, uint8_t) {
 #define CARBON_TOKEN(TokenName) CARBON_RAW_ENUM_ENUMERATOR(TokenName)
@@ -138,15 +138,15 @@ constexpr TokenKind TokenKind::KeywordTokensStorage[] = {
 constexpr llvm::ArrayRef<TokenKind> TokenKind::KeywordTokens =
     KeywordTokensStorage;
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 namespace llvm {
 
 // We use formatv primarily for diagnostics. In these cases, it's expected that
 // the spelling in source code should be used.
 template <>
-struct format_provider<Carbon::TokenKind> {
-  static void format(const Carbon::TokenKind& kind, raw_ostream& out,
+struct format_provider<Carbon::Lex::TokenKind> {
+  static void format(const Carbon::Lex::TokenKind& kind, raw_ostream& out,
                      StringRef /*style*/) {
     auto spelling = kind.fixed_spelling();
     if (!spelling.empty()) {

--- a/toolchain/lexer/token_kind_test.cpp
+++ b/toolchain/lexer/token_kind_test.cpp
@@ -12,6 +12,7 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::TokenKind;
 using ::testing::MatchesRegex;
 
 // We restrict symbols to punctuation characters that are expected to be widely

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -25,7 +25,7 @@
 #include <x86intrin.h>
 #endif
 
-namespace Carbon {
+namespace Carbon::Lex {
 
 // TODO: Move Overload and VariantMatch somewhere more central.
 
@@ -1213,4 +1213,4 @@ auto TokenizedBuffer::TokenLocationTranslator::GetLocation(Token token)
   return SourceBufferLocationTranslator(buffer_).GetLocation(token_start);
 }
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -21,9 +21,7 @@
 #include "toolchain/lexer/token_kind.h"
 #include "toolchain/source/source_buffer.h"
 
-namespace Carbon {
-
-class TokenizedBuffer;
+namespace Carbon::Lex {
 
 // A buffer of tokenized Carbon source code.
 //
@@ -422,6 +420,6 @@ using LexerDiagnosticEmitter = DiagnosticEmitter<const char*>;
 // A diagnostic emitter that uses tokens as its source of location information.
 using TokenDiagnosticEmitter = DiagnosticEmitter<TokenizedBuffer::Token>;
 
-}  // namespace Carbon
+}  // namespace Carbon::Lex
 
 #endif  // CARBON_TOOLCHAIN_LEXER_TOKENIZED_BUFFER_H_

--- a/toolchain/lexer/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lexer/tokenized_buffer_benchmark.cpp
@@ -17,6 +17,9 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::TokenizedBuffer;
+using Lex::TokenKind;
+
 // A large value for measurement stability without making benchmarking too slow.
 // Needs to be a multiple of 100 so we can easily divide it up into percentages,
 // and 1% itself needs to not be too tiny. This makes 100,000 a great balance.

--- a/toolchain/lexer/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lexer/tokenized_buffer_fuzzer.cpp
@@ -32,7 +32,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                        /*RequiresNullTerminator=*/false)));
   auto source = SourceBuffer::CreateFromFile(fs, TestFileName);
 
-  auto buffer = TokenizedBuffer::Lex(*source, NullDiagnosticConsumer());
+  auto buffer = Lex::TokenizedBuffer::Lex(*source, NullDiagnosticConsumer());
   if (buffer.has_errors()) {
     return 0;
   }
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   //
   // TODO: We should enhance this to do more sanity checks on the resulting
   // token stream.
-  for (TokenizedBuffer::Token token : buffer.tokens()) {
+  for (Lex::TokenizedBuffer::Token token : buffer.tokens()) {
     int line_number = buffer.GetLineNumber(token);
     CARBON_CHECK(line_number > 0) << "Invalid line number!";
     CARBON_CHECK(line_number < INT_MAX) << "Invalid line number!";

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -20,6 +20,8 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::TokenizedBuffer;
+using Lex::TokenKind;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Eq;

--- a/toolchain/lexer/tokenized_buffer_test_helpers.h
+++ b/toolchain/lexer/tokenized_buffer_test_helpers.h
@@ -40,7 +40,7 @@ struct ExpectedToken {
     return output;
   }
 
-  TokenKind kind;
+  Lex::TokenKind kind;
   int line = -1;
   int column = -1;
   int indent_column = -1;
@@ -54,7 +54,7 @@ struct ExpectedToken {
 // mismatches first.
 // NOLINTNEXTLINE: Expands from GoogleTest.
 MATCHER_P(HasTokens, raw_all_expected, "") {
-  const TokenizedBuffer& buffer = arg;
+  const Lex::TokenizedBuffer& buffer = arg;
   llvm::ArrayRef<ExpectedToken> all_expected = raw_all_expected;
 
   bool matches = true;
@@ -68,7 +68,7 @@ MATCHER_P(HasTokens, raw_all_expected, "") {
     int index = buffer_it - buffer.tokens().begin();
     auto token = *buffer_it++;
 
-    TokenKind actual_kind = buffer.GetKind(token);
+    Lex::TokenKind actual_kind = buffer.GetKind(token);
     if (actual_kind != expected.kind) {
       *result_listener << "\nToken " << index << " is a " << actual_kind
                        << ", expected a " << expected.kind << ".";
@@ -119,8 +119,9 @@ MATCHER_P(HasTokens, raw_all_expected, "") {
     }
 
     CARBON_CHECK(!expected.string_contents ||
-                 expected.kind == TokenKind::StringLiteral);
-    if (expected.string_contents && actual_kind == TokenKind::StringLiteral) {
+                 expected.kind == Lex::TokenKind::StringLiteral);
+    if (expected.string_contents &&
+        actual_kind == Lex::TokenKind::StringLiteral) {
       llvm::StringRef actual_contents = buffer.GetStringLiteral(token);
       if (actual_contents != *expected.string_contents) {
         *result_listener << "\nToken " << index << " has contents `"

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -15,10 +15,10 @@
 
 namespace Carbon::Parse {
 
-auto Tree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
+auto Tree::Parse(Lex::TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                  llvm::raw_ostream* vlog_stream) -> Tree {
-  TokenizedBuffer::TokenLocationTranslator translator(&tokens);
-  TokenDiagnosticEmitter emitter(translator, consumer);
+  Lex::TokenizedBuffer::TokenLocationTranslator translator(&tokens);
+  Lex::TokenDiagnosticEmitter emitter(translator, consumer);
 
   // Delegate to the parser.
   Tree tree(tokens);
@@ -30,7 +30,7 @@ auto Tree::Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
 
   // The package should always be the first token, if it's present. Any other
   // use is invalid.
-  if (context.PositionIs(TokenKind::Package)) {
+  if (context.PositionIs(Lex::TokenKind::Package)) {
     context.PushState(State::Package);
   }
 
@@ -95,7 +95,7 @@ auto Tree::node_kind(Node n) const -> NodeKind {
   return node_impls_[n.index].kind;
 }
 
-auto Tree::node_token(Node n) const -> TokenizedBuffer::Token {
+auto Tree::node_token(Node n) const -> Lex::TokenizedBuffer::Token {
   CARBON_CHECK(n.is_valid());
   return node_impls_[n.index].token;
 }
@@ -281,7 +281,7 @@ auto Tree::Verify() const -> ErrorOr<Success> {
                           tokens_->expected_parse_tree_size()) {
     return Error(
         llvm::formatv("Tree has {0} nodes and no errors, but "
-                      "TokenizedBuffer expected {1} nodes for {2} tokens.",
+                      "Lex::TokenizedBuffer expected {1} nodes for {2} tokens.",
                       node_impls_.size(), tokens_->expected_parse_tree_size(),
                       tokens_->size()));
   }

--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -65,7 +65,7 @@ class Tree : public Printable<Tree> {
   // Parses the token buffer into a `Tree`.
   //
   // This is the factory function which is used to build parse trees.
-  static auto Parse(TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
+  static auto Parse(Lex::TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                     llvm::raw_ostream* vlog_stream) -> Tree;
 
   // Tests whether there are any errors in the parse tree.
@@ -103,7 +103,7 @@ class Tree : public Printable<Tree> {
   [[nodiscard]] auto node_kind(Node n) const -> NodeKind;
 
   // Returns the token the given parse tree node models.
-  [[nodiscard]] auto node_token(Node n) const -> TokenizedBuffer::Token;
+  [[nodiscard]] auto node_token(Node n) const -> Lex::TokenizedBuffer::Token;
 
   [[nodiscard]] auto node_subtree_size(Node n) const -> int32_t;
 
@@ -171,7 +171,7 @@ class Tree : public Printable<Tree> {
   // tree.
   struct NodeImpl {
     explicit NodeImpl(NodeKind kind, bool has_error,
-                      TokenizedBuffer::Token token, int subtree_size)
+                      Lex::TokenizedBuffer::Token token, int subtree_size)
         : kind(kind),
           has_error(has_error),
           token(token),
@@ -199,7 +199,7 @@ class Tree : public Printable<Tree> {
     bool has_error = false;
 
     // The token root of this node.
-    TokenizedBuffer::Token token;
+    Lex::TokenizedBuffer::Token token;
 
     // The size of this node's subtree of the parse tree. This is the number of
     // nodes (and thus tokens) that are covered by this node (and its
@@ -223,7 +223,7 @@ class Tree : public Printable<Tree> {
 
   // Wires up the reference to the tokenized buffer. The `Parse` function should
   // be used to actually parse the tokens into a tree.
-  explicit Tree(TokenizedBuffer& tokens_arg) : tokens_(&tokens_arg) {
+  explicit Tree(Lex::TokenizedBuffer& tokens_arg) : tokens_(&tokens_arg) {
     // If the tree is valid, there will be one node per token, so reserve once.
     node_impls_.reserve(tokens_->expected_parse_tree_size());
   }
@@ -236,7 +236,7 @@ class Tree : public Printable<Tree> {
   // Depth-first postorder sequence of node implementation data.
   llvm::SmallVector<NodeImpl> node_impls_;
 
-  TokenizedBuffer* tokens_;
+  Lex::TokenizedBuffer* tokens_;
 
   // Indicates if any errors were encountered while parsing.
   //

--- a/toolchain/parser/parse_tree_fuzzer.cpp
+++ b/toolchain/parser/parse_tree_fuzzer.cpp
@@ -30,7 +30,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   auto source = SourceBuffer::CreateFromFile(fs, TestFileName);
 
   // Lex the input.
-  auto tokens = TokenizedBuffer::Lex(*source, NullDiagnosticConsumer());
+  auto tokens = Lex::TokenizedBuffer::Lex(*source, NullDiagnosticConsumer());
   if (tokens.has_errors()) {
     return 0;
   }

--- a/toolchain/parser/parse_tree_node_location_translator.h
+++ b/toolchain/parser/parse_tree_node_location_translator.h
@@ -11,7 +11,7 @@ namespace Carbon::Parse {
 
 class NodeLocationTranslator : public DiagnosticLocationTranslator<Node> {
  public:
-  explicit NodeLocationTranslator(const TokenizedBuffer* tokens,
+  explicit NodeLocationTranslator(const Lex::TokenizedBuffer* tokens,
                                   const Tree* parse_tree)
       : token_translator_(tokens), parse_tree_(parse_tree) {}
 
@@ -21,7 +21,7 @@ class NodeLocationTranslator : public DiagnosticLocationTranslator<Node> {
   }
 
  private:
-  TokenizedBuffer::TokenLocationTranslator token_translator_;
+  Lex::TokenizedBuffer::TokenLocationTranslator token_translator_;
   const Tree* parse_tree_;
 };
 

--- a/toolchain/parser/parse_tree_test.cpp
+++ b/toolchain/parser/parse_tree_test.cpp
@@ -31,26 +31,26 @@ class TreeTest : public ::testing::Test {
     return source_storage.front();
   }
 
-  auto GetTokenizedBuffer(llvm::StringRef t) -> TokenizedBuffer& {
+  auto GetTokenizedBuffer(llvm::StringRef t) -> Lex::TokenizedBuffer& {
     token_storage.push_front(
-        TokenizedBuffer::Lex(GetSourceBuffer(t), consumer));
+        Lex::TokenizedBuffer::Lex(GetSourceBuffer(t), consumer));
     return token_storage.front();
   }
 
   llvm::vfs::InMemoryFileSystem fs;
   std::forward_list<SourceBuffer> source_storage;
-  std::forward_list<TokenizedBuffer> token_storage;
+  std::forward_list<Lex::TokenizedBuffer> token_storage;
   DiagnosticConsumer& consumer = ConsoleDiagnosticConsumer();
 };
 
 TEST_F(TreeTest, IsValid) {
-  TokenizedBuffer tokens = GetTokenizedBuffer("");
+  Lex::TokenizedBuffer tokens = GetTokenizedBuffer("");
   Tree tree = Tree::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
   EXPECT_TRUE((*tree.postorder().begin()).is_valid());
 }
 
 TEST_F(TreeTest, PrintPostorderAsYAML) {
-  TokenizedBuffer tokens = GetTokenizedBuffer("fn F();");
+  Lex::TokenizedBuffer tokens = GetTokenizedBuffer("fn F();");
   Tree tree = Tree::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
   EXPECT_FALSE(tree.has_errors());
   TestRawOstream print_stream;
@@ -72,7 +72,7 @@ TEST_F(TreeTest, PrintPostorderAsYAML) {
 }
 
 TEST_F(TreeTest, PrintPreorderAsYAML) {
-  TokenizedBuffer tokens = GetTokenizedBuffer("fn F();");
+  Lex::TokenizedBuffer tokens = GetTokenizedBuffer("fn F();");
   Tree tree = Tree::Parse(tokens, consumer, /*vlog_stream=*/nullptr);
   EXPECT_FALSE(tree.has_errors());
   TestRawOstream print_stream;
@@ -112,7 +112,7 @@ TEST_F(TreeTest, HighRecursion) {
   code.append(10000, '(');
   code.append(10000, ')');
   code += "; }";
-  TokenizedBuffer tokens = GetTokenizedBuffer(code);
+  Lex::TokenizedBuffer tokens = GetTokenizedBuffer(code);
   ASSERT_FALSE(tokens.has_errors());
   Testing::MockDiagnosticConsumer consumer;
   Tree tree = Tree::Parse(tokens, consumer, /*vlog_stream=*/nullptr);

--- a/toolchain/parser/parser_context.cpp
+++ b/toolchain/parser/parser_context.cpp
@@ -49,10 +49,10 @@ Context::Context(Tree& tree, Lex::TokenizedBuffer& tokens,
       vlog_stream_(vlog_stream),
       position_(tokens_->tokens().begin()),
       end_(tokens_->tokens().end()) {
-  CARBON_CHECK(position_ != end_) << "Empty Lex::TokenizedBuffer";
+  CARBON_CHECK(position_ != end_) << "Empty TokenizedBuffer";
   --end_;
   CARBON_CHECK(tokens_->GetKind(*end_) == Lex::TokenKind::EndOfFile)
-      << "Lex::TokenizedBuffer should end with EndOfFile, ended with "
+      << "TokenizedBuffer should end with EndOfFile, ended with "
       << tokens_->GetKind(*end_);
 }
 

--- a/toolchain/parser/parser_handle_array_expression.cpp
+++ b/toolchain/parser/parser_handle_array_expression.cpp
@@ -14,7 +14,7 @@ auto HandleArrayExpression(Context& context) -> void {
   auto state = context.PopState();
   state.state = State::ArrayExpressionSemi;
   context.AddLeafNode(NodeKind::ArrayExpressionStart,
-                      context.ConsumeChecked(TokenKind::OpenSquareBracket),
+                      context.ConsumeChecked(Lex::TokenKind::OpenSquareBracket),
                       state.has_error);
   context.PushState(state);
   context.PushState(State::Expression);
@@ -22,7 +22,7 @@ auto HandleArrayExpression(Context& context) -> void {
 
 auto HandleArrayExpressionSemi(Context& context) -> void {
   auto state = context.PopState();
-  auto semi = context.ConsumeIf(TokenKind::Semi);
+  auto semi = context.ConsumeIf(Lex::TokenKind::Semi);
   if (!semi) {
     context.AddNode(NodeKind::ArrayExpressionSemi, *context.position(),
                     state.subtree_start, true);
@@ -35,7 +35,7 @@ auto HandleArrayExpressionSemi(Context& context) -> void {
   }
   state.state = State::ArrayExpressionFinish;
   context.PushState(state);
-  if (!context.PositionIs(TokenKind::CloseSquareBracket)) {
+  if (!context.PositionIs(Lex::TokenKind::CloseSquareBracket)) {
     context.PushState(State::Expression);
   }
 }
@@ -43,7 +43,7 @@ auto HandleArrayExpressionSemi(Context& context) -> void {
 auto HandleArrayExpressionFinish(Context& context) -> void {
   auto state = context.PopState();
   context.ConsumeAndAddCloseSymbol(
-      *(TokenizedBuffer::TokenIterator(state.token)), state,
+      *(Lex::TokenizedBuffer::TokenIterator(state.token)), state,
       NodeKind::ArrayExpression);
 }
 

--- a/toolchain/parser/parser_handle_brace_expression.cpp
+++ b/toolchain/parser/parser_handle_brace_expression.cpp
@@ -13,9 +13,9 @@ auto HandleBraceExpression(Context& context) -> void {
   context.PushState(state);
 
   CARBON_CHECK(context.ConsumeAndAddLeafNodeIf(
-      TokenKind::OpenCurlyBrace,
+      Lex::TokenKind::OpenCurlyBrace,
       NodeKind::StructLiteralOrStructTypeLiteralStart));
-  if (!context.PositionIs(TokenKind::CloseCurlyBrace)) {
+  if (!context.PositionIs(Lex::TokenKind::CloseCurlyBrace)) {
     context.PushState(State::BraceExpressionParameterAsUnknown);
   }
 }
@@ -50,7 +50,7 @@ static auto HandleBraceExpressionParameter(Context& context,
                                            State param_finish_state) -> void {
   auto state = context.PopState();
 
-  if (!context.PositionIs(TokenKind::Period)) {
+  if (!context.PositionIs(Lex::TokenKind::Period)) {
     HandleBraceExpressionParameterError(context, state, param_finish_state);
     return;
   }
@@ -85,9 +85,9 @@ static auto HandleBraceExpressionParameterAfterDesignator(
 
   if (state.has_error) {
     auto recovery_pos = context.FindNextOf(
-        {TokenKind::Equal, TokenKind::Colon, TokenKind::Comma});
+        {Lex::TokenKind::Equal, Lex::TokenKind::Colon, Lex::TokenKind::Comma});
     if (!recovery_pos ||
-        context.tokens().GetKind(*recovery_pos) == TokenKind::Comma) {
+        context.tokens().GetKind(*recovery_pos) == Lex::TokenKind::Comma) {
       state.state = param_finish_state;
       context.PushState(state);
       return;
@@ -97,9 +97,9 @@ static auto HandleBraceExpressionParameterAfterDesignator(
 
   // Work out the kind of this element.
   bool is_type;
-  if (context.PositionIs(TokenKind::Colon)) {
+  if (context.PositionIs(Lex::TokenKind::Colon)) {
     is_type = true;
-  } else if (context.PositionIs(TokenKind::Equal)) {
+  } else if (context.PositionIs(Lex::TokenKind::Equal)) {
     is_type = false;
   } else {
     HandleBraceExpressionParameterError(context, state, param_finish_state);
@@ -168,9 +168,9 @@ static auto HandleBraceExpressionParameterFinish(Context& context,
                     /*has_error=*/false);
   }
 
-  if (context.ConsumeListToken(NodeKind::StructComma,
-                               TokenKind::CloseCurlyBrace, state.has_error) ==
-      Context::ListTokenKind::Comma) {
+  if (context.ConsumeListToken(
+          NodeKind::StructComma, Lex::TokenKind::CloseCurlyBrace,
+          state.has_error) == Context::ListTokenKind::Comma) {
     context.PushState(param_state);
   }
 }

--- a/toolchain/parser/parser_handle_call_expression.cpp
+++ b/toolchain/parser/parser_handle_call_expression.cpp
@@ -14,7 +14,7 @@ auto HandleCallExpression(Context& context) -> void {
 
   context.AddNode(NodeKind::CallExpressionStart, context.Consume(),
                   state.subtree_start, state.has_error);
-  if (!context.PositionIs(TokenKind::CloseParen)) {
+  if (!context.PositionIs(Lex::TokenKind::CloseParen)) {
     context.PushState(State::CallExpressionParameterFinish);
     context.PushState(State::Expression);
   }
@@ -28,7 +28,7 @@ auto HandleCallExpressionParameterFinish(Context& context) -> void {
   }
 
   if (context.ConsumeListToken(NodeKind::CallExpressionComma,
-                               TokenKind::CloseParen, state.has_error) ==
+                               Lex::TokenKind::CloseParen, state.has_error) ==
       Context::ListTokenKind::Comma) {
     context.PushState(State::CallExpressionParameterFinish);
     context.PushState(State::Expression);

--- a/toolchain/parser/parser_handle_code_block.cpp
+++ b/toolchain/parser/parser_handle_code_block.cpp
@@ -10,7 +10,7 @@ auto HandleCodeBlock(Context& context) -> void {
   context.PopAndDiscardState();
 
   context.PushState(State::CodeBlockFinish);
-  if (context.ConsumeAndAddLeafNodeIf(TokenKind::OpenCurlyBrace,
+  if (context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::OpenCurlyBrace,
                                       NodeKind::CodeBlockStart)) {
     context.PushState(State::StatementScopeLoop);
   } else {
@@ -29,7 +29,7 @@ auto HandleCodeBlockFinish(Context& context) -> void {
   auto state = context.PopState();
 
   // If the block started with an open curly, this is a close curly.
-  if (context.tokens().GetKind(state.token) == TokenKind::OpenCurlyBrace) {
+  if (context.tokens().GetKind(state.token) == Lex::TokenKind::OpenCurlyBrace) {
     context.AddNode(NodeKind::CodeBlock, context.Consume(), state.subtree_start,
                     state.has_error);
   } else {

--- a/toolchain/parser/parser_handle_declaration_name_and_params.cpp
+++ b/toolchain/parser/parser_handle_declaration_name_and_params.cpp
@@ -12,11 +12,11 @@ static auto HandleDeclarationNameAndParams(Context& context, State after_name)
   auto state = context.PopState();
 
   // TODO: Should handle designated names.
-  if (auto identifier = context.ConsumeIf(TokenKind::Identifier)) {
+  if (auto identifier = context.ConsumeIf(Lex::TokenKind::Identifier)) {
     state.state = after_name;
     context.PushState(state);
 
-    if (context.PositionIs(TokenKind::Period)) {
+    if (context.PositionIs(Lex::TokenKind::Period)) {
       // Because there's a qualifier, we process the first segment as an
       // expression for simplicity. This just means semantics has one less thing
       // to handle here.
@@ -29,7 +29,7 @@ static auto HandleDeclarationNameAndParams(Context& context, State after_name)
   } else {
     CARBON_DIAGNOSTIC(ExpectedDeclarationName, Error,
                       "`{0}` introducer should be followed by a name.",
-                      TokenKind);
+                      Lex::TokenKind);
     context.emitter().Emit(*context.position(), ExpectedDeclarationName,
                            context.tokens().GetKind(state.token));
     context.ReturnErrorOnState();
@@ -62,7 +62,7 @@ static auto HandleDeclarationNameAndParamsAfterName(Context& context,
                                                     Params params) -> void {
   auto state = context.PopState();
 
-  if (context.PositionIs(TokenKind::Period)) {
+  if (context.PositionIs(Lex::TokenKind::Period)) {
     // Continue designator processing.
     context.PushState(state);
     state.state = State::PeriodAsDeclaration;
@@ -74,14 +74,14 @@ static auto HandleDeclarationNameAndParamsAfterName(Context& context,
     return;
   }
 
-  if (context.PositionIs(TokenKind::OpenSquareBracket)) {
+  if (context.PositionIs(Lex::TokenKind::OpenSquareBracket)) {
     context.PushState(State::DeclarationNameAndParamsAfterDeduced);
     context.PushState(State::ParameterListAsDeduced);
-  } else if (context.PositionIs(TokenKind::OpenParen)) {
+  } else if (context.PositionIs(Lex::TokenKind::OpenParen)) {
     context.PushState(State::ParameterListAsRegular);
   } else if (params == Params::Required) {
     CARBON_DIAGNOSTIC(ParametersRequiredByIntroducer, Error,
-                      "`{0}` requires a `(` for parameters.", TokenKind);
+                      "`{0}` requires a `(` for parameters.", Lex::TokenKind);
     context.emitter().Emit(*context.position(), ParametersRequiredByIntroducer,
                            context.tokens().GetKind(state.token));
     context.ReturnErrorOnState();
@@ -105,7 +105,7 @@ auto HandleDeclarationNameAndParamsAfterNameAsRequired(Context& context)
 auto HandleDeclarationNameAndParamsAfterDeduced(Context& context) -> void {
   context.PopAndDiscardState();
 
-  if (context.PositionIs(TokenKind::OpenParen)) {
+  if (context.PositionIs(Lex::TokenKind::OpenParen)) {
     context.PushState(State::ParameterListAsRegular);
   } else {
     CARBON_DIAGNOSTIC(

--- a/toolchain/parser/parser_handle_declaration_scope_loop.cpp
+++ b/toolchain/parser/parser_handle_declaration_scope_loop.cpp
@@ -23,37 +23,37 @@ auto HandleDeclarationScopeLoop(Context& context) -> void {
   // This maintains the current state unless we're at the end of the scope.
 
   switch (context.PositionKind()) {
-    case TokenKind::CloseCurlyBrace:
-    case TokenKind::EndOfFile: {
+    case Lex::TokenKind::CloseCurlyBrace:
+    case Lex::TokenKind::EndOfFile: {
       // This is the end of the scope, so the loop state ends.
       context.PopAndDiscardState();
       break;
     }
-    case TokenKind::Class: {
+    case Lex::TokenKind::Class: {
       context.PushState(State::TypeIntroducerAsClass);
       break;
     }
-    case TokenKind::Constraint: {
+    case Lex::TokenKind::Constraint: {
       context.PushState(State::TypeIntroducerAsNamedConstraint);
       break;
     }
-    case TokenKind::Fn: {
+    case Lex::TokenKind::Fn: {
       context.PushState(State::FunctionIntroducer);
       break;
     }
-    case TokenKind::Interface: {
+    case Lex::TokenKind::Interface: {
       context.PushState(State::TypeIntroducerAsInterface);
       break;
     }
-    case TokenKind::Namespace: {
+    case Lex::TokenKind::Namespace: {
       context.PushState(State::Namespace);
       break;
     }
-    case TokenKind::Semi: {
+    case Lex::TokenKind::Semi: {
       context.AddLeafNode(NodeKind::EmptyDeclaration, context.Consume());
       break;
     }
-    case TokenKind::Var: {
+    case Lex::TokenKind::Var: {
       context.PushState(State::VarAsSemicolon);
       break;
     }

--- a/toolchain/parser/parser_handle_function.cpp
+++ b/toolchain/parser/parser_handle_function.cpp
@@ -25,7 +25,7 @@ auto HandleFunctionAfterParameters(Context& context) -> void {
 
   // If there is a return type, parse the expression before adding the return
   // type nod.e
-  if (context.PositionIs(TokenKind::MinusGreater)) {
+  if (context.PositionIs(Lex::TokenKind::MinusGreater)) {
     context.PushState(State::FunctionReturnTypeFinish);
     ++context.position();
     context.PushStateForExpression(PrecedenceGroup::ForType());
@@ -43,12 +43,12 @@ auto HandleFunctionSignatureFinish(Context& context) -> void {
   auto state = context.PopState();
 
   switch (context.PositionKind()) {
-    case TokenKind::Semi: {
+    case Lex::TokenKind::Semi: {
       context.AddNode(NodeKind::FunctionDeclaration, context.Consume(),
                       state.subtree_start, state.has_error);
       break;
     }
-    case TokenKind::OpenCurlyBrace: {
+    case Lex::TokenKind::OpenCurlyBrace: {
       if (auto decl_context = context.GetDeclarationContext();
           decl_context == Context::DeclarationContext::Interface ||
           decl_context == Context::DeclarationContext::NamedConstraint) {
@@ -73,7 +73,7 @@ auto HandleFunctionSignatureFinish(Context& context) -> void {
     }
     default: {
       if (!state.has_error) {
-        context.EmitExpectedDeclarationSemiOrDefinition(TokenKind::Fn);
+        context.EmitExpectedDeclarationSemiOrDefinition(Lex::TokenKind::Fn);
       }
       // Only need to skip if we've not already found a new line.
       bool skip_past_likely_end =

--- a/toolchain/parser/parser_handle_index_expression.cpp
+++ b/toolchain/parser/parser_handle_index_expression.cpp
@@ -12,7 +12,7 @@ auto HandleIndexExpression(Context& context) -> void {
   state.state = State::IndexExpressionFinish;
   context.PushState(state);
   context.AddNode(NodeKind::IndexExpressionStart,
-                  context.ConsumeChecked(TokenKind::OpenSquareBracket),
+                  context.ConsumeChecked(Lex::TokenKind::OpenSquareBracket),
                   state.subtree_start, state.has_error);
   context.PushState(State::Expression);
 }

--- a/toolchain/parser/parser_handle_namespace.cpp
+++ b/toolchain/parser/parser_handle_namespace.cpp
@@ -26,11 +26,11 @@ auto HandleNamespaceFinish(Context& context) -> void {
     return;
   }
 
-  if (auto semi = context.ConsumeIf(TokenKind::Semi)) {
+  if (auto semi = context.ConsumeIf(Lex::TokenKind::Semi)) {
     context.AddNode(NodeKind::Namespace, *semi, state.subtree_start,
                     state.has_error);
   } else {
-    context.EmitExpectedDeclarationSemi(TokenKind::Namespace);
+    context.EmitExpectedDeclarationSemi(Lex::TokenKind::Namespace);
     context.RecoverFromDeclarationError(state, NodeKind::Namespace,
                                         /*skip_past_likely_end=*/true);
   }

--- a/toolchain/parser/parser_handle_package.cpp
+++ b/toolchain/parser/parser_handle_package.cpp
@@ -19,7 +19,8 @@ auto HandlePackage(Context& context) -> void {
                            /*has_error=*/true);
   };
 
-  if (!context.ConsumeAndAddLeafNodeIf(TokenKind::Identifier, NodeKind::Name)) {
+  if (!context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::Identifier,
+                                       NodeKind::Name)) {
     CARBON_DIAGNOSTIC(ExpectedIdentifierAfterPackage, Error,
                       "Expected identifier after `package`.");
     context.emitter().Emit(*context.position(), ExpectedIdentifierAfterPackage);
@@ -28,10 +29,10 @@ auto HandlePackage(Context& context) -> void {
   }
 
   bool library_parsed = false;
-  if (auto library_token = context.ConsumeIf(TokenKind::Library)) {
+  if (auto library_token = context.ConsumeIf(Lex::TokenKind::Library)) {
     auto library_start = context.tree().size();
 
-    if (!context.ConsumeAndAddLeafNodeIf(TokenKind::StringLiteral,
+    if (!context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::StringLiteral,
                                          NodeKind::Literal)) {
       CARBON_DIAGNOSTIC(
           ExpectedLibraryName, Error,
@@ -48,16 +49,17 @@ auto HandlePackage(Context& context) -> void {
 
   switch (auto api_or_impl_token =
               context.tokens().GetKind(*(context.position()))) {
-    case TokenKind::Api: {
+    case Lex::TokenKind::Api: {
       context.AddLeafNode(NodeKind::PackageApi, context.Consume());
       break;
     }
-    case TokenKind::Impl: {
+    case Lex::TokenKind::Impl: {
       context.AddLeafNode(NodeKind::PackageImpl, context.Consume());
       break;
     }
     default: {
-      if (!library_parsed && api_or_impl_token == TokenKind::StringLiteral) {
+      if (!library_parsed &&
+          api_or_impl_token == Lex::TokenKind::StringLiteral) {
         // If we come acroess a string literal and we didn't parse `library
         // "..."` yet, then most probably the user forgot to add `library`
         // before the library name.
@@ -74,8 +76,8 @@ auto HandlePackage(Context& context) -> void {
     }
   }
 
-  if (!context.PositionIs(TokenKind::Semi)) {
-    context.EmitExpectedDeclarationSemi(TokenKind::Package);
+  if (!context.PositionIs(Lex::TokenKind::Semi)) {
+    context.EmitExpectedDeclarationSemi(Lex::TokenKind::Package);
     exit_on_parse_error();
     return;
   }

--- a/toolchain/parser/parser_handle_parameter.cpp
+++ b/toolchain/parser/parser_handle_parameter.cpp
@@ -26,7 +26,7 @@ auto HandleParameterAsRegular(Context& context) -> void {
 }
 
 // Handles ParameterFinishAs(Deduced|Regular).
-static auto HandleParameterFinish(Context& context, TokenKind close_token,
+static auto HandleParameterFinish(Context& context, Lex::TokenKind close_token,
                                   State param_state) -> void {
   auto state = context.PopState();
 
@@ -42,20 +42,20 @@ static auto HandleParameterFinish(Context& context, TokenKind close_token,
 }
 
 auto HandleParameterFinishAsDeduced(Context& context) -> void {
-  HandleParameterFinish(context, TokenKind::CloseSquareBracket,
+  HandleParameterFinish(context, Lex::TokenKind::CloseSquareBracket,
                         State::ParameterAsDeduced);
 }
 
 auto HandleParameterFinishAsRegular(Context& context) -> void {
-  HandleParameterFinish(context, TokenKind::CloseParen,
+  HandleParameterFinish(context, Lex::TokenKind::CloseParen,
                         State::ParameterAsRegular);
 }
 
 // Handles ParameterListAs(Deduced|Regular).
 static auto HandleParameterList(Context& context, NodeKind parse_node_kind,
-                                TokenKind open_token_kind,
-                                TokenKind close_token_kind, State param_state,
-                                State finish_state) -> void {
+                                Lex::TokenKind open_token_kind,
+                                Lex::TokenKind close_token_kind,
+                                State param_state, State finish_state) -> void {
   context.PopAndDiscardState();
 
   context.PushState(finish_state);
@@ -67,15 +67,15 @@ static auto HandleParameterList(Context& context, NodeKind parse_node_kind,
 }
 
 auto HandleParameterListAsDeduced(Context& context) -> void {
-  HandleParameterList(context, NodeKind::DeducedParameterListStart,
-                      TokenKind::OpenSquareBracket,
-                      TokenKind::CloseSquareBracket, State::ParameterAsDeduced,
-                      State::ParameterListFinishAsDeduced);
+  HandleParameterList(
+      context, NodeKind::DeducedParameterListStart,
+      Lex::TokenKind::OpenSquareBracket, Lex::TokenKind::CloseSquareBracket,
+      State::ParameterAsDeduced, State::ParameterListFinishAsDeduced);
 }
 
 auto HandleParameterListAsRegular(Context& context) -> void {
   HandleParameterList(context, NodeKind::ParameterListStart,
-                      TokenKind::OpenParen, TokenKind::CloseParen,
+                      Lex::TokenKind::OpenParen, Lex::TokenKind::CloseParen,
                       State::ParameterAsRegular,
                       State::ParameterListFinishAsRegular);
 }
@@ -83,7 +83,7 @@ auto HandleParameterListAsRegular(Context& context) -> void {
 // Handles ParameterListFinishAs(Deduced|Regular).
 static auto HandleParameterListFinish(Context& context,
                                       NodeKind parse_node_kind,
-                                      TokenKind token_kind) -> void {
+                                      Lex::TokenKind token_kind) -> void {
   auto state = context.PopState();
 
   context.AddNode(parse_node_kind, context.ConsumeChecked(token_kind),
@@ -92,12 +92,12 @@ static auto HandleParameterListFinish(Context& context,
 
 auto HandleParameterListFinishAsDeduced(Context& context) -> void {
   HandleParameterListFinish(context, NodeKind::DeducedParameterList,
-                            TokenKind::CloseSquareBracket);
+                            Lex::TokenKind::CloseSquareBracket);
 }
 
 auto HandleParameterListFinishAsRegular(Context& context) -> void {
   HandleParameterListFinish(context, NodeKind::ParameterList,
-                            TokenKind::CloseParen);
+                            Lex::TokenKind::CloseParen);
 }
 
 }  // namespace Carbon::Parse

--- a/toolchain/parser/parser_handle_paren_condition.cpp
+++ b/toolchain/parser/parser_handle_paren_condition.cpp
@@ -11,7 +11,7 @@ static auto HandleParenCondition(Context& context, NodeKind start_kind,
                                  State finish_state) -> void {
   auto state = context.PopState();
 
-  std::optional<TokenizedBuffer::Token> open_paren =
+  std::optional<Lex::TokenizedBuffer::Token> open_paren =
       context.ConsumeAndAddOpenParen(state.token, start_kind);
   if (open_paren) {
     state.token = *open_paren;
@@ -19,7 +19,7 @@ static auto HandleParenCondition(Context& context, NodeKind start_kind,
   state.state = finish_state;
   context.PushState(state);
 
-  if (!open_paren && context.PositionIs(TokenKind::OpenCurlyBrace)) {
+  if (!open_paren && context.PositionIs(Lex::TokenKind::OpenCurlyBrace)) {
     // For an open curly, assume the condition was completely omitted.
     // Expression parsing would treat the { as a struct, but instead assume it's
     // a code block and just emit an invalid parse.

--- a/toolchain/parser/parser_handle_paren_expression.cpp
+++ b/toolchain/parser/parser_handle_paren_expression.cpp
@@ -11,9 +11,9 @@ auto HandleParenExpression(Context& context) -> void {
 
   // Advance past the open paren.
   context.AddLeafNode(NodeKind::ParenExpressionOrTupleLiteralStart,
-                      context.ConsumeChecked(TokenKind::OpenParen));
+                      context.ConsumeChecked(Lex::TokenKind::OpenParen));
 
-  if (context.PositionIs(TokenKind::CloseParen)) {
+  if (context.PositionIs(Lex::TokenKind::CloseParen)) {
     state.state = State::ParenExpressionFinishAsTuple;
     context.PushState(state);
   } else {
@@ -30,7 +30,7 @@ static auto HandleParenExpressionParameterFinish(Context& context,
   auto state = context.PopState();
 
   auto list_token_kind = context.ConsumeListToken(
-      NodeKind::TupleLiteralComma, TokenKind::CloseParen, state.has_error);
+      NodeKind::TupleLiteralComma, Lex::TokenKind::CloseParen, state.has_error);
   if (list_token_kind == Context::ListTokenKind::Close) {
     return;
   }

--- a/toolchain/parser/parser_handle_pattern.cpp
+++ b/toolchain/parser/parser_handle_pattern.cpp
@@ -14,9 +14,9 @@ static auto HandlePattern(Context& context, Context::PatternKind pattern_kind)
   // Parameters may have keywords prefixing the pattern. They become the parent
   // for the full PatternBinding.
   if (pattern_kind != Context::PatternKind::Variable) {
-    context.ConsumeIfPatternKeyword(TokenKind::Template, State::PatternTemplate,
-                                    state.subtree_start);
-    context.ConsumeIfPatternKeyword(TokenKind::Addr, State::PatternAddress,
+    context.ConsumeIfPatternKeyword(
+        Lex::TokenKind::Template, State::PatternTemplate, state.subtree_start);
+    context.ConsumeIfPatternKeyword(Lex::TokenKind::Addr, State::PatternAddress,
                                     state.subtree_start);
   }
 
@@ -47,11 +47,11 @@ static auto HandlePattern(Context& context, Context::PatternKind pattern_kind)
 
   // The first item should be an identifier or, for deduced parameters, `self`.
   bool has_name = false;
-  if (auto identifier = context.ConsumeIf(TokenKind::Identifier)) {
+  if (auto identifier = context.ConsumeIf(Lex::TokenKind::Identifier)) {
     context.AddLeafNode(NodeKind::Name, *identifier);
     has_name = true;
   } else if (pattern_kind == Context::PatternKind::DeducedParameter) {
-    if (auto self = context.ConsumeIf(TokenKind::SelfValueIdentifier)) {
+    if (auto self = context.ConsumeIf(Lex::TokenKind::SelfValueIdentifier)) {
       context.AddLeafNode(NodeKind::SelfValueName, *self);
       has_name = true;
     }
@@ -65,9 +65,9 @@ static auto HandlePattern(Context& context, Context::PatternKind pattern_kind)
   }
 
   if (auto kind = context.PositionKind();
-      kind == TokenKind::Colon || kind == TokenKind::ColonExclaim) {
-    state.state = kind == TokenKind::Colon ? State::PatternFinishAsRegular
-                                           : State::PatternFinishAsGeneric;
+      kind == Lex::TokenKind::Colon || kind == Lex::TokenKind::ColonExclaim) {
+    state.state = kind == Lex::TokenKind::Colon ? State::PatternFinishAsRegular
+                                                : State::PatternFinishAsGeneric;
     // Use the `:` or `:!` for the root node.
     state.token = context.Consume();
     context.PushState(state);

--- a/toolchain/parser/parser_handle_period.cpp
+++ b/toolchain/parser/parser_handle_period.cpp
@@ -14,10 +14,11 @@ static auto HandlePeriodOrArrow(Context& context, NodeKind node_kind,
   auto state = context.PopState();
 
   // `.` identifier
-  auto dot = context.ConsumeChecked(is_arrow ? TokenKind::MinusGreater
-                                             : TokenKind::Period);
+  auto dot = context.ConsumeChecked(is_arrow ? Lex::TokenKind::MinusGreater
+                                             : Lex::TokenKind::Period);
 
-  if (!context.ConsumeAndAddLeafNodeIf(TokenKind::Identifier, NodeKind::Name)) {
+  if (!context.ConsumeAndAddLeafNodeIf(Lex::TokenKind::Identifier,
+                                       NodeKind::Name)) {
     CARBON_DIAGNOSTIC(ExpectedIdentifierAfterDotOrArrow, Error,
                       "Expected identifier after `{0}`.", llvm::StringRef);
     context.emitter().Emit(*context.position(),

--- a/toolchain/parser/parser_handle_type.cpp
+++ b/toolchain/parser/parser_handle_type.cpp
@@ -46,13 +46,13 @@ static auto HandleTypeAfterParams(Context& context, NodeKind declaration_kind,
     return;
   }
 
-  if (auto semi = context.ConsumeIf(TokenKind::Semi)) {
+  if (auto semi = context.ConsumeIf(Lex::TokenKind::Semi)) {
     context.AddNode(declaration_kind, *semi, state.subtree_start,
                     state.has_error);
     return;
   }
 
-  if (!context.PositionIs(TokenKind::OpenCurlyBrace)) {
+  if (!context.PositionIs(Lex::TokenKind::OpenCurlyBrace)) {
     context.EmitExpectedDeclarationSemiOrDefinition(
         context.tokens().GetKind(state.token));
     context.RecoverFromDeclarationError(state, declaration_kind,

--- a/toolchain/parser/parser_handle_var.cpp
+++ b/toolchain/parser/parser_handle_var.cpp
@@ -33,12 +33,12 @@ auto HandleVarAfterPattern(Context& context) -> void {
 
   if (state.has_error) {
     if (auto after_pattern =
-            context.FindNextOf({TokenKind::Equal, TokenKind::Semi})) {
+            context.FindNextOf({Lex::TokenKind::Equal, Lex::TokenKind::Semi})) {
       context.SkipTo(*after_pattern);
     }
   }
 
-  if (auto equals = context.ConsumeIf(TokenKind::Equal)) {
+  if (auto equals = context.ConsumeIf(Lex::TokenKind::Equal)) {
     context.AddLeafNode(NodeKind::VariableInitializer, *equals);
     context.PushState(State::Expression);
   }
@@ -48,11 +48,11 @@ auto HandleVarFinishAsSemicolon(Context& context) -> void {
   auto state = context.PopState();
 
   auto end_token = state.token;
-  if (context.PositionIs(TokenKind::Semi)) {
+  if (context.PositionIs(Lex::TokenKind::Semi)) {
     end_token = context.Consume();
   } else {
     // TODO: Disambiguate between statement and member declaration.
-    context.EmitExpectedDeclarationSemi(TokenKind::Var);
+    context.EmitExpectedDeclarationSemi(Lex::TokenKind::Var);
     state.has_error = true;
     if (auto semi_token = context.SkipPastLikelyEnd(state.token)) {
       end_token = *semi_token;
@@ -66,9 +66,9 @@ auto HandleVarFinishAsFor(Context& context) -> void {
   auto state = context.PopState();
 
   auto end_token = state.token;
-  if (context.PositionIs(TokenKind::In)) {
+  if (context.PositionIs(Lex::TokenKind::In)) {
     end_token = context.Consume();
-  } else if (context.PositionIs(TokenKind::Colon)) {
+  } else if (context.PositionIs(Lex::TokenKind::Colon)) {
     CARBON_DIAGNOSTIC(ExpectedInNotColon, Error,
                       "`:` should be replaced by `in`.");
     context.emitter().Emit(*context.position(), ExpectedInNotColon);

--- a/toolchain/parser/parser_state.def
+++ b/toolchain/parser/parser_state.def
@@ -21,7 +21,7 @@
 // the stack.
 //
 // Where state output is conditional on a lexed token, the name of
-// the TokenKind should be used rather than the string name in order to make it
+// the Lex::TokenKind should be used rather than the string name in order to make it
 // easier to compare with code.
 
 #ifndef CARBON_PARSE_STATE

--- a/toolchain/parser/precedence.cpp
+++ b/toolchain/parser/precedence.cpp
@@ -193,30 +193,30 @@ auto PrecedenceGroup::ForType() -> PrecedenceGroup {
   return ForTopLevelExpression();
 }
 
-auto PrecedenceGroup::ForLeading(TokenKind kind)
+auto PrecedenceGroup::ForLeading(Lex::TokenKind kind)
     -> std::optional<PrecedenceGroup> {
   switch (kind) {
-    case TokenKind::Star:
-    case TokenKind::Amp:
+    case Lex::TokenKind::Star:
+    case Lex::TokenKind::Amp:
       return PrecedenceGroup(TermPrefix);
 
-    case TokenKind::Not:
+    case Lex::TokenKind::Not:
       return PrecedenceGroup(LogicalPrefix);
 
-    case TokenKind::Minus:
+    case Lex::TokenKind::Minus:
       return PrecedenceGroup(NumericPrefix);
 
-    case TokenKind::MinusMinus:
-    case TokenKind::PlusPlus:
+    case Lex::TokenKind::MinusMinus:
+    case Lex::TokenKind::PlusPlus:
       return PrecedenceGroup(IncrementDecrement);
 
-    case TokenKind::Caret:
+    case Lex::TokenKind::Caret:
       return PrecedenceGroup(BitwisePrefix);
 
-    case TokenKind::If:
+    case Lex::TokenKind::If:
       return PrecedenceGroup(If);
 
-    case TokenKind::Const:
+    case Lex::TokenKind::Const:
       return PrecedenceGroup(TypePrefix);
 
     default:
@@ -224,96 +224,96 @@ auto PrecedenceGroup::ForLeading(TokenKind kind)
   }
 }
 
-auto PrecedenceGroup::ForTrailing(TokenKind kind, bool infix)
+auto PrecedenceGroup::ForTrailing(Lex::TokenKind kind, bool infix)
     -> std::optional<Trailing> {
   switch (kind) {
     // Assignment operators.
-    case TokenKind::Equal:
-    case TokenKind::PlusEqual:
-    case TokenKind::MinusEqual:
-    case TokenKind::StarEqual:
-    case TokenKind::SlashEqual:
-    case TokenKind::PercentEqual:
-    case TokenKind::AmpEqual:
-    case TokenKind::PipeEqual:
-    case TokenKind::CaretEqual:
-    case TokenKind::GreaterGreaterEqual:
-    case TokenKind::LessLessEqual:
+    case Lex::TokenKind::Equal:
+    case Lex::TokenKind::PlusEqual:
+    case Lex::TokenKind::MinusEqual:
+    case Lex::TokenKind::StarEqual:
+    case Lex::TokenKind::SlashEqual:
+    case Lex::TokenKind::PercentEqual:
+    case Lex::TokenKind::AmpEqual:
+    case Lex::TokenKind::PipeEqual:
+    case Lex::TokenKind::CaretEqual:
+    case Lex::TokenKind::GreaterGreaterEqual:
+    case Lex::TokenKind::LessLessEqual:
       return Trailing{.level = Assignment, .is_binary = true};
 
     // Logical operators.
-    case TokenKind::And:
+    case Lex::TokenKind::And:
       return Trailing{.level = LogicalAnd, .is_binary = true};
-    case TokenKind::Or:
+    case Lex::TokenKind::Or:
       return Trailing{.level = LogicalOr, .is_binary = true};
 
     // Bitwise operators.
-    case TokenKind::Amp:
+    case Lex::TokenKind::Amp:
       return Trailing{.level = BitwiseAnd, .is_binary = true};
-    case TokenKind::Pipe:
+    case Lex::TokenKind::Pipe:
       return Trailing{.level = BitwiseOr, .is_binary = true};
-    case TokenKind::Caret:
+    case Lex::TokenKind::Caret:
       return Trailing{.level = BitwiseXor, .is_binary = true};
-    case TokenKind::GreaterGreater:
-    case TokenKind::LessLess:
+    case Lex::TokenKind::GreaterGreater:
+    case Lex::TokenKind::LessLess:
       return Trailing{.level = BitShift, .is_binary = true};
 
     // Relational operators.
-    case TokenKind::EqualEqual:
-    case TokenKind::ExclaimEqual:
-    case TokenKind::Less:
-    case TokenKind::LessEqual:
-    case TokenKind::Greater:
-    case TokenKind::GreaterEqual:
-    case TokenKind::LessEqualGreater:
+    case Lex::TokenKind::EqualEqual:
+    case Lex::TokenKind::ExclaimEqual:
+    case Lex::TokenKind::Less:
+    case Lex::TokenKind::LessEqual:
+    case Lex::TokenKind::Greater:
+    case Lex::TokenKind::GreaterEqual:
+    case Lex::TokenKind::LessEqualGreater:
       return Trailing{.level = Relational, .is_binary = true};
 
     // Additive operators.
-    case TokenKind::Plus:
-    case TokenKind::Minus:
+    case Lex::TokenKind::Plus:
+    case Lex::TokenKind::Minus:
       return Trailing{.level = Additive, .is_binary = true};
 
     // Multiplicative operators.
-    case TokenKind::Slash:
+    case Lex::TokenKind::Slash:
       return Trailing{.level = Multiplicative, .is_binary = true};
-    case TokenKind::Percent:
+    case Lex::TokenKind::Percent:
       return Trailing{.level = Modulo, .is_binary = true};
 
     // `*` could be multiplication or pointer type formation.
-    case TokenKind::Star:
+    case Lex::TokenKind::Star:
       return infix ? Trailing{.level = Multiplicative, .is_binary = true}
                    : Trailing{.level = TypePostfix, .is_binary = false};
 
     // Cast operator.
-    case TokenKind::As:
+    case Lex::TokenKind::As:
       return Trailing{.level = As, .is_binary = true};
 
     // Prefix-only operators.
-    case TokenKind::Const:
-    case TokenKind::MinusMinus:
-    case TokenKind::Not:
-    case TokenKind::PlusPlus:
+    case Lex::TokenKind::Const:
+    case Lex::TokenKind::MinusMinus:
+    case Lex::TokenKind::Not:
+    case Lex::TokenKind::PlusPlus:
       break;
 
     // Symbolic tokens that might be operators eventually.
-    case TokenKind::Tilde:
-    case TokenKind::Backslash:
-    case TokenKind::Comma:
-    case TokenKind::TildeEqual:
-    case TokenKind::Exclaim:
-    case TokenKind::LessGreater:
-    case TokenKind::Question:
-    case TokenKind::Colon:
+    case Lex::TokenKind::Tilde:
+    case Lex::TokenKind::Backslash:
+    case Lex::TokenKind::Comma:
+    case Lex::TokenKind::TildeEqual:
+    case Lex::TokenKind::Exclaim:
+    case Lex::TokenKind::LessGreater:
+    case Lex::TokenKind::Question:
+    case Lex::TokenKind::Colon:
       break;
 
     // Symbolic tokens that are intentionally not operators.
-    case TokenKind::At:
-    case TokenKind::LessMinus:
-    case TokenKind::MinusGreater:
-    case TokenKind::EqualGreater:
-    case TokenKind::ColonEqual:
-    case TokenKind::Period:
-    case TokenKind::Semi:
+    case Lex::TokenKind::At:
+    case Lex::TokenKind::LessMinus:
+    case Lex::TokenKind::MinusGreater:
+    case Lex::TokenKind::EqualGreater:
+    case Lex::TokenKind::ColonEqual:
+    case Lex::TokenKind::Period:
+    case Lex::TokenKind::Semi:
       break;
 
     default:

--- a/toolchain/parser/precedence.h
+++ b/toolchain/parser/precedence.h
@@ -56,14 +56,14 @@ class PrecedenceGroup {
 
   // Look up the operator information of the given prefix operator token, or
   // return std::nullopt if the given token is not a prefix operator.
-  static auto ForLeading(TokenKind kind) -> std::optional<PrecedenceGroup>;
+  static auto ForLeading(Lex::TokenKind kind) -> std::optional<PrecedenceGroup>;
 
   // Look up the operator information of the given infix or postfix operator
   // token, or return std::nullopt if the given token is not an infix or postfix
   // operator. `infix` indicates whether this is a valid infix operator, but is
   // only considered if the same operator symbol is available as both infix and
   // postfix.
-  static auto ForTrailing(TokenKind kind, bool infix)
+  static auto ForTrailing(Lex::TokenKind kind, bool infix)
       -> std::optional<Trailing>;
 
   friend auto operator==(PrecedenceGroup lhs, PrecedenceGroup rhs) -> bool {

--- a/toolchain/parser/precedence_test.cpp
+++ b/toolchain/parser/precedence_test.cpp
@@ -18,123 +18,143 @@ using Parse::PrecedenceGroup;
 using ::testing::Eq;
 
 TEST(PrecedenceTest, OperatorsAreRecognized) {
-  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Minus).has_value());
-  EXPECT_TRUE(PrecedenceGroup::ForLeading(TokenKind::Caret).has_value());
-  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Slash).has_value());
-  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Identifier).has_value());
-  EXPECT_FALSE(PrecedenceGroup::ForLeading(TokenKind::Tilde).has_value());
+  EXPECT_TRUE(PrecedenceGroup::ForLeading(Lex::TokenKind::Minus).has_value());
+  EXPECT_TRUE(PrecedenceGroup::ForLeading(Lex::TokenKind::Caret).has_value());
+  EXPECT_FALSE(PrecedenceGroup::ForLeading(Lex::TokenKind::Slash).has_value());
+  EXPECT_FALSE(
+      PrecedenceGroup::ForLeading(Lex::TokenKind::Identifier).has_value());
+  EXPECT_FALSE(PrecedenceGroup::ForLeading(Lex::TokenKind::Tilde).has_value());
 
   EXPECT_TRUE(
-      PrecedenceGroup::ForTrailing(TokenKind::Minus, false).has_value());
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Minus, false).has_value());
   EXPECT_TRUE(
-      PrecedenceGroup::ForTrailing(TokenKind::Caret, false).has_value());
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Caret, false).has_value());
   EXPECT_FALSE(
-      PrecedenceGroup::ForTrailing(TokenKind::Tilde, false).has_value());
-  EXPECT_TRUE(PrecedenceGroup::ForTrailing(TokenKind::Slash, true).has_value());
-  EXPECT_FALSE(
-      PrecedenceGroup::ForTrailing(TokenKind::Identifier, false).has_value());
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Tilde, false).has_value());
+  EXPECT_TRUE(
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Slash, true).has_value());
+  EXPECT_FALSE(PrecedenceGroup::ForTrailing(Lex::TokenKind::Identifier, false)
+                   .has_value());
 
-  EXPECT_TRUE(PrecedenceGroup::ForTrailing(TokenKind::Minus, true)->is_binary);
-  EXPECT_FALSE(
-      PrecedenceGroup::ForTrailing(TokenKind::MinusMinus, false).has_value());
+  EXPECT_TRUE(
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Minus, true)->is_binary);
+  EXPECT_FALSE(PrecedenceGroup::ForTrailing(Lex::TokenKind::MinusMinus, false)
+                   .has_value());
 }
 
 TEST(PrecedenceTest, InfixVsPostfix) {
   // A trailing `-` is always binary, even when written with whitespace that
   // suggests it's postfix.
-  EXPECT_TRUE(PrecedenceGroup::ForTrailing(TokenKind::Minus, /*infix*/ false)
-                  ->is_binary);
+  EXPECT_TRUE(
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Minus, /*infix*/ false)
+          ->is_binary);
 
   // A trailing `*` is interpreted based on context.
-  EXPECT_TRUE(PrecedenceGroup::ForTrailing(TokenKind::Star, true)->is_binary);
-  EXPECT_FALSE(PrecedenceGroup::ForTrailing(TokenKind::Star, false)->is_binary);
+  EXPECT_TRUE(
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->is_binary);
+  EXPECT_FALSE(
+      PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, false)->is_binary);
 
   // Infix `*` can appear in `+` contexts; postfix `*` cannot.
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Plus, true)->level),
-              Eq(OperatorPriority::LeftFirst));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, false)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Plus, true)->level),
-              Eq(OperatorPriority::Ambiguous));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)->level),
+      Eq(OperatorPriority::LeftFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, false)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)->level),
+      Eq(OperatorPriority::Ambiguous));
 }
 
 TEST(PrecedenceTest, Associativity) {
-  EXPECT_THAT(PrecedenceGroup::ForLeading(TokenKind::Minus)->GetAssociativity(),
-              Eq(Associativity::None));
-  EXPECT_THAT(PrecedenceGroup::ForLeading(TokenKind::Star)->GetAssociativity(),
-              Eq(Associativity::RightToLeft));
-  EXPECT_THAT(PrecedenceGroup::ForTrailing(TokenKind::Plus, true)
+  EXPECT_THAT(
+      PrecedenceGroup::ForLeading(Lex::TokenKind::Minus)->GetAssociativity(),
+      Eq(Associativity::None));
+  EXPECT_THAT(
+      PrecedenceGroup::ForLeading(Lex::TokenKind::Star)->GetAssociativity(),
+      Eq(Associativity::RightToLeft));
+  EXPECT_THAT(PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)
                   ->level.GetAssociativity(),
               Eq(Associativity::LeftToRight));
-  EXPECT_THAT(PrecedenceGroup::ForTrailing(TokenKind::Equal, true)
+  EXPECT_THAT(PrecedenceGroup::ForTrailing(Lex::TokenKind::Equal, true)
                   ->level.GetAssociativity(),
               Eq(Associativity::None));
 }
 
 TEST(PrecedenceTest, DirectRelations) {
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Plus, true)->level),
-              Eq(OperatorPriority::LeftFirst));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Plus, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, true)->level),
-              Eq(OperatorPriority::RightFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)->level),
+      Eq(OperatorPriority::LeftFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->level),
+      Eq(OperatorPriority::RightFirst));
 
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Amp, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Less, true)->level),
-              Eq(OperatorPriority::LeftFirst));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Less, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Amp, true)->level),
-              Eq(OperatorPriority::RightFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Amp, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Less, true)->level),
+      Eq(OperatorPriority::LeftFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Less, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Amp, true)->level),
+      Eq(OperatorPriority::RightFirst));
 }
 
 TEST(PrecedenceTest, IndirectRelations) {
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Or, true)->level),
-              Eq(OperatorPriority::LeftFirst));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Or, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Star, true)->level),
-              Eq(OperatorPriority::RightFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Or, true)->level),
+      Eq(OperatorPriority::LeftFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Or, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Star, true)->level),
+      Eq(OperatorPriority::RightFirst));
 
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  *PrecedenceGroup::ForLeading(TokenKind::Caret),
-                  PrecedenceGroup::ForTrailing(TokenKind::Equal, true)->level),
-              Eq(OperatorPriority::LeftFirst));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Equal, true)->level,
-                  *PrecedenceGroup::ForLeading(TokenKind::Caret)),
-              Eq(OperatorPriority::RightFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          *PrecedenceGroup::ForLeading(Lex::TokenKind::Caret),
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Equal, true)->level),
+      Eq(OperatorPriority::LeftFirst));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Equal, true)->level,
+          *PrecedenceGroup::ForLeading(Lex::TokenKind::Caret)),
+      Eq(OperatorPriority::RightFirst));
 }
 
 TEST(PrecedenceTest, IncomparableOperators) {
   EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  *PrecedenceGroup::ForLeading(TokenKind::Caret),
-                  *PrecedenceGroup::ForLeading(TokenKind::Not)),
+                  *PrecedenceGroup::ForLeading(Lex::TokenKind::Caret),
+                  *PrecedenceGroup::ForLeading(Lex::TokenKind::Not)),
               Eq(OperatorPriority::Ambiguous));
   EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  *PrecedenceGroup::ForLeading(TokenKind::Caret),
-                  *PrecedenceGroup::ForLeading(TokenKind::Minus)),
-              Eq(OperatorPriority::Ambiguous));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  *PrecedenceGroup::ForLeading(TokenKind::Not),
-                  PrecedenceGroup::ForTrailing(TokenKind::Amp, true)->level),
+                  *PrecedenceGroup::ForLeading(Lex::TokenKind::Caret),
+                  *PrecedenceGroup::ForLeading(Lex::TokenKind::Minus)),
               Eq(OperatorPriority::Ambiguous));
   EXPECT_THAT(
       PrecedenceGroup::GetPriority(
-          PrecedenceGroup::ForTrailing(TokenKind::Equal, true)->level,
-          PrecedenceGroup::ForTrailing(TokenKind::PipeEqual, true)->level),
+          *PrecedenceGroup::ForLeading(Lex::TokenKind::Not),
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Amp, true)->level),
       Eq(OperatorPriority::Ambiguous));
-  EXPECT_THAT(PrecedenceGroup::GetPriority(
-                  PrecedenceGroup::ForTrailing(TokenKind::Plus, true)->level,
-                  PrecedenceGroup::ForTrailing(TokenKind::Amp, true)->level),
-              Eq(OperatorPriority::Ambiguous));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Equal, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::PipeEqual, true)->level),
+      Eq(OperatorPriority::Ambiguous));
+  EXPECT_THAT(
+      PrecedenceGroup::GetPriority(
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Plus, true)->level,
+          PrecedenceGroup::ForTrailing(Lex::TokenKind::Amp, true)->level),
+      Eq(OperatorPriority::Ambiguous));
 }
 
 }  // namespace

--- a/toolchain/semantics/check.cpp
+++ b/toolchain/semantics/check.cpp
@@ -12,7 +12,7 @@
 namespace Carbon::Check {
 
 auto CheckParseTree(const SemIR::File& builtin_ir,
-                    const TokenizedBuffer& tokens,
+                    const Lex::TokenizedBuffer& tokens,
                     const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
                     llvm::raw_ostream* vlog_stream) -> SemIR::File {
   auto semantics_ir = SemIR::File(&builtin_ir);

--- a/toolchain/semantics/check.h
+++ b/toolchain/semantics/check.h
@@ -19,7 +19,7 @@ inline auto MakeBuiltins() -> SemIR::File { return SemIR::File(); }
 
 // Produces and checks the IR for the provided Parse::Tree.
 extern auto CheckParseTree(const SemIR::File& builtin_ir,
-                           const TokenizedBuffer& tokens,
+                           const Lex::TokenizedBuffer& tokens,
                            const Parse::Tree& parse_tree,
                            DiagnosticConsumer& consumer,
                            llvm::raw_ostream* vlog_stream) -> SemIR::File;

--- a/toolchain/semantics/semantics_context.cpp
+++ b/toolchain/semantics/semantics_context.cpp
@@ -20,7 +20,7 @@
 
 namespace Carbon::Check {
 
-Context::Context(const TokenizedBuffer& tokens,
+Context::Context(const Lex::TokenizedBuffer& tokens,
                  DiagnosticEmitter<Parse::Node>& emitter,
                  const Parse::Tree& parse_tree, SemIR::File& semantics_ir,
                  llvm::raw_ostream* vlog_stream)

--- a/toolchain/semantics/semantics_context.h
+++ b/toolchain/semantics/semantics_context.h
@@ -22,7 +22,7 @@ namespace Carbon::Check {
 class Context {
  public:
   // Stores references for work.
-  explicit Context(const TokenizedBuffer& tokens,
+  explicit Context(const Lex::TokenizedBuffer& tokens,
                    DiagnosticEmitter<Parse::Node>& emitter,
                    const Parse::Tree& parse_tree, SemIR::File& semantics,
                    llvm::raw_ostream* vlog_stream);
@@ -229,7 +229,7 @@ class Context {
   // Prints information for a stack dump.
   auto PrintForStackDump(llvm::raw_ostream& output) const -> void;
 
-  auto tokens() -> const TokenizedBuffer& { return *tokens_; }
+  auto tokens() -> const Lex::TokenizedBuffer& { return *tokens_; }
 
   auto emitter() -> DiagnosticEmitter<Parse::Node>& { return *emitter_; }
 
@@ -333,7 +333,7 @@ class Context {
   auto current_scope() -> ScopeStackEntry& { return scope_stack_.back(); }
 
   // Tokens for getting data on literals.
-  const TokenizedBuffer* tokens_;
+  const Lex::TokenizedBuffer* tokens_;
 
   // Handles diagnostics.
   DiagnosticEmitter<Parse::Node>* emitter_;

--- a/toolchain/semantics/semantics_handle_literal.cpp
+++ b/toolchain/semantics/semantics_handle_literal.cpp
@@ -9,18 +9,18 @@ namespace Carbon::Check {
 auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
   auto token = context.parse_tree().node_token(parse_node);
   switch (auto token_kind = context.tokens().GetKind(token)) {
-    case TokenKind::False:
-    case TokenKind::True: {
+    case Lex::TokenKind::False:
+    case Lex::TokenKind::True: {
       context.AddNodeAndPush(
           parse_node,
           SemIR::Node::BoolLiteral::Make(
               parse_node,
               context.CanonicalizeType(SemIR::NodeId::BuiltinBoolType),
-              token_kind == TokenKind::True ? SemIR::BoolValue::True
-                                            : SemIR::BoolValue::False));
+              token_kind == Lex::TokenKind::True ? SemIR::BoolValue::True
+                                                 : SemIR::BoolValue::False));
       break;
     }
-    case TokenKind::IntegerLiteral: {
+    case Lex::TokenKind::IntegerLiteral: {
       auto id = context.semantics_ir().AddIntegerLiteral(
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
@@ -30,7 +30,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
               context.CanonicalizeType(SemIR::NodeId::BuiltinIntegerType), id));
       break;
     }
-    case TokenKind::RealLiteral: {
+    case Lex::TokenKind::RealLiteral: {
       auto token_value = context.tokens().GetRealLiteral(token);
       auto id = context.semantics_ir().AddRealLiteral(
           {.mantissa = token_value.Mantissa(),
@@ -44,7 +44,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
               id));
       break;
     }
-    case TokenKind::StringLiteral: {
+    case Lex::TokenKind::StringLiteral: {
       auto id = context.semantics_ir().AddString(
           context.tokens().GetStringLiteral(token));
       context.AddNodeAndPush(
@@ -54,15 +54,15 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
               context.CanonicalizeType(SemIR::NodeId::BuiltinStringType), id));
       break;
     }
-    case TokenKind::Type: {
+    case Lex::TokenKind::Type: {
       context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinTypeType);
       break;
     }
-    case TokenKind::Bool: {
+    case Lex::TokenKind::Bool: {
       context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinBoolType);
       break;
     }
-    case TokenKind::IntegerTypeLiteral: {
+    case Lex::TokenKind::IntegerTypeLiteral: {
       auto text = context.tokens().GetTokenText(token);
       if (text != "i32") {
         return context.TODO(parse_node, "Currently only i32 is allowed");
@@ -70,7 +70,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
       context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinIntegerType);
       break;
     }
-    case TokenKind::FloatingPointTypeLiteral: {
+    case Lex::TokenKind::FloatingPointTypeLiteral: {
       auto text = context.tokens().GetTokenText(token);
       if (text != "f64") {
         return context.TODO(parse_node, "Currently only f64 is allowed");
@@ -79,7 +79,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
                                 SemIR::NodeId::BuiltinFloatingPointType);
       break;
     }
-    case TokenKind::StringTypeLiteral: {
+    case Lex::TokenKind::StringTypeLiteral: {
       context.node_stack().Push(parse_node, SemIR::NodeId::BuiltinStringType);
       break;
     }

--- a/toolchain/semantics/semantics_ir_formatter.cpp
+++ b/toolchain/semantics/semantics_ir_formatter.cpp
@@ -30,7 +30,7 @@ class NodeNamer {
   };
   static_assert(sizeof(ScopeIndex) == sizeof(FunctionId));
 
-  NodeNamer(const TokenizedBuffer& tokenized_buffer,
+  NodeNamer(const Lex::TokenizedBuffer& tokenized_buffer,
             const Parse::Tree& parse_tree, const File& semantics_ir)
       : tokenized_buffer_(tokenized_buffer),
         parse_tree_(parse_tree),
@@ -309,7 +309,7 @@ class NodeNamer {
       case Parse::NodeKind::ShortCircuitOperand: {
         bool is_rhs = node.kind() == NodeKind::BranchIf;
         bool is_and = tokenized_buffer_.GetKind(parse_tree_.node_token(
-                          node.parse_node())) == TokenKind::And;
+                          node.parse_node())) == Lex::TokenKind::And;
         name = is_and ? (is_rhs ? "and.rhs" : "and.result")
                       : (is_rhs ? "or.rhs" : "or.result");
         break;
@@ -382,7 +382,7 @@ class NodeNamer {
     }
   }
 
-  const TokenizedBuffer& tokenized_buffer_;
+  const Lex::TokenizedBuffer& tokenized_buffer_;
   const Parse::Tree& parse_tree_;
   const File& semantics_ir_;
 
@@ -396,7 +396,7 @@ class NodeNamer {
 // Formatter for printing textual Semantics IR.
 class Formatter {
  public:
-  explicit Formatter(const TokenizedBuffer& tokenized_buffer,
+  explicit Formatter(const Lex::TokenizedBuffer& tokenized_buffer,
                      const Parse::Tree& parse_tree, const File& semantics_ir,
                      llvm::raw_ostream& out)
       : semantics_ir_(semantics_ir),
@@ -770,7 +770,7 @@ class Formatter {
   bool in_terminator_sequence = false;
 };
 
-auto FormatFile(const TokenizedBuffer& tokenized_buffer,
+auto FormatFile(const Lex::TokenizedBuffer& tokenized_buffer,
                 const Parse::Tree& parse_tree, const File& semantics_ir,
                 llvm::raw_ostream& out) -> void {
   Formatter(tokenized_buffer, parse_tree, semantics_ir, out).Format();

--- a/toolchain/semantics/semantics_ir_formatter.h
+++ b/toolchain/semantics/semantics_ir_formatter.h
@@ -10,7 +10,7 @@
 
 namespace Carbon::SemIR {
 
-auto FormatFile(const TokenizedBuffer& tokenized_buffer,
+auto FormatFile(const Lex::TokenizedBuffer& tokenized_buffer,
                 const Parse::Tree& parse_tree, const File& semantics_ir,
                 llvm::raw_ostream& out) -> void;
 


### PR DESCRIPTION
Continuing with #3070, this creates a `Lex` namespace for lexer. This is probably the last namespace addition right now, and will be followed by file moves, although I'll also share a PR separately moving member classes out of TokenizedBuffer.
