### PR TITLE
Refactor SemIR YAML printing to use dashed lists.

### DIFF
--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -41,6 +41,8 @@ cc_test(
     deps = [
         ":value_store",
         "//testing/base:gtest_main",
+        "//testing/base:test_raw_ostream",
+        "//toolchain/testing:yaml_test_helpers",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/toolchain/check/testdata/basics/builtin_nodes.carbon
+++ b/toolchain/check/testdata/basics/builtin_nodes.carbon
@@ -9,25 +9,18 @@
 // CHECK:STDOUT: - filename: builtin_nodes.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeTypeType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeError, type: typeError},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeBoolType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeIntegerType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeFloatingPointType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeStringType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeFunctionType, type: typeTypeType},
-// CHECK:STDOUT:       {kind: CrossReference, arg0: ir0, arg1: nodeNamespaceType, type: typeTypeType},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions: []
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types: []
+// CHECK:STDOUT:     type_blocks: []
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeTypeType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeError, type: typeError}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeBoolType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeIntegerType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeFloatingPointType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeStringType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeFunctionType, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: CrossReference, arg0: ir0, arg1: nodeNamespaceType, type: typeTypeType}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -17,30 +17,19 @@ fn B() {}
 // CHECK:STDOUT: - filename: a.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
-// CHECK:STDOUT:       {kind: Return},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type_blocks: []
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type0}
+// CHECK:STDOUT:       - {kind: Return}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+1
+// CHECK:STDOUT:       - - node+0
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "a.carbon" {
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
@@ -53,30 +42,19 @@ fn B() {}
 // CHECK:STDOUT: - filename: b.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str1, param_refs: block0, body: [block1]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
-// CHECK:STDOUT:       {kind: Return},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str1, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type_blocks: []
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type0}
+// CHECK:STDOUT:       - {kind: Return}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+1
+// CHECK:STDOUT:       - - node+0
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "b.carbon" {
 // CHECK:STDOUT:   %B: <function> = fn_decl @B

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -17,54 +17,32 @@ fn B() {}
 // CHECK:STDOUT: - filename: a.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block0, body: [block1]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
-// CHECK:STDOUT:       {kind: Return},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type_blocks: []
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type0}
+// CHECK:STDOUT:       - {kind: Return}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+1
+// CHECK:STDOUT:       - - node+0
 // CHECK:STDOUT: - filename: b.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str1, param_refs: block0, body: [block1]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type0},
