### PR TITLE
Remove `Check::Context::AddNodeToBlock` and `SemIR::File::AddNode`.

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -61,7 +61,7 @@ auto Context::VerifyOnFinish() -> void {
 }
 
 auto Context::AddNode(SemIR::Node node) -> SemIR::NodeId {
-  auto node_id = semantics_ir_->AddNodeNoBlock(node);
+  auto node_id = semantics_ir_->AddNodeInNoBlock(node);
   node_block_stack_.AddNodeId(node_id);
   CARBON_VLOG() << "AddNode " << node_block_stack_.Peek() << ": " << node
                 << "\n";

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -9,6 +9,7 @@
 #include "common/check.h"
 #include "common/vlog.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
 #include "toolchain/check/declaration_name_stack.h"
 #include "toolchain/check/node_block_stack.h"
 #include "toolchain/diagnostics/diagnostic_kind.h"
@@ -60,18 +61,11 @@ auto Context::VerifyOnFinish() -> void {
 }
 
 auto Context::AddNode(SemIR::Node node) -> SemIR::NodeId {
-  return AddNodeToBlock(node_block_stack_.PeekForAdd(), node);
-}
-
-auto Context::AddNodeToBlock(SemIR::NodeBlockId block, SemIR::Node node)
-    -> SemIR::NodeId {
-  CARBON_VLOG() << "AddNode " << block << ": " << node << "\n";
-  return semantics_ir_->AddNode(block, node);
-}
-
-auto Context::AddNodeIdToBlock(SemIR::NodeBlockId block, SemIR::NodeId node_id)
-    -> void {
-  semantics_ir_->AddNodeId(block, node_id);
+  auto node_id = semantics_ir_->AddNodeNoBlock(node);
+  node_block_stack_.AddNodeId(node_id);
+  CARBON_VLOG() << "AddNode " << node_block_stack_.Peek() << ": " << node
+                << "\n";
+  return node_id;
 }
 
 auto Context::AddNodeAndPush(Parse::Node parse_node, SemIR::Node node) -> void {
@@ -183,45 +177,44 @@ auto Context::AddDominatedBlockAndBranchIf(Parse::Node parse_node,
       *this, parse_node, cond_id);
 }
 
-auto Context::AddConvergenceBlockAndPush(
-    Parse::Node parse_node, std::initializer_list<SemIR::NodeBlockId> blocks)
+auto Context::AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
     -> void {
-  CARBON_CHECK(blocks.size() >= 2) << "no convergence";
+  CARBON_CHECK(num_blocks >= 2) << "no convergence";
 
   SemIR::NodeBlockId new_block_id = SemIR::NodeBlockId::Unreachable;
-  for (SemIR::NodeBlockId block_id : blocks) {
-    if (block_id != SemIR::NodeBlockId::Unreachable) {
+  for ([[maybe_unused]] auto _ : llvm::seq(num_blocks)) {
+    if (node_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlock();
       }
-      AddNodeToBlock(block_id,
-                     SemIR::Node::Branch::Make(parse_node, new_block_id));
+      AddNode(SemIR::Node::Branch::Make(parse_node, new_block_id));
     }
+    node_block_stack().Pop();
   }
   node_block_stack().Push(new_block_id);
 }
 
 auto Context::AddConvergenceBlockWithArgAndPush(
-    Parse::Node parse_node,
-    std::initializer_list<std::pair<SemIR::NodeBlockId, SemIR::NodeId>>
-        blocks_and_args) -> SemIR::NodeId {
-  CARBON_CHECK(blocks_and_args.size() >= 2) << "no convergence";
+    Parse::Node parse_node, std::initializer_list<SemIR::NodeId> block_args)
+    -> SemIR::NodeId {
+  CARBON_CHECK(block_args.size() >= 2) << "no convergence";
 
   SemIR::NodeBlockId new_block_id = SemIR::NodeBlockId::Unreachable;
-  for (auto [block_id, arg_id] : blocks_and_args) {
-    if (block_id != SemIR::NodeBlockId::Unreachable) {
+  for (auto arg_id : block_args) {
+    if (node_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlock();
       }
-      AddNodeToBlock(block_id, SemIR::Node::BranchWithArg::Make(
-                                   parse_node, new_block_id, arg_id));
+      AddNode(
+          SemIR::Node::BranchWithArg::Make(parse_node, new_block_id, arg_id));
     }
+    node_block_stack().Pop();
   }
   node_block_stack().Push(new_block_id);
 
   // Acquire the result value.
   SemIR::TypeId result_type_id =
-      semantics_ir().GetNode(blocks_and_args.begin()->second).type_id();
+      semantics_ir().GetNode(*block_args.begin()).type_id();
   return AddNode(
       SemIR::Node::BlockArg::Make(parse_node, result_type_id, new_block_id));
 }
@@ -624,7 +617,7 @@ auto Context::ParamOrArgSave(bool for_args) -> void {
   }
 
   // Save the param or arg ID.
-  AddNodeIdToBlock(params_or_args_stack_.PeekForAdd(), entry_node_id);
+  params_or_args_stack_.AddNodeId(entry_node_id);
 }
 
 auto Context::CanonicalizeTypeImpl(

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -83,14 +83,14 @@ class Context {
                                     SemIR::NodeId cond_id)
       -> SemIR::NodeBlockId;
 
-  // Adds branches from the top `num_blocks` on the node block stack to a new
-  // block, for reconvergence of control flow, pops the existing blocks, and
-  // pushes the new block onto the node block stack.
+  // Handles recovergence of control flow. Adds branches from the top
+  // `num_blocks` on the node block stack to a new block, pops the existing
+  // blocks, and pushes the new block onto the node block stack.
   auto AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
       -> void;
 
-  // Adds branches from the top few blocks on the node block stack to a new
-  // block, for reconvergence of control flow with a result value, pops the
+  // Handles recovergence of control flow with a result value. Adds branches
+  // from the top few blocks on the node block stack to a new block, pops the
   // existing blocks, and pushes the new block onto the node block stack. The
   // number of blocks popped is the size of `block_args`, and the corresponding
   // result values are the elements of `block_args`. Returns a node referring

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -36,14 +36,6 @@ class Context {
   // Adds a node to the current block, returning the produced ID.
   auto AddNode(SemIR::Node node) -> SemIR::NodeId;
 
-  // Adds a node to the given block, returning the produced ID.
-  auto AddNodeToBlock(SemIR::NodeBlockId block, SemIR::Node node)
-      -> SemIR::NodeId;
-
-  // Adds the ID of an existing node to the given block.
-  auto AddNodeIdToBlock(SemIR::NodeBlockId block, SemIR::NodeId node_id)
-      -> void;
-
   // Pushes a parse tree node onto the stack, storing the SemIR::Node as the
   // result.
   auto AddNodeAndPush(Parse::Node parse_node, SemIR::Node node) -> void;
@@ -91,21 +83,21 @@ class Context {
                                     SemIR::NodeId cond_id)
       -> SemIR::NodeBlockId;
 
-  // Adds branches from the given list of blocks to a new block, for
-  // reconvergence of control flow, and pushes the new block onto the node
-  // block stack.
-  auto AddConvergenceBlockAndPush(
-      Parse::Node parse_node, std::initializer_list<SemIR::NodeBlockId> blocks)
+  // Adds branches from the top `num_blocks` on the node block stack to a new
+  // block, for reconvergence of control flow, pops the existing blocks, and
+  // pushes the new block onto the node block stack.
+  auto AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
       -> void;
 
-  // Adds branches from the given list of blocks and values to a new block, for
-  // reconvergence of control flow with a result value, and pushes the new
-  // block onto the node block stack. Returns a node referring to the result
-  // value.
+  // Adds branches from the top few blocks on the node block stack to a new
+  // block, for reconvergence of control flow with a result value, pops the
+  // existing blocks, and pushes the new block onto the node block stack. The
+  // number of blocks popped is the size of `block_args`, and the corresponding
+  // result values are the elements of `block_args`. Returns a node referring
+  // to the result value.
   auto AddConvergenceBlockWithArgAndPush(
       Parse::Node parse_node,
-      std::initializer_list<std::pair<SemIR::NodeBlockId, SemIR::NodeId>>
-          blocks_and_args) -> SemIR::NodeId;
+      std::initializer_list<SemIR::NodeId> blocks_and_args) -> SemIR::NodeId;
 
   // Add the current code block to the enclosing function.
   auto AddCurrentCodeBlockToFunction() -> void;

--- a/toolchain/check/handle_if_expression.cpp
+++ b/toolchain/check/handle_if_expression.cpp
@@ -29,16 +29,12 @@ auto HandleIfExpressionIf(Context& context, Parse::Node parse_node) -> bool {
 }
 
 auto HandleIfExpressionThen(Context& context, Parse::Node parse_node) -> bool {
-  // Alias parse_node for if/then/else consistency.
-  auto& then_node = parse_node;
-
   // Convert the first operand to a value.
-  auto [then_value_node, then_value_id] =
-      context.node_stack().PopExpressionWithParseNode();
-  context.node_stack().Push(then_value_node,
+  auto then_value_id = context.node_stack().PopExpression();
+  context.node_stack().Push(parse_node,
                             context.ConvertToValueExpression(then_value_id));
 
-  context.node_stack().Push(then_node, context.node_block_stack().Pop());
+  context.node_block_stack().SwapTopBlocks();
   context.AddCurrentCodeBlockToFunction();
   return true;
 }
@@ -48,10 +44,8 @@ auto HandleIfExpressionElse(Context& context, Parse::Node parse_node) -> bool {
   auto& else_node = parse_node;
 
   auto else_value_id = context.node_stack().PopExpression();
-  auto [then_node, then_end_block_id] =
-      context.node_stack()
-          .PopWithParseNode<Parse::NodeKind::IfExpressionThen>();
-  auto then_value_id = context.node_stack().PopExpression();
+  auto then_value_id =
+      context.node_stack().Pop<Parse::NodeKind::IfExpressionThen>();
   auto if_node = context.node_stack()
                      .PopForSoloParseNode<Parse::NodeKind::IfExpressionIf>();
 
@@ -61,12 +55,10 @@ auto HandleIfExpressionElse(Context& context, Parse::Node parse_node) -> bool {
   auto result_type_id = context.semantics_ir().GetNode(then_value_id).type_id();
   else_value_id =
       context.ConvertToValueOfType(else_node, else_value_id, result_type_id);
-  auto else_end_block_id = context.node_block_stack().Pop();
 
   // Create a resumption block and branches to it.
   auto chosen_value_id = context.AddConvergenceBlockWithArgAndPush(
-      if_node,
-      {{then_end_block_id, then_value_id}, {else_end_block_id, else_value_id}});
+      if_node, {else_value_id, then_value_id});
   context.AddCurrentCodeBlockToFunction();
 
   // Push the result value.

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -36,11 +36,10 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
 
       // When the second operand is evaluated, the result of `and` and `or` is
       // its value.
-      auto rhs_block_id = context.node_block_stack().PopForAdd();
-      auto resume_block_id = context.node_block_stack().PeekForAdd();
-      context.AddNodeToBlock(rhs_block_id,
-                             SemIR::Node::BranchWithArg::Make(
-                                 parse_node, resume_block_id, rhs_id));
+      auto resume_block_id = context.node_block_stack().PeekForAdd(/*depth=*/1);
+      context.AddNode(SemIR::Node::BranchWithArg::Make(
+          parse_node, resume_block_id, rhs_id));
+      context.node_block_stack().Pop();
       context.AddCurrentCodeBlockToFunction();
 
       // Collect the result from either the first or second operand.

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -52,9 +52,10 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
 
   // Store the name for the type.
   context.args_type_info_stack().AddNodeId(
-      context.semantics_ir().AddNodeNoBlock(SemIR::Node::StructTypeField::Make(
-          parse_node, name_id,
-          context.semantics_ir().GetNode(value_node_id).type_id())));
+      context.semantics_ir().AddNodeInNoBlock(
+          SemIR::Node::StructTypeField::Make(
+              parse_node, name_id,
+              context.semantics_ir().GetNode(value_node_id).type_id())));
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(parse_node, value_node_id);

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -51,12 +51,10 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
   value_node_id = context.ConvertToValueExpression(value_node_id);
 
   // Store the name for the type.
-  auto type_block_id = context.args_type_info_stack().PeekForAdd();
-  context.semantics_ir().AddNode(
-      type_block_id,
-      SemIR::Node::StructTypeField::Make(
+  context.args_type_info_stack().AddNodeId(
+      context.semantics_ir().AddNodeNoBlock(SemIR::Node::StructTypeField::Make(
           parse_node, name_id,
-          context.semantics_ir().GetNode(value_node_id).type_id()));
+          context.semantics_ir().GetNode(value_node_id).type_id())));
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(parse_node, value_node_id);

--- a/toolchain/check/node_block_stack.cpp
+++ b/toolchain/check/node_block_stack.cpp
@@ -17,15 +17,15 @@ auto NodeBlockStack::Push(SemIR::NodeBlockId id) -> void {
   stack_.push_back(id);
 }
 
-auto NodeBlockStack::PeekForAdd() -> SemIR::NodeBlockId {
-  CARBON_CHECK(!stack_.empty()) << "no current block";
-  auto& back = stack_.back();
-  if (!back.is_valid()) {
-    back = semantics_ir_->AddNodeBlock();
-    CARBON_VLOG() << name_ << " Add " << stack_.size() - 1 << ": " << back
-                  << "\n";
+auto NodeBlockStack::PeekForAdd(int depth) -> SemIR::NodeBlockId {
+  CARBON_CHECK(static_cast<int>(stack_.size()) > depth) << "no such block";
+  int index = stack_.size() - depth - 1;
+  auto& slot = stack_[index];
+  if (!slot.is_valid()) {
+    slot = semantics_ir_->AddNodeBlock();
+    CARBON_VLOG() << name_ << " Add " << index << ": " << slot << "\n";
   }
-  return back;
+  return slot;
 }
 
 auto NodeBlockStack::Pop() -> SemIR::NodeBlockId {

--- a/toolchain/check/node_block_stack.h
+++ b/toolchain/check/node_block_stack.h
@@ -59,12 +59,6 @@ class NodeBlockStack {
     return Pop();
   }
 
-  // Swaps the two blocks on the top of the stack.
-  auto SwapTopBlocks() -> void {
-    CARBON_CHECK(size() >= 2) << "not enough blocks on stack";
-    std::swap(stack_[size() - 1], stack_[size() - 2]);
-  }
-
   // Adds the given node ID to the block at the top of the stack.
   auto AddNodeId(SemIR::NodeId node_id) -> void {
     semantics_ir_->AddNodeIdForNodeBlockStack(PeekForAdd(), node_id);

--- a/toolchain/check/node_block_stack.h
+++ b/toolchain/check/node_block_stack.h
@@ -43,7 +43,9 @@ class NodeBlockStack {
     return stack_.back();
   }
 
-  // Returns the top node block, allocating one if it's still invalid.
+  // Returns the top node block, allocating one if it's still invalid. If
+  // `depth` is specified, returns the node at `depth` levels from the top of
+  // the stack, where the top block is at depth 0.
   auto PeekForAdd(int depth = 0) -> SemIR::NodeBlockId;
 
   // Pops the top node block. This will always return a valid node block;

--- a/toolchain/check/node_block_stack.h
+++ b/toolchain/check/node_block_stack.h
@@ -44,7 +44,7 @@ class NodeBlockStack {
   }
 
   // Returns the top node block, allocating one if it's still invalid.
-  auto PeekForAdd() -> SemIR::NodeBlockId;
+  auto PeekForAdd(int depth = 0) -> SemIR::NodeBlockId;
 
   // Pops the top node block. This will always return a valid node block;
   // SemIR::NodeBlockId::Empty is returned if one wasn't allocated.
@@ -55,6 +55,17 @@ class NodeBlockStack {
   auto PopForAdd() -> SemIR::NodeBlockId {
     PeekForAdd();
     return Pop();
+  }
+
+  // Swaps the two blocks on the top of the stack.
+  auto SwapTopBlocks() -> void {
+    CARBON_CHECK(size() >= 2) << "not enough blocks on stack";
+    std::swap(stack_[size() - 1], stack_[size() - 2]);
+  }
+
+  // Adds the given node ID to the block at the top of the stack.
+  auto AddNodeId(SemIR::NodeId node_id) -> void {
+    semantics_ir_->AddNodeIdForNodeBlockStack(PeekForAdd(), node_id);
   }
 
   // Returns whether the current block is statically reachable.

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -261,6 +261,8 @@ class NodeStack {
       case Parse::NodeKind::StructTypeLiteral:
       case Parse::NodeKind::TupleLiteral:
         return IdKind::NodeId;
+      case Parse::NodeKind::IfCondition:
+      case Parse::NodeKind::IfExpressionIf:
       case Parse::NodeKind::ParameterList:
         return IdKind::NodeBlockId;
       case Parse::NodeKind::FunctionDefinitionStart:
@@ -270,8 +272,6 @@ class NodeStack {
       case Parse::NodeKind::ArrayExpressionSemi:
       case Parse::NodeKind::CodeBlockStart:
       case Parse::NodeKind::FunctionIntroducer:
-      case Parse::NodeKind::IfCondition:
-      case Parse::NodeKind::IfExpressionIf:
       case Parse::NodeKind::IfStatementElse:
       case Parse::NodeKind::ParameterListStart:
       case Parse::NodeKind::ParenExpressionOrTupleLiteralStart:

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -242,6 +242,7 @@ class NodeStack {
       case Parse::NodeKind::ArrayExpression:
       case Parse::NodeKind::CallExpression:
       case Parse::NodeKind::CallExpressionStart:
+      case Parse::NodeKind::IfExpressionThen:
       case Parse::NodeKind::IfExpressionElse:
       case Parse::NodeKind::IndexExpression:
       case Parse::NodeKind::InfixOperator:
@@ -260,8 +261,6 @@ class NodeStack {
       case Parse::NodeKind::StructTypeLiteral:
       case Parse::NodeKind::TupleLiteral:
         return IdKind::NodeId;
-      case Parse::NodeKind::IfExpressionThen:
-      case Parse::NodeKind::IfStatementElse:
       case Parse::NodeKind::ParameterList:
         return IdKind::NodeBlockId;
       case Parse::NodeKind::FunctionDefinitionStart:
@@ -273,6 +272,7 @@ class NodeStack {
       case Parse::NodeKind::FunctionIntroducer:
       case Parse::NodeKind::IfCondition:
       case Parse::NodeKind::IfExpressionIf:
+      case Parse::NodeKind::IfStatementElse:
       case Parse::NodeKind::ParameterListStart:
       case Parse::NodeKind::ParenExpressionOrTupleLiteralStart:
       case Parse::NodeKind::QualifiedDeclaration:

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -148,16 +148,17 @@ class File : public Printable<File> {
     return name_scopes_[scope_id.index];
   }
 
-  // Adds a node to a specified block, returning an ID to reference the node.
-  auto AddNode(NodeBlockId block_id, Node node) -> NodeId {
+  // Adds a node to the node list, returning an ID to reference the node.
+  auto AddNodeNoBlock(Node node) -> NodeId {
     NodeId node_id(nodes_.size());
     nodes_.push_back(node);
-    AddNodeId(block_id, node_id);
     return node_id;
   }
 
-  // Adds the ID of an existing node to the specified block.
-  auto AddNodeId(NodeBlockId block_id, NodeId node_id) -> void {
+  // Adds the ID of an existing node to the specified block. Temporary, should
+  // only be called by Check::NodeBlockStack.
+  auto AddNodeIdForNodeBlockStack(NodeBlockId block_id, NodeId node_id)
+      -> void {
     if (block_id != NodeBlockId::Unreachable) {
       node_blocks_[block_id.index].push_back(node_id);
     }

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -151,7 +151,7 @@ class File : public Printable<File> {
   // Adds a node to the node list, returning an ID to reference the node. Note
   // that this doesn't add the node to any node block. Check::Context::AddNode
   // should usually be used instead, to add the node to the current code block.
-  auto AddNodeNoBlock(Node node) -> NodeId {
+  auto AddNodeInNoBlock(Node node) -> NodeId {
     NodeId node_id(nodes_.size());
     nodes_.push_back(node);
     return node_id;

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -148,7 +148,9 @@ class File : public Printable<File> {
     return name_scopes_[scope_id.index];
   }
 
-  // Adds a node to the node list, returning an ID to reference the node.
+  // Adds a node to the node list, returning an ID to reference the node. Note
+  // that this doesn't add the node to any node block. Check::Context::AddNode
+  // should usually be used instead, to add the node to the current code block.
   auto AddNodeNoBlock(Node node) -> NodeId {
     NodeId node_id(nodes_.size());
     nodes_.push_back(node);


### PR DESCRIPTION
Nodes are now only ever added to the current block in the node block stack.

This is a preparation step towards the new node block allocation design.