### PR TITLE
SEMANTICS->SEM_IR in macro names. Update comments in `sem_ir/node.h`.

### DIFF
--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -44,7 +44,7 @@ auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(Name)                  \
+#define CARBON_SEM_IR_NODE_KIND(Name)                     \
   case SemIR::Name::Kind:                                 \
     Handle##Name(*this, node_id, node.As<SemIR::Name>()); \
     break;

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -131,7 +131,7 @@ class FunctionContext {
 };
 
 // Declare handlers for each SemIR::File node.
-#define CARBON_SEMANTICS_NODE_KIND(Name)                             \
+#define CARBON_SEM_IR_NODE_KIND(Name)                                \
   auto Handle##Name(FunctionContext& context, SemIR::NodeId node_id, \
                     SemIR::Name node)                                \
       ->void;

--- a/toolchain/sem_ir/builtin_kind.cpp
+++ b/toolchain/sem_ir/builtin_kind.cpp
@@ -7,14 +7,14 @@
 namespace Carbon::SemIR {
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(BuiltinKind) = {
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) \
   CARBON_ENUM_CLASS_NAME_STRING(Name)
 #include "toolchain/sem_ir/builtin_kind.def"
 };
 
 auto BuiltinKind::label() -> llvm::StringRef {
   static constexpr llvm::StringLiteral Labels[] = {
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, Label) Label,
+#define CARBON_SEM_IR_BUILTIN_KIND(Name, Label) Label,
 #include "toolchain/sem_ir/builtin_kind.def"
   };
   return Labels[AsInt()];

--- a/toolchain/sem_ir/builtin_kind.def
+++ b/toolchain/sem_ir/builtin_kind.def
@@ -8,43 +8,43 @@
 // at the end of this file.
 //
 // Supported x-macros are:
-// - CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)
+// - CARBON_SEM_IR_BUILTIN_KIND_NAME(Name)
 //   Used as a fallback if other macros are missing. Used directly by Invalid
 //   only, which is defined last.
-//   - CARBON_SEMANTICS_BUILTIN_KIND(Name, Label)
+//   - CARBON_SEM_IR_BUILTIN_KIND(Name, Label)
 //     Defines a non-Invalid builtin type. The label is used for stringifying
 //     types.
 //
 // This tree represents the subset relationship between these macros, where if a
 // specific x-macro isn't defined, it'll fall back to the parent macro.
 
-#if !(defined(CARBON_SEMANTICS_BUILTIN_KIND_NAME) || \
-      defined(CARBON_SEMANTICS_BUILTIN_KIND))
+#if !(defined(CARBON_SEM_IR_BUILTIN_KIND_NAME) || \
+      defined(CARBON_SEM_IR_BUILTIN_KIND))
 #error \
-    "Must define CARBON_SEMANTICS_BUILTIN_KIND family x-macros to use this file."
+    "Must define CARBON_SEM_IR_BUILTIN_KIND family x-macros to use this file."
 #endif
 
-// If CARBON_SEMANTICS_BUILTIN_KIND_NAME is undefined, ignore calls.
-#ifndef CARBON_SEMANTICS_BUILTIN_KIND_NAME
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)
+// If CARBON_SEM_IR_BUILTIN_KIND_NAME is undefined, ignore calls.
+#ifndef CARBON_SEM_IR_BUILTIN_KIND_NAME
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name)
 #endif
 
-// If CARBON_SEMANTICS_BUILTIN_KIND is undefined, delegate calls to
-// CARBON_SEMANTICS_BUILTIN_KIND_NAME.
-#ifndef CARBON_SEMANTICS_BUILTIN_KIND
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...) \
-  CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name)
+// If CARBON_SEM_IR_BUILTIN_KIND is undefined, delegate calls to
+// CARBON_SEM_IR_BUILTIN_KIND_NAME.
+#ifndef CARBON_SEM_IR_BUILTIN_KIND
+#define CARBON_SEM_IR_BUILTIN_KIND(Name, ...) \
+  CARBON_SEM_IR_BUILTIN_KIND_NAME(Name)
 #endif
 
 // Tracks expressions which are valid as types.
 // This has a deliberately self-referential type.