-// CHECK:STDOUT:       {kind: Return},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str1, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type_blocks: []
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type0}
+// CHECK:STDOUT:       - {kind: Return}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+1
+// CHECK:STDOUT:       - - node+0

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -15,92 +15,67 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: - filename: raw_and_textual_ir.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeIntegerType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:       {node: node+1, value_rep: {kind: unknown, type: type<invalid>}},
-// CHECK:STDOUT:       {node: nodeFloatingPointType, value_rep: {kind: copy, type: type2}},
-// CHECK:STDOUT:       {node: node+3, value_rep: {kind: pointer, type: type4}},
-// CHECK:STDOUT:       {node: node+5, value_rep: {kind: copy, type: type4}},
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type5}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         typeTypeType,
-// CHECK:STDOUT:         typeTypeType,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         type0,
-// CHECK:STDOUT:         type2,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: Parameter, arg0: str1, type: type0},
-// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
-// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block2, type: type1},
-// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
-// CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:       {kind: PointerType, arg0: type3, type: typeTypeType},
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type5},
-// CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
-// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int3, type: type0},
-// CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0},
-// CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
-// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block5, type: type3},
-// CHECK:STDOUT:       {kind: TupleAccess, arg0: node+4, arg1: member0, type: type0},
-// CHECK:STDOUT:       {kind: InitializeFrom, arg0: node+9, arg1: node+12, type: type0},
-// CHECK:STDOUT:       {kind: TupleAccess, arg0: node+4, arg1: member1, type: type2},
-// CHECK:STDOUT:       {kind: InitializeFrom, arg0: node+10, arg1: node+14, type: type2},
-// CHECK:STDOUT:       {kind: TupleInit, arg0: node+11, arg1: block6, type: type3},
-// CHECK:STDOUT:       {kind: ReturnExpression, arg0: node+16},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         nodeIntegerType,
-// CHECK:STDOUT:         nodeFloatingPointType,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:         node+2,
-// CHECK:STDOUT:         node+3,
-// CHECK:STDOUT:         node+4,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+7,
-// CHECK:STDOUT:         node+8,
-// CHECK:STDOUT:         node+9,
-// CHECK:STDOUT:         node+10,
-// CHECK:STDOUT:         node+11,
-// CHECK:STDOUT:         node+12,
-// CHECK:STDOUT:         node+13,
-// CHECK:STDOUT:         node+14,
-// CHECK:STDOUT:         node+15,
-// CHECK:STDOUT:         node+16,
-// CHECK:STDOUT:         node+17,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+9,
-// CHECK:STDOUT:         node+10,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+13,
-// CHECK:STDOUT:         node+15,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+5,
-// CHECK:STDOUT:         node+6,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeIntegerType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:       - {node: node+1, value_rep: {kind: unknown, type: type<invalid>}}
+// CHECK:STDOUT:       - {node: nodeFloatingPointType, value_rep: {kind: copy, type: type2}}
+// CHECK:STDOUT:       - {node: node+3, value_rep: {kind: pointer, type: type4}}
+// CHECK:STDOUT:       - {node: node+5, value_rep: {kind: copy, type: type4}}
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type_blocks:
+// CHECK:STDOUT:       - - typeTypeType
+// CHECK:STDOUT:         - typeTypeType
+// CHECK:STDOUT:       - - type0
+// CHECK:STDOUT:         - type2
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: Parameter, arg0: str1, type: type0}
+// CHECK:STDOUT:       - {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: TupleLiteral, arg0: block2, type: type1}
+// CHECK:STDOUT:       - {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: VarStorage, arg0: str2, type: type3}
+// CHECK:STDOUT:       - {kind: PointerType, arg0: type3, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type5}
+// CHECK:STDOUT:       - {kind: NameReference, arg0: str1, arg1: node+0, type: type0}
+// CHECK:STDOUT:       - {kind: IntegerLiteral, arg0: int3, type: type0}
+// CHECK:STDOUT:       - {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0}
+// CHECK:STDOUT:       - {kind: RealLiteral, arg0: real0, type: type2}
+// CHECK:STDOUT:       - {kind: TupleLiteral, arg0: block5, type: type3}
+// CHECK:STDOUT:       - {kind: TupleAccess, arg0: node+4, arg1: member0, type: type0}
+// CHECK:STDOUT:       - {kind: InitializeFrom, arg0: node+9, arg1: node+12, type: type0}
+// CHECK:STDOUT:       - {kind: TupleAccess, arg0: node+4, arg1: member1, type: type2}
+// CHECK:STDOUT:       - {kind: InitializeFrom, arg0: node+10, arg1: node+14, type: type2}
+// CHECK:STDOUT:       - {kind: TupleInit, arg0: node+11, arg1: block6, type: type3}
+// CHECK:STDOUT:       - {kind: ReturnExpression, arg0: node+16}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+0
+// CHECK:STDOUT:       - - nodeIntegerType
+// CHECK:STDOUT:         - nodeFloatingPointType
+// CHECK:STDOUT:       - - node+0
+// CHECK:STDOUT:         - node+1
+// CHECK:STDOUT:         - node+2
+// CHECK:STDOUT:         - node+3
+// CHECK:STDOUT:         - node+4
+// CHECK:STDOUT:       - - node+7
+// CHECK:STDOUT:         - node+8
+// CHECK:STDOUT:         - node+9
+// CHECK:STDOUT:         - node+10
+// CHECK:STDOUT:         - node+11
+// CHECK:STDOUT:         - node+12
+// CHECK:STDOUT:         - node+13
+// CHECK:STDOUT:         - node+14
+// CHECK:STDOUT:         - node+15
+// CHECK:STDOUT:         - node+16
+// CHECK:STDOUT:         - node+17
+// CHECK:STDOUT:       - - node+9
+// CHECK:STDOUT:         - node+10
+// CHECK:STDOUT:       - - node+13
+// CHECK:STDOUT:         - node+15
+// CHECK:STDOUT:       - - node+5
+// CHECK:STDOUT:         - node+6
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
 // CHECK:STDOUT:   %.loc11: type = ptr_type (i32, f64)

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -15,89 +15,64 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: - filename: raw_ir.carbon
 // CHECK:STDOUT:   sem_ir:
 // CHECK:STDOUT:   - cross_reference_irs_size: 1
