### PR TITLE
Fix toolchain glob_sh_run uses.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -86,8 +86,10 @@ cc_fuzz_test(
 glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
-        "dump",
-        "semantics-ir",
+        "compile",
+        "--phase=check",
+        "--dump-semantics-ir",
+        "--dump-raw-semantics-ir",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],
@@ -97,8 +99,8 @@ glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
         "-v",
-        "dump",
-        "semantics-ir",
+        "compile",
+        "--phase=check",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -448,18 +448,25 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
 
   has_errors |= semantics_ir.has_errors();
   CARBON_VLOG() << "*** SemIR::File::MakeFromParseTree done ***\n";
+
+  CARBON_VLOG() << "*** raw semantics_ir ***\n" << semantics_ir << "\n";
   if (options.dump_raw_semantics_ir) {
     semantics_ir.Print(output_stream_, options.builtin_semantics_ir);
     if (options.dump_semantics_ir) {
       output_stream_ << "\n";
     }
   }
+
+  if (vlog_stream_) {
+    CARBON_VLOG() << "*** semantics_ir ***\n";
+    SemIR::FormatFile(tokenized_source, parse_tree, semantics_ir,
+                      *vlog_stream_);
+  }
   if (options.dump_semantics_ir) {
-    consumer->Flush();
     SemIR::FormatFile(tokenized_source, parse_tree, semantics_ir,
                       output_stream_);
   }
-  CARBON_VLOG() << "semantics_ir: " << semantics_ir;
+
   if (options.phase == Phase::Check) {
     return !has_errors;
   }

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -262,9 +262,22 @@ file_test(
 glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
-        "dump",
-        "tokens",
+        "compile",
+        "--phase=lex",
+        "--dump-tokens",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],
+)
+
+glob_sh_run(
+    args = [
+        "$(location //toolchain/driver:carbon)",
+        "-v",
+        "compile",
+        "--phase=lex",
+    ],
+    data = ["//toolchain/driver:carbon"],
+    file_exts = ["carbon"],
+    run_ext = "verbose",
 )

--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -58,8 +58,9 @@ file_test(
 glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
-        "dump",
-        "llvm-ir",
+        "compile",
+        "--phase=lower",
+        "--dump-llvm-ir",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],
@@ -69,8 +70,8 @@ glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
         "-v",
-        "dump",
-        "llvm-ir",
+        "compile",
+        "--phase=lower",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -132,8 +132,9 @@ file_test(
 glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
-        "dump",
-        "parse-tree",
+        "compile",
+        "--phase=parse",
+        "--dump-parse-tree",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],
@@ -143,8 +144,8 @@ glob_sh_run(
     args = [
         "$(location //toolchain/driver:carbon)",
         "-v",
-        "dump",
-        "parse-tree",
+        "compile",
+        "--phase=parse",
     ],
     data = ["//toolchain/driver:carbon"],
     file_exts = ["carbon"],


### PR DESCRIPTION
These were missed when changing the command line.

Also brings -v output to parity with formatted IR printing, and removes a redundant flush.