### PR TITLE
Add typed nodes to SemIR.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -154,6 +154,22 @@ cc_test(
 )
 
 cc_library(
+    name = "struct_reflection",
+    hdrs = ["struct_reflection.h"],
+)
+
+cc_test(
+    name = "struct_reflection_test",
+    size = "small",
+    srcs = ["struct_reflection_test.cpp"],
+    deps = [
+        ":struct_reflection",
+        "//testing/base:gtest_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "vlog",
     srcs = ["vlog_internal.h"],
     hdrs = ["vlog.h"],

--- a/common/struct_reflection.h
+++ b/common/struct_reflection.h
@@ -2,8 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_
-#define CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_
+#ifndef CARBON_COMMON_STRUCT_REFLECTION_H_
+#define CARBON_COMMON_STRUCT_REFLECTION_H_
 
 // Reflection support for simple struct types.
 //
@@ -159,4 +159,4 @@ auto AsTuple(T value) -> auto {
 
 }  // namespace Carbon::StructReflection
 
-#endif  // CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_
+#endif  // CARBON_COMMON_STRUCT_REFLECTION_H_

--- a/common/struct_reflection_test.cpp
+++ b/common/struct_reflection_test.cpp
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/base/struct_reflection.h"
+#include "common/struct_reflection.h"
 
 #include <gtest/gtest.h>
 
@@ -38,7 +38,7 @@ struct TwoFieldsNoDefaultConstructor {
   NoDefaultConstructor y;
 };
 
-TEST(ReflectionTest, CanListInitialize) {
+TEST(StructReflectionTest, CanListInitialize) {
   {
     using Type = OneField;
     using Field = Internal::AnyField<Type>;
@@ -56,7 +56,7 @@ TEST(ReflectionTest, CanListInitialize) {
   }
 }
 
-TEST(ReflectionTest, CountFields) {
+TEST(StructReflectionTest, CountFields) {
   static_assert(Internal::CountFields<ZeroFields>() == 0);
   static_assert(Internal::CountFields<OneField>() == 1);
   static_assert(Internal::CountFields<TwoFields>() == 2);
@@ -64,30 +64,30 @@ TEST(ReflectionTest, CountFields) {
   static_assert(Internal::CountFields<OneFieldNoDefaultConstructor>() == 1);
 }
 
-TEST(ReflectionTest, EmptyStruct) {
+TEST(StructReflectionTest, EmptyStruct) {
   std::tuple<> fields = AsTuple(ZeroFields());
   static_cast<void>(fields);
 }
 
-TEST(ReflectionTest, OneField) {
+TEST(StructReflectionTest, OneField) {
   std::tuple<int> fields = AsTuple(OneField{.x = 1});
   EXPECT_EQ(std::get<0>(fields), 1);
 }
 
-TEST(ReflectionTest, TwoField) {
+TEST(StructReflectionTest, TwoField) {
   std::tuple<int, int> fields = AsTuple(TwoFields{.x = 1, .y = 2});
   EXPECT_EQ(std::get<0>(fields), 1);
   EXPECT_EQ(std::get<1>(fields), 2);
 }
 
-TEST(ReflectionTest, NoDefaultConstructor) {
+TEST(StructReflectionTest, NoDefaultConstructor) {
   std::tuple<NoDefaultConstructor, NoDefaultConstructor> fields =
       AsTuple(TwoFieldsNoDefaultConstructor{.x = 1, .y = 2});
   EXPECT_EQ(std::get<0>(fields).v, 1);
   EXPECT_EQ(std::get<1>(fields).v, 2);
 }
 
-TEST(ReflectionTest, ReferenceField) {
+TEST(StructReflectionTest, ReferenceField) {
   int n = 0;
   std::tuple<int&> fields = AsTuple(ReferenceField{.ref = n});
   EXPECT_EQ(&std::get<0>(fields), &n);

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,5 +20,21 @@ cc_library(
     hdrs = ["pretty_stack_trace_function.h"],
     deps = [
         "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "struct_reflection",
+    hdrs = ["struct_reflection.h"],
+)
+
+cc_test(
+    name = "struct_reflection_test",
+    size = "small",
+    srcs = ["struct_reflection_test.cpp"],
+    deps = [
+        ":struct_reflection",
+        "//testing/base:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -2,7 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,21 +20,5 @@ cc_library(
     hdrs = ["pretty_stack_trace_function.h"],
     deps = [
         "@llvm-project//llvm:Support",
-    ],
-)
-
-cc_library(
-    name = "struct_reflection",
-    hdrs = ["struct_reflection.h"],
-)
-
-cc_test(
-    name = "struct_reflection_test",
-    size = "small",
-    srcs = ["struct_reflection_test.cpp"],
-    deps = [
-        ":struct_reflection",
-        "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
     ],
 )

--- a/toolchain/base/struct_reflection.h
+++ b/toolchain/base/struct_reflection.h
@@ -1,0 +1,162 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_
+#define CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_
+
+// Reflection support for simple struct types.
+//
+// Example usage:
+//
+// ```
+// struct A { int x; std::string y; };
+//
+// A a;
+// std::tuple<int, std::string> t = StructReflection::AsTuple(a);
+// ```
+//
+// Limitations:
+//
+// - Only simple aggregate structs are supported. Types with base classes,
+//   non-public data members, constructors, or virtual functions are not
+//   supported.
+// - Structs with more than 5 fields are not supported. This limit is easy to
+//   increase if needed, but removing it entirely is hard.
+// - Structs containing a reference to the same type are not supported.
+
+#include <tuple>
+#include <type_traits>
+
+namespace Carbon::StructReflection {
+
+namespace Internal {
+
+// A type that can be converted to any field type within type T.
+template <typename T>
+struct AnyField {
+  template <typename FieldT>
+  operator FieldT&() const;
+  template <typename FieldT>
+  operator FieldT&&() const;
+
+  // Don't allow conversion to T itself. This ensures we don't match against a
+  // copy or move constructor.
+  operator T&() const = delete;
+  operator T&&() const = delete;
+};
+
+// The detection mechanism below intentionally misses field initializers.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+
+// Detector for whether we can list-initialize T from the given list of fields.
+template <typename T, typename... Fields>
+constexpr bool CanListInitialize(decltype(T{Fields()...})*) {
+  return true;
+}
+template <typename T, typename... Fields>
+constexpr bool CanListInitialize(...) {
+  return false;
+}
+
+#pragma clang diagnostic pop
+
+// Simple detector to find the number of data fields in a struct. This proceeds
+// in two passes:
+//
+// 1) Add AnyField<T>s until we can initialize T from our list of initializers.
+// 2) Add more AnyField<T>s until we can't initialize any more.
+template <typename T, bool AnyWorkedSoFar = false, typename... Fields>
+constexpr auto CountFields() -> int {
+  if constexpr (CanListInitialize<T, Fields...>(0)) {
+    return CountFields<T, true, Fields..., AnyField<T>>();
+  } else if constexpr (AnyWorkedSoFar) {
+    static_assert(sizeof...(Fields) <= 5,
+                  "Unsupported: too many fields in struct");
+    return sizeof...(Fields) - 1;
+  } else if constexpr (sizeof...(Fields) > 32) {
+    // If we go too far without finding a working initializer, something
+    // probably went wrong with our calculation. Bail out before we recurse too
+    // deeply.
+    static_assert(sizeof...(Fields) <= 32,
+                  "Internal error, could not count fields in struct");
+  } else {
+    return CountFields<T, false, Fields..., AnyField<T>>();
+  }
+}
+
+// Utility to access fields by index.
+template <int NumFields>
+struct FieldAccessor;
+
+template <>
+struct FieldAccessor<0> {
+  template <typename T>
+  static auto Get(T& /*value*/) -> auto {
+    return std::tuple<>();
+  }
+};
+
+template <>
+struct FieldAccessor<1> {
+  template <typename T>
+  static auto Get(T& value) -> auto {
+    auto& [field0] = value;
+    return std::tuple<decltype(field0)>(field0);
+  }
+};
+
+template <>
+struct FieldAccessor<2> {
+  template <typename T>
+  static auto Get(T& value) -> auto {
+    auto& [field0, field1] = value;
+    return std::tuple<decltype(field0), decltype(field1)>(field0, field1);
+  }
+};
+
+template <>
+struct FieldAccessor<3> {
+  template <typename T>
+  static auto Get(T& value) -> auto {
+    auto& [field0, field1, field2] = value;
+    return std::tuple<decltype(field0), decltype(field1), decltype(field2)>(
+        field0, field1, field2);
+  }
+};
+
+template <>
+struct FieldAccessor<4> {
+  template <typename T>
+  static auto Get(T& value) -> auto {
+    auto& [field0, field1, field2, field3] = value;
+    return std::tuple<decltype(field0), decltype(field1), decltype(field2),
+                      decltype(field3)>(field0, field1, field2, field3);
+  }
+};
+
+template <>
+struct FieldAccessor<5> {
+  template <typename T>
+  static auto Get(T& value) -> auto {
+    auto& [field0, field1, field2, field3, field4] = value;
+    return std::tuple<decltype(field0), decltype(field1), decltype(field2),
+                      decltype(field3), decltype(field4)>(
+        field0, field1, field2, field3, field4);
+  }
+};
+
+}  // namespace Internal
+
+// Get the fields of the struct `T` as a tuple.
+template <typename T>
+auto AsTuple(T value) -> auto {
+  // We use aggregate initialization to detect the number of fields.
+  static_assert(std::is_aggregate_v<T>, "Only aggregates are supported");
+  return Internal::FieldAccessor<Internal::CountFields<T>()>::Get(value);
+}
+
+}  // namespace Carbon::StructReflection
+
+#endif  // CARBON_TOOLCHAIN_BASE_STRUCT_REFLECTION_H_

--- a/toolchain/base/struct_reflection_test.cpp
+++ b/toolchain/base/struct_reflection_test.cpp
@@ -1,0 +1,97 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/base/struct_reflection.h"
+
+#include <gtest/gtest.h>
+
+namespace Carbon::StructReflection {
+namespace {
+
+struct ZeroFields {};
+
+struct OneField {
+  int x;
+};
+
+struct TwoFields {
+  int x;
+  int y;
+};
+
+struct ReferenceField {
+  int& ref;
+};
+
+struct NoDefaultConstructor {
+  NoDefaultConstructor(int n) : v(n) {}
+  int v;
+};
+
+struct OneFieldNoDefaultConstructor {
+  NoDefaultConstructor x;
+};
+
+struct TwoFieldsNoDefaultConstructor {
+  NoDefaultConstructor x;
+  NoDefaultConstructor y;
+};
+
+TEST(ReflectionTest, CanListInitialize) {
+  {
+    using Type = OneField;
+    using Field = Internal::AnyField<Type>;
+    static_assert(Internal::CanListInitialize<Type>(0));
+    static_assert(Internal::CanListInitialize<Type, Field>(0));
+    static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
+  }
+
+  {
+    using Type = OneFieldNoDefaultConstructor;
+    using Field = Internal::AnyField<Type>;
+    static_assert(!Internal::CanListInitialize<Type>(0));
+    static_assert(Internal::CanListInitialize<Type, Field>(0));
+    static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
+  }
+}
+
+TEST(ReflectionTest, CountFields) {
+  static_assert(Internal::CountFields<ZeroFields>() == 0);
+  static_assert(Internal::CountFields<OneField>() == 1);
+  static_assert(Internal::CountFields<TwoFields>() == 2);
+  static_assert(Internal::CountFields<ReferenceField>() == 1);
+  static_assert(Internal::CountFields<OneFieldNoDefaultConstructor>() == 1);
+}
+
+TEST(ReflectionTest, EmptyStruct) {
+  std::tuple<> fields = AsTuple(ZeroFields());
+  static_cast<void>(fields);
+}
+
+TEST(ReflectionTest, OneField) {
+  std::tuple<int> fields = AsTuple(OneField{.x = 1});
+  EXPECT_EQ(std::get<0>(fields), 1);
+}
+
+TEST(ReflectionTest, TwoField) {
+  std::tuple<int, int> fields = AsTuple(TwoFields{.x = 1, .y = 2});
+  EXPECT_EQ(std::get<0>(fields), 1);
+  EXPECT_EQ(std::get<1>(fields), 2);
+}
+
+TEST(ReflectionTest, NoDefaultConstructor) {
+  std::tuple<NoDefaultConstructor, NoDefaultConstructor> fields =
+      AsTuple(TwoFieldsNoDefaultConstructor{.x = 1, .y = 2});
+  EXPECT_EQ(std::get<0>(fields).v, 1);
+  EXPECT_EQ(std::get<1>(fields).v, 2);
+}
+
+TEST(ReflectionTest, ReferenceField) {
+  int n = 0;
+  std::tuple<int&> fields = AsTuple(ReferenceField{.ref = n});
+  EXPECT_EQ(&std::get<0>(fields), &n);
+}
+
+}  // namespace
+}  // namespace Carbon::StructReflection

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -170,27 +170,27 @@ static auto AddDominatedBlockAndBranchImpl(Context& context,
     return SemIR::NodeBlockId::Unreachable;
   }
   auto block_id = context.semantics_ir().AddNodeBlockId();
-  context.AddNode(BranchNode::Make(parse_node, block_id, args...));
+  context.AddNode(BranchNode(parse_node, block_id, args...));
   return block_id;
 }
 
 auto Context::AddDominatedBlockAndBranch(Parse::Node parse_node)
     -> SemIR::NodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemIR::Node::Branch>(*this, parse_node);
+  return AddDominatedBlockAndBranchImpl<SemIR::Branch>(*this, parse_node);
 }
 
 auto Context::AddDominatedBlockAndBranchWithArg(Parse::Node parse_node,
                                                 SemIR::NodeId arg_id)
     -> SemIR::NodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemIR::Node::BranchWithArg>(
-      *this, parse_node, arg_id);
+  return AddDominatedBlockAndBranchImpl<SemIR::BranchWithArg>(*this, parse_node,
+                                                              arg_id);
 }
 
 auto Context::AddDominatedBlockAndBranchIf(Parse::Node parse_node,
                                            SemIR::NodeId cond_id)
     -> SemIR::NodeBlockId {
-  return AddDominatedBlockAndBranchImpl<SemIR::Node::BranchIf>(
-      *this, parse_node, cond_id);
+  return AddDominatedBlockAndBranchImpl<SemIR::BranchIf>(*this, parse_node,
+                                                         cond_id);
 }
 
 auto Context::AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
@@ -203,7 +203,7 @@ auto Context::AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlockId();
       }
-      AddNode(SemIR::Node::Branch::Make(parse_node, new_block_id));
+      AddNode(SemIR::Branch(parse_node, new_block_id));
     }
     node_block_stack().Pop();
   }
@@ -222,7 +222,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
         new_block_id = semantics_ir().AddNodeBlockId();
       }
       AddNode(
-          SemIR::Node::BranchWithArg::Make(parse_node, new_block_id, arg_id));
+          SemIR::BranchWithArg(parse_node, new_block_id, arg_id));
     }
     node_block_stack().Pop();
   }
@@ -232,7 +232,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
   SemIR::TypeId result_type_id =
       semantics_ir().GetNode(*block_args.begin()).type_id();
   return AddNode(
-      SemIR::Node::BlockArg::Make(parse_node, result_type_id, new_block_id));
+      SemIR::BlockArg(parse_node, result_type_id, new_block_id));
 }
 
 // Add the current code block to the enclosing function.
@@ -412,7 +412,7 @@ auto Context::CanonicalizeType(SemIR::NodeId node_id) -> SemIR::TypeId {
 auto Context::CanonicalizeStructType(Parse::Node parse_node,
                                      SemIR::NodeBlockId refs_id)
     -> SemIR::TypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemIR::Node::StructType::Make(
+  return CanonicalizeTypeAndAddNodeIfNew(SemIR::StructType(
       parse_node, SemIR::TypeId::TypeType, refs_id));
 }
 
@@ -425,7 +425,7 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
   };
   auto make_tuple_node = [&] {
     return AddNode(
-        SemIR::Node::TupleType::Make(parse_node, SemIR::TypeId::TypeType,
+        SemIR::TupleType(parse_node, SemIR::TypeId::TypeType,
                                      semantics_ir_->AddTypeBlock(type_ids)));
   };
   return CanonicalizeTypeImpl(SemIR::NodeKind::TupleType, profile_tuple,
@@ -434,7 +434,7 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
 
 auto Context::GetPointerType(Parse::Node parse_node,
                              SemIR::TypeId pointee_type_id) -> SemIR::TypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemIR::Node::PointerType::Make(
+  return CanonicalizeTypeAndAddNodeIfNew(SemIR::PointerType(
       parse_node, SemIR::TypeId::TypeType, pointee_type_id));
 }
 

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -221,8 +221,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
         new_block_id = semantics_ir().AddNodeBlockId();
       }
-      AddNode(
-          SemIR::BranchWithArg(parse_node, new_block_id, arg_id));
+      AddNode(SemIR::BranchWithArg(parse_node, new_block_id, arg_id));
     }
     node_block_stack().Pop();
   }
@@ -231,8 +230,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
   // Acquire the result value.
   SemIR::TypeId result_type_id =
       semantics_ir().GetNode(*block_args.begin()).type_id();
-  return AddNode(
-      SemIR::BlockArg(parse_node, result_type_id, new_block_id));
+  return AddNode(SemIR::BlockArg(parse_node, result_type_id, new_block_id));
 }
 
 // Add the current code block to the enclosing function.
