### PR TITLE
Add more value store types to File.

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -91,6 +91,13 @@ class ValueStore : public Printable<ValueStore<IdT, ValueT>> {
     return id;
   }
 
+  // Adds a default constructed value and returns an ID to reference it.
+  auto AddDefaultValue() -> IdT {
+    auto id = IdT(values_.size());
+    values_.resize(id.index + 1);
+    return id;
+  }
+
   // Returns a mutable value for an ID.
   auto Get(IdT id) -> ValueT& {
     CARBON_CHECK(id.index >= 0) << id.index;
@@ -102,6 +109,9 @@ class ValueStore : public Printable<ValueStore<IdT, ValueT>> {
     CARBON_CHECK(id.index >= 0) << id.index;
     return values_[id.index];
   }
+
+  // Reserves space.
+  auto Reserve(size_t size) -> void { values_.reserve(size); }
 
   auto Print(llvm::raw_ostream& out) const -> void { Print(out, 0); }
   auto Print(llvm::raw_ostream& out, int indent) const -> void {

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_BASE_VALUE_STORE_H_
 #define CARBON_TOOLCHAIN_BASE_VALUE_STORE_H_
 
+#include <type_traits>
+
 #include "common/check.h"
 #include "common/ostream.h"
 #include "llvm/ADT/APInt.h"
@@ -44,7 +46,7 @@ class Real : public Printable<Real> {
 
 // Corresponds to an integer value represented by an APInt.
 struct IntegerId : public IndexBase, public Printable<IntegerId> {
-  using IndexedType = llvm::APInt;
+  using IndexedType = const llvm::APInt;
   static const IntegerId Invalid;
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -56,7 +58,7 @@ constexpr IntegerId IntegerId::Invalid(IntegerId::InvalidIndex);
 
 // Corresponds to a Real value.
 struct RealId : public IndexBase, public Printable<RealId> {
-  using IndexedType = Real;
+  using IndexedType = const Real;
   static const RealId Invalid;
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -68,7 +70,7 @@ constexpr RealId RealId::Invalid(RealId::InvalidIndex);
 
 // Corresponds to a StringRef.
 struct StringId : public IndexBase, public Printable<StringId> {
-  using IndexedType = std::string;
+  using IndexedType = const std::string;
   static const StringId Invalid;
   using IndexBase::IndexBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -78,10 +80,19 @@ struct StringId : public IndexBase, public Printable<StringId> {
 };
 constexpr StringId StringId::Invalid(StringId::InvalidIndex);
 
+namespace Internal {
+// Used as a parent class for non-printable types. This is just for
+// std::conditional, not as an API.
+class ValueStoreNotPrintable {};
+}  // namespace Internal
+
 // A simple wrapper for accumulating values, providing IDs to later retrieve the
 // value. This does not do deduplication.
 template <typename IdT, typename ValueT = typename IdT::IndexedType>
-class ValueStore : public Printable<ValueStore<IdT, ValueT>> {
+class ValueStore
+    : public std::conditional<std::is_base_of_v<Printable<ValueT>, ValueT>,
+                              Printable<ValueStore<IdT, ValueT>>,
+                              Internal::ValueStoreNotPrintable> {
  public:
   // Stores the value and returns an ID to reference it.
   auto Add(ValueT value) -> IdT {
@@ -113,6 +124,7 @@ class ValueStore : public Printable<ValueStore<IdT, ValueT>> {
   // Reserves space.
   auto Reserve(size_t size) -> void { values_.reserve(size); }
 
+  // These are to support printable structures, and are not guaranteed.
   auto Print(llvm::raw_ostream& out) const -> void { Print(out, 0); }
   auto Print(llvm::raw_ostream& out, int indent) const -> void {
     for (const auto& value : values_) {
@@ -125,7 +137,7 @@ class ValueStore : public Printable<ValueStore<IdT, ValueT>> {
   auto size() const -> int { return values_.size(); }
 
  private:
-  llvm::SmallVector<ValueT> values_;
+  llvm::SmallVector<std::decay_t<ValueT>> values_;
 };
 
 // Storage for StringRefs. The caller is responsible for ensuring storage is

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -75,7 +75,7 @@ auto Context::DiagnoseDuplicateName(Parse::Node parse_node,
                     "Duplicate name being declared in the same scope.");
   CARBON_DIAGNOSTIC(NameDeclarationPrevious, Note,
                     "Name is previously declared here.");
-  auto prev_def = semantics_ir_->GetNode(prev_def_id);
+  auto prev_def = semantics_ir_->nodes().Get(prev_def_id);
   emitter_->Build(parse_node, NameDeclarationDuplicate)
       .Note(prev_def.parse_node(), NameDeclarationPrevious)
       .Emit();
@@ -124,7 +124,7 @@ auto Context::LookupName(Parse::Node parse_node, StringId name_id,
     // TODO: Check for ambiguous lookups.
     return it->second.back();
   } else {
-    const auto& scope = semantics_ir_->GetNameScope(scope_id);
+    const auto& scope = semantics_ir_->name_scopes().Get(scope_id);
     auto it = scope.find(name_id);
     if (it == scope.end()) {
       if (print_diagnostics) {
@@ -155,8 +155,9 @@ auto Context::PopScope() -> void {
 }
 
 auto Context::FollowNameReferences(SemIR::NodeId node_id) -> SemIR::NodeId {
-  while (auto name_ref =
-             semantics_ir().GetNode(node_id).TryAs<SemIR::NameReference>()) {
+  while (
+      auto name_ref =
+          semantics_ir().nodes().Get(node_id).TryAs<SemIR::NameReference>()) {
     node_id = name_ref->value_id;
   }
   return node_id;
@@ -169,7 +170,7 @@ static auto AddDominatedBlockAndBranchImpl(Context& context,
   if (!context.node_block_stack().is_current_block_reachable()) {
     return SemIR::NodeBlockId::Unreachable;
   }
-  auto block_id = context.semantics_ir().AddNodeBlockId();
+  auto block_id = context.semantics_ir().node_blocks().AddDefaultValue();
   context.AddNode(BranchNode{parse_node, block_id, args...});
   return block_id;
 }
@@ -201,7 +202,7 @@ auto Context::AddConvergenceBlockAndPush(Parse::Node parse_node, int num_blocks)
   for ([[maybe_unused]] auto _ : llvm::seq(num_blocks)) {
     if (node_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
-        new_block_id = semantics_ir().AddNodeBlockId();
+        new_block_id = semantics_ir().node_blocks().AddDefaultValue();
       }
       AddNode(SemIR::Branch{parse_node, new_block_id});
     }
@@ -219,7 +220,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
   for (auto arg_id : block_args) {
     if (node_block_stack().is_current_block_reachable()) {
       if (new_block_id == SemIR::NodeBlockId::Unreachable) {
-        new_block_id = semantics_ir().AddNodeBlockId();
+        new_block_id = semantics_ir().node_blocks().AddDefaultValue();
       }
       AddNode(SemIR::BranchWithArg{parse_node, new_block_id, arg_id});
     }
@@ -229,7 +230,7 @@ auto Context::AddConvergenceBlockWithArgAndPush(
 
   // Acquire the result value.
   SemIR::TypeId result_type_id =
-      semantics_ir().GetNode(*block_args.begin()).type_id();
+      semantics_ir().nodes().Get(*block_args.begin()).type_id();
   return AddNode(SemIR::BlockArg{parse_node, result_type_id, new_block_id});
 }
 
@@ -245,7 +246,8 @@ auto Context::AddCurrentCodeBlockToFunction() -> void {
 
   auto function_id =
       semantics_ir()
-          .GetNodeAs<SemIR::FunctionDeclaration>(return_scope_stack().back())
+          .nodes()
+          .GetAs<SemIR::FunctionDeclaration>(return_scope_stack().back())
           .function_id;
   semantics_ir()
       .functions()
@@ -264,7 +266,7 @@ auto Context::is_current_position_reachable() -> bool {
   if (block_contents.empty()) {
     return true;
   }
-  const auto& last_node = semantics_ir().GetNode(block_contents.back());
+  const auto& last_node = semantics_ir().nodes().Get(block_contents.back());
   return last_node.kind().terminator_kind() !=
          SemIR::TerminatorKind::Terminator;
 }
@@ -343,7 +345,7 @@ class TypeCompleter {
     }
 
     auto node_id = context_.semantics_ir().GetTypeAllowBuiltinTypes(type_id);
-    auto node = context_.semantics_ir().GetNode(node_id);
+    auto node = context_.semantics_ir().nodes().Get(node_id);
 
     auto old_work_list_size = work_list_.size();
 
@@ -397,16 +399,17 @@ class TypeCompleter {
         break;
 
       case SemIR::StructType::Kind:
-        for (auto field_id : context_.semantics_ir().GetNodeBlock(
+        for (auto field_id : context_.semantics_ir().node_blocks().Get(
                  type_node.As<SemIR::StructType>().fields_id)) {
           Push(context_.semantics_ir()
-                   .GetNodeAs<SemIR::StructTypeField>(field_id)
+                   .nodes()
+                   .GetAs<SemIR::StructTypeField>(field_id)
                    .field_type_id);
         }
         break;
 
       case SemIR::TupleType::Kind:
-        for (auto element_type_id : context_.semantics_ir().GetTypeBlock(
+        for (auto element_type_id : context_.semantics_ir().type_blocks().Get(
                  type_node.As<SemIR::TupleType>().elements_id)) {
           Push(element_type_id);
         }
@@ -475,7 +478,8 @@ class TypeCompleter {
       -> SemIR::ValueRepresentation {
     auto xref_node = context_.semantics_ir()
                          .GetCrossReferenceIR(xref.ir_id)
-                         .GetNode(xref.node_id);
+                         .nodes()
+                         .Get(xref.node_id);
 
     // The canonical description of a type should only have cross-references
     // for entities owned by another File, such as builtins, which are owned
@@ -510,7 +514,8 @@ class TypeCompleter {
                                           SemIR::StructType struct_type) const
       -> SemIR::ValueRepresentation {
     // TODO: Share code with tuples.
-    auto fields = context_.semantics_ir().GetNodeBlock(struct_type.fields_id);
+    auto fields =
+        context_.semantics_ir().node_blocks().Get(struct_type.fields_id);
     if (fields.empty()) {
       return MakeEmptyRepresentation(struct_type.parse_node);
     }
@@ -522,7 +527,8 @@ class TypeCompleter {
     bool same_as_object_rep = true;
     for (auto field_id : fields) {
       auto field =
-          context_.semantics_ir().GetNodeAs<SemIR::StructTypeField>(field_id);
+          context_.semantics_ir().nodes().GetAs<SemIR::StructTypeField>(
+              field_id);
       auto field_value_rep = GetNestedValueRepresentation(field.field_type_id);
       if (field_value_rep.type_id != field.field_type_id) {
         same_as_object_rep = false;
@@ -537,7 +543,7 @@ class TypeCompleter {
             ? type_id
             : context_.CanonicalizeStructType(
                   struct_type.parse_node,
-                  context_.semantics_ir().AddNodeBlock(value_rep_fields));
+                  context_.semantics_ir().node_blocks().Add(value_rep_fields));
     if (fields.size() == 1) {
       // The value representation for a struct with a single field is a
       // struct containing the value representation of the field.
@@ -554,7 +560,7 @@ class TypeCompleter {
       -> SemIR::ValueRepresentation {
     // TODO: Share code with structs.
     auto elements =
-        context_.semantics_ir().GetTypeBlock(tuple_type.elements_id);
+        context_.semantics_ir().type_blocks().Get(tuple_type.elements_id);
     if (elements.empty()) {
       return MakeEmptyRepresentation(tuple_type.parse_node);
     }
@@ -784,19 +790,19 @@ static auto ProfileType(Context& semantics_context, SemIR::Node node,
       canonical_id.AddInteger(node.As<SemIR::PointerType>().pointee_id.index);
       break;
     case SemIR::StructType::Kind: {
-      auto fields = semantics_context.semantics_ir().GetNodeBlock(
+      auto fields = semantics_context.semantics_ir().node_blocks().Get(
           node.As<SemIR::StructType>().fields_id);
       for (const auto& field_id : fields) {
-        auto field =
-            semantics_context.semantics_ir().GetNodeAs<SemIR::StructTypeField>(
-                field_id);
+        auto field = semantics_context.semantics_ir()
+                         .nodes()
+                         .GetAs<SemIR::StructTypeField>(field_id);
         canonical_id.AddInteger(field.name_id.index);
         canonical_id.AddInteger(field.field_type_id.index);
       }
       break;
     }
     case SemIR::TupleType::Kind:
-      ProfileTupleType(semantics_context.semantics_ir().GetTypeBlock(
+      ProfileTupleType(semantics_context.semantics_ir().type_blocks().Get(
                            node.As<SemIR::TupleType>().elements_id),
                        canonical_id);
       break;
@@ -822,7 +828,7 @@ auto Context::CanonicalizeType(SemIR::NodeId node_id) -> SemIR::TypeId {
     return it->second;
   }
 
-  auto node = semantics_ir_->GetNode(node_id);
+  auto node = semantics_ir_->nodes().Get(node_id);
   auto profile_node = [&](llvm::FoldingSetNodeID& canonical_id) {
     ProfileType(*this, node, canonical_id);
   };
@@ -845,8 +851,9 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
     ProfileTupleType(type_ids, canonical_id);
   };
   auto make_tuple_node = [&] {
-    return AddNode(SemIR::TupleType{parse_node, SemIR::TypeId::TypeType,
-                                    semantics_ir_->AddTypeBlock(type_ids)});
+    return AddNode(
+        SemIR::TupleType{parse_node, SemIR::TypeId::TypeType,
+                         semantics_ir_->type_blocks().Add(type_ids)});
   };
   return CanonicalizeTypeImpl(SemIR::TupleType::Kind, profile_tuple,
                               make_tuple_node);
@@ -868,8 +875,8 @@ auto Context::GetPointerType(Parse::Node parse_node,
 }
 
 auto Context::GetUnqualifiedType(SemIR::TypeId type_id) -> SemIR::TypeId {
-  SemIR::Node type_node =
-      semantics_ir_->GetNode(semantics_ir_->GetTypeAllowBuiltinTypes(type_id));
+  SemIR::Node type_node = semantics_ir_->nodes().Get(
+      semantics_ir_->GetTypeAllowBuiltinTypes(type_id));
   if (auto const_type = type_node.TryAs<SemIR::ConstType>()) {
     return const_type->inner_id;
   }

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -94,8 +94,9 @@ auto Context::NoteIncompleteClass(SemIR::ClassId class_id,
   CARBON_DIAGNOSTIC(ClassForwardDeclaredHere, Note,
                     "Class was forward declared here.");
   const auto& class_info = semantics_ir().classes().Get(class_id);
-  builder.Note(semantics_ir().GetNode(class_info.declaration_id).parse_node(),
-               ClassForwardDeclaredHere);
+  builder.Note(
+      semantics_ir().nodes().Get(class_info.declaration_id).parse_node(),
+      ClassForwardDeclaredHere);
 }
 
 auto Context::AddNameToLookup(Parse::Node name_node, StringId name_id,

--- a/toolchain/check/declaration_name_stack.cpp
+++ b/toolchain/check/declaration_name_stack.cpp
@@ -65,7 +65,7 @@ auto DeclarationNameStack::LookupOrAddName(NameContext name_context,
       } else {
         // TODO: Reject unless the scope is a namespace scope or the name is
         // unqualified.
-        bool success = context_->semantics_ir().AddNameScopeEntry(
+        bool success = context_->semantics_ir().name_scopes().AddEntry(
             name_context.target_scope_id, name_context.unresolved_name_id,
             target_id);
         CARBON_CHECK(success)
@@ -122,7 +122,7 @@ auto DeclarationNameStack::UpdateScopeIfNeeded(NameContext& name_context)
   // This will only be reached for resolved nodes. We update the target
   // scope based on the resolved type.
   auto resolved_node =
-      context_->semantics_ir().GetNode(name_context.resolved_node_id);
+      context_->semantics_ir().nodes().Get(name_context.resolved_node_id);
   switch (resolved_node.kind()) {
     case SemIR::ClassDeclaration::Kind: {
       const auto& class_info = context_->semantics_ir().classes().Get(
@@ -166,7 +166,8 @@ auto DeclarationNameStack::CanResolveQualifier(NameContext& name_context,
       // Because more qualifiers were found, we diagnose that the earlier
       // qualifier didn't resolve to a scoped entity.
       if (auto class_decl = context_->semantics_ir()
-                                .GetNode(name_context.resolved_node_id)
+                                .nodes()
+                                .Get(name_context.resolved_node_id)
                                 .TryAs<SemIR::ClassDeclaration>()) {
         CARBON_DIAGNOSTIC(QualifiedDeclarationInIncompleteClassScope, Error,
                           "Cannot declare a member of incomplete class `{0}`.",

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -34,7 +34,7 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::ArrayExpressionSemi>();
   auto element_type_node_id = context.node_stack().PopExpression();
-  auto bound_node = context.semantics_ir().GetNode(bound_node_id);
+  auto bound_node = context.semantics_ir().nodes().Get(bound_node_id);
   if (auto literal = bound_node.TryAs<SemIR::IntegerLiteral>()) {
     const auto& bound_value =
         context.semantics_ir().integers().Get(literal->integer_id);

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -17,8 +17,8 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   auto [call_expr_parse_node, callee_id] =
       context.node_stack()
           .PopWithParseNode<Parse::NodeKind::CallExpressionStart>();
-  auto callee_node =
-      context.semantics_ir().GetNode(context.FollowNameReferences(callee_id));
+  auto callee_node = context.semantics_ir().nodes().Get(
+      context.FollowNameReferences(callee_id));
   auto function_name = callee_node.TryAs<SemIR::FunctionDeclaration>();
   if (!function_name) {
     // TODO: Work on error.

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -35,7 +35,8 @@ static auto BuildClassDeclaration(Context& context)
       name_context, class_decl_id);
   if (existing_id.is_valid()) {
     if (auto existing_class_decl = context.semantics_ir()
-                                       .GetNode(existing_id)
+                                       .nodes()
+                                       .Get(existing_id)
                                        .TryAs<SemIR::ClassDeclaration>()) {
       // This is a redeclaration of an existing class.
       class_decl.class_id = existing_class_decl->class_id;
@@ -69,7 +70,7 @@ static auto BuildClassDeclaration(Context& context)
   }
 
   // Write the class ID into the ClassDeclaration.
-  context.semantics_ir().ReplaceNode(class_decl_id, class_decl);
+  context.semantics_ir().nodes().Set(class_decl_id, class_decl);
 
   return {class_decl.class_id, class_decl_id};
 }
@@ -95,13 +96,14 @@ auto HandleClassDefinitionStart(Context& context, Parse::Node parse_node)
         .Build(parse_node, ClassRedefinition,
                context.semantics_ir().strings().Get(class_info.name_id))
         .Note(context.semantics_ir()
-                  .GetNode(class_info.definition_id)
+                  .nodes()
+                  .Get(class_info.definition_id)
                   .parse_node(),
               ClassPreviousDefinition)
         .Emit();
   } else {
     class_info.definition_id = class_decl_id;
-    class_info.scope_id = context.semantics_ir().AddNameScope();
+    class_info.scope_id = context.semantics_ir().name_scopes().Add();
 
     // TODO: Introduce `Self`.
   }

--- a/toolchain/check/handle_if_expression.cpp
+++ b/toolchain/check/handle_if_expression.cpp
@@ -57,7 +57,8 @@ auto HandleIfExpressionElse(Context& context, Parse::Node parse_node) -> bool {
   // Convert the `else` value to the `then` value's type, and finish the `else`
   // block.
   // TODO: Find a common type, and convert both operands to it instead.
-  auto result_type_id = context.semantics_ir().GetNode(then_value_id).type_id();
+  auto result_type_id =
+      context.semantics_ir().nodes().Get(then_value_id).type_id();
   else_value_id =
       ConvertToValueOfType(context, else_node, else_value_id, result_type_id);
 

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -40,13 +40,13 @@ static auto ValidateIntegerLiteralBound(Context& context,
 
 auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
   auto index_node_id = context.node_stack().PopExpression();
-  auto index_node = context.semantics_ir().GetNode(index_node_id);
+  auto index_node = context.semantics_ir().nodes().Get(index_node_id);
   auto operand_node_id = context.node_stack().PopExpression();
   operand_node_id =
       ConvertToValueOrReferenceExpression(context, operand_node_id);
-  auto operand_node = context.semantics_ir().GetNode(operand_node_id);
+  auto operand_node = context.semantics_ir().nodes().Get(operand_node_id);
   auto operand_type_id = operand_node.type_id();
-  auto operand_type_node = context.semantics_ir().GetNode(
+  auto operand_type_node = context.semantics_ir().nodes().Get(
       context.semantics_ir().GetTypeAllowBuiltinTypes(operand_type_id));
 
   switch (operand_type_node.kind()) {
@@ -88,7 +88,7 @@ auto HandleIndexExpression(Context& context, Parse::Node parse_node) -> bool {
     case SemIR::TupleType::Kind: {
       SemIR::TypeId element_type_id = SemIR::TypeId::Error;
       if (auto index_literal = index_node.TryAs<SemIR::IntegerLiteral>()) {
-        auto type_block = context.semantics_ir().GetTypeBlock(
+        auto type_block = context.semantics_ir().type_blocks().Get(
             operand_type_node.As<SemIR::TupleType>().elements_id);
         if (const auto* index_val = ValidateIntegerLiteralBound(
                 context, parse_node, operand_node, *index_literal,

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -16,7 +16,7 @@ auto HandleLetDeclaration(Context& context, Parse::Node parse_node) -> bool {
       .PopAndDiscardSoloParseNode<Parse::NodeKind::LetIntroducer>();
 
   // Convert the value to match the type of the pattern.
-  auto pattern = context.semantics_ir().GetNode(pattern_id);
+  auto pattern = context.semantics_ir().nodes().Get(pattern_id);
   value_id =
       ConvertToValueOfType(context, parse_node, value_id, pattern.type_id());
 
@@ -27,7 +27,7 @@ auto HandleLetDeclaration(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(!bind_name.value_id.is_valid())
       << "Binding should not already have a value!";
   bind_name.value_id = value_id;
-  context.semantics_ir().ReplaceNode(pattern_id, bind_name);
+  context.semantics_ir().nodes().Set(pattern_id, bind_name);
   context.node_block_stack().AddNodeId(pattern_id);
 
   // Add the name of the binding to the current scope.

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -17,7 +17,7 @@ auto HandleNamespace(Context& context, Parse::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
   auto namespace_id = context.AddNode(SemIR::Namespace{
       parse_node, context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
-      context.semantics_ir().AddNameScope()});
+      context.semantics_ir().name_scopes().Add()});
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;
 }

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -19,13 +19,13 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       // very trivial check of validity on the operation.
       lhs_id = ConvertToValueOfType(
           context, parse_node, lhs_id,
-          context.semantics_ir().GetNode(rhs_id).type_id());
+          context.semantics_ir().nodes().Get(rhs_id).type_id());
       rhs_id = ConvertToValueExpression(context, rhs_id);
 
       context.AddNodeAndPush(
           parse_node,
           SemIR::BinaryOperatorAdd{
-              parse_node, context.semantics_ir().GetNode(lhs_id).type_id(),
+              parse_node, context.semantics_ir().nodes().Get(lhs_id).type_id(),
               lhs_id, rhs_id});
       return true;
 
@@ -48,7 +48,7 @@ auto HandleInfixOperator(Context& context, Parse::Node parse_node) -> bool {
       context.AddNodeAndPush(
           parse_node,
           SemIR::BlockArg{parse_node,
-                          context.semantics_ir().GetNode(rhs_id).type_id(),
+                          context.semantics_ir().nodes().Get(rhs_id).type_id(),
                           resume_block_id});
       return true;
     }
@@ -127,7 +127,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
               parse_node,
               context.GetPointerType(
                   parse_node,
-                  context.semantics_ir().GetNode(value_id).type_id()),
+                  context.semantics_ir().nodes().Get(value_id).type_id()),
               value_id});
       return true;
     }
@@ -136,7 +136,7 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       // `const (const T)` is probably not what the developer intended.
       // TODO: Detect `const (const T)*` and suggest moving the `*` inside the
       // parentheses.
-      if (context.semantics_ir().GetNode(value_id).kind() ==
+      if (context.semantics_ir().nodes().Get(value_id).kind() ==
           SemIR::ConstType::Kind) {
         CARBON_DIAGNOSTIC(RepeatedConst, Warning,
                           "`const` applied repeatedly to the same type has no "
@@ -155,15 +155,16 @@ auto HandlePrefixOperator(Context& context, Parse::Node parse_node) -> bool {
       context.AddNodeAndPush(
           parse_node,
           SemIR::UnaryOperatorNot{
-              parse_node, context.semantics_ir().GetNode(value_id).type_id(),
+              parse_node,
+              context.semantics_ir().nodes().Get(value_id).type_id(),
               value_id});
       return true;
 
     case Lex::TokenKind::Star: {
       value_id = ConvertToValueExpression(context, value_id);
       auto type_id = context.GetUnqualifiedType(
-          context.semantics_ir().GetNode(value_id).type_id());
-      auto type_node = context.semantics_ir().GetNode(
+          context.semantics_ir().nodes().Get(value_id).type_id());
+      auto type_node = context.semantics_ir().nodes().Get(
           context.semantics_ir().GetTypeAllowBuiltinTypes(type_id));
       auto result_type_id = SemIR::TypeId::Error;
       if (auto pointer_type = type_node.TryAs<SemIR::PointerType>()) {
@@ -200,7 +201,8 @@ auto HandleShortCircuitOperand(Context& context, Parse::Node parse_node)
   // Convert the condition to `bool`.
   auto cond_value_id = context.node_stack().PopExpression();
   cond_value_id = ConvertToBoolValue(context, parse_node, cond_value_id);
-  auto bool_type_id = context.semantics_ir().GetNode(cond_value_id).type_id();
+  auto bool_type_id =
+      context.semantics_ir().nodes().Get(cond_value_id).type_id();
 
   // Compute the branch value: the condition for `and`, inverted for `or`.
   auto token = context.parse_tree().node_token(parse_node);

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -40,11 +40,11 @@ auto HandleTupleLiteral(Context& context, Parse::Node parse_node) -> bool {
   context.node_stack()
       .PopAndDiscardSoloParseNode<
           Parse::NodeKind::ParenExpressionOrTupleLiteralStart>();
-  const auto& node_block = context.semantics_ir().GetNodeBlock(refs_id);
+  const auto& node_block = context.semantics_ir().node_blocks().Get(refs_id);
   llvm::SmallVector<SemIR::TypeId> type_ids;
   type_ids.reserve(node_block.size());
   for (auto node : node_block) {
-    type_ids.push_back(context.semantics_ir().GetNode(node).type_id());
+    type_ids.push_back(context.semantics_ir().nodes().Get(node).type_id());
   }
   auto type_id = context.CanonicalizeTupleType(parse_node, std::move(type_ids));
 

--- a/toolchain/check/handle_pattern_binding.cpp
+++ b/toolchain/check/handle_pattern_binding.cpp
@@ -71,7 +71,7 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
       // the `let` pattern before we see the initializer.
       context.node_stack().Push(
           parse_node,
-          context.semantics_ir().AddNodeInNoBlock(SemIR::BindName{
+          context.semantics_ir().nodes().AddInNoBlock(SemIR::BindName{
               name_node, cast_type_id, name_id, SemIR::NodeId::Invalid}));
       break;
 

--- a/toolchain/check/handle_statement.cpp
+++ b/toolchain/check/handle_statement.cpp
@@ -14,7 +14,7 @@ static auto HandleDiscardedExpression(Context& context, SemIR::NodeId expr_id)
     -> void {
   // If we discard an initializing expression, convert it to a value or
   // reference so that it has something to initialize.
-  auto expr = context.semantics_ir().GetNode(expr_id);
+  auto expr = context.semantics_ir().nodes().Get(expr_id);
   Convert(context, expr.parse_node(), expr_id,
           {.kind = ConversionTarget::Discarded, .type_id = expr.type_id()});
 
@@ -29,8 +29,9 @@ auto HandleExpressionStatement(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(!context.return_scope_stack().empty());
-  auto fn_node = context.semantics_ir().GetNodeAs<SemIR::FunctionDeclaration>(
-      context.return_scope_stack().back());
+  auto fn_node =
+      context.semantics_ir().nodes().GetAs<SemIR::FunctionDeclaration>(
+          context.return_scope_stack().back());
   const auto& callable =
       context.semantics_ir().functions().Get(fn_node.function_id);
 

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -46,7 +46,7 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
   // Store the name for the type.
   context.args_type_info_stack().AddNode(SemIR::StructTypeField{
       parse_node, name_id,
-      context.semantics_ir().GetNode(value_node_id).type_id()});
+      context.semantics_ir().nodes().Get(value_node_id).type_id()});
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(parse_node, value_node_id);

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -24,7 +24,7 @@ auto HandleVariableDeclaration(Context& context, Parse::Node parse_node)
   // Extract the name binding.
   SemIR::NodeId var_id =
       context.node_stack().Pop<Parse::NodeKind::PatternBinding>();
-  auto var = context.semantics_ir().GetNodeAs<SemIR::VarStorage>(var_id);
+  auto var = context.semantics_ir().nodes().GetAs<SemIR::VarStorage>(var_id);
 
   // Form a corresponding name in the current context, and bind the name to the
   // variable.

--- a/toolchain/check/node_block_stack.cpp
+++ b/toolchain/check/node_block_stack.cpp
@@ -27,7 +27,7 @@ auto NodeBlockStack::PeekOrAdd(int depth) -> SemIR::NodeBlockId {
   int index = size() - depth - 1;
   auto& slot = stack_[index];
   if (!slot.id.is_valid()) {
-    slot.id = semantics_ir_->AddNodeBlockId();
+    slot.id = semantics_ir_->node_blocks().AddDefaultValue();
   }
   return slot.id;
 }
@@ -40,9 +40,9 @@ auto NodeBlockStack::Pop() -> SemIR::NodeBlockId {
   // Finalize the block.
   if (!back.content.empty() && back.id != SemIR::NodeBlockId::Unreachable) {
     if (back.id.is_valid()) {
-      semantics_ir_->SetNodeBlock(back.id, back.content);
+      semantics_ir_->node_blocks().Set(back.id, back.content);
     } else {
-      back.id = semantics_ir_->AddNodeBlock(back.content);
+      back.id = semantics_ir_->node_blocks().Add(back.content);
     }
   }
 

--- a/toolchain/check/node_block_stack.h
+++ b/toolchain/check/node_block_stack.h
@@ -48,7 +48,7 @@ class NodeBlockStack {
   // Adds the given node to the block at the top of the stack and returns its
   // ID.
   auto AddNode(SemIR::Node node) -> SemIR::NodeId {
-    auto node_id = semantics_ir_->AddNodeInNoBlock(node);
+    auto node_id = semantics_ir_->nodes().AddInNoBlock(node);
     AddNodeId(node_id);
     return node_id;
   }

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -40,7 +40,7 @@ class PendingBlock {
   };
 
   auto AddNode(SemIR::Node node) -> SemIR::NodeId {
-    auto node_id = context_.semantics_ir().AddNodeInNoBlock(node);
+    auto node_id = context_.semantics_ir().nodes().AddInNoBlock(node);
     nodes_.push_back(node_id);
     return node_id;
   }
@@ -56,26 +56,26 @@ class PendingBlock {
   // Replace the node at target_id with the nodes in this block. The new value
   // for target_id should be value_id.
   auto MergeReplacing(SemIR::NodeId target_id, SemIR::NodeId value_id) -> void {
-    auto value = context_.semantics_ir().GetNode(value_id);
+    auto value = context_.semantics_ir().nodes().Get(value_id);
 
     // There are three cases here:
 
     if (nodes_.empty()) {
       // 1) The block is empty. Replace `target_id` with an empty splice
       // pointing at `value_id`.
-      context_.semantics_ir().ReplaceNode(
+      context_.semantics_ir().nodes().Set(
           target_id, SemIR::SpliceBlock{value.parse_node(), value.type_id(),
                                         SemIR::NodeBlockId::Empty, value_id});
     } else if (nodes_.size() == 1 && nodes_[0] == value_id) {
       // 2) The block is {value_id}. Replace `target_id` with the node referred
       // to by `value_id`. This is intended to be the common case.
-      context_.semantics_ir().ReplaceNode(target_id, value);
+      context_.semantics_ir().nodes().Set(target_id, value);
     } else {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
-      context_.semantics_ir().ReplaceNode(
+      context_.semantics_ir().nodes().Set(
           target_id,
           SemIR::SpliceBlock{value.parse_node(), value.type_id(),
-                             context_.semantics_ir().AddNodeBlock(nodes_),
+                             context_.semantics_ir().node_blocks().Add(nodes_),
                              value_id});
     }
 

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -38,8 +38,8 @@ auto FunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
 }
 
 auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
-  for (const auto& node_id : semantics_ir().GetNodeBlock(block_id)) {
-    auto node = semantics_ir().GetNode(node_id);
+  for (const auto& node_id : semantics_ir().node_blocks().Get(block_id)) {
+    auto node = semantics_ir().nodes().Get(node_id);
     CARBON_VLOG() << "Lowering " << node_id << ": " << node << "\n";
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -48,7 +48,7 @@ class FunctionContext {
 
     auto it = locals_.find(node_id);
     CARBON_CHECK(it != locals_.end()) << "Missing local: " << node_id << " "
-                                      << semantics_ir().GetNode(node_id);
+                                      << semantics_ir().nodes().Get(node_id);
     return it->second;
   }
 
@@ -56,7 +56,7 @@ class FunctionContext {
   auto SetLocal(SemIR::NodeId node_id, llvm::Value* value) {
     bool added = locals_.insert({node_id, value}).second;
     CARBON_CHECK(added) << "Duplicate local insert: " << node_id << " "
-                        << semantics_ir().GetNode(node_id);
+                        << semantics_ir().nodes().Get(node_id);
   }
 
   // Gets a callable's function.

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -47,13 +47,13 @@ cc_library(
     srcs = ["node.cpp"],
     hdrs = ["node.h"],
     deps = [
+        ":builtin_kind",
+        ":node_kind",
         "//common:check",
         "//common:ostream",
         "//common:struct_reflection",
         "//toolchain/base:index_base",
         "//toolchain/parse:tree",
-        "//toolchain/sem_ir:builtin_kind",
-        "//toolchain/sem_ir:node_kind",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -63,11 +63,12 @@ cc_library(
     srcs = ["file.cpp"],
     hdrs = ["file.h"],
     deps = [
+        ":builtin_kind",
+        ":node",
+        ":node_kind",
+        ":value_stores",
         "//common:check",
         "//toolchain/base:value_store",
-        "//toolchain/sem_ir:builtin_kind",
-        "//toolchain/sem_ir:node",
-        "//toolchain/sem_ir:node_kind",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -77,10 +78,10 @@ cc_library(
     srcs = ["formatter.cpp"],
     hdrs = ["formatter.h"],
     deps = [
+        ":file",
+        ":node_kind",
         "//toolchain/lex:tokenized_buffer",
         "//toolchain/parse:tree",
-        "//toolchain/sem_ir:file",
-        "//toolchain/sem_ir:node_kind",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -91,6 +92,16 @@ cc_library(
     hdrs = ["entry_point.h"],
     deps = [
         ":file",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "value_stores",
+    hdrs = ["value_stores.h"],
+    deps = [
+        ":node",
+        "//toolchain/base:value_store",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -5,13 +5,13 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 #define CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/sem_ir/node.h"
+#include "toolchain/sem_ir/value_stores.h"
 
 namespace Carbon::SemIR {
 
@@ -145,111 +145,13 @@ class File : public Printable<File> {
   // Returns array bound value from the bound node.
   auto GetArrayBoundValue(NodeId bound_id) const -> uint64_t {
     return integers()
-        .Get(GetNodeAs<IntegerLiteral>(bound_id).integer_id)
+        .Get(nodes().GetAs<IntegerLiteral>(bound_id).integer_id)
         .getZExtValue();
   }
 
   // Returns the requested IR.
   auto GetCrossReferenceIR(CrossReferenceIRId xref_id) const -> const File& {
     return *cross_reference_irs_[xref_id.index];
-  }
-
-  // Adds a name scope, returning an ID to reference it.
-  auto AddNameScope() -> NameScopeId {
-    NameScopeId name_scopes_id(name_scopes_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(name_scopes_id.index >= 0);
-    name_scopes_.resize(name_scopes_id.index + 1);
-    return name_scopes_id;
-  }
-
-  // Adds an entry to a name scope. Returns true on success, false on
-  // duplicates.
-  auto AddNameScopeEntry(NameScopeId scope_id, StringId name_id,
-                         NodeId target_id) -> bool {
-    return name_scopes_[scope_id.index].insert({name_id, target_id}).second;
-  }
-
-  // Returns the requested name scope.
-  auto GetNameScope(NameScopeId scope_id) const
-      -> const llvm::DenseMap<StringId, NodeId>& {
-    return name_scopes_[scope_id.index];
-  }
-
-  // Adds a node to the node list, returning an ID to reference the node. Note
-  // that this doesn't add the node to any node block. Check::Context::AddNode
-  // or NodeBlockStack::AddNode should usually be used instead, to add the node
-  // to the current block.
-  auto AddNodeInNoBlock(Node node) -> NodeId {
-    NodeId node_id(nodes_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(node_id.index >= 0);
-    nodes_.push_back(node);
-    return node_id;
-  }
-
-  // Overwrites a given node with a new value.
-  auto ReplaceNode(NodeId node_id, Node node) -> void {
-    nodes_[node_id.index] = node;
-  }
-
-  // Returns the requested node.
-  auto GetNode(NodeId node_id) const -> Node { return nodes_[node_id.index]; }
-
-  // Returns the requested node, which is known to have the specified type.
-  template <typename NodeT>
-  auto GetNodeAs(NodeId node_id) const -> NodeT {
-    return GetNode(node_id).As<NodeT>();
-  }
-
-  // Reserves and returns a node block ID. The contents of the node block
-  // should be specified by calling SetNodeBlock, or by pushing the ID onto the
-  // NodeBlockStack.
-  auto AddNodeBlockId() -> NodeBlockId {
-    NodeBlockId id(node_blocks_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(id.index >= 0);
-    node_blocks_.push_back({});
-    return id;
-  }
-
-  // Sets the contents of an empty node block to the given content.
-  auto SetNodeBlock(NodeBlockId block_id, llvm::ArrayRef<NodeId> content)
-      -> void {
-    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
-    CARBON_CHECK(node_blocks_[block_id.index].empty())
-        << "node block content set more than once";
-    node_blocks_[block_id.index] = AllocateCopy(content);
-  }
-
-  // Adds a node block with the given content, returning an ID to reference it.
-  auto AddNodeBlock(llvm::ArrayRef<NodeId> content) -> NodeBlockId {
-    NodeBlockId id(node_blocks_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(id.index >= 0);
-    node_blocks_.push_back(AllocateCopy(content));
-    return id;
-  }
-
-  // Adds a node block of the given size.
-  auto AddUninitializedNodeBlock(size_t size) -> NodeBlockId {
-    NodeBlockId id(node_blocks_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(id.index >= 0);
-    node_blocks_.push_back(AllocateUninitialized<NodeId>(size));
-    return id;
-  }
-
-  // Returns the requested node block.
-  auto GetNodeBlock(NodeBlockId block_id) const -> llvm::ArrayRef<NodeId> {
-    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
-    return node_blocks_[block_id.index];
-  }
-
-  // Returns the requested node block.
-  auto GetNodeBlock(NodeBlockId block_id) -> llvm::MutableArrayRef<NodeId> {
-    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
-    return node_blocks_[block_id.index];
   }
 
   // Marks a type as complete, and sets its value representation.
@@ -296,26 +198,9 @@ class File : public Printable<File> {
 
   // Gets the pointee type of the given type, which must be a pointer type.
   auto GetPointeeType(TypeId pointer_id) const -> TypeId {
-    return GetNodeAs<PointerType>(types().Get(pointer_id).node_id).pointee_id;
-  }
-
-  // Adds a type block with the given content, returning an ID to reference it.
-  auto AddTypeBlock(llvm::ArrayRef<TypeId> content) -> TypeBlockId {
-    TypeBlockId id(type_blocks_.size());
-    // TODO: Return failure on overflow instead of crashing.
-    CARBON_CHECK(id.index >= 0);
-    type_blocks_.push_back(AllocateCopy(content));
-    return id;
-  }
-
-  // Returns the requested type block.
-  auto GetTypeBlock(TypeBlockId block_id) const -> llvm::ArrayRef<TypeId> {
-    return type_blocks_[block_id.index];
-  }
-
-  // Returns the requested type block.
-  auto GetTypeBlock(TypeBlockId block_id) -> llvm::MutableArrayRef<TypeId> {
-    return type_blocks_[block_id.index];
+    return nodes()
+        .GetAs<PointerType>(types().Get(pointer_id).node_id)
+        .pointee_id;
   }
 
   // Produces a string version of a type. If `in_type_context` is false, an
@@ -352,11 +237,20 @@ class File : public Printable<File> {
   }
   auto classes() -> ValueStore<ClassId, Class>& { return classes_; }
   auto classes() const -> const ValueStore<ClassId, Class>& { return classes_; }
+  auto name_scopes() -> NameScopeStore& { return name_scopes_; }
+  auto name_scopes() const -> const NameScopeStore& { return name_scopes_; }
   auto types() -> ValueStore<TypeId, TypeInfo>& { return types_; }
   auto types() const -> const ValueStore<TypeId, TypeInfo>& { return types_; }
-
-  auto nodes_size() const -> int { return nodes_.size(); }
-  auto node_blocks_size() const -> int { return node_blocks_.size(); }
+  auto type_blocks() -> BlockValueStore<TypeBlockId, TypeId>& {
+    return type_blocks_;
+  }
+  auto type_blocks() const -> const BlockValueStore<TypeBlockId, TypeId>& {
+    return type_blocks_;
+  }
+  auto nodes() -> NodeStore& { return nodes_; }
+  auto nodes() const -> const NodeStore& { return nodes_; }
+  auto node_blocks() -> NodeBlockStore& { return node_blocks_; }
+  auto node_blocks() const -> const NodeBlockStore& { return node_blocks_; }
 
   // A list of types that were completed in this file, in the order in which
   // they were completed. Earlier types in this list cannot contain instances of
@@ -377,25 +271,6 @@ class File : public Printable<File> {
   auto filename() const -> llvm::StringRef { return filename_; }
 
  private:
-  // Allocates an uninitialized array using our slab allocator.
-  template <typename T>
-  auto AllocateUninitialized(std::size_t size) -> llvm::MutableArrayRef<T> {
-    // We're not going to run a destructor, so ensure that's OK.
-    static_assert(std::is_trivially_destructible_v<T>);
-
-    T* storage =
-        static_cast<T*>(allocator_.Allocate(size * sizeof(T), alignof(T)));
-    return llvm::MutableArrayRef<T>(storage, size);
-  }
-
-  // Allocates a copy of the given data using our slab allocator.
-  template <typename T>
-  auto AllocateCopy(llvm::ArrayRef<T> data) -> llvm::MutableArrayRef<T> {
-    auto result = AllocateUninitialized<T>(data.size());
-    std::uninitialized_copy(data.begin(), data.end(), result.begin());
-    return result;
-  }
-
   bool has_errors_ = false;
 
   // Shared, compile-scoped values.
@@ -420,7 +295,7 @@ class File : public Printable<File> {
   llvm::SmallVector<const File*> cross_reference_irs_;
 
   // Storage for name scopes.
-  llvm::SmallVector<llvm::DenseMap<StringId, NodeId>> name_scopes_;
+  NameScopeStore name_scopes_;
 
   // Descriptions of types used in this file.
   ValueStore<TypeId, TypeInfo> types_;
@@ -430,15 +305,15 @@ class File : public Printable<File> {
 
   // Type blocks within the IR. These reference entries in types_. Storage for
   // the data is provided by allocator_.
-  llvm::SmallVector<llvm::MutableArrayRef<TypeId>> type_blocks_;
+  BlockValueStore<TypeBlockId, TypeId> type_blocks_;
 
   // All nodes. The first entries will always be cross-references to builtins,
   // at indices matching BuiltinKind ordering.
-  llvm::SmallVector<Node> nodes_;
+  NodeStore nodes_;
 
   // Node blocks within the IR. These reference entries in nodes_. Storage for
   // the data is provided by allocator_.
-  llvm::SmallVector<llvm::MutableArrayRef<NodeId>> node_blocks_;
+  NodeBlockStore node_blocks_;
 
   // The top node block ID.
   NodeBlockId top_node_block_id_ = NodeBlockId::Invalid;

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -1,0 +1,151 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEM_IR_VALUE_STORES_H_
+#define CARBON_TOOLCHAIN_SEM_IR_VALUE_STORES_H_
+
+#include "llvm/ADT/DenseMap.h"
+#include "toolchain/base/value_store.h"
+#include "toolchain/sem_ir/node.h"
+
+namespace Carbon::SemIR {
+
+// Provides a ValueStore wrapper for an API specific to nodes.
+class NodeStore {
+ public:
+  // Adds a node to the node list, returning an ID to reference the node. Note
+  // that this doesn't add the node to any node block. Check::Context::AddNode
+  // or NodeBlockStack::AddNode should usually be used instead, to add the node
+  // to the current block.
+  auto AddInNoBlock(Node node) -> NodeId { return values_.Add(node); }
+
+  // Returns the requested node.
+  auto Get(NodeId node_id) const -> Node { return values_.Get(node_id); }
+
+  // Returns the requested node, which is known to have the specified type.
+  template <typename NodeT>
+  auto GetAs(NodeId node_id) const -> NodeT {
+    return Get(node_id).As<NodeT>();
+  }
+
+  // Overwrites a given node with a new value.
+  auto Set(NodeId node_id, Node node) -> void { values_.Get(node_id) = node; }
+
+  // Reserves space.
+  auto Reserve(size_t size) -> void { values_.Reserve(size); }
+
+  auto array_ref() const -> llvm::ArrayRef<Node> { return values_.array_ref(); }
+  auto size() const -> int { return values_.size(); }
+
+ private:
+  ValueStore<NodeId, Node> values_;
+};
+
+// Provides a ValueStore wrapper for an API specific to name scopes.
+class NameScopeStore {
+ public:
+  // Adds a name scope, returning an ID to reference it.
+  auto Add() -> NameScopeId { return values_.AddDefaultValue(); }
+
+  // Adds an entry to a name scope. Returns true on success, false on
+  // duplicates.
+  auto AddEntry(NameScopeId scope_id, StringId name_id, NodeId target_id)
+      -> bool {
+    return values_.Get(scope_id).insert({name_id, target_id}).second;
+  }
+
+  // Returns the requested name scope.
+  auto Get(NameScopeId scope_id) const
+      -> const llvm::DenseMap<StringId, NodeId>& {
+    return values_.Get(scope_id);
+  }
+
+ private:
+  ValueStore<NameScopeId, llvm::DenseMap<StringId, NodeId>> values_;
+};
+
+// Provides a block-based ValueStore, which uses slab allocation of added
+// blocks. This allows references to values to outlast vector resizes that might
+// otherwise invalidate references.
+//
+// BlockValueStore is used as-is, but there are also children that expose the
+// protected members for type-specific functionality.
+template <typename IdT, typename ValueT>
+class BlockValueStore {
+ public:
+  explicit BlockValueStore(llvm::BumpPtrAllocator& allocator)
+      : allocator_(&allocator) {}
+
+  // Adds a block with the given content, returning an ID to reference it.
+  auto Add(llvm::ArrayRef<ValueT> content) -> IdT {
+    return values_.Add(AllocateCopy(content));
+  }
+
+  // Returns the requested block.
+  auto Get(IdT id) const -> llvm::ArrayRef<ValueT> { return values_.Get(id); }
+
+  // Returns the requested block.
+  auto Get(IdT id) -> llvm::MutableArrayRef<ValueT> { return values_.Get(id); }
+
+  auto size() const -> int { return values_.size(); }
+
+ protected:
+  // Reserves and returns a block ID. The contents of the block
+  // should be specified by calling Set, or similar.
+  auto AddDefaultValue() -> NodeBlockId { return values_.AddDefaultValue(); }
+
+  // Adds an uninitialized block of the given size.
+  auto AddUninitialized(size_t size) -> NodeBlockId {
+    return values_.Add(AllocateUninitialized(size));
+  }
+
+  // Sets the contents of an empty block to the given content.
+  auto Set(NodeBlockId block_id, llvm::ArrayRef<NodeId> content) -> void {
+    CARBON_CHECK(Get(block_id).empty())
+        << "node block content set more than once";
+    values_.Get(block_id) = AllocateCopy(content);
+  }
+
+ private:
+  // Allocates an uninitialized array using our slab allocator.
+  auto AllocateUninitialized(std::size_t size)
+      -> llvm::MutableArrayRef<ValueT> {
+    // We're not going to run a destructor, so ensure that's OK.
+    static_assert(std::is_trivially_destructible_v<ValueT>);
+
+    auto storage = static_cast<ValueT*>(
+        allocator_->Allocate(size * sizeof(ValueT), alignof(ValueT)));
+    return llvm::MutableArrayRef<ValueT>(storage, size);
+  }
+
+  // Allocates a copy of the given data using our slab allocator.
+  auto AllocateCopy(llvm::ArrayRef<ValueT> data)
+      -> llvm::MutableArrayRef<ValueT> {
+    auto result = AllocateUninitialized(data.size());
+    std::uninitialized_copy(data.begin(), data.end(), result.begin());
+    return result;
+  }
+
+  llvm::BumpPtrAllocator* allocator_;
+  ValueStore<IdT, llvm::MutableArrayRef<ValueT>> values_;
+};
+
+// Adapts BlockValueStore for node blocks.
+class NodeBlockStore : public BlockValueStore<NodeBlockId, NodeId> {
+ public:
+  using BaseType = BlockValueStore<NodeBlockId, NodeId>;
+
+  using BaseType::AddDefaultValue;
+  using BaseType::AddUninitialized;
+  using BaseType::BaseType;
+
+  auto Set(NodeBlockId block_id, llvm::ArrayRef<NodeId> content) -> void {
+    CARBON_CHECK(block_id != NodeBlockId::Unreachable);
+    BlockValueStore<NodeBlockId, NodeId>::Set(block_id, content);
+  }
+};
+
+}  // namespace Carbon::SemIR
+
+#endif  // CARBON_TOOLCHAIN_SEM_IR_VALUE_STORES_H_


### PR DESCRIPTION
Finishing what #3316 started, add more bespoke ValueStore-like structures to File. With this, the things which previously had somewhat boilerplate Add/Get functions are now all on side classes, giving a uniform style of API for calling.

Note, I was on the fence about making things public on ValueStore. If it's preferred that I make some things there protected I certainly can, there's just a trade-off that may mean more distinct child/wrapper types.