### PR TITLE
Reduce bazel job limit to try to avoid IOExceptions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -182,7 +182,11 @@ jobs:
           # There is a new effort (yay!) but until then it seems worth using the
           # workaround of a high jobs value. The biggest downside (increased
           # heap usage) seems like it isn't currently a big loss for our builds.
-          build --jobs=50
+          #
+          # Higher values like 50 have led to CI failures with network errors
+          # and IOExceptions, see
+          # https://discord.com/channels/655572317891461132/707150492370862090/1151605725576056934
+          build --jobs=32
 
           # General build options.
           build --verbose_failures


### PR DESCRIPTION
Issue reported in [#infra on Discord](https://discord.com/channels/655572317891461132/707150492370862090/1152031995740827718).