### PR TITLE
Fix printing of integer literals with the high bit set.

### DIFF
--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -115,7 +115,7 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT: ]
 // CHECK:STDOUT:
 // CHECK:STDOUT: package {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal -7
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 9] = var "a"
 // CHECK:STDOUT:   %.loc7_20.1: i32 = int_literal 1
@@ -132,9 +132,9 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.loc7_35.2: i32 = stub_reference %.loc7_35.1
 // CHECK:STDOUT:   %.loc7_38.1: i32 = int_literal 7
 // CHECK:STDOUT:   %.loc7_38.2: i32 = stub_reference %.loc7_38.1
-// CHECK:STDOUT:   %.loc7_41.1: i32 = int_literal -8
+// CHECK:STDOUT:   %.loc7_41.1: i32 = int_literal 8
 // CHECK:STDOUT:   %.loc7_41.2: i32 = stub_reference %.loc7_41.1
-// CHECK:STDOUT:   %.loc7_44.1: i32 = int_literal -7
+// CHECK:STDOUT:   %.loc7_44.1: i32 = int_literal 9
 // CHECK:STDOUT:   %.loc7_44.2: i32 = stub_reference %.loc7_44.1
 // CHECK:STDOUT:   %.loc7_45.1: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32)
 // CHECK:STDOUT:   %.loc7_45.2: (i32, i32, i32, i32, i32, i32, i32, i32, i32) = tuple_value (%.loc7_20.2, %.loc7_23.2, %.loc7_26.2, %.loc7_29.2, %.loc7_32.2, %.loc7_35.2, %.loc7_38.2, %.loc7_41.2, %.loc7_44.2)

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -85,7 +85,7 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc7_23.3: [i32; 1] = array_value %.loc7_23.2
 // CHECK:STDOUT:   assign %a, %.loc7_23.3
 // CHECK:STDOUT:   %b: ref i32 = var "b"
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal -1
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 295147905179352825855
 // CHECK:STDOUT:   %.loc11_35.1: ref i32 = array_index %a, <error>
 // CHECK:STDOUT:   %.loc11_35.2: i32 = bind_value %.loc11_35.1
 // CHECK:STDOUT:   assign %b, %.loc11_35.2

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -108,7 +108,7 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc7_5: (i32,) = bind_value %a
 // CHECK:STDOUT:   assign %b, %.loc7_5
 // CHECK:STDOUT:   %c: ref i32 = var "c"
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal -1
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855
 // CHECK:STDOUT:   %.loc12_35: ref <error> = tuple_index %b, <error>
 // CHECK:STDOUT:   assign %c, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -241,7 +241,7 @@ fn Main() {
 // CHECK:STDOUT:   %a: ref i32 = var "a"
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 12
 // CHECK:STDOUT:   assign %a, %.loc8
-// CHECK:STDOUT:   %.loc9: i32 = int_literal -7
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 9
 // CHECK:STDOUT:   assign %a, %.loc9
 // CHECK:STDOUT:   %.loc11_11: type = stub_reference i32
 // CHECK:STDOUT:   %.loc11_16: type = stub_reference i32

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -674,7 +674,7 @@ class Formatter {
   auto FormatArg(FunctionId id) -> void { FormatFunctionName(id); }
 
   auto FormatArg(IntegerLiteralId id) -> void {
-    out_ << semantics_ir_.GetIntegerLiteral(id);
+    semantics_ir_.GetIntegerLiteral(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(MemberIndex index) -> void { out_ << index; }


### PR DESCRIPTION
Integer literals are not signed, so don't print them as signed.