### PR TITLE
Rename some classes in Lex namespace

### DIFF
--- a/toolchain/lexer/numeric_literal.cpp
+++ b/toolchain/lexer/numeric_literal.cpp
@@ -17,25 +17,25 @@ namespace Carbon::Lex {
 // NOTE: clangd may see this as unused, but it will be invoked by diagnostics.
 // We don't do anything to disable the warning because clang compile invocations
 // should warn if it's actually unused.
-static auto operator<<(llvm::raw_ostream& out, LexedNumericLiteral::Radix radix)
+static auto operator<<(llvm::raw_ostream& out, NumericLiteral::Radix radix)
     -> llvm::raw_ostream& {
   switch (radix) {
-    case LexedNumericLiteral::Radix::Binary:
+    case NumericLiteral::Radix::Binary:
       out << "binary";
       break;
-    case LexedNumericLiteral::Radix::Decimal:
+    case NumericLiteral::Radix::Decimal:
       out << "decimal";
       break;
-    case LexedNumericLiteral::Radix::Hexadecimal:
+    case NumericLiteral::Radix::Hexadecimal:
       out << "hexadecimal";
       break;
   }
   return out;
 }
 
-auto LexedNumericLiteral::Lex(llvm::StringRef source_text)
-    -> std::optional<LexedNumericLiteral> {
-  LexedNumericLiteral result;
+auto NumericLiteral::Lex(llvm::StringRef source_text)
+    -> std::optional<NumericLiteral> {
+  NumericLiteral result;
 
   if (source_text.empty() || !IsDecimalDigit(source_text.front())) {
     return std::nullopt;
@@ -103,9 +103,9 @@ auto LexedNumericLiteral::Lex(llvm::StringRef source_text)
 //
 // Responsible for checking that a numeric literal is valid and meaningful and
 // either diagnosing or extracting its meaning.
-class LexedNumericLiteral::Parser {
+class NumericLiteral::Parser {
  public:
-  Parser(DiagnosticEmitter<const char*>& emitter, LexedNumericLiteral literal);
+  Parser(DiagnosticEmitter<const char*>& emitter, NumericLiteral literal);
 
   auto IsInteger() -> bool {
     return literal_.radix_point_ == static_cast<int>(literal_.text_.size());
@@ -144,7 +144,7 @@ class LexedNumericLiteral::Parser {
   auto CheckExponentPart() -> bool;
 
   DiagnosticEmitter<const char*>& emitter_;
-  LexedNumericLiteral literal_;
+  NumericLiteral literal_;
 
   // The radix of the literal: 2, 10, or 16, for a prefix of '0b', no prefix,
   // or '0x', respectively.
@@ -166,8 +166,8 @@ class LexedNumericLiteral::Parser {
   bool exponent_is_negative_ = false;
 };
 
-LexedNumericLiteral::Parser::Parser(DiagnosticEmitter<const char*>& emitter,
-                                    LexedNumericLiteral literal)
+NumericLiteral::Parser::Parser(DiagnosticEmitter<const char*>& emitter,
+                               NumericLiteral literal)
     : emitter_(emitter), literal_(literal) {
   int_part_ = literal.text_.substr(0, literal.radix_point_);
   if (int_part_.consume_front("0x")) {
@@ -187,7 +187,7 @@ LexedNumericLiteral::Parser::Parser(DiagnosticEmitter<const char*>& emitter,
 
 // Check that the numeric literal token is syntactically valid and meaningful,
 // and diagnose if not.
-auto LexedNumericLiteral::Parser::Check() -> bool {
+auto NumericLiteral::Parser::Check() -> bool {
   return CheckLeadingZero() && CheckIntPart() && CheckFractionalPart() &&
          CheckExponentPart();
 }
@@ -200,9 +200,8 @@ auto LexedNumericLiteral::Parser::Check() -> bool {
 // parsing 123.456e7, we want to decompose it into an integer mantissa
 // (123456) and an exponent (7 - 3 = 4), and this routine is given the
 // "123.456" to parse as the mantissa.
-static auto ParseInteger(llvm::StringRef digits,
-                         LexedNumericLiteral::Radix radix, bool needs_cleaning)
-    -> llvm::APInt {
+static auto ParseInteger(llvm::StringRef digits, NumericLiteral::Radix radix,
+                         bool needs_cleaning) -> llvm::APInt {
   llvm::SmallString<32> cleaned;
   if (needs_cleaning) {
     cleaned.reserve(digits.size());
@@ -219,13 +218,13 @@ static auto ParseInteger(llvm::StringRef digits,
   return value;
 }
 
-auto LexedNumericLiteral::Parser::GetMantissa() -> llvm::APInt {
+auto NumericLiteral::Parser::GetMantissa() -> llvm::APInt {
   const char* end = IsInteger() ? int_part_.end() : fract_part_.end();
   llvm::StringRef digits(int_part_.begin(), end - int_part_.begin());
   return ParseInteger(digits, radix_, mantissa_needs_cleaning_);
 }
 
-auto LexedNumericLiteral::Parser::GetExponent() -> llvm::APInt {
+auto NumericLiteral::Parser::GetExponent() -> llvm::APInt {
   // Compute the effective exponent from the specified exponent, if any,
   // and the position of the radix point.
   llvm::APInt exponent(64, 0);
@@ -265,8 +264,9 @@ auto LexedNumericLiteral::Parser::GetExponent() -> llvm::APInt {
 // Check that a digit sequence is valid: that it contains one or more digits,
 // contains only digits in the specified base, and that any digit separators
 // are present and correctly positioned.
-auto LexedNumericLiteral::Parser::CheckDigitSequence(
-    llvm::StringRef text, Radix radix, bool allow_digit_separators)
+auto NumericLiteral::Parser::CheckDigitSequence(llvm::StringRef text,
+                                                Radix radix,
+                                                bool allow_digit_separators)
     -> CheckDigitSequenceResult {
   std::bitset<256> valid_digits;
   switch (radix) {
@@ -310,7 +310,7 @@ auto LexedNumericLiteral::Parser::CheckDigitSequence(
 
     CARBON_DIAGNOSTIC(InvalidDigit, Error,
                       "Invalid digit '{0}' in {1} numeric literal.", char,
-                      LexedNumericLiteral::Radix);
+                      NumericLiteral::Radix);
     emitter_.Emit(text.begin() + i, InvalidDigit, c, radix);
     return {.ok = false};
   }
@@ -336,7 +336,7 @@ auto LexedNumericLiteral::Parser::CheckDigitSequence(
 
 // Given a number with digit separators, check that the digit separators are
 // correctly positioned.
-auto LexedNumericLiteral::Parser::CheckDigitSeparatorPlacement(
+auto NumericLiteral::Parser::CheckDigitSeparatorPlacement(
     llvm::StringRef text, Radix radix, int num_digit_separators) -> void {
   CARBON_DCHECK(std::count(text.begin(), text.end(), '_') ==
                 num_digit_separators)
@@ -353,7 +353,7 @@ auto LexedNumericLiteral::Parser::CheckDigitSeparatorPlacement(
         IrregularDigitSeparators, Error,
         "Digit separators in {0} number should appear every {1} characters "
         "from the right.",
-        LexedNumericLiteral::Radix, int);
+        NumericLiteral::Radix, int);
     emitter_.Emit(text.begin(), IrregularDigitSeparators, radix,
                   radix == Radix::Decimal ? 3 : 4);
   };
@@ -380,7 +380,7 @@ auto LexedNumericLiteral::Parser::CheckDigitSeparatorPlacement(
 };
 
 // Check that we don't have a '0' prefix on a non-zero decimal integer.
-auto LexedNumericLiteral::Parser::CheckLeadingZero() -> bool {
+auto NumericLiteral::Parser::CheckLeadingZero() -> bool {
   if (radix_ == Radix::Decimal && int_part_.startswith("0") &&
       int_part_ != "0") {
     CARBON_DIAGNOSTIC(UnknownBaseSpecifier, Error,
@@ -392,7 +392,7 @@ auto LexedNumericLiteral::Parser::CheckLeadingZero() -> bool {
 }
 
 // Check the integer part (before the '.', if any) is valid.
-auto LexedNumericLiteral::Parser::CheckIntPart() -> bool {
+auto NumericLiteral::Parser::CheckIntPart() -> bool {
   auto int_result = CheckDigitSequence(int_part_, radix_);
   mantissa_needs_cleaning_ |= int_result.has_digit_separators;
   return int_result.ok;
@@ -400,7 +400,7 @@ auto LexedNumericLiteral::Parser::CheckIntPart() -> bool {
 
 // Check the fractional part (after the '.' and before the exponent, if any)
 // is valid.
-auto LexedNumericLiteral::Parser::CheckFractionalPart() -> bool {
+auto NumericLiteral::Parser::CheckFractionalPart() -> bool {
   if (IsInteger()) {
     return true;
   }
@@ -422,7 +422,7 @@ auto LexedNumericLiteral::Parser::CheckFractionalPart() -> bool {
 }
 
 // Check the exponent part (if any) is valid.
-auto LexedNumericLiteral::Parser::CheckExponentPart() -> bool {
+auto NumericLiteral::Parser::CheckExponentPart() -> bool {
   if (literal_.exponent_ == static_cast<int>(literal_.text_.size())) {
     return true;
   }
@@ -442,8 +442,8 @@ auto LexedNumericLiteral::Parser::CheckExponentPart() -> bool {
 }
 
 // Parse the token and compute its value.
-auto LexedNumericLiteral::ComputeValue(
-    DiagnosticEmitter<const char*>& emitter) const -> Value {
+auto NumericLiteral::ComputeValue(DiagnosticEmitter<const char*>& emitter) const
+    -> Value {
   Parser parser(emitter, *this);
 
   if (!parser.Check()) {

--- a/toolchain/lexer/numeric_literal.h
+++ b/toolchain/lexer/numeric_literal.h
@@ -15,7 +15,7 @@
 namespace Carbon::Lex {
 
 // A numeric literal token that has been extracted from a source buffer.
-class LexedNumericLiteral {
+class NumericLiteral {
  public:
   enum class Radix : int8_t { Binary = 2, Decimal = 10, Hexadecimal = 16 };
 
@@ -42,8 +42,7 @@ class LexedNumericLiteral {
   // Extract a numeric literal from the given text, if it has a suitable form.
   //
   // The supplied `source_text` must outlive the return value.
-  static auto Lex(llvm::StringRef source_text)
-      -> std::optional<LexedNumericLiteral>;
+  static auto Lex(llvm::StringRef source_text) -> std::optional<NumericLiteral>;
 
   // Compute the value of the token, if possible. Emit diagnostics to the given
   // emitter if the token is not valid.
@@ -55,7 +54,7 @@ class LexedNumericLiteral {
  private:
   class Parser;
 
-  LexedNumericLiteral() = default;
+  NumericLiteral() = default;
 
   // The text of the token.
   llvm::StringRef text_;

--- a/toolchain/lexer/numeric_literal_benchmark.cpp
+++ b/toolchain/lexer/numeric_literal_benchmark.cpp
@@ -11,22 +11,22 @@
 namespace Carbon::Testing {
 namespace {
 
-using Lex::LexedNumericLiteral;
+using Lex::NumericLiteral;
 
 static void BM_Lex_Float(benchmark::State& state) {
   for (auto _ : state) {
-    CARBON_CHECK(LexedNumericLiteral::Lex("0.000001"));
+    CARBON_CHECK(NumericLiteral::Lex("0.000001"));
   }
 }
 
 static void BM_Lex_Integer(benchmark::State& state) {
   for (auto _ : state) {
-    CARBON_CHECK(LexedNumericLiteral::Lex("1_234_567_890"));
+    CARBON_CHECK(NumericLiteral::Lex("1_234_567_890"));
   }
 }
 
 static void BM_ComputeValue_Float(benchmark::State& state) {
-  auto val = LexedNumericLiteral::Lex("0.000001");
+  auto val = NumericLiteral::Lex("0.000001");
   CARBON_CHECK(val);
   auto emitter = NullDiagnosticEmitter<const char*>();
   for (auto _ : state) {
@@ -35,7 +35,7 @@ static void BM_ComputeValue_Float(benchmark::State& state) {
 }
 
 static void BM_ComputeValue_Integer(benchmark::State& state) {
-  auto val = LexedNumericLiteral::Lex("1_234_567_890");
+  auto val = NumericLiteral::Lex("1_234_567_890");
   auto emitter = NullDiagnosticEmitter<const char*>();
   CARBON_CHECK(val);
   for (auto _ : state) {

--- a/toolchain/lexer/numeric_literal_fuzzer.cpp
+++ b/toolchain/lexer/numeric_literal_fuzzer.cpp
@@ -13,7 +13,7 @@ namespace Carbon::Testing {
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                       std::size_t size) {
-  auto token = Lex::LexedNumericLiteral::Lex(
+  auto token = Lex::NumericLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {
     // Lexically not a numeric literal.

--- a/toolchain/lexer/numeric_literal_test.cpp
+++ b/toolchain/lexer/numeric_literal_test.cpp
@@ -14,7 +14,7 @@
 namespace Carbon::Testing {
 namespace {
 
-using Lex::LexedNumericLiteral;
+using Lex::NumericLiteral;
 using ::testing::_;
 using ::testing::Field;
 using ::testing::Matcher;
@@ -26,14 +26,14 @@ class NumericLiteralTest : public ::testing::Test {
  protected:
   NumericLiteralTest() : error_tracker(ConsoleDiagnosticConsumer()) {}
 
-  auto Lex(llvm::StringRef text) -> LexedNumericLiteral {
-    std::optional<LexedNumericLiteral> result = LexedNumericLiteral::Lex(text);
+  auto Lex(llvm::StringRef text) -> NumericLiteral {
+    std::optional<NumericLiteral> result = NumericLiteral::Lex(text);
     CARBON_CHECK(result);
     EXPECT_EQ(result->text(), text);
     return *result;
   }
 
-  auto Parse(llvm::StringRef text) -> LexedNumericLiteral::Value {
+  auto Parse(llvm::StringRef text) -> NumericLiteral::Value {
     Testing::SingleTokenDiagnosticTranslator translator(text);
     DiagnosticEmitter<const char*> emitter(translator, error_tracker);
     return Lex(text).ComputeValue(emitter);
@@ -55,9 +55,9 @@ auto IsUnsignedInteger(uint64_t value) -> Matcher<llvm::APInt> {
 // Matcher for an integer literal value.
 template <typename ValueMatcher>
 auto HasIntValue(const ValueMatcher& value_matcher)
-    -> Matcher<LexedNumericLiteral::Value> {
-  return VariantWith<LexedNumericLiteral::IntegerValue>(
-      Field(&LexedNumericLiteral::IntegerValue::value, value_matcher));
+    -> Matcher<NumericLiteral::Value> {
+  return VariantWith<NumericLiteral::IntegerValue>(
+      Field(&NumericLiteral::IntegerValue::value, value_matcher));
 }
 
 struct RealMatcher {
@@ -68,16 +68,16 @@ struct RealMatcher {
 
 // Matcher for a real literal value.
 auto HasRealValue(const RealMatcher& real_matcher)
-    -> Matcher<LexedNumericLiteral::Value> {
-  return VariantWith<LexedNumericLiteral::RealValue>(AllOf(
-      Field(&LexedNumericLiteral::RealValue::radix, real_matcher.radix),
-      Field(&LexedNumericLiteral::RealValue::mantissa, real_matcher.mantissa),
-      Field(&LexedNumericLiteral::RealValue::exponent, real_matcher.exponent)));
+    -> Matcher<NumericLiteral::Value> {
+  return VariantWith<NumericLiteral::RealValue>(AllOf(
+      Field(&NumericLiteral::RealValue::radix, real_matcher.radix),
+      Field(&NumericLiteral::RealValue::mantissa, real_matcher.mantissa),
+      Field(&NumericLiteral::RealValue::exponent, real_matcher.exponent)));
 }
 
 // Matcher for an unrecoverable parse error.
-auto HasUnrecoverableError() -> Matcher<LexedNumericLiteral::Value> {
-  return VariantWith<LexedNumericLiteral::UnrecoverableError>(_);
+auto HasUnrecoverableError() -> Matcher<NumericLiteral::Value> {
+  return VariantWith<NumericLiteral::UnrecoverableError>(_);
 }
 
 TEST_F(NumericLiteralTest, HandlesIntegerLiteral) {

--- a/toolchain/lexer/string_literal.h
+++ b/toolchain/lexer/string_literal.h
@@ -13,15 +13,14 @@
 
 namespace Carbon::Lex {
 
-class LexedStringLiteral {
+class StringLiteral {
  public:
   // Extract a string literal token from the given text, if it has a suitable
   // form. Returning std::nullopt indicates no string literal was found;
   // returning an invalid literal indicates a string prefix was found, but it's
   // malformed and is returning a partial string literal to assist error
   // construction.
-  static auto Lex(llvm::StringRef source_text)
-      -> std::optional<LexedStringLiteral>;
+  static auto Lex(llvm::StringRef source_text) -> std::optional<StringLiteral>;
 
   // Expand any escape sequences in the given string literal and compute the
   // resulting value. This handles error recovery internally and cannot fail.
@@ -46,9 +45,9 @@ class LexedStringLiteral {
 
   struct Introducer;
 
-  explicit LexedStringLiteral(llvm::StringRef text, llvm::StringRef content,
-                              int hash_level, MultiLineKind multi_line,
-                              bool is_terminated)
+  explicit StringLiteral(llvm::StringRef text, llvm::StringRef content,
+                         int hash_level, MultiLineKind multi_line,
+                         bool is_terminated)
       : text_(text),
         content_(content),
         hash_level_(hash_level),

--- a/toolchain/lexer/string_literal_benchmark.cpp
+++ b/toolchain/lexer/string_literal_benchmark.cpp
@@ -10,7 +10,7 @@
 namespace Carbon::Testing {
 namespace {
 
-using Lex::LexedStringLiteral;
+using Lex::StringLiteral;
 
 static void BM_ValidString(benchmark::State& state, std::string_view introducer,
                            std::string_view terminator) {
@@ -18,7 +18,7 @@ static void BM_ValidString(benchmark::State& state, std::string_view introducer,
   x.append(100000, 'a');
   x.append(terminator);
   for (auto _ : state) {
-    LexedStringLiteral::Lex(x);
+    StringLiteral::Lex(x);
   }
 }
 
@@ -58,7 +58,7 @@ static void BM_IncompleteWithRepeatedEscapes(benchmark::State& state,
     x.append("n ");
   }
   for (auto _ : state) {
-    LexedStringLiteral::Lex(x);
+    StringLiteral::Lex(x);
   }
 }
 
@@ -91,8 +91,7 @@ static void BM_SimpleStringValue(benchmark::State& state,
   x.append(100000, 'a');
   x.append(terminator);
   for (auto _ : state) {
-    LexedStringLiteral::Lex(x)->ComputeValue(
-        NullDiagnosticEmitter<const char*>());
+    StringLiteral::Lex(x)->ComputeValue(NullDiagnosticEmitter<const char*>());
   }
 }
 

--- a/toolchain/lexer/string_literal_fuzzer.cpp
+++ b/toolchain/lexer/string_literal_fuzzer.cpp
@@ -14,7 +14,7 @@ namespace Carbon::Testing {
 // NOLINTNEXTLINE: Match the documented fuzzer entry point declaration style.
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                       std::size_t size) {
-  auto token = Lex::LexedStringLiteral::Lex(
+  auto token = Lex::StringLiteral::Lex(
       llvm::StringRef(reinterpret_cast<const char*>(data), size));
   if (!token) {
     // Lexically not a string literal.

--- a/toolchain/lexer/string_literal_test.cpp
+++ b/toolchain/lexer/string_literal_test.cpp
@@ -14,21 +14,21 @@
 namespace Carbon::Testing {
 namespace {
 
-using Lex::LexedStringLiteral;
+using Lex::StringLiteral;
 
 class StringLiteralTest : public ::testing::Test {
  protected:
   StringLiteralTest() : error_tracker(ConsoleDiagnosticConsumer()) {}
 
-  auto Lex(llvm::StringRef text) -> LexedStringLiteral {
-    std::optional<LexedStringLiteral> result = LexedStringLiteral::Lex(text);
+  auto Lex(llvm::StringRef text) -> StringLiteral {
+    std::optional<StringLiteral> result = StringLiteral::Lex(text);
     CARBON_CHECK(result);
     EXPECT_EQ(result->text(), text);
     return *result;
   }
 
   auto Parse(llvm::StringRef text) -> std::string {
-    LexedStringLiteral token = Lex(text);
+    StringLiteral token = Lex(text);
     Testing::SingleTokenDiagnosticTranslator translator(text);
     DiagnosticEmitter<const char*> emitter(translator, error_tracker);
     return token.ComputeValue(emitter);
@@ -93,7 +93,7 @@ TEST_F(StringLiteralTest, StringLiteralBounds) {
 
   for (llvm::StringLiteral test : valid) {
     SCOPED_TRACE(test);
-    std::optional<LexedStringLiteral> result = LexedStringLiteral::Lex(test);
+    std::optional<StringLiteral> result = StringLiteral::Lex(test);
     EXPECT_TRUE(result.has_value());
     if (result) {
       EXPECT_EQ(result->text(), test);
@@ -118,7 +118,7 @@ TEST_F(StringLiteralTest, StringLiteralBounds) {
 
   for (llvm::StringLiteral test : invalid) {
     SCOPED_TRACE(test);
-    std::optional<LexedStringLiteral> result = LexedStringLiteral::Lex(test);
+    std::optional<StringLiteral> result = StringLiteral::Lex(test);
     EXPECT_TRUE(result.has_value());
     if (result) {
       EXPECT_FALSE(result->is_terminated());

--- a/toolchain/lexer/tokenized_buffer.cpp
+++ b/toolchain/lexer/tokenized_buffer.cpp
@@ -381,7 +381,7 @@ class TokenizedBuffer::Lexer {
               buffer_->literal_int_storage_.size();
           buffer_->literal_int_storage_.push_back(std::move(value.mantissa));
           buffer_->literal_int_storage_.push_back(std::move(value.exponent));
-          CARBON_CHECK(buffer_->GetRealLiteral(token).IsDecimal() ==
+          CARBON_CHECK(buffer_->GetRealLiteral(token).is_decimal ==
                        (value.radix == NumericLiteral::Radix::Decimal));
           return token;
         },
@@ -947,8 +947,9 @@ auto TokenizedBuffer::GetRealLiteral(Token token) const -> RealLiteralValue {
   char second_char = source_->text()[token_start + 1];
   bool is_decimal = second_char != 'x' && second_char != 'b';
 
-  return RealLiteralValue(&literal_int_storage_, token_info.literal_index,
-                          is_decimal);
+  return {.mantissa = literal_int_storage_[token_info.literal_index],
+          .exponent = literal_int_storage_[token_info.literal_index + 1],
+          .is_decimal = is_decimal};
 }
 
 auto TokenizedBuffer::GetStringLiteral(Token token) const -> llvm::StringRef {

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -123,39 +123,24 @@ class TokenIterator
 // This is either a dyadic fraction (mantissa * 2^exponent) or a decadic
 // fraction (mantissa * 10^exponent).
 //
-// The `TokenizedBuffer` must outlive any `RealLiteralValue`s referring to
-// its tokens.
+// `RealLiteralValue` carries a reference back to `TokenizedBuffer` which can be
+// invalidated if the buffer is edited or destroyed.
 class RealLiteralValue : public Printable<RealLiteralValue> {
  public:
+  auto Print(llvm::raw_ostream& output_stream) const -> void {
+    output_stream << mantissa << "*" << (is_decimal ? "10" : "2") << "^"
+                  << exponent;
+  }
+
   // The mantissa, represented as an unsigned integer.
-  [[nodiscard]] auto Mantissa() const -> const llvm::APInt& {
-    return (*literal_int_storage_)[literal_index_];
-  }
+  const llvm::APInt& mantissa;
+
   // The exponent, represented as a signed integer.
-  [[nodiscard]] auto Exponent() const -> const llvm::APInt& {
-    return (*literal_int_storage_)[literal_index_ + 1];
-  }
+  const llvm::APInt& exponent;
+
   // If false, the value is mantissa * 2^exponent.
   // If true, the value is mantissa * 10^exponent.
-  [[nodiscard]] auto IsDecimal() const -> bool { return is_decimal_; }
-
-  auto Print(llvm::raw_ostream& output_stream) const -> void {
-    output_stream << Mantissa() << "*" << (is_decimal_ ? "10" : "2") << "^"
-                  << Exponent();
-  }
-
- private:
-  friend class TokenizedBuffer;
-
-  RealLiteralValue(const llvm::SmallVector<llvm::APInt>* literal_int_storage,
-                   int32_t literal_index, bool is_decimal)
-      : literal_int_storage_(literal_int_storage),
-        literal_index_(literal_index),
-        is_decimal_(is_decimal) {}
-
-  const llvm::SmallVector<llvm::APInt>* literal_int_storage_;
-  int32_t literal_index_;
-  bool is_decimal_;
+  bool is_decimal;
 };
 
 // A diagnostic location translator that maps token locations into source

--- a/toolchain/lexer/tokenized_buffer.h
+++ b/toolchain/lexer/tokenized_buffer.h
@@ -23,6 +23,155 @@
 
 namespace Carbon::Lex {
 
+class TokenizedBuffer;
+
+// A lightweight handle to a lexed token in a `TokenizedBuffer`.
+//
+// `Token` objects are designed to be passed by value, not reference or
+// pointer. They are also designed to be small and efficient to store in data
+// structures.
+//
+// `Token` objects from the same `TokenizedBuffer` can be compared with each
+// other, both for being the same token within the buffer, and to establish
+// relative position within the token stream that has been lexed out of the
+// buffer. `Token` objects from different `TokenizedBuffer`s cannot be
+// meaningfully compared.
+//
+// All other APIs to query a `Token` are on the `TokenizedBuffer`.
+struct Token : public ComparableIndexBase {
+  using ComparableIndexBase::ComparableIndexBase;
+};
+
+// A lightweight handle to a lexed line in a `TokenizedBuffer`.
+//
+// `Line` objects are designed to be passed by value, not reference or
+// pointer. They are also designed to be small and efficient to store in data
+// structures.
+//
+// Each `Line` object refers to a specific line in the source code that was
+// lexed. They can be compared directly to establish that they refer to the
+// same line or the relative position of different lines within the source.
+//
+// All other APIs to query a `Line` are on the `TokenizedBuffer`.
+struct Line : public ComparableIndexBase {
+  using ComparableIndexBase::ComparableIndexBase;
+};
+
+// A lightweight handle to a lexed identifier in a `TokenizedBuffer`.
+//
+// `Identifier` objects are designed to be passed by value, not reference or
+// pointer. They are also designed to be small and efficient to store in data
+// structures.
+//
+// Each identifier lexed is canonicalized to a single entry in the identifier
+// table. `Identifier` objects will compare equal if they refer to the same
+// identifier spelling. Where the identifier was written is not preserved.
+//
+// All other APIs to query a `Identifier` are on the `TokenizedBuffer`.
+struct Identifier : public IndexBase {
+  using IndexBase::IndexBase;
+
+  static const Identifier Invalid;
+};
+
+constexpr Identifier Identifier::Invalid = Identifier(Identifier::InvalidIndex);
+
+// Random-access iterator over tokens within the buffer.
+class TokenIterator
+    : public llvm::iterator_facade_base<
+          TokenIterator, std::random_access_iterator_tag, const Token, int>,
+      public Printable<TokenIterator> {
+ public:
+  TokenIterator() = delete;
+
+  explicit TokenIterator(Token token) : token_(token) {}
+
+  auto operator==(const TokenIterator& rhs) const -> bool {
+    return token_ == rhs.token_;
+  }
+  auto operator<(const TokenIterator& rhs) const -> bool {
+    return token_ < rhs.token_;
+  }
+
+  auto operator*() const -> const Token& { return token_; }
+
+  using iterator_facade_base::operator-;
+  auto operator-(const TokenIterator& rhs) const -> int {
+    return token_.index - rhs.token_.index;
+  }
+
+  auto operator+=(int n) -> TokenIterator& {
+    token_.index += n;
+    return *this;
+  }
+  auto operator-=(int n) -> TokenIterator& {
+    token_.index -= n;
+    return *this;
+  }
+
+  // Prints the raw token index.
+  auto Print(llvm::raw_ostream& output) const -> void;
+
+ private:
+  friend class TokenizedBuffer;
+
+  Token token_;
+};
+
+// The value of a real literal.
+//
+// This is either a dyadic fraction (mantissa * 2^exponent) or a decadic
+// fraction (mantissa * 10^exponent).
+//
+// The `TokenizedBuffer` must outlive any `RealLiteralValue`s referring to
+// its tokens.
+class RealLiteralValue : public Printable<RealLiteralValue> {
+ public:
+  // The mantissa, represented as an unsigned integer.
+  [[nodiscard]] auto Mantissa() const -> const llvm::APInt& {
+    return (*literal_int_storage_)[literal_index_];
+  }
+  // The exponent, represented as a signed integer.
+  [[nodiscard]] auto Exponent() const -> const llvm::APInt& {
+    return (*literal_int_storage_)[literal_index_ + 1];
+  }
+  // If false, the value is mantissa * 2^exponent.
+  // If true, the value is mantissa * 10^exponent.
+  [[nodiscard]] auto IsDecimal() const -> bool { return is_decimal_; }
+
+  auto Print(llvm::raw_ostream& output_stream) const -> void {
+    output_stream << Mantissa() << "*" << (is_decimal_ ? "10" : "2") << "^"
+                  << Exponent();
+  }
+
+ private:
+  friend class TokenizedBuffer;
+
+  RealLiteralValue(const llvm::SmallVector<llvm::APInt>* literal_int_storage,
+                   int32_t literal_index, bool is_decimal)
+      : literal_int_storage_(literal_int_storage),
+        literal_index_(literal_index),
+        is_decimal_(is_decimal) {}
+
+  const llvm::SmallVector<llvm::APInt>* literal_int_storage_;
+  int32_t literal_index_;
+  bool is_decimal_;
+};
+
+// A diagnostic location translator that maps token locations into source
+// buffer locations.
+class TokenLocationTranslator : public DiagnosticLocationTranslator<Token> {
+ public:
+  explicit TokenLocationTranslator(const TokenizedBuffer* buffer)
+      : buffer_(buffer) {}
+
+  // Map the given token into a diagnostic location.
+  auto GetLocation(Token token) -> DiagnosticLocation override;
+
+ private:
+  const TokenizedBuffer* buffer_;
+};
+
 // A buffer of tokenized Carbon source code.
 //
 // This is constructed by lexing the source code text into a series of tokens.
@@ -33,151 +182,6 @@ namespace Carbon::Lex {
 // `HasError` returning true.
 class TokenizedBuffer : public Printable<TokenizedBuffer> {
  public:
-  // A lightweight handle to a lexed token in a `TokenizedBuffer`.
-  //
-  // `Token` objects are designed to be passed by value, not reference or
-  // pointer. They are also designed to be small and efficient to store in data
-  // structures.
-  //
-  // `Token` objects from the same `TokenizedBuffer` can be compared with each
-  // other, both for being the same token within the buffer, and to establish
-  // relative position within the token stream that has been lexed out of the
-  // buffer. `Token` objects from different `TokenizedBuffer`s cannot be
-  // meaningfully compared.
-  //
-  // All other APIs to query a `Token` are on the `TokenizedBuffer`.
-  struct Token : public ComparableIndexBase {
-    using ComparableIndexBase::ComparableIndexBase;
-  };
-
-  // A lightweight handle to a lexed line in a `TokenizedBuffer`.
-  //
-  // `Line` objects are designed to be passed by value, not reference or
-  // pointer. They are also designed to be small and efficient to store in data
-  // structures.
-  //
-  // Each `Line` object refers to a specific line in the source code that was
-  // lexed. They can be compared directly to establish that they refer to the
-  // same line or the relative position of different lines within the source.
-  //
-  // All other APIs to query a `Line` are on the `TokenizedBuffer`.
-  struct Line : public ComparableIndexBase {
-    using ComparableIndexBase::ComparableIndexBase;
-  };
-
-  // A lightweight handle to a lexed identifier in a `TokenizedBuffer`.
-  //
-  // `Identifier` objects are designed to be passed by value, not reference or
-  // pointer. They are also designed to be small and efficient to store in data
-  // structures.
-  //
-  // Each identifier lexed is canonicalized to a single entry in the identifier
-  // table. `Identifier` objects will compare equal if they refer to the same
-  // identifier spelling. Where the identifier was written is not preserved.
-  //
-  // All other APIs to query a `Identifier` are on the `TokenizedBuffer`.
-  struct Identifier : public IndexBase {
-    using IndexBase::IndexBase;
-
-    static const Identifier Invalid;
-  };
-
-  // Random-access iterator over tokens within the buffer.
-  class TokenIterator
-      : public llvm::iterator_facade_base<
-            TokenIterator, std::random_access_iterator_tag, const Token, int>,
-        public Printable<TokenIterator> {
-   public:
-    TokenIterator() = delete;
-
-    explicit TokenIterator(Token token) : token_(token) {}
-
-    auto operator==(const TokenIterator& rhs) const -> bool {
-      return token_ == rhs.token_;
-    }
-    auto operator<(const TokenIterator& rhs) const -> bool {
-      return token_ < rhs.token_;
-    }
-
-    auto operator*() const -> const Token& { return token_; }
-
-    using iterator_facade_base::operator-;
-    auto operator-(const TokenIterator& rhs) const -> int {
-      return token_.index - rhs.token_.index;
-    }
-
-    auto operator+=(int n) -> TokenIterator& {
-      token_.index += n;
-      return *this;
-    }
-    auto operator-=(int n) -> TokenIterator& {
-      token_.index -= n;
-      return *this;
-    }
-
-    // Prints the raw token index.
-    auto Print(llvm::raw_ostream& output) const -> void;
-
-   private:
-    friend class TokenizedBuffer;
-
-    Token token_;
-  };
-
-  // The value of a real literal.
-  //
-  // This is either a dyadic fraction (mantissa * 2^exponent) or a decadic
-  // fraction (mantissa * 10^exponent).
-  //
-  // The `TokenizedBuffer` must outlive any `RealLiteralValue`s referring to
-  // its tokens.
-  class RealLiteralValue : public Printable<RealLiteralValue> {
-   public:
-    // The mantissa, represented as an unsigned integer.
-    [[nodiscard]] auto Mantissa() const -> const llvm::APInt& {
-      return buffer_->literal_int_storage_[literal_index_];
-    }
-    // The exponent, represented as a signed integer.
-    [[nodiscard]] auto Exponent() const -> const llvm::APInt& {
-      return buffer_->literal_int_storage_[literal_index_ + 1];
-    }
-    // If false, the value is mantissa * 2^exponent.
-    // If true, the value is mantissa * 10^exponent.
-    [[nodiscard]] auto IsDecimal() const -> bool { return is_decimal_; }
-
-    auto Print(llvm::raw_ostream& output_stream) const -> void {
-      output_stream << Mantissa() << "*" << (is_decimal_ ? "10" : "2") << "^"
-                    << Exponent();
-    }
-
-   private:
-    friend class TokenizedBuffer;
-
-    RealLiteralValue(const TokenizedBuffer* buffer, int32_t literal_index,
-                     bool is_decimal)
-        : buffer_(buffer),
-          literal_index_(literal_index),
-          is_decimal_(is_decimal) {}
-
-    const TokenizedBuffer* buffer_;
-    int32_t literal_index_;
-    bool is_decimal_;
-  };
-
-  // A diagnostic location translator that maps token locations into source
-  // buffer locations.
-  class TokenLocationTranslator : public DiagnosticLocationTranslator<Token> {
-   public:
-    explicit TokenLocationTranslator(const TokenizedBuffer* buffer)
-        : buffer_(buffer) {}
-
-    // Map the given token into a diagnostic location.
-    auto GetLocation(Token token) -> DiagnosticLocation override;
-
-   private:
-    const TokenizedBuffer* buffer_;
-  };
-
   // Lexes a buffer of source code into a tokenized buffer.
   //
   // The provided source buffer must outlive any returned `TokenizedBuffer`
@@ -286,6 +290,8 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   // Implementation detail struct implementing the actual lexer logic.
   class Lexer;
   friend Lexer;
+
+  friend class TokenLocationTranslator;
 
   // A diagnostic location translator that maps token locations into source
   // buffer locations.
@@ -410,15 +416,12 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   bool has_errors_ = false;
 };
 
-constexpr TokenizedBuffer::Identifier TokenizedBuffer::Identifier::Invalid =
-    TokenizedBuffer::Identifier(TokenizedBuffer::Identifier::InvalidIndex);
-
 // A diagnostic emitter that uses positions within a source buffer's text as
 // its source of location information.
 using LexerDiagnosticEmitter = DiagnosticEmitter<const char*>;
 
 // A diagnostic emitter that uses tokens as its source of location information.
-using TokenDiagnosticEmitter = DiagnosticEmitter<TokenizedBuffer::Token>;
+using TokenDiagnosticEmitter = DiagnosticEmitter<Token>;
 
 }  // namespace Carbon::Lex
 

--- a/toolchain/lexer/tokenized_buffer_fuzzer.cpp
+++ b/toolchain/lexer/tokenized_buffer_fuzzer.cpp
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   //
   // TODO: We should enhance this to do more sanity checks on the resulting
   // token stream.
-  for (Lex::TokenizedBuffer::Token token : buffer.tokens()) {
+  for (Lex::Token token : buffer.tokens()) {
     int line_number = buffer.GetLineNumber(token);
     CARBON_CHECK(line_number > 0) << "Invalid line number!";
     CARBON_CHECK(line_number < INT_MAX) << "Invalid line number!";

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -20,6 +20,7 @@
 namespace Carbon::Testing {
 namespace {
 
+using Lex::Token;
 using Lex::TokenizedBuffer;
 using Lex::TokenKind;
 using ::testing::_;
@@ -543,7 +544,7 @@ TEST_F(LexerTest, Whitespace) {
                   // EOF
                   false};
   int pos = 0;
-  for (TokenizedBuffer::Token token : buffer.tokens()) {
+  for (Token token : buffer.tokens()) {
     ASSERT_LT(pos, std::size(space));
     EXPECT_THAT(buffer.HasLeadingWhitespace(token), Eq(space[pos]));
     ++pos;
@@ -791,7 +792,7 @@ TEST_F(LexerTest, InvalidStringLiterals) {
 
     // We should have formed at least one error token.
     bool found_error = false;
-    for (TokenizedBuffer::Token token : buffer.tokens()) {
+    for (Token token : buffer.tokens()) {
       if (buffer.GetKind(token) == TokenKind::Error) {
         found_error = true;
         break;

--- a/toolchain/lexer/tokenized_buffer_test.cpp
+++ b/toolchain/lexer/tokenized_buffer_test.cpp
@@ -157,9 +157,9 @@ TEST_F(LexerTest, HandlesNumericLiteral) {
   EXPECT_EQ(buffer.GetIntegerLiteral(*token_1_234_567), 1'234'567);
   auto token_1_5e9 = buffer.tokens().begin() + 8;
   auto value_1_5e9 = buffer.GetRealLiteral(*token_1_5e9);
-  EXPECT_EQ(value_1_5e9.Mantissa().getZExtValue(), 15);
-  EXPECT_EQ(value_1_5e9.Exponent().getSExtValue(), 8);
-  EXPECT_EQ(value_1_5e9.IsDecimal(), true);
+  EXPECT_EQ(value_1_5e9.mantissa.getZExtValue(), 15);
+  EXPECT_EQ(value_1_5e9.exponent.getSExtValue(), 8);
+  EXPECT_EQ(value_1_5e9.is_decimal, true);
 }
 
 TEST_F(LexerTest, HandlesInvalidNumericLiterals) {

--- a/toolchain/lexer/tokenized_buffer_test_helpers.h
+++ b/toolchain/lexer/tokenized_buffer_test_helpers.h
@@ -8,7 +8,6 @@
 #include <gmock/gmock.h>
 
 #include "common/check.h"
-#include "llvm/Support/YAMLParser.h"
 #include "toolchain/lexer/tokenized_buffer.h"
 
 namespace Carbon::Testing {

--- a/toolchain/parser/parse_tree.cpp
+++ b/toolchain/parser/parse_tree.cpp
@@ -17,7 +17,7 @@ namespace Carbon::Parse {
 
 auto Tree::Parse(Lex::TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                  llvm::raw_ostream* vlog_stream) -> Tree {
-  Lex::TokenizedBuffer::TokenLocationTranslator translator(&tokens);
+  Lex::TokenLocationTranslator translator(&tokens);
   Lex::TokenDiagnosticEmitter emitter(translator, consumer);
 
   // Delegate to the parser.
@@ -95,7 +95,7 @@ auto Tree::node_kind(Node n) const -> NodeKind {
   return node_impls_[n.index].kind;
 }
 
-auto Tree::node_token(Node n) const -> Lex::TokenizedBuffer::Token {
+auto Tree::node_token(Node n) const -> Lex::Token {
   CARBON_CHECK(n.is_valid());
   return node_impls_[n.index].token;
 }

--- a/toolchain/parser/parse_tree.h
+++ b/toolchain/parser/parse_tree.h
@@ -103,7 +103,7 @@ class Tree : public Printable<Tree> {
   [[nodiscard]] auto node_kind(Node n) const -> NodeKind;
 
   // Returns the token the given parse tree node models.
-  [[nodiscard]] auto node_token(Node n) const -> Lex::TokenizedBuffer::Token;
+  [[nodiscard]] auto node_token(Node n) const -> Lex::Token;
 
   [[nodiscard]] auto node_subtree_size(Node n) const -> int32_t;
 
@@ -170,8 +170,8 @@ class Tree : public Printable<Tree> {
   // The in-memory representation of data used for a particular node in the
   // tree.
   struct NodeImpl {
-    explicit NodeImpl(NodeKind kind, bool has_error,
-                      Lex::TokenizedBuffer::Token token, int subtree_size)
+    explicit NodeImpl(NodeKind kind, bool has_error, Lex::Token token,
+                      int subtree_size)
         : kind(kind),
           has_error(has_error),
           token(token),
@@ -199,7 +199,7 @@ class Tree : public Printable<Tree> {
     bool has_error = false;
 
     // The token root of this node.
-    Lex::TokenizedBuffer::Token token;
+    Lex::Token token;
 
     // The size of this node's subtree of the parse tree. This is the number of
     // nodes (and thus tokens) that are covered by this node (and its

--- a/toolchain/parser/parse_tree_node_location_translator.h
+++ b/toolchain/parser/parse_tree_node_location_translator.h
@@ -21,7 +21,7 @@ class NodeLocationTranslator : public DiagnosticLocationTranslator<Node> {
   }
 
  private:
-  Lex::TokenizedBuffer::TokenLocationTranslator token_translator_;
+  Lex::TokenLocationTranslator token_translator_;
   const Tree* parse_tree_;
 };
 

--- a/toolchain/parser/parser_handle_array_expression.cpp
+++ b/toolchain/parser/parser_handle_array_expression.cpp
@@ -42,9 +42,8 @@ auto HandleArrayExpressionSemi(Context& context) -> void {
 
 auto HandleArrayExpressionFinish(Context& context) -> void {
   auto state = context.PopState();
-  context.ConsumeAndAddCloseSymbol(
-      *(Lex::TokenizedBuffer::TokenIterator(state.token)), state,
-      NodeKind::ArrayExpression);
+  context.ConsumeAndAddCloseSymbol(*(Lex::TokenIterator(state.token)), state,
+                                   NodeKind::ArrayExpression);
 }
 
 }  // namespace Carbon::Parse

--- a/toolchain/parser/parser_handle_paren_condition.cpp
+++ b/toolchain/parser/parser_handle_paren_condition.cpp
@@ -11,7 +11,7 @@ static auto HandleParenCondition(Context& context, NodeKind start_kind,
                                  State finish_state) -> void {
   auto state = context.PopState();
 
-  std::optional<Lex::TokenizedBuffer::Token> open_paren =
+  std::optional<Lex::Token> open_paren =
       context.ConsumeAndAddOpenParen(state.token, start_kind);
   if (open_paren) {
     state.token = *open_paren;

--- a/toolchain/parser/parser_handle_statement.cpp
+++ b/toolchain/parser/parser_handle_statement.cpp
@@ -83,7 +83,7 @@ auto HandleStatementContinueFinish(Context& context) -> void {
 auto HandleStatementForHeader(Context& context) -> void {
   auto state = context.PopState();
 
-  std::optional<Lex::TokenizedBuffer::Token> open_paren =
+  std::optional<Lex::Token> open_paren =
       context.ConsumeAndAddOpenParen(state.token, NodeKind::ForHeaderStart);
   if (open_paren) {
     state.token = *open_paren;

--- a/toolchain/semantics/semantics_handle_literal.cpp
+++ b/toolchain/semantics/semantics_handle_literal.cpp
@@ -33,9 +33,9 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
     case Lex::TokenKind::RealLiteral: {
       auto token_value = context.tokens().GetRealLiteral(token);
       auto id = context.semantics_ir().AddRealLiteral(
-          {.mantissa = token_value.Mantissa(),
-           .exponent = token_value.Exponent(),
-           .is_decimal = token_value.IsDecimal()});
+          {.mantissa = token_value.mantissa,
+           .exponent = token_value.exponent,
+           .is_decimal = token_value.is_decimal});
       context.AddNodeAndPush(
           parse_node,
           SemIR::Node::RealLiteral::Make(


### PR DESCRIPTION
Versus the namespace change in #3170, these felt like they may get more nuanced review, so I'm splitting them out:

- Removing "Lexed" from LexedNumericLiteral and LexedStringLiteral
- Moving classes out of the TokenizedBuffer class, so that they're now things like Lex::Token instead of Lex::TokenizedBuffer::Token (i.e., much shorter to type, more consistent with things like Parse::Node).