### PR TITLE
Extend SharedValueStores to SemIR

### DIFF
--- a/language_server/BUILD
+++ b/language_server/BUILD
@@ -21,6 +21,7 @@ cc_binary(
     copts = ["-Wno-unused-parameter"],
     deps = [
         "//common:error",
+        "//toolchain/base:value_store",
         "//toolchain/diagnostics:null_diagnostics",
         "//toolchain/lex:tokenized_buffer",
         "//toolchain/parse:node_kind",

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -18,6 +18,9 @@ namespace Carbon {
 //
 // This is either a dyadic fraction (mantissa * 2^exponent) or a decadic
 // fraction (mantissa * 10^exponent).
+//
+// TODO: For SemIR, replace this with a Rational type, per the design:
+// docs/design/expressions/literals.md
 class Real : public Printable<Real> {
  public:
   auto Print(llvm::raw_ostream& output_stream) const -> void {
@@ -127,8 +130,11 @@ class ValueStore<StringId> {
 class SharedValueStores {
  public:
   auto integers() -> ValueStore<IntegerId>& { return integers_; }
+  auto integers() const -> const ValueStore<IntegerId>& { return integers_; }
   auto reals() -> ValueStore<RealId>& { return reals_; }
+  auto reals() const -> const ValueStore<RealId>& { return reals_; }
   auto strings() -> ValueStore<StringId>& { return strings_; }
+  auto strings() const -> const ValueStore<StringId>& { return strings_; }
 
  private:
   ValueStore<IntegerId> integers_;

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -55,6 +55,7 @@ cc_library(
         "//common:ostream",
         "//common:vlog",
         "//toolchain/base:pretty_stack_trace_function",
+        "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:diagnostic_kind",
         "//toolchain/lex:tokenized_buffer",

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -11,11 +11,13 @@
 
 namespace Carbon::Check {
 
-auto CheckParseTree(const SemIR::File& builtin_ir,
+auto CheckParseTree(SharedValueStores& value_stores,
+                    const SemIR::File& builtin_ir,
                     const Lex::TokenizedBuffer& tokens,
                     const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
                     llvm::raw_ostream* vlog_stream) -> SemIR::File {
-  auto semantics_ir = SemIR::File(tokens.filename().str(), &builtin_ir);
+  auto semantics_ir =
+      SemIR::File(value_stores, tokens.filename().str(), &builtin_ir);
 
   Parse::NodeLocationTranslator translator(&tokens, &parse_tree);
   ErrorTrackingDiagnosticConsumer err_tracker(consumer);

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_CHECK_CHECK_H_
 
 #include "common/ostream.h"
+#include "toolchain/base/value_store.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/tree.h"
@@ -15,10 +16,13 @@ namespace Carbon::Check {
 
 // Constructs builtins. A single instance should be reused with CheckParseTree
 // calls associated with a given compilation.
-inline auto MakeBuiltins() -> SemIR::File { return SemIR::File(); }
+inline auto MakeBuiltins(SharedValueStores& value_stores) -> SemIR::File {
+  return SemIR::File(value_stores);
+}
 
 // Produces and checks the IR for the provided Parse::Tree.
-extern auto CheckParseTree(const SemIR::File& builtin_ir,
+extern auto CheckParseTree(SharedValueStores& value_stores,
+                           const SemIR::File& builtin_ir,
                            const Lex::TokenizedBuffer& tokens,
                            const Parse::Tree& parse_tree,
                            DiagnosticConsumer& consumer,

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -12,7 +12,6 @@
 #include "llvm/ADT/Sequence.h"
 #include "toolchain/check/declaration_name_stack.h"
 #include "toolchain/check/node_block_stack.h"
-#include "toolchain/diagnostics/diagnostic_kind.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/sem_ir/file.h"
@@ -86,7 +85,8 @@ auto Context::DiagnoseNameNotFound(Parse::Node parse_node, StringId name_id)
     -> void {
   CARBON_DIAGNOSTIC(NameNotFound, Error, "Name `{0}` not found.",
                     llvm::StringRef);
-  emitter_->Emit(parse_node, NameNotFound, semantics_ir_->GetString(name_id));
+  emitter_->Emit(parse_node, NameNotFound,
+                 semantics_ir_->strings().Get(name_id));
 }
 
 auto Context::NoteIncompleteClass(SemIR::ClassDeclaration class_decl,
@@ -117,7 +117,7 @@ auto Context::LookupName(Parse::Node parse_node, StringId name_id,
       return SemIR::NodeId::BuiltinError;
     }
     CARBON_CHECK(!it->second.empty())
-        << "Should have been erased: " << semantics_ir_->GetString(name_id);
+        << "Should have been erased: " << semantics_ir_->strings().Get(name_id);
 
     // TODO: Check for ambiguous lookups.
     return it->second.back();

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -134,7 +134,7 @@ static auto MakeElemAccessNode(Context& context, Parse::Node parse_node,
     // special case.
     auto index_id = block.AddNode(SemIR::IntegerLiteral(
         parse_node, context.GetBuiltinType(SemIR::BuiltinKind::IntegerType),
-        context.semantics_ir().AddInteger(llvm::APInt(32, i))));
+        context.semantics_ir().integers().Add(llvm::APInt(32, i))));
     return block.AddNode(
         AccessNodeT(parse_node, elem_type_id, aggregate_id, index_id));
   } else {
@@ -454,8 +454,9 @@ static auto ConvertStructToStruct(Context& context,
           "source has field name `{1}`, destination has field name `{2}`.",
           size_t, llvm::StringRef, llvm::StringRef);
       context.emitter().Emit(value.parse_node(), StructInitFieldNameMismatch,
-                             i + 1, semantics_ir.GetString(src_field.name_id),
-                             semantics_ir.GetString(dest_field.name_id));
+                             i + 1,
+                             semantics_ir.strings().Get(src_field.name_id),
+                             semantics_ir.strings().Get(dest_field.name_id));
       return SemIR::NodeId::BuiltinError;
     }
 

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -37,7 +37,7 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
   auto bound_node = context.semantics_ir().GetNode(bound_node_id);
   if (auto literal = bound_node.TryAs<SemIR::IntegerLiteral>()) {
     const auto& bound_value =
-        context.semantics_ir().GetInteger(literal->integer_id);
+        context.semantics_ir().integers().Get(literal->integer_id);
     // TODO: Produce an error if the array type is too large.
     if (bound_value.getActiveBits() <= 64) {
       context.AddNodeAndPush(

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -83,7 +83,7 @@ auto HandleClassDefinitionStart(Context& context, Parse::Node parse_node)
                       "Previous definition was here.");
     context.emitter()
         .Build(parse_node, ClassRedefinition,
-               context.semantics_ir().GetString(class_info.name_id))
+               context.semantics_ir().strings().Get(class_info.name_id))
         .Note(context.semantics_ir()
                   .GetNode(class_info.definition_id)
                   .parse_node(),

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -170,7 +170,7 @@ auto HandleFunctionDefinitionStart(Context& context, Parse::Node parse_node)
                       "Previous definition was here.");
     context.emitter()
         .Build(parse_node, FunctionRedefinition,
-               context.semantics_ir().GetString(function.name_id))
+               context.semantics_ir().strings().Get(function.name_id))
         .Note(
             context.semantics_ir().GetNode(function.definition_id).parse_node(),
             FunctionPreviousDefinition)
@@ -229,7 +229,7 @@ auto HandleReturnType(Context& context, Parse::Node parse_node) -> bool {
   context.AddNodeAndPush(
       parse_node,
       SemIR::VarStorage(parse_node, type_id,
-                        context.semantics_ir().AddString("return")));
+                        context.semantics_ir().strings().Add("return")));
   return true;
 }
 

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -24,7 +24,7 @@ static auto ValidateIntegerLiteralBound(Context& context,
                                         SemIR::IntegerLiteral index_node,
                                         int size) -> const llvm::APInt* {
   const auto& index_val =
-      context.semantics_ir().GetInteger(index_node.integer_id);
+      context.semantics_ir().integers().Get(index_node.integer_id);
   if (index_val.uge(size)) {
     CARBON_DIAGNOSTIC(IndexOutOfBounds, Error,
                       "Index `{0}` is past the end of `{1}`.", llvm::APSInt,

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -20,32 +20,25 @@ auto HandleLiteral(Context& context, Parse::Node parse_node) -> bool {
       break;
     }
     case Lex::TokenKind::IntegerLiteral: {
-      auto id = context.semantics_ir().AddInteger(
-          context.tokens().GetIntegerLiteral(token));
       context.AddNodeAndPush(
           parse_node,
           SemIR::IntegerLiteral(
               parse_node,
-              context.GetBuiltinType(SemIR::BuiltinKind::IntegerType), id));
+              context.GetBuiltinType(SemIR::BuiltinKind::IntegerType),
+              context.tokens().GetIntegerLiteral(token)));
       break;
     }
     case Lex::TokenKind::RealLiteral: {
-      auto token_value = context.tokens().GetRealLiteral(token);
-      auto id = context.semantics_ir().AddReal(
-          {.mantissa = token_value.mantissa,
-           .exponent = token_value.exponent,
-           .is_decimal = token_value.is_decimal});
       context.AddNodeAndPush(
           parse_node,
           SemIR::RealLiteral(
               parse_node,
               context.GetBuiltinType(SemIR::BuiltinKind::FloatingPointType),
-              id));
+              context.tokens().GetRealLiteral(token)));
       break;
     }
     case Lex::TokenKind::StringLiteral: {
-      auto id = context.semantics_ir().AddString(
-          context.tokens().GetStringLiteral(token));
+      auto id = context.tokens().GetStringLiteral(token);
       context.AddNodeAndPush(
           parse_node,
           SemIR::StringLiteral(

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -83,7 +83,7 @@ auto HandleMemberAccessExpression(Context& context, Parse::Node parse_node)
                         llvm::StringRef);
       context.emitter().Emit(parse_node, QualifiedExpressionNameNotFound,
                              context.semantics_ir().StringifyType(base_type_id),
-                             context.semantics_ir().GetString(name_id));
+                             context.semantics_ir().strings().Get(name_id));
       break;
     }
     default: {
@@ -110,16 +110,16 @@ auto HandlePointerMemberAccessExpression(Context& context,
 }
 
 auto HandleName(Context& context, Parse::Node parse_node) -> bool {
-  auto name_str = context.parse_tree().GetNodeText(parse_node);
-  auto name_id = context.semantics_ir().AddString(name_str);
+  auto name_id = context.tokens().GetIdentifier(
+      context.parse_tree().node_token(parse_node));
   // The parent is responsible for binding the name.
   context.node_stack().Push(parse_node, name_id);
   return true;
 }
 
 auto HandleNameExpression(Context& context, Parse::Node parse_node) -> bool {
-  auto name_str = context.parse_tree().GetNodeText(parse_node);
-  auto name_id = context.semantics_ir().AddString(name_str);
+  auto name_id = context.tokens().GetIdentifier(
+      context.parse_tree().node_token(parse_node));
   auto value_id =
       context.LookupName(parse_node, name_id, SemIR::NameScopeId::Invalid,
                          /*print_diagnostics=*/true);

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -13,12 +13,6 @@
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     type_blocks: [

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -22,13 +22,6 @@ fn B() {}
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       A,
-// CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
 // CHECK:STDOUT:     ]
@@ -61,16 +54,9 @@ fn B() {}
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
 // CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
+// CHECK:STDOUT:       {name: str1, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       B,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -22,13 +22,6 @@ fn B() {}
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       A,
-// CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
 // CHECK:STDOUT:     ]
@@ -52,16 +45,9 @@ fn B() {}
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
 // CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
+// CHECK:STDOUT:       {name: str1, param_refs: block0, body: [block1]},
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       B,
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -20,17 +20,6 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:       2,
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       Foo,
-// CHECK:STDOUT:       n,
-// CHECK:STDOUT:       return,
-// CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeIntegerType, value_rep: {kind: copy, type: type0}},
 // CHECK:STDOUT:       {node: node+1, value_rep: {kind: unknown, type: type<invalid>}},
@@ -58,7 +47,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       {kind: PointerType, arg0: type3, type: typeTypeType},
 // CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type5},
 // CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
-// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
+// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int3, type: type0},
 // CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0},
 // CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
 // CHECK:STDOUT:       {kind: TupleLiteral, arg0: block5, type: type3},

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -20,17 +20,6 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:     ]
 // CHECK:STDOUT:     classes: [
 // CHECK:STDOUT:     ]
-// CHECK:STDOUT:     integers: [
-// CHECK:STDOUT:       2,
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     reals: [
-// CHECK:STDOUT:       {mantissa: 34, exponent: -1, is_decimal: 1},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     strings: [
-// CHECK:STDOUT:       Foo,
-// CHECK:STDOUT:       n,
-// CHECK:STDOUT:       return,
-// CHECK:STDOUT:     ]
 // CHECK:STDOUT:     types: [
 // CHECK:STDOUT:       {node: nodeIntegerType, value_rep: {kind: copy, type: type0}},
 // CHECK:STDOUT:       {node: node+1, value_rep: {kind: unknown, type: type<invalid>}},
@@ -58,7 +47,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       {kind: PointerType, arg0: type3, type: typeTypeType},
 // CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type5},
 // CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
-// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int0, type: type0},
+// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int3, type: type0},
 // CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0},
 // CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
 // CHECK:STDOUT:       {kind: TupleLiteral, arg0: block5, type: type3},

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -451,8 +451,8 @@ class Driver::CompilationUnit {
     CARBON_CHECK(parse_tree_);
 
     LogCall("Check::CheckParseTree", [&] {
-      sem_ir_ = Check::CheckParseTree(builtins, *tokens_, *parse_tree_,
-                                      *consumer_, vlog_stream_);
+      sem_ir_ = Check::CheckParseTree(*value_stores_, builtins, *tokens_,
+                                      *parse_tree_, *consumer_, vlog_stream_);
     });
 
     // We've finished all steps that can produce diagnostics. Emit the
@@ -632,7 +632,7 @@ auto Driver::Compile(const CompileOptions& options) -> bool {
   }
 
   // Check.
-  auto builtins = Check::MakeBuiltins();
+  auto builtins = Check::MakeBuiltins(value_stores);
   // TODO: Organize units to compile in dependency order.
   for (auto& unit : units) {
     success_before_lower &= unit->RunCheck(builtins);

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -202,6 +202,7 @@ cc_library(
     deps = [
         ":tokenized_buffer",
         "//common:check",
+        "//toolchain/base:value_store",
         "@com_google_googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -1232,23 +1232,22 @@ auto TokenizedBuffer::GetIdentifier(Token token) const -> StringId {
   return token_info.string_id;
 }
 
-auto TokenizedBuffer::GetIntegerLiteral(Token token) const
-    -> const llvm::APInt& {
+auto TokenizedBuffer::GetIntegerLiteral(Token token) const -> IntegerId {
   const auto& token_info = GetTokenInfo(token);
   CARBON_CHECK(token_info.kind == TokenKind::IntegerLiteral) << token_info.kind;
-  return value_stores_->integers().Get(token_info.integer_id);
+  return token_info.integer_id;
 }
 
-auto TokenizedBuffer::GetRealLiteral(Token token) const -> Real {
+auto TokenizedBuffer::GetRealLiteral(Token token) const -> RealId {
   const auto& token_info = GetTokenInfo(token);
   CARBON_CHECK(token_info.kind == TokenKind::RealLiteral) << token_info.kind;
-  return value_stores_->reals().Get(token_info.real_id);
+  return token_info.real_id;
 }
 
-auto TokenizedBuffer::GetStringLiteral(Token token) const -> llvm::StringRef {
+auto TokenizedBuffer::GetStringLiteral(Token token) const -> StringId {
   const auto& token_info = GetTokenInfo(token);
   CARBON_CHECK(token_info.kind == TokenKind::StringLiteral) << token_info.kind;
-  return value_stores_->strings().Get(token_info.string_id);
+  return token_info.string_id;
 }
 
 auto TokenizedBuffer::GetTypeLiteralSize(Token token) const
@@ -1393,14 +1392,19 @@ auto TokenizedBuffer::PrintToken(llvm::raw_ostream& output_stream, Token token,
       break;
     case TokenKind::IntegerLiteral:
       output_stream << ", value: `";
-      GetIntegerLiteral(token).print(output_stream, /*isSigned=*/false);
+      value_stores_->integers()
+          .Get(GetIntegerLiteral(token))
+          .print(output_stream, /*isSigned=*/false);
       output_stream << "`";
       break;
     case TokenKind::RealLiteral:
-      output_stream << ", value: `" << GetRealLiteral(token) << "`";
+      output_stream << ", value: `"
+                    << value_stores_->reals().Get(GetRealLiteral(token)) << "`";
       break;
     case TokenKind::StringLiteral:
-      output_stream << ", value: `" << GetStringLiteral(token) << "`";
+      output_stream << ", value: `"
+                    << value_stores_->strings().Get(GetStringLiteral(token))
+                    << "`";
       break;
     default:
       if (token_info.kind.is_opening_symbol()) {

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -151,13 +151,13 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   [[nodiscard]] auto GetIdentifier(Token token) const -> StringId;
 
   // Returns the value of an `IntegerLiteral()` token.
-  [[nodiscard]] auto GetIntegerLiteral(Token token) const -> const llvm::APInt&;
+  [[nodiscard]] auto GetIntegerLiteral(Token token) const -> IntegerId;
 
   // Returns the value of an `RealLiteral()` token.
-  [[nodiscard]] auto GetRealLiteral(Token token) const -> Real;
+  [[nodiscard]] auto GetRealLiteral(Token token) const -> RealId;
 
   // Returns the value of a `StringLiteral()` token.
-  [[nodiscard]] auto GetStringLiteral(Token token) const -> llvm::StringRef;
+  [[nodiscard]] auto GetStringLiteral(Token token) const -> StringId;
 
   // Returns the size specified in a `*TypeLiteral()` token.
   [[nodiscard]] auto GetTypeLiteralSize(Token token) const

--- a/toolchain/lex/tokenized_buffer_test.cpp
+++ b/toolchain/lex/tokenized_buffer_test.cpp
@@ -153,21 +153,32 @@ TEST_F(LexerTest, HandlesNumericLiteral) {
               }));
   auto token_start = buffer.tokens().begin();
   auto token_12 = token_start + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_12), 12);
+  EXPECT_EQ(value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_12)),
+            12);
   auto token_578 = token_12 + 2;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_578), 578);
+  EXPECT_EQ(value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_578)),
+            578);
   auto token_1 = token_578 + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_1), 1);
+  EXPECT_EQ(value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_1)),
+            1);
   auto token_2 = token_1 + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_2), 2);
+  EXPECT_EQ(value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_2)),
+            2);
   auto token_0x12_3abc = token_2 + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_0x12_3abc), 0x12'3abc);
+  EXPECT_EQ(
+      value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_0x12_3abc)),
+      0x12'3abc);
   auto token_0b10_10_11 = token_0x12_3abc + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_0b10_10_11), 0b10'10'11);
