### PR TITLE
Disable field-initializers when building.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -133,6 +133,7 @@ def _impl(ctx):
                             "-Wimplicit-fallthrough",
                             "-Wctad-maybe-unsupported",
                             "-Wdelete-non-virtual-dtor",
+                            "-Wno-missing-field-initializers",
                             # Don't warn on external code as we can't
                             # necessarily patch it easily.
                             "--system-header-prefix=external/",


### PR DESCRIPTION
This allows building carbon with newer versions of clang. This makes the build aligned with the `compile_flags.txt` file, which also has this warning disabled.
