### PR TITLE
Change StringLiteral to less frequently allocate a new string.

### DIFF
--- a/toolchain/lex/string_literal.cpp
+++ b/toolchain/lex/string_literal.cpp
@@ -482,7 +482,7 @@ auto StringLiteral::ComputeValue(llvm::BumpPtrAllocator& allocator,
   }
 
   // "Expanding" escape sequences should only ever shorten content. As a
-  // consequence, the output string should allows fit within this allocation.
+  // consequence, the output string should always fit within this allocation.
   // Although this may waste some space, it avoids a reallocation.
   auto result = ExpandEscapeSequencesAndRemoveIndent(
       emitter, content_, hash_level_, indent,

--- a/toolchain/lex/string_literal.h
+++ b/toolchain/lex/string_literal.h
@@ -6,26 +6,15 @@
 #define CARBON_TOOLCHAIN_LEX_STRING_LITERAL_H_
 
 #include <optional>
-#include <string>
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 
 namespace Carbon::Lex {
 
 class StringLiteral {
  public:
-  // The result of ComputeValue.
-  struct ComputedValue {
-    // A StringRef that should be used for the value. May point at either
-    // `generated` or the original text.
-    llvm::StringRef value;
-
-    // An optional generated value which should be retained. Null if there is no
-    // need for it, such as if the string is unchanged.
-    std::unique_ptr<std::string> generated;
-  };
-
   // Extract a string literal token from the given text, if it has a suitable
   // form. Returning std::nullopt indicates no string literal was found;
   // returning an invalid literal indicates a string prefix was found, but it's
@@ -37,9 +26,11 @@ class StringLiteral {
   // resulting value. This handles error recovery internally and cannot fail.
   //
   // When content_needs_validation_ is false and the string has no indent to
-  // deal with, this can return the content directly.
-  auto ComputeValue(DiagnosticEmitter<const char*>& emitter) const
-      -> ComputedValue;
+  // deal with, this can return the content directly. Otherwise, the allocator
+  // will be used for the StringRef.
+  auto ComputeValue(llvm::BumpPtrAllocator& allocator,
+                    DiagnosticEmitter<const char*>& emitter) const
+      -> llvm::StringRef;
 
   // Get the text corresponding to this literal.
   [[nodiscard]] auto text() const -> llvm::StringRef { return text_; }

--- a/toolchain/lex/string_literal_benchmark.cpp
+++ b/toolchain/lex/string_literal_benchmark.cpp
@@ -82,46 +82,61 @@ BENCHMARK(BM_IncompleteWithEscapes_Multiline);
 BENCHMARK(BM_IncompleteWithEscapes_MultilineDoubleQuote);
 BENCHMARK(BM_IncompleteWithEscapes_Raw);
 
-static void BM_SimpleStringValue(benchmark::State& state,
+static void BM_SimpleStringValue(benchmark::State& state, int size,
                                  std::string_view introducer, bool add_escape,
                                  std::string_view terminator) {
+  llvm::BumpPtrAllocator allocator;
   std::string x(introducer);
-  x.append(100000, 'a');
+  x.append(size, 'a');
   if (add_escape) {
     // Adds a basic escape that forces ComputeValue to generate a new string.
     x.append("\\\\");
   }
   x.append(terminator);
   for (auto _ : state) {
-    StringLiteral::Lex(x)->ComputeValue(NullDiagnosticEmitter<const char*>());
+    StringLiteral::Lex(x)->ComputeValue(allocator,
+                                        NullDiagnosticEmitter<const char*>());
   }
 }
 
-static void BM_SimpleStringValue_NoGeneratedString(benchmark::State& state) {
-  BM_SimpleStringValue(state, "\"", /*add_escape=*/false, "\"");
+static void BM_ComputeValue_NoGenerate_Short(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10, "\"", /*add_escape=*/false, "\"");
 }
 
-static void BM_SimpleStringValue_Simple(benchmark::State& state) {
-  BM_SimpleStringValue(state, "\"", /*add_escape=*/true, "\"");
+static void BM_ComputeValue_NoGenerate_Long(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10000, "\"", /*add_escape=*/false, "\"");
 }
 
-static void BM_SimpleStringValue_Multiline(benchmark::State& state) {
-  BM_SimpleStringValue(state, "'''\n", /*add_escape=*/true, "\n'''");
+static void BM_ComputeValue_WillGenerate_Short(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10, "\"", /*add_escape=*/true, "\"");
 }
 
-static void BM_SimpleStringValue_MultilineDoubleQuote(benchmark::State& state) {
-  BM_SimpleStringValue(state, "\"\"\"\n", /*add_escape=*/true, "\n\"\"\"");
+static void BM_ComputeValue_WillGenerate_Long(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10000, "\"", /*add_escape=*/true, "\"");
 }
 
-static void BM_SimpleStringValue_Raw(benchmark::State& state) {
-  BM_SimpleStringValue(state, "#\"", /*add_escape=*/true, "\"#");
+static void BM_ComputeValue_WillGenerate_Multiline(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10000, "'''\n", /*add_escape=*/true, "\n'''");
 }
 
-BENCHMARK(BM_SimpleStringValue_NoGeneratedString);
-BENCHMARK(BM_SimpleStringValue_Simple);
-BENCHMARK(BM_SimpleStringValue_Multiline);
-BENCHMARK(BM_SimpleStringValue_MultilineDoubleQuote);
-BENCHMARK(BM_SimpleStringValue_Raw);
+static void BM_ComputeValue_WillGenerate_MultilineDoubleQuote(
+    benchmark::State& state) {
+  BM_SimpleStringValue(state, 10000, "\"\"\"\n", /*add_escape=*/true,
+                       "\n\"\"\"");
+}
+
+static void BM_ComputeValue_WillGenerate_Raw(benchmark::State& state) {
+  BM_SimpleStringValue(state, 10000, "#\"", /*add_escape=*/true, "\"#");
+}
+
+BENCHMARK(BM_ComputeValue_NoGenerate_Short);
+BENCHMARK(BM_ComputeValue_NoGenerate_Long);
+
+BENCHMARK(BM_ComputeValue_WillGenerate_Short);
+BENCHMARK(BM_ComputeValue_WillGenerate_Long);
+BENCHMARK(BM_ComputeValue_WillGenerate_Multiline);
+BENCHMARK(BM_ComputeValue_WillGenerate_MultilineDoubleQuote);
+BENCHMARK(BM_ComputeValue_WillGenerate_Raw);
 
 }  // namespace
 }  // namespace Carbon::Lex

--- a/toolchain/lex/string_literal_benchmark.cpp
+++ b/toolchain/lex/string_literal_benchmark.cpp
@@ -83,32 +83,41 @@ BENCHMARK(BM_IncompleteWithEscapes_MultilineDoubleQuote);
 BENCHMARK(BM_IncompleteWithEscapes_Raw);
 
 static void BM_SimpleStringValue(benchmark::State& state,
-                                 std::string_view introducer,
+                                 std::string_view introducer, bool add_escape,
                                  std::string_view terminator) {
   std::string x(introducer);
   x.append(100000, 'a');
+  if (add_escape) {
+    // Adds a basic escape that forces ComputeValue to generate a new string.
+    x.append("\\\\");
+  }
   x.append(terminator);
   for (auto _ : state) {
     StringLiteral::Lex(x)->ComputeValue(NullDiagnosticEmitter<const char*>());
   }
 }
 
+static void BM_SimpleStringValue_NoGeneratedString(benchmark::State& state) {
+  BM_SimpleStringValue(state, "\"", /*add_escape=*/false, "\"");
+}
+
 static void BM_SimpleStringValue_Simple(benchmark::State& state) {
-  BM_SimpleStringValue(state, "\"", "\"");
+  BM_SimpleStringValue(state, "\"", /*add_escape=*/true, "\"");
 }
 
 static void BM_SimpleStringValue_Multiline(benchmark::State& state) {
-  BM_SimpleStringValue(state, "'''\n", "\n'''");
+  BM_SimpleStringValue(state, "'''\n", /*add_escape=*/true, "\n'''");
 }
 
 static void BM_SimpleStringValue_MultilineDoubleQuote(benchmark::State& state) {
-  BM_SimpleStringValue(state, "\"\"\"\n", "\n\"\"\"");
+  BM_SimpleStringValue(state, "\"\"\"\n", /*add_escape=*/true, "\n\"\"\"");
 }
 
 static void BM_SimpleStringValue_Raw(benchmark::State& state) {
-  BM_SimpleStringValue(state, "#\"", "\"#");
+  BM_SimpleStringValue(state, "#\"", /*add_escape=*/true, "\"#");
 }
 
+BENCHMARK(BM_SimpleStringValue_NoGeneratedString);
 BENCHMARK(BM_SimpleStringValue_Simple);
 BENCHMARK(BM_SimpleStringValue_Multiline);
 BENCHMARK(BM_SimpleStringValue_MultilineDoubleQuote);

--- a/toolchain/lex/string_literal_fuzzer.cpp
+++ b/toolchain/lex/string_literal_fuzzer.cpp
@@ -33,8 +33,9 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
   // Check multiline flag was computed correctly.
   CARBON_CHECK(token->is_multi_line() == token->text().contains('\n'));
 
+  llvm::BumpPtrAllocator allocator;
   volatile auto value =
-      token->ComputeValue(NullDiagnosticEmitter<const char*>());
+      token->ComputeValue(allocator, NullDiagnosticEmitter<const char*>());
   (void)value;
 
   return 0;

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -652,13 +652,8 @@ class [[clang::internal_linkage]] TokenizedBuffer::Lexer {
     }
 
     if (literal->is_terminated()) {
-      auto computed = literal->ComputeValue(emitter_);
-      // If computing the value generated a string, we need to store it since
-      // the value will point at it.
-      if (computed.generated) {
-        buffer_.computed_strings_.push_back(std::move(computed.generated));
-      }
-      auto string_id = buffer_.value_stores_->strings().Add(computed.value);
+      auto string_id = buffer_.value_stores_->strings().Add(
+          literal->ComputeValue(buffer_.allocator_, emitter_));
       auto token = buffer_.AddToken({.kind = TokenKind::StringLiteral,
                                      .token_line = string_line,
                                      .column = string_column,

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/raw_ostream.h"
 #include "toolchain/base/index_base.h"
 #include "toolchain/base/value_store.h"
@@ -344,6 +345,9 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   [[nodiscard]] auto GetTokenPrintWidths(Token token) const -> PrintWidths;
   auto PrintToken(llvm::raw_ostream& output_stream, Token token,
                   PrintWidths widths) const -> void;
+
+  // Used to allocate computed string literals.
+  llvm::BumpPtrAllocator allocator_;
 
   SharedValueStores* value_stores_;
   SourceBuffer* source_;


### PR DESCRIPTION
Building on #3311, which started moving the result string into a `unique_ptr`, instead have `StringLiteral` use a `BumpPtrAllocator` to manage memory. But also, detect when a string is really trivial during `Lex` and, if so, return `contents_` directly.