### PR TITLE
Switch from `SemIR::NodeKind::Foo` to `SemIR::Foo::Kind` wherever possible.

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -148,11 +148,11 @@ auto Context::FollowNameReferences(SemIR::NodeId node_id) -> SemIR::NodeId {
   while (true) {
     auto node = semantics_ir().GetNode(node_id);
     switch (node.kind()) {
-      case SemIR::NodeKind::NameReference: {
+      case SemIR::NameReference::Kind: {
         node_id = node.As<SemIR::NameReference>().value_id;
         break;
       }
-      case SemIR::NodeKind::NameReferenceUntyped: {
+      case SemIR::NameReferenceUntyped::Kind: {
         node_id = node.As<SemIR::NameReferenceUntyped>().value_id;
         break;
       }
@@ -335,7 +335,7 @@ static auto ProfileTupleType(llvm::ArrayRef<SemIR::TypeId> type_ids,
 static auto ProfileType(Context& semantics_context, SemIR::Node node,
                         llvm::FoldingSetNodeID& canonical_id) -> void {
   switch (node.kind()) {
-    case SemIR::NodeKind::ArrayType: {
+    case SemIR::ArrayType::Kind: {
       auto array_type = node.As<SemIR::ArrayType>();
       canonical_id.AddInteger(
           semantics_context.semantics_ir().GetArrayBoundValue(
@@ -343,10 +343,10 @@ static auto ProfileType(Context& semantics_context, SemIR::Node node,
       canonical_id.AddInteger(array_type.element_type_id.index);
       break;
     }
-    case SemIR::NodeKind::Builtin:
+    case SemIR::Builtin::Kind:
       canonical_id.AddInteger(node.As<SemIR::Builtin>().builtin_kind.AsInt());
       break;
-    case SemIR::NodeKind::CrossReference: {
+    case SemIR::CrossReference::Kind: {
       // TODO: Cross-references should be canonicalized by looking at their
       // target rather than treating them as new unique types.
       auto xref = node.As<SemIR::CrossReference>();
@@ -354,16 +354,16 @@ static auto ProfileType(Context& semantics_context, SemIR::Node node,
       canonical_id.AddInteger(xref.node_id.index);
       break;
     }
-    case SemIR::NodeKind::ConstType:
+    case SemIR::ConstType::Kind:
       canonical_id.AddInteger(
           semantics_context
               .GetUnqualifiedType(node.As<SemIR::ConstType>().inner_id)
               .index);
       break;
-    case SemIR::NodeKind::PointerType:
+    case SemIR::PointerType::Kind:
       canonical_id.AddInteger(node.As<SemIR::PointerType>().pointee_id.index);
       break;
-    case SemIR::NodeKind::StructType: {
+    case SemIR::StructType::Kind: {
       auto fields = semantics_context.semantics_ir().GetNodeBlock(
           node.As<SemIR::StructType>().fields_id);
       for (const auto& field_id : fields) {
@@ -375,7 +375,7 @@ static auto ProfileType(Context& semantics_context, SemIR::Node node,
       }
       break;
     }
-    case SemIR::NodeKind::TupleType:
+    case SemIR::TupleType::Kind:
       ProfileTupleType(semantics_context.semantics_ir().GetTypeBlock(
                            node.As<SemIR::TupleType>().elements_id),
                        canonical_id);
@@ -426,7 +426,7 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
     return AddNode(SemIR::TupleType(parse_node, SemIR::TypeId::TypeType,
                                     semantics_ir_->AddTypeBlock(type_ids)));
   };
-  return CanonicalizeTypeImpl(SemIR::NodeKind::TupleType, profile_tuple,
+  return CanonicalizeTypeImpl(SemIR::TupleType::Kind, profile_tuple,
                               make_tuple_node);
 }
 

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -29,18 +29,18 @@ static auto FindReturnSlotForInitializer(SemIR::File& semantics_ir,
     default:
       CARBON_FATAL() << "Initialization from unexpected node " << init;
 
-    case SemIR::NodeKind::StructInit:
-    case SemIR::NodeKind::TupleInit:
+    case SemIR::StructInit::Kind:
+    case SemIR::TupleInit::Kind:
       // TODO: Track a return slot for these initializers.
       CARBON_FATAL() << init
                      << " should be created with its return slot already "
                         "filled in properly";
 
-    case SemIR::NodeKind::InitializeFrom: {
+    case SemIR::InitializeFrom::Kind: {
       return init.As<SemIR::InitializeFrom>().dest_id;
     }
 
-    case SemIR::NodeKind::Call: {
+    case SemIR::Call::Kind: {
       auto call = init.As<SemIR::Call>();
       if (!semantics_ir.GetFunction(call.function_id)
                .return_slot_id.is_valid()) {
@@ -49,7 +49,7 @@ static auto FindReturnSlotForInitializer(SemIR::File& semantics_ir,
       return semantics_ir.GetNodeBlock(call.args_id).back();
     }
 
-    case SemIR::NodeKind::ArrayInit: {
+    case SemIR::ArrayInit::Kind: {
       return semantics_ir
           .GetNodeBlock(init.As<SemIR::ArrayInit>().inits_and_return_slot_id)
           .back();
@@ -65,7 +65,7 @@ static auto MarkInitializerFor(SemIR::File& semantics_ir, SemIR::NodeId init_id,
   if (return_slot_id.is_valid()) {
     // Replace the temporary in the return slot with a reference to our target.
     CARBON_CHECK(semantics_ir.GetNode(return_slot_id).kind() ==
-                 SemIR::NodeKind::TemporaryStorage)
+                 SemIR::TemporaryStorage::Kind)
         << "Return slot for initializer does not contain a temporary; "
         << "initialized multiple times? Have "
         << semantics_ir.GetNode(return_slot_id);
@@ -85,7 +85,7 @@ static auto FinalizeTemporary(Context& context, SemIR::NodeId init_id,
   if (return_slot_id.is_valid()) {
     // The return slot should already have a materialized temporary in it.
     CARBON_CHECK(semantics_ir.GetNode(return_slot_id).kind() ==
-                 SemIR::NodeKind::TemporaryStorage)
+                 SemIR::TemporaryStorage::Kind)
         << "Return slot for initializer does not contain a temporary; "
         << "initialized multiple times? Have "
         << semantics_ir.GetNode(return_slot_id);

--- a/toolchain/check/declaration_name_stack.cpp
+++ b/toolchain/check/declaration_name_stack.cpp
@@ -118,7 +118,7 @@ auto DeclarationNameStack::UpdateScopeIfNeeded(NameContext& name_context)
   auto resolved_node =
       context_->semantics_ir().GetNode(name_context.resolved_node_id);
   switch (resolved_node.kind()) {
-    case SemIR::NodeKind::Namespace:
+    case SemIR::Namespace::Kind:
       name_context.state = NameContext::State::Resolved;
       name_context.target_scope_id =
           resolved_node.As<SemIR::Namespace>().name_scope_id;

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -50,7 +50,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
       context.semantics_ir().GetTypeAllowBuiltinTypes(operand_type_id));
 
   switch (operand_type_node.kind()) {
-    case SemIR::NodeKind::ArrayType: {
+    case SemIR::ArrayType::Kind: {
       auto array_type = operand_type_node.As<SemIR::ArrayType>();
       // We can check whether integers are in-bounds, although it doesn't affect
       // the IR for an array.
@@ -85,7 +85,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
       context.node_stack().Push(parse_node, elem_id);
       return true;
     }
-    case SemIR::NodeKind::TupleType: {
+    case SemIR::TupleType::Kind: {
       SemIR::TypeId element_type_id = SemIR::TypeId::Error;
       if (auto index_literal = index_node.TryAs<SemIR::IntegerLiteral>()) {
         auto type_block = context.semantics_ir().GetTypeBlock(

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -33,7 +33,7 @@ auto HandleMemberAccessExpression(Context& context, Parse::Node parse_node)
       context.semantics_ir().GetTypeAllowBuiltinTypes(base.type_id()));
 
   switch (base_type.kind()) {
-    case SemIR::NodeKind::StructType: {
+    case SemIR::StructType::Kind: {
       auto refs = context.semantics_ir().GetNodeBlock(
           base_type.As<SemIR::StructType>().fields_id);
       // TODO: Do we need to optimize this with a lookup table for O(1)?

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -134,7 +134,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       // TODO: Detect `const (const T)*` and suggest moving the `*` inside the
       // parentheses.
       if (context.semantics_ir().GetNode(value_id).kind() ==
-          SemIR::NodeKind::ConstType) {
+          SemIR::ConstType::Kind) {
         CARBON_DIAGNOSTIC(RepeatedConst, Warning,
                           "`const` applied repeatedly to the same type has no "
                           "additional effect.");

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -207,17 +207,17 @@ auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
 
   auto node = semantics_ir_->GetNode(node_id);
   switch (node.kind()) {
-    case SemIR::NodeKind::ArrayType: {
+    case SemIR::ArrayType::Kind: {
       auto array_type = node.As<SemIR::ArrayType>();
       return llvm::ArrayType::get(
           GetType(array_type.element_type_id),
           semantics_ir_->GetArrayBoundValue(array_type.bound_id));
     }
-    case SemIR::NodeKind::ConstType:
+    case SemIR::ConstType::Kind:
       return GetType(node.As<SemIR::ConstType>().inner_id);
-    case SemIR::NodeKind::PointerType:
+    case SemIR::PointerType::Kind:
       return llvm::PointerType::get(*llvm_context_, /*AddressSpace=*/0);
-    case SemIR::NodeKind::StructType: {
+    case SemIR::StructType::Kind: {
       auto fields =
           semantics_ir_->GetNodeBlock(node.As<SemIR::StructType>().fields_id);
       llvm::SmallVector<llvm::Type*> subtypes;
@@ -232,7 +232,7 @@ auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
       }
       return llvm::StructType::get(*llvm_context_, subtypes);
     }
-    case SemIR::NodeKind::TupleType: {
+    case SemIR::TupleType::Kind: {
       // TODO: Investigate special-casing handling of empty tuples so that they
       // can be collectively replaced with LLVM's void, particularly around
       // function returns. LLVM doesn't allow declaring variables with a void

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -45,7 +45,7 @@ auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
 #define CARBON_SEMANTICS_NODE_KIND(Name)                  \
-  case SemIR::NodeKind::Name:                             \
+  case SemIR::Name::Kind:                                 \
     Handle##Name(*this, node_id, node.As<SemIR::Name>()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -177,64 +177,64 @@ static auto GetTypePrecedence(NodeKind kind) -> int {
   // clang warns on unhandled enum values; clang-tidy is incorrect here.
   // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (kind) {
-    case NodeKind::ArrayType:
-    case NodeKind::Builtin:
-    case NodeKind::StructType:
-    case NodeKind::TupleType:
+    case ArrayType::Kind:
+    case Builtin::Kind:
+    case StructType::Kind:
+    case TupleType::Kind:
       return 0;
-    case NodeKind::ConstType:
+    case ConstType::Kind:
       return -1;
-    case NodeKind::PointerType:
+    case PointerType::Kind:
       return -2;
 
-    case NodeKind::CrossReference:
+    case CrossReference::Kind:
       // TODO: Once we support stringification of cross-references, we'll need
       // to determine the precedence of the target of the cross-reference. For
       // now, all cross-references refer to builtin types from the prelude.
       return 0;
 
-    case NodeKind::AddressOf:
-    case NodeKind::ArrayIndex:
-    case NodeKind::ArrayInit:
-    case NodeKind::Assign:
-    case NodeKind::BinaryOperatorAdd:
-    case NodeKind::BindName:
-    case NodeKind::BindValue:
-    case NodeKind::BlockArg:
-    case NodeKind::BoolLiteral:
-    case NodeKind::Branch:
-    case NodeKind::BranchIf:
-    case NodeKind::BranchWithArg:
-    case NodeKind::Call:
-    case NodeKind::Dereference:
-    case NodeKind::FunctionDeclaration:
-    case NodeKind::InitializeFrom:
-    case NodeKind::IntegerLiteral:
-    case NodeKind::NameReference:
-    case NodeKind::NameReferenceUntyped:
-    case NodeKind::Namespace:
-    case NodeKind::NoOp:
-    case NodeKind::Parameter:
-    case NodeKind::RealLiteral:
-    case NodeKind::Return:
-    case NodeKind::ReturnExpression:
-    case NodeKind::SpliceBlock:
-    case NodeKind::StringLiteral:
-    case NodeKind::StructAccess:
-    case NodeKind::StructTypeField:
-    case NodeKind::StructLiteral:
-    case NodeKind::StructInit:
-    case NodeKind::StructValue:
-    case NodeKind::Temporary:
-    case NodeKind::TemporaryStorage:
-    case NodeKind::TupleAccess:
-    case NodeKind::TupleIndex:
-    case NodeKind::TupleLiteral:
-    case NodeKind::TupleInit:
-    case NodeKind::TupleValue:
-    case NodeKind::UnaryOperatorNot:
-    case NodeKind::ValueAsReference:
-    case NodeKind::VarStorage:
+    case AddressOf::Kind:
+    case ArrayIndex::Kind:
+    case ArrayInit::Kind:
+    case Assign::Kind:
+    case BinaryOperatorAdd::Kind:
+    case BindName::Kind:
+    case BindValue::Kind:
+    case BlockArg::Kind:
+    case BoolLiteral::Kind:
+    case Branch::Kind:
+    case BranchIf::Kind:
+    case BranchWithArg::Kind:
+    case Call::Kind:
+    case Dereference::Kind:
+    case FunctionDeclaration::Kind:
+    case InitializeFrom::Kind:
+    case IntegerLiteral::Kind:
+    case NameReference::Kind:
+    case NameReferenceUntyped::Kind:
+    case Namespace::Kind:
+    case NoOp::Kind:
+    case Parameter::Kind:
+    case RealLiteral::Kind:
+    case Return::Kind:
+    case ReturnExpression::Kind:
+    case SpliceBlock::Kind:
+    case StringLiteral::Kind:
+    case StructAccess::Kind:
+    case StructTypeField::Kind:
+    case StructLiteral::Kind:
+    case StructInit::Kind:
+    case StructValue::Kind:
+    case Temporary::Kind:
+    case TemporaryStorage::Kind:
+    case TupleAccess::Kind:
+    case TupleIndex::Kind:
+    case TupleLiteral::Kind:
+    case TupleInit::Kind:
+    case TupleValue::Kind:
+    case UnaryOperatorNot::Kind:
+    case ValueAsReference::Kind:
+    case VarStorage::Kind:
       CARBON_FATAL() << "GetTypePrecedence for non-type node kind " << kind;
   }
 }
@@ -274,7 +274,7 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-      case NodeKind::ArrayType: {
+      case ArrayType::Kind: {
         auto array = node.As<ArrayType>();
         if (step.index == 0) {
           out << "[";
@@ -286,7 +286,7 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
         }
         break;
       }
-      case NodeKind::ConstType: {
+      case ConstType::Kind: {
         if (step.index == 0) {
           out << "const ";
 
@@ -305,7 +305,7 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
         }
         break;
       }
-      case NodeKind::PointerType: {
+      case PointerType::Kind: {
         if (step.index == 0) {
           steps.push_back(step.Next());
           steps.push_back({.node_id = GetTypeAllowBuiltinTypes(
@@ -315,7 +315,7 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
         }
         break;
       }
-      case NodeKind::StructType: {
+      case StructType::Kind: {
         auto refs = GetNodeBlock(node.As<StructType>().fields_id);
         if (refs.empty()) {
           out << "{}";
@@ -333,13 +333,13 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
         steps.push_back({.node_id = refs[step.index]});
         break;
       }
-      case NodeKind::StructTypeField: {
+      case StructTypeField::Kind: {
         auto field = node.As<StructTypeField>();
         out << "." << GetString(field.name_id) << ": ";
         steps.push_back({.node_id = GetTypeAllowBuiltinTypes(field.type_id)});
         break;
       }
-      case NodeKind::TupleType: {
+      case TupleType::Kind: {
         auto refs = GetTypeBlock(node.As<TupleType>().elements_id);
         if (refs.empty()) {
           out << "()";
@@ -362,49 +362,49 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
             {.node_id = GetTypeAllowBuiltinTypes(refs[step.index])});
         break;
       }
-      case NodeKind::AddressOf:
-      case NodeKind::ArrayIndex:
-      case NodeKind::ArrayInit:
-      case NodeKind::Assign:
-      case NodeKind::BinaryOperatorAdd:
-      case NodeKind::BindName:
-      case NodeKind::BindValue:
-      case NodeKind::BlockArg:
-      case NodeKind::BoolLiteral:
-      case NodeKind::Branch:
-      case NodeKind::BranchIf:
-      case NodeKind::BranchWithArg:
-      case NodeKind::Builtin:
-      case NodeKind::Call:
-      case NodeKind::CrossReference:
-      case NodeKind::Dereference:
-      case NodeKind::FunctionDeclaration:
-      case NodeKind::InitializeFrom:
-      case NodeKind::IntegerLiteral:
-      case NodeKind::NameReference:
-      case NodeKind::NameReferenceUntyped:
-      case NodeKind::Namespace:
-      case NodeKind::NoOp:
-      case NodeKind::Parameter:
-      case NodeKind::RealLiteral:
-      case NodeKind::Return:
-      case NodeKind::ReturnExpression:
-      case NodeKind::SpliceBlock:
-      case NodeKind::StringLiteral:
-      case NodeKind::StructAccess:
-      case NodeKind::StructLiteral:
-      case NodeKind::StructInit:
-      case NodeKind::StructValue:
-      case NodeKind::Temporary:
-      case NodeKind::TemporaryStorage:
-      case NodeKind::TupleAccess:
-      case NodeKind::TupleIndex:
-      case NodeKind::TupleLiteral:
-      case NodeKind::TupleInit:
-      case NodeKind::TupleValue:
-      case NodeKind::UnaryOperatorNot:
-      case NodeKind::ValueAsReference:
-      case NodeKind::VarStorage:
+      case AddressOf::Kind:
+      case ArrayIndex::Kind:
+      case ArrayInit::Kind:
+      case Assign::Kind:
+      case BinaryOperatorAdd::Kind:
+      case BindName::Kind:
+      case BindValue::Kind:
+      case BlockArg::Kind:
+      case BoolLiteral::Kind:
+      case Branch::Kind:
+      case BranchIf::Kind:
+      case BranchWithArg::Kind:
+      case Builtin::Kind:
+      case Call::Kind:
+      case CrossReference::Kind:
+      case Dereference::Kind:
+      case FunctionDeclaration::Kind:
+      case InitializeFrom::Kind:
+      case IntegerLiteral::Kind:
+      case NameReference::Kind:
+      case NameReferenceUntyped::Kind:
+      case Namespace::Kind:
+      case NoOp::Kind:
+      case Parameter::Kind:
+      case RealLiteral::Kind:
+      case Return::Kind:
+      case ReturnExpression::Kind:
+      case SpliceBlock::Kind:
+      case StringLiteral::Kind:
+      case StructAccess::Kind:
+      case StructLiteral::Kind:
+      case StructInit::Kind:
+      case StructValue::Kind:
+      case Temporary::Kind:
+      case TemporaryStorage::Kind:
+      case TupleAccess::Kind:
+      case TupleIndex::Kind:
+      case TupleLiteral::Kind:
+      case TupleInit::Kind:
+      case TupleValue::Kind:
+      case UnaryOperatorNot::Kind:
+      case ValueAsReference::Kind:
+      case VarStorage::Kind:
         // We don't need to handle stringification for nodes that don't show up
         // in errors, but make it clear what's going on so that it's clearer
         // when stringification is needed.
@@ -417,8 +417,8 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
   // conversion to type `type` if it's not implied by the context.
   if (!in_type_context) {
     auto outer_node = GetNode(outer_node_id);
-    if (outer_node.kind() == NodeKind::TupleType ||
-        (outer_node.kind() == NodeKind::StructType &&
+    if (outer_node.kind() == TupleType::Kind ||
+        (outer_node.kind() == StructType::Kind &&
          GetNodeBlock(outer_node.As<StructType>().fields_id).empty())) {
       out << " as type";
     }
@@ -435,99 +435,99 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-      case NodeKind::Assign:
-      case NodeKind::Branch:
-      case NodeKind::BranchIf:
-      case NodeKind::BranchWithArg:
-      case NodeKind::FunctionDeclaration:
-      case NodeKind::NameReferenceUntyped:
-      case NodeKind::Namespace:
-      case NodeKind::NoOp:
-      case NodeKind::Return:
-      case NodeKind::ReturnExpression:
-      case NodeKind::StructTypeField:
+      case Assign::Kind:
+      case Branch::Kind:
+      case BranchIf::Kind:
+      case BranchWithArg::Kind:
+      case FunctionDeclaration::Kind:
+      case NameReferenceUntyped::Kind:
+      case Namespace::Kind:
+      case NoOp::Kind:
+      case Return::Kind:
+      case ReturnExpression::Kind:
+      case StructTypeField::Kind:
         return ExpressionCategory::NotExpression;
 
-      case NodeKind::CrossReference: {
+      case CrossReference::Kind: {
         auto xref = node.As<CrossReference>();
         ir = &ir->GetCrossReferenceIR(xref.ir_id);
         node_id = xref.node_id;
         continue;
       }
 
-      case NodeKind::NameReference: {
+      case NameReference::Kind: {
         node_id = node.As<NameReference>().value_id;
         continue;
       }
 
-      case NodeKind::AddressOf:
-      case NodeKind::ArrayType:
-      case NodeKind::BinaryOperatorAdd:
-      case NodeKind::BindValue:
-      case NodeKind::BlockArg:
-      case NodeKind::BoolLiteral:
-      case NodeKind::Builtin:
-      case NodeKind::ConstType:
-      case NodeKind::IntegerLiteral:
-      case NodeKind::Parameter:
-      case NodeKind::PointerType:
-      case NodeKind::RealLiteral:
-      case NodeKind::StringLiteral:
-      case NodeKind::StructValue:
-      case NodeKind::StructType:
-      case NodeKind::TupleValue:
-      case NodeKind::TupleType:
-      case NodeKind::UnaryOperatorNot:
+      case AddressOf::Kind:
+      case ArrayType::Kind:
+      case BinaryOperatorAdd::Kind:
+      case BindValue::Kind:
+      case BlockArg::Kind:
+      case BoolLiteral::Kind:
+      case Builtin::Kind:
+      case ConstType::Kind:
+      case IntegerLiteral::Kind:
+      case Parameter::Kind:
+      case PointerType::Kind:
+      case RealLiteral::Kind:
+      case StringLiteral::Kind:
+      case StructValue::Kind:
+      case StructType::Kind:
+      case TupleValue::Kind:
+      case TupleType::Kind:
+      case UnaryOperatorNot::Kind:
         return ExpressionCategory::Value;
 
-      case NodeKind::BindName: {
+      case BindName::Kind: {
         node_id = node.As<BindName>().value_id;
         continue;
       }
 
-      case NodeKind::ArrayIndex: {
+      case ArrayIndex::Kind: {
         node_id = node.As<ArrayIndex>().array_id;
         continue;
       }
 
-      case NodeKind::StructAccess: {
+      case StructAccess::Kind: {
         node_id = node.As<StructAccess>().struct_id;
         continue;
       }
 
-      case NodeKind::TupleAccess: {
+      case TupleAccess::Kind: {
         node_id = node.As<TupleAccess>().tuple_id;
         continue;
       }
 
-      case NodeKind::TupleIndex: {
+      case TupleIndex::Kind: {
         node_id = node.As<TupleIndex>().tuple_id;
         continue;
       }
 
-      case NodeKind::SpliceBlock: {
+      case SpliceBlock::Kind: {
         node_id = node.As<SpliceBlock>().result_id;
         continue;
       }
 
-      case NodeKind::StructLiteral:
-      case NodeKind::TupleLiteral:
+      case StructLiteral::Kind:
+      case TupleLiteral::Kind:
         return ExpressionCategory::Mixed;
 
-      case NodeKind::ArrayInit:
-      case NodeKind::Call:
-      case NodeKind::InitializeFrom:
-      case NodeKind::StructInit:
-      case NodeKind::TupleInit:
+      case ArrayInit::Kind:
+      case Call::Kind:
+      case InitializeFrom::Kind:
+      case StructInit::Kind:
+      case TupleInit::Kind:
         return ExpressionCategory::Initializing;
 
-      case NodeKind::Dereference:
-      case NodeKind::VarStorage:
+      case Dereference::Kind:
+      case VarStorage::Kind:
         return ExpressionCategory::DurableReference;
 
-      case NodeKind::Temporary:
-      case NodeKind::TemporaryStorage:
-      case NodeKind::ValueAsReference:
+      case Temporary::Kind:
+      case TemporaryStorage::Kind:
+      case ValueAsReference::Kind:
         return ExpressionCategory::EphemeralReference;
     }
   }
@@ -542,68 +542,68 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-      case NodeKind::AddressOf:
-      case NodeKind::ArrayIndex:
-      case NodeKind::ArrayInit:
-      case NodeKind::Assign:
-      case NodeKind::BinaryOperatorAdd:
-      case NodeKind::BindName:
-      case NodeKind::BindValue:
-      case NodeKind::BlockArg:
-      case NodeKind::BoolLiteral:
-      case NodeKind::Branch:
-      case NodeKind::BranchIf:
-      case NodeKind::BranchWithArg:
-      case NodeKind::Call:
-      case NodeKind::Dereference:
-      case NodeKind::FunctionDeclaration:
-      case NodeKind::InitializeFrom:
-      case NodeKind::IntegerLiteral:
-      case NodeKind::NameReference:
-      case NodeKind::NameReferenceUntyped:
-      case NodeKind::Namespace:
-      case NodeKind::NoOp:
-      case NodeKind::Parameter:
-      case NodeKind::RealLiteral:
-      case NodeKind::Return:
-      case NodeKind::ReturnExpression:
-      case NodeKind::StringLiteral:
-      case NodeKind::StructAccess:
-      case NodeKind::StructTypeField:
-      case NodeKind::StructLiteral:
-      case NodeKind::StructInit:
-      case NodeKind::StructValue:
-      case NodeKind::Temporary:
-      case NodeKind::TemporaryStorage:
-      case NodeKind::TupleAccess:
-      case NodeKind::TupleIndex:
-      case NodeKind::TupleLiteral:
-      case NodeKind::TupleInit:
-      case NodeKind::TupleValue:
-      case NodeKind::UnaryOperatorNot:
-      case NodeKind::ValueAsReference:
-      case NodeKind::VarStorage:
+      case AddressOf::Kind:
+      case ArrayIndex::Kind:
+      case ArrayInit::Kind:
+      case Assign::Kind:
+      case BinaryOperatorAdd::Kind:
+      case BindName::Kind:
+      case BindValue::Kind:
+      case BlockArg::Kind:
+      case BoolLiteral::Kind:
+      case Branch::Kind:
+      case BranchIf::Kind:
+      case BranchWithArg::Kind:
+      case Call::Kind:
+      case Dereference::Kind:
+      case FunctionDeclaration::Kind:
+      case InitializeFrom::Kind:
+      case IntegerLiteral::Kind:
+      case NameReference::Kind:
+      case NameReferenceUntyped::Kind:
+      case Namespace::Kind:
+      case NoOp::Kind:
+      case Parameter::Kind:
+      case RealLiteral::Kind:
+      case Return::Kind:
+      case ReturnExpression::Kind:
+      case StringLiteral::Kind:
+      case StructAccess::Kind:
+      case StructTypeField::Kind:
+      case StructLiteral::Kind:
+      case StructInit::Kind:
+      case StructValue::Kind:
+      case Temporary::Kind:
+      case TemporaryStorage::Kind:
+      case TupleAccess::Kind:
+      case TupleIndex::Kind:
+      case TupleLiteral::Kind:
+      case TupleInit::Kind:
+      case TupleValue::Kind:
+      case UnaryOperatorNot::Kind:
+      case ValueAsReference::Kind:
+      case VarStorage::Kind:
         CARBON_FATAL() << "Type refers to non-type node " << node;
 
-      case NodeKind::CrossReference: {
+      case CrossReference::Kind: {
         auto xref = node.As<CrossReference>();
         ir = &ir->GetCrossReferenceIR(xref.ir_id);
         node_id = xref.node_id;
         continue;
       }
 
-      case NodeKind::SpliceBlock: {
+      case SpliceBlock::Kind: {
         node_id = node.As<SpliceBlock>().result_id;
         continue;
       }
 
-      case NodeKind::ArrayType:
+      case ArrayType::Kind:
         // For arrays, it's convenient to always use a pointer representation,
         // even when the array has zero or one element, in order to support
         // indexing.
         return {.kind = ValueRepresentation::Pointer, .type = type_id};
 
-      case NodeKind::StructType: {
+      case StructType::Kind: {
         const auto& fields = ir->GetNodeBlock(node.As<StructType>().fields_id);
         if (fields.empty()) {
           // An empty struct has an empty representation.
@@ -619,7 +619,7 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
         return {.kind = ValueRepresentation::Pointer, .type = type_id};
       }
 
-      case NodeKind::TupleType: {
+      case TupleType::Kind: {
         const auto& elements =
             ir->GetTypeBlock(node.As<TupleType>().elements_id);
         if (elements.empty()) {
@@ -635,7 +635,7 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
         return {.kind = ValueRepresentation::Pointer, .type = type_id};
       }
 
-      case NodeKind::Builtin:
+      case Builtin::Kind:
         // clang warns on unhandled enum values; clang-tidy is incorrect here.
         // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
         switch (node.As<Builtin>().builtin_kind) {
@@ -654,10 +654,10 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
             return {.kind = ValueRepresentation::Pointer, .type = type_id};
         }
 
-      case NodeKind::PointerType:
+      case PointerType::Kind:
         return {.kind = ValueRepresentation::Copy, .type = type_id};
 
-      case NodeKind::ConstType:
+      case ConstType::Kind:
         node_id = ir->GetTypeAllowBuiltinTypes(node.As<ConstType>().inner_id);
         continue;
     }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -275,13 +275,13 @@ class NodeNamer {
     switch (parse_tree_.node_kind(node.parse_node())) {
       case Parse::NodeKind::IfExpressionIf:
         switch (node.kind()) {
-          case NodeKind::BranchIf:
+          case BranchIf::Kind:
             name = "if.expr.then";
             break;
-          case NodeKind::Branch:
+          case Branch::Kind:
             name = "if.expr.else";
             break;
-          case NodeKind::BranchWithArg:
+          case BranchWithArg::Kind:
             name = "if.expr.result";
             break;
           default:
@@ -291,10 +291,10 @@ class NodeNamer {
 
       case Parse::NodeKind::IfCondition:
         switch (node.kind()) {
-          case NodeKind::BranchIf:
+          case BranchIf::Kind:
             name = "if.then";
             break;
-          case NodeKind::Branch:
+          case Branch::Kind:
             name = "if.else";
             break;
           default:
@@ -307,7 +307,7 @@ class NodeNamer {
         break;
 
       case Parse::NodeKind::ShortCircuitOperand: {
-        bool is_rhs = node.kind() == NodeKind::BranchIf;
+        bool is_rhs = node.kind() == BranchIf::Kind;
         bool is_and = tokenized_buffer_.GetKind(parse_tree_.node_token(
                           node.parse_node())) == Lex::TokenKind::And;
         name = is_and ? (is_rhs ? "and.rhs" : "and.result")
@@ -349,51 +349,51 @@ class NodeNamer {
       };
 
       switch (node.kind()) {
-        case NodeKind::Branch: {
+        case Branch::Kind: {
           AddBlockLabel(scope_idx, node.As<Branch>().target_id, node);
           break;
         }
-        case NodeKind::BranchIf: {
+        case BranchIf::Kind: {
           AddBlockLabel(scope_idx, node.As<BranchIf>().target_id, node);
           break;
         }
-        case NodeKind::BranchWithArg: {
+        case BranchWithArg::Kind: {
           AddBlockLabel(scope_idx, node.As<BranchWithArg>().target_id, node);
           break;
         }
-        case NodeKind::SpliceBlock: {
+        case SpliceBlock::Kind: {
           CollectNamesInBlock(scope_idx, node.As<SpliceBlock>().block_id);
           break;
         }
-        case NodeKind::BindName: {
+        case BindName::Kind: {
           add_node_name_id(node.As<BindName>().name_id);
           continue;
         }
-        case NodeKind::FunctionDeclaration: {
+        case FunctionDeclaration::Kind: {
           add_node_name_id(
               semantics_ir_
                   .GetFunction(node.As<FunctionDeclaration>().function_id)
                   .name_id);
           continue;
         }
-        case NodeKind::NameReference: {
+        case NameReference::Kind: {
           add_node_name(
               semantics_ir_.GetString(node.As<NameReference>().name_id).str() +
               ".ref");
           continue;
         }
-        case NodeKind::NameReferenceUntyped: {
+        case NameReferenceUntyped::Kind: {
           add_node_name(
               semantics_ir_.GetString(node.As<NameReferenceUntyped>().name_id)
                   .str() +
               ".ref");
           continue;
         }
-        case NodeKind::Parameter: {
+        case Parameter::Kind: {
           add_node_name_id(node.As<Parameter>().name_id);
           continue;
         }
-        case NodeKind::VarStorage: {
+        case VarStorage::Kind: {
           // TODO: Eventually this name will be optional, and we'll want to
           // provide something like `var` as a default. However, that's not
           // possible right now so cannot be tested.
@@ -525,9 +525,9 @@ class Formatter {
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(Kind)         \
-  case NodeKind::Kind:                           \
-    FormatInstruction(node_id, node.As<Kind>()); \
+#define CARBON_SEMANTICS_NODE_KIND(NodeT)         \
+  case NodeT::Kind:                               \
+    FormatInstruction(node_id, node.As<NodeT>()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"
     }
@@ -591,7 +591,7 @@ class Formatter {
     }
     out_ << "if ";
     FormatNodeName(node.cond_id);
-    out_ << " " << NodeKind::Branch.ir_name() << " ";
+    out_ << " " << Branch::Kind.ir_name() << " ";
     FormatLabel(node.target_id);
     out_ << " else ";
     in_terminator_sequence_ = true;
@@ -601,7 +601,7 @@ class Formatter {
     if (!in_terminator_sequence_) {
       Indent();
     }
-    out_ << NodeKind::BranchWithArg.ir_name() << " ";
+    out_ << BranchWithArg::Kind.ir_name() << " ";
     FormatLabel(node.target_id);
     out_ << "(";
     FormatNodeName(node.arg_id);
@@ -613,7 +613,7 @@ class Formatter {
     if (!in_terminator_sequence_) {
       Indent();
     }
-    out_ << NodeKind::Branch.ir_name() << " ";
+    out_ << Branch::Kind.ir_name() << " ";
     FormatLabel(node.target_id);
     out_ << "\n";
     in_terminator_sequence_ = false;

--- a/toolchain/sem_ir/node.cpp
+++ b/toolchain/sem_ir/node.cpp
@@ -18,7 +18,7 @@ auto Node::Print(llvm::raw_ostream& out) const -> void {
   // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (kind_) {
 #define CARBON_SEMANTICS_NODE_KIND(Name)                    \
-  case NodeKind::Name:                                      \
+  case Name::Kind:                                          \
     std::apply(print_args, As<SemIR::Name>().args_tuple()); \
     break;
 #include "toolchain/sem_ir/node_kind.def"


### PR DESCRIPTION
This is shorter, more closely connected to code using the typed node types, and avoids using the ambiguous word `Node` in places referring to typed `SemIR` nodes.