@@ -358,7 +356,8 @@ static auto ProfileType(Context& semantics_context, SemIR::Node node,
     }
     case SemIR::NodeKind::ConstType:
       canonical_id.AddInteger(
-          semantics_context.GetUnqualifiedType(node.As<SemIR::ConstType>().inner_id)
+          semantics_context
+              .GetUnqualifiedType(node.As<SemIR::ConstType>().inner_id)
               .index);
       break;
     case SemIR::NodeKind::PointerType:
@@ -412,8 +411,8 @@ auto Context::CanonicalizeType(SemIR::NodeId node_id) -> SemIR::TypeId {
 auto Context::CanonicalizeStructType(Parse::Node parse_node,
                                      SemIR::NodeBlockId refs_id)
     -> SemIR::TypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemIR::StructType(
-      parse_node, SemIR::TypeId::TypeType, refs_id));
+  return CanonicalizeTypeAndAddNodeIfNew(
+      SemIR::StructType(parse_node, SemIR::TypeId::TypeType, refs_id));
 }
 
 auto Context::CanonicalizeTupleType(Parse::Node parse_node,
@@ -424,9 +423,8 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
     ProfileTupleType(type_ids, canonical_id);
   };
   auto make_tuple_node = [&] {
-    return AddNode(
-        SemIR::TupleType(parse_node, SemIR::TypeId::TypeType,
-                                     semantics_ir_->AddTypeBlock(type_ids)));
+    return AddNode(SemIR::TupleType(parse_node, SemIR::TypeId::TypeType,
+                                    semantics_ir_->AddTypeBlock(type_ids)));
   };
   return CanonicalizeTypeImpl(SemIR::NodeKind::TupleType, profile_tuple,
                               make_tuple_node);
