### PR TITLE
Switch to a slab allocator for node and type block storage.

### DIFF
--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -306,7 +306,7 @@ class File : public Printable<File> {
  private:
   // Allocates a copy of the given data using our slab allocator.
   template <typename T>
-  llvm::MutableArrayRef<T> AllocateCopy(llvm::ArrayRef<T> data) {
+  auto AllocateCopy(llvm::ArrayRef<T> data) -> llvm::MutableArrayRef<T> {
     // We're not going to run a destructor, so ensure that's OK.
     static_assert(std::is_trivially_destructible_v<T>);
 
@@ -318,7 +318,7 @@ class File : public Printable<File> {
 
   bool has_errors_ = false;
 
-  // Slab allocator, used to allocate node blocks.
+  // Slab allocator, used to allocate node and type blocks.
   llvm::BumpPtrAllocator allocator_;
 
   // The associated filename.


### PR DESCRIPTION
Per [discussion on #toolchain](https://discord.com/channels/655572317891461132/655578254970716160/1150961563054903398) and [design document](https://docs.google.com/document/d/1IgEvm5ojqxZ6dMACq6M4Lu4LQ_h1T8bvvYN3kKUQBWk/edit), switch to a slab allocation strategy for blocks.