### PR TITLE
Fix minor UB in the treesitter scanner.

### DIFF
--- a/utils/treesitter/src/scanner.c
+++ b/utils/treesitter/src/scanner.c
@@ -11,7 +11,7 @@ enum TokenType {
 };
 
 // our scanner is stateless
-void* tree_sitter_carbon_external_scanner_create() { return NULL; }
+void* tree_sitter_carbon_external_scanner_create(void) { return NULL; }
 
 unsigned tree_sitter_carbon_external_scanner_serialize(
     __attribute__((unused)) void* payload,


### PR DESCRIPTION
In C, the signature `f()` is distinct from `f(void)` -- dating from K&R style prototype-less functions. We need to use the `f(void)` form for the scanner creation function so that it can be called by function pointer `void *(*)(void)` without UB.

This was causing a local test that includes treesitter to fail with our fastbuild that enables most sanitizers. With this, we may be able to enable treesitter on our CI as well, but it at least fixes my local test runs.