### PR TITLE
Make SemIR::File access more terse.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -16,15 +16,13 @@ auto CheckParseTree(SharedValueStores& value_stores,
                     const Lex::TokenizedBuffer& tokens,
                     const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
                     llvm::raw_ostream* vlog_stream) -> SemIR::File {
-  auto semantics_ir =
-      SemIR::File(value_stores, tokens.filename().str(), &builtin_ir);
+  auto sem_ir = SemIR::File(value_stores, tokens.filename().str(), &builtin_ir);
 
   Parse::NodeLocationTranslator translator(&tokens, &parse_tree);
   ErrorTrackingDiagnosticConsumer err_tracker(consumer);
   DiagnosticEmitter<Parse::Node> emitter(translator, err_tracker);
 
-  Check::Context context(tokens, emitter, parse_tree, semantics_ir,
-                         vlog_stream);
+  Check::Context context(tokens, emitter, parse_tree, sem_ir, vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -43,8 +41,8 @@ auto CheckParseTree(SharedValueStores& value_stores,
     if (!Check::Handle##Name(context, parse_node)) {                         \
       CARBON_CHECK(err_tracker.seen_error())                                 \
           << "Handle" #Name " returned false without printing a diagnostic"; \
-      semantics_ir.set_has_errors(true);                                     \
-      return semantics_ir;                                                   \
+      sem_ir.set_has_errors(true);                                           \
+      return sem_ir;                                                         \
     }                                                                        \
     break;                                                                   \
   }
@@ -53,21 +51,21 @@ auto CheckParseTree(SharedValueStores& value_stores,
   }
 
   // Pop information for the file-level scope.
-  semantics_ir.set_top_node_block_id(context.node_block_stack().Pop());
+  sem_ir.set_top_node_block_id(context.node_block_stack().Pop());
   context.PopScope();
 
   context.VerifyOnFinish();
 
-  semantics_ir.set_has_errors(err_tracker.seen_error());
+  sem_ir.set_has_errors(err_tracker.seen_error());
 
 #ifndef NDEBUG
-  if (auto verify = semantics_ir.Verify(); !verify.ok()) {
-    CARBON_FATAL() << semantics_ir
-                   << "Built invalid semantics IR: " << verify.error() << "\n";
+  if (auto verify = sem_ir.Verify(); !verify.ok()) {
+    CARBON_FATAL() << sem_ir << "Built invalid semantics IR: " << verify.error()
+                   << "\n";
   }
 #endif
 
-  return semantics_ir;
+  return sem_ir;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -202,7 +202,7 @@ class Context {
 
   auto parse_tree() -> const Parse::Tree& { return *parse_tree_; }
 
-  auto semantics_ir() -> SemIR::File& { return *semantics_ir_; }
+  auto sem_ir() -> SemIR::File& { return *sem_ir_; }
 
   auto node_stack() -> NodeStack& { return node_stack_; }
 
@@ -222,6 +222,31 @@ class Context {
 
   auto declaration_name_stack() -> DeclarationNameStack& {
     return declaration_name_stack_;
+  }
+
+  // Directly expose SemIR::File data accessors for brevity in calls.
+  auto integers() -> ValueStore<IntegerId>& { return sem_ir().integers(); }
+  auto reals() -> ValueStore<RealId>& { return sem_ir().reals(); }
+  auto strings() -> ValueStore<StringId>& { return sem_ir().strings(); }
+  auto functions() -> ValueStore<SemIR::FunctionId, SemIR::Function>& {
+    return sem_ir().functions();
+  }
+  auto classes() -> ValueStore<SemIR::ClassId, SemIR::Class>& {
+    return sem_ir().classes();
+  }
+  auto name_scopes() -> SemIR::NameScopeStore& {
+    return sem_ir().name_scopes();
+  }
+  auto types() -> ValueStore<SemIR::TypeId, SemIR::TypeInfo>& {
+    return sem_ir().types();
+  }
+  auto type_blocks()
+      -> SemIR::BlockValueStore<SemIR::TypeBlockId, SemIR::TypeId>& {
+    return sem_ir().type_blocks();
+  }
+  auto nodes() -> SemIR::NodeStore& { return sem_ir().nodes(); }
+  auto node_blocks() -> SemIR::NodeBlockStore& {
+    return sem_ir().node_blocks();
   }
 
  private:
@@ -283,7 +308,7 @@ class Context {
   const Parse::Tree* parse_tree_;
 
   // The SemIR::File being added to.
-  SemIR::File* semantics_ir_;
+  SemIR::File* sem_ir_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -34,10 +34,9 @@ auto HandleArrayExpression(Context& context, Parse::Node parse_node) -> bool {
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::ArrayExpressionSemi>();
   auto element_type_node_id = context.node_stack().PopExpression();
-  auto bound_node = context.semantics_ir().nodes().Get(bound_node_id);
+  auto bound_node = context.nodes().Get(bound_node_id);
   if (auto literal = bound_node.TryAs<SemIR::IntegerLiteral>()) {
-    const auto& bound_value =
-        context.semantics_ir().integers().Get(literal->integer_id);
+    const auto& bound_value = context.integers().Get(literal->integer_id);
     // TODO: Produce an error if the array type is too large.
     if (bound_value.getActiveBits() <= 64) {
       context.AddNodeAndPush(

--- a/toolchain/check/handle_call_expression.cpp
+++ b/toolchain/check/handle_call_expression.cpp
@@ -17,8 +17,8 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   auto [call_expr_parse_node, callee_id] =
       context.node_stack()
           .PopWithParseNode<Parse::NodeKind::CallExpressionStart>();
-  auto callee_node = context.semantics_ir().nodes().Get(
-      context.FollowNameReferences(callee_id));
+  auto callee_node =
+      context.nodes().Get(context.FollowNameReferences(callee_id));
   auto function_name = callee_node.TryAs<SemIR::FunctionDeclaration>();
   if (!function_name) {
     // TODO: Work on error.
@@ -29,7 +29,7 @@ auto HandleCallExpression(Context& context, Parse::Node parse_node) -> bool {
   }
 
   auto function_id = function_name->function_id;
-  const auto& callable = context.semantics_ir().functions().Get(function_id);
+  const auto& callable = context.functions().Get(function_id);
 
   // For functions with an implicit return type, the return type is the empty
   // tuple type.

--- a/toolchain/check/handle_if_expression.cpp
+++ b/toolchain/check/handle_if_expression.cpp
@@ -57,8 +57,7 @@ auto HandleIfExpressionElse(Context& context, Parse::Node parse_node) -> bool {
   // Convert the `else` value to the `then` value's type, and finish the `else`
   // block.
   // TODO: Find a common type, and convert both operands to it instead.
-  auto result_type_id =
-      context.semantics_ir().nodes().Get(then_value_id).type_id();
+  auto result_type_id = context.nodes().Get(then_value_id).type_id();
   else_value_id =
       ConvertToValueOfType(context, else_node, else_value_id, result_type_id);
 

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -16,7 +16,7 @@ auto HandleLetDeclaration(Context& context, Parse::Node parse_node) -> bool {
       .PopAndDiscardSoloParseNode<Parse::NodeKind::LetIntroducer>();
 
   // Convert the value to match the type of the pattern.
-  auto pattern = context.semantics_ir().nodes().Get(pattern_id);
+  auto pattern = context.nodes().Get(pattern_id);
   value_id =
       ConvertToValueOfType(context, parse_node, value_id, pattern.type_id());
 
@@ -27,7 +27,7 @@ auto HandleLetDeclaration(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(!bind_name.value_id.is_valid())
       << "Binding should not already have a value!";
   bind_name.value_id = value_id;
-  context.semantics_ir().nodes().Set(pattern_id, bind_name);
+  context.nodes().Set(pattern_id, bind_name);
   context.node_block_stack().AddNodeId(pattern_id);
 
   // Add the name of the binding to the current scope.

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -17,7 +17,7 @@ auto HandleNamespace(Context& context, Parse::Node parse_node) -> bool {
   auto name_context = context.declaration_name_stack().Pop();
   auto namespace_id = context.AddNode(SemIR::Namespace{
       parse_node, context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
-      context.semantics_ir().name_scopes().Add()});
+      context.name_scopes().Add()});
   context.declaration_name_stack().AddNameToLookup(name_context, namespace_id);
   return true;
 }

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -40,11 +40,11 @@ auto HandleTupleLiteral(Context& context, Parse::Node parse_node) -> bool {
   context.node_stack()
       .PopAndDiscardSoloParseNode<
           Parse::NodeKind::ParenExpressionOrTupleLiteralStart>();
-  const auto& node_block = context.semantics_ir().node_blocks().Get(refs_id);
+  const auto& node_block = context.node_blocks().Get(refs_id);
   llvm::SmallVector<SemIR::TypeId> type_ids;
   type_ids.reserve(node_block.size());
   for (auto node : node_block) {
-    type_ids.push_back(context.semantics_ir().nodes().Get(node).type_id());
+    type_ids.push_back(context.nodes().Get(node).type_id());
   }
   auto type_id = context.CanonicalizeTupleType(parse_node, std::move(type_ids));
 

--- a/toolchain/check/handle_pattern_binding.cpp
+++ b/toolchain/check/handle_pattern_binding.cpp
@@ -39,7 +39,7 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
                               std::string);
             return context.emitter().Build(
                 type_node_copy, IncompleteTypeInVarDeclaration,
-                context.semantics_ir().StringifyType(cast_type_id, true));
+                context.sem_ir().StringifyType(cast_type_id, true));
           })) {
         cast_type_id = SemIR::TypeId::Error;
       }
@@ -61,7 +61,7 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
                               std::string);
             return context.emitter().Build(
                 type_node_copy, IncompleteTypeInLetDeclaration,
-                context.semantics_ir().StringifyType(cast_type_id, true));
+                context.sem_ir().StringifyType(cast_type_id, true));
           })) {
         cast_type_id = SemIR::TypeId::Error;
       }
@@ -71,7 +71,7 @@ auto HandlePatternBinding(Context& context, Parse::Node parse_node) -> bool {
       // the `let` pattern before we see the initializer.
       context.node_stack().Push(
           parse_node,
-          context.semantics_ir().nodes().AddInNoBlock(SemIR::BindName{
+          context.nodes().AddInNoBlock(SemIR::BindName{
               name_node, cast_type_id, name_id, SemIR::NodeId::Invalid}));
       break;
 

--- a/toolchain/check/handle_statement.cpp
+++ b/toolchain/check/handle_statement.cpp
@@ -14,7 +14,7 @@ static auto HandleDiscardedExpression(Context& context, SemIR::NodeId expr_id)
     -> void {
   // If we discard an initializing expression, convert it to a value or
   // reference so that it has something to initialize.
-  auto expr = context.semantics_ir().nodes().Get(expr_id);
+  auto expr = context.nodes().Get(expr_id);
   Convert(context, expr.parse_node(), expr_id,
           {.kind = ConversionTarget::Discarded, .type_id = expr.type_id()});
 
@@ -29,11 +29,9 @@ auto HandleExpressionStatement(Context& context, Parse::Node /*parse_node*/)
 
 auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
   CARBON_CHECK(!context.return_scope_stack().empty());
-  auto fn_node =
-      context.semantics_ir().nodes().GetAs<SemIR::FunctionDeclaration>(
-          context.return_scope_stack().back());
-  const auto& callable =
-      context.semantics_ir().functions().Get(fn_node.function_id);
+  auto fn_node = context.nodes().GetAs<SemIR::FunctionDeclaration>(
+      context.return_scope_stack().back());
+  const auto& callable = context.functions().Get(fn_node.function_id);
 
   if (context.parse_tree().node_kind(context.node_stack().PeekParseNode()) ==
       Parse::NodeKind::ReturnStatementStart) {
@@ -46,7 +44,7 @@ auto HandleReturnStatement(Context& context, Parse::Node parse_node) -> bool {
                         "Must return a {0}.", std::string);
       context.emitter()
           .Build(parse_node, ReturnStatementMissingExpression,
-                 context.semantics_ir().StringifyType(callable.return_type_id))
+                 context.sem_ir().StringifyType(callable.return_type_id))
           .Emit();
     }
 

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -45,8 +45,7 @@ auto HandleStructFieldValue(Context& context, Parse::Node parse_node) -> bool {
 
   // Store the name for the type.
   context.args_type_info_stack().AddNode(SemIR::StructTypeField{
-      parse_node, name_id,
-      context.semantics_ir().nodes().Get(value_node_id).type_id()});
+      parse_node, name_id, context.nodes().Get(value_node_id).type_id()});
 
   // Push the value back on the stack as an argument.
   context.node_stack().Push(parse_node, value_node_id);

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -24,7 +24,7 @@ auto HandleVariableDeclaration(Context& context, Parse::Node parse_node)
   // Extract the name binding.
   SemIR::NodeId var_id =
       context.node_stack().Pop<Parse::NodeKind::PatternBinding>();
-  auto var = context.semantics_ir().nodes().GetAs<SemIR::VarStorage>(var_id);
+  auto var = context.nodes().GetAs<SemIR::VarStorage>(var_id);
 
   // Form a corresponding name in the current context, and bind the name to the
   // variable.

--- a/toolchain/check/node_block_stack.cpp
+++ b/toolchain/check/node_block_stack.cpp
@@ -27,7 +27,7 @@ auto NodeBlockStack::PeekOrAdd(int depth) -> SemIR::NodeBlockId {
   int index = size() - depth - 1;
   auto& slot = stack_[index];
   if (!slot.id.is_valid()) {
-    slot.id = semantics_ir_->node_blocks().AddDefaultValue();
+    slot.id = sem_ir_->node_blocks().AddDefaultValue();
   }
   return slot.id;
 }
@@ -40,9 +40,9 @@ auto NodeBlockStack::Pop() -> SemIR::NodeBlockId {
   // Finalize the block.
   if (!back.content.empty() && back.id != SemIR::NodeBlockId::Unreachable) {
     if (back.id.is_valid()) {
-      semantics_ir_->node_blocks().Set(back.id, back.content);
+      sem_ir_->node_blocks().Set(back.id, back.content);
     } else {
-      back.id = semantics_ir_->node_blocks().Add(back.content);
+      back.id = sem_ir_->node_blocks().Add(back.content);
     }
   }
 

--- a/toolchain/check/node_block_stack.h
+++ b/toolchain/check/node_block_stack.h
@@ -19,9 +19,9 @@ namespace Carbon::Check {
 // All pushes and pops will be vlogged.
 class NodeBlockStack {
  public:
-  explicit NodeBlockStack(llvm::StringLiteral name, SemIR::File& semantics_ir,
+  explicit NodeBlockStack(llvm::StringLiteral name, SemIR::File& sem_ir,
                           llvm::raw_ostream* vlog_stream)
-      : name_(name), semantics_ir_(&semantics_ir), vlog_stream_(vlog_stream) {}
+      : name_(name), sem_ir_(&sem_ir), vlog_stream_(vlog_stream) {}
 
   // Pushes an existing node block.
   auto Push(SemIR::NodeBlockId id) -> void;
@@ -48,7 +48,7 @@ class NodeBlockStack {
   // Adds the given node to the block at the top of the stack and returns its
   // ID.
   auto AddNode(SemIR::Node node) -> SemIR::NodeId {
-    auto node_id = semantics_ir_->nodes().AddInNoBlock(node);
+    auto node_id = sem_ir_->nodes().AddInNoBlock(node);
     AddNodeId(node_id);
     return node_id;
   }
@@ -102,7 +102,7 @@ class NodeBlockStack {
   llvm::StringLiteral name_;
 
   // The underlying SemIR::File instance. Always non-null.
-  SemIR::File* semantics_ir_;
+  SemIR::File* sem_ir_;
 
   // Whether to print verbose output.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -40,7 +40,7 @@ class PendingBlock {
   };
 
   auto AddNode(SemIR::Node node) -> SemIR::NodeId {
-    auto node_id = context_.semantics_ir().nodes().AddInNoBlock(node);
+    auto node_id = context_.nodes().AddInNoBlock(node);
     nodes_.push_back(node_id);
     return node_id;
   }
@@ -56,27 +56,26 @@ class PendingBlock {
   // Replace the node at target_id with the nodes in this block. The new value
   // for target_id should be value_id.
   auto MergeReplacing(SemIR::NodeId target_id, SemIR::NodeId value_id) -> void {
-    auto value = context_.semantics_ir().nodes().Get(value_id);
+    auto value = context_.nodes().Get(value_id);
 
     // There are three cases here:
 
     if (nodes_.empty()) {
       // 1) The block is empty. Replace `target_id` with an empty splice
       // pointing at `value_id`.
-      context_.semantics_ir().nodes().Set(
+      context_.nodes().Set(
           target_id, SemIR::SpliceBlock{value.parse_node(), value.type_id(),
                                         SemIR::NodeBlockId::Empty, value_id});
     } else if (nodes_.size() == 1 && nodes_[0] == value_id) {
       // 2) The block is {value_id}. Replace `target_id` with the node referred
       // to by `value_id`. This is intended to be the common case.
-      context_.semantics_ir().nodes().Set(target_id, value);
+      context_.nodes().Set(target_id, value);
     } else {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
-      context_.semantics_ir().nodes().Set(
+      context_.nodes().Set(
           target_id,
           SemIR::SpliceBlock{value.parse_node(), value.type_id(),
-                             context_.semantics_ir().node_blocks().Add(nodes_),
-                             value_id});
+                             context_.node_blocks().Add(nodes_), value_id});
     }
 
     // Prepare to stash more pending instructions.

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -17,8 +17,7 @@ namespace Carbon::Lower {
 class FileContext {
  public:
   explicit FileContext(llvm::LLVMContext& llvm_context,
-                       llvm::StringRef module_name,
-                       const SemIR::File& semantics_ir,
+                       llvm::StringRef module_name, const SemIR::File& sem_ir,
                        llvm::raw_ostream* vlog_stream);
 
   // Lowers the SemIR::File to LLVM IR. Should only be called once, and handles
@@ -49,7 +48,7 @@ class FileContext {
 
   auto llvm_context() -> llvm::LLVMContext& { return *llvm_context_; }
   auto llvm_module() -> llvm::Module& { return *llvm_module_; }
-  auto semantics_ir() -> const SemIR::File& { return *semantics_ir_; }
+  auto sem_ir() -> const SemIR::File& { return *sem_ir_; }
 
  private:
   // Builds the declaration for the given function, which should then be cached
@@ -79,7 +78,7 @@ class FileContext {
   std::unique_ptr<llvm::Module> llvm_module_;
 
   // The input SemIR.
-  const SemIR::File* const semantics_ir_;
+  const SemIR::File* const sem_ir_;
 
   // The optional vlog stream.
   llvm::raw_ostream* vlog_stream_;

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -38,8 +38,8 @@ auto FunctionContext::TryToReuseBlock(SemIR::NodeBlockId block_id,
 }
 
 auto FunctionContext::LowerBlock(SemIR::NodeBlockId block_id) -> void {
-  for (const auto& node_id : semantics_ir().node_blocks().Get(block_id)) {
-    auto node = semantics_ir().nodes().Get(node_id);
+  for (const auto& node_id : sem_ir().node_blocks().Get(block_id)) {
+    auto node = sem_ir().nodes().Get(node_id);
     CARBON_VLOG() << "Lowering " << node_id << ": " << node << "\n";
     // clang warns on unhandled enum values; clang-tidy is incorrect here.
     // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
@@ -81,7 +81,7 @@ auto FunctionContext::CreateSyntheticBlock() -> llvm::BasicBlock* {
 auto FunctionContext::FinishInitialization(SemIR::TypeId type_id,
                                            SemIR::NodeId dest_id,
                                            SemIR::NodeId source_id) -> void {
-  switch (SemIR::GetInitializingRepresentation(semantics_ir(), type_id).kind) {
+  switch (SemIR::GetInitializingRepresentation(sem_ir(), type_id).kind) {
     case SemIR::InitializingRepresentation::None:
     case SemIR::InitializingRepresentation::InPlace:
       break;
@@ -93,7 +93,7 @@ auto FunctionContext::FinishInitialization(SemIR::TypeId type_id,
 
 auto FunctionContext::CopyValue(SemIR::TypeId type_id, SemIR::NodeId source_id,
                                 SemIR::NodeId dest_id) -> void {
-  switch (auto rep = SemIR::GetValueRepresentation(semantics_ir(), type_id);
+  switch (auto rep = SemIR::GetValueRepresentation(sem_ir(), type_id);
           rep.kind) {
     case SemIR::ValueRepresentation::Unknown:
       CARBON_FATAL() << "Attempt to copy incomplete type";

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -47,8 +47,8 @@ class FunctionContext {
     }
 
     auto it = locals_.find(node_id);
-    CARBON_CHECK(it != locals_.end()) << "Missing local: " << node_id << " "
-                                      << semantics_ir().nodes().Get(node_id);
+    CARBON_CHECK(it != locals_.end())
+        << "Missing local: " << node_id << " " << sem_ir().nodes().Get(node_id);
     return it->second;
   }
 
@@ -56,7 +56,7 @@ class FunctionContext {
   auto SetLocal(SemIR::NodeId node_id, llvm::Value* value) {
     bool added = locals_.insert({node_id, value}).second;
     CARBON_CHECK(added) << "Duplicate local insert: " << node_id << " "
-                        << semantics_ir().nodes().Get(node_id);
+                        << sem_ir().nodes().Get(node_id);
   }
 
   // Gets a callable's function.
@@ -97,9 +97,7 @@ class FunctionContext {
   }
   auto llvm_module() -> llvm::Module& { return file_context_->llvm_module(); }
   auto builder() -> llvm::IRBuilder<>& { return builder_; }
-  auto semantics_ir() -> const SemIR::File& {
-    return file_context_->semantics_ir();
-  }
+  auto sem_ir() -> const SemIR::File& { return file_context_->sem_ir(); }
 
  private:
   // Emits a value copy for type `type_id` from `source_id` to `dest_id`.

--- a/toolchain/lower/handle_expression_category.cpp
+++ b/toolchain/lower/handle_expression_category.cpp
@@ -9,8 +9,8 @@ namespace Carbon::Lower {
 
 auto HandleBindValue(FunctionContext& context, SemIR::NodeId node_id,
                      SemIR::BindValue node) -> void {
-  switch (auto rep = SemIR::GetValueRepresentation(context.semantics_ir(),
-                                                   node.type_id);
+  switch (auto rep =
+              SemIR::GetValueRepresentation(context.sem_ir(), node.type_id);
           rep.kind) {
     case SemIR::ValueRepresentation::Unknown:
       CARBON_FATAL()
@@ -50,12 +50,11 @@ auto HandleTemporaryStorage(FunctionContext& context, SemIR::NodeId node_id,
 
 auto HandleValueAsReference(FunctionContext& context, SemIR::NodeId node_id,
                             SemIR::ValueAsReference node) -> void {
+  CARBON_CHECK(SemIR::GetExpressionCategory(context.sem_ir(), node.value_id) ==
+               SemIR::ExpressionCategory::Value);
   CARBON_CHECK(
-      SemIR::GetExpressionCategory(context.semantics_ir(), node.value_id) ==
-      SemIR::ExpressionCategory::Value);
-  CARBON_CHECK(
-      SemIR::GetValueRepresentation(context.semantics_ir(), node.type_id)
-          .kind == SemIR::ValueRepresentation::Pointer);
+      SemIR::GetValueRepresentation(context.sem_ir(), node.type_id).kind ==
+      SemIR::ValueRepresentation::Pointer);
   context.SetLocal(node_id, context.GetLocal(node.value_id));
 }
 

--- a/toolchain/lower/lower.cpp
+++ b/toolchain/lower/lower.cpp
@@ -9,10 +9,9 @@
 namespace Carbon::Lower {
 
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
-                 const SemIR::File& semantics_ir,
-                 llvm::raw_ostream* vlog_stream)
+                 const SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module> {
-  FileContext context(llvm_context, module_name, semantics_ir, vlog_stream);
+  FileContext context(llvm_context, module_name, sem_ir, vlog_stream);
   return context.Run();
 }
 

--- a/toolchain/lower/lower.h
+++ b/toolchain/lower/lower.h
@@ -13,8 +13,7 @@ namespace Carbon::Lower {
 
 // Lowers SemIR to LLVM IR.
 auto LowerToLLVM(llvm::LLVMContext& llvm_context, llvm::StringRef module_name,
-                 const SemIR::File& semantics_ir,
-                 llvm::raw_ostream* vlog_stream)
+                 const SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream)
     -> std::unique_ptr<llvm::Module>;
 
 }  // namespace Carbon::Lower

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -223,6 +223,7 @@ class File : public Printable<File> {
   auto integers() const -> const ValueStore<IntegerId>& {
     return value_stores_->integers();
   }
+  auto reals() -> ValueStore<RealId>& { return value_stores_->reals(); }
   auto reals() const -> const ValueStore<RealId>& {
     return value_stores_->reals();
   }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -32,22 +32,21 @@ class NodeNamer {
   static_assert(sizeof(ScopeIndex) == sizeof(FunctionId));
 
   NodeNamer(const Lex::TokenizedBuffer& tokenized_buffer,
-            const Parse::Tree& parse_tree, const File& semantics_ir)
+            const Parse::Tree& parse_tree, const File& sem_ir)
       : tokenized_buffer_(tokenized_buffer),
         parse_tree_(parse_tree),
-        semantics_ir_(semantics_ir) {
-    nodes.resize(semantics_ir.nodes().size());
-    labels.resize(semantics_ir.node_blocks().size());
-    scopes.resize(1 + semantics_ir.functions().size() +
-                  semantics_ir.classes().size());
+        sem_ir_(sem_ir) {
+    nodes.resize(sem_ir.nodes().size());
+    labels.resize(sem_ir.node_blocks().size());
+    scopes.resize(1 + sem_ir.functions().size() + sem_ir.classes().size());
 
     // Build the package scope.
     GetScopeInfo(ScopeIndex::Package).name =
         globals.AddNameUnchecked("package");
-    CollectNamesInBlock(ScopeIndex::Package, semantics_ir.top_node_block_id());
+    CollectNamesInBlock(ScopeIndex::Package, sem_ir.top_node_block_id());
 
     // Build each function scope.
-    for (auto [i, fn] : llvm::enumerate(semantics_ir.functions().array_ref())) {
+    for (auto [i, fn] : llvm::enumerate(sem_ir.functions().array_ref())) {
       auto fn_id = FunctionId(i);
       auto fn_scope = GetScopeFor(fn_id);
       // TODO: Provide a location for the function for use as a
@@ -55,14 +54,13 @@ class NodeNamer {
       auto fn_loc = Parse::Node::Invalid;
       GetScopeInfo(fn_scope).name = globals.AllocateName(
           *this, fn_loc,
-          fn.name_id.is_valid() ? semantics_ir.strings().Get(fn.name_id).str()
-                                : "");
+          fn.name_id.is_valid() ? sem_ir.strings().Get(fn.name_id).str() : "");
       CollectNamesInBlock(fn_scope, fn.param_refs_id);
       if (fn.return_slot_id.is_valid()) {
         nodes[fn.return_slot_id.index] = {
             fn_scope,
             GetScopeInfo(fn_scope).nodes.AllocateName(
-                *this, semantics_ir.nodes().Get(fn.return_slot_id).parse_node(),
+                *this, sem_ir.nodes().Get(fn.return_slot_id).parse_node(),
                 "return")};
       }
       if (!fn.body_block_ids.empty()) {
@@ -77,8 +75,7 @@ class NodeNamer {
     }
 
     // Build each class scope.
-    for (auto [i, class_info] :
-         llvm::enumerate(semantics_ir.classes().array_ref())) {
+    for (auto [i, class_info] : llvm::enumerate(sem_ir.classes().array_ref())) {
       auto class_id = ClassId(i);
       auto class_scope = GetScopeFor(class_id);
       // TODO: Provide a location for the class for use as a
@@ -87,7 +84,7 @@ class NodeNamer {
       GetScopeInfo(class_scope).name = globals.AllocateName(
           *this, class_loc,
           class_info.name_id.is_valid()
-              ? semantics_ir.strings().Get(class_info.name_id).str()
+              ? sem_ir.strings().Get(class_info.name_id).str()
               : "");
       AddBlockLabel(class_scope, class_info.body_block_id, "class", class_loc);
       CollectNamesInBlock(class_scope, class_info.body_block_id);
@@ -101,7 +98,7 @@ class NodeNamer {
 
   // Returns the scope index corresponding to a class.
   auto GetScopeFor(ClassId class_id) -> ScopeIndex {
-    return static_cast<ScopeIndex>(1 + semantics_ir_.functions().size() +
+    return static_cast<ScopeIndex>(1 + sem_ir_.functions().size() +
                                    class_id.index);
   }
 
@@ -288,9 +285,9 @@ class NodeNamer {
     }
 
     if (parse_node == Parse::Node::Invalid) {
-      if (const auto& block = semantics_ir_.node_blocks().Get(block_id);
+      if (const auto& block = sem_ir_.node_blocks().Get(block_id);
           !block.empty()) {
-        parse_node = semantics_ir_.nodes().Get(block.front()).parse_node();
+        parse_node = sem_ir_.nodes().Get(block.front()).parse_node();
       }
     }
 
@@ -379,19 +376,19 @@ class NodeNamer {
     Scope& scope = GetScopeInfo(scope_idx);
 
     // Use bound names where available. Otherwise, assign a backup name.
-    for (auto node_id : semantics_ir_.node_blocks().Get(block_id)) {
+    for (auto node_id : sem_ir_.node_blocks().Get(block_id)) {
       if (!node_id.is_valid()) {
         continue;
       }
 
-      auto node = semantics_ir_.nodes().Get(node_id);
+      auto node = sem_ir_.nodes().Get(node_id);
       auto add_node_name = [&](std::string name) {
         nodes[node_id.index] = {scope_idx, scope.nodes.AllocateName(
                                                *this, node.parse_node(), name)};
       };
       auto add_node_name_id = [&](StringId name_id) {
         if (name_id.is_valid()) {
-          add_node_name(semantics_ir_.strings().Get(name_id).str());
+          add_node_name(sem_ir_.strings().Get(name_id).str());
         } else {
           add_node_name("");
         }
@@ -419,22 +416,20 @@ class NodeNamer {
           continue;
         }
         case FunctionDeclaration::Kind: {
-          add_node_name_id(semantics_ir_.functions()
+          add_node_name_id(sem_ir_.functions()
                                .Get(node.As<FunctionDeclaration>().function_id)
                                .name_id);
           continue;
         }
         case ClassType::Kind: {
-          add_node_name_id(semantics_ir_.classes()
-                               .Get(node.As<ClassType>().class_id)
-                               .name_id);
+          add_node_name_id(
+              sem_ir_.classes().Get(node.As<ClassType>().class_id).name_id);
           continue;
         }
         case NameReference::Kind: {
-          add_node_name(semantics_ir_.strings()
-                            .Get(node.As<NameReference>().name_id)
-                            .str() +
-                        ".ref");
+          add_node_name(
+              sem_ir_.strings().Get(node.As<NameReference>().name_id).str() +
+              ".ref");
           continue;
         }
         case Parameter::Kind: {
@@ -462,7 +457,7 @@ class NodeNamer {
 
   const Lex::TokenizedBuffer& tokenized_buffer_;
   const Parse::Tree& parse_tree_;
-  const File& semantics_ir_;
+  const File& sem_ir_;
 
   Namespace globals = {.prefix = "@"};
   std::vector<std::pair<ScopeIndex, Namespace::Name>> nodes;
@@ -475,38 +470,37 @@ class NodeNamer {
 class Formatter {
  public:
   explicit Formatter(const Lex::TokenizedBuffer& tokenized_buffer,
-                     const Parse::Tree& parse_tree, const File& semantics_ir,
+                     const Parse::Tree& parse_tree, const File& sem_ir,
                      llvm::raw_ostream& out)
-      : semantics_ir_(semantics_ir),
+      : sem_ir_(sem_ir),
         out_(out),
-        node_namer_(tokenized_buffer, parse_tree, semantics_ir) {}
+        node_namer_(tokenized_buffer, parse_tree, sem_ir) {}
 
   auto Format() -> void {
-    out_ << "file \"" << semantics_ir_.filename() << "\" {\n";
+    out_ << "file \"" << sem_ir_.filename() << "\" {\n";
     // TODO: Include information from the package declaration, once we
     // fully support it.
     // TODO: Handle the case where there are multiple top-level node blocks.
     // For example, there may be branching in the initializer of a global or a
     // type expression.
-    if (auto block_id = semantics_ir_.top_node_block_id();
-        block_id.is_valid()) {
+    if (auto block_id = sem_ir_.top_node_block_id(); block_id.is_valid()) {
       llvm::SaveAndRestore package_scope(scope_,
                                          NodeNamer::ScopeIndex::Package);
       FormatCodeBlock(block_id);
     }
     out_ << "}\n";
 
-    for (int i : llvm::seq(semantics_ir_.classes().size())) {
+    for (int i : llvm::seq(sem_ir_.classes().size())) {
       FormatClass(ClassId(i));
     }
 
-    for (int i : llvm::seq(semantics_ir_.functions().size())) {
+    for (int i : llvm::seq(sem_ir_.functions().size())) {
       FormatFunction(FunctionId(i));
     }
   }
 
   auto FormatClass(ClassId id) -> void {
-    const Class& class_info = semantics_ir_.classes().Get(id);
+    const Class& class_info = sem_ir_.classes().Get(id);
 
     out_ << "\nclass ";
     FormatClassName(id);
@@ -525,7 +519,7 @@ class Formatter {
   }
 
   auto FormatFunction(FunctionId id) -> void {
-    const Function& fn = semantics_ir_.functions().Get(id);
+    const Function& fn = sem_ir_.functions().Get(id);
 
     out_ << "\nfn ";
     FormatFunctionName(id);
@@ -534,8 +528,7 @@ class Formatter {
     llvm::SaveAndRestore function_scope(scope_, node_namer_.GetScopeFor(id));
 
     llvm::ListSeparator sep;
-    for (const NodeId param_id :
-         semantics_ir_.node_blocks().Get(fn.param_refs_id)) {
+    for (const NodeId param_id : sem_ir_.node_blocks().Get(fn.param_refs_id)) {
       out_ << sep;
       if (!param_id.is_valid()) {
         out_ << "invalid";
@@ -543,7 +536,7 @@ class Formatter {
       }
       FormatNodeName(param_id);
       out_ << ": ";
-      FormatType(semantics_ir_.nodes().Get(param_id).type_id());
+      FormatType(sem_ir_.nodes().Get(param_id).type_id());
     }
     out_ << ")";
     if (fn.return_type_id.is_valid()) {
@@ -578,7 +571,7 @@ class Formatter {
       return;
     }
 
-    for (const NodeId node_id : semantics_ir_.node_blocks().Get(block_id)) {
+    for (const NodeId node_id : sem_ir_.node_blocks().Get(block_id)) {
       FormatInstruction(node_id);
     }
   }
@@ -588,7 +581,7 @@ class Formatter {
     // Name scopes aren't kept in any particular order. Sort the entries before
     // we print them for stability and consistency.
     llvm::SmallVector<std::pair<NodeId, StringId>> entries;
-    for (auto [name_id, node_id] : semantics_ir_.name_scopes().Get(id)) {
+    for (auto [name_id, node_id] : sem_ir_.name_scopes().Get(id)) {
       entries.push_back({node_id, name_id});
     }
     llvm::sort(entries,
@@ -610,7 +603,7 @@ class Formatter {
       return;
     }
 
-    FormatInstruction(node_id, semantics_ir_.nodes().Get(node_id));
+    FormatInstruction(node_id, sem_ir_.nodes().Get(node_id));
   }
 
   auto FormatInstruction(NodeId node_id, Node node) -> void {
@@ -641,7 +634,7 @@ class Formatter {
       case NodeValueKind::Typed:
         FormatNodeName(node_id);
         out_ << ": ";
-        switch (GetExpressionCategory(semantics_ir_, node_id)) {
+        switch (GetExpressionCategory(sem_ir_, node_id)) {
           case ExpressionCategory::NotExpression:
           case ExpressionCategory::Error:
           case ExpressionCategory::Value:
@@ -720,7 +713,7 @@ class Formatter {
     FormatArg(node.tuple_id);
 
     llvm::ArrayRef<NodeId> inits_and_return_slot =
-        semantics_ir_.node_blocks().Get(node.inits_and_return_slot_id);
+        sem_ir_.node_blocks().Get(node.inits_and_return_slot_id);
     auto inits = inits_and_return_slot.drop_back(1);
     auto return_slot_id = inits_and_return_slot.back();
 
@@ -738,11 +731,10 @@ class Formatter {
     out_ << " ";
     FormatArg(node.callee_id);
 
-    llvm::ArrayRef<NodeId> args = semantics_ir_.node_blocks().Get(node.args_id);
+    llvm::ArrayRef<NodeId> args = sem_ir_.node_blocks().Get(node.args_id);
 
     bool has_return_slot =
-        GetInitializingRepresentation(semantics_ir_, node.type_id)
-            .has_return_slot();
+        GetInitializingRepresentation(sem_ir_, node.type_id).has_return_slot();
     NodeId return_slot_id = NodeId::Invalid;
     if (has_return_slot) {
       return_slot_id = args.back();
@@ -776,7 +768,7 @@ class Formatter {
   auto FormatInstructionRHS(SpliceBlock node) -> void {
     FormatArgs(node.result_id);
     out_ << " {";
-    if (!semantics_ir_.node_blocks().Get(node.block_id).empty()) {
+    if (!sem_ir_.node_blocks().Get(node.block_id).empty()) {
       out_ << "\n";
       indent_ += 2;
       FormatCodeBlock(node.block_id);
@@ -793,9 +785,9 @@ class Formatter {
   auto FormatInstructionRHS(StructType node) -> void {
     out_ << " {";
     llvm::ListSeparator sep;
-    for (auto field_id : semantics_ir_.node_blocks().Get(node.fields_id)) {
+    for (auto field_id : sem_ir_.node_blocks().Get(node.fields_id)) {
       out_ << sep << ".";
-      auto field = semantics_ir_.nodes().GetAs<StructTypeField>(field_id);
+      auto field = sem_ir_.nodes().GetAs<StructTypeField>(field_id);
       FormatString(field.name_id);
       out_ << ": ";
       FormatType(field.field_type_id);
@@ -821,7 +813,7 @@ class Formatter {
   auto FormatArg(ClassId id) -> void { FormatClassName(id); }
 
   auto FormatArg(IntegerId id) -> void {
-    semantics_ir_.integers().Get(id).print(out_, /*isSigned=*/false);
+    sem_ir_.integers().Get(id).print(out_, /*isSigned=*/false);
   }
 
   auto FormatArg(MemberIndex index) -> void { out_ << index; }
@@ -837,7 +829,7 @@ class Formatter {
   auto FormatArg(NodeBlockId id) -> void {
     out_ << '(';
     llvm::ListSeparator sep;
-    for (auto node_id : semantics_ir_.node_blocks().Get(id)) {
+    for (auto node_id : sem_ir_.node_blocks().Get(id)) {
       out_ << sep;
       FormatArg(node_id);
     }
@@ -846,14 +838,14 @@ class Formatter {
 
   auto FormatArg(RealId id) -> void {
     // TODO: Format with a `.` when the exponent is near zero.
-    const auto& real = semantics_ir_.reals().Get(id);
+    const auto& real = sem_ir_.reals().Get(id);
     real.mantissa.print(out_, /*isSigned=*/false);
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }
 
   auto FormatArg(StringId id) -> void {
     out_ << '"';
-    out_.write_escaped(semantics_ir_.strings().Get(id), /*UseHexEscapes=*/true);
+    out_.write_escaped(sem_ir_.strings().Get(id), /*UseHexEscapes=*/true);
     out_ << '"';
   }
 
@@ -862,7 +854,7 @@ class Formatter {
   auto FormatArg(TypeBlockId id) -> void {
     out_ << '(';
     llvm::ListSeparator sep;
-    for (auto type_id : semantics_ir_.type_blocks().Get(id)) {
+    for (auto type_id : sem_ir_.type_blocks().Get(id)) {
       out_ << sep;
       FormatArg(type_id);
     }
@@ -882,9 +874,7 @@ class Formatter {
     out_ << node_namer_.GetLabelFor(scope_, id);
   }
 
-  auto FormatString(StringId id) -> void {
-    out_ << semantics_ir_.strings().Get(id);
-  }
+  auto FormatString(StringId id) -> void { out_ << sem_ir_.strings().Get(id); }
 
   auto FormatFunctionName(FunctionId id) -> void {
     out_ << node_namer_.GetNameFor(id);
@@ -898,12 +888,12 @@ class Formatter {
     if (!id.is_valid()) {
       out_ << "invalid";
     } else {
-      out_ << semantics_ir_.StringifyType(id, /*in_type_context=*/true);
+      out_ << sem_ir_.StringifyType(id, /*in_type_context=*/true);
     }
   }
 
  private:
-  const File& semantics_ir_;
+  const File& sem_ir_;
   llvm::raw_ostream& out_;
   NodeNamer node_namer_;
   NodeNamer::ScopeIndex scope_ = NodeNamer::ScopeIndex::None;
@@ -912,9 +902,9 @@ class Formatter {
 };
 
 auto FormatFile(const Lex::TokenizedBuffer& tokenized_buffer,
-                const Parse::Tree& parse_tree, const File& semantics_ir,
+                const Parse::Tree& parse_tree, const File& sem_ir,
                 llvm::raw_ostream& out) -> void {
-  Formatter(tokenized_buffer, parse_tree, semantics_ir, out).Format();
+  Formatter(tokenized_buffer, parse_tree, sem_ir, out).Format();
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -11,7 +11,7 @@
 namespace Carbon::SemIR {
 
 auto FormatFile(const Lex::TokenizedBuffer& tokenized_buffer,
-                const Parse::Tree& parse_tree, const File& semantics_ir,
+                const Parse::Tree& parse_tree, const File& sem_ir,
                 llvm::raw_ostream& out) -> void;
 
 }  // namespace Carbon::SemIR


### PR DESCRIPTION
1. In general, `semantics_ir` -> `sem_ir`, to match the directory name.
2. For the list of `ValueStore`-related accessors on `SemIR::File`, add them to `check`'s `Context` object, shortening access.