### PR TITLE
Update LLVM and fix related breaks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,7 +113,7 @@ http_archive(
 
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
-llvm_version = "0e17372b380467ac8339afdec992fbf887a11feb"
+llvm_version = "bf8fd086d09cfeeec44f29e6aed6ce61cede2334"
 
 http_archive(
     name = "llvm-raw",
@@ -125,7 +125,7 @@ http_archive(
         "@carbon//bazel/patches/llvm:0003_Modernize_py_binary_rule_for_lit.patch",
         "@carbon//bazel/patches/llvm:0004_Add_library_for_clangd.patch",
     ],
-    sha256 = "50b8ff1c8088f2ebec19a523575b76c52e0a251d8fc4a8b5282a33177b109f49",
+    sha256 = "4dfb44c8ec17c6cc1d1f883c631dd1175e916891babe52ddda0b4d0c7ab6970e",
     strip_prefix = "llvm-project-{0}".format(llvm_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_version)],
 )

--- a/bazel/patches/llvm/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
+++ b/bazel/patches/llvm/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
@@ -1,20 +1,20 @@
-From 2c9527d988d2f5935b9406511104819463c37662 Mon Sep 17 00:00:00 2001
-From: P K <pk19604014@gmail.com>
-Date: Mon, 11 Jul 2022 17:32:57 -0400
-Subject: [PATCH] Added Bazel build for compiler-rt/fuzzer
+From 20d0f1fb854d9b7ce135d08575112fc58c4c7ce7 Mon Sep 17 00:00:00 2001
+From: jonmeow <jperkins@google.com>
+Date: Thu, 14 Sep 2023 20:31:11 +0000
+Subject: [PATCH] Add libfuzzer target to compiler-rt.
 
 ---
- .../compiler-rt/BUILD.bazel                    | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
- create mode 100644 compiler-rt/BUILD.bazel
+ .../compiler-rt/BUILD.bazel                     | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
 
-diff --git a/compiler-rt/BUILD.bazel b/compiler-rt/BUILD.bazel
-new file mode 100644
-index 000000000000..c6796b24a8e1
---- /dev/null
-+++ b/compiler-rt/BUILD.bazel
-@@ -0,0 +1,18 @@
-+package(default_visibility = ["//visibility:public"])
+diff --git a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+index 573549781ab7..65c9522e022b 100644
+--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+@@ -49,3 +49,20 @@ cc_library(
+     ],
+     linkstatic = True,
+ )
 +
 +cc_library(
 +    name = "FuzzerMain",
@@ -33,4 +33,4 @@ index 000000000000..c6796b24a8e1
 +    includes = ["lib/fuzzer"],
 +)
 --
-2.37.0.144.g8ac04bfd2-goog
+2.42.0

--- a/migrate_cpp/cpp_refactoring/main.cpp
+++ b/migrate_cpp/cpp_refactoring/main.cpp
@@ -17,10 +17,10 @@ static void InitReplacements(RefactoringTool* tool) {
   clang::FileManager& files = tool->getFiles();
   Carbon::Matcher::ReplacementMap& repl = tool->getReplacements();
   for (const std::string& path : tool->getSourcePaths()) {
-    llvm::ErrorOr<const clang::FileEntry*> file = files.getFile(path);
-    if (file.getError()) {
+    llvm::Expected<clang::FileEntryRef> file = files.getFileRef(path);
+    if (!file) {
       llvm::report_fatal_error(llvm::Twine("Error accessing `") + path +
-                               "`: " + file.getError().message() + "\n");
+                               "`: " + llvm::toString(file.takeError()) + "\n");
     }
     repl.insert({files.getCanonicalName(*file).str(), {}});
   }


### PR DESCRIPTION
Updates to a recent LLVM commit.

The patch file changes because there's now an upstream BUILD.bazel for compiler-rt in the overlay, although it still doesn't expose the libfuzzer target, so we need to keep patching it.

Clang's FileManager API changed slightly so we update migrate_cpp for that.