### PR TITLE
Update SemIR yaml and text for multi-file.

### DIFF
--- a/toolchain/base/yaml_test_helpers.h
+++ b/toolchain/base/yaml_test_helpers.h
@@ -132,7 +132,7 @@ MATCHER_P(Sequence, contents,
 // Same as testing::VariantWith<ScalarValue>(contents).
 // NOLINTNEXTLINE: Expands from GoogleTest.
 MATCHER_P(Scalar, value,
-          "has scalar value " + ::testing::PrintToString(value)) {
+          "has scalar value " + DescribeMatcher<std::string>(value)) {
   ::testing::Matcher<ScalarValue> value_matcher = value;
 
   if (auto* map = std::get_if<ScalarValue>(&arg)) {

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -15,7 +15,7 @@ auto CheckParseTree(const SemIR::File& builtin_ir,
                     const Lex::TokenizedBuffer& tokens,
                     const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
                     llvm::raw_ostream* vlog_stream) -> SemIR::File {
-  auto semantics_ir = SemIR::File(&builtin_ir);
+  auto semantics_ir = SemIR::File(tokens.filename().str(), &builtin_ir);
 
   Parse::NodeLocationTranslator translator(&tokens, &parse_tree);
   ErrorTrackingDiagnosticConsumer err_tracker(consumer);

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -10,7 +10,7 @@ fn Run() {
   var t: [i32; 1] = F();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "assign_return_value.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -7,7 +7,7 @@
 var a: (i32, i32, i32) = (1, 2, 3);
 var b: [i32; 3] = a;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "assign_var.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_19: type = stub_reference i32

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -8,7 +8,7 @@ var a: [i32; 1] = (1,);
 var b: [f64; 2] = (11.1, 2.2,);
 var c: [(); 5] = ((), (), (), (), (),);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "base.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 1] = var "a"

--- a/toolchain/check/testdata/array/fail_bound_overflow.carbon
+++ b/toolchain/check/testdata/array/fail_bound_overflow.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                                ^
 var a: [1; 39999999999999999993];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_bound_overflow.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993
 // CHECK:STDOUT:   %a: ref <error> = var "a"

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:             ^
 var a: [1; 1];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_invalid_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error>

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                            ^
 var a: [i32; 1] = (1, 2, 3);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_out_of_bound.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 1] = var "a"

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                           ^
 var a: [i32; 2] = (1, 2.5);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 2] = var "a"

--- a/toolchain/check/testdata/array/fail_undefined_bound.carbon
+++ b/toolchain/check/testdata/array/fail_undefined_bound.carbon
@@ -9,5 +9,5 @@
 // CHECK:STDERR:              ^
 var a: [i32; ];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_undefined_bound.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -6,7 +6,7 @@
 
 var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "nine_elements.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 9] = var "a"

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -6,28 +6,30 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: functions: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: integer_literals: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: real_literals: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: strings: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: types: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: type_blocks: [
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: nodes: [
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeTypeType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeError, type: typeError},
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeBoolType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeIntegerType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeFloatingPointType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: CrossReference, arg0: ir0, arg1: nodeStringType, type: typeTypeType},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: node_blocks: [
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT: ]
+// CHECK:STDOUT: - filename: builtin_nodes.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeTypeType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeError, type: typeError},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeBoolType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeIntegerType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeFloatingPointType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeStringType, type: typeTypeType},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -9,7 +9,7 @@ var test_f64: f64 = 0.1;
 var test_str: String = "Test";
 var test_type: type = i32;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "builtin_types.carbon" {
 // CHECK:STDOUT:   %test_i32: ref i32 = var "test_i32"
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0
 // CHECK:STDOUT:   assign %test_i32, %.loc7

--- a/toolchain/check/testdata/basics/empty.carbon
+++ b/toolchain/check/testdata/basics/empty.carbon
@@ -4,5 +4,5 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/empty_decl.carbon
+++ b/toolchain/check/testdata/basics/empty_decl.carbon
@@ -6,5 +6,5 @@
 
 ;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty_decl.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/check/testdata/basics/fail_name_lookup.carbon
@@ -11,7 +11,7 @@ fn Main() {
   x;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_name_lookup.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
+++ b/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                 ^
 var x: type = 42;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_non_type_as_type.carbon" {
 // CHECK:STDOUT:   %x: ref type = var "x"
 // CHECK:STDOUT:   %.loc10: i32 = int_literal 42
 // CHECK:STDOUT:   assign %x, <error>

--- a/toolchain/check/testdata/basics/fail_qualifier_unsupported.carbon
+++ b/toolchain/check/testdata/basics/fail_qualifier_unsupported.carbon
@@ -10,7 +10,7 @@ var x: i32;
 // CHECK:STDERR:               ^
 var y: i32 = x.b;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_qualifier_unsupported.carbon" {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT:   %y: ref i32 = var "y"
 // CHECK:STDOUT:   assign %y, <error>

--- a/toolchain/check/testdata/basics/multifile.carbon
+++ b/toolchain/check/testdata/basics/multifile.carbon
@@ -4,20 +4,24 @@
 //
 // AUTOUPDATE
 
-fn Foo(a: i32) {}
-fn Bar(a: i32) {}
+// CHECK:STDOUT: file "a.carbon" {
+// CHECK:STDOUT:   %.loc1 = fn_decl @A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "b.carbon" {
+// CHECK:STDOUT:   %.loc1 = fn_decl @B
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @B() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// --- a.carbon
+fn A() {}
 
-// CHECK:STDOUT: file "same_param_name.carbon" {
-// CHECK:STDOUT:   %.loc7 = fn_decl @Foo
-// CHECK:STDOUT:   %.loc8 = fn_decl @Bar
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @Foo(%a: i32) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @Bar(%a: i32) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
+// --- b.carbon
+fn B() {}

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -1,0 +1,95 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: compile --phase=check --dump-semantics-ir --dump-raw-semantics-ir %s
+//
+// Check that we can combine textual IR and raw IR dumping in one compile.
+//
+// AUTOUPDATE
+
+// CHECK:STDOUT: - filename: a.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block2]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       A,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: Return},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "a.carbon" {
+// CHECK:STDOUT:   %.loc1 = fn_decl @A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT: - filename: b.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block2]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       B,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: Return},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "b.carbon" {
+// CHECK:STDOUT:   %.loc1 = fn_decl @B
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @B() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -1,0 +1,77 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: compile --phase=check --dump-raw-semantics-ir %s
+//
+// Check that raw IR dumping works as expected.
+//
+// AUTOUPDATE
+
+// CHECK:STDOUT: - filename: a.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block2]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       A,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: Return},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT: - filename: b.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block2]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       B,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: Return},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -25,7 +25,7 @@ fn F() {
   );
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "numeric_literals.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/parens.carbon
+++ b/toolchain/check/testdata/basics/parens.carbon
@@ -6,7 +6,7 @@
 
 var test_i32: i32 = ((1) + (2));
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "parens.carbon" {
 // CHECK:STDOUT:   %test_i32: ref i32 = var "test_i32"
 // CHECK:STDOUT:   %.loc7_23: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_29: i32 = int_literal 2

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -12,92 +12,94 @@ fn Foo(n: i32) -> (i32, f64) {
   return (n + 2, 3.4);
 }
 
-// CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: functions: [
-// CHECK:STDOUT:   {name: str0, param_refs: block2, return_type: type3, return_slot: node+6, body: [block5]},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: integer_literals: [
-// CHECK:STDOUT:   2,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: real_literals: [
-// CHECK:STDOUT:   {mantissa: 34, exponent: -1, is_decimal: 1},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: strings: [
-// CHECK:STDOUT:   Foo,
-// CHECK:STDOUT:   n,
-// CHECK:STDOUT:   return,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: types: [
-// CHECK:STDOUT:   nodeIntegerType,
-// CHECK:STDOUT:   node+3,
-// CHECK:STDOUT:   nodeFloatingPointType,
-// CHECK:STDOUT:   node+5,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: type_blocks: [
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     typeTypeType,
-// CHECK:STDOUT:     typeTypeType,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     type0,
-// CHECK:STDOUT:     type2,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: nodes: [
-// CHECK:STDOUT:   {kind: Parameter, arg0: str1, type: type0},
-// CHECK:STDOUT:   {kind: StubReference, arg0: nodeIntegerType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: StubReference, arg0: nodeFloatingPointType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
-// CHECK:STDOUT:   {kind: TupleLiteral, arg0: block3, type: type1},
-// CHECK:STDOUT:   {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
-// CHECK:STDOUT:   {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: function0},
-// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: type0},
-// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node+0, arg1: node+8, type: type0},
-// CHECK:STDOUT:   {kind: StubReference, arg0: node+9, type: type0},
-// CHECK:STDOUT:   {kind: RealLiteral, arg0: real0, type: type2},
-// CHECK:STDOUT:   {kind: StubReference, arg0: node+11, type: type2},
-// CHECK:STDOUT:   {kind: TupleLiteral, arg0: block6, type: type3},
-// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node+13},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: node_blocks: [
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+0,
-// CHECK:STDOUT:     node+1,
-// CHECK:STDOUT:     node+2,
-// CHECK:STDOUT:     node+3,
-// CHECK:STDOUT:     node+4,
-// CHECK:STDOUT:     node+5,
-// CHECK:STDOUT:     node+6,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+0,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+1,
-// CHECK:STDOUT:     node+2,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+7,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+8,
-// CHECK:STDOUT:     node+9,
-// CHECK:STDOUT:     node+10,
-// CHECK:STDOUT:     node+11,
-// CHECK:STDOUT:     node+12,
-// CHECK:STDOUT:     node+13,
-// CHECK:STDOUT:     node+14,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+10,
-// CHECK:STDOUT:     node+12,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT: ]
+// CHECK:STDOUT: - filename: raw_and_textual_ir.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block2, return_type: type3, return_slot: node+6, body: [block5]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:       2,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       Foo,
+// CHECK:STDOUT:       n,
+// CHECK:STDOUT:       return,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeIntegerType,
+// CHECK:STDOUT:       node+3,
+// CHECK:STDOUT:       nodeFloatingPointType,
+// CHECK:STDOUT:       node+5,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         typeTypeType,
+// CHECK:STDOUT:         typeTypeType,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         type0,
+// CHECK:STDOUT:         type2,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: Parameter, arg0: str1, type: type0},
+// CHECK:STDOUT:       {kind: StubReference, arg0: nodeIntegerType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: StubReference, arg0: nodeFloatingPointType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
+// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block3, type: type1},
+// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
+// CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
+// CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+0, arg1: node+8, type: type0},
+// CHECK:STDOUT:       {kind: StubReference, arg0: node+9, type: type0},
+// CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
+// CHECK:STDOUT:       {kind: StubReference, arg0: node+11, type: type2},
+// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block6, type: type3},
+// CHECK:STDOUT:       {kind: ReturnExpression, arg0: node+13},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:         node+2,
+// CHECK:STDOUT:         node+3,
+// CHECK:STDOUT:         node+4,
+// CHECK:STDOUT:         node+5,
+// CHECK:STDOUT:         node+6,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:         node+2,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+7,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+8,
+// CHECK:STDOUT:         node+9,
+// CHECK:STDOUT:         node+10,
+// CHECK:STDOUT:         node+11,
+// CHECK:STDOUT:         node+12,
+// CHECK:STDOUT:         node+13,
+// CHECK:STDOUT:         node+14,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+10,
+// CHECK:STDOUT:         node+12,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
 // CHECK:STDOUT:
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
 // CHECK:STDOUT:   %.loc11 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -12,87 +12,89 @@ fn Foo(n: i32) -> (i32, f64) {
   return (n + 2, 3.4);
 }
 
-// CHECK:STDOUT: cross_reference_irs_size: 1
-// CHECK:STDOUT: functions: [
-// CHECK:STDOUT:   {name: str0, param_refs: block2, return_type: type3, return_slot: node+6, body: [block5]},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: integer_literals: [
-// CHECK:STDOUT:   2,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: real_literals: [
-// CHECK:STDOUT:   {mantissa: 34, exponent: -1, is_decimal: 1},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: strings: [
-// CHECK:STDOUT:   Foo,
-// CHECK:STDOUT:   n,
-// CHECK:STDOUT:   return,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: types: [
-// CHECK:STDOUT:   nodeIntegerType,
-// CHECK:STDOUT:   node+3,
-// CHECK:STDOUT:   nodeFloatingPointType,
-// CHECK:STDOUT:   node+5,
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: type_blocks: [
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     typeTypeType,
-// CHECK:STDOUT:     typeTypeType,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     type0,
-// CHECK:STDOUT:     type2,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: nodes: [
-// CHECK:STDOUT:   {kind: Parameter, arg0: str1, type: type0},
-// CHECK:STDOUT:   {kind: StubReference, arg0: nodeIntegerType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: StubReference, arg0: nodeFloatingPointType, type: typeTypeType},
-// CHECK:STDOUT:   {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
-// CHECK:STDOUT:   {kind: TupleLiteral, arg0: block3, type: type1},
-// CHECK:STDOUT:   {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
-// CHECK:STDOUT:   {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:   {kind: FunctionDeclaration, arg0: function0},
-// CHECK:STDOUT:   {kind: IntegerLiteral, arg0: int0, type: type0},
-// CHECK:STDOUT:   {kind: BinaryOperatorAdd, arg0: node+0, arg1: node+8, type: type0},
-// CHECK:STDOUT:   {kind: StubReference, arg0: node+9, type: type0},
-// CHECK:STDOUT:   {kind: RealLiteral, arg0: real0, type: type2},
-// CHECK:STDOUT:   {kind: StubReference, arg0: node+11, type: type2},
-// CHECK:STDOUT:   {kind: TupleLiteral, arg0: block6, type: type3},
-// CHECK:STDOUT:   {kind: ReturnExpression, arg0: node+13},
-// CHECK:STDOUT: ]
-// CHECK:STDOUT: node_blocks: [
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+0,
-// CHECK:STDOUT:     node+1,
-// CHECK:STDOUT:     node+2,
-// CHECK:STDOUT:     node+3,
-// CHECK:STDOUT:     node+4,
-// CHECK:STDOUT:     node+5,
-// CHECK:STDOUT:     node+6,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+0,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+1,
-// CHECK:STDOUT:     node+2,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+7,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+8,
-// CHECK:STDOUT:     node+9,
-// CHECK:STDOUT:     node+10,
-// CHECK:STDOUT:     node+11,
-// CHECK:STDOUT:     node+12,
-// CHECK:STDOUT:     node+13,
-// CHECK:STDOUT:     node+14,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT:   [
-// CHECK:STDOUT:     node+10,
-// CHECK:STDOUT:     node+12,
-// CHECK:STDOUT:   ],
-// CHECK:STDOUT: ]
+// CHECK:STDOUT: - filename: raw_ir.carbon
+// CHECK:STDOUT:   sem_ir:
+// CHECK:STDOUT:   - cross_reference_irs_size: 1
+// CHECK:STDOUT:     functions: [
+// CHECK:STDOUT:       {name: str0, param_refs: block2, return_type: type3, return_slot: node+6, body: [block5]},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:       2,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     strings: [
+// CHECK:STDOUT:       Foo,
+// CHECK:STDOUT:       n,
+// CHECK:STDOUT:       return,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeIntegerType,
+// CHECK:STDOUT:       node+3,
+// CHECK:STDOUT:       nodeFloatingPointType,
+// CHECK:STDOUT:       node+5,
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     type_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         typeTypeType,
+// CHECK:STDOUT:         typeTypeType,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         type0,
+// CHECK:STDOUT:         type2,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     nodes: [
+// CHECK:STDOUT:       {kind: Parameter, arg0: str1, type: type0},
+// CHECK:STDOUT:       {kind: StubReference, arg0: nodeIntegerType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: StubReference, arg0: nodeFloatingPointType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
+// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block3, type: type1},
+// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
+// CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
+// CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+0, arg1: node+8, type: type0},
+// CHECK:STDOUT:       {kind: StubReference, arg0: node+9, type: type0},
+// CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
+// CHECK:STDOUT:       {kind: StubReference, arg0: node+11, type: type2},
+// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block6, type: type3},
+// CHECK:STDOUT:       {kind: ReturnExpression, arg0: node+13},
+// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     node_blocks: [
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:         node+2,
+// CHECK:STDOUT:         node+3,
+// CHECK:STDOUT:         node+4,
+// CHECK:STDOUT:         node+5,
+// CHECK:STDOUT:         node+6,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+0,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+1,
+// CHECK:STDOUT:         node+2,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+7,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+8,
+// CHECK:STDOUT:         node+9,
+// CHECK:STDOUT:         node+10,
+// CHECK:STDOUT:         node+11,
+// CHECK:STDOUT:         node+12,
+// CHECK:STDOUT:         node+13,
+// CHECK:STDOUT:         node+14,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:       [
+// CHECK:STDOUT:         node+10,
+// CHECK:STDOUT:         node+12,
+// CHECK:STDOUT:       ],
+// CHECK:STDOUT:     ]

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -12,7 +12,7 @@ fn Foo(n: i32) -> (i32, f64) {
   return (n + 2, 3.4);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "textual_ir.carbon" {
 // CHECK:STDOUT:   %.loc11 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/const/collapse.carbon
+++ b/toolchain/check/testdata/const/collapse.carbon
@@ -12,7 +12,7 @@ fn F(p: const i32**) -> const (const i32)** {
   return p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "collapse.carbon" {
 // CHECK:STDOUT:   %.loc11 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -14,7 +14,7 @@ fn G(p: const (const i32)**) -> i32** {
   return p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_collapse.carbon" {
 // CHECK:STDOUT:   %.loc10 = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
+++ b/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
@@ -16,7 +16,7 @@ fn H() -> i32 {
   return G()[0];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "in_place_tuple_initialization.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @G
 // CHECK:STDOUT:   %.loc15 = fn_decl @H

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -12,7 +12,7 @@ fn Main() {
   Echo({});
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty_struct.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Echo
 // CHECK:STDOUT:   %.loc11 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -12,7 +12,7 @@ fn Main() {
   Echo(());
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty_tuple.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Echo
 // CHECK:STDOUT:   %.loc11 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -55,7 +55,7 @@ fn Main() {
   Run2(0);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_param_count.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Run0
 // CHECK:STDOUT:   %.loc8 = fn_decl @Run1
 // CHECK:STDOUT:   %.loc9 = fn_decl @Run2

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -16,7 +16,7 @@ fn Main() {
   Run(1.0);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_param_type.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Run
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -13,7 +13,7 @@ fn Run() {
   var x: i32 = Foo();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_return_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -12,7 +12,7 @@ fn Main() {
   var b: i32 = Echo(1);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "i32.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Echo
 // CHECK:STDOUT:   %.loc11 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -11,7 +11,7 @@ fn Main() {
   Foo(1 + 2 + 3, 4 + 5, 6);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "more_param_ir.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -10,7 +10,7 @@ fn Main() {
   Foo(1);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_one.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -11,7 +11,7 @@ fn Main() {
   Foo(1,);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_one_comma.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -10,7 +10,7 @@ fn Main() {
   Foo(1, 2);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_two.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -11,7 +11,7 @@ fn Main() {
   Foo(1, 2,);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_two_comma.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -10,7 +10,7 @@ fn Main() {
   Foo();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_zero.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -11,7 +11,7 @@ fn Main() {
   var b: () = MakeImplicitEmptyTuple();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "return_implicit.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @MakeImplicitEmptyTuple
 // CHECK:STDOUT:   %.loc10 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -8,7 +8,7 @@ fn F();
 
 fn G() { F(); }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "simple.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
@@ -12,7 +12,7 @@
 // CHECK:STDERR:        ^
 fn Bar(a: i32, a: i32) {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_param_name_conflict.carbon" {
 // CHECK:STDOUT:   %.loc13 = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/order.carbon
+++ b/toolchain/check/testdata/function/definition/order.carbon
@@ -8,7 +8,7 @@ fn Foo() {}
 fn Bar() {}
 fn Baz() {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "order.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT:   %.loc8 = fn_decl @Bar
 // CHECK:STDOUT:   %.loc9 = fn_decl @Baz

--- a/toolchain/check/testdata/function/definition/params_one.carbon
+++ b/toolchain/check/testdata/function/definition/params_one.carbon
@@ -6,7 +6,7 @@
 
 fn Foo(a: i32) {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_one.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_one_comma.carbon
@@ -6,7 +6,7 @@
 
 fn Foo(a: i32,) {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_one_comma.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_two.carbon
+++ b/toolchain/check/testdata/function/definition/params_two.carbon
@@ -6,7 +6,7 @@
 
 fn Foo(a: i32, b: i32) {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_two.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_two_comma.carbon
@@ -6,7 +6,7 @@
 
 fn Foo(a: i32, b: i32,) {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_two_comma.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_zero.carbon
+++ b/toolchain/check/testdata/function/definition/params_zero.carbon
@@ -6,7 +6,7 @@
 
 fn Foo() {}
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "params_zero.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -17,7 +17,7 @@ fn If(b: bool) {
   H();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "else.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc8 = fn_decl @G
 // CHECK:STDOUT:   %.loc9 = fn_decl @H

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -33,7 +33,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDERR: ^
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_reachable_fallthrough.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @If1
 // CHECK:STDOUT:   %.loc17 = fn_decl @If2
 // CHECK:STDOUT:   %.loc27 = fn_decl @If3

--- a/toolchain/check/testdata/if/fail_scope.carbon
+++ b/toolchain/check/testdata/if/fail_scope.carbon
@@ -15,7 +15,7 @@ fn VarScope(b: bool) -> i32 {
   return n;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_scope.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @VarScope
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -14,7 +14,7 @@ fn If(b: bool) {
   G();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "no_else.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc8 = fn_decl @G
 // CHECK:STDOUT:   %.loc10 = fn_decl @If

--- a/toolchain/check/testdata/if/unreachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/unreachable_fallthrough.carbon
@@ -13,7 +13,7 @@ fn If(b: bool) -> i32 {
   // Missing return here is OK.
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "unreachable_fallthrough.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expression/basic.carbon
+++ b/toolchain/check/testdata/if_expression/basic.carbon
@@ -8,7 +8,7 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
   return if b then n + m else m + n;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "basic.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expression/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expression/constant_condition.carbon
@@ -15,7 +15,7 @@ fn G() -> i32 {
   return if false then A() else B();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "constant_condition.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @A
 // CHECK:STDOUT:   %.loc8 = fn_decl @B
 // CHECK:STDOUT:   %.loc10 = fn_decl @F

--- a/toolchain/check/testdata/if_expression/control_flow.carbon
+++ b/toolchain/check/testdata/if_expression/control_flow.carbon
@@ -11,7 +11,7 @@ fn F(b: bool) -> i32 {
   return if b then A() else B();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "control_flow.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @A
 // CHECK:STDOUT:   %.loc8 = fn_decl @B
 // CHECK:STDOUT:   %.loc10 = fn_decl @F

--- a/toolchain/check/testdata/if_expression/nested.carbon
+++ b/toolchain/check/testdata/if_expression/nested.carbon
@@ -8,7 +8,7 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
   return if a then if b then 1 else 2 else if c then 3 else 4;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "nested.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -9,7 +9,7 @@ var b: i32 = 1;
 var c: i32 = a[0];
 var d: i32 = a[b];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "array_element_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 2] = var "a"

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -10,7 +10,7 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                                   ^
 var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_array_large_index.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 1] = var "a"

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -10,7 +10,7 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                ^
 var b: i32 = a[2.6];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_array_non_int_indexing.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 1] = var "a"

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -10,7 +10,7 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                 ^
 var b: i32 = a[2];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_array_out_of_bound_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a: ref [i32; 1] = var "a"

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -13,7 +13,7 @@ fn Run() {
   F()[0];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_empty_tuple_access.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_name_not_found.carbon
+++ b/toolchain/check/testdata/index/fail_name_not_found.carbon
@@ -11,7 +11,7 @@ fn Main() {
   var b: i32 = a[0];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_name_not_found.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -10,5 +10,5 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                ^
 var b: i32 = a[-10];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_negative_indexing.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -11,7 +11,7 @@ var b: i32 = 0;
 // CHECK:STDERR:                 ^
 var c: i32 = a[b];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_non_deterministic_type.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/index/fail_non_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_non_tuple_access.carbon
@@ -11,7 +11,7 @@ fn Main() {
   0[1];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_non_tuple_access.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -11,7 +11,7 @@ var b: (i32,) = a;
 // CHECK:STDERR:                                   ^
 var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_tuple_large_index.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (%.loc7_9)

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -10,7 +10,7 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                   ^
 var b: i32 = a[2.6];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_tuple_non_int_indexing.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -10,7 +10,7 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                 ^
 var b: i32 = a[2];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_tuple_out_of_bound_access.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -8,7 +8,7 @@ var a: (i32,) = (12,);
 var b: (i32,) = a;
 var c: i32 = b[0];
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "tuple_element_access.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (%.loc7_9)

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -10,7 +10,7 @@ fn Run() -> i32 {
   return F()[0];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "tuple_return_value_access.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
@@ -6,7 +6,7 @@
 
 fn A() { var n: i32 = 1; if (true) { var n: i32 = 2; } }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "duplicate_name_same_line.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -18,7 +18,7 @@ fn Foo.Baz() {
 fn Foo.Baz() {
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_duplicate.carbon" {
 // CHECK:STDOUT:   %.loc7 = namespace {.Baz = %.loc9}
 // CHECK:STDOUT:   %.loc9 = fn_decl @Baz
 // CHECK:STDOUT:   %.loc18 = fn_decl @.1

--- a/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
+++ b/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
@@ -10,7 +10,7 @@
 fn Foo.Baz() {
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_unresolved_scope.carbon" {
 // CHECK:STDOUT:   %.loc10 = fn_decl @.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -17,7 +17,7 @@ fn Bar() {
   Foo.Baz();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "function.carbon" {
 // CHECK:STDOUT:   %.loc7 = namespace {.Baz = %.loc13}
 // CHECK:STDOUT:   %.loc10 = fn_decl @Baz.1
 // CHECK:STDOUT:   %.loc13 = fn_decl @Baz.2

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -14,7 +14,7 @@ fn Foo.Bar.Baz() {
   Foo.Bar.Wiz();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "nested.carbon" {
 // CHECK:STDOUT:   %.loc7 = namespace {.Bar = %.loc8}
 // CHECK:STDOUT:   %.loc8 = namespace {.Wiz = %.loc10, .Baz = %.loc13}
 // CHECK:STDOUT:   %.loc10 = fn_decl @Wiz

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -11,7 +11,7 @@ fn And() -> bool {
   return F() and G();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "and.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc8 = fn_decl @G
 // CHECK:STDOUT:   %.loc10 = fn_decl @And

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -22,7 +22,7 @@ fn Main() {
   *(if true then p else &a) = 10;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "assignment.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/binary_op.carbon
+++ b/toolchain/check/testdata/operators/binary_op.carbon
@@ -8,7 +8,7 @@ fn Main() -> i32 {
   return 12 + 34;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "binary_op.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_assigment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assigment_to_non_assignable.carbon
@@ -45,7 +45,7 @@ fn Main() {
   (if true then a else a) = 10;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assigment_to_non_assignable.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc9 = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
   return 12 + 3.4;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
@@ -12,7 +12,7 @@ fn Main() {
   a = 5.6;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch_assignment.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
@@ -13,7 +13,7 @@ fn Main() -> i32 {
   return 12 + 3.4 + 12;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch_once.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -11,7 +11,7 @@ fn Or() -> bool {
   return F() or G();
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "or.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT:   %.loc8 = fn_decl @G
 // CHECK:STDOUT:   %.loc10 = fn_decl @Or

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -8,7 +8,7 @@ fn Not(b: bool) -> bool {
   return not b;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "unary_op.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Not
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -9,7 +9,7 @@ fn F() -> i32 {
   return *&*&n;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "address_of_deref.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -16,7 +16,7 @@ fn F() {
   var t1: i32* = &t[1];
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "address_of_lvalue.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -11,7 +11,7 @@ fn F() -> i32 {
   return *p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "basic.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -82,7 +82,7 @@ fn AddressOfParameter(param: i32) {
   var param_addr: i32* = &param;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_address_of_value.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @G
 // CHECK:STDOUT:   %.loc9 = fn_decl @H
 // CHECK:STDOUT:   %.loc11 = fn_decl @AddressOfLiteral

--- a/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
@@ -19,7 +19,7 @@ fn Deref(n: i32) {
   *{};
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_dereference_not_pointer.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Deref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_dereference_type.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_type.carbon
@@ -12,7 +12,7 @@
 // CHECK:STDERR:        ^
 var p: *i32;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_dereference_type.carbon" {
 // CHECK:STDOUT:   %.loc13: ref <error> = dereference i32
 // CHECK:STDOUT:   %p: ref <error> = var "p"
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -11,7 +11,7 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
   return p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @ConstMismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/nested_const.carbon
+++ b/toolchain/check/testdata/pointer/nested_const.carbon
@@ -9,7 +9,7 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
   return **p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "nested_const.carbon" {
 // CHECK:STDOUT:   %.loc8 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/types.carbon
+++ b/toolchain/check/testdata/pointer/types.carbon
@@ -12,7 +12,7 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
   return p;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "types.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Ptr
 // CHECK:STDOUT:   %.loc11 = fn_decl @ConstPtr
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/code_after_return.carbon
+++ b/toolchain/check/testdata/return/code_after_return.carbon
@@ -9,7 +9,7 @@ fn Main() {
   var n: i32 = 1 + 1;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "code_after_return.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/code_after_return_value.carbon
+++ b/toolchain/check/testdata/return/code_after_return_value.carbon
@@ -16,7 +16,7 @@ fn F(b: bool) -> i32 {
   // Unreachable, no error on missing return.
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "code_after_return_value.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_missing_return.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return.carbon
@@ -10,7 +10,7 @@ fn Main() -> i32 {
 // CHECK:STDERR: ^
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_missing_return.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -10,7 +10,7 @@ fn F() -> () {
 // CHECK:STDERR: ^
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_missing_return_empty_tuple.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/return/fail_type_mismatch.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
   return 1.0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -14,7 +14,7 @@ fn Main() {
   return 0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_value_disallowed.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_missing.carbon
+++ b/toolchain/check/testdata/return/fail_value_missing.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
   return;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_value_missing.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/missing_return_no_return_type.carbon
+++ b/toolchain/check/testdata/return/missing_return_no_return_type.carbon
@@ -7,7 +7,7 @@
 fn F() {
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "missing_return_no_return_type.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/no_value.carbon
+++ b/toolchain/check/testdata/return/no_value.carbon
@@ -8,7 +8,7 @@ fn Main() {
   return;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "no_value.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -8,7 +8,7 @@ fn Main() -> {.a: i32} {
   return {.a = 3};
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "struct.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -9,7 +9,7 @@ fn Main() -> (i32, i32) {
   return (15, 35);
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "tuple.carbon" {
 // CHECK:STDOUT:   %.loc8 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/value.carbon
+++ b/toolchain/check/testdata/return/value.carbon
@@ -8,7 +8,7 @@ fn Main() -> i32 {
   return 0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "value.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -7,7 +7,7 @@
 var x: {} = {};
 var y: {} = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty.carbon" {
 // CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_9.2: {} = struct_literal ()
 // CHECK:STDOUT:   %x: ref {} = var "x"

--- a/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
+++ b/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
@@ -10,7 +10,7 @@
 // CHECK:STDERR:          ^
 fn F() { a.b; }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_access_into_invalid.carbon" {
 // CHECK:STDOUT:   %.loc11 = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                      ^
 var x: {.a: i32} = {};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc10_21.1: type = struct_type {}

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                            ^
 var x: {.a: {}} = {.b = {}};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_nested.carbon" {
 // CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc10_14.2: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}}

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                     ^
 var x: {} = {.a = 1};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc10_9.2: {} = struct_literal ()
 // CHECK:STDOUT:   %x: ref {} = var "x"

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                            ^
 var x: {.a: i32} = {.b = 1};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_field_name_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                              ^
 var x: {.a: i32} = {.b = 1.0};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_field_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -10,7 +10,7 @@ var x: {.a: f64} = {.a = 4.0};
 // CHECK:STDERR:               ^
 var y: i32 = x.b;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_member_access_type.carbon" {
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: f64}
 // CHECK:STDOUT:   %x: ref {.a: f64} = var "x"
 // CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -10,7 +10,7 @@ var x: {.a: i32} = {.a = 4};
 // CHECK:STDERR:               ^
 var y: i32 = x.b;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_non_member_access.carbon" {
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                                     ^
 var x: {.a: i32, .b: i32} = {.a = 1};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_too_few_values.carbon" {
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = var "x"
 // CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1

--- a/toolchain/check/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/check/testdata/struct/fail_type_assign.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                             ^
 var x: {.a: i32} = {.a: i32};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_assign.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc10_28: type = struct_type {.a: i32}

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:               ^
 var x: {.a = 1};
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = stub_reference %.loc10_14
 // CHECK:STDOUT:   %.loc10_15.1: type = struct_type {.a: i32}

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -8,7 +8,7 @@ var x: {.a: f64, .b: i32} = {.a = 0.0, .b = 1};
 var y: i32 = x.b;
 var z: i32 = y;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "member_access.carbon" {
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32}
 // CHECK:STDOUT:   %x: ref {.a: f64, .b: i32} = var "x"
 // CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -7,7 +7,7 @@
 var x: {.a: i32} = {.a = 4};
 var y: {.a: i32} = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "one_entry.carbon" {
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -7,7 +7,7 @@
 var x: {.a: i32, .b: (i32,)} = {.a = 1, .b = (2,)};
 var y: {.a: i32, .b: (i32,)} = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "tuple_as_element.carbon" {
 // CHECK:STDOUT:   %.loc7_23: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_27.2: (type,) = tuple_literal (%.loc7_23)

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -7,7 +7,7 @@
 var x: {.a: i32, .b: i32} = {.a = 1, .b = 2};
 var y: {.a: i32, .b: i32} = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "two_entries.carbon" {
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = var "x"
 // CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -7,7 +7,7 @@
 var x: () = ();
 var y: () = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "empty.carbon" {
 // CHECK:STDOUT:   %.loc7_9.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7_9.2: () = tuple_literal ()
 // CHECK:STDOUT:   %x: ref () = var "x"

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                   ^
 var x: (i32,) = ();
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc10_13.2: (type,) = tuple_literal (%.loc10_9)

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                                                         ^
 var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_nested.carbon" {
 // CHECK:STDOUT:   %.loc10_10: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_15: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_18.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                 ^
 var x: () = (66);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_9.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_9.2: () = tuple_literal ()
 // CHECK:STDOUT:   %x: ref () = var "x"

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                               ^
 var x: (i32, i32) = (2, 65.89);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_element_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                          ^
 var x: (i32, i32) = (2, );
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_too_few_element.carbon" {
 // CHECK:STDOUT:   %.loc10_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:                         ^
 var x: (i32, ) = (i32, );
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_type_assign.carbon" {
 // CHECK:STDOUT:   %.loc10_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc10_14.2: (type,) = tuple_literal (%.loc10_9)

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDERR:            ^
 var x: (1, );
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9.1: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_9.2: i32 = stub_reference %.loc10_9.1
 // CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32)

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -6,7 +6,7 @@
 
 var x: ((i32, i32), i32) = ((12, 76), 6);
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "nested_tuple.carbon" {
 // CHECK:STDOUT:   %.loc7_10: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_15: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_18.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -7,7 +7,7 @@
 var x: (i32,) = (4,);
 var y: (i32,) = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "one_element.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (%.loc7_9)

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -7,7 +7,7 @@
 var x: (i32, i32) = (4, 102);
 var y: (i32, i32) = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "two_elements.carbon" {
 // CHECK:STDOUT:   %.loc7_9: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_14: type = stub_reference i32
 // CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)

--- a/toolchain/check/testdata/var/decl.carbon
+++ b/toolchain/check/testdata/var/decl.carbon
@@ -8,7 +8,7 @@ fn Main() {
   var x: i32;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "decl.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/decl_with_init.carbon
@@ -8,7 +8,7 @@ fn Main() {
   var x: i32 = 0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "decl_with_init.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/fail_duplicate_decl.carbon
@@ -16,7 +16,7 @@ fn Main() {
   var x: i32 = 0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_duplicate_decl.carbon" {
 // CHECK:STDOUT:   %.loc8 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
@@ -11,7 +11,7 @@ fn Main() {
   var x: i32 = 1.0;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_init_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/check/testdata/var/fail_init_with_self.carbon
@@ -11,7 +11,7 @@ fn Main() {
   var x: i32 = x;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_init_with_self.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
@@ -13,7 +13,7 @@ fn Main() {
 // CHECK:STDERR:              ^
 var y: i32 = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_lookup_outside_scope.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT:   %y: ref i32 = var "y"
 // CHECK:STDOUT:   assign %y, <error>

--- a/toolchain/check/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/check/testdata/var/fail_storage_is_literal.carbon
@@ -11,7 +11,7 @@ fn Main() {
   var x: 1 = 1;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "fail_storage_is_literal.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/global_decl.carbon
+++ b/toolchain/check/testdata/var/global_decl.carbon
@@ -6,6 +6,6 @@
 
 var x: i32;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "global_decl.carbon" {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/check/testdata/var/global_decl_with_init.carbon
@@ -6,7 +6,7 @@
 
 var x: i32 = 0;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "global_decl_with_init.carbon" {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0
 // CHECK:STDOUT:   assign %x, %.loc7

--- a/toolchain/check/testdata/var/global_lookup.carbon
+++ b/toolchain/check/testdata/var/global_lookup.carbon
@@ -7,7 +7,7 @@
 var x: i32 = 0;
 var y: i32 = x;
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "global_lookup.carbon" {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 0
 // CHECK:STDOUT:   assign %x, %.loc7_14

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -10,7 +10,7 @@ fn Main() {
   var y: i32 = x;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "global_lookup_in_scope.carbon" {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0
 // CHECK:STDOUT:   assign %x, %.loc7

--- a/toolchain/check/testdata/var/lookup.carbon
+++ b/toolchain/check/testdata/var/lookup.carbon
@@ -9,7 +9,7 @@ fn Main() {
   x;
 }
 
-// CHECK:STDOUT: package {
+// CHECK:STDOUT: file "lookup.carbon" {
 // CHECK:STDOUT:   %.loc7 = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -71,6 +71,7 @@ cc_test(
     size = "small",
     srcs = ["file_test.cpp"],
     deps = [
+        "//common:ostream",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
         "//toolchain/base:yaml_test_helpers",

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -15,7 +15,8 @@ namespace Carbon::SemIR {
 
 File::File()
     // Builtins are always the first IR, even when self-referential.
-    : cross_reference_irs_({this}),
+    : filename_("<builtins>"),
+      cross_reference_irs_({this}),
       // Default entry for NodeBlockId::Empty.
       node_blocks_(1) {
   nodes_.reserve(BuiltinKind::ValidCount);
@@ -35,9 +36,10 @@ File::File()
       << " nodes, actual: " << nodes_.size();
 }
 
-File::File(const File* builtins)
+File::File(std::string filename, const File* builtins)
     // Builtins are always the first IR.
-    : cross_reference_irs_({builtins}),
+    : filename_(std::move(filename)),
+      cross_reference_irs_({builtins}),
       // Default entry for NodeBlockId::Empty.
       node_blocks_(1) {
   CARBON_CHECK(builtins != nullptr);
@@ -90,43 +92,62 @@ auto File::Verify() const -> ErrorOr<Success> {
   return Success();
 }
 
-static constexpr int Indent = 2;
+static constexpr int BaseIndent = 4;
+static constexpr int IndentStep = 2;
 
+// Define PrintList for ArrayRef.
+template <typename T, typename PrintT =
+                          std::function<void(llvm::raw_ostream&, const T& val)>>
+static auto PrintList(
+    llvm::raw_ostream& out, llvm::StringLiteral name, llvm::ArrayRef<T> list,
+    PrintT print = [](llvm::raw_ostream& out, const T& val) { out << val; }) {
+  out.indent(BaseIndent);
+  out << name << ": [\n";
+  for (const auto& element : list) {
+    out.indent(BaseIndent + IndentStep);
+    print(out, element);
+    out << ",\n";
+  }
+  out.indent(BaseIndent);
+  out << "]\n";
+}
+
+// Adapt PrintList for a vector.
 template <typename T, typename PrintT =
                           std::function<void(llvm::raw_ostream&, const T& val)>>
 static auto PrintList(
     llvm::raw_ostream& out, llvm::StringLiteral name,
     const llvm::SmallVector<T>& list,
     PrintT print = [](llvm::raw_ostream& out, const T& val) { out << val; }) {
-  out << name << ": [\n";
-  for (const auto& element : list) {
-    out.indent(Indent);
-    print(out, element);
-    out << ",\n";
-  }
-  out << "]\n";
+  PrintList(out, name, llvm::ArrayRef(list), print);
 }
 
+// PrintBlock is only used for vectors.
 template <typename T>
 static auto PrintBlock(llvm::raw_ostream& out, llvm::StringLiteral block_name,
                        const llvm::SmallVector<T>& blocks) {
+  out.indent(BaseIndent);
   out << block_name << ": [\n";
   for (const auto& block : blocks) {
-    out.indent(Indent);
+    out.indent(BaseIndent + IndentStep);
     out << "[\n";
 
     for (const auto& node : block) {
-      out.indent(2 * Indent);
+      out.indent(BaseIndent + 2 * IndentStep);
       out << node << ",\n";
     }
-    out.indent(Indent);
+    out.indent(BaseIndent + IndentStep);
     out << "],\n";
   }
+  out.indent(BaseIndent);
   out << "]\n";
 }
 
 auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
-  out << "cross_reference_irs_size: " << cross_reference_irs_.size() << "\n";
+  out << "- filename: " << filename_ << "\n"
+      << "  sem_ir:\n"
+      << "  - cross_reference_irs_size: " << cross_reference_irs_.size()
+      << "\n";
 
   PrintList(out, "functions", functions_);
   // Integer literals are an APInt, and default to a signed print, but the
@@ -138,17 +159,13 @@ auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
   PrintList(out, "real_literals", real_literals_);
   PrintList(out, "strings", strings_);
   PrintList(out, "types", types_);
-
   PrintBlock(out, "type_blocks", type_blocks_);
 
-  out << "nodes: [\n";
-  for (int i = include_builtins ? 0 : BuiltinKind::ValidCount;
-       i < static_cast<int>(nodes_.size()); ++i) {
-    const auto& element = nodes_[i];
-    out.indent(Indent);
-    out << element << ",\n";
+  llvm::ArrayRef nodes = nodes_;
+  if (!include_builtins) {
+    nodes = nodes.drop_front(BuiltinKind::ValidCount);
   }
-  out << "]\n";
+  PrintList(out, "nodes", nodes);
 
   PrintBlock(out, "node_blocks", node_blocks_);
 }

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -72,7 +72,7 @@ class File : public Printable<File> {
   explicit File();
 
   // Starts a new file for Check::CheckParseTree. Builtins are required.
-  explicit File(const File* builtins);
+  explicit File(std::string filename, const File* builtins);
 
   // Verifies that invariants of the semantics IR hold.
   auto Verify() const -> ErrorOr<Success>;
@@ -290,8 +290,14 @@ class File : public Printable<File> {
   auto has_errors() const -> bool { return has_errors_; }
   auto set_has_errors(bool has_errors) -> void { has_errors_ = has_errors; }
 
+  auto filename() const -> llvm::StringRef { return filename_; }
+
  private:
   bool has_errors_ = false;
+
+  // The associated filename.
+  // TODO: If SemIR starts linking back to tokens, reuse its filename.
+  std::string filename_;
 
   // Storage for callable objects.
   llvm::SmallVector<Function> functions_;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -404,9 +404,9 @@ class Formatter {
         node_namer_(tokenized_buffer, parse_tree, semantics_ir) {}
 
   auto Format() -> void {
-    // TODO: Include information from the package declaration, once we fully
-    // support it.
-    out_ << "package {\n";
+    out_ << "file \"" << semantics_ir_.filename() << "\" {\n";
+    // TODO: Include information from the package declaration, once we
+    // fully support it.
     // TODO: Handle the case where there are multiple top-level node blocks.
     // For example, there may be branching in the initializer of a global or a
     // type expression.


### PR DESCRIPTION
Building on #3214 and #3215, updates sem_ir yaml to be:

```
- filename: name
  sem_ir: [ ... ]
```

Also, changes the textual format from `package { ... }` to `file <filename> { ... }`. My thought on packages there is:

```
file "foo.carbon" {
  package MyPackage

  ...
}
```

The reason for putting the file first is that it's easier if we put what we're grouping on first, whereas the package is an "annotation" on the file.