### PR TITLE
Explorer: Print self pattern for callable declarations

### DIFF
--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -421,7 +421,7 @@ void CallableDeclaration::PrintIndent(int indent_num_spaces,
     for (Nonnull<const GenericBinding*> deduced : deduced_parameters_) {
       out << sep << *deduced;
     }
-    if(self_pattern_) {
+    if (self_pattern_) {
       out << sep << **self_pattern_;
     }
     out << "]";

--- a/explorer/ast/declaration.cpp
+++ b/explorer/ast/declaration.cpp
@@ -415,11 +415,14 @@ void CallableDeclaration::PrintIndent(int indent_num_spaces,
   auto name = GetName(*this);
   CARBON_CHECK(name) << "Unexpected missing name for `" << *this << "`.";
   out.indent(indent_num_spaces) << "fn " << *name << " ";
-  if (!deduced_parameters_.empty()) {
+  if (!deduced_parameters_.empty() || self_pattern_) {
     out << "[";
     llvm::ListSeparator sep;
     for (Nonnull<const GenericBinding*> deduced : deduced_parameters_) {
       out << sep << *deduced;
+    }
+    if(self_pattern_) {
+      out << sep << **self_pattern_;
     }
     out << "]";
   }


### PR DESCRIPTION
When printing callable declarations, it does not print the self pattern in the deduced bindings.
Example:

User code:
```
class A {
    fn Fun[self: Self]() {}
} 
```

Print output is missing the self pattern
```
class A {
  fn Fun ()
  {
  }
}
```

This PR fixes it and includes the self pattern in the print output.
```
class A {
  fn Fun [self: Self]()
  {
  }
}
```