### PR TITLE
Fix use of backtick in shell code.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -173,7 +173,7 @@ jobs:
           # number based on the available host CPUs and the reality will be a
           # long chain of largely serialized download events with little or no
           # usage of the host machine. Fortunately, local actions are
-          # *separately* gated on `--local_*_resources` that will avoid a large
+          # *separately* gated on '--local_*_resources' that will avoid a large
           # jobs value overwhelming the host. There is a bug to make downloads
           # behave completely asynchronously and remove the need for this filed
           # back in 2018 but work seemed to not finish:


### PR DESCRIPTION
The way this is written, it's executed, not a comment.

`/home/runner/work/_temp/1007824c-f2f7-49dd-ab5f-f5f5364a1864.sh: line 1: --local_*_resources: command not found`
https://github.com/carbon-language/carbon-lang/actions/runs/6203167016/job/16843338592
