### PR TITLE
Fix missing include for ids.h

### DIFF
--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "ids",
     hdrs = ["ids.h"],
     deps = [
+        "//common:check",
         "//common:ostream",
         "//toolchain/base:index_base",
         "//toolchain/sem_ir:builtin_kind",

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "common/check.h"
 #include "common/ostream.h"
 #include "toolchain/base/index_base.h"
 #include "toolchain/sem_ir/builtin_kind.h"


### PR DESCRIPTION
I think this is only noticeable in a more modular build, but we try to keep that working.