### PR TITLE
Clean up interface of node block stack after recent changes.

### DIFF
--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -36,7 +36,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
 
       // When the second operand is evaluated, the result of `and` and `or` is
       // its value.
-      auto resume_block_id = context.node_block_stack().PeekForAdd(/*depth=*/1);
+      auto resume_block_id = context.node_block_stack().PeekOrAdd(/*depth=*/1);
       context.AddNode(SemIR::Node::BranchWithArg::Make(
           parse_node, resume_block_id, rhs_id));
       context.node_block_stack().Pop();

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -51,11 +51,9 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
   value_node_id = context.ConvertToValueExpression(value_node_id);
 
   // Store the name for the type.
-  context.args_type_info_stack().AddNodeId(
-      context.semantics_ir().AddNodeInNoBlock(
-          SemIR::Node::StructTypeField::Make(
-              parse_node, name_id,
-              context.semantics_ir().GetNode(value_node_id).type_id())));
+  context.args_type_info_stack().AddNode(SemIR::Node::StructTypeField::Make(
+      parse_node, name_id,
+      context.semantics_ir().GetNode(value_node_id).type_id()));
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(parse_node, value_node_id);

--- a/toolchain/check/node_block_stack.cpp
+++ b/toolchain/check/node_block_stack.cpp
@@ -28,7 +28,6 @@ auto NodeBlockStack::PeekOrAdd(int depth) -> SemIR::NodeBlockId {
   auto& slot = stack_[index];
   if (!slot.id.is_valid()) {
     slot.id = semantics_ir_->AddNodeBlockId();
-    CARBON_VLOG() << name_ << " Add " << index << ": " << slot.id << "\n";
   }
   return slot.id;
 }

--- a/toolchain/check/node_block_stack.cpp
+++ b/toolchain/check/node_block_stack.cpp
@@ -22,7 +22,7 @@ auto NodeBlockStack::Push(SemIR::NodeBlockId id) -> void {
   ++size_;
 }
 
-auto NodeBlockStack::PeekForAdd(int depth) -> SemIR::NodeBlockId {
+auto NodeBlockStack::PeekOrAdd(int depth) -> SemIR::NodeBlockId {
   CARBON_CHECK(size() > depth) << "no such block";
   int index = size() - depth - 1;
   auto& slot = stack_[index];

--- a/toolchain/check/testdata/basics/verbose.carbon
+++ b/toolchain/check/testdata/basics/verbose.carbon
@@ -8,7 +8,10 @@
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
 // CHECK:STDERR: Node Push 0: FunctionIntroducer -> <none>
-// CHECK:STDERR: AddNode block{{[0-9]+}}: {kind: Return}
+// CHECK:STDERR: AddNode: {kind: FunctionDeclaration, arg0: function{{[0-9]+}}}
+// CHECK:STDERR: node_block_stack_ Push 1
+// CHECK:STDERR: AddNode: {kind: Return}
+// CHECK:STDERR: node_block_stack_ Pop 1: block{{[0-9]+}}
 
 fn Foo() {
   return;

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -151,7 +151,8 @@ class File : public Printable<File> {
 
   // Adds a node to the node list, returning an ID to reference the node. Note
   // that this doesn't add the node to any node block. Check::Context::AddNode
-  // should usually be used instead, to add the node to the current code block.
+  // or NodeBlockStack::AddNode should usually be used instead, to add the node
+  // to the current block.
   auto AddNodeInNoBlock(Node node) -> NodeId {
     NodeId node_id(nodes_.size());
     nodes_.push_back(node);


### PR DESCRIPTION
- `Peek()` no longer returns a useful value, because we often don't allocate a `NodeBlockId` until we finish building the block. Remove it and update both its callers.
- Rename `PeekForAdd()` to `PeekOrAdd()` since it's no longer used to get a block ID to add elements into.
- `PushForAdd()` was unused. Remove it.
- Add `NodeBlockStack::AddNode` to combine the operations of adding a node and inserting it into a block.