### PR TITLE
Switch benchmarks to match unit test namespacing.

### DIFF
--- a/toolchain/lex/numeric_literal_benchmark.cpp
+++ b/toolchain/lex/numeric_literal_benchmark.cpp
@@ -8,10 +8,8 @@
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/numeric_literal.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
-
-using Lex::NumericLiteral;
 
 static void BM_Lex_Float(benchmark::State& state) {
   for (auto _ : state) {
@@ -49,4 +47,4 @@ BENCHMARK(BM_ComputeValue_Float);
 BENCHMARK(BM_ComputeValue_Integer);
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/lex/string_literal_benchmark.cpp
+++ b/toolchain/lex/string_literal_benchmark.cpp
@@ -7,10 +7,8 @@
 #include "toolchain/diagnostics/null_diagnostics.h"
 #include "toolchain/lex/string_literal.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
-
-using Lex::StringLiteral;
 
 static void BM_ValidString(benchmark::State& state, std::string_view introducer,
                            std::string_view terminator) {
@@ -117,4 +115,4 @@ BENCHMARK(BM_SimpleStringValue_MultilineDoubleQuote);
 BENCHMARK(BM_SimpleStringValue_Raw);
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -15,11 +15,8 @@
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
 
-namespace Carbon::Testing {
+namespace Carbon::Lex {
 namespace {
-
-using Lex::TokenizedBuffer;
-using Lex::TokenKind;
 
 // A large value for measurement stability without making benchmarking too slow.
 // Needs to be a multiple of 100 so we can easily divide it up into percentages,
@@ -383,4 +380,4 @@ BENCHMARK(BM_ValidMix)
     ->Args({75, 10});
 
 }  // namespace
-}  // namespace Carbon::Testing
+}  // namespace Carbon::Lex


### PR DESCRIPTION
Specifically, rather than nesting them in `Carbon::Testing`, nest them in `Carbon::Foo` for whatever component they're benchmarking. All our current benchmarks are lexer benchmarks so its `Carbon::Lex`.

This makes even more sense for benchmarks than unittests I think.