### PR TITLE
When there are split files, put unattached stdout at the end of the last file.

### DIFF
--- a/testing/file_test/autoupdate.h
+++ b/testing/file_test/autoupdate.h
@@ -160,8 +160,10 @@ class FileTestAutoupdater {
   auto AddCheckLines(CheckLines& check_lines, int to_line_number,
                      llvm::StringRef indent) -> void;
 
-  // Adds remaining check lines for the current file.
-  auto FinishFile() -> void;
+  // Adds remaining check lines for the current file. stderr is always included,
+  // but stdout is only included when either any_attached_stdout_lines_ or
+  // is_last_file is true.
+  auto FinishFile(bool is_last_file) -> void;
 
   // Starts a new split file, updating file and line numbers. Advances past the
   // split line.

--- a/testing/file_test/testdata/unattached_multi_file.carbon
+++ b/testing/file_test/testdata/unattached_multi_file.carbon
@@ -6,11 +6,12 @@
 // CHECK:STDERR: unattached message 3
 // CHECK:STDERR: unattached message 4
 
-// CHECK:STDOUT: 3 args: `default_args`, `a.carbon`, `b.carbon`
-// CHECK:STDOUT: unattached message 1
-// CHECK:STDOUT: unattached message 2
 // --- a.carbon
 aaa
 
 // --- b.carbon
 bbb
+
+// CHECK:STDOUT: 3 args: `default_args`, `a.carbon`, `b.carbon`
+// CHECK:STDOUT: unattached message 1
+// CHECK:STDOUT: unattached message 2

--- a/toolchain/check/testdata/basics/multifile.carbon
+++ b/toolchain/check/testdata/basics/multifile.carbon
@@ -4,6 +4,12 @@
 //
 // AUTOUPDATE
 
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}
+
 // CHECK:STDOUT: file "a.carbon" {
 // CHECK:STDOUT:   %.loc1 = fn_decl @A
 // CHECK:STDOUT: }
@@ -20,8 +26,3 @@
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
-// --- a.carbon
-fn A() {}
-
-// --- b.carbon
-fn B() {}

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -8,6 +8,12 @@
 //
 // AUTOUPDATE
 
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}
+
 // CHECK:STDOUT: - filename: a.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
@@ -88,8 +94,3 @@
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
-// --- a.carbon
-fn A() {}
-
-// --- b.carbon
-fn B() {}

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -8,6 +8,12 @@
 //
 // AUTOUPDATE
 
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}
+
 // CHECK:STDOUT: - filename: a.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
@@ -70,8 +76,3 @@
 // CHECK:STDOUT:         node+0,
 // CHECK:STDOUT:       ],
 // CHECK:STDOUT:     ]
-// --- a.carbon
-fn A() {}
-
-// --- b.carbon
-fn B() {}

--- a/toolchain/parse/testdata/basics/multifile.carbon
+++ b/toolchain/parse/testdata/basics/multifile.carbon
@@ -4,6 +4,12 @@
 //
 // AUTOUPDATE
 
+// --- a.carbon
+fn A() {}
+
+// --- b.carbon
+fn B() {}
+
 // CHECK:STDOUT: - filename: a.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:         {kind: 'FunctionIntroducer', text: 'fn'},
@@ -24,8 +30,3 @@
 // CHECK:STDOUT:     {kind: 'FunctionDefinition', text: '}', subtree_size: 6},
 // CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT:   ]
-// --- a.carbon
-fn A() {}
-
-// --- b.carbon
-fn B() {}


### PR DESCRIPTION
This is consistent with the goal of trying to push unattached stdout to the bottom of the test file. The current logic had a single file in mind, and was not adapted for split file logic.

Addresses https://github.com/carbon-language/carbon-lang/pull/3217#discussion_r1323584624

Note this depends on #3233 