+  EXPECT_EQ(
+      value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_0b10_10_11)),
+      0b10'10'11);
   auto token_1_234_567 = token_0b10_10_11 + 1;
-  EXPECT_EQ(buffer.GetIntegerLiteral(*token_1_234_567), 1'234'567);
+  EXPECT_EQ(
+      value_stores_.integers().Get(buffer.GetIntegerLiteral(*token_1_234_567)),
+      1'234'567);
   auto token_1_5e9 = token_1_234_567 + 1;
-  auto value_1_5e9 = buffer.GetRealLiteral(*token_1_5e9);
+  auto value_1_5e9 =
+      value_stores_.reals().Get(buffer.GetRealLiteral(*token_1_5e9));
   EXPECT_EQ(value_1_5e9.mantissa.getZExtValue(), 15);
   EXPECT_EQ(value_1_5e9.exponent.getSExtValue(), 8);
   EXPECT_EQ(value_1_5e9.is_decimal, true);
@@ -759,11 +770,13 @@ TEST_F(LexerTest, StringLiterals) {
                    .line = 2,
                    .column = 5,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {"hello world\n"}},
                   {.kind = TokenKind::StringLiteral,
                    .line = 4,
                    .column = 5,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {" test  \xAB\n"}},
                   {.kind = TokenKind::Identifier,
                    .line = 7,
@@ -774,16 +787,19 @@ TEST_F(LexerTest, StringLiterals) {
                    .line = 9,
                    .column = 7,
                    .indent_column = 7,
+                   .value_stores = &value_stores_,
                    .string_contents = {"\""}},
                   {.kind = TokenKind::StringLiteral,
                    .line = 11,
                    .column = 5,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = llvm::StringLiteral::withInnerNUL("\0")},
                   {.kind = TokenKind::StringLiteral,
                    .line = 13,
                    .column = 5,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {"\\0\"foo\"\\1"}},
 
                   // """x""" is three string literals, not one invalid
@@ -792,16 +808,19 @@ TEST_F(LexerTest, StringLiterals) {
                    .line = 15,
                    .column = 5,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {""}},
                   {.kind = TokenKind::StringLiteral,
                    .line = 15,
                    .column = 7,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {"x"}},
                   {.kind = TokenKind::StringLiteral,
                    .line = 15,
                    .column = 10,
                    .indent_column = 5,
+                   .value_stores = &value_stores_,
                    .string_contents = {""}},
                   {.kind = TokenKind::EndOfFile, .line = 16, .column = 3},
               }));

