### PR TITLE
Stop looking for llvm-15 due to config issues.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,10 +100,12 @@ jobs:
         if:
           steps.filter.outputs.ignore == 'false' && matrix.os == 'ubuntu-22.04'
         run: |
-          LLVM_PATH="/usr/lib/llvm-15"
-          if [[ ! -e "${LLVM_PATH}" ]]; then
-            LLVM_PATH="/usr/lib/llvm-14"
-          fi
+          # TODO: Re-enable once llvm-15 is working.
+          # https://github.com/actions/runner-images/issues/8253
+          # LLVM_PATH="/usr/lib/llvm-15"
+          # if [[ ! -e "${LLVM_PATH}" ]]; then
+          LLVM_PATH="/usr/lib/llvm-14"
+          # fi
           echo "Using ${LLVM_PATH}"
           echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
           echo '*** ls "${LLVM_PATH}"'


### PR DESCRIPTION
We're seeing issues building on the 20230911.1.0 release. I think there may be a misconfiguration; using `/usr/lib/llvm-15/bin/clang++`, I'm getting errors such as:

```
external/com_google_absl/absl/base/config.h:56:10: fatal error: 'cstddef' file not found
#include <cstddef>
         ^~~~~~~~~
```

e.g.: https://github.com/carbon-language/carbon-lang/actions/runs/6166275499/job/16735504697 (the passing ubuntu run is on a 20230903.1.0 image using llvm-14)

(note if this PR fails testing, it needs to be merged before it would take effect)

Reported on https://github.com/actions/runner-images/issues/8253