### PR TITLE
Switch File functions, classes, and types to ValueStores

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -246,7 +246,8 @@ auto Context::AddCurrentCodeBlockToFunction() -> void {
           .GetNodeAs<SemIR::FunctionDeclaration>(return_scope_stack().back())
           .function_id;
   semantics_ir()
-      .GetFunction(function_id)
+      .functions()
+      .Get(function_id)
       .body_block_ids.push_back(node_block_stack().PeekOrAdd());
 }
 
@@ -709,7 +710,7 @@ auto Context::CanonicalizeTypeImpl(
   }
 
   auto node_id = make_node();
-  auto type_id = semantics_ir_->AddType(node_id);
+  auto type_id = semantics_ir_->types().Add({.node_id = node_id});
   CARBON_CHECK(canonical_types_.insert({node_id, type_id}).second);
   type_node_storage_.push_back(
       std::make_unique<TypeNode>(canonical_id, type_id));

--- a/toolchain/check/declaration_name_stack.cpp
+++ b/toolchain/check/declaration_name_stack.cpp
@@ -145,7 +145,7 @@ auto DeclarationNameStack::UpdateScopeIfNeeded(NameContext& name_context)
       context_->semantics_ir().GetNode(name_context.resolved_node_id);
   switch (resolved_node.kind()) {
     case SemIR::ClassDeclaration::Kind: {
-      auto& class_info = context_->semantics_ir().GetClass(
+      const auto& class_info = context_->semantics_ir().classes().Get(
           resolved_node.As<SemIR::ClassDeclaration>().class_id);
       // TODO: Check that the class is complete rather than that it has a scope.
       if (class_info.scope_id.is_valid()) {

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -29,7 +29,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   }
 
   auto function_id = function_name->function_id;
-  const auto& callable = context.semantics_ir().GetFunction(function_id);
+  const auto& callable = context.semantics_ir().functions().Get(function_id);
 
   // For functions with an implicit return type, the return type is the empty
   // tuple type.

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -51,7 +51,7 @@ static auto BuildClassDeclaration(Context& context)
     // TODO: If this is an invalid redeclaration of a non-class entity or there
     // was an error in the qualifier, we will have lost track of the class name
     // here. We should keep track of it even if the name is invalid.
-    class_decl.class_id = context.semantics_ir().AddClass(
+    class_decl.class_id = context.semantics_ir().classes().Add(
         {.name_id = name_context.state ==
                             DeclarationNameStack::NameContext::State::Unresolved
                         ? name_context.unresolved_name_id
@@ -73,7 +73,7 @@ auto HandleClassDeclaration(Context& context, Parse::Node /*parse_node*/)
 auto HandleClassDefinitionStart(Context& context, Parse::Node parse_node)
     -> bool {
   auto [class_id, class_decl_id] = BuildClassDeclaration(context);
-  auto& class_info = context.semantics_ir().GetClass(class_id);
+  auto& class_info = context.semantics_ir().classes().Get(class_id);
 
   // Track that this declaration is the definition.
   if (class_info.definition_id.is_valid()) {

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -80,7 +80,7 @@ static auto BuildFunctionDeclaration(Context& context, bool is_definition)
       // IDs in the signature.
       if (is_definition) {
         auto& function_info =
-            context.semantics_ir().GetFunction(function_decl.function_id);
+            context.semantics_ir().functions().Get(function_decl.function_id);
         function_info.param_refs_id = param_refs_id;
         function_info.return_type_id = return_type_id;
         function_info.return_slot_id = return_slot_id;
@@ -93,7 +93,7 @@ static auto BuildFunctionDeclaration(Context& context, bool is_definition)
 
   // Create a new function if this isn't a valid redeclaration.
   if (!function_decl.function_id.is_valid()) {
-    function_decl.function_id = context.semantics_ir().AddFunction(
+    function_decl.function_id = context.semantics_ir().functions().Add(
         {.name_id = name_context.state ==
                             DeclarationNameStack::NameContext::State::Unresolved
                         ? name_context.unresolved_name_id
@@ -138,7 +138,8 @@ auto HandleFunctionDefinition(Context& context, Parse::Node parse_node)
   // and otherwise add an implicit `return;`.
   if (context.is_current_position_reachable()) {
     if (context.semantics_ir()
-            .GetFunction(function_id)
+            .functions()
+            .Get(function_id)
             .return_type_id.is_valid()) {
       CARBON_DIAGNOSTIC(
           MissingReturnStatement, Error,
@@ -160,7 +161,7 @@ auto HandleFunctionDefinitionStart(Context& context, Parse::Node parse_node)
   // Process the declaration portion of the function.
   auto [function_id, decl_id] =
       BuildFunctionDeclaration(context, /*is_definition=*/true);
-  auto& function = context.semantics_ir().GetFunction(function_id);
+  auto& function = context.semantics_ir().functions().Get(function_id);
 
   // Track that this declaration is the definition.
   if (function.definition_id.is_valid()) {

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -19,7 +19,8 @@ static auto GetAsNameScope(Context& context, SemIR::NodeId base_id)
     return base_as_namespace->name_scope_id;
   }
   if (auto base_as_class = base.TryAs<SemIR::ClassDeclaration>()) {
-    auto& class_info = context.semantics_ir().GetClass(base_as_class->class_id);
+    auto& class_info =
+        context.semantics_ir().classes().Get(base_as_class->class_id);
     if (!class_info.scope_id.is_valid()) {
       CARBON_DIAGNOSTIC(QualifiedExpressionInIncompleteClassScope, Error,
                         "Member access into incomplete class `{0}`.",

--- a/toolchain/check/handle_statement.cpp
+++ b/toolchain/check/handle_statement.cpp
@@ -32,7 +32,7 @@ auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
   auto fn_node = context.semantics_ir().GetNodeAs<SemIR::FunctionDeclaration>(
       context.return_scope_stack().back());
   const auto& callable =
-      context.semantics_ir().GetFunction(fn_node.function_id);
+      context.semantics_ir().functions().Get(fn_node.function_id);
 
   if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==
       Parse::NodeKind::ReturnStatementStart) {

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -32,22 +32,22 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
   CARBON_CHECK(llvm_module_) << "Run can only be called once.";
 
   // Lower types.
-  auto types = semantics_ir_->types();
+  auto types = semantics_ir_->types().array_ref();
   types_.resize_for_overwrite(types.size());
   for (auto [i, type] : llvm::enumerate(types)) {
     types_[i] = BuildType(type.node_id);
   }
 
   // Lower function declarations.
-  functions_.resize_for_overwrite(semantics_ir_->functions_size());
-  for (auto i : llvm::seq(semantics_ir_->functions_size())) {
+  functions_.resize_for_overwrite(semantics_ir_->functions().size());
+  for (auto i : llvm::seq(semantics_ir_->functions().size())) {
     functions_[i] = BuildFunctionDeclaration(SemIR::FunctionId(i));
   }
 
   // TODO: Lower global variable declarations.
 
   // Lower function definitions.
-  for (auto i : llvm::seq(semantics_ir_->functions_size())) {
+  for (auto i : llvm::seq(semantics_ir_->functions().size())) {
     BuildFunctionDefinition(SemIR::FunctionId(i));
   }
 
@@ -58,7 +58,7 @@ auto FileContext::Run() -> std::unique_ptr<llvm::Module> {
 
 auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
     -> llvm::Function* {
-  const auto& function = semantics_ir().GetFunction(function_id);
+  const auto& function = semantics_ir().functions().Get(function_id);
   const bool has_return_slot = function.return_slot_id.is_valid();
   auto param_refs = semantics_ir().GetNodeBlock(function.param_refs_id);
 
@@ -141,7 +141,7 @@ auto FileContext::BuildFunctionDeclaration(SemIR::FunctionId function_id)
 
 auto FileContext::BuildFunctionDefinition(SemIR::FunctionId function_id)
     -> void {
-  const auto& function = semantics_ir().GetFunction(function_id);
+  const auto& function = semantics_ir().functions().Get(function_id);
   const auto& body_block_ids = function.body_block_ids;
   if (body_block_ids.empty()) {
     // Function is probably defined in another file; not an error.

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -344,7 +344,7 @@ auto HandleStructAccess(FunctionContext& context, SemIR::NodeId node_id,
   auto fields = context.semantics_ir().GetNodeBlock(
       context.semantics_ir()
           .GetNodeAs<SemIR::StructType>(
-              context.semantics_ir().GetType(struct_type_id))
+              context.semantics_ir().types().Get(struct_type_id).node_id)
           .fields_id);
   auto field = context.semantics_ir().GetNodeAs<SemIR::StructTypeField>(
       fields[node.index.index]);

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -13,7 +13,7 @@ static constexpr llvm::StringLiteral EntryPointFunction = "Run";
 auto IsEntryPoint(const SemIR::File& file, SemIR::FunctionId function_id)
     -> bool {
   // TODO: Check if `file` is in the `Main` package.
-  const auto& function = file.GetFunction(function_id);
+  const auto& function = file.functions().Get(function_id);
   // TODO: Check if `function` is in a namespace.
   return function.name_id.is_valid() &&
          file.strings().Get(function.name_id) == EntryPointFunction;


### PR DESCRIPTION
Building on #3313, start using ValueStore on File. Functions and classes are straightforward. Types here I present as a borderline case where maybe we want a more bespoke API, but maybe this is okay? Most other things probably need a slightly different API, which although I might do that for a consistent interface, felt more out-of-scope for this change.