### PR TITLE
sem-ir: Write references to the `file` block as `file.` not `package.`

### DIFF
--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -25,13 +25,13 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_29.1: type = array_type %.loc10_28, (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_29.2: type = ptr_type [(i32, i32, i32); 2]
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_42.3: ref (i32, i32, i32) = splice_block %.loc10_42.2 {
 // CHECK:STDOUT:     %.loc10_42.1: i32 = int_literal 0
 // CHECK:STDOUT:     %.loc10_42.2: ref (i32, i32, i32) = array_index %v, %.loc10_42.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_35: init (i32, i32, i32) = call %F.ref.loc10_34() to %.loc10_42.3
-// CHECK:STDOUT:   %F.ref.loc10_39: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_39: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_42.6: ref (i32, i32, i32) = splice_block %.loc10_42.5 {
 // CHECK:STDOUT:     %.loc10_42.4: i32 = int_literal 1
 // CHECK:STDOUT:     %.loc10_42.5: ref (i32, i32, i32) = array_index %v, %.loc10_42.4

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -29,7 +29,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc10_17.1: type = array_type %.loc10_16, i32
 // CHECK:STDOUT:   %.loc10_17.2: type = ptr_type [i32; 1]
 // CHECK:STDOUT:   %t: ref [i32; 1] = var "t"
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_22.1: init (i32,) = call %F.ref()
 // CHECK:STDOUT:   %.loc10_22.2: ref (i32,) = temporary_storage
 // CHECK:STDOUT:   %.loc10_22.3: ref (i32,) = temporary %.loc10_22.2, %.loc10_22.1

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -30,7 +30,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -54,7 +54,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", package.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", @Class.%F
 // CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4
 // CHECK:STDOUT:   %.loc22_17.1: init i32 = call %F.ref(%.loc22_18)

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -144,7 +144,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallClassFunction() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", package.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
 // CHECK:STDOUT:   %Function.ref: <error> = name_reference "Function", <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -172,7 +172,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Let(%p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", package.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
 // CHECK:STDOUT:   %p.ref: Class* = name_reference "p", %p
 // CHECK:STDOUT:   %.loc78: ref Class = dereference %p.ref
 // CHECK:STDOUT:   %c: <error> = bind_name "c", <error>
@@ -185,18 +185,18 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallTakeIncomplete(%p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc103: <function> = name_reference "TakeIncomplete", package.%TakeIncomplete
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc103: <function> = name_reference "TakeIncomplete", file.%TakeIncomplete
 // CHECK:STDOUT:   %p.ref: Class* = name_reference "p", %p
 // CHECK:STDOUT:   %.loc103_18: ref Class = dereference %p.ref
 // CHECK:STDOUT:   %.loc103_17: type = tuple_type ()
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc114: <function> = name_reference "TakeIncomplete", package.%TakeIncomplete
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc114: <function> = name_reference "TakeIncomplete", file.%TakeIncomplete
 // CHECK:STDOUT:   %.loc114: {} = struct_literal ()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallReturnIncomplete() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %ReturnIncomplete.ref: <function> = name_reference "ReturnIncomplete", package.%ReturnIncomplete
+// CHECK:STDOUT:   %ReturnIncomplete.ref: <function> = name_reference "ReturnIncomplete", file.%ReturnIncomplete
 // CHECK:STDOUT:   %.loc118: init <error> = call %ReturnIncomplete.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -38,7 +38,7 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", package.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
 // CHECK:STDOUT:   %F.ref: <error> = name_reference "F", <error>
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -46,9 +46,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref.loc18_10: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc18_10: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc18_11.1: init i32 = call %F.ref.loc18_10()
-// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", package.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
 // CHECK:STDOUT:   %F.ref.loc18_21: <function> = name_reference "F", @Class.%F
 // CHECK:STDOUT:   %.loc18_23.1: init i32 = call %F.ref.loc18_21()
 // CHECK:STDOUT:   %.loc18_11.2: ref i32 = temporary_storage

--- a/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
+++ b/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
@@ -29,16 +29,16 @@ fn H() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_19: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %v: ref (i32, i32) = var "v"
-// CHECK:STDOUT:   %F.ref.loc10: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_7: ref (i32, i32) = splice_block %v {}
 // CHECK:STDOUT:   %.loc10_24: init (i32, i32) = call %F.ref.loc10() to %.loc10_7
 // CHECK:STDOUT:   assign %v, %.loc10_24
 // CHECK:STDOUT:   %v.ref: ref (i32, i32) = name_reference "v", %v
-// CHECK:STDOUT:   %F.ref.loc11: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc11: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc11_3: ref (i32, i32) = splice_block %v.ref {}
 // CHECK:STDOUT:   %.loc11_8: init (i32, i32) = call %F.ref.loc11() to %.loc11_3
 // CHECK:STDOUT:   assign %v.ref, %.loc11_8
-// CHECK:STDOUT:   %F.ref.loc12: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc12: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc9: ref (i32, i32) = splice_block %return {}
 // CHECK:STDOUT:   %.loc12: init (i32, i32) = call %F.ref.loc12() to %.loc9
 // CHECK:STDOUT:   return %.loc12
@@ -46,7 +46,7 @@ fn H() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc16_11.1: ref (i32, i32) = temporary_storage
 // CHECK:STDOUT:   %.loc16_11.2: init (i32, i32) = call %G.ref() to %.loc16_11.1
 // CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", file.%Echo
 // CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: {} = struct_value %.loc12_9.1, ()
 // CHECK:STDOUT:   %.loc12_7: init {} = call %Echo.ref(%.loc12_9.2)

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -25,7 +25,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", file.%Echo
 // CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: () = tuple_value %.loc12_9.1, ()
 // CHECK:STDOUT:   %.loc12_7: init () = call %Echo.ref(%.loc12_9.2)

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -79,18 +79,18 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_reference "Run0", package.%Run0
+// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_reference "Run0", file.%Run0
 // CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc18_7: type = tuple_type ()
-// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_reference "Run0", package.%Run0
+// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_reference "Run0", file.%Run0
 // CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1
-// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_reference "Run1", package.%Run1
-// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_reference "Run1", package.%Run1
+// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_reference "Run1", file.%Run1
+// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_reference "Run1", file.%Run1
 // CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1
-// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_reference "Run2", package.%Run2
-// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_reference "Run2", package.%Run2
+// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_reference "Run2", file.%Run2
+// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_reference "Run2", file.%Run2
 // CHECK:STDOUT:   %.loc55: i32 = int_literal 0
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -28,7 +28,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1
 // CHECK:STDOUT:   %.loc16_4: type = tuple_type ()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x: ref i32 = var "x"
-// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc13: init f64 = call %Foo.ref()
 // CHECK:STDOUT:   assign %x, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %b: ref i32 = var "b"
-// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", package.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_reference "Echo", file.%Echo
 // CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc12_20: init i32 = call %Echo.ref(%.loc12_21)
 // CHECK:STDOUT:   assign %b, %.loc12_20

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -23,7 +23,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_11: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_9: i32 = add %.loc11_7, %.loc11_11

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref(%.loc10_7)

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -23,11 +23,11 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref.loc10(%.loc10_7)
-// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -23,12 +23,12 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref.loc10(%.loc10_7, %.loc10_10)
-// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7, %.loc11_10)

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -22,7 +22,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", package.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_11.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc11_11.2: () = tuple_literal ()
 // CHECK:STDOUT:   %b: ref () = var "b"
-// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_reference "MakeImplicitEmptyTuple", package.%MakeImplicitEmptyTuple
+// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_reference "MakeImplicitEmptyTuple", file.%MakeImplicitEmptyTuple
 // CHECK:STDOUT:   %.loc11_37: init () = call %MakeImplicitEmptyTuple.ref()
 // CHECK:STDOUT:   assign %b, %.loc11_37
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -17,7 +17,7 @@ fn G() { F(); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc9_11.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc9_11.2: init () = call %F.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -45,18 +45,18 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc13_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc13_6.2: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc15: init () = call %G.ref()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", file.%H
 // CHECK:STDOUT:   %.loc17: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -36,13 +36,13 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc12_6.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc12_6.2: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc14: init () = call %G.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if_expression/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expression/constant_condition.carbon
@@ -40,7 +40,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   if %.loc11_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   %.loc11_24.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc11_24.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_24.3: ref i32 = temporary %.loc11_24.2, %.loc11_24.1
@@ -48,7 +48,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_24.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", file.%B
 // CHECK:STDOUT:   %.loc11_33.1: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc11_33.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_33.3: ref i32 = temporary %.loc11_33.2, %.loc11_33.1
@@ -66,7 +66,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   if %.loc15_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   %.loc15_25.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc15_25.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc15_25.3: ref i32 = temporary %.loc15_25.2, %.loc15_25.1
@@ -74,7 +74,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc15_25.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", file.%B
 // CHECK:STDOUT:   %.loc15_34.1: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc15_34.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc15_34.3: ref i32 = temporary %.loc15_34.2, %.loc15_34.1

--- a/toolchain/check/testdata/if_expression/control_flow.carbon
+++ b/toolchain/check/testdata/if_expression/control_flow.carbon
@@ -35,7 +35,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   %.loc11_21.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc11_21.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_21.3: ref i32 = temporary %.loc11_21.2, %.loc11_21.1
@@ -43,7 +43,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_21.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", file.%B
 // CHECK:STDOUT:   %.loc11_30.1: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc11_30.2: ref i32 = temporary_storage
 // CHECK:STDOUT:   %.loc11_30.3: ref i32 = temporary %.loc11_30.2, %.loc11_30.1

--- a/toolchain/check/testdata/if_expression/struct.carbon
+++ b/toolchain/check/testdata/if_expression/struct.carbon
@@ -32,7 +32,7 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_46.5: init i32 = initialize_from %.loc10_45 to %.loc10_46.4
 // CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init %.loc10_46.1, (%.loc10_46.3, %.loc10_46.5)
 // CHECK:STDOUT:   assign %a, %.loc10_46.6
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %cond.ref: bool = name_reference "cond", %cond
 // CHECK:STDOUT:   if %cond.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/expression_category.carbon
+++ b/toolchain/check/testdata/index/expression_category.carbon
@@ -97,7 +97,7 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc23_6.1: ref [i32; 3] = value_as_reference %b.ref
 // CHECK:STDOUT:   %.loc23_6.2: ref i32 = array_index %.loc23_6.1, %.loc23_5
 // CHECK:STDOUT:   %.loc23_6.3: i32 = bind_value %.loc23_6.2
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc24_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc24_4.2: init [i32; 3] = call %F.ref() to %.loc24_4.1
 // CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -25,7 +25,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc13_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc13_4.2: init () = call %F.ref()
 // CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/fail_expression_category.carbon
+++ b/toolchain/check/testdata/index/fail_expression_category.carbon
@@ -57,7 +57,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   assign %.loc18_6.3, %.loc18_10
 // CHECK:STDOUT:   %.loc25_14: type = ptr_type i32
 // CHECK:STDOUT:   %pf: ref i32* = var "pf"
-// CHECK:STDOUT:   %F.ref.loc25: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc25: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc25_20.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc25_20.2: init [i32; 3] = call %F.ref.loc25() to %.loc25_20.1
 // CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0
@@ -66,7 +66,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc25_24.2: i32 = bind_value %.loc25_24.1
 // CHECK:STDOUT:   %.loc25_18: i32* = address_of %.loc25_24.2
 // CHECK:STDOUT:   assign %pf, %.loc25_18
-// CHECK:STDOUT:   %F.ref.loc29: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc29: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc29_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc29_4.2: init [i32; 3] = call %F.ref.loc29() to %.loc29_4.1
 // CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -25,7 +25,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_11.1: init (i32,) = call %F.ref()
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_11.2: ref (i32,) = temporary_storage

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -16,6 +16,6 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref: i32 = name_reference "n", package.%n
+// CHECK:STDOUT:   %n.ref: i32 = name_reference "n", file.%n
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -36,8 +36,8 @@ fn Bar() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Bar() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", package.%.loc7
-// CHECK:STDOUT:   %Baz.ref: <function> = name_reference "Baz", package.%Baz.loc13
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", file.%.loc7
+// CHECK:STDOUT:   %Baz.ref: <function> = name_reference "Baz", file.%Baz.loc13
 // CHECK:STDOUT:   %.loc17_10.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc17_10.2: init () = call %Baz.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -28,9 +28,9 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", package.%.loc7
-// CHECK:STDOUT:   %Bar.ref: <namespace> = name_reference "Bar", package.%.loc8
-// CHECK:STDOUT:   %Wiz.ref: <function> = name_reference "Wiz", package.%Wiz
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", file.%.loc7
+// CHECK:STDOUT:   %Bar.ref: <namespace> = name_reference "Bar", file.%.loc8
+// CHECK:STDOUT:   %Wiz.ref: <function> = name_reference "Wiz", file.%Wiz
 // CHECK:STDOUT:   %.loc14_14.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_14.2: init () = call %Wiz.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -31,7 +31,7 @@ fn And() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @And() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc11_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_11.3: ref bool = temporary %.loc11_11.2, %.loc11_11.1
@@ -40,7 +40,7 @@ fn And() -> bool {
 // CHECK:STDOUT:   if %.loc11_11.4 br !and.rhs else br !and.result(%.loc11_14.1)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc11_19.1: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc11_19.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_19.3: ref bool = temporary %.loc11_19.2, %.loc11_19.1

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -57,7 +57,7 @@ fn Main() {
 // CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2
 // CHECK:STDOUT:   assign %.loc13_3, %.loc13_7
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc17_4: init i32 = call %F.ref()
 // CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -31,7 +31,7 @@ fn Or() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Or() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc11_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_11.3: ref bool = temporary %.loc11_11.2, %.loc11_11.1
@@ -41,7 +41,7 @@ fn Or() -> bool {
 // CHECK:STDOUT:   if %.loc11_14.1 br !or.rhs else br !or.result(%.loc11_14.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc11_18.1: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc11_18.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc11_18.3: ref bool = temporary %.loc11_18.2, %.loc11_18.1

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -130,7 +130,7 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:   %.loc42_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc42_7: i32 = add %.loc42_5, %.loc42_9
 // CHECK:STDOUT:   %.loc42_3: i32* = address_of %.loc42_7
-// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", file.%H
 // CHECK:STDOUT:   %.loc46_5.1: init {.a: i32} = call %H.ref()
 // CHECK:STDOUT:   %.loc46_5.2: ref {.a: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc46_5.3: ref {.a: i32} = temporary %.loc46_5.2, %.loc46_5.1
@@ -144,7 +144,7 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfCall() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc57_5: init i32 = call %G.ref()
 // CHECK:STDOUT:   %.loc57_3: i32* = address_of %.loc57_5
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/pointer/fail_dereference_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_function.carbon
@@ -17,7 +17,7 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   %.loc11: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_namespace.carbon
@@ -20,7 +20,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <namespace> = name_reference "A", package.%.loc7
+// CHECK:STDOUT:   %A.ref: <namespace> = name_reference "A", file.%.loc7
 // CHECK:STDOUT:   %.loc13: ref <error> = dereference <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_member_of_function.carbon
+++ b/toolchain/check/testdata/struct/fail_member_of_function.carbon
@@ -17,6 +17,6 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -21,7 +21,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc10_25.1: ref {.x: i32, .y: i32, .z: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc10_25.2: init {.x: i32, .y: i32, .z: i32} = call %G.ref() to %.loc10_25.1
 // CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -26,10 +26,10 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_51.2: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
 // CHECK:STDOUT:   %.loc10_51.3: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_74.1: ref (i32, i32, i32) = struct_access %v, member0
 // CHECK:STDOUT:   %.loc10_62: init (i32, i32, i32) = call %F.ref.loc10_61() to %.loc10_74.1
-// CHECK:STDOUT:   %F.ref.loc10_71: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_71: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_74.2: ref (i32, i32, i32) = struct_access %v, member1
 // CHECK:STDOUT:   %.loc10_72: init (i32, i32, i32) = call %F.ref.loc10_71() to %.loc10_74.2
 // CHECK:STDOUT:   %.loc10_74.3: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = struct_literal (%.loc10_62, %.loc10_72)

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -33,10 +33,10 @@ fn H() {
 // CHECK:STDOUT:   %.loc10_43.4: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*)
 // CHECK:STDOUT:   %.loc10_43.5: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*)
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = var "v"
-// CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_56.1: ref (i32, i32, i32) = tuple_access %v, member0
 // CHECK:STDOUT:   %.loc10_49: init (i32, i32, i32) = call %F.ref.loc10_48() to %.loc10_56.1
-// CHECK:STDOUT:   %F.ref.loc10_53: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref.loc10_53: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc10_56.2: ref (i32, i32, i32) = tuple_access %v, member1
 // CHECK:STDOUT:   %.loc10_54: init (i32, i32, i32) = call %F.ref.loc10_53() to %.loc10_56.2
 // CHECK:STDOUT:   %.loc10_56.3: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_49, %.loc10_54)
@@ -55,7 +55,7 @@ fn H() {
 // CHECK:STDOUT:   %.loc14_36.5: type = ptr_type (i32, (i32, i32, i32)*, i32)
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = var "v"
 // CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc14_50.1: ref (i32, i32, i32) = tuple_access %v, member1
 // CHECK:STDOUT:   %.loc14_45: init (i32, i32, i32) = call %F.ref() to %.loc14_50.1
 // CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %y: ref i32 = var "y"
-// CHECK:STDOUT:   %x.ref: ref i32 = name_reference "x", package.%x
+// CHECK:STDOUT:   %x.ref: ref i32 = name_reference "x", file.%x
 // CHECK:STDOUT:   %.loc10: i32 = bind_value %x.ref
 // CHECK:STDOUT:   assign %y, %.loc10
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -59,7 +59,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc17:
-// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", package.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_reference "A", file.%A
 // CHECK:STDOUT:   %.loc17_11.1: init bool = call %A.ref()
 // CHECK:STDOUT:   %.loc17_11.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc17_11.3: ref bool = temporary %.loc17_11.2, %.loc17_11.1
@@ -67,7 +67,7 @@ fn While() {
 // CHECK:STDOUT:   if %.loc17_11.4 br !while.body.loc17 else br !while.done.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc17:
-// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", package.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_reference "B", file.%B
 // CHECK:STDOUT:   %.loc18_10.1: init bool = call %B.ref()
 // CHECK:STDOUT:   %.loc18_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc18_10.3: ref bool = temporary %.loc18_10.2, %.loc18_10.1
@@ -78,7 +78,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc18:
-// CHECK:STDOUT:   %C.ref: <function> = name_reference "C", package.%C
+// CHECK:STDOUT:   %C.ref: <function> = name_reference "C", file.%C
 // CHECK:STDOUT:   %.loc19_10.1: init bool = call %C.ref()
 // CHECK:STDOUT:   %.loc19_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc19_10.3: ref bool = temporary %.loc19_10.2, %.loc19_10.1
@@ -92,7 +92,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc20:
-// CHECK:STDOUT:   %D.ref: <function> = name_reference "D", package.%D
+// CHECK:STDOUT:   %D.ref: <function> = name_reference "D", file.%D
 // CHECK:STDOUT:   %.loc20_13.1: init bool = call %D.ref()
 // CHECK:STDOUT:   %.loc20_13.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc20_13.3: ref bool = temporary %.loc20_13.2, %.loc20_13.1
@@ -100,7 +100,7 @@ fn While() {
 // CHECK:STDOUT:   if %.loc20_13.4 br !while.body.loc20 else br !while.done.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc20:
-// CHECK:STDOUT:   %E.ref: <function> = name_reference "E", package.%E
+// CHECK:STDOUT:   %E.ref: <function> = name_reference "E", file.%E
 // CHECK:STDOUT:   %.loc21_12.1: init bool = call %E.ref()
 // CHECK:STDOUT:   %.loc21_12.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc21_12.3: ref bool = temporary %.loc21_12.2, %.loc21_12.1
@@ -111,7 +111,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc21:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc22_12.1: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc22_12.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc22_12.3: ref bool = temporary %.loc22_12.2, %.loc22_12.1
@@ -125,7 +125,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done.loc20:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc24_10.1: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc24_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc24_10.3: ref bool = temporary %.loc24_10.2, %.loc24_10.1
@@ -136,7 +136,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc24:
-// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", file.%H
 // CHECK:STDOUT:   %.loc25_10.1: init bool = call %H.ref()
 // CHECK:STDOUT:   %.loc25_10.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc25_10.3: ref bool = temporary %.loc25_10.2, %.loc25_10.1

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -37,13 +37,13 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_4.2: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", package.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", file.%Cond
 // CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
 // CHECK:STDOUT:   %.loc15_14.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc15_14.3: ref bool = temporary %.loc15_14.2, %.loc15_14.1
@@ -51,12 +51,12 @@ fn While() {
 // CHECK:STDOUT:   if %.loc15_14.4 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc16: init () = call %G.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", file.%H
 // CHECK:STDOUT:   %.loc19: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -36,13 +36,13 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", package.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
 // CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
 // CHECK:STDOUT:   %.loc14_4.2: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", package.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_reference "Cond", file.%Cond
 // CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
 // CHECK:STDOUT:   %.loc15_14.2: ref bool = temporary_storage
 // CHECK:STDOUT:   %.loc15_14.3: ref bool = temporary %.loc15_14.2, %.loc15_14.1
@@ -50,12 +50,12 @@ fn While() {
 // CHECK:STDOUT:   if %.loc15_14.4 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", package.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc16: init () = call %G.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", package.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_reference "H", file.%H
 // CHECK:STDOUT:   %.loc18: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }


### PR DESCRIPTION
This matches the renaming of the `package { ... }` block to `file { ... }`.