### PR TITLE
Suppress follow-on errors for various forms of expression.

### DIFF
--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -617,9 +617,6 @@ auto Convert(Context& context, Parse::Node parse_node, SemIR::NodeId expr_id,
 
   // Start by making sure both sides are valid. If any part is invalid, the
   // result is invalid and we shouldn't error.
-  if (expr_id == SemIR::NodeId::BuiltinError) {
-    return expr_id;
-  }
   if (semantics_ir.GetNode(expr_id).type_id() == SemIR::TypeId::Error ||
       target.type_id == SemIR::TypeId::Error) {
     return SemIR::NodeId::BuiltinError;
@@ -664,6 +661,9 @@ auto Convert(Context& context, Parse::Node parse_node, SemIR::NodeId expr_id,
     case SemIR::ExpressionCategory::Mixed:
       CARBON_FATAL() << "Unexpected expression " << expr
                      << " after builtin conversions";
+
+    case SemIR::ExpressionCategory::Error:
+      return SemIR::NodeId::BuiltinError;
 
     case SemIR::ExpressionCategory::Initializing:
       if (target.is_initializer()) {

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -97,7 +97,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
         } else {
           index_node_id = SemIR::NodeId::BuiltinError;
         }
-      } else {
+      } else if (index_node.type_id() != SemIR::TypeId::Error) {
         CARBON_DIAGNOSTIC(TupleIndexIntegerLiteral, Error,
                           "Tuples indices must be integer literals.");
         context.emitter().Emit(parse_node, TupleIndexIntegerLiteral);

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+var a: (i32, i32) = (12, 6);
+// CHECK:STDERR: fail_tuple_index_error.carbon:[[@LINE+3]]:16: ERROR: Name `oops` not found.
+// CHECK:STDERR: var b: i32 = a[oops];
+// CHECK:STDERR:                ^
+var b: i32 = a[oops];
+
+// CHECK:STDOUT: file "fail_tuple_index_error.carbon" {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %a: ref (i32, i32) = var "a"
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6
+// CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
+// CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a, member0
+// CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2
+// CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access %a, member1
+// CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4
+// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init %.loc7_27.1, (%.loc7_27.3, %.loc7_27.5)
+// CHECK:STDOUT:   assign %a, %.loc7_27.6
+// CHECK:STDOUT:   %b: ref i32 = var "b"
+// CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_reference "a", %a
+// CHECK:STDOUT:   %oops.ref: <error> = name_reference "oops", <error>
+// CHECK:STDOUT:   %.loc11: ref <error> = tuple_index %a.ref, %oops.ref
+// CHECK:STDOUT:   assign %b, <error>
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
@@ -1,0 +1,32 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn Main() {
+  // CHECK:STDERR: fail_assignment_to_error.carbon:[[@LINE+3]]:3: ERROR: Name `undeclared` not found.
+  // CHECK:STDERR:   undeclared = 42;
+  // CHECK:STDERR:   ^
+  undeclared = 42;
+  // CHECK:STDERR: fail_assignment_to_error.carbon:[[@LINE+3]]:4: ERROR: Name `also_undeclared` not found.
+  // CHECK:STDERR:   *also_undeclared = 42;
+  // CHECK:STDERR:    ^
+  *also_undeclared = 42;
+}
+
+// CHECK:STDOUT: file "fail_assignment_to_error.carbon" {
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Main() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %undeclared.ref: <error> = name_reference "undeclared", <error>
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 42
+// CHECK:STDOUT:   assign %undeclared.ref, <error>
+// CHECK:STDOUT:   %also_undeclared.ref: <error> = name_reference "also_undeclared", <error>
+// CHECK:STDOUT:   %.loc15_3: ref <error> = dereference <error>
+// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42
+// CHECK:STDOUT:   assign %.loc15_3, <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn Test() {
+  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+3]]:4: ERROR: Name `undeclared` not found.
+  // CHECK:STDERR:   &undeclared;
+  // CHECK:STDERR:    ^
+  &undeclared;
+  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+6]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR:   &(&undeclared);
+  // CHECK:STDERR:   ^
+  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+3]]:6: ERROR: Name `undeclared` not found.
+  // CHECK:STDERR:   &(&undeclared);
+  // CHECK:STDERR:      ^
+  &(&undeclared);
+}
+
+// CHECK:STDOUT: file "fail_address_of_error.carbon" {
+// CHECK:STDOUT:   %Test: <function> = fn_decl @Test
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Test() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %undeclared.ref.loc11: <error> = name_reference "undeclared", <error>
+// CHECK:STDOUT:   %.loc11_3.1: type = ptr_type <error>
+// CHECK:STDOUT:   %.loc11_3.2: <error>* = address_of %undeclared.ref.loc11
+// CHECK:STDOUT:   %undeclared.ref.loc18: <error> = name_reference "undeclared", <error>
+// CHECK:STDOUT:   %.loc18_5: <error>* = address_of %undeclared.ref.loc18
+// CHECK:STDOUT:   %.loc18_3.1: type = ptr_type <error>*
+// CHECK:STDOUT:   %.loc18_3.2: <error>** = address_of %.loc18_5
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_error.carbon
@@ -1,0 +1,16 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: fail_dereference_error.carbon:[[@LINE+3]]:15: ERROR: Name `undeclared` not found.
+// CHECK:STDERR: let n: i32 = *undeclared;
+// CHECK:STDERR:               ^
+let n: i32 = *undeclared;
+
+// CHECK:STDOUT: file "fail_dereference_error.carbon" {
+// CHECK:STDOUT:   %undeclared.ref: <error> = name_reference "undeclared", <error>
+// CHECK:STDOUT:   %.loc10: ref <error> = dereference <error>
+// CHECK:STDOUT:   %n: i32 = bind_name "n", <error>
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_function.carbon
@@ -5,9 +5,6 @@
 // AUTOUPDATE
 
 fn A() {
-  // CHECK:STDERR: fail_dereference_function.carbon:[[@LINE+6]]:3: ERROR: Cannot dereference operand of non-pointer type `<function>`.
-  // CHECK:STDERR:   *A;
-  // CHECK:STDERR:   ^
   // CHECK:STDERR: fail_dereference_function.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   *A;
   // CHECK:STDERR:    ^
@@ -21,6 +18,6 @@ fn A() {
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
-// CHECK:STDOUT:   %.loc14: ref <error> = dereference <error>
+// CHECK:STDOUT:   %.loc11: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
@@ -7,9 +7,6 @@
 namespace A;
 
 fn F() {
-  // CHECK:STDERR: fail_dereference_namespace.carbon:[[@LINE+6]]:3: ERROR: Cannot dereference operand of non-pointer type `<namespace>`.
-  // CHECK:STDERR:   *A;
-  // CHECK:STDERR:   ^
   // CHECK:STDERR: fail_dereference_namespace.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   *A;
   // CHECK:STDERR:    ^
@@ -24,6 +21,6 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref: <namespace> = name_reference "A", package.%.loc7
-// CHECK:STDOUT:   %.loc16: ref <error> = dereference <error>
+// CHECK:STDOUT:   %.loc13: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -463,7 +463,6 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
       case BindValue::Kind:
       case BlockArg::Kind:
       case BoolLiteral::Kind:
-      case Builtin::Kind:
       case ConstType::Kind:
       case IntegerLiteral::Kind:
       case Parameter::Kind:
@@ -476,6 +475,13 @@ auto GetExpressionCategory(const File& file, NodeId node_id)
       case TupleType::Kind:
       case UnaryOperatorNot::Kind:
         return ExpressionCategory::Value;
+
+      case Builtin::Kind: {
+        if (node.As<Builtin>().builtin_kind == BuiltinKind::Error) {
+          return ExpressionCategory::Error;
+        }
+        return ExpressionCategory::Value;
+      }
 
       case BindName::Kind: {
         node_id = node.As<BindName>().value_id;

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -420,6 +420,8 @@ enum class ExpressionCategory : int8_t {
   // This node does not correspond to an expression, and as such has no
   // category.
   NotExpression,
+  // The category of this node is not known due to an error.
+  Error,
   // This node represents a value expression.
   Value,
   // This node represents a durable reference expression, that denotes an

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -561,6 +561,7 @@ class Formatter {
         out_ << ": ";
         switch (GetExpressionCategory(semantics_ir_, node_id)) {
           case ExpressionCategory::NotExpression:
+          case ExpressionCategory::Error:
           case ExpressionCategory::Value:
           case ExpressionCategory::Mixed:
             break;


### PR DESCRIPTION
Don't produce an error diagnostic if any of the information leading to identifying that error is itself known to be affected by an already-diagnosed error.