-CARBON_SEMANTICS_BUILTIN_KIND(TypeType, "type")
+CARBON_SEM_IR_BUILTIN_KIND(TypeType, "type")
 
 // Used when a semantic error has been detected, and a SemanticNodeId is still
 // required. For example, when there is a type checking issue, this will be used
 // in the type_id. It's typically used as a cue that semantic checking doesn't
 // need to issue further diagnostics.
-CARBON_SEMANTICS_BUILTIN_KIND(Error, "<error>")
+CARBON_SEM_IR_BUILTIN_KIND(Error, "<error>")
 
 // -----------------------------------------------------------------------------
 // TODO: Below types are all placeholders. While the above may last, the below
@@ -53,26 +53,26 @@ CARBON_SEMANTICS_BUILTIN_KIND(Error, "<error>")
 // -----------------------------------------------------------------------------
 
 // The type of bool literals and branch conditions, bool.
-CARBON_SEMANTICS_BUILTIN_KIND(BoolType, "bool")
+CARBON_SEM_IR_BUILTIN_KIND(BoolType, "bool")
 
 // The type of integer values and integer literals, currently always i32.
-CARBON_SEMANTICS_BUILTIN_KIND(IntegerType, "i32")
+CARBON_SEM_IR_BUILTIN_KIND(IntegerType, "i32")
 
 // The type of floating point values and real literals, currently always f64.
-CARBON_SEMANTICS_BUILTIN_KIND(FloatingPointType, "f64")
+CARBON_SEM_IR_BUILTIN_KIND(FloatingPointType, "f64")
 
 // The type of string values and String literals.
-CARBON_SEMANTICS_BUILTIN_KIND(StringType, "String")
+CARBON_SEM_IR_BUILTIN_KIND(StringType, "String")
 
 // The type of function values.
-CARBON_SEMANTICS_BUILTIN_KIND(FunctionType, "<function>")
+CARBON_SEM_IR_BUILTIN_KIND(FunctionType, "<function>")
 
 // The type of namespace names.
-CARBON_SEMANTICS_BUILTIN_KIND(NamespaceType, "<namespace>")
+CARBON_SEM_IR_BUILTIN_KIND(NamespaceType, "<namespace>")
 
 // Keep invalid last, so that we can use values as array indices without needing
 // an invalid entry.
-CARBON_SEMANTICS_BUILTIN_KIND_NAME(Invalid)
+CARBON_SEM_IR_BUILTIN_KIND_NAME(Invalid)
 
-#undef CARBON_SEMANTICS_BUILTIN_KIND_NAME
-#undef CARBON_SEMANTICS_BUILTIN_KIND
+#undef CARBON_SEM_IR_BUILTIN_KIND_NAME
+#undef CARBON_SEM_IR_BUILTIN_KIND

--- a/toolchain/sem_ir/builtin_kind.h
+++ b/toolchain/sem_ir/builtin_kind.h
@@ -12,14 +12,13 @@
 namespace Carbon::SemIR {
 
 CARBON_DEFINE_RAW_ENUM_CLASS(BuiltinKind, uint8_t) {
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
-  CARBON_RAW_ENUM_ENUMERATOR(Name)
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/sem_ir/builtin_kind.def"
 };
 
 class BuiltinKind : public CARBON_ENUM_BASE(BuiltinKind) {
  public:
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) \
   CARBON_ENUM_CONSTANT_DECLARATION(Name)
 #include "toolchain/sem_ir/builtin_kind.def"
 
@@ -36,7 +35,7 @@ class BuiltinKind : public CARBON_ENUM_BASE(BuiltinKind) {
   using EnumBase::FromInt;
 };
 
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) \
   CARBON_ENUM_CONSTANT_DEFINITION(BuiltinKind, Name)
 #include "toolchain/sem_ir/builtin_kind.def"
 

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -50,7 +50,7 @@ File::File()
   // Error uses a self-referential type so that it's not accidentally treated as
   // a normal type. Every other builtin is a type, including the
   // self-referential TypeType.
