### PR TITLE
Adding ValueStore printing and --dump-shared-values

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -10,6 +10,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/YAMLParser.h"
 #include "toolchain/base/index_base.h"
 
 namespace Carbon {
@@ -132,8 +133,7 @@ class ValueStore<StringId> : public Printable<ValueStore<StringId>> {
   auto Print(llvm::raw_ostream& out, int indent) const -> void {
     for (auto value : values_) {
       out.indent(indent);
-      // TODO: Consider making this more robust for strings that need escaping.
-      out << "- \"" << value << "\"\n";
+      out << "- \"" << llvm::yaml::escape(value) << "\"\n";
     }
   }
 

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -7,6 +7,7 @@
 // AUTOUPDATE
 
 var a: f64 = 1.0;
+var b: String = "ab\"c";
 
 // CHECK:STDOUT: shared_values:
 // CHECK:STDOUT:   - integers:
@@ -15,3 +16,5 @@ var a: f64 = 1.0;
 // CHECK:STDOUT:       - 10*10^-1
 // CHECK:STDOUT:   - strings:
 // CHECK:STDOUT:       - "a"
+// CHECK:STDOUT:       - "b"
+// CHECK:STDOUT:       - "ab\"c"

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -1,0 +1,17 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ARGS: compile --phase=lex --dump-shared-values %s
+//
+// AUTOUPDATE
+
+var a: f64 = 1.0;
+
+// CHECK:STDOUT: shared_values:
+// CHECK:STDOUT:   - integers:
+// CHECK:STDOUT:       - 64
+// CHECK:STDOUT:   - reals:
+// CHECK:STDOUT:       - 10*10^-1
+// CHECK:STDOUT:   - strings:
+// CHECK:STDOUT:       - "a"


### PR DESCRIPTION
This replaces the printing that was removed from SemIR's raw dump. It's separate because (for example) lexing generates shared values, and so reviewing them is not specific to any particular phase.