### PR TITLE
Fix typo in value_expr_from_reference_deref.carbon

### DIFF
--- a/explorer/testdata/let/value_expr_from_reference_deref.carbon
+++ b/explorer/testdata/let/value_expr_from_reference_deref.carbon
@@ -16,7 +16,7 @@ fn FromReferenceExpressionDeref() {
   var c_var: C = {};
   var c_ref: C* = &c_var;
   heap.PrintAllocs();
-  Print("Initialize c from reference expression from deferenced pointer");
+  Print("Initialize c from reference expression from dereferenced pointer");
   let c: C = *c_ref;
   heap.PrintAllocs();
 }
@@ -27,7 +27,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: 0: Heap{}, 1: C{}, 2: ptr<Allocation(1)>
-// CHECK:STDOUT: Initialize c from reference expression from deferenced pointer
+// CHECK:STDOUT: Initialize c from reference expression from dereferenced pointer
 // CHECK:STDOUT: 0: Heap{}, 1: C{}, 2: ptr<Allocation(1)>
 // CHECK:STDOUT: c destroyed
 // CHECK:STDOUT: result: 0


### PR DESCRIPTION
deferenced -> dereferenced