@@ -434,8 +432,8 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
 
 auto Context::GetPointerType(Parse::Node parse_node,
                              SemIR::TypeId pointee_type_id) -> SemIR::TypeId {
-  return CanonicalizeTypeAndAddNodeIfNew(SemIR::PointerType(
-      parse_node, SemIR::TypeId::TypeType, pointee_type_id));
+  return CanonicalizeTypeAndAddNodeIfNew(
+      SemIR::PointerType(parse_node, SemIR::TypeId::TypeType, pointee_type_id));
 }
 
 auto Context::GetUnqualifiedType(SemIR::TypeId type_id) -> SemIR::TypeId {

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -134,7 +134,7 @@ static auto MakeElemAccessNode(Context& context, Parse::Node parse_node,
     // special case.
     auto index_id = block.AddNode(SemIR::IntegerLiteral(
         parse_node, context.CanonicalizeType(SemIR::NodeId::BuiltinIntegerType),
-        context.semantics_ir().AddIntegerValue(llvm::APInt(32, i))));
+        context.semantics_ir().AddInteger(llvm::APInt(32, i))));
     return block.AddNode(
         AccessNodeT(parse_node, elem_type_id, aggregate_id, index_id));
   } else {

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -133,7 +133,7 @@ static auto MakeElemAccessNode(Context& context, Parse::Node parse_node,
     // special case.
     auto index_id = block.AddNode(SemIR::Node::IntegerLiteral::Make(
         parse_node, context.CanonicalizeType(SemIR::NodeId::BuiltinIntegerType),
-        context.semantics_ir().AddIntegerLiteral(llvm::APInt(32, i))));
+        context.semantics_ir().AddIntegerValue(llvm::APInt(32, i))));
     return block.AddNode(
         AccessNodeT::Make(parse_node, elem_type_id, aggregate_id, index_id));
   } else {

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -37,21 +37,22 @@ static auto FindReturnSlotForInitializer(SemIR::File& semantics_ir,
                         "filled in properly";
 
     case SemIR::NodeKind::InitializeFrom: {
-      auto [src_id, dest_id] = init.GetAsInitializeFrom();
-      return dest_id;
+      return init.As<SemIR::InitializeFrom>().dest_id;
     }
 
     case SemIR::NodeKind::Call: {
-      auto [refs_id, callee_id] = init.GetAsCall();
-      if (!semantics_ir.GetFunction(callee_id).return_slot_id.is_valid()) {
+      auto call = init.As<SemIR::Call>();
+      if (!semantics_ir.GetFunction(call.function_id)
+               .return_slot_id.is_valid()) {
         return SemIR::NodeId::Invalid;
       }
-      return semantics_ir.GetNodeBlock(refs_id).back();
+      return semantics_ir.GetNodeBlock(call.args_id).back();
     }
 
     case SemIR::NodeKind::ArrayInit: {
-      auto [src_id, refs_id] = init.GetAsArrayInit();
-      return semantics_ir.GetNodeBlock(refs_id).back();
+      return semantics_ir
+          .GetNodeBlock(init.As<SemIR::ArrayInit>().inits_and_return_slot_id)
+          .back();
     }
   }
 }
@@ -229,13 +230,13 @@ class CopyOnWriteBlock {
 
 // Performs a conversion from a tuple to an array type. Does not perform a
 // final conversion to the requested expression category.
-static auto ConvertTupleToArray(Context& context, SemIR::Node tuple_type,
-                                SemIR::Node array_type, SemIR::NodeId value_id,
-                                ConversionTarget target) -> SemIR::NodeId {
+static auto ConvertTupleToArray(Context& context,
+                                SemIR::TupleType::Data tuple_type,
+                                SemIR::ArrayType::Data array_type,
+                                SemIR::NodeId value_id, ConversionTarget target)
+    -> SemIR::NodeId {
   auto& semantics_ir = context.semantics_ir();
-  auto [array_bound_id, element_type_id] = array_type.GetAsArrayType();
-  auto tuple_elem_types_id = tuple_type.GetAsTupleType();
-  const auto& tuple_elem_types = semantics_ir.GetTypeBlock(tuple_elem_types_id);
+  auto tuple_elem_types = semantics_ir.GetTypeBlock(tuple_type.elements_id);
 
   auto value = semantics_ir.GetNode(value_id);
 
@@ -243,14 +244,14 @@ static auto ConvertTupleToArray(Context& context, SemIR::Node tuple_type,
   // directly. Otherwise, materialize a temporary if needed and index into the
   // result.
   llvm::ArrayRef<SemIR::NodeId> literal_elems;
-  if (value.kind() == SemIR::NodeKind::TupleLiteral) {
-    literal_elems = semantics_ir.GetNodeBlock(value.GetAsTupleLiteral());
+  if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
+    literal_elems = semantics_ir.GetNodeBlock(tuple_literal->elements_id);
   } else {
     value_id = MaterializeIfInitializing(context, value_id);
   }
 
   // Check that the tuple is the right size.
-  uint64_t array_bound = semantics_ir.GetArrayBoundValue(array_bound_id);
+  uint64_t array_bound = semantics_ir.GetArrayBoundValue(array_type.bound_id);
   if (tuple_elem_types.size() != array_bound) {
     CARBON_DIAGNOSTIC(
         ArrayInitFromLiteralArgCountMismatch, Error,
@@ -292,8 +293,8 @@ static auto ConvertTupleToArray(Context& context, SemIR::Node tuple_type,
     auto init_id = ConvertAggregateElement<SemIR::Node::TupleAccess,
                                            SemIR::Node::ArrayIndex>(
         context, value.parse_node(), value_id, src_type_id, literal_elems,
-        ConversionTarget::FullInitializer, return_slot_id, element_type_id,
-        target_block, i);
+        ConversionTarget::FullInitializer, return_slot_id,
+        array_type.element_type_id, target_block, i);
     if (init_id == SemIR::NodeId::BuiltinError) {
       return SemIR::NodeId::BuiltinError;
     }
@@ -312,12 +313,14 @@ static auto ConvertTupleToArray(Context& context, SemIR::Node tuple_type,
 
 // Performs a conversion from a tuple to a tuple type. Does not perform a
 // final conversion to the requested expression category.
-static auto ConvertTupleToTuple(Context& context, SemIR::Node src_type,
-                                SemIR::Node dest_type, SemIR::NodeId value_id,
-                                ConversionTarget target) -> SemIR::NodeId {
+static auto ConvertTupleToTuple(Context& context,
+                                SemIR::TupleType::Data src_type,
+                                SemIR::TupleType::Data dest_type,
+                                SemIR::NodeId value_id, ConversionTarget target)
+    -> SemIR::NodeId {
   auto& semantics_ir = context.semantics_ir();
-  auto src_elem_types = semantics_ir.GetTypeBlock(src_type.GetAsTupleType());
-  auto dest_elem_types = semantics_ir.GetTypeBlock(dest_type.GetAsTupleType());
+  auto src_elem_types = semantics_ir.GetTypeBlock(src_type.elements_id);
+  auto dest_elem_types = semantics_ir.GetTypeBlock(dest_type.elements_id);
 
   auto value = semantics_ir.GetNode(value_id);
 
@@ -325,8 +328,10 @@ static auto ConvertTupleToTuple(Context& context, SemIR::Node src_type,
   // directly. Otherwise, materialize a temporary if needed and index into the
   // result.
   llvm::ArrayRef<SemIR::NodeId> literal_elems;
-  if (value.kind() == SemIR::NodeKind::TupleLiteral) {
-    literal_elems = semantics_ir.GetNodeBlock(value.GetAsTupleLiteral());
+  auto literal_elems_id = SemIR::NodeBlockId::Invalid;
+  if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
+    literal_elems_id = tuple_literal->elements_id;
+    literal_elems = semantics_ir.GetNodeBlock(literal_elems_id);
   } else {
     value_id = MaterializeIfInitializing(context, value_id);
   }
@@ -357,10 +362,7 @@ static auto ConvertTupleToTuple(Context& context, SemIR::Node src_type,
   // Initialize each element of the destination from the corresponding element
   // of the source.
   // TODO: Annotate diagnostics coming from here with the element index.
-  CopyOnWriteBlock new_block(semantics_ir,
-                             value.kind() == SemIR::NodeKind::TupleLiteral
-                                 ? value.GetAsTupleLiteral()
-                                 : SemIR::NodeBlockId::Invalid,
+  CopyOnWriteBlock new_block(semantics_ir, literal_elems_id,
                              src_elem_types.size());
   for (auto [i, src_type_id, dest_type_id] :
        llvm::enumerate(src_elem_types, dest_elem_types)) {
@@ -386,13 +388,14 @@ static auto ConvertTupleToTuple(Context& context, SemIR::Node src_type,
 
 // Performs a conversion from a struct to a struct type. Does not perform a
 // final conversion to the requested expression category.
-static auto ConvertStructToStruct(Context& context, SemIR::Node src_type,
-                                  SemIR::Node dest_type, SemIR::NodeId value_id,
+static auto ConvertStructToStruct(Context& context,
+                                  SemIR::StructType::Data src_type,
+                                  SemIR::StructType::Data dest_type,
+                                  SemIR::NodeId value_id,
                                   ConversionTarget target) -> SemIR::NodeId {
   auto& semantics_ir = context.semantics_ir();
-  auto src_elem_fields = semantics_ir.GetNodeBlock(src_type.GetAsStructType());
-  auto dest_elem_fields =
-      semantics_ir.GetNodeBlock(dest_type.GetAsStructType());
+  auto src_elem_fields = semantics_ir.GetNodeBlock(src_type.fields_id);
+  auto dest_elem_fields = semantics_ir.GetNodeBlock(dest_type.fields_id);
 
   auto value = semantics_ir.GetNode(value_id);
 
@@ -400,8 +403,10 @@ static auto ConvertStructToStruct(Context& context, SemIR::Node src_type,
   // directly. Otherwise, materialize a temporary if needed and index into the
   // result.
   llvm::ArrayRef<SemIR::NodeId> literal_elems;
-  if (value.kind() == SemIR::NodeKind::StructLiteral) {
-    literal_elems = semantics_ir.GetNodeBlock(value.GetAsStructLiteral());
+  auto literal_elems_id = SemIR::NodeBlockId::Invalid;
+  if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
+    literal_elems_id = tuple_literal->elements_id;
+    literal_elems = semantics_ir.GetNodeBlock(literal_elems_id);
   } else {
     value_id = MaterializeIfInitializing(context, value_id);
   }
@@ -434,26 +439,23 @@ static auto ConvertStructToStruct(Context& context, SemIR::Node src_type,
   // Initialize each element of the destination from the corresponding element
   // of the source.
   // TODO: Annotate diagnostics coming from here with the element index.
-  CopyOnWriteBlock new_block(semantics_ir,
-                             value.kind() == SemIR::NodeKind::StructLiteral
-                                 ? value.GetAsStructLiteral()
-                                 : SemIR::NodeBlockId::Invalid,
+  CopyOnWriteBlock new_block(semantics_ir, literal_elems_id,
                              src_elem_fields.size());
   for (auto [i, src_field_id, dest_field_id] :
        llvm::enumerate(src_elem_fields, dest_elem_fields)) {
-    auto [src_name_id, src_type_id] =
-        semantics_ir.GetNode(src_field_id).GetAsStructTypeField();
-    auto [dest_name_id, dest_type_id] =
-        semantics_ir.GetNode(dest_field_id).GetAsStructTypeField();
-    if (src_name_id != dest_name_id) {
+    auto src_field =
+        semantics_ir.GetNodeAs<SemIR::StructTypeField>(src_field_id);
+    auto dest_field =
+        semantics_ir.GetNodeAs<SemIR::StructTypeField>(dest_field_id);
+    if (src_field.name_id != dest_field.name_id) {
       CARBON_DIAGNOSTIC(
           StructInitFieldNameMismatch, Error,
           "Mismatched names for field {0} in struct initialization: "
           "source has field name `{1}`, destination has field name `{2}`.",
           size_t, llvm::StringRef, llvm::StringRef);
       context.emitter().Emit(value.parse_node(), StructInitFieldNameMismatch,
-                             i + 1, semantics_ir.GetString(src_name_id),
-                             semantics_ir.GetString(dest_name_id));
+                             i + 1, semantics_ir.GetString(src_field.name_id),
+                             semantics_ir.GetString(dest_field.name_id));
       return SemIR::NodeId::BuiltinError;
     }
 
@@ -461,8 +463,8 @@ static auto ConvertStructToStruct(Context& context, SemIR::Node src_type,
     // approach.
     auto init_id = ConvertAggregateElement<SemIR::Node::StructAccess,
                                            SemIR::Node::StructAccess>(
-        context, value.parse_node(), value_id, src_type_id, literal_elems,
-        inner_kind, target.init_id, dest_type_id, target.init_block, i);
+        context, value.parse_node(), value_id, src_field.type_id, literal_elems,
+        inner_kind, target.init_id, dest_field.type_id, target.init_block, i);
     if (init_id == SemIR::NodeId::BuiltinError) {
       return SemIR::NodeId::BuiltinError;
     }
@@ -544,11 +546,11 @@ static auto PerformBuiltinConversion(Context& context, Parse::Node parse_node,
 
   // A tuple (T1, T2, ..., Tn) converts to (U1, U2, ..., Un) if each Ti
   // converts to Ui.
-  if (target_type_node.kind() == SemIR::NodeKind::TupleType) {
+  if (auto target_tuple_type = target_type_node.TryAs<SemIR::TupleType>()) {
     auto value_type_node = semantics_ir.GetNode(
         semantics_ir.GetTypeAllowBuiltinTypes(value_type_id));
-    if (value_type_node.kind() == SemIR::NodeKind::TupleType) {
-      return ConvertTupleToTuple(context, value_type_node, target_type_node,
+    if (auto src_tuple_type = value_type_node.TryAs<SemIR::TupleType>()) {
+      return ConvertTupleToTuple(context, *src_tuple_type, *target_tuple_type,
                                  value_id, target);
     }
   }
@@ -557,21 +559,21 @@ static auto PerformBuiltinConversion(Context& context, Parse::Node parse_node,
   // {.f_p(1): U_p(1), .f_p(2): U_p(2), ..., .f_p(n): U_p(n)} if
   // (p(1), ..., p(n)) is a permutation of (1, ..., n) and each Ti converts
   // to Ui.
-  if (target_type_node.kind() == SemIR::NodeKind::StructType) {
+  if (auto target_struct_type = target_type_node.TryAs<SemIR::StructType>()) {
     auto value_type_node = semantics_ir.GetNode(
         semantics_ir.GetTypeAllowBuiltinTypes(value_type_id));
-    if (value_type_node.kind() == SemIR::NodeKind::StructType) {
-      return ConvertStructToStruct(context, value_type_node, target_type_node,
-                                   value_id, target);
+    if (auto src_struct_type = value_type_node.TryAs<SemIR::StructType>()) {
+      return ConvertStructToStruct(context, *src_struct_type,
+                                   *target_struct_type, value_id, target);
     }
   }
 
   // A tuple (T1, T2, ..., Tn) converts to [T; n] if each Ti converts to T.
-  if (target_type_node.kind() == SemIR::NodeKind::ArrayType) {
+  if (auto target_array_type = target_type_node.TryAs<SemIR::ArrayType>()) {
     auto value_type_node = semantics_ir.GetNode(
         semantics_ir.GetTypeAllowBuiltinTypes(value_type_id));
-    if (value_type_node.kind() == SemIR::NodeKind::TupleType) {
-      return ConvertTupleToArray(context, value_type_node, target_type_node,
+    if (auto src_tuple_type = value_type_node.TryAs<SemIR::TupleType>()) {
+      return ConvertTupleToArray(context, *src_tuple_type, *target_array_type,
                                  value_id, target);
     }
   }
@@ -579,18 +581,14 @@ static auto PerformBuiltinConversion(Context& context, Parse::Node parse_node,
   if (target.type_id == SemIR::TypeId::TypeType) {
     // A tuple of types converts to type `type`.
     // TODO: This should apply even for non-literal tuples.
-    if (value.kind() == SemIR::NodeKind::TupleLiteral) {
-      auto tuple_block_id = value.GetAsTupleLiteral();
+    if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
       llvm::SmallVector<SemIR::TypeId> type_ids;
-      // If it is empty tuple type, we don't fetch anything.
-      if (tuple_block_id != SemIR::NodeBlockId::Empty) {
-        const auto& tuple_block = semantics_ir.GetNodeBlock(tuple_block_id);
-        for (auto tuple_node_id : tuple_block) {
-          // TODO: This call recurses back into conversion. Switch to an
-          // iterative approach.
-          type_ids.push_back(
-              ExpressionAsType(context, parse_node, tuple_node_id));
-        }
+      for (auto tuple_node_id :
+           semantics_ir.GetNodeBlock(tuple_literal->elements_id)) {
+        // TODO: This call recurses back into conversion. Switch to an
+        // iterative approach.
+        type_ids.push_back(
+            ExpressionAsType(context, parse_node, tuple_node_id));
       }
       auto tuple_type_id =
           context.CanonicalizeTupleType(parse_node, std::move(type_ids));
@@ -600,8 +598,9 @@ static auto PerformBuiltinConversion(Context& context, Parse::Node parse_node,
     // `{}` converts to `{} as type`.
     // TODO: This conversion should also be performed for a non-literal value
     // of type `{}`.
-    if (value.kind() == SemIR::NodeKind::StructLiteral &&
-        value.GetAsStructLiteral() == SemIR::NodeBlockId::Empty) {
+    if (auto struct_literal = value.TryAs<SemIR::StructLiteral>();
+        struct_literal &&
+        struct_literal->elements_id == SemIR::NodeBlockId::Empty) {
       value_id = semantics_ir.GetTypeAllowBuiltinTypes(value_type_id);
     }
   }

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -90,8 +90,8 @@ static auto FinalizeTemporary(Context& context, SemIR::NodeId init_id,
         << "initialized multiple times? Have "
         << semantics_ir.GetNode(return_slot_id);
     auto init = semantics_ir.GetNode(init_id);
-    return context.AddNode(SemIR::Temporary(
-        init.parse_node(), init.type_id(), return_slot_id, init_id));
+    return context.AddNode(SemIR::Temporary(init.parse_node(), init.type_id(),
+                                            return_slot_id, init_id));
   }
 
   if (discarded) {
@@ -107,8 +107,8 @@ static auto FinalizeTemporary(Context& context, SemIR::NodeId init_id,
   auto init = semantics_ir.GetNode(init_id);
   auto temporary_id = context.AddNode(
       SemIR::TemporaryStorage(init.parse_node(), init.type_id()));
-  return context.AddNode(SemIR::Temporary(
-      init.parse_node(), init.type_id(), temporary_id, init_id));
+  return context.AddNode(SemIR::Temporary(init.parse_node(), init.type_id(),
+                                          temporary_id, init_id));
 }
 
 // Materialize a temporary to hold the result of the given expression if it is
@@ -277,8 +277,8 @@ static auto ConvertTupleToArray(Context& context,
   // destination for the array initialization if we weren't given one.
   SemIR::NodeId return_slot_id = target.init_id;
   if (!target.init_id.is_valid()) {
-    return_slot_id = target_block->AddNode(SemIR::TemporaryStorage(
-        value.parse_node(), target.type_id));
+    return_slot_id = target_block->AddNode(
+        SemIR::TemporaryStorage(value.parse_node(), target.type_id));
   }
 
   // Initialize each element of the array from the corresponding element of the
@@ -306,9 +306,9 @@ static auto ConvertTupleToArray(Context& context,
   target_block->InsertHere();
   inits.push_back(return_slot_id);
 
-  return context.AddNode(
-      SemIR::ArrayInit(value.parse_node(), target.type_id, value_id,
-                                   semantics_ir.AddNodeBlock(inits)));
+  return context.AddNode(SemIR::ArrayInit(value.parse_node(), target.type_id,
+                                          value_id,
+                                          semantics_ir.AddNodeBlock(inits)));
 }
 
 // Performs a conversion from a tuple to a tuple type. Does not perform a
@@ -692,8 +692,8 @@ auto Convert(Context& context, Parse::Node parse_node, SemIR::NodeId expr_id,
       if (target.kind != ConversionTarget::ValueOrReference &&
           target.kind != ConversionTarget::Discarded) {
         // TODO: Support types with custom value representations.
-        expr_id = context.AddNode(SemIR::BindValue(
-            expr.parse_node(), expr.type_id(), expr_id));
+        expr_id = context.AddNode(
+            SemIR::BindValue(expr.parse_node(), expr.type_id(), expr_id));
       }
       break;
     }

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -404,8 +404,8 @@ static auto ConvertStructToStruct(Context& context,
   // result.
   llvm::ArrayRef<SemIR::NodeId> literal_elems;
   auto literal_elems_id = SemIR::NodeBlockId::Invalid;
-  if (auto tuple_literal = value.TryAs<SemIR::TupleLiteral>()) {
-    literal_elems_id = tuple_literal->elements_id;
+  if (auto struct_literal = value.TryAs<SemIR::StructLiteral>()) {
+    literal_elems_id = struct_literal->elements_id;
     literal_elems = semantics_ir.GetNodeBlock(literal_elems_id);
   } else {
     value_id = MaterializeIfInitializing(context, value_id);

--- a/toolchain/check/declaration_name_stack.cpp
+++ b/toolchain/check/declaration_name_stack.cpp
@@ -120,7 +120,8 @@ auto DeclarationNameStack::UpdateScopeIfNeeded(NameContext& name_context)
   switch (resolved_node.kind()) {
     case SemIR::NodeKind::Namespace:
       name_context.state = NameContext::State::Resolved;
-      name_context.target_scope_id = resolved_node.GetAsNamespace();
+      name_context.target_scope_id =
+          resolved_node.As<SemIR::Namespace>().name_scope_id;
       break;
     default:
       name_context.state = NameContext::State::ResolvedNonScope;

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -35,9 +35,9 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
       .PopAndDiscardSoloParseNode<Parse::NodeKind::ArrayExpressionSemi>();
   auto element_type_node_id = context.node_stack().PopExpression();
   auto bound_node = context.semantics_ir().GetNode(bound_node_id);
-  if (bound_node.kind() == SemIR::NodeKind::IntegerLiteral) {
-    auto bound_value = context.semantics_ir().GetIntegerValue(
-        bound_node.GetAsIntegerLiteral());
+  if (auto literal = bound_node.TryAs<SemIR::IntegerLiteral>()) {
+    const auto& bound_value =
+        context.semantics_ir().GetIntegerValue(literal->integer_id);
     // TODO: Produce an error if the array type is too large.
     if (bound_value.getActiveBits() <= 64) {
       context.AddNodeAndPush(

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -37,7 +37,7 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
   auto bound_node = context.semantics_ir().GetNode(bound_node_id);
   if (auto literal = bound_node.TryAs<SemIR::IntegerLiteral>()) {
     const auto& bound_value =
-        context.semantics_ir().GetIntegerValue(literal->integer_id);
+        context.semantics_ir().GetInteger(literal->integer_id);
     // TODO: Produce an error if the array type is too large.
     if (bound_value.getActiveBits() <= 64) {
       context.AddNodeAndPush(

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -36,7 +36,7 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
   auto element_type_node_id = context.node_stack().PopExpression();
   auto bound_node = context.semantics_ir().GetNode(bound_node_id);
   if (bound_node.kind() == SemIR::NodeKind::IntegerLiteral) {
-    auto bound_value = context.semantics_ir().GetIntegerLiteral(
+    auto bound_value = context.semantics_ir().GetIntegerValue(
         bound_node.GetAsIntegerLiteral());
     // TODO: Produce an error if the array type is too large.
     if (bound_value.getActiveBits() <= 64) {

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -42,7 +42,7 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
     if (bound_value.getActiveBits() <= 64) {
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::ArrayType::Make(
+          SemIR::ArrayType(
               parse_node, SemIR::TypeId::TypeType, bound_node_id,
               ExpressionAsType(context, parse_node, element_type_node_id)));
       return true;

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -27,7 +27,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
     return true;
   }
 
-  auto function_id = name_node.GetAsFunctionDeclaration();
+  auto function_id = name_node.As<SemIR::FunctionDeclaration>().function_id;
   const auto& callable = context.semantics_ir().GetFunction(function_id);
 
   // For functions with an implicit return type, the return type is the empty

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -41,8 +41,8 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   if (callable.return_slot_id.is_valid()) {
     // Tentatively put storage for a temporary in the function's return slot.
     // This will be replaced if necessary when we perform initialization.
-    auto temp_id = context.AddNode(SemIR::TemporaryStorage(
-        call_expr_parse_node, callable.return_type_id));
+    auto temp_id = context.AddNode(
+        SemIR::TemporaryStorage(call_expr_parse_node, callable.return_type_id));
     context.ParamOrArgSave(temp_id);
   }
 
@@ -55,8 +55,8 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
     return true;
   }
 
-  auto call_node_id = context.AddNode(SemIR::Call(
-      call_expr_parse_node, type_id, refs_id, function_id));
+  auto call_node_id = context.AddNode(
+      SemIR::Call(call_expr_parse_node, type_id, refs_id, function_id));
 
   context.node_stack().Push(parse_node, call_node_id);
   return true;

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -41,7 +41,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   if (callable.return_slot_id.is_valid()) {
     // Tentatively put storage for a temporary in the function's return slot.
     // This will be replaced if necessary when we perform initialization.
-    auto temp_id = context.AddNode(SemIR::Node::TemporaryStorage::Make(
+    auto temp_id = context.AddNode(SemIR::TemporaryStorage(
         call_expr_parse_node, callable.return_type_id));
     context.ParamOrArgSave(temp_id);
   }
@@ -55,7 +55,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
     return true;
   }
 
-  auto call_node_id = context.AddNode(SemIR::Node::Call::Make(
+  auto call_node_id = context.AddNode(SemIR::Call(
       call_expr_parse_node, type_id, refs_id, function_id));
 
   context.node_stack().Push(parse_node, call_node_id);

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -19,7 +19,8 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
           .PopWithParseNode<Parse::NodeKind::CallExpressionStart>();
   auto name_node =
       context.semantics_ir().GetNode(context.FollowNameReferences(name_id));
-  if (name_node.kind() != SemIR::NodeKind::FunctionDeclaration) {
+  auto function_name = name_node.TryAs<SemIR::FunctionDeclaration>();
+  if (!function_name) {
     // TODO: Work on error.
     context.TODO(parse_node, "Not a callable name");
     context.node_stack().Push(parse_node, name_id);
@@ -27,7 +28,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
     return true;
   }
 
-  auto function_id = name_node.As<SemIR::FunctionDeclaration>().function_id;
+  auto function_id = function_name->function_id;
   const auto& callable = context.semantics_ir().GetFunction(function_id);
 
   // For functions with an implicit return type, the return type is the empty

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -57,8 +57,8 @@ static auto BuildFunctionDeclaration(Context& context)
        .return_type_id = return_type_id,
        .return_slot_id = return_slot_id,
        .body_block_ids = {}});
-  auto decl_id = context.AddNode(
-      SemIR::FunctionDeclaration(fn_node, function_id));
+  auto decl_id =
+      context.AddNode(SemIR::FunctionDeclaration(fn_node, function_id));
   context.declaration_name_stack().AddNameToLookup(name_context, decl_id);
 
   if (SemIR::IsEntryPoint(context.semantics_ir(), function_id)) {
@@ -153,8 +153,8 @@ auto HandleReturnType(Context& context, Parse::Node parse_node) -> bool {
   // TODO: Use a dedicated node rather than VarStorage here.
   context.AddNodeAndPush(
       parse_node,
-      SemIR::VarStorage(
-          parse_node, type_id, context.semantics_ir().AddString("return")));
+      SemIR::VarStorage(parse_node, type_id,
+                        context.semantics_ir().AddString("return")));
   return true;
 }
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -123,11 +123,10 @@ auto HandleFunctionDefinitionStart(Context& context, Parse::Node parse_node)
   context.AddCurrentCodeBlockToFunction();
 
   // Bring the parameters into scope.
-  for (auto ref_id :
+  for (auto param_id :
        context.semantics_ir().GetNodeBlock(function.param_refs_id)) {
-    auto ref = context.semantics_ir().GetNode(ref_id);
-    auto name_id = ref.GetAsParameter();
-    context.AddNameToLookup(ref.parse_node(), name_id, ref_id);
+    auto param = context.semantics_ir().GetNodeAs<SemIR::Parameter>(param_id);
+    context.AddNameToLookup(param.parse_node, param.name_id, param_id);
   }
 
   context.node_stack().Push(parse_node, function_id);

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -58,7 +58,7 @@ static auto BuildFunctionDeclaration(Context& context)
        .return_slot_id = return_slot_id,
        .body_block_ids = {}});
   auto decl_id = context.AddNode(
-      SemIR::Node::FunctionDeclaration::Make(fn_node, function_id));
+      SemIR::FunctionDeclaration(fn_node, function_id));
   context.declaration_name_stack().AddNameToLookup(name_context, decl_id);
 
   if (SemIR::IsEntryPoint(context.semantics_ir(), function_id)) {
@@ -100,7 +100,7 @@ auto HandleFunctionDefinition(Context& context, Parse::Node parse_node)
           "Missing `return` at end of function with declared return type.");
       context.emitter().Emit(parse_node, MissingReturnStatement);
     } else {
-      context.AddNode(SemIR::Node::Return::Make(parse_node));
+      context.AddNode(SemIR::Return(parse_node));
     }
   }
 
@@ -153,7 +153,7 @@ auto HandleReturnType(Context& context, Parse::Node parse_node) -> bool {
   // TODO: Use a dedicated node rather than VarStorage here.
   context.AddNodeAndPush(
       parse_node,
-      SemIR::Node::VarStorage::Make(
+      SemIR::VarStorage(
           parse_node, type_id, context.semantics_ir().AddString("return")));
   return true;
 }

--- a/toolchain/check/handle_if_statement.cpp
+++ b/toolchain/check/handle_if_statement.cpp
@@ -53,7 +53,7 @@ auto HandleIfStatement(Context& context, Parse::Node parse_node) -> bool {
       // block.
       auto else_block_id =
           context.node_stack().Pop<Parse::NodeKind::IfCondition>();
-      context.AddNode(SemIR::Node::Branch::Make(parse_node, else_block_id));
+      context.AddNode(SemIR::Branch(parse_node, else_block_id));
       context.node_block_stack().Pop();
       context.node_block_stack().Push(else_block_id);
       break;

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -69,11 +69,11 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
       if (array_cat == SemIR::ExpressionCategory::Value) {
         // If the operand is an array value, convert it to an ephemeral
         // reference to an array so we can perform a primitive indexing into it.
-        operand_node_id = context.AddNode(SemIR::Node::ValueAsReference::Make(
+        operand_node_id = context.AddNode(SemIR::ValueAsReference(
             parse_node, operand_type_id, operand_node_id));
       }
       auto elem_id = context.AddNode(
-          SemIR::Node::ArrayIndex::Make(parse_node, array_type.element_type_id,
+          SemIR::ArrayIndex(parse_node, array_type.element_type_id,
                                         operand_node_id, cast_index_id));
       if (array_cat != SemIR::ExpressionCategory::DurableReference) {
         // Indexing a durable reference gives a durable reference expression.
@@ -103,7 +103,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
         context.emitter().Emit(parse_node, TupleIndexIntegerLiteral);
         index_node_id = SemIR::NodeId::BuiltinError;
       }
-      context.AddNodeAndPush(parse_node, SemIR::Node::TupleIndex::Make(
+      context.AddNodeAndPush(parse_node, SemIR::TupleIndex(
                                              parse_node, element_type_id,
                                              operand_node_id, index_node_id));
       return true;

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -24,7 +24,7 @@ static auto ValidateIntegerLiteralBound(Context& context,
                                         SemIR::IntegerLiteral index_node,
                                         int size) -> const llvm::APInt* {
   const auto& index_val =
-      context.semantics_ir().GetIntegerValue(index_node.integer_id);
+      context.semantics_ir().GetInteger(index_node.integer_id);
   if (index_val.uge(size)) {
     CARBON_DIAGNOSTIC(IndexOutOfBounds, Error,
                       "Index `{0}` is past the end of `{1}`.", llvm::APSInt,

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -74,7 +74,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
       }
       auto elem_id = context.AddNode(
           SemIR::ArrayIndex(parse_node, array_type.element_type_id,
-                                        operand_node_id, cast_index_id));
+                            operand_node_id, cast_index_id));
       if (array_cat != SemIR::ExpressionCategory::DurableReference) {
         // Indexing a durable reference gives a durable reference expression.
         // Indexing anything else gives a value expression.
@@ -103,9 +103,9 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
         context.emitter().Emit(parse_node, TupleIndexIntegerLiteral);
         index_node_id = SemIR::NodeId::BuiltinError;
       }
-      context.AddNodeAndPush(parse_node, SemIR::TupleIndex(
-                                             parse_node, element_type_id,
-                                             operand_node_id, index_node_id));
+      context.AddNodeAndPush(parse_node,
+                             SemIR::TupleIndex(parse_node, element_type_id,
+                                               operand_node_id, index_node_id));
       return true;
     }
     default: {

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -23,8 +23,8 @@ static auto ValidateIntegerLiteralBound(Context& context,
                                         SemIR::Node operand_node,
                                         SemIR::Node index_node, int size)
     -> const llvm::APInt* {
-  const auto& index_val = context.semantics_ir().GetIntegerLiteral(
-      index_node.GetAsIntegerLiteral());
+  const auto& index_val =
+      context.semantics_ir().GetIntegerValue(index_node.GetAsIntegerLiteral());
   if (index_val.uge(size)) {
     CARBON_DIAGNOSTIC(IndexOutOfBounds, Error,
                       "Index `{0}` is past the end of `{1}`.", llvm::APSInt,

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -22,17 +22,16 @@ auto HandleLetDeclaration(Context& context, Parse::Node parse_node) -> bool {
 
   // Update the binding with its value and add it to the current block, after
   // the computation of the value.
-  auto [name_id, absent_value_id] = pattern.GetAsBindName();
-  CARBON_CHECK(!absent_value_id.is_valid())
+  // TODO: Support other kinds of pattern here.
+  auto bind_name = pattern.As<SemIR::BindName>();
+  CARBON_CHECK(!bind_name.value_id.is_valid())
       << "Binding should not already have a value!";
-  context.semantics_ir().ReplaceNode(
-      pattern_id,
-      SemIR::Node::BindName::Make(pattern.parse_node(), pattern.type_id(),
-                                  name_id, value_id));
+  bind_name.value_id = value_id;
+  context.semantics_ir().ReplaceNode(pattern_id, bind_name);
   context.node_block_stack().AddNodeId(pattern_id);
 
   // Add the name of the binding to the current scope.
-  context.AddNameToLookup(pattern.parse_node(), name_id, pattern_id);
+  context.AddNameToLookup(pattern.parse_node(), bind_name.name_id, pattern_id);
   return true;
 }
 

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -13,7 +13,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
     case Lex::TokenKind::True: {
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::BoolLiteral::Make(
+          SemIR::BoolLiteral(
               parse_node,
               context.CanonicalizeType(SemIR::NodeId::BuiltinBoolType),
               token_kind == Lex::TokenKind::True ? SemIR::BoolValue::True
@@ -25,7 +25,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::IntegerLiteral::Make(
+          SemIR::IntegerLiteral(
               parse_node,
               context.CanonicalizeType(SemIR::NodeId::BuiltinIntegerType), id));
       break;
@@ -38,7 +38,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
            .is_decimal = token_value.is_decimal});
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::RealLiteral::Make(
+          SemIR::RealLiteral(
               parse_node,
               context.CanonicalizeType(SemIR::NodeId::BuiltinFloatingPointType),
               id));
@@ -49,7 +49,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
           context.tokens().GetStringLiteral(token));
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::StringLiteral::Make(
+          SemIR::StringLiteral(
               parse_node,
               context.CanonicalizeType(SemIR::NodeId::BuiltinStringType), id));
       break;

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -21,7 +21,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
       break;
     }
     case Lex::TokenKind::IntegerLiteral: {
-      auto id = context.semantics_ir().AddIntegerValue(
+      auto id = context.semantics_ir().AddInteger(
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
           parse_node,
@@ -32,7 +32,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
     }
     case Lex::TokenKind::RealLiteral: {
       auto token_value = context.tokens().GetRealLiteral(token);
-      auto id = context.semantics_ir().AddRealValue(
+      auto id = context.semantics_ir().AddReal(
           {.mantissa = token_value.mantissa,
            .exponent = token_value.exponent,
            .is_decimal = token_value.is_decimal});

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -21,7 +21,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
       break;
     }
     case Lex::TokenKind::IntegerLiteral: {
-      auto id = context.semantics_ir().AddIntegerLiteral(
+      auto id = context.semantics_ir().AddIntegerValue(
           context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
           parse_node,
@@ -32,7 +32,7 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
     }
     case Lex::TokenKind::RealLiteral: {
       auto token_value = context.tokens().GetRealLiteral(token);
-      auto id = context.semantics_ir().AddRealLiteral(
+      auto id = context.semantics_ir().AddRealValue(
           {.mantissa = token_value.mantissa,
            .exponent = token_value.exponent,
            .is_decimal = token_value.is_decimal});

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -38,11 +38,11 @@ auto HandleMemberAccessExpression(Context& context, Parse::Node parse_node)
           base_type.As<SemIR::StructType>().fields_id);
       // TODO: Do we need to optimize this with a lookup table for O(1)?
       for (auto [i, ref_id] : llvm::enumerate(refs)) {
-        auto field = context.semantics_ir().GetNodeAs<SemIR::StructTypeField>(ref_id);
+        auto field =
+            context.semantics_ir().GetNodeAs<SemIR::StructTypeField>(ref_id);
         if (name_id == field.name_id) {
           context.AddNodeAndPush(
-              parse_node,
-              SemIR::StructAccess(parse_node, field.type_id,
+              parse_node, SemIR::StructAccess(parse_node, field.type_id,
                                               base_id, SemIR::MemberIndex(i)));
           return true;
         }
@@ -96,15 +96,15 @@ auto HandleNameExpression(Context& context, Parse::Node parse_node) -> bool {
   auto value = context.semantics_ir().GetNode(value_id);
   if (value.kind().value_kind() == SemIR::NodeValueKind::Typed) {
     // This is a reference to a name binding that has a value and a type.
-    context.AddNodeAndPush(parse_node,
-                           SemIR::NameReference(
-                               parse_node, value.type_id(), name_id, value_id));
+    context.AddNodeAndPush(
+        parse_node,
+        SemIR::NameReference(parse_node, value.type_id(), name_id, value_id));
   } else {
     // This is something like a namespace name, that can be found by name lookup
     // but isn't a first-class value with a type.
-    context.AddNodeAndPush(parse_node,
-                           SemIR::NameReferenceUntyped(
-                               parse_node, value.type_id(), name_id, value_id));
+    context.AddNodeAndPush(
+        parse_node, SemIR::NameReferenceUntyped(parse_node, value.type_id(),
+                                                name_id, value_id));
   }
   return true;
 }

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -42,7 +42,7 @@ auto HandleMemberAccessExpression(Context& context, Parse::Node parse_node)
         if (name_id == field.name_id) {
           context.AddNodeAndPush(
               parse_node,
-              SemIR::Node::StructAccess::Make(parse_node, field.type_id,
+              SemIR::StructAccess(parse_node, field.type_id,
                                               base_id, SemIR::MemberIndex(i)));
           return true;
         }
@@ -97,13 +97,13 @@ auto HandleNameExpression(Context& context, Parse::Node parse_node) -> bool {
   if (value.kind().value_kind() == SemIR::NodeValueKind::Typed) {
     // This is a reference to a name binding that has a value and a type.
     context.AddNodeAndPush(parse_node,
-                           SemIR::Node::NameReference::Make(
+                           SemIR::NameReference(
                                parse_node, value.type_id(), name_id, value_id));
   } else {
     // This is something like a namespace name, that can be found by name lookup
     // but isn't a first-class value with a type.
     context.AddNodeAndPush(parse_node,
-                           SemIR::Node::NameReferenceUntyped::Make(
+                           SemIR::NameReferenceUntyped(
                                parse_node, value.type_id(), name_id, value_id));
   }
   return true;

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -15,7 +15,7 @@ auto HandleNamespaceStart(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleNamespace(Context& context, Parse::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
-  auto namespace_id = context.AddNode(SemIR::Node::Namespace::Make(
+  auto namespace_id = context.AddNode(SemIR::Namespace(
       parse_node, context.semantics_ir().AddNameScope()));
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -15,8 +15,8 @@ auto HandleNamespaceStart(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleNamespace(Context& context, Parse::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
-  auto namespace_id = context.AddNode(SemIR::Namespace(
-      parse_node, context.semantics_ir().AddNameScope()));
+  auto namespace_id = context.AddNode(
+      SemIR::Namespace(parse_node, context.semantics_ir().AddNameScope()));
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;
 }

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -39,17 +39,17 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       // When the second operand is evaluated, the result of `and` and `or` is
       // its value.
       auto resume_block_id = context.node_block_stack().PeekOrAdd(/*depth=*/1);
-      context.AddNode(SemIR::BranchWithArg(
-          parse_node, resume_block_id, rhs_id));
+      context.AddNode(
+          SemIR::BranchWithArg(parse_node, resume_block_id, rhs_id));
       context.node_block_stack().Pop();
       context.AddCurrentCodeBlockToFunction();
 
       // Collect the result from either the first or second operand.
       context.AddNodeAndPush(
           parse_node,
-          SemIR::BlockArg(
-              parse_node, context.semantics_ir().GetNode(rhs_id).type_id(),
-              resume_block_id));
+          SemIR::BlockArg(parse_node,
+                          context.semantics_ir().GetNode(rhs_id).type_id(),
+                          resume_block_id));
       return true;
     }
     case Lex::TokenKind::Equal: {
@@ -85,8 +85,8 @@ auto HandlePostfixOperator(Context& context, Parse::Node parse_node) -> bool {
     case Lex::TokenKind::Star: {
       auto inner_type_id = ExpressionAsType(context, parse_node, value_id);
       context.AddNodeAndPush(
-          parse_node, SemIR::PointerType(
-                          parse_node, SemIR::TypeId::TypeType, inner_type_id));
+          parse_node, SemIR::PointerType(parse_node, SemIR::TypeId::TypeType,
+                                         inner_type_id));
       return true;
     }
 
@@ -142,8 +142,8 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       }
       auto inner_type_id = ExpressionAsType(context, parse_node, value_id);
       context.AddNodeAndPush(
-          parse_node, SemIR::ConstType(
-                          parse_node, SemIR::TypeId::TypeType, inner_type_id));
+          parse_node,
+          SemIR::ConstType(parse_node, SemIR::TypeId::TypeType, inner_type_id));
       return true;
     }
 
@@ -183,8 +183,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       }
       value_id = ConvertToValueExpression(context, value_id);
       context.AddNodeAndPush(
-          parse_node,
-          SemIR::Dereference(parse_node, result_type_id, value_id));
+          parse_node, SemIR::Dereference(parse_node, result_type_id, value_id));
       return true;
     }
 
@@ -212,10 +211,10 @@ auto HandleShortCircuitOperand(Context& context, Parse::Node parse_node)
       break;
 
     case Lex::TokenKind::Or:
-      branch_value_id = context.AddNode(SemIR::UnaryOperatorNot(
-          parse_node, bool_type_id, cond_value_id));
-      short_circuit_result_id = context.AddNode(SemIR::BoolLiteral(
-          parse_node, bool_type_id, SemIR::BoolValue::True));
+      branch_value_id = context.AddNode(
+          SemIR::UnaryOperatorNot(parse_node, bool_type_id, cond_value_id));
+      short_circuit_result_id = context.AddNode(
+          SemIR::BoolLiteral(parse_node, bool_type_id, SemIR::BoolValue::True));
       break;
 
     default:

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -163,7 +163,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
           context.semantics_ir().GetTypeAllowBuiltinTypes(type_id));
       auto result_type_id = SemIR::TypeId::Error;
       if (type_node.kind() == SemIR::NodeKind::PointerType) {
-        result_type_id = type_node.GetAsPointerType();
+        result_type_id = type_node.As<SemIR::PointerType>().pointee_id;
       } else {
         CARBON_DIAGNOSTIC(
             DereferenceOfNonPointer, Error,

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -24,7 +24,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
 
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::BinaryOperatorAdd::Make(
+          SemIR::BinaryOperatorAdd(
               parse_node, context.semantics_ir().GetNode(lhs_id).type_id(),
               lhs_id, rhs_id));
       return true;
@@ -39,7 +39,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       // When the second operand is evaluated, the result of `and` and `or` is
       // its value.
       auto resume_block_id = context.node_block_stack().PeekOrAdd(/*depth=*/1);
-      context.AddNode(SemIR::Node::BranchWithArg::Make(
+      context.AddNode(SemIR::BranchWithArg(
           parse_node, resume_block_id, rhs_id));
       context.node_block_stack().Pop();
       context.AddCurrentCodeBlockToFunction();
@@ -47,7 +47,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       // Collect the result from either the first or second operand.
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::BlockArg::Make(
+          SemIR::BlockArg(
               parse_node, context.semantics_ir().GetNode(rhs_id).type_id(),
               resume_block_id));
       return true;
@@ -63,7 +63,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       // TODO: Destroy the old value before reinitializing. This will require
       // building the destruction code before we build the RHS subexpression.
       rhs_id = Initialize(context, parse_node, lhs_id, rhs_id);
-      context.AddNode(SemIR::Node::Assign::Make(parse_node, lhs_id, rhs_id));
+      context.AddNode(SemIR::Assign(parse_node, lhs_id, rhs_id));
       // We model assignment as an expression, so we need to push a value for
       // it, even though it doesn't produce a value.
       // TODO: Consider changing our parse tree to model assignment as a
@@ -85,7 +85,7 @@ auto HandlePostfixOperator(Context& context, Parse::Node parse_node) -> bool {
     case Lex::TokenKind::Star: {
       auto inner_type_id = ExpressionAsType(context, parse_node, value_id);
       context.AddNodeAndPush(
-          parse_node, SemIR::Node::PointerType::Make(
+          parse_node, SemIR::PointerType(
                           parse_node, SemIR::TypeId::TypeType, inner_type_id));
       return true;
     }
@@ -120,7 +120,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       }
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::AddressOf::Make(
+          SemIR::AddressOf(
               parse_node,
               context.GetPointerType(
                   parse_node,
@@ -142,7 +142,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       }
       auto inner_type_id = ExpressionAsType(context, parse_node, value_id);
       context.AddNodeAndPush(
-          parse_node, SemIR::Node::ConstType::Make(
+          parse_node, SemIR::ConstType(
                           parse_node, SemIR::TypeId::TypeType, inner_type_id));
       return true;
     }
@@ -151,7 +151,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       value_id = ConvertToBoolValue(context, parse_node, value_id);
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::UnaryOperatorNot::Make(
+          SemIR::UnaryOperatorNot(
               parse_node, context.semantics_ir().GetNode(value_id).type_id(),
               value_id));
       return true;
@@ -184,7 +184,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       value_id = ConvertToValueExpression(context, value_id);
       context.AddNodeAndPush(
           parse_node,
-          SemIR::Node::Dereference::Make(parse_node, result_type_id, value_id));
+          SemIR::Dereference(parse_node, result_type_id, value_id));
       return true;
     }
 
@@ -207,14 +207,14 @@ auto HandleShortCircuitOperand(Context& context, Parse::Node parse_node)
   switch (auto token_kind = context.tokens().GetKind(token)) {
     case Lex::TokenKind::And:
       branch_value_id = cond_value_id;
-      short_circuit_result_id = context.AddNode(SemIR::Node::BoolLiteral::Make(
+      short_circuit_result_id = context.AddNode(SemIR::BoolLiteral(
           parse_node, bool_type_id, SemIR::BoolValue::False));
       break;
 
     case Lex::TokenKind::Or:
-      branch_value_id = context.AddNode(SemIR::Node::UnaryOperatorNot::Make(
+      branch_value_id = context.AddNode(SemIR::UnaryOperatorNot(
           parse_node, bool_type_id, cond_value_id));
-      short_circuit_result_id = context.AddNode(SemIR::Node::BoolLiteral::Make(
+      short_circuit_result_id = context.AddNode(SemIR::BoolLiteral(
           parse_node, bool_type_id, SemIR::BoolValue::True));
       break;
 

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -162,8 +162,8 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       auto type_node = context.semantics_ir().GetNode(
           context.semantics_ir().GetTypeAllowBuiltinTypes(type_id));
       auto result_type_id = SemIR::TypeId::Error;
-      if (type_node.kind() == SemIR::NodeKind::PointerType) {
-        result_type_id = type_node.As<SemIR::PointerType>().pointee_id;
+      if (auto pointer_type = type_node.TryAs<SemIR::PointerType>()) {
+        result_type_id = pointer_type->pointee_id;
       } else {
         CARBON_DIAGNOSTIC(
             DereferenceOfNonPointer, Error,

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -49,7 +49,7 @@ auto HandleTupleLiteral(Context& context, Parse::Node parse_node) -> bool {
   auto type_id = context.CanonicalizeTupleType(parse_node, std::move(type_ids));
 
   auto value_id = context.AddNode(
-      SemIR::Node::TupleLiteral::Make(parse_node, type_id, refs_id));
+      SemIR::TupleLiteral(parse_node, type_id, refs_id));
   context.node_stack().Push(parse_node, value_id);
   return true;
 }

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -48,8 +48,8 @@ auto HandleTupleLiteral(Context& context, Parse::Node parse_node) -> bool {
   }
   auto type_id = context.CanonicalizeTupleType(parse_node, std::move(type_ids));
 
-  auto value_id = context.AddNode(
-      SemIR::TupleLiteral(parse_node, type_id, refs_id));
+  auto value_id =
+      context.AddNode(SemIR::TupleLiteral(parse_node, type_id, refs_id));
   context.node_stack().Push(parse_node, value_id);
   return true;
 }

--- a/toolchain/check/handle_pattern_binding.cpp
+++ b/toolchain/check/handle_pattern_binding.cpp
@@ -32,11 +32,11 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
   switch (auto context_parse_node_kind = context.parse_tree().node_kind(
               context.node_stack().PeekParseNode())) {
     case Parse::NodeKind::VariableIntroducer:
-      context.AddNodeAndPush(parse_node, SemIR::Node::VarStorage::Make(
+      context.AddNodeAndPush(parse_node, SemIR::VarStorage(
                                              name_node, cast_type_id, name_id));
       break;
     case Parse::NodeKind::ParameterListStart:
-      context.AddNodeAndPush(parse_node, SemIR::Node::Parameter::Make(
+      context.AddNodeAndPush(parse_node, SemIR::Parameter(
                                              name_node, cast_type_id, name_id));
       break;
     case Parse::NodeKind::LetIntroducer:
@@ -46,7 +46,7 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
       // the `let` pattern before we see the initializer.
       context.node_stack().Push(
           parse_node,
-          context.semantics_ir().AddNodeInNoBlock(SemIR::Node::BindName::Make(
+          context.semantics_ir().AddNodeInNoBlock(SemIR::BindName(
               name_node, cast_type_id, name_id, SemIR::NodeId::Invalid)));
       break;
     default:

--- a/toolchain/check/handle_pattern_binding.cpp
+++ b/toolchain/check/handle_pattern_binding.cpp
@@ -32,12 +32,12 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
   switch (auto context_parse_node_kind = context.parse_tree().node_kind(
               context.node_stack().PeekParseNode())) {
     case Parse::NodeKind::VariableIntroducer:
-      context.AddNodeAndPush(parse_node, SemIR::VarStorage(
-                                             name_node, cast_type_id, name_id));
+      context.AddNodeAndPush(
+          parse_node, SemIR::VarStorage(name_node, cast_type_id, name_id));
       break;
     case Parse::NodeKind::ParameterListStart:
-      context.AddNodeAndPush(parse_node, SemIR::Parameter(
-                                             name_node, cast_type_id, name_id));
+      context.AddNodeAndPush(
+          parse_node, SemIR::Parameter(name_node, cast_type_id, name_id));
       break;
     case Parse::NodeKind::LetIntroducer:
       // Create the node, but don't add it to a block until after we've formed

--- a/toolchain/check/handle_statement.cpp
+++ b/toolchain/check/handle_statement.cpp
@@ -29,10 +29,10 @@ auto HandleExpressionStatement(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(!context.return_scope_stack().empty());
-  const auto& fn_node =
-      context.semantics_ir().GetNode(context.return_scope_stack().back());
+  auto fn_node = context.semantics_ir().GetNodeAs<SemIR::FunctionDeclaration>(
+      context.return_scope_stack().back());
   const auto& callable =
-      context.semantics_ir().GetFunction(fn_node.GetAsFunctionDeclaration());
+      context.semantics_ir().GetFunction(fn_node.function_id);
 
   if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==
       Parse::NodeKind::ReturnStatementStart) {
@@ -63,7 +63,7 @@ auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
                         "There was no return type provided.");
       context.emitter()
           .Build(parse_node, ReturnStatementDisallowExpression)
-          .Note(fn_node.parse_node(), ReturnStatementImplicitNote)
+          .Note(fn_node.parse_node, ReturnStatementImplicitNote)
           .Emit();
     } else if (callable.return_slot_id.is_valid()) {
       arg = Initialize(context, parse_node, callable.return_slot_id, arg);

--- a/toolchain/check/handle_statement.cpp
+++ b/toolchain/check/handle_statement.cpp
@@ -49,7 +49,7 @@ auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
           .Emit();
     }
 
-    context.AddNode(SemIR::Node::Return::Make(parse_node));
+    context.AddNode(SemIR::Return(parse_node));
   } else {
     auto arg = context.node_stack().PopExpression();
     context.node_stack()
@@ -72,7 +72,7 @@ auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
                                  callable.return_type_id);
     }
 
-    context.AddNode(SemIR::Node::ReturnExpression::Make(parse_node, arg));
+    context.AddNode(SemIR::ReturnExpression(parse_node, arg));
   }
 
   // Switch to a new, unreachable, empty node block. This typically won't

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -28,8 +28,8 @@ auto HandleStructFieldType(Context& context, Parse::Node parse_node) -> bool {
   auto [name_node, name_id] =
       context.node_stack().PopWithParseNode<Parse::NodeKind::Name>();
 
-  context.AddNodeAndPush(parse_node, SemIR::StructTypeField(
-                                         name_node, name_id, cast_type_id));
+  context.AddNodeAndPush(
+      parse_node, SemIR::StructTypeField(name_node, name_id, cast_type_id));
   return true;
 }
 
@@ -65,8 +65,8 @@ auto HandleStructLiteral(Context& context, Parse::Node parse_node) -> bool {
 
   auto type_id = context.CanonicalizeStructType(parse_node, type_block_id);
 
-  auto value_id = context.AddNode(
-      SemIR::StructLiteral(parse_node, type_id, refs_id));
+  auto value_id =
+      context.AddNode(SemIR::StructLiteral(parse_node, type_id, refs_id));
   context.node_stack().Push(parse_node, value_id);
   return true;
 }
@@ -98,9 +98,9 @@ auto HandleStructTypeLiteral(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(refs_id != SemIR::NodeBlockId::Empty)
       << "{} is handled by StructLiteral.";
 
-  context.AddNodeAndPush(parse_node,
-                         SemIR::StructType(
-                             parse_node, SemIR::TypeId::TypeType, refs_id));
+  context.AddNodeAndPush(
+      parse_node,
+      SemIR::StructType(parse_node, SemIR::TypeId::TypeType, refs_id));
   return true;
 }
 

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -28,7 +28,7 @@ auto HandleStructFieldType(Context& context, Parse::Node parse_node) -> bool {
   auto [name_node, name_id] =
       context.node_stack().PopWithParseNode<Parse::NodeKind::Name>();
 
-  context.AddNodeAndPush(parse_node, SemIR::Node::StructTypeField::Make(
+  context.AddNodeAndPush(parse_node, SemIR::StructTypeField(
                                          name_node, name_id, cast_type_id));
   return true;
 }
@@ -44,7 +44,7 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
   SemIR::StringId name_id = context.node_stack().Pop<Parse::NodeKind::Name>();
 
   // Store the name for the type.
-  context.args_type_info_stack().AddNode(SemIR::Node::StructTypeField::Make(
+  context.args_type_info_stack().AddNode(SemIR::StructTypeField(
       parse_node, name_id,
       context.semantics_ir().GetNode(value_node_id).type_id()));
 
@@ -66,7 +66,7 @@ auto HandleStructLiteral(Context& context, Parse::Node parse_node) -> bool {
   auto type_id = context.CanonicalizeStructType(parse_node, type_block_id);
 
   auto value_id = context.AddNode(
-      SemIR::Node::StructLiteral::Make(parse_node, type_id, refs_id));
+      SemIR::StructLiteral(parse_node, type_id, refs_id));
   context.node_stack().Push(parse_node, value_id);
   return true;
 }
@@ -99,7 +99,7 @@ auto HandleStructTypeLiteral(Context& context, Parse::Node parse_node) -> bool {
       << "{} is handled by StructLiteral.";
 
   context.AddNodeAndPush(parse_node,
-                         SemIR::Node::StructType::Make(
+                         SemIR::StructType(
                              parse_node, SemIR::TypeId::TypeType, refs_id));
   return true;
 }

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -24,9 +24,8 @@ auto HandleVariableDeclaration(Context& context, Parse::Node parse_node)
   // Get the storage and add it to name lookup.
   SemIR::NodeId var_id =
       context.node_stack().Pop<Parse::NodeKind::PatternBinding>();
-  auto var = context.semantics_ir().GetNode(var_id);
-  auto name_id = var.GetAsVarStorage();
-  context.AddNameToLookup(var.parse_node(), name_id, var_id);
+  auto var = context.semantics_ir().GetNodeAs<SemIR::VarStorage>(var_id);
+  context.AddNameToLookup(var.parse_node, var.name_id, var_id);
   // If there was an initializer, assign it to storage.
   if (has_init) {
     init_id = Initialize(context, parse_node, var_id, init_id);

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -31,7 +31,7 @@ auto HandleVariableDeclaration(Context& context, Parse::Node parse_node)
     init_id = Initialize(context, parse_node, var_id, init_id);
     // TODO: Consider using different node kinds for assignment versus
     // initialization.
-    context.AddNode(SemIR::Node::Assign::Make(parse_node, var_id, init_id));
+    context.AddNode(SemIR::Assign(parse_node, var_id, init_id));
   }
 
   context.node_stack()

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -64,9 +64,8 @@ class PendingBlock {
       // 1) The block is empty. Replace `target_id` with an empty splice
       // pointing at `value_id`.
       context_.semantics_ir().ReplaceNode(
-          target_id,
-          SemIR::SpliceBlock(value.parse_node(), value.type_id(),
-                                         SemIR::NodeBlockId::Empty, value_id));
+          target_id, SemIR::SpliceBlock(value.parse_node(), value.type_id(),
+                                        SemIR::NodeBlockId::Empty, value_id));
     } else if (nodes_.size() == 1 && nodes_[0] == value_id) {
       // 2) The block is {value_id}. Replace `target_id` with the node referred
       // to by `value_id`. This is intended to be the common case.
@@ -75,9 +74,9 @@ class PendingBlock {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
       context_.semantics_ir().ReplaceNode(
           target_id,
-          SemIR::SpliceBlock(
-              value.parse_node(), value.type_id(),
-              context_.semantics_ir().AddNodeBlock(nodes_), value_id));
+          SemIR::SpliceBlock(value.parse_node(), value.type_id(),
+                             context_.semantics_ir().AddNodeBlock(nodes_),
+                             value_id));
     }
 
     // Prepare to stash more pending instructions.

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -65,7 +65,7 @@ class PendingBlock {
       // pointing at `value_id`.
       context_.semantics_ir().ReplaceNode(
           target_id,
-          SemIR::Node::SpliceBlock::Make(value.parse_node(), value.type_id(),
+          SemIR::SpliceBlock(value.parse_node(), value.type_id(),
                                          SemIR::NodeBlockId::Empty, value_id));
     } else if (nodes_.size() == 1 && nodes_[0] == value_id) {
       // 2) The block is {value_id}. Replace `target_id` with the node referred
@@ -75,7 +75,7 @@ class PendingBlock {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
       context_.semantics_ir().ReplaceNode(
           target_id,
-          SemIR::Node::SpliceBlock::Make(
+          SemIR::SpliceBlock(
               value.parse_node(), value.type_id(),
               context_.semantics_ir().AddNodeBlock(nodes_), value_id));
     }

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -11,9 +11,9 @@
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:     ]

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -11,9 +11,9 @@
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:     ]

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -20,9 +20,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       A,
@@ -60,9 +60,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       B,

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -20,9 +20,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       A,
@@ -60,9 +60,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       B,

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -20,9 +20,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       A,
@@ -51,9 +51,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       B,

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -20,9 +20,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       A,
@@ -51,9 +51,9 @@ fn B() {}
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [
 // CHECK:STDOUT:       B,

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -18,10 +18,10 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:       2,
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -18,10 +18,10 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:       2,
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -18,10 +18,10 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_values: [
+// CHECK:STDOUT:     integers: [
 // CHECK:STDOUT:       2,
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_values: [
+// CHECK:STDOUT:     reals: [
 // CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -18,10 +18,10 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     functions: [
 // CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integer_literals: [
+// CHECK:STDOUT:     integer_values: [
 // CHECK:STDOUT:       2,
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     real_literals: [
+// CHECK:STDOUT:     real_values: [
 // CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     strings: [

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -132,7 +132,7 @@ auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
           llvm_context(), GetType(function.return_type_id)));
     } else {
       arg.setName(semantics_ir().GetString(
-          semantics_ir().GetNode(node_id).GetAsParameter()));
+          semantics_ir().GetNodeAs<SemIR::Parameter>(node_id).name_id));
     }
   }
 
@@ -208,26 +208,27 @@ auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
   auto node = semantics_ir_->GetNode(node_id);
   switch (node.kind()) {
     case SemIR::NodeKind::ArrayType: {
-      auto [bound_node_id, type_id] = node.GetAsArrayType();
+      auto array_type = node.As<SemIR::ArrayType>();
       return llvm::ArrayType::get(
-          GetType(type_id), semantics_ir_->GetArrayBoundValue(bound_node_id));
+          GetType(array_type.element_type_id),
+          semantics_ir_->GetArrayBoundValue(array_type.bound_id));
     }
     case SemIR::NodeKind::ConstType:
-      return GetType(node.GetAsConstType());
+      return GetType(node.As<SemIR::ConstType>().inner_id);
     case SemIR::NodeKind::PointerType:
       return llvm::PointerType::get(*llvm_context_, /*AddressSpace=*/0);
     case SemIR::NodeKind::StructType: {
-      auto refs = semantics_ir_->GetNodeBlock(node.GetAsStructType());
+      auto fields =
+          semantics_ir_->GetNodeBlock(node.As<SemIR::StructType>().fields_id);
       llvm::SmallVector<llvm::Type*> subtypes;
-      subtypes.reserve(refs.size());
-      for (auto ref_id : refs) {
-        auto [field_name_id, field_type_id] =
-            semantics_ir_->GetNode(ref_id).GetAsStructTypeField();
+      subtypes.reserve(fields.size());
+      for (auto field_id : fields) {
+        auto field = semantics_ir_->GetNodeAs<SemIR::StructTypeField>(field_id);
         // TODO: Handle recursive types. The restriction for builtins prevents
         // recursion while still letting them cache.
-        CARBON_CHECK(field_type_id.index < SemIR::BuiltinKind::ValidCount)
-            << field_type_id;
-        subtypes.push_back(GetType(field_type_id));
+        CARBON_CHECK(field.type_id.index < SemIR::BuiltinKind::ValidCount)
+            << field.type_id;
+        subtypes.push_back(GetType(field.type_id));
       }
       return llvm::StructType::get(*llvm_context_, subtypes);
     }
@@ -236,11 +237,12 @@ auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
       // can be collectively replaced with LLVM's void, particularly around
       // function returns. LLVM doesn't allow declaring variables with a void
       // type, so that may require significant special casing.
-      auto refs = semantics_ir_->GetTypeBlock(node.GetAsTupleType());
+      auto elements =
+          semantics_ir_->GetTypeBlock(node.As<SemIR::TupleType>().elements_id);
       llvm::SmallVector<llvm::Type*> subtypes;
-      subtypes.reserve(refs.size());
-      for (auto ref_id : refs) {
-        subtypes.push_back(GetType(ref_id));
+      subtypes.reserve(elements.size());
+      for (auto element_id : elements) {
+        subtypes.push_back(GetType(element_id));
       }
       return llvm::StructType::get(*llvm_context_, subtypes);
     }

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -44,9 +44,9 @@ auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(Name) \
-  case SemIR::NodeKind::Name:            \
-    Handle##Name(*this, node_id, node);  \
+#define CARBON_SEMANTICS_NODE_KIND(Name)           \
+  case SemIR::NodeKind::Name:                      \
+    Handle##Name(*this, node_id, node.As<SemIR::Name>()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"
     }

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -44,8 +44,8 @@ auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(Name)           \
-  case SemIR::NodeKind::Name:                      \
+#define CARBON_SEMANTICS_NODE_KIND(Name)                  \
+  case SemIR::NodeKind::Name:                             \
     Handle##Name(*this, node_id, node.As<SemIR::Name>()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -133,8 +133,7 @@ class FunctionContext {
 // Declare handlers for each SemIR::File node.
 #define CARBON_SEMANTICS_NODE_KIND(Name)                             \
   auto Handle##Name(FunctionContext& context, SemIR::NodeId node_id, \
-                    SemIR::Node node)                                \
-      ->void;
+                    SemIR::Name node) -> void;
 #include "toolchain/sem_ir/node_kind.def"
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -133,7 +133,8 @@ class FunctionContext {
 // Declare handlers for each SemIR::File node.
 #define CARBON_SEMANTICS_NODE_KIND(Name)                             \
   auto Handle##Name(FunctionContext& context, SemIR::NodeId node_id, \
-                    SemIR::Name node) -> void;
+                    SemIR::Name node)                                \
+      ->void;
 #include "toolchain/sem_ir/node_kind.def"
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -15,7 +15,8 @@ auto HandleInvalid(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
 }
 
 auto HandleCrossReference(FunctionContext& /*context*/,
-                          SemIR::NodeId /*node_id*/, SemIR::CrossReference node) -> void {
+                          SemIR::NodeId /*node_id*/, SemIR::CrossReference node)
+    -> void {
   CARBON_FATAL() << "TODO: Add support: " << node;
 }
 

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -9,11 +9,6 @@
 
 namespace Carbon::Lower {
 
-auto HandleInvalid(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
-                   SemIR::Invalid /*node*/) -> void {
-  llvm_unreachable("never in actual IR");
-}
-
 auto HandleCrossReference(FunctionContext& /*context*/,
                           SemIR::NodeId /*node_id*/, SemIR::CrossReference node)
     -> void {

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -183,8 +183,7 @@ auto HandleInitializeFrom(FunctionContext& context, SemIR::NodeId /*node_id*/,
 
 auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
                           SemIR::IntegerLiteral node) -> void {
-  const llvm::APInt& i =
-      context.semantics_ir().GetIntegerValue(node.integer_id);
+  const llvm::APInt& i = context.semantics_ir().GetInteger(node.integer_id);
   // TODO: This won't offer correct semantics, but seems close enough for now.
   llvm::Value* v =
       llvm::ConstantInt::get(context.builder().getInt32Ty(), i.getZExtValue());
@@ -219,8 +218,7 @@ auto HandleParameter(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
 
 auto HandleRealLiteral(FunctionContext& context, SemIR::NodeId node_id,
                        SemIR::RealLiteral node) -> void {
-  const SemIR::RealValue& real =
-      context.semantics_ir().GetRealValue(node.real_id);
+  const SemIR::Real& real = context.semantics_ir().GetReal(node.real_id);
   // TODO: This will probably have overflow issues, and should be fixed.
   double val =
       real.mantissa.getZExtValue() *
@@ -428,9 +426,8 @@ auto HandleTupleIndex(FunctionContext& context, SemIR::NodeId node_id,
                       SemIR::TupleIndex node) -> void {
   auto index_node =
       context.semantics_ir().GetNodeAs<SemIR::IntegerLiteral>(node.index_id);
-  auto index = context.semantics_ir()
-                   .GetIntegerValue(index_node.integer_id)
-                   .getZExtValue();
+  auto index =
+      context.semantics_ir().GetInteger(index_node.integer_id).getZExtValue();
   context.SetLocal(node_id,
                    GetStructOrTupleElement(context, node.tuple_id, index,
                                            node.type_id, "tuple.index"));

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -197,7 +197,7 @@ auto HandleInitializeFrom(FunctionContext& context, SemIR::NodeId /*node_id*/,
 auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
                           SemIR::Node node) -> void {
   llvm::APInt i =
-      context.semantics_ir().GetIntegerLiteral(node.GetAsIntegerLiteral());
+      context.semantics_ir().GetIntegerValue(node.GetAsIntegerLiteral());
   // TODO: This won't offer correct semantics, but seems close enough for now.
   llvm::Value* v =
       llvm::ConstantInt::get(context.builder().getInt32Ty(), i.getZExtValue());
@@ -233,8 +233,8 @@ auto HandleParameter(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
 
 auto HandleRealLiteral(FunctionContext& context, SemIR::NodeId node_id,
                        SemIR::Node node) -> void {
-  SemIR::RealLiteral real =
-      context.semantics_ir().GetRealLiteral(node.GetAsRealLiteral());
+  SemIR::RealValue real =
+      context.semantics_ir().GetRealValue(node.GetAsRealLiteral());
   // TODO: This will probably have overflow issues, and should be fixed.
   double val =
       real.mantissa.getZExtValue() *
@@ -447,7 +447,7 @@ auto HandleTupleIndex(FunctionContext& context, SemIR::NodeId node_id,
   auto [tuple_node_id, index_node_id] = node.GetAsTupleIndex();
   auto index_node = context.semantics_ir().GetNode(index_node_id);
   const auto index = context.semantics_ir()
-                         .GetIntegerLiteral(index_node.GetAsIntegerLiteral())
+                         .GetIntegerValue(index_node.GetAsIntegerLiteral())
                          .getZExtValue();
   context.SetLocal(node_id,
                    GetStructOrTupleElement(context, tuple_node_id, index,

--- a/toolchain/lower/handle_expression_category.cpp
+++ b/toolchain/lower/handle_expression_category.cpp
@@ -8,24 +8,24 @@
 namespace Carbon::Lower {
 
 auto HandleBindValue(FunctionContext& context, SemIR::NodeId node_id,
-                     SemIR::Node node) -> void {
+                     SemIR::BindValue node) -> void {
   switch (auto rep = SemIR::GetValueRepresentation(context.semantics_ir(),
-                                                   node.type_id());
+                                                   node.type_id);
           rep.kind) {
     case SemIR::ValueRepresentation::None:
       // Nothing should use this value, but StubReference needs a value to
       // propagate.
       // TODO: Remove this now the StubReferences are gone.
       context.SetLocal(node_id,
-                       llvm::PoisonValue::get(context.GetType(node.type_id())));
+                       llvm::PoisonValue::get(context.GetType(node.type_id)));
       break;
     case SemIR::ValueRepresentation::Copy:
       context.SetLocal(node_id, context.builder().CreateLoad(
-                                    context.GetType(node.type_id()),
-                                    context.GetLocal(node.GetAsBindValue())));
+                                    context.GetType(node.type_id),
+                                    context.GetLocal(node.value_id)));
       break;
     case SemIR::ValueRepresentation::Pointer:
-      context.SetLocal(node_id, context.GetLocal(node.GetAsBindValue()));
+      context.SetLocal(node_id, context.GetLocal(node.value_id));
       break;
     case SemIR::ValueRepresentation::Custom:
       CARBON_FATAL() << "TODO: Add support for BindValue with custom value rep";
@@ -33,28 +33,27 @@ auto HandleBindValue(FunctionContext& context, SemIR::NodeId node_id,
 }
 
 auto HandleTemporary(FunctionContext& context, SemIR::NodeId node_id,
-                     SemIR::Node node) -> void {
-  auto [temporary_id, init_id] = node.GetAsTemporary();
-  context.FinishInitialization(node.type_id(), temporary_id, init_id);
-  context.SetLocal(node_id, context.GetLocal(temporary_id));
+                     SemIR::Temporary node) -> void {
+  context.FinishInitialization(node.type_id, node.storage_id, node.init_id);
+  context.SetLocal(node_id, context.GetLocal(node.storage_id));
 }
 
 auto HandleTemporaryStorage(FunctionContext& context, SemIR::NodeId node_id,
-                            SemIR::Node node) -> void {
-  context.SetLocal(
-      node_id, context.builder().CreateAlloca(context.GetType(node.type_id()),
-                                              nullptr, "temp"));
+                            SemIR::TemporaryStorage node) -> void {
+  context.SetLocal(node_id,
+                   context.builder().CreateAlloca(context.GetType(node.type_id),
+                                                  nullptr, "temp"));
 }
 
 auto HandleValueAsReference(FunctionContext& context, SemIR::NodeId node_id,
-                            SemIR::Node node) -> void {
-  CARBON_CHECK(SemIR::GetExpressionCategory(context.semantics_ir(),
-                                            node.GetAsValueAsReference()) ==
-               SemIR::ExpressionCategory::Value);
+                            SemIR::ValueAsReference node) -> void {
   CARBON_CHECK(
-      SemIR::GetValueRepresentation(context.semantics_ir(), node.type_id())
+      SemIR::GetExpressionCategory(context.semantics_ir(), node.value_id) ==
+      SemIR::ExpressionCategory::Value);
+  CARBON_CHECK(
+      SemIR::GetValueRepresentation(context.semantics_ir(), node.type_id)
           .kind == SemIR::ValueRepresentation::Pointer);
-  context.SetLocal(node_id, context.GetLocal(node.GetAsValueAsReference()));
+  context.SetLocal(node_id, context.GetLocal(node.value_id));
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/handle_type.cpp
+++ b/toolchain/lower/handle_type.cpp
@@ -7,27 +7,27 @@
 namespace Carbon::Lower {
 
 auto HandleArrayType(FunctionContext& context, SemIR::NodeId node_id,
-                     SemIR::Node /*node*/) -> void {
+                     SemIR::ArrayType /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto HandleConstType(FunctionContext& context, SemIR::NodeId node_id,
-                     SemIR::Node /*node*/) -> void {
+                     SemIR::ConstType /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto HandlePointerType(FunctionContext& context, SemIR::NodeId node_id,
-                       SemIR::Node /*node*/) -> void {
+                       SemIR::PointerType /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto HandleStructType(FunctionContext& context, SemIR::NodeId node_id,
-                      SemIR::Node /*node*/) -> void {
+                      SemIR::StructType /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 
 auto HandleTupleType(FunctionContext& context, SemIR::NodeId node_id,
-                     SemIR::Node /*node*/) -> void {
+                     SemIR::TupleType /*node*/) -> void {
   context.SetLocal(node_id, context.GetTypeAsValue());
 }
 

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -32,8 +32,8 @@ cc_library(
     deps = [
         "//common:check",
         "//common:ostream",
+        "//common:struct_reflection",
         "//toolchain/base:index_base",
-        "//toolchain/base:struct_reflection",
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:node_kind",

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "//common:check",
         "//common:ostream",
         "//toolchain/base:index_base",
+        "//toolchain/base:struct_reflection",
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:node_kind",

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -150,13 +150,13 @@ auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
       << "\n";
 
   PrintList(out, "functions", functions_);
-  // Integer literals are an APInt, and default to a signed print, but the
-  // ZExtValue print is correct.
-  PrintList(out, "integer_literals", integer_literals_,
+  // Integer values are APInts, and default to a signed print, but we currently
+  // treat them as unsigned.
+  PrintList(out, "integer_values", integer_values_,
             [](llvm::raw_ostream& out, const llvm::APInt& val) {
               val.print(out, /*isSigned=*/false);
             });
-  PrintList(out, "real_literals", real_literals_);
+  PrintList(out, "real_values", real_values_);
   PrintList(out, "strings", strings_);
   PrintList(out, "types", types_);
   PrintBlock(out, "type_blocks", type_blocks_);

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -24,11 +24,11 @@ File::File()
   // Error uses a self-referential type so that it's not accidentally treated as
   // a normal type. Every other builtin is a type, including the
   // self-referential TypeType.
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                               \
-  nodes_.push_back(Node::Builtin::Make(BuiltinKind::Name,                      \
-                                       BuiltinKind::Name == BuiltinKind::Error \
-                                           ? TypeId::Error                     \
-                                           : TypeId::TypeType));
+#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                   \
+  nodes_.push_back(Builtin(BuiltinKind::Name == BuiltinKind::Error \
+                               ? TypeId::Error                     \
+                               : TypeId::TypeType,                 \
+                           BuiltinKind::Name));
 #include "toolchain/sem_ir/builtin_kind.def"
 
   CARBON_CHECK(nodes_.size() == BuiltinKind::ValidCount)
@@ -51,8 +51,8 @@ File::File(std::string filename, const File* builtins)
   static constexpr auto BuiltinIR = CrossReferenceIRId(0);
   for (auto [i, node] : llvm::enumerate(builtins->nodes_)) {
     // We can reuse builtin type IDs because they're special-cased values.
-    nodes_.push_back(Node::CrossReference::Make(node.type_id(), BuiltinIR,
-                                                SemIR::NodeId(i)));
+    nodes_.push_back(
+        CrossReference(node.type_id(), BuiltinIR, SemIR::NodeId(i)));
   }
 }
 

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -152,11 +152,11 @@ auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
   PrintList(out, "functions", functions_);
   // Integer values are APInts, and default to a signed print, but we currently
   // treat them as unsigned.
-  PrintList(out, "integer_values", integer_values_,
+  PrintList(out, "integers", integers_,
             [](llvm::raw_ostream& out, const llvm::APInt& val) {
               val.print(out, /*isSigned=*/false);
             });
-  PrintList(out, "real_values", real_values_);
+  PrintList(out, "reals", reals_);
   PrintList(out, "strings", strings_);
   PrintList(out, "types", types_);
   PrintBlock(out, "type_blocks", type_blocks_);

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -210,7 +210,6 @@ static auto GetTypePrecedence(NodeKind kind) -> int {
     case NodeKind::FunctionDeclaration:
     case NodeKind::InitializeFrom:
     case NodeKind::IntegerLiteral:
-    case NodeKind::Invalid:
     case NodeKind::NameReference:
     case NodeKind::NameReferenceUntyped:
     case NodeKind::Namespace:
@@ -411,8 +410,6 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
         // when stringification is needed.
         out << "<cannot stringify " << step.node_id << ">";
         break;
-      case NodeKind::Invalid:
-        llvm_unreachable("NodeKind::Invalid is never used.");
     }
   }
 
@@ -438,7 +435,6 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-      case NodeKind::Invalid:
       case NodeKind::Assign:
       case NodeKind::Branch:
       case NodeKind::BranchIf:
@@ -563,7 +559,6 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
       case NodeKind::FunctionDeclaration:
       case NodeKind::InitializeFrom:
       case NodeKind::IntegerLiteral:
-      case NodeKind::Invalid:
       case NodeKind::NameReference:
       case NodeKind::NameReferenceUntyped:
       case NodeKind::Namespace:

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -91,7 +91,7 @@ class File : public Printable<File> {
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
-    return GetIntegerValue(GetNode(bound_id).GetAsIntegerLiteral())
+    return GetIntegerValue(GetNode(bound_id).As<IntegerLiteral>().integer_id)
         .getZExtValue();
   }
 

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -91,7 +91,7 @@ class File : public Printable<File> {
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
-    return GetIntegerValue(GetNode(bound_id).As<IntegerLiteral>().integer_id)
+    return GetIntegerValue(GetNodeAs<IntegerLiteral>(bound_id).integer_id)
         .getZExtValue();
   }
 
@@ -174,6 +174,12 @@ class File : public Printable<File> {
 
   // Returns the requested node.
   auto GetNode(NodeId node_id) const -> Node { return nodes_[node_id.index]; }
+
+  // Returns the requested node, which is known to have the specified type.
+  template <typename NodeT>
+  auto GetNodeAs(NodeId node_id) const -> NodeT {
+    return GetNode(node_id).As<NodeT>();
+  }
 
   // Reserves and returns a node block ID. The contents of the node block
   // should be specified by calling SetNodeBlock, or by pushing the ID onto the

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -51,7 +51,7 @@ struct Function : public Printable<Function> {
   llvm::SmallVector<NodeBlockId> body_block_ids;
 };
 
-struct RealLiteral : public Printable<RealLiteral> {
+struct RealValue : public Printable<RealValue> {
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{mantissa: ";
     mantissa.print(out, /*isSigned=*/false);
@@ -91,7 +91,7 @@ class File : public Printable<File> {
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
-    return GetIntegerLiteral(GetNode(bound_id).GetAsIntegerLiteral())
+    return GetIntegerValue(GetNode(bound_id).GetAsIntegerLiteral())
         .getZExtValue();
   }
 
@@ -119,18 +119,18 @@ class File : public Printable<File> {
     return functions_[function_id.index];
   }
 
-  // Adds an integer literal, returning an ID to reference it.
-  auto AddIntegerLiteral(llvm::APInt integer_literal) -> IntegerLiteralId {
-    IntegerLiteralId id(integer_literals_.size());
+  // Adds an integer value, returning an ID to reference it.
+  auto AddIntegerValue(llvm::APInt integer_value) -> IntegerValueId {
+    IntegerValueId id(integer_values_.size());
     // TODO: Return failure on overflow instead of crashing.
     CARBON_CHECK(id.index >= 0);
-    integer_literals_.push_back(integer_literal);
+    integer_values_.push_back(integer_value);
     return id;
   }
 
-  // Returns the requested integer literal.
-  auto GetIntegerLiteral(IntegerLiteralId int_id) const -> const llvm::APInt& {
-    return integer_literals_[int_id.index];
+  // Returns the requested integer value.
+  auto GetIntegerValue(IntegerValueId int_id) const -> const llvm::APInt& {
+    return integer_values_[int_id.index];
   }
 
   // Adds a name scope, returning an ID to reference it.
@@ -225,18 +225,18 @@ class File : public Printable<File> {
     return node_blocks_[block_id.index];
   }
 
-  // Adds a real literal, returning an ID to reference it.
-  auto AddRealLiteral(RealLiteral real_literal) -> RealLiteralId {
-    RealLiteralId id(real_literals_.size());
+  // Adds a real value, returning an ID to reference it.
+  auto AddRealValue(RealValue real_value) -> RealValueId {
+    RealValueId id(real_values_.size());
     // TODO: Return failure on overflow instead of crashing.
     CARBON_CHECK(id.index >= 0);
-    real_literals_.push_back(real_literal);
+    real_values_.push_back(real_value);
     return id;
   }
 
-  // Returns the requested real literal.
-  auto GetRealLiteral(RealLiteralId int_id) const -> const RealLiteral& {
-    return real_literals_[int_id.index];
+  // Returns the requested real value.
+  auto GetRealValue(RealValueId int_id) const -> const RealValue& {
+    return real_values_[int_id.index];
   }
 
   // Adds an string, returning an ID to reference it.
@@ -372,14 +372,14 @@ class File : public Printable<File> {
   // crossing node blocks).
   llvm::SmallVector<const File*> cross_reference_irs_;
 
-  // Storage for integer literals.
-  llvm::SmallVector<llvm::APInt> integer_literals_;
+  // Storage for integer values.
+  llvm::SmallVector<llvm::APInt> integer_values_;
 
   // Storage for name scopes.
   llvm::SmallVector<llvm::DenseMap<StringId, NodeId>> name_scopes_;
 
-  // Storage for real literals.
-  llvm::SmallVector<RealLiteral> real_literals_;
+  // Storage for real value.
+  llvm::SmallVector<RealValue> real_values_;
 
   // Storage for strings. strings_ provides a list of allocated strings, while
   // string_to_id_ provides a mapping to identify strings.

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -51,7 +51,9 @@ struct Function : public Printable<Function> {
   llvm::SmallVector<NodeBlockId> body_block_ids;
 };
 
-struct RealValue : public Printable<RealValue> {
+// TODO: Replace this with a Rational type, per the design:
+// docs/design/expressions/literals.md
+struct Real : public Printable<Real> {
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{mantissa: ";
     mantissa.print(out, /*isSigned=*/false);
@@ -91,7 +93,7 @@ class File : public Printable<File> {
 
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
-    return GetIntegerValue(GetNodeAs<IntegerLiteral>(bound_id).integer_id)
+    return GetInteger(GetNodeAs<IntegerLiteral>(bound_id).integer_id)
         .getZExtValue();
   }
 
@@ -120,17 +122,17 @@ class File : public Printable<File> {
   }
 
   // Adds an integer value, returning an ID to reference it.
-  auto AddIntegerValue(llvm::APInt integer_value) -> IntegerValueId {
-    IntegerValueId id(integer_values_.size());
+  auto AddInteger(llvm::APInt integer) -> IntegerId {
+    IntegerId id(integers_.size());
     // TODO: Return failure on overflow instead of crashing.
     CARBON_CHECK(id.index >= 0);
-    integer_values_.push_back(integer_value);
+    integers_.push_back(integer);
     return id;
   }
 
   // Returns the requested integer value.
-  auto GetIntegerValue(IntegerValueId int_id) const -> const llvm::APInt& {
-    return integer_values_[int_id.index];
+  auto GetInteger(IntegerId int_id) const -> const llvm::APInt& {
+    return integers_[int_id.index];
   }
 
   // Adds a name scope, returning an ID to reference it.
@@ -232,17 +234,17 @@ class File : public Printable<File> {
   }
 
   // Adds a real value, returning an ID to reference it.
-  auto AddRealValue(RealValue real_value) -> RealValueId {
-    RealValueId id(real_values_.size());
+  auto AddReal(Real real) -> RealId {
+    RealId id(reals_.size());
     // TODO: Return failure on overflow instead of crashing.
     CARBON_CHECK(id.index >= 0);
-    real_values_.push_back(real_value);
+    reals_.push_back(real);
     return id;
   }
 
   // Returns the requested real value.
-  auto GetRealValue(RealValueId int_id) const -> const RealValue& {
-    return real_values_[int_id.index];
+  auto GetReal(RealId real_id) const -> const Real& {
+    return reals_[real_id.index];
   }
 
   // Adds an string, returning an ID to reference it.
@@ -379,13 +381,13 @@ class File : public Printable<File> {
   llvm::SmallVector<const File*> cross_reference_irs_;
 
   // Storage for integer values.
-  llvm::SmallVector<llvm::APInt> integer_values_;
+  llvm::SmallVector<llvm::APInt> integers_;
 
   // Storage for name scopes.
   llvm::SmallVector<llvm::DenseMap<StringId, NodeId>> name_scopes_;
 
-  // Storage for real value.
-  llvm::SmallVector<RealValue> real_values_;
+  // Storage for real values.
+  llvm::SmallVector<Real> reals_;
 
   // Storage for strings. strings_ provides a list of allocated strings, while
   // string_to_id_ provides a mapping to identify strings.

--- a/toolchain/sem_ir/file_test.cpp
+++ b/toolchain/sem_ir/file_test.cpp
@@ -47,8 +47,8 @@ TEST(SemIRTest, YAML) {
   auto file = Yaml::Sequence(ElementsAre(Yaml::Mapping(ElementsAre(
       Pair("cross_reference_irs_size", "1"),
       Pair("functions", Yaml::Sequence(SizeIs(1))),
-      Pair("integer_literals", Yaml::Sequence(ElementsAre("0"))),
-      Pair("real_literals", Yaml::Sequence(IsEmpty())),
+      Pair("integer_values", Yaml::Sequence(ElementsAre("0"))),
+      Pair("real_values", Yaml::Sequence(IsEmpty())),
       Pair("strings", Yaml::Sequence(ElementsAre("F", "x"))),
       Pair("types", Yaml::Sequence(ElementsAre(node_builtin))),
       Pair("type_blocks", Yaml::Sequence(IsEmpty())),

--- a/toolchain/sem_ir/file_test.cpp
+++ b/toolchain/sem_ir/file_test.cpp
@@ -47,8 +47,8 @@ TEST(SemIRTest, YAML) {
   auto file = Yaml::Sequence(ElementsAre(Yaml::Mapping(ElementsAre(
       Pair("cross_reference_irs_size", "1"),
       Pair("functions", Yaml::Sequence(SizeIs(1))),
-      Pair("integer_values", Yaml::Sequence(ElementsAre("0"))),
-      Pair("real_values", Yaml::Sequence(IsEmpty())),
+      Pair("integers", Yaml::Sequence(ElementsAre("0"))),
+      Pair("reals", Yaml::Sequence(IsEmpty())),
       Pair("strings", Yaml::Sequence(ElementsAre("F", "x"))),
       Pair("types", Yaml::Sequence(ElementsAre(node_builtin))),
       Pair("type_blocks", Yaml::Sequence(IsEmpty())),

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -697,11 +697,10 @@ class Formatter {
     llvm::ListSeparator sep;
     for (auto field_id : semantics_ir_.GetNodeBlock(node.fields_id)) {
       out_ << sep << ".";
-      auto [field_name_id, field_type_id] =
-          semantics_ir_.GetNode(field_id).GetAsStructTypeField();
-      FormatString(field_name_id);
+      auto field = semantics_ir_.GetNode(field_id).As<StructTypeField>();
+      FormatString(field.name_id);
       out_ << ": ";
-      FormatType(field_type_id);
+      FormatType(field.type_id);
     }
     out_ << "}";
   }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -721,8 +721,8 @@ class Formatter {
 
   auto FormatArg(FunctionId id) -> void { FormatFunctionName(id); }
 
-  auto FormatArg(IntegerValueId id) -> void {
-    semantics_ir_.GetIntegerValue(id).print(out_, /*isSigned=*/false);
+  auto FormatArg(IntegerId id) -> void {
+    semantics_ir_.GetInteger(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(MemberIndex index) -> void { out_ << index; }
@@ -762,9 +762,9 @@ class Formatter {
     out_ << ')';
   }
 
-  auto FormatArg(RealValueId id) -> void {
+  auto FormatArg(RealId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.
-    const auto& real = semantics_ir_.GetRealValue(id);
+    const auto& real = semantics_ir_.GetReal(id);
     real.mantissa.print(out_, /*isSigned=*/false);
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -623,9 +623,10 @@ class Formatter {
     out_ << " ";
     FormatArg(node.tuple_id);
 
-    llvm::ArrayRef<NodeId> refs = semantics_ir_.GetNodeBlock(node.refs_id);
-    auto inits = refs.drop_back(1);
-    auto return_slot_id = refs.back();
+    llvm::ArrayRef<NodeId> inits_and_return_slot =
+        semantics_ir_.GetNodeBlock(node.inits_and_return_slot_id);
+    auto inits = inits_and_return_slot.drop_back(1);
+    auto return_slot_id = inits_and_return_slot.back();
 
     out_ << ", (";
     llvm::ListSeparator sep;
@@ -697,7 +698,7 @@ class Formatter {
     llvm::ListSeparator sep;
     for (auto field_id : semantics_ir_.GetNodeBlock(node.fields_id)) {
       out_ << sep << ".";
-      auto field = semantics_ir_.GetNode(field_id).As<StructTypeField>();
+      auto field = semantics_ir_.GetNodeAs<StructTypeField>(field_id);
       FormatString(field.name_id);
       out_ << ": ";
       FormatType(field.type_id);

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -749,8 +749,8 @@ class Formatter {
 
   auto FormatArg(FunctionId id) -> void { FormatFunctionName(id); }
 
-  auto FormatArg(IntegerLiteralId id) -> void {
-    semantics_ir_.GetIntegerLiteral(id).print(out_, /*isSigned=*/false);
+  auto FormatArg(IntegerValueId id) -> void {
+    semantics_ir_.GetIntegerValue(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(MemberIndex index) -> void { out_ << index; }
@@ -790,9 +790,9 @@ class Formatter {
     out_ << ')';
   }
 
-  auto FormatArg(RealLiteralId id) -> void {
+  auto FormatArg(RealValueId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.
-    const auto& real = semantics_ir_.GetRealLiteral(id);
+    const auto& real = semantics_ir_.GetRealValue(id);
     real.mantissa.print(out_, /*isSigned=*/false);
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -690,8 +690,8 @@ class Formatter {
   }
 
   // StructTypeFields are formatted as part of their StructType.
-  auto FormatInstruction(NodeId /*node_id*/, StructTypeField /*node*/)
-      -> void {}
+  auto FormatInstruction(NodeId /*node_id*/, StructTypeField /*node*/) -> void {
+  }
 
   auto FormatInstructionRHS(StructType node) -> void {
     out_ << " {";

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -514,7 +514,7 @@ class Formatter {
   auto FormatInstruction(NodeId node_id) -> void {
     if (!node_id.is_valid()) {
       Indent();
-      out_ << NodeKind::Invalid.ir_name() << "\n";
+      out_ << "invalid\n";
       return;
     }
 

--- a/toolchain/sem_ir/node.cpp
+++ b/toolchain/sem_ir/node.cpp
@@ -6,28 +6,20 @@
 
 namespace Carbon::SemIR {
 
-static auto PrintArgs(llvm::raw_ostream& /*out*/,
-                      const Node::NoArgs /*no_args*/) -> void {}
-
-template <typename T>
-static auto PrintArgs(llvm::raw_ostream& out, T arg) -> void {
-  out << ", arg0: " << arg;
-}
-
-template <typename T0, typename T1>
-static auto PrintArgs(llvm::raw_ostream& out, std::pair<T0, T1> args) -> void {
-  PrintArgs(out, args.first);
-  out << ", arg1: " << args.second;
-}
-
 auto Node::Print(llvm::raw_ostream& out) const -> void {
   out << "{kind: " << kind_;
+
+  auto print_args = [&](auto... args) {
+    int n = 0;
+    ((out << ", arg" << n++ << ": " << args), ...);
+  };
+
   // clang warns on unhandled enum values; clang-tidy is incorrect here.
   // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (kind_) {
-#define CARBON_SEMANTICS_NODE_KIND(Name) \
-  case NodeKind::Name:                   \
-    PrintArgs(out, GetAs##Name());       \
+#define CARBON_SEMANTICS_NODE_KIND(Name)                    \
+  case NodeKind::Name:                                      \
+    std::apply(print_args, As<SemIR::Name>().args_tuple()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"
   }

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -93,7 +93,7 @@ constexpr BoolValue BoolValue::False = BoolValue(0);
 constexpr BoolValue BoolValue::True = BoolValue(1);
 
 // The ID of an integer value.
-struct IntegerValueId : public IndexBase, public Printable<IntegerValueId> {
+struct IntegerId : public IndexBase, public Printable<IntegerId> {
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "int";
@@ -144,9 +144,8 @@ constexpr NodeBlockId NodeBlockId::Invalid =
 constexpr NodeBlockId NodeBlockId::Unreachable =
     NodeBlockId(NodeBlockId::InvalidIndex - 1);
 
-// The ID of a value of a real number type. Despite the name, this type only
-// represents rational numbers.
-struct RealValueId : public IndexBase, public Printable<RealValueId> {
+// The ID of a real number value.
+struct RealId : public IndexBase, public Printable<RealId> {
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "real";
@@ -342,7 +341,7 @@ struct InitializeFrom {
 };
 
 struct IntegerLiteral {
-  IntegerValueId integer_id;
+  IntegerId integer_id;
 };
 
 struct NameReference {
@@ -374,7 +373,7 @@ struct PointerType {
 };
 
 struct RealLiteral {
-  RealValueId real_id;
+  RealId real_id;
 };
 
 struct Return {

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -92,7 +92,7 @@ struct BoolValue : public IndexBase, public Printable<BoolValue> {
 constexpr BoolValue BoolValue::False = BoolValue(0);
 constexpr BoolValue BoolValue::True = BoolValue(1);
 
-// The ID of an integer literal.
+// The ID of an integer value.
 struct IntegerValueId : public IndexBase, public Printable<IntegerValueId> {
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -144,7 +144,8 @@ constexpr NodeBlockId NodeBlockId::Invalid =
 constexpr NodeBlockId NodeBlockId::Unreachable =
     NodeBlockId(NodeBlockId::InvalidIndex - 1);
 
-// The ID of a real literal.
+// The ID of a value of a real number type. Despite the name, this type only
+// represents rational numbers.
 struct RealValueId : public IndexBase, public Printable<RealValueId> {
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -209,6 +210,17 @@ struct MemberIndex : public IndexBase, public Printable<MemberIndex> {
 };
 
 // Data storage for the operands of each kind of node.
+//
+// For each node kind declared in `node_kinds.def`, a struct here with the same
+// name describes the kind-specific storage for that node. A node kind can
+// store up to two IDs.
+//
+// A typed node also has:
+//
+// -  An injected `Parse::Node parse_node;` field, unless it specifies
+//    `using HasParseNode = std::false_type;`, and
+// -  An injected `TypeId type_id;` field, unless it specifies
+//    `using HasTypeId = std::false_type;`.
 namespace NodeData {
 struct AddressOf {
   NodeId lvalue_id;
@@ -696,7 +708,8 @@ struct DataBase<T, std::tuple<Fields...>> : T {
 template <typename, typename, typename, typename>
 struct TypedNodeBase;
 
-// A helper base class that produces a constructor with the desired signature.
+// A helper base class that produces a constructor with one correctly-typed
+// parameter for each struct field.
 template <typename DataT, typename... ParseNodeFields, typename... TypeFields,
           typename... DataFields>
 struct TypedNodeBase<DataT, std::tuple<ParseNodeFields...>,

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -211,9 +211,7 @@ struct MemberIndex : public IndexBase, public Printable<MemberIndex> {
 namespace NodeData {
 // The Invalid NodeKind exists, but nodes of this kind cannot be created.
 struct Invalid {
-  Invalid() {
-    CARBON_FATAL() << "Attempted to create an Invalid node";
-  }
+  Invalid() { CARBON_FATAL() << "Attempted to create an Invalid node"; }
 };
 
 struct AddressOf {
@@ -485,7 +483,7 @@ struct TypedNode;
 
 // Declare type names for each specific kind of node.
 #define CARBON_SEMANTICS_NODE_KIND(Name) \
-using Name = TypedNode<NodeKind::Name, NodeData::Name>;
+  using Name = TypedNode<NodeKind::Name, NodeData::Name>;
 #include "toolchain/sem_ir/node_kind.def"
 
 // The standard structure for Node. This is trying to provide a minimal
@@ -664,8 +662,7 @@ constexpr auto ToRaw(BuiltinKind kind) -> int32_t { return kind.AsInt(); }
 // A type that can be converted to any field type.
 struct AnyField {
   // Allow any field type that we can convert to a raw representation.
-  template <typename FieldT,
-            typename = decltype(ToRaw(std::declval<FieldT>()))>
+  template <typename FieldT, typename = decltype(ToRaw(std::declval<FieldT>()))>
   operator FieldT() const;
 };
 
@@ -695,7 +692,8 @@ constexpr int FieldCount =
 template <int NumFields>
 struct FieldAccessor;
 
-template<> struct FieldAccessor<1> {
+template <>
+struct FieldAccessor<1> {
   template <int Field, typename T>
   static auto Get(T&& value) -> auto& {
     auto& [field] = value;
@@ -703,7 +701,8 @@ template<> struct FieldAccessor<1> {
   }
 };
 
-template<> struct FieldAccessor<2> {
+template <>
+struct FieldAccessor<2> {
   template <int Field, typename T>
   static auto Get(T&& value) -> auto& {
     auto& [field0, field1] = value;
@@ -787,7 +786,8 @@ struct DataBase : T {
   }
 };
 
-template <typename, typename, typename, typename> struct TypedNodeBase;
+template <typename, typename, typename, typename>
+struct TypedNodeBase;
 
 // A helper base class that produces a constructor with the desired signature.
 template <typename DataT, typename... ParseNodeFields, typename... TypeFields,

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -402,7 +402,7 @@ struct StructAccess {
 };
 
 struct StructInit {
-  NodeId literal_id;
+  NodeId src_id;
   NodeBlockId elements_id;
 };
 
@@ -422,7 +422,7 @@ struct StructTypeField {
 };
 
 struct StructValue {
-  NodeId literal_id;
+  NodeId src_id;
   NodeBlockId elements_id;
 };
 
@@ -444,7 +444,7 @@ struct TupleIndex {
 };
 
 struct TupleInit {
-  NodeId literal_id;
+  NodeId src_id;
   NodeBlockId elements_id;
 };
 
@@ -457,7 +457,7 @@ struct TupleType {
 };
 
 struct TupleValue {
-  NodeId literal_id;
+  NodeId src_id;
   NodeBlockId elements_id;
 };
 

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -9,8 +9,8 @@
 
 #include "common/check.h"
 #include "common/ostream.h"
+#include "common/struct_reflection.h"
 #include "toolchain/base/index_base.h"
-#include "toolchain/base/struct_reflection.h"
 #include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/node_kind.h"

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -477,11 +477,6 @@ struct VarStorage {
 template <NodeKind::RawEnumType KindT, typename DataT>
 struct TypedNode;
 
-// Declare type names for each specific kind of node.
-#define CARBON_SEMANTICS_NODE_KIND(Name) \
-  using Name = TypedNode<NodeKind::Name, NodeData::Name>;
-#include "toolchain/sem_ir/node_kind.def"
-
 // The standard structure for Node. This is trying to provide a minimal
 // amount of information for a node:
 //
@@ -623,6 +618,11 @@ struct TypedNode : NodeInternals::TypedNodeImpl<DataT>,
 
   auto Print(llvm::raw_ostream& out) const -> void { Node(*this).Print(out); }
 };
+
+// Declare type names for each specific kind of node.
+#define CARBON_SEMANTICS_NODE_KIND(Name) \
+  using Name = TypedNode<NodeKind::Name, NodeData::Name>;
+#include "toolchain/sem_ir/node_kind.def"
 
 // Implementation details for typed nodes.
 namespace NodeInternals {

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -233,8 +233,8 @@ struct ArrayInit {
 };
 
 struct ArrayType {
-  NodeId bound_node_id;
-  TypeId array_element_type_id;
+  NodeId bound_id;
+  TypeId element_type_id;
 };
 
 // Performs a source-level initialization or assignment of `lhs_id` from
@@ -437,20 +437,20 @@ struct TupleIndex {
 
 struct TupleInit {
   NodeId literal_id;
-  NodeBlockId converted_refs_id;
+  NodeBlockId elements_id;
 };
 
 struct TupleLiteral {
-  NodeBlockId refs_id;
+  NodeBlockId elements_id;
 };
 
 struct TupleType {
-  TypeBlockId refs_id;
+  TypeBlockId elements_id;
 };
 
 struct TupleValue {
   NodeId literal_id;
-  NodeBlockId converted_refs_id;
+  NodeBlockId elements_id;
 };
 
 struct UnaryOperatorNot {

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -391,12 +391,12 @@ struct StringLiteral {
 
 struct StructAccess {
   NodeId struct_id;
-  MemberIndex ref_index;
+  MemberIndex index;
 };
 
 struct StructInit {
   NodeId literal_id;
-  NodeBlockId converted_refs_id;
+  NodeBlockId elements_id;
 };
 
 struct StructLiteral {
@@ -416,7 +416,7 @@ struct StructTypeField {
 
 struct StructValue {
   NodeId literal_id;
-  NodeBlockId converted_refs_id;
+  NodeBlockId elements_id;
 };
 
 struct Temporary {
@@ -433,7 +433,7 @@ struct TupleAccess {
 
 struct TupleIndex {
   NodeId tuple_id;
-  NodeId index;
+  NodeId index_id;
 };
 
 struct TupleInit {
@@ -1046,7 +1046,8 @@ struct DataBase : T {
 template <NodeKind::RawEnumType KindT, typename DataT>
 struct TypedNode : NodeInternals::ParseNodeBase<DataT>,
                    NodeInternals::TypeBase<DataT>,
-                   NodeInternals::DataBase<DataT> {
+                   NodeInternals::DataBase<DataT>,
+                   Printable<TypedNode<KindT, DataT>> {
   static constexpr NodeKind Kind = NodeKind::Create(KindT);
   using Data = DataT;
 
@@ -1056,6 +1057,8 @@ struct TypedNode : NodeInternals::ParseNodeBase<DataT>,
                      TypedNode::FromTypeId(type_id),
                      TypedNode::FromRawArgs(arg0, arg1)};
   }
+
+  auto Print(llvm::raw_ostream& out) const -> void { Node(*this).Print(out); }
 };
 
 // Provides base support for use of Id types as DenseMap/DenseSet keys.

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -225,11 +225,12 @@ struct ArrayIndex {
 };
 
 // Initializes an array from a tuple. `tuple_id` is the source tuple
-// expression. `refs_id` contains one initializer per array element, plus a
-// final element that is the return slot for the initialization.
+// expression. `inits_and_return_slot_id` contains one initializer per array
+// element, plus a final element that is the return slot for the
+// initialization.
 struct ArrayInit {
   NodeId tuple_id;
-  NodeBlockId refs_id;
+  NodeBlockId inits_and_return_slot_id;
 };
 
 struct ArrayType {
@@ -399,7 +400,7 @@ struct StructInit {
 };
 
 struct StructLiteral {
-  NodeBlockId refs_id;
+  NodeBlockId elements_id;
 };
 
 struct StructType {
@@ -1042,11 +1043,12 @@ struct DataBase : T {
 };
 }  // namespace NodeInternals
 
-template <NodeKind::RawEnumType KindT, typename Data>
-struct TypedNode : NodeInternals::ParseNodeBase<Data>,
-                   NodeInternals::TypeBase<Data>,
-                   NodeInternals::DataBase<Data> {
+template <NodeKind::RawEnumType KindT, typename DataT>
+struct TypedNode : NodeInternals::ParseNodeBase<DataT>,
+                   NodeInternals::TypeBase<DataT>,
+                   NodeInternals::DataBase<DataT> {
   static constexpr NodeKind Kind = NodeKind::Create(KindT);
+  using Data = DataT;
 
   static auto FromRawData(Parse::Node parse_node, TypeId type_id, int32_t arg0,
                           int32_t arg1) -> TypedNode {

--- a/toolchain/sem_ir/node_kind.def
+++ b/toolchain/sem_ir/node_kind.def
@@ -40,8 +40,6 @@
 #error "Must define the x-macro to use this file."
 #endif
 
-CARBON_SEMANTICS_NODE_KIND_IMPL(Invalid, "invalid", None, NotTerminator)
-
 // A cross-reference between IRs.
 CARBON_SEMANTICS_NODE_KIND_IMPL(CrossReference, "xref", Typed, NotTerminator)
 


### PR DESCRIPTION
Replace `SemIR::Node::GetAsFoo` and `SemIR::Node::Foo::Make` with `SemIR::Foo` class that represents a particular kind of node, with named fields.

Rename `SemIR::IntegerLiteral` and `SemIR::RealLiteral` to `IntegerValue` / `RealValue` to better reflect their purpose and avoid a name collision with the corresponding `SemIR` node kinds.

Remove `NodeKind::Invalid` and the `SemIR::Node` default constructor entirely, as they were not used for anything.