### PR TITLE
Disable -Wmissing-field-initializers for clang-18 due to false positives.

### DIFF
--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -105,6 +105,14 @@ def _impl(ctx):
     if ctx.attr.target_cpu != "x64_windows":
         std_compile_flags.append("-stdlib=libc++")
 
+    # TODO: Regression that warns on anonymous unions; remove depending on fix.
+    # Sets the flag for unknown clang versions, which are assumed to be at head.
+    # https://github.com/llvm/llvm-project/issues/70384
+    if not clang_version or clang_version == 18:
+        missing_field_init_flags = ["-Wno-missing-field-initializers"]
+    else:
+        missing_field_init_flags = []
+
     default_flags_feature = feature(
         name = "default_flags",
         enabled = True,
@@ -138,7 +146,7 @@ def _impl(ctx):
                             "--system-header-prefix=external/",
                             # Compile actions shouldn't link anything.
                             "-c",
-                        ],
+                        ] + missing_field_init_flags,
                     ),
                     flag_group(
                         expand_if_available = "output_assembly_file",


### PR DESCRIPTION
It warns on anonymous unions even when they have a field initialized. Reported at https://github.com/llvm/llvm-project/issues/70384

Depending on how it's fixed, we may be able to remove this. If it's fixed at head but still released in clang-18, we'd probably just change the conditional.

Reported by guille2718; this is a version-dependent approach from #3339 

Co-authored-by: Guillermo Rey <10690205+guille2718@users.noreply.github.com>