### PR TITLE
Make autoupdate leave blaze-bin alone and produce less spam.

### DIFF
--- a/explorer/autoupdate_testdata.sh
+++ b/explorer/autoupdate_testdata.sh
@@ -4,5 +4,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-bazel run -c opt --test_sharding_strategy=disabled //explorer:file_test \
-  -- --autoupdate
+bazel run -c opt --experimental_convenience_symlinks=ignore \
+  --ui_event_filters=-info,-stdout,-stderr,-finish \
+  --test_sharding_strategy=disabled \
+  //explorer:file_test -- --autoupdate

--- a/testing/file_test/autoupdate_testdata.sh
+++ b/testing/file_test/autoupdate_testdata.sh
@@ -4,4 +4,6 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-bazel run -c opt //testing/file_test:file_test_base_test -- --autoupdate "$@"
+bazel run -c opt --experimental_convenience_symlinks=ignore \
+  --ui_event_filters=-info,-stdout,-stderr,-finish \
+  //testing/file_test:file_test_base_test -- --autoupdate "$@"

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -19,6 +19,8 @@ def main() -> None:
         "run",
         "-c",
         "opt",
+        "--experimental_convenience_symlinks=ignore",
+        "--ui_event_filters=-info,-stdout,-stderr,-finish",
         "//toolchain/testing:file_test",
         "--",
         "--autoupdate",


### PR DESCRIPTION
Minor changes to the blaze command line executed by our autoupdate scripts:

- Don't change the convenience symlinks. Running autoupdate shouldn't cause `./bazel-bin/...` to switch to running a different binary.
- Don't produce so much spam. Bazel will still log its build progress if necessary, and still report compile and runtime errors, but won't produce half a dozen lines of INFO at the start of the command.