### PR TITLE
Made function and namespace nodes typed to remove a crash

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -145,21 +145,11 @@ auto Context::PopScope() -> void {
 }
 
 auto Context::FollowNameReferences(SemIR::NodeId node_id) -> SemIR::NodeId {
-  while (true) {
-    auto node = semantics_ir().GetNode(node_id);
-    switch (node.kind()) {
-      case SemIR::NodeKind::NameReference: {
-        node_id = node.As<SemIR::NameReference>().value_id;
-        break;
-      }
-      case SemIR::NodeKind::NameReferenceUntyped: {
-        node_id = node.As<SemIR::NameReferenceUntyped>().value_id;
-        break;
-      }
-      default:
-        return node_id;
-    }
+  while (auto name_ref =
+             semantics_ir().GetNode(node_id).TryAs<SemIR::NameReference>()) {
+    node_id = name_ref->value_id;
   }
+  return node_id;
 }
 
 template <typename BranchNode, typename... Args>

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -57,8 +57,9 @@ static auto BuildFunctionDeclaration(Context& context)
        .return_type_id = return_type_id,
        .return_slot_id = return_slot_id,
        .body_block_ids = {}});
-  auto decl_id =
-      context.AddNode(SemIR::FunctionDeclaration(fn_node, function_id));
+  auto decl_id = context.AddNode(SemIR::FunctionDeclaration(
+      fn_node, context.CanonicalizeType(SemIR::NodeId::BuiltinFunctionType),
+      function_id));
   context.declaration_name_stack().AddNameToLookup(name_context, decl_id);
 
   if (SemIR::IsEntryPoint(context.semantics_ir(), function_id)) {

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -94,18 +94,11 @@ auto HandleNameExpression(Context& context, Parse::Node parse_node) -> bool {
       context.LookupName(parse_node, name_id, SemIR::NameScopeId::Invalid,
                          /*print_diagnostics=*/true);
   auto value = context.semantics_ir().GetNode(value_id);
-  if (value.kind().value_kind() == SemIR::NodeValueKind::Typed) {
-    // This is a reference to a name binding that has a value and a type.
-    context.AddNodeAndPush(
-        parse_node,
-        SemIR::NameReference(parse_node, value.type_id(), name_id, value_id));
-  } else {
-    // This is something like a namespace name, that can be found by name lookup
-    // but isn't a first-class value with a type.
-    context.AddNodeAndPush(
-        parse_node, SemIR::NameReferenceUntyped(parse_node, value.type_id(),
-                                                name_id, value_id));
-  }
+  // This is a reference to a name binding that has a value and a type.
+  CARBON_CHECK(value.kind().value_kind() == SemIR::NodeValueKind::Typed);
+  context.AddNodeAndPush(
+      parse_node,
+      SemIR::NameReference(parse_node, value.type_id(), name_id, value_id));
   return true;
 }
 

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -15,8 +15,9 @@ auto HandleNamespaceStart(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleNamespace(Context& context, Parse::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
-  auto namespace_id = context.AddNode(
-      SemIR::Namespace(parse_node, context.semantics_ir().AddNameScope()));
+  auto namespace_id = context.AddNode(SemIR::Namespace(
+      parse_node, context.CanonicalizeType(SemIR::NodeId::BuiltinNamespaceType),
+      context.semantics_ir().AddNameScope()));
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;
 }

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -11,8 +11,8 @@ fn G() {
 }
 
 // CHECK:STDOUT: file "array_in_place.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -23,13 +23,13 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32)
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_34 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_42.3: ref (i32, i32, i32) = splice_block %.loc10_42.2 {
 // CHECK:STDOUT:     %.loc10_42.1: i32 = int_literal 0
 // CHECK:STDOUT:     %.loc10_42.2: ref (i32, i32, i32) = array_index %v, %.loc10_42.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_35: init (i32, i32, i32) = call @F() to %.loc10_42.3
-// CHECK:STDOUT:   %F.ref.loc10_39 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_39: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_42.6: ref (i32, i32, i32) = splice_block %.loc10_42.5 {
 // CHECK:STDOUT:     %.loc10_42.4: i32 = int_literal 1
 // CHECK:STDOUT:     %.loc10_42.5: ref (i32, i32, i32) = array_index %v, %.loc10_42.4

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -11,8 +11,8 @@ fn Run() {
 }
 
 // CHECK:STDOUT: file "assign_return_value.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
@@ -28,7 +28,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32
 // CHECK:STDOUT:   %t: ref [i32; 1] = var "t"
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_22.1: init (i32,) = call @F()
 // CHECK:STDOUT:   %.loc10_22.2: ref (i32,) = temporary_storage
 // CHECK:STDOUT:   %.loc10_22.3: ref (i32,) = temporary %.loc10_22.2, %.loc10_22.1

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -13,8 +13,8 @@ fn G() -> i32 {
 }
 
 // CHECK:STDOUT: file "function_param.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%arr: [i32; 3], %i: i32) -> i32 {
@@ -29,7 +29,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -28,6 +28,8 @@
 // CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeIntegerType, type: typeTypeType},
 // CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeFloatingPointType, type: typeTypeType},
 // CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeStringType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeFunctionType, type: typeTypeType},
+// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeNamespaceType, type: typeTypeType},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     node_blocks: [
 // CHECK:STDOUT:       [

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -13,7 +13,7 @@
 fn Run() -> String {}
 
 // CHECK:STDOUT: file "fail_bad_run.carbon" {
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT:   %.loc13: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_bad_run_2.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run_2.carbon
@@ -10,7 +10,7 @@
 fn Run(n: i32) {}
 
 // CHECK:STDOUT: file "fail_bad_run_2.carbon" {
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run(%n: i32) {

--- a/toolchain/check/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/check/testdata/basics/fail_name_lookup.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_name_lookup.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/basics/multifile.carbon
+++ b/toolchain/check/testdata/basics/multifile.carbon
@@ -11,7 +11,7 @@ fn A() {}
 fn B() {}
 
 // CHECK:STDOUT: file "a.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
@@ -19,7 +19,7 @@ fn B() {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT: file "b.carbon" {
-// CHECK:STDOUT:   %B = fn_decl @B
+// CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() {

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -28,11 +28,12 @@ fn B() {}
 // CHECK:STDOUT:       A,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
 // CHECK:STDOUT:       {kind: Return},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     node_blocks: [
@@ -47,7 +48,7 @@ fn B() {}
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "a.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
@@ -68,11 +69,12 @@ fn B() {}
 // CHECK:STDOUT:       B,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
 // CHECK:STDOUT:       {kind: Return},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     node_blocks: [
@@ -87,7 +89,7 @@ fn B() {}
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "b.carbon" {
-// CHECK:STDOUT:   %B = fn_decl @B
+// CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() {

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -28,11 +28,12 @@ fn B() {}
 // CHECK:STDOUT:       A,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
 // CHECK:STDOUT:       {kind: Return},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     node_blocks: [
@@ -59,11 +60,12 @@ fn B() {}
 // CHECK:STDOUT:       B,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
 // CHECK:STDOUT:       {kind: Return},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     node_blocks: [

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -26,7 +26,7 @@ fn F() {
 }
 
 // CHECK:STDOUT: file "numeric_literals.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -34,6 +34,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       node+1,
 // CHECK:STDOUT:       nodeFloatingPointType,
 // CHECK:STDOUT:       node+3,
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:       [
@@ -51,7 +52,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       {kind: TupleLiteral, arg0: block2, type: type1},
 // CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
 // CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type4},
 // CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
 // CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
 // CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+6, arg1: node+7, type: type0},
@@ -108,7 +109,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -34,6 +34,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       node+1,
 // CHECK:STDOUT:       nodeFloatingPointType,
 // CHECK:STDOUT:       node+3,
+// CHECK:STDOUT:       nodeFunctionType,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [
 // CHECK:STDOUT:       [
@@ -51,7 +52,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       {kind: TupleLiteral, arg0: block2, type: type1},
 // CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
 // CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0},
+// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type4},
 // CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
 // CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
 // CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+6, arg1: node+7, type: type0},

--- a/toolchain/check/testdata/basics/run.carbon
+++ b/toolchain/check/testdata/basics/run.carbon
@@ -7,7 +7,7 @@
 fn Run() {}
 
 // CHECK:STDOUT: file "run.carbon" {
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/basics/run_i32.carbon
+++ b/toolchain/check/testdata/basics/run_i32.carbon
@@ -7,7 +7,7 @@
 fn Run() -> i32 { return 0; }
 
 // CHECK:STDOUT: file "run_i32.carbon" {
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -13,7 +13,7 @@ fn Foo(n: i32) -> (i32, f64) {
 }
 
 // CHECK:STDOUT: file "textual_ir.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/basics/verbose.carbon
+++ b/toolchain/check/testdata/basics/verbose.carbon
@@ -8,7 +8,7 @@
 // NOAUTOUPDATE
 // SET-CHECK-SUBSET
 // CHECK:STDERR: Node Push 0: FunctionIntroducer -> <none>
-// CHECK:STDERR: AddNode: {kind: FunctionDeclaration, arg0: function{{[0-9]+}}}
+// CHECK:STDERR: AddNode: {kind: FunctionDeclaration, arg0: function{{[0-9]+}}, type: type{{[0-9]+}}}
 // CHECK:STDERR: node_block_stack_ Push 1
 // CHECK:STDERR: AddNode: {kind: Return}
 // CHECK:STDERR: node_block_stack_ Pop 1: block{{[0-9]+}}

--- a/toolchain/check/testdata/const/collapse.carbon
+++ b/toolchain/check/testdata/const/collapse.carbon
@@ -13,7 +13,7 @@ fn F(p: const i32**) -> const (const i32)** {
 }
 
 // CHECK:STDOUT: file "collapse.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%p: const i32**) -> const i32** {

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -15,7 +15,7 @@ fn G(p: const (const i32)**) -> i32** {
 }
 
 // CHECK:STDOUT: file "fail_collapse.carbon" {
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%p: const i32**) -> i32** {

--- a/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
+++ b/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
@@ -17,9 +17,9 @@ fn H() -> i32 {
 }
 
 // CHECK:STDOUT: file "in_place_tuple_initialization.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32);
@@ -28,16 +28,16 @@ fn H() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_19: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %v: ref (i32, i32) = var "v"
-// CHECK:STDOUT:   %F.ref.loc10 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_7: ref (i32, i32) = splice_block %v {}
 // CHECK:STDOUT:   %.loc10_24: init (i32, i32) = call @F() to %.loc10_7
 // CHECK:STDOUT:   assign %v, %.loc10_24
 // CHECK:STDOUT:   %v.ref: ref (i32, i32) = name_reference "v", %v
-// CHECK:STDOUT:   %F.ref.loc11 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc11: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc11_3: ref (i32, i32) = splice_block %v.ref {}
 // CHECK:STDOUT:   %.loc11_8: init (i32, i32) = call @F() to %.loc11_3
 // CHECK:STDOUT:   assign %v.ref, %.loc11_8
-// CHECK:STDOUT:   %F.ref.loc12 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc12: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc9: ref (i32, i32) = splice_block %return {}
 // CHECK:STDOUT:   %.loc12: init (i32, i32) = call @F() to %.loc9
 // CHECK:STDOUT:   return %.loc12
@@ -45,7 +45,7 @@ fn H() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc16_11.1: ref (i32, i32) = temporary_storage
 // CHECK:STDOUT:   %.loc16_11.2: init (i32, i32) = call @G() to %.loc16_11.1
 // CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -13,8 +13,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "empty_struct.carbon" {
-// CHECK:STDOUT:   %Echo = fn_decl @Echo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: {}) -> {} {
@@ -25,7 +25,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref = name_reference_untyped "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
 // CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: {} = struct_value %.loc12_9.1, ()
 // CHECK:STDOUT:   %.loc12_7: init {} = call @Echo(%.loc12_9.2)

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -13,8 +13,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "empty_tuple.carbon" {
-// CHECK:STDOUT:   %Echo = fn_decl @Echo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: ()) -> () {
@@ -25,7 +25,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref = name_reference_untyped "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
 // CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: () = tuple_value %.loc12_9.1, ()
 // CHECK:STDOUT:   %.loc12_7: init () = call @Echo(%.loc12_9.2)

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -15,7 +15,7 @@ fn Run() {
 }
 
 // CHECK:STDOUT: file "fail_not_callable.carbon" {
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -56,10 +56,10 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_param_count.carbon" {
-// CHECK:STDOUT:   %Run0 = fn_decl @Run0
-// CHECK:STDOUT:   %Run1 = fn_decl @Run1
-// CHECK:STDOUT:   %Run2 = fn_decl @Run2
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Run0: <function> = fn_decl @Run0
+// CHECK:STDOUT:   %Run1: <function> = fn_decl @Run1
+// CHECK:STDOUT:   %Run2: <function> = fn_decl @Run2
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run0() {
@@ -79,18 +79,18 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Run0.ref.loc18 = name_reference_untyped "Run0", package.%Run0
+// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_reference "Run0", package.%Run0
 // CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc18_7: type = tuple_type ()
-// CHECK:STDOUT:   %Run0.ref.loc25 = name_reference_untyped "Run0", package.%Run0
+// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_reference "Run0", package.%Run0
 // CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1
-// CHECK:STDOUT:   %Run1.ref.loc33 = name_reference_untyped "Run1", package.%Run1
-// CHECK:STDOUT:   %Run1.ref.loc40 = name_reference_untyped "Run1", package.%Run1
+// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_reference "Run1", package.%Run1
+// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_reference "Run1", package.%Run1
 // CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1
-// CHECK:STDOUT:   %Run2.ref.loc48 = name_reference_untyped "Run2", package.%Run2
-// CHECK:STDOUT:   %Run2.ref.loc55 = name_reference_untyped "Run2", package.%Run2
+// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_reference "Run2", package.%Run2
+// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_reference "Run2", package.%Run2
 // CHECK:STDOUT:   %.loc55: i32 = int_literal 0
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -17,8 +17,8 @@ fn F() {
 }
 
 // CHECK:STDOUT: file "fail_param_type.carbon" {
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%a: i32) {
@@ -28,7 +28,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1
 // CHECK:STDOUT:   %.loc16_4: type = tuple_type ()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -14,8 +14,8 @@ fn Run() {
 }
 
 // CHECK:STDOUT: file "fail_return_type_mismatch.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() -> f64 {
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x: ref i32 = var "x"
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc13: init f64 = call @Foo()
 // CHECK:STDOUT:   assign %x, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -13,8 +13,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "i32.carbon" {
-// CHECK:STDOUT:   %Echo = fn_decl @Echo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: i32) -> i32 {
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %b: ref i32 = var "b"
-// CHECK:STDOUT:   %Echo.ref = name_reference_untyped "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
 // CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc12_20: init i32 = call @Echo(%.loc12_21)
 // CHECK:STDOUT:   assign %b, %.loc12_20

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -12,8 +12,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "more_param_ir.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32, %c: i32) {
@@ -23,7 +23,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_11: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_9: i32 = add %.loc11_7, %.loc11_11

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -11,8 +11,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "params_one.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call @Foo(%.loc10_7)

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -12,8 +12,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "params_one_comma.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
@@ -23,11 +23,11 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10 = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call @Foo(%.loc10_7)
-// CHECK:STDOUT:   %Foo.ref.loc11 = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_6: init () = call @Foo(%.loc11_7)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -11,8 +11,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "params_two.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -12,8 +12,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "params_two_comma.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
@@ -23,12 +23,12 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10 = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call @Foo(%.loc10_7, %.loc10_10)
-// CHECK:STDOUT:   %Foo.ref.loc11 = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_6: init () = call @Foo(%.loc11_7, %.loc11_10)

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -11,8 +11,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "params_zero.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call @Foo()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -12,8 +12,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "return_implicit.carbon" {
-// CHECK:STDOUT:   %MakeImplicitEmptyTuple = fn_decl @MakeImplicitEmptyTuple
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %MakeImplicitEmptyTuple: <function> = fn_decl @MakeImplicitEmptyTuple
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeImplicitEmptyTuple() {
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_11.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc11_11.2: () = tuple_literal ()
 // CHECK:STDOUT:   %b: ref () = var "b"
-// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref = name_reference_untyped "MakeImplicitEmptyTuple", package.%MakeImplicitEmptyTuple
+// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_reference "MakeImplicitEmptyTuple", package.%MakeImplicitEmptyTuple
 // CHECK:STDOUT:   %.loc11_37: init () = call @MakeImplicitEmptyTuple()
 // CHECK:STDOUT:   assign %b, %.loc11_37
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -9,15 +9,15 @@ fn F();
 fn G() { F(); }
 
 // CHECK:STDOUT: file "simple.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc9_11.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc9_11.2: init () = call @F()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
@@ -13,7 +13,7 @@
 fn Bar(a: i32, a: i32) {}
 
 // CHECK:STDOUT: file "fail_param_name_conflict.carbon" {
-// CHECK:STDOUT:   %Bar = fn_decl @Bar
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Bar(%a.loc13_8: i32, %a.loc13_16: i32) {

--- a/toolchain/check/testdata/function/definition/order.carbon
+++ b/toolchain/check/testdata/function/definition/order.carbon
@@ -9,9 +9,9 @@ fn Bar() {}
 fn Baz() {}
 
 // CHECK:STDOUT: file "order.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Bar = fn_decl @Bar
-// CHECK:STDOUT:   %Baz = fn_decl @Baz
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
+// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {

--- a/toolchain/check/testdata/function/definition/params_one.carbon
+++ b/toolchain/check/testdata/function/definition/params_one.carbon
@@ -7,7 +7,7 @@
 fn Foo(a: i32) {}
 
 // CHECK:STDOUT: file "params_one.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/definition/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_one_comma.carbon
@@ -7,7 +7,7 @@
 fn Foo(a: i32,) {}
 
 // CHECK:STDOUT: file "params_one_comma.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/definition/params_two.carbon
+++ b/toolchain/check/testdata/function/definition/params_two.carbon
@@ -7,7 +7,7 @@
 fn Foo(a: i32, b: i32) {}
 
 // CHECK:STDOUT: file "params_two.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/definition/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_two_comma.carbon
@@ -7,7 +7,7 @@
 fn Foo(a: i32, b: i32,) {}
 
 // CHECK:STDOUT: file "params_two_comma.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/definition/params_zero.carbon
+++ b/toolchain/check/testdata/function/definition/params_zero.carbon
@@ -7,7 +7,7 @@
 fn Foo() {}
 
 // CHECK:STDOUT: file "params_zero.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {

--- a/toolchain/check/testdata/function/definition/same_param_name.carbon
+++ b/toolchain/check/testdata/function/definition/same_param_name.carbon
@@ -8,8 +8,8 @@ fn Foo(a: i32) {}
 fn Bar(a: i32) {}
 
 // CHECK:STDOUT: file "same_param_name.carbon" {
-// CHECK:STDOUT:   %Foo = fn_decl @Foo
-// CHECK:STDOUT:   %Bar = fn_decl @Bar
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -18,10 +18,10 @@ fn If(b: bool) {
 }
 
 // CHECK:STDOUT: file "else.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
-// CHECK:STDOUT:   %If = fn_decl @If
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -45,18 +45,18 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc13_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc13_6.2: init () = call @F()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc15: init () = call @G()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
-// CHECK:STDOUT:   %H.ref = name_reference_untyped "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
 // CHECK:STDOUT:   %.loc17: init () = call @H()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -34,9 +34,9 @@ fn If3(b: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_reachable_fallthrough.carbon" {
-// CHECK:STDOUT:   %If1 = fn_decl @If1
-// CHECK:STDOUT:   %If2 = fn_decl @If2
-// CHECK:STDOUT:   %If3 = fn_decl @If3
+// CHECK:STDOUT:   %If1: <function> = fn_decl @If1
+// CHECK:STDOUT:   %If2: <function> = fn_decl @If2
+// CHECK:STDOUT:   %If3: <function> = fn_decl @If3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @If1(%b: bool) -> i32 {

--- a/toolchain/check/testdata/if/fail_scope.carbon
+++ b/toolchain/check/testdata/if/fail_scope.carbon
@@ -16,7 +16,7 @@ fn VarScope(b: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_scope.carbon" {
-// CHECK:STDOUT:   %VarScope = fn_decl @VarScope
+// CHECK:STDOUT:   %VarScope: <function> = fn_decl @VarScope
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @VarScope(%b: bool) -> i32 {

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -15,9 +15,9 @@ fn If(b: bool) {
 }
 
 // CHECK:STDOUT: file "no_else.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %If = fn_decl @If
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -36,13 +36,13 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc12_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc12_6.2: init () = call @F()
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc14: init () = call @G()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/unreachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/unreachable_fallthrough.carbon
@@ -14,7 +14,7 @@ fn If(b: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "unreachable_fallthrough.carbon" {
-// CHECK:STDOUT:   %If = fn_decl @If
+// CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @If(%b: bool) -> i32 {

--- a/toolchain/check/testdata/if_expression/basic.carbon
+++ b/toolchain/check/testdata/if_expression/basic.carbon
@@ -9,7 +9,7 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 }
 
 // CHECK:STDOUT: file "basic.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool, %n: i32, %m: i32) -> i32 {

--- a/toolchain/check/testdata/if_expression/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expression/constant_condition.carbon
@@ -16,10 +16,10 @@ fn G() -> i32 {
 }
 
 // CHECK:STDOUT: file "constant_condition.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
-// CHECK:STDOUT:   %B = fn_decl @B
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
+// CHECK:STDOUT:   %B: <function> = fn_decl @B
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
@@ -40,7 +40,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   if %.loc11_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref = name_reference_untyped "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
 // CHECK:STDOUT:   %.loc11_24.1: init i32 = call @A()
 // CHECK:STDOUT:   %.loc11_24.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_24.3: ref i32 = temporary %.loc11_24.2, %.loc11_24.1
@@ -48,7 +48,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_24.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref = name_reference_untyped "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
 // CHECK:STDOUT:   %.loc11_33.1: init i32 = call @B()
 // CHECK:STDOUT:   %.loc11_33.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_33.3: ref i32 = temporary %.loc11_33.2, %.loc11_33.1
@@ -66,7 +66,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   if %.loc15_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref = name_reference_untyped "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
 // CHECK:STDOUT:   %.loc15_25.1: init i32 = call @A()
 // CHECK:STDOUT:   %.loc15_25.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc15_25.3: ref i32 = temporary %.loc15_25.2, %.loc15_25.1
@@ -74,7 +74,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc15_25.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref = name_reference_untyped "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
 // CHECK:STDOUT:   %.loc15_34.1: init i32 = call @B()
 // CHECK:STDOUT:   %.loc15_34.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc15_34.3: ref i32 = temporary %.loc15_34.2, %.loc15_34.1

--- a/toolchain/check/testdata/if_expression/control_flow.carbon
+++ b/toolchain/check/testdata/if_expression/control_flow.carbon
@@ -12,9 +12,9 @@ fn F(b: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "control_flow.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
-// CHECK:STDOUT:   %B = fn_decl @B
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
+// CHECK:STDOUT:   %B: <function> = fn_decl @B
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
@@ -35,7 +35,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref = name_reference_untyped "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
 // CHECK:STDOUT:   %.loc11_21.1: init i32 = call @A()
 // CHECK:STDOUT:   %.loc11_21.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_21.3: ref i32 = temporary %.loc11_21.2, %.loc11_21.1
@@ -43,7 +43,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_21.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref = name_reference_untyped "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
 // CHECK:STDOUT:   %.loc11_30.1: init i32 = call @B()
 // CHECK:STDOUT:   %.loc11_30.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_30.3: ref i32 = temporary %.loc11_30.2, %.loc11_30.1

--- a/toolchain/check/testdata/if_expression/nested.carbon
+++ b/toolchain/check/testdata/if_expression/nested.carbon
@@ -9,7 +9,7 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "nested.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: bool, %b: bool, %c: bool) -> i32 {

--- a/toolchain/check/testdata/if_expression/struct.carbon
+++ b/toolchain/check/testdata/if_expression/struct.carbon
@@ -12,8 +12,8 @@ fn F(cond: bool) {
 }
 
 // CHECK:STDOUT: file "struct.carbon" {
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%s: {.a: i32, .b: i32});
@@ -31,7 +31,7 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_46.5: init i32 = initialize_from %.loc10_45 to %.loc10_46.4
 // CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init %.loc10_46.1, (%.loc10_46.3, %.loc10_46.5)
 // CHECK:STDOUT:   assign %a, %.loc10_46.6
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %cond.ref: bool = name_reference "cond", %cond
 // CHECK:STDOUT:   if %cond.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/expression_category.carbon
+++ b/toolchain/check/testdata/index/expression_category.carbon
@@ -25,9 +25,9 @@ fn ValueBinding(b: [i32; 3]) {
 }
 
 // CHECK:STDOUT: file "expression_category.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %ValueBinding = fn_decl @ValueBinding
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];
@@ -96,7 +96,7 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc23_6.1: ref [i32; 3] = value_as_reference %b.ref
 // CHECK:STDOUT:   %.loc23_6.2: ref i32 = array_index %.loc23_6.1, %.loc23_5
 // CHECK:STDOUT:   %.loc23_6.3: i32 = bind_value %.loc23_6.2
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc24_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc24_4.2: init [i32; 3] = call @F() to %.loc24_4.1
 // CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -14,8 +14,8 @@ fn Run() {
 }
 
 // CHECK:STDOUT: file "fail_empty_tuple_access.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -25,7 +25,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc13_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc13_4.2: init () = call @F()
 // CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/fail_expression_category.carbon
+++ b/toolchain/check/testdata/index/fail_expression_category.carbon
@@ -30,8 +30,8 @@ fn G(b: [i32; 3]) {
 }
 
 // CHECK:STDOUT: file "fail_expression_category.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];
@@ -56,7 +56,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   assign %.loc18_6.3, %.loc18_10
 // CHECK:STDOUT:   %.loc25_14: type = ptr_type i32
 // CHECK:STDOUT:   %pf: ref i32* = var "pf"
-// CHECK:STDOUT:   %F.ref.loc25 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc25: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc25_20.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc25_20.2: init [i32; 3] = call @F() to %.loc25_20.1
 // CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0
@@ -65,7 +65,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc25_24.2: i32 = bind_value %.loc25_24.1
 // CHECK:STDOUT:   %.loc25_18: i32* = address_of %.loc25_24.2
 // CHECK:STDOUT:   assign %pf, %.loc25_18
-// CHECK:STDOUT:   %F.ref.loc29 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc29: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc29_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc29_4.2: init [i32; 3] = call @F() to %.loc29_4.1
 // CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -31,14 +31,14 @@ var c: i32 = {.a = 1, .b = 2}[0];
 var d: i32 = {.a: i32, .b: i32}[0];
 
 // CHECK:STDOUT: file "fail_invalid_base.carbon" {
-// CHECK:STDOUT:   %.loc11 = namespace {}
+// CHECK:STDOUT:   %.loc11: <namespace> = namespace {}
 // CHECK:STDOUT:   %a: ref i32 = var "a"
-// CHECK:STDOUT:   %N.ref = name_reference_untyped "N", %.loc11
+// CHECK:STDOUT:   %N.ref: <namespace> = name_reference "N", %.loc11
 // CHECK:STDOUT:   %.loc15: i32 = int_literal 0
 // CHECK:STDOUT:   assign %a, <error>
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %b: ref i32 = var "b"
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", %F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", %F
 // CHECK:STDOUT:   %.loc21: i32 = int_literal 1
 // CHECK:STDOUT:   assign %b, <error>
 // CHECK:STDOUT:   %c: ref i32 = var "c"

--- a/toolchain/check/testdata/index/fail_name_not_found.carbon
+++ b/toolchain/check/testdata/index/fail_name_not_found.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_name_not_found.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/index/fail_non_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_non_tuple_access.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_non_tuple_access.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -11,8 +11,8 @@ fn Run() -> i32 {
 }
 
 // CHECK:STDOUT: file "tuple_return_value_access.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %Run = fn_decl @Run
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
@@ -25,7 +25,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_11.1: init (i32,) = call @F()
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_11.2: ref (i32,) = temporary_storage

--- a/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
@@ -7,7 +7,7 @@
 fn A() { var n: i32 = 1; if (true) { var n: i32 = 2; } }
 
 // CHECK:STDOUT: file "duplicate_name_same_line.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -12,7 +12,7 @@ fn F() -> i32 {
 }
 
 // CHECK:STDOUT: file "convert.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -15,7 +15,7 @@ fn F(a: i32) {
 }
 
 // CHECK:STDOUT: file "fail_duplicate_decl.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a.loc7: i32) {

--- a/toolchain/check/testdata/let/fail_use_in_init.carbon
+++ b/toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -12,7 +12,7 @@ fn F() {
 }
 
 // CHECK:STDOUT: file "fail_use_in_init.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -11,7 +11,7 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT: file "global.carbon" {
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 1
 // CHECK:STDOUT:   %n: i32 = bind_name "n", %.loc7
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/let/local.carbon
+++ b/toolchain/check/testdata/let/local.carbon
@@ -10,7 +10,7 @@ fn F(a: i32) -> i32 {
 }
 
 // CHECK:STDOUT: file "local.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: i32) -> i32 {

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -19,9 +19,9 @@ fn Foo.Baz() {
 }
 
 // CHECK:STDOUT: file "fail_duplicate.carbon" {
-// CHECK:STDOUT:   %.loc7 = namespace {.Baz = %Baz}
-// CHECK:STDOUT:   %Baz = fn_decl @Baz
-// CHECK:STDOUT:   %.loc18 = fn_decl @.1
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Baz = %Baz}
+// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz
+// CHECK:STDOUT:   %.loc18: <function> = fn_decl @.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz() {

--- a/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
+++ b/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
@@ -11,7 +11,7 @@ fn Foo.Baz() {
 }
 
 // CHECK:STDOUT: file "fail_unresolved_scope.carbon" {
-// CHECK:STDOUT:   %.loc10 = fn_decl @.1
+// CHECK:STDOUT:   %.loc10: <function> = fn_decl @.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1() {

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -18,10 +18,10 @@ fn Bar() {
 }
 
 // CHECK:STDOUT: file "function.carbon" {
-// CHECK:STDOUT:   %.loc7 = namespace {.Baz = %Baz.loc13}
-// CHECK:STDOUT:   %Baz.loc10 = fn_decl @Baz.1
-// CHECK:STDOUT:   %Baz.loc13 = fn_decl @Baz.2
-// CHECK:STDOUT:   %Bar = fn_decl @Bar
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Baz = %Baz.loc13}
+// CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1
+// CHECK:STDOUT:   %Baz.loc13: <function> = fn_decl @Baz.2
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz.1() {
@@ -36,7 +36,7 @@ fn Bar() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Bar() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%.loc7
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", package.%.loc7
 // CHECK:STDOUT:   %.loc17_10.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc17_10.2: init () = call @Baz.2()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -15,11 +15,11 @@ fn Foo.Bar.Baz() {
 }
 
 // CHECK:STDOUT: file "nested.carbon" {
-// CHECK:STDOUT:   %.loc7 = namespace {.Bar = %.loc8}
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", %.loc7
-// CHECK:STDOUT:   %.loc8 = namespace {.Wiz = %Wiz, .Baz = %Baz}
-// CHECK:STDOUT:   %Wiz = fn_decl @Wiz
-// CHECK:STDOUT:   %Baz = fn_decl @Baz
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Bar = %.loc8}
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", %.loc7
+// CHECK:STDOUT:   %.loc8: <namespace> = namespace {.Wiz = %Wiz, .Baz = %Baz}
+// CHECK:STDOUT:   %Wiz: <function> = fn_decl @Wiz
+// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Wiz() {
@@ -29,7 +29,7 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref = name_reference_untyped "Foo", package.%.loc7
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", package.%.loc7
 // CHECK:STDOUT:   %.loc14_14.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_14.2: init () = call @Wiz()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -12,9 +12,9 @@ fn And() -> bool {
 }
 
 // CHECK:STDOUT: file "and.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %And = fn_decl @And
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %And: <function> = fn_decl @And
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
@@ -31,7 +31,7 @@ fn And() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @And() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc11_11.1: init bool = call @F()
 // CHECK:STDOUT:   %.loc11_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_11.3: ref bool = temporary %.loc11_11.2, %.loc11_11.1
@@ -40,7 +40,7 @@ fn And() -> bool {
 // CHECK:STDOUT:   if %.loc11_11.4 br !and.rhs else br !and.result(%.loc11_14.1)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc11_19.1: init bool = call @G()
 // CHECK:STDOUT:   %.loc11_19.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_19.3: ref bool = temporary %.loc11_19.2, %.loc11_19.1

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -23,7 +23,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "assignment.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/operators/binary_op.carbon
+++ b/toolchain/check/testdata/operators/binary_op.carbon
@@ -9,7 +9,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "binary_op.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/operators/fail_assigment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assigment_to_non_assignable.carbon
@@ -46,8 +46,8 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_assigment_to_non_assignable.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32;
@@ -57,7 +57,7 @@ fn Main() {
 // CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2
 // CHECK:STDOUT:   assign %.loc13_3, %.loc13_7
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc17_4: init i32 = call @F()
 // CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9

--- a/toolchain/check/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch.carbon
@@ -12,7 +12,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_type_mismatch.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
@@ -13,7 +13,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_type_mismatch_assignment.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
@@ -14,7 +14,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_type_mismatch_once.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -12,9 +12,9 @@ fn Or() -> bool {
 }
 
 // CHECK:STDOUT: file "or.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %Or = fn_decl @Or
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %Or: <function> = fn_decl @Or
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
@@ -31,7 +31,7 @@ fn Or() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Or() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc11_11.1: init bool = call @F()
 // CHECK:STDOUT:   %.loc11_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_11.3: ref bool = temporary %.loc11_11.2, %.loc11_11.1
@@ -41,7 +41,7 @@ fn Or() -> bool {
 // CHECK:STDOUT:   if %.loc11_14.1 br !or.rhs else br !or.result(%.loc11_14.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc11_18.1: init bool = call @G()
 // CHECK:STDOUT:   %.loc11_18.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_18.3: ref bool = temporary %.loc11_18.2, %.loc11_18.1

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -9,7 +9,7 @@ fn Not(b: bool) -> bool {
 }
 
 // CHECK:STDOUT: file "unary_op.carbon" {
-// CHECK:STDOUT:   %Not = fn_decl @Not
+// CHECK:STDOUT:   %Not: <function> = fn_decl @Not
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Not(%b: bool) -> bool {

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -10,7 +10,7 @@ fn F() -> i32 {
 }
 
 // CHECK:STDOUT: file "address_of_deref.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -17,7 +17,7 @@ fn F() {
 }
 
 // CHECK:STDOUT: file "address_of_lvalue.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -12,7 +12,7 @@ fn F() -> i32 {
 }
 
 // CHECK:STDOUT: file "basic.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -83,14 +83,14 @@ fn AddressOfParameter(param: i32) {
 }
 
 // CHECK:STDOUT: file "fail_address_of_value.carbon" {
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
-// CHECK:STDOUT:   %AddressOfLiteral = fn_decl @AddressOfLiteral
-// CHECK:STDOUT:   %AddressOfOperator = fn_decl @AddressOfOperator
-// CHECK:STDOUT:   %AddressOfCall = fn_decl @AddressOfCall
-// CHECK:STDOUT:   %AddressOfType = fn_decl @AddressOfType
-// CHECK:STDOUT:   %AddressOfTupleElementValue = fn_decl @AddressOfTupleElementValue
-// CHECK:STDOUT:   %AddressOfParameter = fn_decl @AddressOfParameter
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral
+// CHECK:STDOUT:   %AddressOfOperator: <function> = fn_decl @AddressOfOperator
+// CHECK:STDOUT:   %AddressOfCall: <function> = fn_decl @AddressOfCall
+// CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType
+// CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue
+// CHECK:STDOUT:   %AddressOfParameter: <function> = fn_decl @AddressOfParameter
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;
@@ -130,7 +130,7 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:   %.loc42_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc42_7: i32 = add %.loc42_5, %.loc42_9
 // CHECK:STDOUT:   %.loc42_3: i32* = address_of %.loc42_7
-// CHECK:STDOUT:   %H.ref = name_reference_untyped "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
 // CHECK:STDOUT:   %.loc46_5.1: init {.a: i32} = call @H()
 // CHECK:STDOUT:   %.loc46_5.2: ref {.a: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc46_5.3: ref {.a: i32} = temporary %.loc46_5.2, %.loc46_5.1
@@ -144,7 +144,7 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfCall() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc57_5: init i32 = call @G()
 // CHECK:STDOUT:   %.loc57_3: i32* = address_of %.loc57_5
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/pointer/fail_dereference_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_function.carbon
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn A() {
+  // CHECK:STDERR: fail_dereference_function.carbon:[[@LINE+6]]:3: ERROR: Cannot dereference operand of non-pointer type `<function>`.
+  // CHECK:STDERR:   *A;
+  // CHECK:STDERR:   ^
+  // CHECK:STDERR: fail_dereference_function.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
+  // CHECK:STDERR:   *A;
+  // CHECK:STDERR:    ^
+  *A;
+}
+
+// CHECK:STDOUT: file "fail_dereference_function.carbon" {
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %.loc8: ref <error> = dereference <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_function.carbon
@@ -21,6 +21,6 @@ fn A() {
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
-// CHECK:STDOUT:   %.loc8: ref <error> = dereference <error>
+// CHECK:STDOUT:   %.loc14: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
@@ -24,6 +24,6 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref: <namespace> = name_reference "A", package.%.loc7
-// CHECK:STDOUT:   %.loc10: ref <error> = dereference <error>
+// CHECK:STDOUT:   %.loc16: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+namespace A;
+
+fn F() {
+  // CHECK:STDERR: fail_dereference_namespace.carbon:[[@LINE+6]]:3: ERROR: Cannot dereference operand of non-pointer type `<namespace>`.
+  // CHECK:STDERR:   *A;
+  // CHECK:STDERR:   ^
+  // CHECK:STDERR: fail_dereference_namespace.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
+  // CHECK:STDERR:   *A;
+  // CHECK:STDERR:    ^
+  *A;
+}
+
+// CHECK:STDOUT: file "fail_dereference_namespace.carbon" {
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {}
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: <namespace> = name_reference "A", package.%.loc7
+// CHECK:STDOUT:   %.loc10: ref <error> = dereference <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
@@ -20,7 +20,7 @@ fn Deref(n: i32) {
 }
 
 // CHECK:STDOUT: file "fail_dereference_not_pointer.carbon" {
-// CHECK:STDOUT:   %Deref = fn_decl @Deref
+// CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n: i32) {

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -12,7 +12,7 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 }
 
 // CHECK:STDOUT: file "fail_type_mismatch.carbon" {
-// CHECK:STDOUT:   %ConstMismatch = fn_decl @ConstMismatch
+// CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConstMismatch(%p: const {}*) -> const ({}*) {

--- a/toolchain/check/testdata/pointer/nested_const.carbon
+++ b/toolchain/check/testdata/pointer/nested_const.carbon
@@ -10,7 +10,7 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
 }
 
 // CHECK:STDOUT: file "nested_const.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%p: const (const (const i32*)*)) -> const i32 {

--- a/toolchain/check/testdata/pointer/types.carbon
+++ b/toolchain/check/testdata/pointer/types.carbon
@@ -13,8 +13,8 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
 }
 
 // CHECK:STDOUT: file "types.carbon" {
-// CHECK:STDOUT:   %Ptr = fn_decl @Ptr
-// CHECK:STDOUT:   %ConstPtr = fn_decl @ConstPtr
+// CHECK:STDOUT:   %Ptr: <function> = fn_decl @Ptr
+// CHECK:STDOUT:   %ConstPtr: <function> = fn_decl @ConstPtr
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Ptr(%p: i32*) -> i32* {

--- a/toolchain/check/testdata/return/code_after_return.carbon
+++ b/toolchain/check/testdata/return/code_after_return.carbon
@@ -10,7 +10,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "code_after_return.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/return/code_after_return_value.carbon
+++ b/toolchain/check/testdata/return/code_after_return_value.carbon
@@ -17,7 +17,7 @@ fn F(b: bool) -> i32 {
 }
 
 // CHECK:STDOUT: file "code_after_return_value.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool) -> i32 {

--- a/toolchain/check/testdata/return/fail_missing_return.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_missing_return.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -11,7 +11,7 @@ fn F() -> () {
 }
 
 // CHECK:STDOUT: file "fail_missing_return_empty_tuple.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> () {

--- a/toolchain/check/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/return/fail_type_mismatch.carbon
@@ -12,7 +12,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_type_mismatch.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -15,7 +15,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_value_disallowed.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/return/fail_value_missing.carbon
+++ b/toolchain/check/testdata/return/fail_value_missing.carbon
@@ -12,7 +12,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "fail_value_missing.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/return/missing_return_no_return_type.carbon
+++ b/toolchain/check/testdata/return/missing_return_no_return_type.carbon
@@ -8,7 +8,7 @@ fn F() {
 }
 
 // CHECK:STDOUT: file "missing_return_no_return_type.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/return/no_value.carbon
+++ b/toolchain/check/testdata/return/no_value.carbon
@@ -9,7 +9,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "no_value.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -9,7 +9,7 @@ fn Main() -> {.a: i32} {
 }
 
 // CHECK:STDOUT: file "struct.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> {.a: i32} {

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -10,7 +10,7 @@ fn Main() -> (i32, i32) {
 }
 
 // CHECK:STDOUT: file "tuple.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %return: (i32, i32) {

--- a/toolchain/check/testdata/return/value.carbon
+++ b/toolchain/check/testdata/return/value.carbon
@@ -9,7 +9,7 @@ fn Main() -> i32 {
 }
 
 // CHECK:STDOUT: file "value.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
+++ b/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
@@ -11,7 +11,7 @@
 fn F() { a.b; }
 
 // CHECK:STDOUT: file "fail_access_into_invalid.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/struct/fail_member_of_function.carbon
+++ b/toolchain/check/testdata/struct/fail_member_of_function.carbon
@@ -1,0 +1,25 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn A() {
+  // CHECK:STDERR: fail_member_of_function.carbon:[[@LINE+6]]:3: ERROR: Expression cannot be used as a value.
+  // CHECK:STDERR:   A.y;
+  // CHECK:STDERR:   ^
+  // CHECK:STDERR: fail_member_of_function.carbon:[[@LINE+3]]:4: ERROR: Type `<function>` does not support qualified expressions.
+  // CHECK:STDERR:   A.y;
+  // CHECK:STDERR:    ^
+  A.y;
+}
+
+// CHECK:STDOUT: file "fail_member_of_function.carbon" {
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -11,8 +11,8 @@ fn F() -> i32 {
 }
 
 // CHECK:STDOUT: file "literal_member_access.carbon" {
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %F = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: {.x: i32, .y: i32, .z: i32};
@@ -20,7 +20,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc10_25.1: ref {.x: i32, .y: i32, .z: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc10_25.2: init {.x: i32, .y: i32, .z: i32} = call @G() to %.loc10_25.1
 // CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -11,8 +11,8 @@ fn G() {
 }
 
 // CHECK:STDOUT: file "nested_struct_in_place.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -23,10 +23,10 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_50: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)}
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_61 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_74.1: ref (i32, i32, i32) = struct_access %v, member0
 // CHECK:STDOUT:   %.loc10_62: init (i32, i32, i32) = call @F() to %.loc10_74.1
-// CHECK:STDOUT:   %F.ref.loc10_71 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_71: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_74.2: ref (i32, i32, i32) = struct_access %v, member1
 // CHECK:STDOUT:   %.loc10_72: init (i32, i32, i32) = call @F() to %.loc10_74.2
 // CHECK:STDOUT:   %.loc10_74.3: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = struct_literal (%.loc10_62, %.loc10_72)

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -15,9 +15,9 @@ fn H() {
 }
 
 // CHECK:STDOUT: file "nested_tuple_in_place.carbon" {
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -30,10 +30,10 @@ fn H() {
 // CHECK:STDOUT:   %.loc10_43.2: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
 // CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_48 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_56.1: ref (i32, i32, i32) = tuple_access %v, member0
 // CHECK:STDOUT:   %.loc10_49: init (i32, i32, i32) = call @F() to %.loc10_56.1
-// CHECK:STDOUT:   %F.ref.loc10_53 = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_53: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc10_56.2: ref (i32, i32, i32) = tuple_access %v, member1
 // CHECK:STDOUT:   %.loc10_54: init (i32, i32, i32) = call @F() to %.loc10_56.2
 // CHECK:STDOUT:   %.loc10_56.3: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_49, %.loc10_54)
@@ -50,7 +50,7 @@ fn H() {
 // CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32), i32)
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = var "v"
 // CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc14_50.1: ref (i32, i32, i32) = tuple_access %v, member1
 // CHECK:STDOUT:   %.loc14_45: init (i32, i32, i32) = call @F() to %.loc14_50.1
 // CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2

--- a/toolchain/check/testdata/var/decl.carbon
+++ b/toolchain/check/testdata/var/decl.carbon
@@ -9,7 +9,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "decl.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/decl_with_init.carbon
@@ -9,7 +9,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "decl_with_init.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/fail_duplicate_decl.carbon
@@ -17,7 +17,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_duplicate_decl.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_init_type_mismatch.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/check/testdata/var/fail_init_with_self.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_init_with_self.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
@@ -14,7 +14,7 @@ fn Main() {
 var y: i32 = x;
 
 // CHECK:STDOUT: file "fail_lookup_outside_scope.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT:   %y: ref i32 = var "y"
 // CHECK:STDOUT:   %x.ref: <error> = name_reference "x", <error>
 // CHECK:STDOUT:   assign %y, <error>

--- a/toolchain/check/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/check/testdata/var/fail_storage_is_literal.carbon
@@ -12,7 +12,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "fail_storage_is_literal.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT:   %x: ref i32 = var "x"
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0
 // CHECK:STDOUT:   assign %x, %.loc7
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/lookup.carbon
+++ b/toolchain/check/testdata/var/lookup.carbon
@@ -10,7 +10,7 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "lookup.carbon" {
-// CHECK:STDOUT:   %Main = fn_decl @Main
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -27,15 +27,15 @@ fn While() {
 }
 
 // CHECK:STDOUT: file "break_continue.carbon" {
-// CHECK:STDOUT:   %A = fn_decl @A
-// CHECK:STDOUT:   %B = fn_decl @B
-// CHECK:STDOUT:   %C = fn_decl @C
-// CHECK:STDOUT:   %D = fn_decl @D
-// CHECK:STDOUT:   %E = fn_decl @E
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
-// CHECK:STDOUT:   %While = fn_decl @While
+// CHECK:STDOUT:   %A: <function> = fn_decl @A
+// CHECK:STDOUT:   %B: <function> = fn_decl @B
+// CHECK:STDOUT:   %C: <function> = fn_decl @C
+// CHECK:STDOUT:   %D: <function> = fn_decl @D
+// CHECK:STDOUT:   %E: <function> = fn_decl @E
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> bool;
@@ -59,7 +59,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc17:
-// CHECK:STDOUT:   %A.ref = name_reference_untyped "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
 // CHECK:STDOUT:   %.loc17_11.1: init bool = call @A()
 // CHECK:STDOUT:   %.loc17_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc17_11.3: ref bool = temporary %.loc17_11.2, %.loc17_11.1
@@ -67,7 +67,7 @@ fn While() {
 // CHECK:STDOUT:   if %.loc17_11.4 br !while.body.loc17 else br !while.done.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc17:
-// CHECK:STDOUT:   %B.ref = name_reference_untyped "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
 // CHECK:STDOUT:   %.loc18_10.1: init bool = call @B()
 // CHECK:STDOUT:   %.loc18_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc18_10.3: ref bool = temporary %.loc18_10.2, %.loc18_10.1
@@ -78,7 +78,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc18:
-// CHECK:STDOUT:   %C.ref = name_reference_untyped "C", package.%C
+// CHECK:STDOUT:   %C.ref: <function> = name_reference "C", package.%C
 // CHECK:STDOUT:   %.loc19_10.1: init bool = call @C()
 // CHECK:STDOUT:   %.loc19_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc19_10.3: ref bool = temporary %.loc19_10.2, %.loc19_10.1
@@ -92,7 +92,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc20:
-// CHECK:STDOUT:   %D.ref = name_reference_untyped "D", package.%D
+// CHECK:STDOUT:   %D.ref: <function> = name_reference "D", package.%D
 // CHECK:STDOUT:   %.loc20_13.1: init bool = call @D()
 // CHECK:STDOUT:   %.loc20_13.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc20_13.3: ref bool = temporary %.loc20_13.2, %.loc20_13.1
@@ -100,7 +100,7 @@ fn While() {
 // CHECK:STDOUT:   if %.loc20_13.4 br !while.body.loc20 else br !while.done.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc20:
-// CHECK:STDOUT:   %E.ref = name_reference_untyped "E", package.%E
+// CHECK:STDOUT:   %E.ref: <function> = name_reference "E", package.%E
 // CHECK:STDOUT:   %.loc21_12.1: init bool = call @E()
 // CHECK:STDOUT:   %.loc21_12.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc21_12.3: ref bool = temporary %.loc21_12.2, %.loc21_12.1
@@ -111,7 +111,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc21:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc22_12.1: init bool = call @F()
 // CHECK:STDOUT:   %.loc22_12.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc22_12.3: ref bool = temporary %.loc22_12.2, %.loc22_12.1
@@ -125,7 +125,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done.loc20:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc24_10.1: init bool = call @G()
 // CHECK:STDOUT:   %.loc24_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc24_10.3: ref bool = temporary %.loc24_10.2, %.loc24_10.1
@@ -136,7 +136,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc24:
-// CHECK:STDOUT:   %H.ref = name_reference_untyped "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
 // CHECK:STDOUT:   %.loc25_10.1: init bool = call @H()
 // CHECK:STDOUT:   %.loc25_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc25_10.3: ref bool = temporary %.loc25_10.2, %.loc25_10.1

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -12,7 +12,7 @@ fn While() {
 }
 
 // CHECK:STDOUT: file "fail_bad_condition.carbon" {
-// CHECK:STDOUT:   %While = fn_decl @While
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {

--- a/toolchain/check/testdata/while/fail_break_continue.carbon
+++ b/toolchain/check/testdata/while/fail_break_continue.carbon
@@ -28,7 +28,7 @@ fn While() {
 }
 
 // CHECK:STDOUT: file "fail_break_continue.carbon" {
-// CHECK:STDOUT:   %While = fn_decl @While
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -20,11 +20,11 @@ fn While() {
 }
 
 // CHECK:STDOUT: file "unreachable_end.carbon" {
-// CHECK:STDOUT:   %Cond = fn_decl @Cond
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
-// CHECK:STDOUT:   %While = fn_decl @While
+// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
@@ -37,13 +37,13 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_4.2: init () = call @F()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref = name_reference_untyped "Cond", package.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", package.%Cond
 // CHECK:STDOUT:   %.loc15_14.1: init bool = call @Cond()
 // CHECK:STDOUT:   %.loc15_14.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc15_14.3: ref bool = temporary %.loc15_14.2, %.loc15_14.1
@@ -51,12 +51,12 @@ fn While() {
 // CHECK:STDOUT:   if %.loc15_14.4 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc16: init () = call @G()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref = name_reference_untyped "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
 // CHECK:STDOUT:   %.loc19: init () = call @H()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -19,11 +19,11 @@ fn While() {
 }
 
 // CHECK:STDOUT: file "while.carbon" {
-// CHECK:STDOUT:   %Cond = fn_decl @Cond
-// CHECK:STDOUT:   %F = fn_decl @F
-// CHECK:STDOUT:   %G = fn_decl @G
-// CHECK:STDOUT:   %H = fn_decl @H
-// CHECK:STDOUT:   %While = fn_decl @While
+// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
@@ -36,13 +36,13 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref = name_reference_untyped "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
 // CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_4.2: init () = call @F()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref = name_reference_untyped "Cond", package.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", package.%Cond
 // CHECK:STDOUT:   %.loc15_14.1: init bool = call @Cond()
 // CHECK:STDOUT:   %.loc15_14.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc15_14.3: ref bool = temporary %.loc15_14.2, %.loc15_14.1
@@ -50,12 +50,12 @@ fn While() {
 // CHECK:STDOUT:   if %.loc15_14.4 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref = name_reference_untyped "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
 // CHECK:STDOUT:   %.loc16: init () = call @G()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref = name_reference_untyped "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
 // CHECK:STDOUT:   %.loc18: init () = call @H()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -208,6 +208,10 @@ auto FileContext::BuildType(SemIR::NodeId node_id) -> llvm::Type* {
       // TODO: We may want to have different representations for `bool` storage
       // (`i8`) versus for `bool` values (`i1`).
       return llvm::Type::getInt1Ty(*llvm_context_);
+    case SemIR::BuiltinKind::FunctionType.AsInt():
+    case SemIR::BuiltinKind::NamespaceType.AsInt():
+      // Return an empty struct as a placeholder.
+      return llvm::StructType::get(*llvm_context_);
     default:
       // Handled below.
       break;

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -5,6 +5,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "toolchain/lower/function_context.h"
+#include "toolchain/sem_ir/node.h"
 #include "toolchain/sem_ir/node_kind.h"
 
 namespace Carbon::Lower {
@@ -193,18 +194,22 @@ auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
 
 auto HandleNameReference(FunctionContext& context, SemIR::NodeId node_id,
                          SemIR::NameReference node) -> void {
+  auto type_node_id =
+      context.semantics_ir().GetTypeAllowBuiltinTypes(node.type_id);
+  if (type_node_id == SemIR::NodeId::BuiltinFunctionType ||
+      type_node_id == SemIR::NodeId::BuiltinNamespaceType) {
+    return;
+  }
+  // TODO: Handle name references to globals
   context.SetLocal(node_id, context.GetLocal(node.value_id));
 }
 
-auto HandleNameReferenceUntyped(FunctionContext& /*context*/,
-                                SemIR::NodeId /*node_id*/,
-                                SemIR::NameReferenceUntyped /*node*/) -> void {
-  // No action to take: untyped name references don't hold a value.
-}
-
 auto HandleNamespace(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
-                     SemIR::Namespace /*node*/) -> void {
-  // No action to take.
+                     SemIR::Namespace node) -> void {
+  CARBON_FATAL()
+      << "Should not be encountered. If that changes, we may want to change "
+         "higher-level logic to skip them rather than calling this. "
+      << node;
 }
 
 auto HandleNoOp(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,

--- a/toolchain/sem_ir/builtin_kind.def
+++ b/toolchain/sem_ir/builtin_kind.def
@@ -64,6 +64,12 @@ CARBON_SEMANTICS_BUILTIN_KIND(FloatingPointType, "f64")
 // The type of string values and String literals.
 CARBON_SEMANTICS_BUILTIN_KIND(StringType, "String")
 
+// The type of function values.
+CARBON_SEMANTICS_BUILTIN_KIND(FunctionType, "<function>")
+
+// The type of namespace names.
+CARBON_SEMANTICS_BUILTIN_KIND(NamespaceType, "<namespace>")
+
 // Keep invalid last, so that we can use values as array indices without needing
 // an invalid entry.
 CARBON_SEMANTICS_BUILTIN_KIND_NAME(Invalid)

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -211,7 +211,6 @@ static auto GetTypePrecedence(NodeKind kind) -> int {
     case NodeKind::InitializeFrom:
     case NodeKind::IntegerLiteral:
     case NodeKind::NameReference:
-    case NodeKind::NameReferenceUntyped:
     case NodeKind::Namespace:
     case NodeKind::NoOp:
     case NodeKind::Parameter:
@@ -382,7 +381,6 @@ auto File::StringifyType(TypeId type_id, bool in_type_context) const
       case NodeKind::InitializeFrom:
       case NodeKind::IntegerLiteral:
       case NodeKind::NameReference:
-      case NodeKind::NameReferenceUntyped:
       case NodeKind::Namespace:
       case NodeKind::NoOp:
       case NodeKind::Parameter:
@@ -440,7 +438,6 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
       case NodeKind::BranchIf:
       case NodeKind::BranchWithArg:
       case NodeKind::FunctionDeclaration:
-      case NodeKind::NameReferenceUntyped:
       case NodeKind::Namespace:
       case NodeKind::NoOp:
       case NodeKind::Return:
@@ -560,7 +557,6 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
       case NodeKind::InitializeFrom:
       case NodeKind::IntegerLiteral:
       case NodeKind::NameReference:
-      case NodeKind::NameReferenceUntyped:
       case NodeKind::Namespace:
       case NodeKind::NoOp:
       case NodeKind::Parameter:
@@ -642,6 +638,8 @@ auto GetValueRepresentation(const File& file, TypeId type_id)
           case BuiltinKind::TypeType:
           case BuiltinKind::Error:
           case BuiltinKind::Invalid:
+          case BuiltinKind::NamespaceType:
+          case BuiltinKind::FunctionType:
             return {.kind = ValueRepresentation::None, .type = TypeId::Invalid};
           case BuiltinKind::BoolType:
           case BuiltinKind::IntegerType:

--- a/toolchain/sem_ir/file_test.cpp
+++ b/toolchain/sem_ir/file_test.cpp
@@ -50,7 +50,7 @@ TEST(SemIRTest, YAML) {
       Pair("integers", Yaml::Sequence(ElementsAre("0"))),
       Pair("reals", Yaml::Sequence(IsEmpty())),
       Pair("strings", Yaml::Sequence(ElementsAre("F", "x"))),
-      Pair("types", Yaml::Sequence(ElementsAre(node_builtin))),
+      Pair("types", Yaml::Sequence(ElementsAre(node_builtin, node_builtin))),
       Pair("type_blocks", Yaml::Sequence(IsEmpty())),
       Pair("nodes",
            Yaml::Sequence(AllOf(

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -575,10 +575,6 @@ class Formatter {
         FormatType(node.type_id());
         out_ << " = ";
         break;
-      case NodeValueKind::Untyped:
-        FormatNodeName(node_id);
-        out_ << " = ";
-        break;
       case NodeValueKind::None:
         break;
     }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -399,13 +399,6 @@ class NodeNamer {
               ".ref");
           continue;
         }
-        case NodeKind::NameReferenceUntyped: {
-          add_node_name(
-              semantics_ir_.GetString(node.As<NameReferenceUntyped>().name_id)
-                  .str() +
-              ".ref");
-          continue;
-        }
         case NodeKind::Parameter: {
           add_node_name_id(node.As<Parameter>().name_id);
           continue;

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -327,8 +327,6 @@ struct Dereference {
 };
 
 struct FunctionDeclaration {
-  using HasType = std::false_type;
-
   FunctionId function_id;
 };
 
@@ -349,14 +347,7 @@ struct NameReference {
   NodeId value_id;
 };
 
-struct NameReferenceUntyped {
-  StringId name_id;
-  NodeId value_id;
-};
-
 struct Namespace {
-  using HasType = std::false_type;
-
   NameScopeId name_scope_id;
 };
 

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -682,7 +682,7 @@ struct HasNoTypeBase {
 };
 
 // TypeBase<T> holds the `type_id` field if the node has a type, and is either
-// TypedNodeBase or UntypedNodeBase.
+// HasTypeBase or HasNoTypeBase.
 template <typename T>
 using TypeBase =
     std::conditional_t<GetWithDefault<T, GetHasType, std::true_type>{},

--- a/toolchain/sem_ir/node_kind.def
+++ b/toolchain/sem_ir/node_kind.def
@@ -20,8 +20,6 @@
 //   Invoked for each kind of semantic node, along with the name that is used
 //   to denote this node in textual Semantics IR.
 
-// FIXME: TODO: everything is now Typed, get rid of Untyped
-
 #if defined(CARBON_SEMANTICS_NODE_KIND)
 #define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
                                         TerminatorKind)          \

--- a/toolchain/sem_ir/node_kind.def
+++ b/toolchain/sem_ir/node_kind.def
@@ -20,6 +20,8 @@
 //   Invoked for each kind of semantic node, along with the name that is used
 //   to denote this node in textual Semantics IR.
 
+// FIXME: TODO: everything is now Typed, get rid of Untyped
+
 #if defined(CARBON_SEMANTICS_NODE_KIND)
 #define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
                                         TerminatorKind)          \
@@ -62,7 +64,7 @@ CARBON_SEMANTICS_NODE_KIND_IMPL(Call, "call", Typed, NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(ConstType, "const_type", Typed, NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(Dereference, "dereference", Typed,
                                 NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(FunctionDeclaration, "fn_decl", Untyped,
+CARBON_SEMANTICS_NODE_KIND_IMPL(FunctionDeclaration, "fn_decl", Typed,
                                 NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(InitializeFrom, "initialize_from", Typed,
                                 NotTerminator)
@@ -70,9 +72,7 @@ CARBON_SEMANTICS_NODE_KIND_IMPL(IntegerLiteral, "int_literal", Typed,
                                 NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(NameReference, "name_reference", Typed,
                                 NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(NameReferenceUntyped, "name_reference_untyped",
-                                Untyped, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Namespace, "namespace", Untyped, NotTerminator)
+CARBON_SEMANTICS_NODE_KIND_IMPL(Namespace, "namespace", Typed, NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(NoOp, "no_op", None, NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(Parameter, "parameter", Typed, NotTerminator)
 CARBON_SEMANTICS_NODE_KIND_IMPL(PointerType, "ptr_type", Typed, NotTerminator)

--- a/toolchain/sem_ir/node_kind.h
+++ b/toolchain/sem_ir/node_kind.h
@@ -17,9 +17,6 @@ enum class NodeValueKind : int8_t {
   // This node doesn't produce a value, and shouldn't be referenced by other
   // nodes.
   None,
-  // This node represents an untyped value. It may be referenced by other nodes
-  // expecting this kind of value.
-  Untyped,
   // This node represents an expression or expression-like construct that
   // produces a value of the type indicated by its `type_id` field.
   Typed,


### PR DESCRIPTION
Bug found by fuzzing. Problem was untyped SemIR nodes had an invalid type id, which was retrieved by `HandlePrefixOperator` and then passed to `context.GetUnqualifiedType`, ultimately performing an invalid access in `semantics_ir_->GetNode`.

We prefer to make a placeholder type for functions and namespaces to remove the need for checking for the untyped case everywhere. Eventually functions will have their own types, but this approach will be needed for namespaces (and perhaps other non-first-class entities like unbound methods and interface members) long term.

Co-authored-by: Richard Smith <richard@metafoo.co.uk>