-#define CARBON_SEMANTICS_BUILTIN_KIND(Name, ...)                   \
+#define CARBON_SEM_IR_BUILTIN_KIND(Name, ...)                      \
   nodes_.push_back(Builtin(BuiltinKind::Name == BuiltinKind::Error \
                                ? TypeId::Error                     \
                                : TypeId::TypeType,                 \

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -586,7 +586,7 @@ class Formatter {
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
     switch (node.kind()) {
-#define CARBON_SEMANTICS_NODE_KIND(NodeT)         \
+#define CARBON_SEM_IR_NODE_KIND(NodeT)            \
   case NodeT::Kind:                               \
     FormatInstruction(node_id, node.As<NodeT>()); \
     break;

--- a/toolchain/sem_ir/node.cpp
+++ b/toolchain/sem_ir/node.cpp
@@ -17,7 +17,7 @@ auto Node::Print(llvm::raw_ostream& out) const -> void {
   // clang warns on unhandled enum values; clang-tidy is incorrect here.
   // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (kind_) {
-#define CARBON_SEMANTICS_NODE_KIND(Name)                    \
+#define CARBON_SEM_IR_NODE_KIND(Name)                       \
   case Name::Kind:                                          \
     std::apply(print_args, As<SemIR::Name>().args_tuple()); \
     break;

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -23,8 +23,7 @@ struct NodeId : public IndexBase, public Printable<NodeId> {
   static const NodeId Invalid;
 
 // Builtin node IDs.
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
-  static const NodeId Builtin##Name;
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) static const NodeId Builtin##Name;
 #include "toolchain/sem_ir/builtin_kind.def"
 
   // Returns the cross-reference node ID for a builtin. This relies on File
@@ -50,8 +49,8 @@ struct NodeId : public IndexBase, public Printable<NodeId> {
 
 constexpr NodeId NodeId::Invalid = NodeId(NodeId::InvalidIndex);
 
-#define CARBON_SEMANTICS_BUILTIN_KIND_NAME(Name) \
-  constexpr NodeId NodeId::Builtin##Name =       \
+#define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) \
+  constexpr NodeId NodeId::Builtin##Name =    \
       NodeId::ForBuiltin(BuiltinKind::Name);
 #include "toolchain/sem_ir/builtin_kind.def"
 
@@ -493,19 +492,21 @@ struct TypedNode;
 // - `type_id` for quick type checking.
 // - Up to two Kind-specific members.
 //
-// For each Kind in NodeKind, a typical flow looks like:
+// To create a specific kind of `Node`, use the appropriate `TypedNode`
+// constructor. A `TypedNode` implicitly converts to a `Node`.
 //
-// - Create a specific kind of `Node` using the appropriate `TypedNode`
-//   constructor.
-// - Access cross-Kind members using `node.type_id()` and similar.
+// Given a `Node`, you may:
+//
+// - Access non-Kind-specific members like `Print`.
+// - Use `node.kind()` or `Is<Kind>` to determine what kind of node it is.
 // - Access Kind-specific members using `node.As<Kind>()`, which produces a
 //   `TypedNode` with type-specific members, including `parse_node` and
 //   `type_id` for nodes that have associated parse nodes and types.
 //   - Using the wrong kind in `node.As<Kind>()` is a programming error, and
 //     will CHECK-fail in debug modes (opt may too, but it's not an API
 //     guarantee).
-//   - Use `node.TryAs<Kind>()` to safely access type-specific node data where
-//     the node's kind is not known.
+// - Use `node.TryAs<Kind>()` to safely access type-specific node data where
+//   the node's kind is not known.
 class Node : public Printable<Node> {
  public:
   template <NodeKind::RawEnumType Kind, typename Data>
@@ -634,7 +635,7 @@ struct TypedNode : NodeInternals::TypedNodeImpl<DataT>,
 };
 
 // Declare type names for each specific kind of node.
-#define CARBON_SEMANTICS_NODE_KIND(Name) \
+#define CARBON_SEM_IR_NODE_KIND(Name) \
   using Name = TypedNode<NodeKind::Name, NodeData::Name>;
 #include "toolchain/sem_ir/node_kind.def"
 

--- a/toolchain/sem_ir/node_kind.cpp
+++ b/toolchain/sem_ir/node_kind.cpp
@@ -7,14 +7,14 @@
 namespace Carbon::SemIR {
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(NodeKind) = {
-#define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_ENUM_CLASS_NAME_STRING(Name)
+#define CARBON_SEM_IR_NODE_KIND(Name) CARBON_ENUM_CLASS_NAME_STRING(Name)
 #include "toolchain/sem_ir/node_kind.def"
 };
 
 // Returns the name to use for this node kind in Semantics IR.
 [[nodiscard]] auto NodeKind::ir_name() const -> llvm::StringRef {
   static constexpr llvm::StringRef Table[] = {
-#define CARBON_SEMANTICS_NODE_KIND_WITH_IR_NAME(Name, IR_Name) IR_Name,
+#define CARBON_SEM_IR_NODE_KIND_WITH_IR_NAME(Name, IR_Name) IR_Name,
 #include "toolchain/sem_ir/node_kind.def"
   };
   return Table[AsInt()];
@@ -22,8 +22,7 @@ CARBON_DEFINE_ENUM_CLASS_NAMES(NodeKind) = {
 
 auto NodeKind::value_kind() const -> NodeValueKind {
   static constexpr NodeValueKind Table[] = {
-#define CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND(Name, Kind) \
-  NodeValueKind::Kind,
+#define CARBON_SEM_IR_NODE_KIND_WITH_VALUE_KIND(Name, Kind) NodeValueKind::Kind,
 #include "toolchain/sem_ir/node_kind.def"
   };
   return Table[AsInt()];
@@ -31,7 +30,7 @@ auto NodeKind::value_kind() const -> NodeValueKind {
 
 auto NodeKind::terminator_kind() const -> TerminatorKind {
   static constexpr TerminatorKind Table[] = {
-#define CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND(Name, Kind) \
+#define CARBON_SEM_IR_NODE_KIND_WITH_TERMINATOR_KIND(Name, Kind) \
   TerminatorKind::Kind,
 #include "toolchain/sem_ir/node_kind.def"
   };

--- a/toolchain/sem_ir/node_kind.def
+++ b/toolchain/sem_ir/node_kind.def
@@ -8,110 +8,100 @@
 // at the end of this file.
 //
 // Exactly one of these macros should be defined before including this header:
-// - CARBON_SEMANTICS_NODE_KIND(Name)
+// - CARBON_SEM_IR_NODE_KIND(Name)
 //   Invoked for each kind of semantic node.
-// - CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND(Name, TypeFieldKind)
+// - CARBON_SEM_IR_NODE_KIND_WITH_VALUE_KIND(Name, TypeFieldKind)
 //   Invoked for each kind of semantic node, along with information about
 //   whether the node produces a value, and if so, what kind of value.
-// - CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND(Name, TerminatorKind)
+// - CARBON_SEM_IR_NODE_KIND_WITH_TERMINATOR_KIND(Name, TerminatorKind)
 //   Invoked for each kind of semantic node, along with information about
 //   whether the node is a terminator node.
-// - CARBON_SEMANTICS_NODE_KIND_WITH_IR_NAME(Name, IRName)
+// - CARBON_SEM_IR_NODE_KIND_WITH_IR_NAME(Name, IRName)
 //   Invoked for each kind of semantic node, along with the name that is used
 //   to denote this node in textual Semantics IR.
 
-#if defined(CARBON_SEMANTICS_NODE_KIND)
-#define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
-                                        TerminatorKind)          \
-  CARBON_SEMANTICS_NODE_KIND(Name)
-#elif defined(CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND)
-#define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
-                                        TerminatorKind)          \
-  CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND(Name, ValueKind)
-#elif defined(CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND)
-#define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
-                                        TerminatorKind)          \
-  CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND(Name, TerminatorKind)
-#elif defined(CARBON_SEMANTICS_NODE_KIND_WITH_IR_NAME)
-#define CARBON_SEMANTICS_NODE_KIND_IMPL(Name, IRName, ValueKind, \
-                                        TerminatorKind)          \
-  CARBON_SEMANTICS_NODE_KIND_WITH_IR_NAME(Name, IRName)
+#if defined(CARBON_SEM_IR_NODE_KIND)
+#define CARBON_SEM_IR_NODE_KIND_IMPL(Name, IRName, ValueKind, TerminatorKind) \
+  CARBON_SEM_IR_NODE_KIND(Name)
+#elif defined(CARBON_SEM_IR_NODE_KIND_WITH_VALUE_KIND)
+#define CARBON_SEM_IR_NODE_KIND_IMPL(Name, IRName, ValueKind, TerminatorKind) \
+  CARBON_SEM_IR_NODE_KIND_WITH_VALUE_KIND(Name, ValueKind)
+#elif defined(CARBON_SEM_IR_NODE_KIND_WITH_TERMINATOR_KIND)
+#define CARBON_SEM_IR_NODE_KIND_IMPL(Name, IRName, ValueKind, TerminatorKind) \
+  CARBON_SEM_IR_NODE_KIND_WITH_TERMINATOR_KIND(Name, TerminatorKind)
+#elif defined(CARBON_SEM_IR_NODE_KIND_WITH_IR_NAME)
+#define CARBON_SEM_IR_NODE_KIND_IMPL(Name, IRName, ValueKind, TerminatorKind) \
+  CARBON_SEM_IR_NODE_KIND_WITH_IR_NAME(Name, IRName)
 #else
 #error "Must define the x-macro to use this file."
 #endif
 
 // A cross-reference between IRs.
-CARBON_SEMANTICS_NODE_KIND_IMPL(CrossReference, "xref", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(CrossReference, "xref", Typed, NotTerminator)
 
-CARBON_SEMANTICS_NODE_KIND_IMPL(AddressOf, "address_of", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ArrayIndex, "array_index", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ArrayInit, "array_init", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ArrayType, "array_type", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Assign, "assign", None, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BinaryOperatorAdd, "add", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BindName, "bind_name", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BindValue, "bind_value", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BlockArg, "block_arg", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BoolLiteral, "bool_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Branch, "br", None, Terminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BranchIf, "br", None, TerminatorSequence)
-CARBON_SEMANTICS_NODE_KIND_IMPL(BranchWithArg, "br", None, Terminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Builtin, "builtin", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Call, "call", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ClassDeclaration, "class_declaration", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ConstType, "const_type", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Dereference, "dereference", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(FunctionDeclaration, "fn_decl", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(InitializeFrom, "initialize_from", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(IntegerLiteral, "int_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(NameReference, "name_reference", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Namespace, "namespace", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(NoOp, "no_op", None, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Parameter, "parameter", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(PointerType, "ptr_type", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(RealLiteral, "real_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ReturnExpression, "return", None, Terminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Return, "return", None, Terminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(SpliceBlock, "splice_block", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StringLiteral, "string_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructAccess, "struct_access", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructInit, "struct_init", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructLiteral, "struct_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructTypeField, "struct_type_field", None,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructType, "struct_type", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(StructValue, "struct_value", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TemporaryStorage, "temporary_storage", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(Temporary, "temporary", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleAccess, "tuple_access", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleIndex, "tuple_index", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleInit, "tuple_init", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleLiteral, "tuple_literal", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleType, "tuple_type", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(TupleValue, "tuple_value", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(UnaryOperatorNot, "not", Typed, NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(ValueAsReference, "value_as_reference", Typed,
-                                NotTerminator)
-CARBON_SEMANTICS_NODE_KIND_IMPL(VarStorage, "var", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(AddressOf, "address_of", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ArrayIndex, "array_index", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ArrayInit, "array_init", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ArrayType, "array_type", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Assign, "assign", None, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BinaryOperatorAdd, "add", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BindName, "bind_name", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BindValue, "bind_value", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BlockArg, "block_arg", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BoolLiteral, "bool_literal", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Branch, "br", None, Terminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(BranchIf, "br", None, TerminatorSequence)
+CARBON_SEM_IR_NODE_KIND_IMPL(BranchWithArg, "br", None, Terminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Builtin, "builtin", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Call, "call", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ClassDeclaration, "class_declaration", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ConstType, "const_type", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Dereference, "dereference", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(FunctionDeclaration, "fn_decl", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(InitializeFrom, "initialize_from", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(IntegerLiteral, "int_literal", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(NameReference, "name_reference", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Namespace, "namespace", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(NoOp, "no_op", None, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Parameter, "parameter", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(PointerType, "ptr_type", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(RealLiteral, "real_literal", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ReturnExpression, "return", None, Terminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Return, "return", None, Terminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(SpliceBlock, "splice_block", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StringLiteral, "string_literal", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructAccess, "struct_access", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructInit, "struct_init", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructLiteral, "struct_literal", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructTypeField, "struct_type_field", None,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructType, "struct_type", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(StructValue, "struct_value", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TemporaryStorage, "temporary_storage", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(Temporary, "temporary", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleAccess, "tuple_access", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleIndex, "tuple_index", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleInit, "tuple_init", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleLiteral, "tuple_literal", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleType, "tuple_type", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(TupleValue, "tuple_value", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(UnaryOperatorNot, "not", Typed, NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(ValueAsReference, "value_as_reference", Typed,
+                             NotTerminator)
+CARBON_SEM_IR_NODE_KIND_IMPL(VarStorage, "var", Typed, NotTerminator)
 
-#undef CARBON_SEMANTICS_NODE_KIND
-#undef CARBON_SEMANTICS_NODE_KIND_WITH_VALUE_KIND
-#undef CARBON_SEMANTICS_NODE_KIND_WITH_TERMINATOR_KIND
-#undef CARBON_SEMANTICS_NODE_KIND_WITH_IR_NAME
-#undef CARBON_SEMANTICS_NODE_KIND_IMPL
+#undef CARBON_SEM_IR_NODE_KIND
+#undef CARBON_SEM_IR_NODE_KIND_WITH_VALUE_KIND
+#undef CARBON_SEM_IR_NODE_KIND_WITH_TERMINATOR_KIND
+#undef CARBON_SEM_IR_NODE_KIND_WITH_IR_NAME
+#undef CARBON_SEM_IR_NODE_KIND_IMPL

--- a/toolchain/sem_ir/node_kind.h
+++ b/toolchain/sem_ir/node_kind.h
@@ -36,13 +36,13 @@ enum class TerminatorKind : int8_t {
 };
 
 CARBON_DEFINE_RAW_ENUM_CLASS(NodeKind, uint8_t) {
-#define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
+#define CARBON_SEM_IR_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/sem_ir/node_kind.def"
 };
 
 class NodeKind : public CARBON_ENUM_BASE(NodeKind) {
  public:
-#define CARBON_SEMANTICS_NODE_KIND(Name) CARBON_ENUM_CONSTANT_DECLARATION(Name)
+#define CARBON_SEM_IR_NODE_KIND(Name) CARBON_ENUM_CONSTANT_DECLARATION(Name)
 #include "toolchain/sem_ir/node_kind.def"
 
   using EnumBase::Create;
@@ -65,7 +65,7 @@ class NodeKind : public CARBON_ENUM_BASE(NodeKind) {
   void Profile(llvm::FoldingSetNodeID& id) { id.AddInteger(AsInt()); }
 };
 
-#define CARBON_SEMANTICS_NODE_KIND(Name) \
+#define CARBON_SEM_IR_NODE_KIND(Name) \
   CARBON_ENUM_CONSTANT_DEFINITION(NodeKind, Name)
 #include "toolchain/sem_ir/node_kind.def"
 


### PR DESCRIPTION
* Shift to "sem_ir" continued from #3176.
* Comments in `node.h` changed to reflect #3280.