### PR TITLE
Fix DenseMapInfo declarations for ValueStore's StringId use.

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 
 #include "common/ostream.h"
+#include "llvm/ADT/DenseMapInfo.h"
 
 namespace Carbon {
 
@@ -77,6 +78,31 @@ template <typename IndexType, typename std::enable_if_t<std::is_base_of_v<
 auto operator>=(IndexType lhs, IndexType rhs) -> bool {
   return lhs.index >= rhs.index;
 }
+
+// Provides base support for use of IndexBase types as DenseMap/DenseSet keys.
+//
+// Usage (in global namespace):
+//   template <>
+//   struct llvm::DenseMapInfo<Carbon::MyType>
+//       : public Carbon::IndexMapInfo<Carbon::MyType> {};
+template <typename Index>
+struct IndexMapInfo {
+  static inline auto getEmptyKey() -> Index {
+    return Index(llvm::DenseMapInfo<int32_t>::getEmptyKey());
+  }
+
+  static inline auto getTombstoneKey() -> Index {
+    return Index(llvm::DenseMapInfo<int32_t>::getTombstoneKey());
+  }
+
+  static auto getHashValue(const Index& val) -> unsigned {
+    return llvm::DenseMapInfo<int32_t>::getHashValue(val.index);
+  }
+
+  static auto isEqual(const Index& lhs, const Index& rhs) -> bool {
+    return lhs == rhs;
+  }
+};
 
 }  // namespace Carbon
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -138,4 +138,9 @@ class SharedValueStores {
 
 }  // namespace Carbon
 
+// Support use of StringId as DenseMap/DenseSet keys.
+template <>
+struct llvm::DenseMapInfo<Carbon::StringId>
+    : public Carbon::IndexMapInfo<Carbon::StringId> {};
+
 #endif  // CARBON_TOOLCHAIN_BASE_VALUE_STORE_H_

--- a/toolchain/sem_ir/node.h
+++ b/toolchain/sem_ir/node.h
@@ -792,38 +792,14 @@ struct TypedNodeImpl : MakeTypedNodeBase<DataT> {
 };
 }  // namespace NodeInternals
 
-// Provides base support for use of Id types as DenseMap/DenseSet keys.
-// Instantiated below.
-template <typename Id>
-struct IdMapInfo {
-  static inline auto getEmptyKey() -> Id {
-    return Id(llvm::DenseMapInfo<int32_t>::getEmptyKey());
-  }
-
-  static inline auto getTombstoneKey() -> Id {
-    return Id(llvm::DenseMapInfo<int32_t>::getTombstoneKey());
-  }
-
-  static auto getHashValue(const Id& val) -> unsigned {
-    return llvm::DenseMapInfo<int32_t>::getHashValue(val.index);
-  }
-
-  static auto isEqual(const Id& lhs, const Id& rhs) -> bool {
-    return lhs == rhs;
-  }
-};
-
 }  // namespace Carbon::SemIR
 
 // Support use of Id types as DenseMap/DenseSet keys.
 template <>
 struct llvm::DenseMapInfo<Carbon::SemIR::NodeBlockId>
-    : public Carbon::SemIR::IdMapInfo<Carbon::SemIR::NodeBlockId> {};
+    : public Carbon::IndexMapInfo<Carbon::SemIR::NodeBlockId> {};
 template <>
 struct llvm::DenseMapInfo<Carbon::SemIR::NodeId>
-    : public Carbon::SemIR::IdMapInfo<Carbon::SemIR::NodeId> {};
-template <>
-struct llvm::DenseMapInfo<Carbon::StringId>
-    : public Carbon::SemIR::IdMapInfo<Carbon::StringId> {};
+    : public Carbon::IndexMapInfo<Carbon::SemIR::NodeId> {};
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_NODE_H_


### PR DESCRIPTION
The move of the DenseMap to value_store.h should have been matched with moving the declaration; this worked by happenstance.