### PR TITLE
Move tests to the namespace of the code under test

### DIFF
--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(CheckTest, CheckTrue) { CARBON_CHECK(true); }
@@ -59,4 +59,4 @@ TEST(ErrorTest, FatalNoReturnRequired) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/common/enum_base_test.cpp
+++ b/common/enum_base_test.cpp
@@ -8,7 +8,7 @@
 
 #include "testing/base/test_raw_ostream.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 // These are directly in the Carbon namespace because the defines require it.
@@ -45,7 +45,7 @@ TEST(EnumBaseTest, NamesAndConstants) {
 }
 
 TEST(EnumBaseTest, Printing) {
-  TestRawOstream stream;
+  Testing::TestRawOstream stream;
 
   TestKind kind = TestKind::Beep;
   stream << kind << " " << TestKind::Beep;
@@ -109,4 +109,4 @@ TEST(EnumBaseTest, IntConversion) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/common/error_test.cpp
+++ b/common/error_test.cpp
@@ -8,7 +8,7 @@
 
 #include "testing/base/test_raw_ostream.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(ErrorTest, Error) {
@@ -107,10 +107,10 @@ TEST(ErrorTest, ErrorBuilderOperatorImplicitCast) {
 
 TEST(ErrorTest, StreamError) {
   Error result = ErrorBuilder("TestFunc") << "msg";
-  TestRawOstream result_stream;
+  Testing::TestRawOstream result_stream;
   result_stream << result;
   EXPECT_EQ(result_stream.TakeStr(), "TestFunc: msg");
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/common/indirect_value_test.cpp
+++ b/common/indirect_value_test.cpp
@@ -8,7 +8,7 @@
 
 #include <string>
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(IndirectValueTest, ConstAccess) {
@@ -126,4 +126,4 @@ TEST(IndirectValueTest, IncompleteType) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/common/string_helpers_test.cpp
+++ b/common/string_helpers_test.cpp
@@ -14,7 +14,7 @@
 using ::testing::Eq;
 using ::testing::Optional;
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(UnescapeStringLiteral, Valid) {
@@ -230,4 +230,4 @@ TEST(ParseBlockStringLiteral, OkMultipleSlashes) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -147,8 +147,8 @@ these.
     namespaces. `static` minimizes the context necessary to notice the internal
     linkage of a definition.
     -   Anonymous namespaces are still necessary for classes and enums.
-    -   Tests are an exception and should typically be wrapped with
-        `namespace Carbon::Testing { namespace { ... } }` to keep everything
+    -   Tests are an exception and should typically be wrapped in an anonymous
+        namespace under the namespace of the code under test, to keep everything
         internal.
 
 ### Copyable and movable types

--- a/explorer/ast/ast_test_matchers_test.cpp
+++ b/explorer/ast/ast_test_matchers_test.cpp
@@ -13,7 +13,7 @@
 #include "explorer/ast/statement.h"
 #include "explorer/base/arena.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 using ::testing::_;
@@ -159,4 +159,4 @@ TEST(ASTDeclarationsTest, BasicUsage) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/ast/element_test.cpp
+++ b/explorer/ast/element_test.cpp
@@ -16,7 +16,7 @@
 #include "explorer/base/arena.h"
 #include "llvm/Support/Casting.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 static auto FakeSourceLoc(int line_num) -> SourceLocation {
@@ -93,4 +93,4 @@ TEST_F(ElementTest, BaseElementIsNamed) {
   EXPECT_FALSE(element.IsNamed("anything"));
 }
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/ast/expression_test.cpp
+++ b/explorer/ast/expression_test.cpp
@@ -13,7 +13,7 @@
 #include "explorer/base/arena.h"
 #include "llvm/Support/Casting.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 using llvm::cast;
@@ -135,4 +135,4 @@ TEST_F(ExpressionTest, BinaryAsTuple) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/ast/pattern_test.cpp
+++ b/explorer/ast/pattern_test.cpp
@@ -12,7 +12,7 @@
 #include "explorer/base/arena.h"
 #include "llvm/Support/Casting.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 using llvm::cast;
@@ -129,4 +129,4 @@ TEST_F(PatternTest, BinaryAsTuplePattern) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/base/error_builders_test.cpp
+++ b/explorer/base/error_builders_test.cpp
@@ -9,7 +9,7 @@
 #include "explorer/base/source_location.h"
 #include "testing/base/test_raw_ostream.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(ErrorBuildersTest, ProgramError) {
@@ -17,10 +17,10 @@ TEST(ErrorBuildersTest, ProgramError) {
   EXPECT_EQ(err.location(), "x:1");
   EXPECT_EQ(err.message(), "test");
 
-  TestRawOstream out;
+  Testing::TestRawOstream out;
   out << err;
   EXPECT_EQ(out.TakeStr(), "x:1: test");
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/base/set_file_context_raii_test.cpp
+++ b/explorer/base/set_file_context_raii_test.cpp
@@ -7,7 +7,7 @@
 
 #include "explorer/base/trace_stream.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(SetFileContextRaiiTest, UpdateFileContext) {
@@ -34,4 +34,4 @@ TEST(SetFileContextRaiiTest, UpdateFileContext) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/base/set_program_phase_raii_test.cpp
+++ b/explorer/base/set_program_phase_raii_test.cpp
@@ -7,7 +7,7 @@
 
 #include "explorer/base/trace_stream.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 TEST(SetProgramPhaseRaiiTest, Simple) {
@@ -33,4 +33,4 @@ TEST(SetProgramPhaseRaiiTest, UpdatePhase) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/parse_and_execute/parse_and_execute_test.cpp
+++ b/explorer/parse_and_execute/parse_and_execute_test.cpp
@@ -7,7 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 using ::testing::MatchesRegex;
@@ -53,4 +53,4 @@ TEST(ParseAndExecuteTest, Recursion) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/syntax/parse_test.cpp
+++ b/explorer/syntax/parse_test.cpp
@@ -12,7 +12,7 @@
 
 #include "explorer/base/arena.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 static constexpr std::string_view FileContents = R"(
@@ -31,4 +31,4 @@ TEST(ParseTest, ParseFromString) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/explorer/syntax/unimplemented_example_test.cpp
+++ b/explorer/syntax/unimplemented_example_test.cpp
@@ -9,7 +9,7 @@
 #include "explorer/syntax/parse.h"
 #include "explorer/syntax/parse_test_matchers.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 using ::testing::ElementsAre;
@@ -34,4 +34,4 @@ TEST(UnimplementedExampleTest, VerifyPrecedence) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -10,8 +10,10 @@
 #include "llvm/ADT/StringRef.h"
 #include "toolchain/diagnostics/mocks.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
+
+using ::Carbon::Testing::IsDiagnostic;
 
 struct FakeDiagnosticLocationTranslator : DiagnosticLocationTranslator<int> {
   auto GetLocation(int n) -> DiagnosticLocation override {
@@ -68,4 +70,4 @@ TEST_F(DiagnosticEmitterTest, EmitNote) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
@@ -11,9 +11,10 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/mocks.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
+using ::Carbon::Testing::IsDiagnostic;
 using ::testing::InSequence;
 
 CARBON_DIAGNOSTIC(TestDiagnostic, Error, "{0}", llvm::StringRef);
@@ -61,4 +62,4 @@ TEST(SortedDiagnosticEmitterTest, SortErrors) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -17,13 +17,16 @@
 #include "testing/base/test_raw_ostream.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::_;
 using ::testing::ContainsRegex;
 using ::testing::HasSubstr;
 using ::testing::StrEq;
+
+namespace Yaml = ::Carbon::Testing::Yaml;
 
 // Reads a file to string.
 // TODO: Extract this to a helper and share it with other tests.
@@ -189,4 +192,4 @@ TEST_F(DriverTest, FileOutput) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon

--- a/toolchain/lex/numeric_literal_test.cpp
+++ b/toolchain/lex/numeric_literal_test.cpp
@@ -11,10 +11,9 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
 
-using Lex::NumericLiteral;
 using ::testing::_;
 using ::testing::Field;
 using ::testing::Matcher;
@@ -328,4 +327,4 @@ TEST_F(NumericLiteralTest, TooManyDigits) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/lex/string_literal_test.cpp
+++ b/toolchain/lex/string_literal_test.cpp
@@ -11,10 +11,8 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
-
-using Lex::StringLiteral;
 
 class StringLiteralTest : public ::testing::Test {
  protected:
@@ -347,4 +345,4 @@ TEST_F(StringLiteralTest, UnicodeTooManyDigits) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/lex/token_kind_test.cpp
+++ b/toolchain/lex/token_kind_test.cpp
@@ -9,10 +9,9 @@
 
 #include "llvm/ADT/StringRef.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
 
-using Lex::TokenKind;
 using ::testing::MatchesRegex;
 
 // We restrict symbols to punctuation characters that are expected to be widely
@@ -85,4 +84,4 @@ TEST(TokenKindTest, SymbolsInDescendingLength) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -17,17 +17,19 @@
 #include "toolchain/lex/tokenized_buffer_test_helpers.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
 
-using Lex::Token;
-using Lex::TokenizedBuffer;
-using Lex::TokenKind;
+using ::Carbon::Testing::ExpectedToken;
+using ::Carbon::Testing::IsDiagnostic;
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Pair;
+
+namespace Yaml = ::Carbon::Testing::Yaml;
 
 class LexerTest : public ::testing::Test {
  protected:
@@ -1030,4 +1032,4 @@ TEST_F(LexerTest, PrintingAsYaml) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/parse/precedence_test.cpp
+++ b/toolchain/parse/precedence_test.cpp
@@ -9,12 +9,9 @@
 
 #include "toolchain/lex/token_kind.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Parse {
 namespace {
 
-using Parse::Associativity;
-using Parse::OperatorPriority;
-using Parse::PrecedenceGroup;
 using ::testing::Eq;
 
 TEST(PrecedenceTest, OperatorsAreRecognized) {
@@ -158,4 +155,4 @@ TEST(PrecedenceTest, IncomparableOperators) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Parse

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -15,12 +15,14 @@
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Parse {
 namespace {
 
-using Parse::Tree;
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::ElementsAre;
 using ::testing::Pair;
+
+namespace Yaml = ::Carbon::Testing::Yaml;
 
 class TreeTest : public ::testing::Test {
  protected:
@@ -126,4 +128,4 @@ TEST_F(TreeTest, HighRecursion) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Parse

--- a/toolchain/sem_ir/file_test.cpp
+++ b/toolchain/sem_ir/file_test.cpp
@@ -12,9 +12,10 @@
 #include "toolchain/driver/driver.h"
 #include "toolchain/testing/yaml_test_helpers.h"
 
-namespace Carbon::Testing {
+namespace Carbon::SemIR {
 namespace {
 
+using ::Carbon::Testing::TestRawOstream;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::Contains;
@@ -24,6 +25,8 @@ using ::testing::IsEmpty;
 using ::testing::MatchesRegex;
 using ::testing::Pair;
 using ::testing::SizeIs;
+
+namespace Yaml = ::Carbon::Testing::Yaml;
 
 TEST(SemIRTest, YAML) {
   llvm::vfs::InMemoryFileSystem fs;
@@ -77,4 +80,4 @@ TEST(SemIRTest, YAML) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::SemIR

--- a/toolchain/source/source_buffer_test.cpp
+++ b/toolchain/source/source_buffer_test.cpp
@@ -10,7 +10,7 @@
 #include "llvm/Support/VirtualFileSystem.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
-namespace Carbon::Testing {
+namespace Carbon {
 namespace {
 
 static constexpr llvm::StringLiteral TestFileName = "test.carbon";
@@ -66,4 +66,4 @@ TEST(SourceBufferTest, EmptyFile) {
 }
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon


### PR DESCRIPTION
Rationale: this convention avoids forcing closely-related code to be far apart in the namespace hierarchy, and vice versa. By the same token, it makes the namespace hierarchy more consistent with the directory hierarchy.