-// CHECK:STDOUT:     functions: [
-// CHECK:STDOUT:       {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     classes: [
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     types: [
-// CHECK:STDOUT:       {node: nodeIntegerType, value_rep: {kind: copy, type: type0}},
-// CHECK:STDOUT:       {node: node+1, value_rep: {kind: unknown, type: type<invalid>}},
-// CHECK:STDOUT:       {node: nodeFloatingPointType, value_rep: {kind: copy, type: type2}},
-// CHECK:STDOUT:       {node: node+3, value_rep: {kind: pointer, type: type4}},
-// CHECK:STDOUT:       {node: node+5, value_rep: {kind: copy, type: type4}},
-// CHECK:STDOUT:       {node: nodeFunctionType, value_rep: {kind: copy, type: type5}},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     type_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         typeTypeType,
-// CHECK:STDOUT:         typeTypeType,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         type0,
-// CHECK:STDOUT:         type2,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     nodes: [
-// CHECK:STDOUT:       {kind: Parameter, arg0: str1, type: type0},
-// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock0, type: typeTypeType},
-// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block2, type: type1},
-// CHECK:STDOUT:       {kind: TupleType, arg0: typeBlock1, type: typeTypeType},
-// CHECK:STDOUT:       {kind: VarStorage, arg0: str2, type: type3},
-// CHECK:STDOUT:       {kind: PointerType, arg0: type3, type: typeTypeType},
-// CHECK:STDOUT:       {kind: FunctionDeclaration, arg0: function0, type: type5},
-// CHECK:STDOUT:       {kind: NameReference, arg0: str1, arg1: node+0, type: type0},
-// CHECK:STDOUT:       {kind: IntegerLiteral, arg0: int3, type: type0},
-// CHECK:STDOUT:       {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0},
-// CHECK:STDOUT:       {kind: RealLiteral, arg0: real0, type: type2},
-// CHECK:STDOUT:       {kind: TupleLiteral, arg0: block5, type: type3},
-// CHECK:STDOUT:       {kind: TupleAccess, arg0: node+4, arg1: member0, type: type0},
-// CHECK:STDOUT:       {kind: InitializeFrom, arg0: node+9, arg1: node+12, type: type0},
-// CHECK:STDOUT:       {kind: TupleAccess, arg0: node+4, arg1: member1, type: type2},
-// CHECK:STDOUT:       {kind: InitializeFrom, arg0: node+10, arg1: node+14, type: type2},
-// CHECK:STDOUT:       {kind: TupleInit, arg0: node+11, arg1: block6, type: type3},
-// CHECK:STDOUT:       {kind: ReturnExpression, arg0: node+16},
-// CHECK:STDOUT:     ]
-// CHECK:STDOUT:     node_blocks: [
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         nodeIntegerType,
-// CHECK:STDOUT:         nodeFloatingPointType,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+0,
-// CHECK:STDOUT:         node+1,
-// CHECK:STDOUT:         node+2,
-// CHECK:STDOUT:         node+3,
-// CHECK:STDOUT:         node+4,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+7,
-// CHECK:STDOUT:         node+8,
-// CHECK:STDOUT:         node+9,
-// CHECK:STDOUT:         node+10,
-// CHECK:STDOUT:         node+11,
-// CHECK:STDOUT:         node+12,
-// CHECK:STDOUT:         node+13,
-// CHECK:STDOUT:         node+14,
-// CHECK:STDOUT:         node+15,
-// CHECK:STDOUT:         node+16,
-// CHECK:STDOUT:         node+17,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+9,
-// CHECK:STDOUT:         node+10,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+13,
-// CHECK:STDOUT:         node+15,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:       [
-// CHECK:STDOUT:         node+5,
-// CHECK:STDOUT:         node+6,
-// CHECK:STDOUT:       ],
-// CHECK:STDOUT:     ]
+// CHECK:STDOUT:     functions:
+// CHECK:STDOUT:       - {name: str0, param_refs: block1, return_type: type3, return_slot: node+4, body: [block4]}
+// CHECK:STDOUT:     classes: []
+// CHECK:STDOUT:     types:
+// CHECK:STDOUT:       - {node: nodeIntegerType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:       - {node: node+1, value_rep: {kind: unknown, type: type<invalid>}}
+// CHECK:STDOUT:       - {node: nodeFloatingPointType, value_rep: {kind: copy, type: type2}}
+// CHECK:STDOUT:       - {node: node+3, value_rep: {kind: pointer, type: type4}}
+// CHECK:STDOUT:       - {node: node+5, value_rep: {kind: copy, type: type4}}
+// CHECK:STDOUT:       - {node: nodeFunctionType, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type_blocks:
+// CHECK:STDOUT:       - - typeTypeType
+// CHECK:STDOUT:         - typeTypeType
+// CHECK:STDOUT:       - - type0
+// CHECK:STDOUT:         - type2
+// CHECK:STDOUT:     nodes:
+// CHECK:STDOUT:       - {kind: Parameter, arg0: str1, type: type0}
+// CHECK:STDOUT:       - {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: TupleLiteral, arg0: block2, type: type1}
+// CHECK:STDOUT:       - {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: VarStorage, arg0: str2, type: type3}
+// CHECK:STDOUT:       - {kind: PointerType, arg0: type3, type: typeTypeType}
+// CHECK:STDOUT:       - {kind: FunctionDeclaration, arg0: function0, type: type5}
+// CHECK:STDOUT:       - {kind: NameReference, arg0: str1, arg1: node+0, type: type0}
+// CHECK:STDOUT:       - {kind: IntegerLiteral, arg0: int3, type: type0}
+// CHECK:STDOUT:       - {kind: BinaryOperatorAdd, arg0: node+7, arg1: node+8, type: type0}
+// CHECK:STDOUT:       - {kind: RealLiteral, arg0: real0, type: type2}
+// CHECK:STDOUT:       - {kind: TupleLiteral, arg0: block5, type: type3}
+// CHECK:STDOUT:       - {kind: TupleAccess, arg0: node+4, arg1: member0, type: type0}
+// CHECK:STDOUT:       - {kind: InitializeFrom, arg0: node+9, arg1: node+12, type: type0}
+// CHECK:STDOUT:       - {kind: TupleAccess, arg0: node+4, arg1: member1, type: type2}
+// CHECK:STDOUT:       - {kind: InitializeFrom, arg0: node+10, arg1: node+14, type: type2}
+// CHECK:STDOUT:       - {kind: TupleInit, arg0: node+11, arg1: block6, type: type3}
+// CHECK:STDOUT:       - {kind: ReturnExpression, arg0: node+16}
+// CHECK:STDOUT:     node_blocks:
+// CHECK:STDOUT:       - []
+// CHECK:STDOUT:       - - node+0
+// CHECK:STDOUT:       - - nodeIntegerType
+// CHECK:STDOUT:         - nodeFloatingPointType
+// CHECK:STDOUT:       - - node+0
+// CHECK:STDOUT:         - node+1
+// CHECK:STDOUT:         - node+2
+// CHECK:STDOUT:         - node+3
+// CHECK:STDOUT:         - node+4
+// CHECK:STDOUT:       - - node+7
+// CHECK:STDOUT:         - node+8
+// CHECK:STDOUT:         - node+9
+// CHECK:STDOUT:         - node+10
+// CHECK:STDOUT:         - node+11
+// CHECK:STDOUT:         - node+12
+// CHECK:STDOUT:         - node+13
+// CHECK:STDOUT:         - node+14
+// CHECK:STDOUT:         - node+15
+// CHECK:STDOUT:         - node+16
+// CHECK:STDOUT:         - node+17
+// CHECK:STDOUT:       - - node+9
+// CHECK:STDOUT:         - node+10
+// CHECK:STDOUT:       - - node+13
+// CHECK:STDOUT:         - node+15
+// CHECK:STDOUT:       - - node+5
+// CHECK:STDOUT:         - node+6

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -6,15 +6,35 @@
 //
 // AUTOUPDATE
 
-var a: f64 = 1.0;
-var b: String = "ab\"c";
+// The value 8 is significant because it can show as negative due to APInt.
+var int1: i32 = 1;
+var int2: i32 = 8;
+var real1: f64 = 1.0;
+var real2: f64 = 0.8e8;
+var real3: f64 = 0.8e9;
+var str1: String = "abc";
+var str2: String = "ab'\"c";
 
 // CHECK:STDOUT: shared_values:
 // CHECK:STDOUT:   - integers:
+// CHECK:STDOUT:       - 32
+// CHECK:STDOUT:       - 1
+// CHECK:STDOUT:       - 32
+// CHECK:STDOUT:       - 8
 // CHECK:STDOUT:       - 64
-// CHECK:STDOUT:   - reals:
+// CHECK:STDOUT:       - 64
+// CHECK:STDOUT:       - 64
+// CHECK:STDOUT:     reals:
 // CHECK:STDOUT:       - 10*10^-1
-// CHECK:STDOUT:   - strings:
-// CHECK:STDOUT:       - "a"
-// CHECK:STDOUT:       - "b"
-// CHECK:STDOUT:       - "ab\"c"
+// CHECK:STDOUT:       - 8*10^7
+// CHECK:STDOUT:       - 8*10^8
+// CHECK:STDOUT:     strings:
+// CHECK:STDOUT:       - "int1"
+// CHECK:STDOUT:       - "int2"
+// CHECK:STDOUT:       - "real1"
+// CHECK:STDOUT:       - "real2"
+// CHECK:STDOUT:       - "real3"
+// CHECK:STDOUT:       - "str1"
+// CHECK:STDOUT:       - "abc"
+// CHECK:STDOUT:       - "str2"
+// CHECK:STDOUT:       - "ab'\"c"

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -88,6 +88,20 @@ class BlockValueStore {
   // Returns the requested block.
   auto Get(IdT id) -> llvm::MutableArrayRef<ValueT> { return values_.Get(id); }
 
+  auto Print(llvm::raw_ostream& out) const -> void {
+    Print(out, std::nullopt, 0, 0);
+  }
+  auto Print(llvm::raw_ostream& out, std::optional<llvm::StringRef> label,
+             int first_line_indent, int later_indent) const -> void {
+    values_.Print(out, label, first_line_indent, later_indent,
+                  [&](llvm::raw_ostream& out,
+                      const llvm::MutableArrayRef<ValueT>& value) {
+                    PrintValueRange<ValueT>(out, llvm::iterator_range(value),
+                                            std::nullopt, 0, later_indent + 2,
+                                            /*trailing_newline=*/false);
+                  });
+  }
+
   auto size() const -> int { return values_.size(); }
 
  protected:


### PR DESCRIPTION
This standardizes on having ValueStore and related structures provide printing, removing the handlers in file.cpp.

The `[]` is provided for empty sequences versus if there was simply nothing, in which case it would be a sequence when non-empty, and a null value when empty. Consistently (and explicitly) providing sequences feels easier to understand.

The changes to the output yaml are overall more terse. My hope is that this is an improvement for most readers.

Also fixes printing of APInt, defaulting to unsigned for consistency with Carbon's use.