--- a/toolchain/lex/tokenized_buffer_test_helpers.h
+++ b/toolchain/lex/tokenized_buffer_test_helpers.h
@@ -8,6 +8,7 @@
 #include <gmock/gmock.h>
 
 #include "common/check.h"
+#include "toolchain/base/value_store.h"
 #include "toolchain/lex/tokenized_buffer.h"
 
 namespace Carbon::Testing {
@@ -45,6 +46,7 @@ struct ExpectedToken {
   int indent_column = -1;
   bool recovery = false;
   llvm::StringRef text = "";
+  SharedValueStores* value_stores = nullptr;
   std::optional<llvm::StringRef> string_contents = std::nullopt;
 };
 
@@ -121,7 +123,8 @@ MATCHER_P(HasTokens, raw_all_expected, "") {
                  expected.kind == Lex::TokenKind::StringLiteral);
     if (expected.string_contents &&
         actual_kind == Lex::TokenKind::StringLiteral) {
-      llvm::StringRef actual_contents = buffer.GetStringLiteral(token);
+      llvm::StringRef actual_contents =
+          expected.value_stores->strings().Get(buffer.GetStringLiteral(token));
       if (actual_contents != *expected.string_contents) {
         *result_listener << "\nToken " << index << " has contents `"
                          << actual_contents.str() << "`, expected `"

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -114,7 +114,7 @@ auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
     mangled_name = "main";
   } else {
     // TODO: Decide on a name mangling scheme.
-    mangled_name = semantics_ir().GetString(function.name_id);
+    mangled_name = semantics_ir().strings().Get(function.name_id);
   }
 
   llvm::FunctionType* function_type =
@@ -131,7 +131,7 @@ auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
       arg.addAttr(llvm::Attribute::getWithStructRetType(
           llvm_context(), GetType(function.return_type_id)));
     } else {
-      arg.setName(semantics_ir().GetString(
+      arg.setName(semantics_ir().strings().Get(
           semantics_ir().GetNodeAs<SemIR::Parameter>(node_id).name_id));
     }
   }

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -187,7 +187,7 @@ auto HandleInitializeFrom(FunctionContext& context, SemIR::NodeId /*node_id*/,
 
 auto HandleIntegerLiteral(FunctionContext& context, SemIR::NodeId node_id,
                           SemIR::IntegerLiteral node) -> void {
-  const llvm::APInt& i = context.semantics_ir().GetInteger(node.integer_id);
+  const llvm::APInt& i = context.semantics_ir().integers().Get(node.integer_id);
   // TODO: This won't offer correct semantics, but seems close enough for now.
   llvm::Value* v =
       llvm::ConstantInt::get(context.builder().getInt32Ty(), i.getZExtValue());
@@ -231,7 +231,7 @@ auto HandleParameter(FunctionContext& /*context*/, SemIR::NodeId /*node_id*/,
 
 auto HandleRealLiteral(FunctionContext& context, SemIR::NodeId node_id,
                        SemIR::RealLiteral node) -> void {
-  const SemIR::Real& real = context.semantics_ir().GetReal(node.real_id);
+  const Real& real = context.semantics_ir().reals().Get(node.real_id);
   // TODO: This will probably have overflow issues, and should be fixed.
   double val =
       real.mantissa.getZExtValue() *
@@ -348,7 +348,7 @@ auto HandleStructAccess(FunctionContext& context, SemIR::NodeId node_id,
           .fields_id);
   auto field = context.semantics_ir().GetNodeAs<SemIR::StructTypeField>(
       fields[node.index.index]);
-  auto member_name = context.semantics_ir().GetString(field.name_id);
+  auto member_name = context.semantics_ir().strings().Get(field.name_id);
 
   context.SetLocal(node_id, GetStructOrTupleElement(context, node.struct_id,
                                                     node.index.index,
@@ -461,8 +461,10 @@ auto HandleTupleIndex(FunctionContext& context, SemIR::NodeId node_id,
                       SemIR::TupleIndex node) -> void {
   auto index_node =
       context.semantics_ir().GetNodeAs<SemIR::IntegerLiteral>(node.index_id);
-  auto index =
-      context.semantics_ir().GetInteger(index_node.integer_id).getZExtValue();
+  auto index = context.semantics_ir()
+                   .integers()
+                   .Get(index_node.integer_id)
+                   .getZExtValue();
   context.SetLocal(node_id,
                    GetStructOrTupleElement(context, node.tuple_id, index,
                                            node.type_id, "tuple.index"));
@@ -516,7 +518,7 @@ auto HandleVarStorage(FunctionContext& context, SemIR::NodeId node_id,
   // TODO: Eventually this name will be optional, and we'll want to provide
   // something like `var` as a default. However, that's not possible right now
   // so cannot be tested.
-  auto name = context.semantics_ir().GetString(node.name_id);
+  auto name = context.semantics_ir().strings().Get(node.name_id);
   auto* alloca = context.builder().CreateAlloca(context.GetType(node.type_id),
                                                 /*ArraySize=*/nullptr, name);
   context.SetLocal(node_id, alloca);

--- a/toolchain/parse/tree.cpp
+++ b/toolchain/parse/tree.cpp
@@ -108,11 +108,6 @@ auto Tree::node_subtree_size(Node n) const -> int32_t {
   return node_impls_[n.index].subtree_size;
 }
 
-auto Tree::GetNodeText(Node n) const -> llvm::StringRef {
-  CARBON_CHECK(n.is_valid());
-  return tokens_->GetTokenText(node_impls_[n.index].token);
-}
-
 auto Tree::PrintNode(llvm::raw_ostream& output, Node n, int depth,
                      bool preorder) const -> bool {
   const auto& n_impl = node_impls_[n.index];

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -107,12 +107,6 @@ class Tree : public Printable<Tree> {
 
   [[nodiscard]] auto node_subtree_size(Node n) const -> int32_t;
 
-  // Returns the text backing the token for the given node.
-  //
-  // This is a convenience method for chaining from a node through its token to
-  // the underlying source text.
-  [[nodiscard]] auto GetNodeText(Node n) const -> llvm::StringRef;
-
   // See the other Print comments.
   auto Print(llvm::raw_ostream& output) const -> void;
 

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -47,6 +47,7 @@ cc_library(
     hdrs = ["file.h"],
     deps = [
         "//common:check",
+        "//toolchain/base:value_store",
         "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:node",
         "//toolchain/sem_ir:node_kind",

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -13,10 +13,10 @@ static constexpr llvm::StringLiteral EntryPointFunction = "Run";
 auto IsEntryPoint(const SemIR::File& file, SemIR::FunctionId function_id)
     -> bool {
   // TODO: Check if `file` is in the `Main` package.
-  auto& function = file.GetFunction(function_id);
+  const auto& function = file.GetFunction(function_id);
   // TODO: Check if `function` is in a namespace.
   return function.name_id.is_valid() &&
-         file.GetString(function.name_id) == EntryPointFunction;
+         file.strings().Get(function.name_id) == EntryPointFunction;
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -7,6 +7,7 @@
 #include "common/check.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "toolchain/base/value_store.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/node.h"
 #include "toolchain/sem_ir/node_kind.h"
@@ -39,9 +40,10 @@ auto TypeInfo::Print(llvm::raw_ostream& out) const -> void {
   out << "{node: " << node_id << ", value_rep: " << value_representation << "}";
 }
 
-File::File()
-    // Builtins are always the first IR, even when self-referential.
-    : filename_("<builtins>"),
+File::File(SharedValueStores& value_stores)
+    : value_stores_(&value_stores),
+      filename_("<builtins>"),
+      // Builtins are always the first IR, even when self-referential.
       cross_reference_irs_({this}),
       // Default entry for NodeBlockId::Empty.
       node_blocks_(1) {
@@ -62,9 +64,11 @@ File::File()
       << " nodes, actual: " << nodes_.size();
 }
 
-File::File(std::string filename, const File* builtins)
-    // Builtins are always the first IR.
-    : filename_(std::move(filename)),
+File::File(SharedValueStores& value_stores, std::string filename,
+           const File* builtins)
+    : value_stores_(&value_stores),
+      filename_(std::move(filename)),
+      // Builtins are always the first IR.
       cross_reference_irs_({builtins}),
       // Default entry for NodeBlockId::Empty.
       node_blocks_(1) {
@@ -177,14 +181,6 @@ auto File::Print(llvm::raw_ostream& out, bool include_builtins) const -> void {
 
   PrintList(out, "functions", functions_);
   PrintList(out, "classes", classes_);
-  // Integer values are APInts, and default to a signed print, but we currently
-  // treat them as unsigned.
-  PrintList(out, "integers", integers_,
-            [](llvm::raw_ostream& out, const llvm::APInt& val) {
-              val.print(out, /*isSigned=*/false);
-            });
-  PrintList(out, "reals", reals_);
-  PrintList(out, "strings", strings_);
   PrintList(out, "types", types_);
   PrintBlock(out, "type_blocks", type_blocks_);
 
@@ -321,7 +317,7 @@ auto File::StringifyTypeExpression(NodeId outer_node_id,
       case ClassDeclaration::Kind: {
         auto class_name_id =
             GetClass(node.As<ClassDeclaration>().class_id).name_id;
-        out << GetString(class_name_id);
+        out << strings().Get(class_name_id);
         break;
       }
       case ConstType::Kind: {
@@ -344,7 +340,7 @@ auto File::StringifyTypeExpression(NodeId outer_node_id,
         break;
       }
       case NameReference::Kind: {
-        out << GetString(node.As<NameReference>().name_id);
+        out << strings().Get(node.As<NameReference>().name_id);
         break;
       }
       case PointerType::Kind: {
@@ -377,7 +373,7 @@ auto File::StringifyTypeExpression(NodeId outer_node_id,
       }
       case StructTypeField::Kind: {
         auto field = node.As<StructTypeField>();
-        out << "." << GetString(field.name_id) << ": ";
+        out << "." << strings().Get(field.name_id) << ": ";
         steps.push_back({.node_id = GetTypeAllowBuiltinTypes(field.type_id)});
         break;
       }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -6,6 +6,7 @@
 
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/tree.h"
@@ -55,7 +56,7 @@ class NodeNamer {
       auto fn_loc = Parse::Node::Invalid;
       GetScopeInfo(fn_scope).name = globals.AllocateName(
           *this, fn_loc,
-          fn.name_id.is_valid() ? semantics_ir.GetString(fn.name_id).str()
+          fn.name_id.is_valid() ? semantics_ir.strings().Get(fn.name_id).str()
                                 : "");
       CollectNamesInBlock(fn_scope, fn.param_refs_id);
       if (fn.return_slot_id.is_valid()) {
@@ -87,7 +88,7 @@ class NodeNamer {
       GetScopeInfo(class_scope).name = globals.AllocateName(
           *this, class_loc,
           class_info.name_id.is_valid()
-              ? semantics_ir.GetString(class_info.name_id).str()
+              ? semantics_ir.strings().Get(class_info.name_id).str()
               : "");
       AddBlockLabel(class_scope, class_info.body_block_id, "class", class_loc);
       CollectNamesInBlock(class_scope, class_info.body_block_id);
@@ -190,7 +191,7 @@ class NodeNamer {
       auto SetAmbiguous() -> void { value_->second.ambiguous = true; }
 
      private:
-      llvm::StringMapEntry<NameResult>* value_;
+      llvm::StringMapEntry<NameResult>* value_ = nullptr;
     };
 
     struct NameResult {
@@ -391,7 +392,7 @@ class NodeNamer {
       };
       auto add_node_name_id = [&](StringId name_id) {
         if (name_id.is_valid()) {
-          add_node_name(semantics_ir_.GetString(name_id).str());
+          add_node_name(semantics_ir_.strings().Get(name_id).str());
         } else {
           add_node_name("");
         }
@@ -432,9 +433,10 @@ class NodeNamer {
           continue;
         }
         case NameReference::Kind: {
-          add_node_name(
-              semantics_ir_.GetString(node.As<NameReference>().name_id).str() +
-              ".ref");
+          add_node_name(semantics_ir_.strings()
+                            .Get(node.As<NameReference>().name_id)
+                            .str() +
+                        ".ref");
           continue;
         }
         case Parameter::Kind: {
@@ -813,7 +815,7 @@ class Formatter {
   auto FormatArg(ClassId id) -> void { FormatClassName(id); }
 
   auto FormatArg(IntegerId id) -> void {
-    semantics_ir_.GetInteger(id).print(out_, /*isSigned=*/false);
+    semantics_ir_.integers().Get(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(MemberIndex index) -> void { out_ << index; }
@@ -838,14 +840,14 @@ class Formatter {
 
   auto FormatArg(RealId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.
-    const auto& real = semantics_ir_.GetReal(id);
+    const auto& real = semantics_ir_.reals().Get(id);
     real.mantissa.print(out_, /*isSigned=*/false);
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }
 
   auto FormatArg(StringId id) -> void {
     out_ << '"';
-    out_.write_escaped(semantics_ir_.GetString(id), /*UseHexEscapes=*/true);
+    out_.write_escaped(semantics_ir_.strings().Get(id), /*UseHexEscapes=*/true);
     out_ << '"';
   }
 
@@ -875,7 +877,7 @@ class Formatter {
   }
 
   auto FormatString(StringId id) -> void {
-    out_ << semantics_ir_.GetString(id);
+    out_ << semantics_ir_.strings().Get(id);
   }
 
   auto FormatFunctionName(FunctionId id) -> void {

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -40,6 +40,7 @@ TEST(SemIRTest, YAML) {
 
   // Matches the ID of a node. The numbers may change because of builtin
   // cross-references, so this code is only doing loose structural checks.
+  auto integer_id = Yaml::Scalar(MatchesRegex(R"(int\d+)"));
   auto node_id = Yaml::Scalar(MatchesRegex(R"(node\+\d+)"));
   auto node_builtin = Yaml::Scalar(MatchesRegex(R"(node\w+)"));
   auto type_id = Yaml::Scalar(MatchesRegex(R"(type\d+)"));
@@ -50,9 +51,6 @@ TEST(SemIRTest, YAML) {
       Pair("cross_reference_irs_size", "1"),
       Pair("functions", Yaml::Sequence(SizeIs(1))),
       Pair("classes", Yaml::Sequence(SizeIs(0))),
-      Pair("integers", Yaml::Sequence(ElementsAre("0"))),
-      Pair("reals", Yaml::Sequence(IsEmpty())),
-      Pair("strings", Yaml::Sequence(ElementsAre("F", "x"))),
       Pair("types", Yaml::Sequence(Each(type_builtin))),
       Pair("type_blocks", Yaml::Sequence(IsEmpty())),
       Pair("nodes",
@@ -62,9 +60,9 @@ TEST(SemIRTest, YAML) {
                // A 0-arg node.
                Contains(Yaml::Mapping(ElementsAre(Pair("kind", "Return")))),
                // A 1-arg node.
-               Contains(Yaml::Mapping(
-                   ElementsAre(Pair("kind", "IntegerLiteral"),
-                               Pair("arg0", "int0"), Pair("type", type_id)))),
+               Contains(Yaml::Mapping(ElementsAre(
+                   Pair("kind", "IntegerLiteral"), Pair("arg0", integer_id),
+                   Pair("type", type_id)))),
                // A 2-arg node.
                Contains(Yaml::Mapping(ElementsAre(Pair("kind", "Assign"),
                                                   Pair("arg0", node_id),


### PR DESCRIPTION
Building on #3311, change SemIR to use the SharedValueStore. Since this removes hermeticity, raw output no longer prints ints, reals, and strings. TokenizedBuffer accessors are modified to return IDs because values are often passed through in semantics without needing to read them.

I would've put SharedValueStores on Context, except for the GetArrayBoundValue convenience method. I felt awkward removing that, so it's on File, at least for now. That's then used by the formatter and Lower too. The flipside of this is that TokenizedBuffer has a SharedValueStores only for printing, so maybe that's similar enough to what File is doing. 

This doesn't start shifting other SemIR members to ValueStore, but that seems like a next step.