### PR TITLE
Handle `let` with no closing semicolon

### DIFF
--- a/toolchain/parse/node_kind.def
+++ b/toolchain/parse/node_kind.def
@@ -203,7 +203,8 @@ CARBON_PARSE_NODE_KIND_CHILD_COUNT(Template, 1, CARBON_TOKEN(Template))
 CARBON_PARSE_NODE_KIND_CHILD_COUNT(LetIntroducer, 0, CARBON_TOKEN(Let))
 CARBON_PARSE_NODE_KIND_CHILD_COUNT(LetInitializer, 0, CARBON_TOKEN(Equal))
 CARBON_PARSE_NODE_KIND_BRACKET(LetDeclaration, LetIntroducer,
-                               CARBON_TOKEN(Semi))
+                               CARBON_TOKEN(Semi)
+                                   CARBON_IF_ERROR(CARBON_TOKEN(Let)))
 
 // `var`:
 //   VariableIntroducer

--- a/toolchain/parse/testdata/let/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/let/fail_no_semi.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+let
+
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+15]]:21: ERROR: Expected pattern in `let` declaration.
+// CHECK:STDERR: // CHECK:STDOUT:   ]
+// CHECK:STDERR:                     ^
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+12]]:21: ERROR: `let` declarations must end with a `;`.
+// CHECK:STDERR: // CHECK:STDOUT:   ]
+// CHECK:STDERR:                     ^
+// CHECK:STDOUT: - filename: fail_no_semi.carbon
+// CHECK:STDOUT:   parse_tree: [
+// CHECK:STDOUT:     {kind: 'FileStart', text: ''},
+// CHECK:STDOUT:       {kind: 'LetIntroducer', text: 'let'},
+// CHECK:STDOUT:         {kind: 'Name', text: '', has_error: yes},
+// CHECK:STDOUT:         {kind: 'InvalidParse', text: '', has_error: yes},
+// CHECK:STDOUT:       {kind: 'PatternBinding', text: '', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'LetDeclaration', text: 'let', has_error: yes, subtree_size: 5},
+// CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT:   ]

--- a/toolchain/parse/testdata/var/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/var/fail_no_semi.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+var
+
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+15]]:21: ERROR: Expected pattern in `var` declaration.
+// CHECK:STDERR: // CHECK:STDOUT:   ]
+// CHECK:STDERR:                     ^
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+12]]:21: ERROR: `var` declarations must end with a `;`.
+// CHECK:STDERR: // CHECK:STDOUT:   ]
+// CHECK:STDERR:                     ^
+// CHECK:STDOUT: - filename: fail_no_semi.carbon
+// CHECK:STDOUT:   parse_tree: [
+// CHECK:STDOUT:     {kind: 'FileStart', text: ''},
+// CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},
+// CHECK:STDOUT:         {kind: 'Name', text: '', has_error: yes},
+// CHECK:STDOUT:         {kind: 'InvalidParse', text: '', has_error: yes},
+// CHECK:STDOUT:       {kind: 'PatternBinding', text: '', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'VariableDeclaration', text: 'var', has_error: yes, subtree_size: 5},
+// CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT:   ]


### PR DESCRIPTION
Also add a test for the `var` case