### PR TITLE
Add size="small" to test targets where advised

### DIFF
--- a/bazel/check_deps/BUILD
+++ b/bazel/check_deps/BUILD
@@ -36,6 +36,7 @@ genquery(
 
 py_test(
     name = "check_non_test_cc_deps",
+    size = "small",
     srcs = ["check_non_test_cc_deps.py"],
     data = [":non_test_cc_deps.txt"],
     main = "check_non_test_cc_deps.py",

--- a/common/BUILD
+++ b/common/BUILD
@@ -102,8 +102,8 @@ cc_library(
 
 cc_test(
     name = "error_test",
-    srcs = ["error_test.cpp"],
     size = "small",
+    srcs = ["error_test.cpp"],
     deps = [
         ":error",
         "//testing/base:gtest_main",

--- a/common/BUILD
+++ b/common/BUILD
@@ -27,6 +27,7 @@ cc_library(
 
 cc_test(
     name = "command_line_test",
+    size = "small",
     srcs = ["command_line_test.cpp"],
     deps = [
         ":command_line",
@@ -52,6 +53,7 @@ cc_library(
 
 cc_test(
     name = "check_test",
+    size = "small",
     srcs = ["check_test.cpp"],
     deps = [
         ":check",
@@ -77,6 +79,7 @@ cc_library(
 
 cc_test(
     name = "enum_base_test",
+    size = "small",
     srcs = ["enum_base_test.cpp"],
     deps = [
         ":enum_base",
@@ -100,6 +103,7 @@ cc_library(
 cc_test(
     name = "error_test",
     srcs = ["error_test.cpp"],
+    size = "small",
     deps = [
         ":error",
         "//testing/base:gtest_main",
@@ -115,6 +119,7 @@ cc_library(
 
 cc_test(
     name = "indirect_value_test",
+    size = "small",
     srcs = ["indirect_value_test.cpp"],
     deps = [
         ":indirect_value",
@@ -144,6 +149,7 @@ cc_library(
 
 cc_test(
     name = "string_helpers_test",
+    size = "small",
     srcs = ["string_helpers_test.cpp"],
     deps = [
         ":string_helpers",
@@ -181,6 +187,7 @@ cc_library(
 
 cc_test(
     name = "vlog_test",
+    size = "small",
     srcs = ["vlog_test.cpp"],
     deps = [
         ":vlog",

--- a/explorer/ast/BUILD
+++ b/explorer/ast/BUILD
@@ -80,6 +80,7 @@ cc_library(
 
 cc_test(
     name = "ast_test_matchers_test",
+    size = "small",
     srcs = ["ast_test_matchers_test.cpp"],
     deps = [
         ":ast",
@@ -92,6 +93,7 @@ cc_test(
 
 cc_test(
     name = "expression_test",
+    size = "small",
     srcs = ["expression_test.cpp"],
     deps = [
         ":ast",
@@ -119,6 +121,7 @@ cc_library(
 
 cc_test(
     name = "element_test",
+    size = "small",
     srcs = ["element_test.cpp"],
     deps = [
         ":ast",
@@ -132,6 +135,7 @@ cc_test(
 
 cc_test(
     name = "pattern_test",
+    size = "small",
     srcs = ["pattern_test.cpp"],
     deps = [
         ":ast",

--- a/explorer/base/BUILD
+++ b/explorer/base/BUILD
@@ -17,6 +17,7 @@ cc_library(
 
 cc_test(
     name = "arena_test",
+    size = "small",
     srcs = ["arena_test.cpp"],
     deps = [
         ":arena",
@@ -35,6 +36,7 @@ cc_library(
 
 cc_test(
     name = "decompose_test",
+    size = "small",
     srcs = ["decompose_test.cpp"],
     deps = [
         ":decompose",
@@ -54,6 +56,7 @@ cc_library(
 
 cc_test(
     name = "error_builders_test",
+    size = "small",
     srcs = ["error_builders_test.cpp"],
     deps = [
         ":error_builders",
@@ -103,6 +106,7 @@ cc_library(
 
 cc_test(
     name = "set_program_phase_raii_test",
+    size = "small",
     srcs = ["set_program_phase_raii_test.cpp"],
     deps = [
         ":trace_stream",
@@ -113,6 +117,7 @@ cc_test(
 
 cc_test(
     name = "set_file_context_raii_test",
+    size = "small",
     srcs = ["set_file_context_raii_test.cpp"],
     deps = [
         ":source_location",

--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -35,6 +35,7 @@ cc_binary(
 
 cc_test(
     name = "ast_to_proto_test",
+    size = "small",
     srcs = ["ast_to_proto_test.cpp"],
     args = [
         "$(locations //explorer:standard_libraries)",
@@ -75,6 +76,7 @@ cc_library(
 
 cc_test(
     name = "fuzzer_util_test",
+    size = "small",
     srcs = ["fuzzer_util_test.cpp"],
     data = [
         "//explorer:standard_libraries",

--- a/explorer/parse_and_execute/BUILD
+++ b/explorer/parse_and_execute/BUILD
@@ -27,6 +27,7 @@ cc_library(
 
 cc_test(
     name = "parse_and_execute_test",
+    size = "small",
     srcs = ["parse_and_execute_test.cpp"],
     deps = [
         ":parse_and_execute",

--- a/explorer/syntax/BUILD
+++ b/explorer/syntax/BUILD
@@ -15,6 +15,7 @@ cc_library(
 
 cc_test(
     name = "parse_test",
+    size = "small",
     srcs = ["parse_test.cpp"],
     deps = [
         ":syntax",
@@ -140,12 +141,14 @@ py_library(
 
 py_test(
     name = "format_grammar_test",
+    size = "small",
     srcs = ["format_grammar_test.py"],
     deps = ["format_grammar_lib"],
 )
 
 cc_test(
     name = "unimplemented_example_test",
+    size = "small",
     srcs = ["unimplemented_example_test.cpp"],
     deps = [
         ":parse_test_matchers",

--- a/github_tools/BUILD
+++ b/github_tools/BUILD
@@ -13,6 +13,7 @@ py_library(
 
 py_test(
     name = "github_helpers_test",
+    size = "small",
     srcs = ["github_helpers_test.py"],
     python_version = "PY3",
     deps = [":github_helpers"],
@@ -27,6 +28,7 @@ py_binary(
 
 py_test(
     name = "pr_comments_test",
+    size = "small",
     srcs = ["pr_comments_test.py"],
     python_version = "PY3",
     deps = [":pr_comments"],

--- a/migrate_cpp/BUILD
+++ b/migrate_cpp/BUILD
@@ -47,6 +47,7 @@ cc_library(
 
 cc_test(
     name = "rewriter_test",
+    size = "small",
     srcs = ["rewriter_test.cpp"],
     deps = [
         ":rewriter",

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -60,6 +60,7 @@ cc_library(
 
 cc_test(
     name = "fn_inserter_test",
+    size = "small",
     srcs = ["fn_inserter_test.cpp"],
     deps = [
         ":fn_inserter",
@@ -82,6 +83,7 @@ cc_library(
 
 cc_test(
     name = "for_range_test",
+    size = "small",
     srcs = ["for_range_test.cpp"],
     deps = [
         ":for_range",
@@ -106,6 +108,7 @@ cc_library(
 
 cc_test(
     name = "var_decl_test",
+    size = "small",
     srcs = ["var_decl_test.cpp"],
     deps = [
         ":matcher_test_base",

--- a/proposals/scripts/BUILD
+++ b/proposals/scripts/BUILD
@@ -12,6 +12,7 @@ py_binary(
 
 py_test(
     name = "new_proposal_test",
+    size = "small",
     srcs = ["new_proposal_test.py"],
     data = ["template.md"],
     python_version = "PY3",

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -6,6 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
     name = "no_op_test",
+    size = "small",
     srcs = ["no_op_test.py"],
     main = "no_op_test.py",
 )

--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -38,6 +38,7 @@ cc_library(
 
 cc_test(
     name = "test_raw_ostream_test",
+    size = "small",
     srcs = ["test_raw_ostream_test.cpp"],
     deps = [
         ":test_raw_ostream",

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -43,6 +43,7 @@ cc_library(
 
 file_test(
     name = "file_test_base_test",
+    size = "small",
     srcs = ["file_test_base_test.cpp"],
     tests = glob(["testdata/**"]),
     deps = [

--- a/testing/fuzzing/BUILD
+++ b/testing/fuzzing/BUILD
@@ -47,6 +47,7 @@ cc_binary(
 
 cc_test(
     name = "proto_to_carbon_test",
+    size = "small",
     srcs = ["proto_to_carbon_test.cpp"],
     deps = [
         ":carbon_cc_proto",

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -9,8 +9,8 @@ package(default_visibility = ["//visibility:public"])
 
 file_test(
     name = "file_test",
-    srcs = ["file_test.cpp"],
     size = "small",
+    srcs = ["file_test.cpp"],
     tests = [
         "//toolchain/check:testdata",
         "//toolchain/codegen:testdata",

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 file_test(
     name = "file_test",
     srcs = ["file_test.cpp"],
+    size = "small",
     tests = [
         "//toolchain/check:testdata",
         "//toolchain/codegen:testdata",

--- a/utils/treesitter/BUILD
+++ b/utils/treesitter/BUILD
@@ -27,6 +27,7 @@ cc_binary(
 
 cc_test(
     name = "explorer_tests",
+    size = "small",
     srcs = ["test_runner.cpp"],
     args = ["$(locations //explorer:treesitter_testdata)"],
     data = ["//explorer:treesitter_testdata"],
@@ -50,6 +51,7 @@ filegroup(
 
 cc_test(
     name = "string_tests",
+    size = "small",
     srcs = ["test_runner.cpp"],
     args = ["$(locations :string_testdata)"],
     data = [":string_testdata"],
@@ -60,6 +62,7 @@ cc_test(
 
 cc_test(
     name = "string_fail_tests",
+    size = "small",
     srcs = ["test_runner.cpp"],
     args = ["$(locations :string_fail_testdata)"],
     data = [":string_fail_testdata"],


### PR DESCRIPTION
Running `bazel test //...` reported:

```
Test execution time outside of range for MODERATE tests.
Consider setting timeout="short" or size="small".
```

This change adds size="small" to avoid such warnings being reported.
