### PR TITLE
Fix incorrect `argc` calculation.

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -215,7 +215,7 @@ auto FileTestBase::ProcessTestFileAndRun(TestContext& context)
 
   // Add a stack trace entry for the test invocation.
   llvm::PrettyStackTraceProgram stack_trace_entry(
-      test_argv_for_stack_trace.size(), test_argv_for_stack_trace.data());
+      test_argv_for_stack_trace.size() - 1, test_argv_for_stack_trace.data());
 
   // Capture trace streaming, but only when in debug mode.
   llvm::raw_svector_ostream stdout(context.stdout);


### PR DESCRIPTION
Fix off-by-one error: the terminating `nullptr` in `argv` is not included in `argc`. This is currently causing crashing tests to crash again in their crash handler, meaning we don't get a backtrace or CHECK-failure message.