### PR TITLE
When running FileTests, verify that autoupdate wouldn't make changes.

### DIFF
--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -258,7 +258,7 @@ auto FileTestAutoupdater::StartSplitFile() -> void {
   ++non_check_line_;
 }
 
-auto FileTestAutoupdater::Run() -> bool {
+auto FileTestAutoupdater::Run(bool dry_run) -> bool {
   bool any_attached_stdout_lines = std::any_of(
       stdout_.lines.begin(), stdout_.lines.end(),
       [&](const CheckLine& line) { return line.line_number() != -1; });
@@ -330,8 +330,10 @@ auto FileTestAutoupdater::Run() -> bool {
   if (new_content == input_content_) {
     return false;
   }
-  std::ofstream out(file_test_path_);
-  out << new_content;
+  if (!dry_run) {
+    std::ofstream out(file_test_path_);
+    out << new_content;
+  }
   return true;
 }
 

--- a/testing/file_test/autoupdate.h
+++ b/testing/file_test/autoupdate.h
@@ -65,8 +65,9 @@ class FileTestAutoupdater {
     }
   }
 
-  // Automatically updates CHECKs in the provided file. Returns true if updated.
-  auto Run() -> bool;
+  // Automatically updates CHECKs in the provided file when dry_run=false.
+  // Returns true if generated file content differs from actual file content.
+  auto Run(bool dry_run) -> bool;
 
  private:
   // The file and line number that a CHECK line refers to, and the

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -151,6 +151,9 @@ class FileTestBase : public testing::Test {
   static auto TransformExpectation(int line_index, llvm::StringRef in)
       -> ErrorOr<testing::Matcher<std::string>>;
 
+  // Runs the FileTestAutoupdater, returning the result.
+  auto RunAutoupdater(const TestContext& context, bool dry_run) -> bool;
+
   llvm::StringRef test_name_;
 };
 


### PR DESCRIPTION
Trying to more proactively catch when autoupdate is missed. Most of the execution time of these tests should be in running the program under test, not processing output, so this should have marginal overhead in order to produce a useful reminder.