### PR TITLE
Make toolchain/testing/file_test more robust

### DIFF
--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -88,9 +88,10 @@ class ToolchainFileTest : public FileTestBase {
  private:
   // Returns the toolchain subdirectory being tested.
   static auto GetComponent(llvm::StringRef test_name) -> llvm::StringRef {
+    // This handles cases where the toolchain directory may be copied into a repository that doesn't put it at the root.
     auto pos = test_name.find("toolchain/");
     CARBON_CHECK(pos != llvm::StringRef::npos) << test_name;
-    test_name = test_name.drop_front(pos + sizeof("toolchain/") - 1);
+    test_name = test_name.drop_front(pos + strlen("toolchain/"));
     test_name = test_name.take_front(test_name.find("/"));
     return test_name;
   }

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -88,7 +88,8 @@ class ToolchainFileTest : public FileTestBase {
  private:
   // Returns the toolchain subdirectory being tested.
   static auto GetComponent(llvm::StringRef test_name) -> llvm::StringRef {
-    // This handles cases where the toolchain directory may be copied into a repository that doesn't put it at the root.
+    // This handles cases where the toolchain directory may be copied into a
+    // repository that doesn't put it at the root.
     auto pos = test_name.find("toolchain/");
     CARBON_CHECK(pos != llvm::StringRef::npos) << test_name;
     test_name = test_name.drop_front(pos + strlen("toolchain/"));

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -88,7 +88,9 @@ class ToolchainFileTest : public FileTestBase {
  private:
   // Returns the toolchain subdirectory being tested.
   static auto GetComponent(llvm::StringRef test_name) -> llvm::StringRef {
-    CARBON_CHECK(test_name.consume_front("toolchain/"));
+    auto pos = test_name.find("toolchain/");
+    CARBON_CHECK(pos != llvm::StringRef::npos) << test_name;
+    test_name = test_name.drop_front(pos + sizeof("toolchain/") - 1);
     test_name = test_name.take_front(test_name.find("/"));
     return test_name;
   }


### PR DESCRIPTION
Support `toolchain/` being a subdirectory rather than the project root.
