### PR TITLE
Factor out check-related logic from SemIR::File

### DIFF
--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "//toolchain/lexer:tokenized_buffer",
         "//toolchain/lower",
         "//toolchain/parser:parse_tree",
+        "//toolchain/semantics:check",
         "//toolchain/semantics:semantics_ir",
         "//toolchain/semantics:semantics_ir_formatter",
         "//toolchain/source:source_buffer",

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -18,7 +18,7 @@
 #include "toolchain/lexer/tokenized_buffer.h"
 #include "toolchain/lower/lower.h"
 #include "toolchain/parser/parse_tree.h"
-#include "toolchain/semantics/semantics_ir.h"
+#include "toolchain/semantics/check.h"
 #include "toolchain/semantics/semantics_ir_formatter.h"
 #include "toolchain/source/source_buffer.h"
 
@@ -436,9 +436,9 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
     return !has_errors;
   }
 
-  const SemIR::File builtin_ir = SemIR::File::MakeBuiltinIR();
+  const SemIR::File builtin_ir = Check::MakeBuiltins();
   CARBON_VLOG() << "*** SemanticsIR::MakeFromParseTree ***\n";
-  const SemIR::File semantics_ir = SemIR::File::MakeFromParseTree(
+  const SemIR::File semantics_ir = Check::CheckParseTree(
       builtin_ir, tokenized_source, parse_tree, *consumer, vlog_stream_);
 
   // We've finished all steps that can produce diagnostics. Emit the

--- a/toolchain/semantics/BUILD
+++ b/toolchain/semantics/BUILD
@@ -59,11 +59,11 @@ cc_library(
 )
 
 cc_library(
-    name = "semantics_ir",
+    name = "check",
     srcs = [
+        "check.cpp",
         "semantics_context.cpp",
         "semantics_declaration_name_stack.cpp",
-        "semantics_ir.cpp",
         "semantics_node_block_stack.cpp",
     ] +
     # Glob handler files to avoid missing any.
@@ -71,13 +71,14 @@ cc_library(
         "semantics_handle*.cpp",
     ]),
     hdrs = [
+        "check.h",
         "semantics_context.h",
         "semantics_declaration_name_stack.h",
-        "semantics_ir.h",
         "semantics_node_block_stack.h",
     ],
     deps = [
         ":semantics_builtin_kind",
+        ":semantics_ir",
         ":semantics_node",
         ":semantics_node_kind",
         ":semantics_node_stack",
@@ -85,9 +86,8 @@ cc_library(
         "//common:ostream",
         "//common:vlog",
         "//toolchain/base:pretty_stack_trace_function",
+        "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:diagnostic_kind",
-        "//toolchain/lexer:numeric_literal",
-        "//toolchain/lexer:token_kind",
         "//toolchain/lexer:tokenized_buffer",
         "//toolchain/parser:parse_node_kind",
         "//toolchain/parser:parse_tree",
@@ -97,13 +97,22 @@ cc_library(
 )
 
 cc_library(
+    name = "semantics_ir",
+    srcs = ["semantics_ir.cpp"],
+    hdrs = ["semantics_ir.h"],
+    deps = [
+        ":semantics_builtin_kind",
+        ":semantics_node",
+        ":semantics_node_kind",
+        "//common:check",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "semantics_ir_formatter",
-    srcs = [
-        "semantics_ir_formatter.cpp",
-    ],
-    hdrs = [
-        "semantics_ir_formatter.h",
-    ],
+    srcs = ["semantics_ir_formatter.cpp"],
+    hdrs = ["semantics_ir_formatter.h"],
     deps = [
         ":semantics_ir",
         ":semantics_node_kind",

--- a/toolchain/semantics/check.cpp
+++ b/toolchain/semantics/check.cpp
@@ -1,0 +1,71 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/check.h"
+
+#include "toolchain/base/pretty_stack_trace_function.h"
+#include "toolchain/parser/parse_tree_node_location_translator.h"
+#include "toolchain/semantics/semantics_context.h"
+#include "toolchain/semantics/semantics_ir.h"
+
+namespace Carbon::Check {
+
+auto CheckParseTree(const SemIR::File& builtin_ir,
+                    const TokenizedBuffer& tokens,
+                    const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
+                    llvm::raw_ostream* vlog_stream) -> SemIR::File {
+  auto semantics_ir = SemIR::File(&builtin_ir);
+
+  Parse::NodeLocationTranslator translator(&tokens, &parse_tree);
+  ErrorTrackingDiagnosticConsumer err_tracker(consumer);
+  DiagnosticEmitter<Parse::Node> emitter(translator, err_tracker);
+
+  Check::Context context(tokens, emitter, parse_tree, semantics_ir,
+                         vlog_stream);
+  PrettyStackTraceFunction context_dumper(
+      [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
+
+  // Add a block for the Parse::Tree.
+  context.node_block_stack().Push();
+  context.PushScope();
+
+  // Loops over all nodes in the tree. On some errors, this may return early,
+  // for example if an unrecoverable state is encountered.
+  for (auto parse_node : parse_tree.postorder()) {
+    // clang warns on unhandled enum values; clang-tidy is incorrect here.
+    // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
+    switch (auto parse_kind = parse_tree.node_kind(parse_node)) {
+#define CARBON_PARSE_NODE_KIND(Name)                                         \
+  case Parse::NodeKind::Name: {                                              \
+    if (!Check::Handle##Name(context, parse_node)) {                         \
+      CARBON_CHECK(err_tracker.seen_error())                                 \
+          << "Handle" #Name " returned false without printing a diagnostic"; \
+      semantics_ir.set_has_errors(true);                                     \
+      return semantics_ir;                                                   \
+    }                                                                        \
+    break;                                                                   \
+  }
+#include "toolchain/parser/parse_node_kind.def"
+    }
+  }
+
+  // Pop information for the file-level scope.
+  semantics_ir.set_top_node_block_id(context.node_block_stack().Pop());
+  context.PopScope();
+
+  context.VerifyOnFinish();
+
+  semantics_ir.set_has_errors(err_tracker.seen_error());
+
+#ifndef NDEBUG
+  if (auto verify = semantics_ir.Verify(); !verify.ok()) {
+    CARBON_FATAL() << semantics_ir
+                   << "Built invalid semantics IR: " << verify.error() << "\n";
+  }
+#endif
+
+  return semantics_ir;
+}
+
+}  // namespace Carbon::Check

--- a/toolchain/semantics/check.h
+++ b/toolchain/semantics/check.h
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEMANTICS_CHECK_H_
+#define CARBON_TOOLCHAIN_SEMANTICS_CHECK_H_
+
+#include "common/ostream.h"
+#include "toolchain/diagnostics/diagnostic_emitter.h"
+#include "toolchain/lexer/tokenized_buffer.h"
+#include "toolchain/parser/parse_tree.h"
+#include "toolchain/semantics/semantics_ir.h"
+
+namespace Carbon::Check {
+
+// Constructs builtins. A single instance should be reused with CheckParseTree
+// calls associated with a given compilation.
+inline auto MakeBuiltins() -> SemIR::File { return SemIR::File(); }
+
+// Produces and checks the IR for the provided Parse::Tree.
+extern auto CheckParseTree(const SemIR::File& builtin_ir,
+                           const TokenizedBuffer& tokens,
+                           const Parse::Tree& parse_tree,
+                           DiagnosticConsumer& consumer,
+                           llvm::raw_ostream* vlog_stream) -> SemIR::File;
+
+}  // namespace Carbon::Check
+
+#endif  // CARBON_TOOLCHAIN_SEMANTICS_CHECK_H_

--- a/toolchain/semantics/semantics_ir.h
+++ b/toolchain/semantics/semantics_ir.h
@@ -9,7 +9,6 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "toolchain/parser/parse_tree.h"
 #include "toolchain/semantics/semantics_node.h"
 
 namespace Carbon::SemIR {
@@ -68,15 +67,11 @@ struct RealLiteral : public Printable<RealLiteral> {
 // Provides semantic analysis on a Parse::Tree.
 class File : public Printable<File> {
  public:
-  // Produces the builtins.
-  static auto MakeBuiltinIR() -> File;
+  // Produces a file for the builtins.
+  explicit File();
 
-  // Adds the IR for the provided Parse::Tree.
-  static auto MakeFromParseTree(const File& builtin_ir,
-                                const TokenizedBuffer& tokens,
-                                const Parse::Tree& parse_tree,
-                                DiagnosticConsumer& consumer,
-                                llvm::raw_ostream* vlog_stream) -> File;
+  // Starts a new file for Check::CheckParseTree. Builtins are required.
+  explicit File(const File* builtins);
 
   // Verifies that invariants of the semantics IR hold.
   auto Verify() const -> ErrorOr<Success>;
@@ -286,17 +281,15 @@ class File : public Printable<File> {
   }
 
   auto top_node_block_id() const -> NodeBlockId { return top_node_block_id_; }
+  auto set_top_node_block_id(NodeBlockId block_id) -> void {
+    top_node_block_id_ = block_id;
+  }
 
   // Returns true if there were errors creating the semantics IR.
   auto has_errors() const -> bool { return has_errors_; }
+  auto set_has_errors(bool has_errors) -> void { has_errors_ = has_errors; }
 
  private:
-  explicit File(const File* builtin_ir)
-      : cross_reference_irs_({builtin_ir == nullptr ? this : builtin_ir}) {
-    // For NodeBlockId::Empty.
-    node_blocks_.resize(1);
-  }
-
   bool has_errors_ = false;
 
   // Storage for callable objects.


### PR DESCRIPTION
This is necessary for a clean split of the SemIR and Check namespaces. My design intent with check.h is that check/check.h provides the factory functions necessary to construct a SemIR, which is the main reason I have the MakeBuiltins wrapper there.

I don't think File's constructors are great, but it felt good enough to me in that context. I considered factory functions, or something like an enum as discriminator, but it felt like more burden than improvement.