### PR TITLE
Fix lowering of 8 and 9.

### DIFF
--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -226,7 +226,7 @@ auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
       context.semantics_ir().GetIntegerLiteral(node.GetAsIntegerLiteral());
   // TODO: This won't offer correct semantics, but seems close enough for now.
   llvm::Value* v =
-      llvm::ConstantInt::get(context.builder().getInt32Ty(), i.getSExtValue());
+      llvm::ConstantInt::get(context.builder().getInt32Ty(), i.getZExtValue());
   context.SetLocal(node_id, v);
 }
 

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -19,7 +19,7 @@ fn Main() {
 // CHECK:STDOUT: define void @Main() {
 // CHECK:STDOUT:   %a = alloca i32, align 4
 // CHECK:STDOUT:   store i32 12, ptr %a, align 4
-// CHECK:STDOUT:   store i32 -7, ptr %a, align 4
+// CHECK:STDOUT:   store i32 9, ptr %a, align 4
 // CHECK:STDOUT:   %tuple = alloca { %type, %type }, align 8
 // CHECK:STDOUT:   %1 = getelementptr inbounds { %type, %type }, ptr %tuple, i32 0, i32 0
 // CHECK:STDOUT:   store %type zeroinitializer, ptr %1, align 1


### PR DESCRIPTION
IntegerLiterals are not signed, so get the zero-extended value rather than the sign-extended value. Sometimes we use the high bit of the `APInt`, though currently this only happens for the literals 8 and 9 due to the way we convert decimal integers to binary.