### PR TITLE
Add a separate store for computed constant values.

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -64,6 +64,13 @@ auto Context::AddInst(SemIR::Inst inst) -> SemIR::InstId {
   return inst_id;
 }
 
+auto Context::AddConstantInst(SemIR::Inst inst) -> SemIR::InstId {
+  auto inst_id = insts().AddInNoBlock(inst);
+  constants().Add(inst_id);
+  CARBON_VLOG() << "AddConstantInst: " << inst << "\n";
+  return inst_id;
+}
+
 auto Context::AddInstAndPush(Parse::Node parse_node, SemIR::Inst inst) -> void {
   auto inst_id = AddInst(inst);
   node_stack_.Push(parse_node, inst_id);
@@ -594,7 +601,7 @@ class TypeCompleter {
       if (field_value_rep.type_id != field.field_type_id) {
         same_as_object_rep = false;
         field.field_type_id = field_value_rep.type_id;
-        field_id = context_.AddInst(field);
+        field_id = context_.AddConstantInst(field);
       }
       value_rep_fields.push_back(field_id);
     }
@@ -882,7 +889,7 @@ auto Context::CanonicalizeTypeAndAddInstIfNew(SemIR::Inst inst)
   auto profile_node = [&](llvm::FoldingSetNodeID& canonical_id) {
     ProfileType(*this, inst, canonical_id);
   };
-  auto make_inst = [&] { return AddInst(inst); };
+  auto make_inst = [&] { return AddConstantInst(inst); };
   return CanonicalizeTypeImpl(inst.kind(), profile_node, make_inst);
 }
 
@@ -917,8 +924,8 @@ auto Context::CanonicalizeTupleType(Parse::Node parse_node,
     ProfileTupleType(type_ids, canonical_id);
   };
   auto make_tuple_inst = [&] {
-    return AddInst(SemIR::TupleType{parse_node, SemIR::TypeId::TypeType,
-                                    type_blocks().Add(type_ids)});
+    return AddConstantInst(SemIR::TupleType{parse_node, SemIR::TypeId::TypeType,
+                                            type_blocks().Add(type_ids)});
   };
   return CanonicalizeTypeImpl(SemIR::TupleType::Kind, profile_tuple,
                               make_tuple_inst);

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -44,6 +44,9 @@ class Context {
   // Adds an instruction to the current block, returning the produced ID.
   auto AddInst(SemIR::Inst inst) -> SemIR::InstId;
 
+  // Adds an instruction to the constants block, returning the produced ID.
+  auto AddConstantInst(SemIR::Inst inst) -> SemIR::InstId;
+
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
   // result.
   auto AddInstAndPush(Parse::Node parse_node, SemIR::Inst inst) -> void;
@@ -275,6 +278,7 @@ class Context {
   auto inst_blocks() -> SemIR::InstBlockStore& {
     return sem_ir().inst_blocks();
   }
+  auto constants() -> SemIR::ConstantStore& { return sem_ir().constants(); }
 
  private:
   // A FoldingSet node for a type.

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -11,9 +11,16 @@ fn G() {
 }
 
 // CHECK:STDOUT: file "array_in_place.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type (i32, i32, i32)
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_29: type = ptr_type [(i32, i32, i32); 2]
+// CHECK:STDOUT:   %.loc10_42: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -22,8 +29,7 @@ fn G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc10_29.1: type = array_type %.loc10_28, (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_29.2: type = ptr_type [(i32, i32, i32); 2]
+// CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32)
 // CHECK:STDOUT:   %v.var: ref [(i32, i32, i32); 2] = var "v"
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = bind_name "v", %v.var
 // CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_reference "F", file.%F
@@ -38,9 +44,8 @@ fn G() {
 // CHECK:STDOUT:     %.loc10_42.5: ref (i32, i32, i32) = array_index %v.var, %.loc10_42.4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_40: init (i32, i32, i32) = call %F.ref.loc10_39() to %.loc10_42.6
-// CHECK:STDOUT:   %.loc10_42.7: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
-// CHECK:STDOUT:   %.loc10_42.8: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_35, %.loc10_40)
-// CHECK:STDOUT:   %.loc10_42.9: init [(i32, i32, i32); 2] = array_init %.loc10_42.8, (%.loc10_35, %.loc10_40) to %v.var
-// CHECK:STDOUT:   assign %v.var, %.loc10_42.9
+// CHECK:STDOUT:   %.loc10_42.7: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_35, %.loc10_40)
+// CHECK:STDOUT:   %.loc10_42.8: init [(i32, i32, i32); 2] = array_init %.loc10_42.7, (%.loc10_35, %.loc10_40) to %v.var
+// CHECK:STDOUT:   assign %v.var, %.loc10_42.8
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -10,17 +10,17 @@ fn G() {
   var v: [(i32, i32, i32); 2] = (F(), F());
 }
 
-// CHECK:STDOUT: file "array_in_place.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
 // CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_29: type = ptr_type [(i32, i32, i32); 2]
 // CHECK:STDOUT:   %.loc10_42: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "array_in_place.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -10,15 +10,15 @@ fn Run() {
   var t: [i32; 1] = F();
 }
 
-// CHECK:STDOUT: file "assign_return_value.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32)
 // CHECK:STDOUT:   %.loc10: type = ptr_type [i32; 1]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "assign_return_value.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -15,6 +15,12 @@ fn Run() {
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10: type = ptr_type [i32; 1]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0
@@ -26,8 +32,7 @@ fn Run() {
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_17.1: type = array_type %.loc10_16, i32
-// CHECK:STDOUT:   %.loc10_17.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32
 // CHECK:STDOUT:   %t.var: ref [i32; 1] = var "t"
 // CHECK:STDOUT:   %t: ref [i32; 1] = bind_name "t", %t.var
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -7,6 +7,13 @@
 var a: (i32, i32, i32) = (1, 2, 3);
 var b: [i32; 3] = a;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc8: type = ptr_type [i32; 3]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "assign_var.carbon" {
 // CHECK:STDOUT:   %.loc7_22: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var "a"
@@ -45,11 +52,4 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc8_19.15: init i32 = initialize_from %.loc8_19.12 to %.loc8_19.14
 // CHECK:STDOUT:   %.loc8_19.16: init [i32; 3] = array_init %a.ref, (%.loc8_19.5, %.loc8_19.10, %.loc8_19.15) to %b.var
 // CHECK:STDOUT:   assign %b.var, %.loc8_19.16
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type)
-// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8: type = ptr_type [i32; 3]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -8,10 +8,7 @@ var a: (i32, i32, i32) = (1, 2, 3);
 var b: [i32; 3] = a;
 
 // CHECK:STDOUT: file "assign_var.carbon" {
-// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type)
-// CHECK:STDOUT:   %.loc7_22.2: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_22.3: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_22.4: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_22: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var "a"
 // CHECK:STDOUT:   %a: ref (i32, i32, i32) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1
@@ -27,8 +24,7 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init %.loc7_34.1, (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7)
 // CHECK:STDOUT:   assign %a.var, %.loc7_34.8
 // CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, i32
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var "b"
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name "b", %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32, i32) = name_reference "a", %a
@@ -49,4 +45,11 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc8_19.15: init i32 = initialize_from %.loc8_19.12 to %.loc8_19.14
 // CHECK:STDOUT:   %.loc8_19.16: init [i32; 3] = array_init %a.ref, (%.loc8_19.5, %.loc8_19.10, %.loc8_19.15) to %b.var
 // CHECK:STDOUT:   assign %b.var, %.loc8_19.16
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc8: type = ptr_type [i32; 3]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -8,6 +8,16 @@ var a: [i32; 1] = (1,);
 var b: [f64; 2] = (11.1, 2.2,);
 var c: [(); 5] = ((), (), (), (), (),);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc8_15: type = ptr_type [f64; 2]
+// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64)
+// CHECK:STDOUT:   %.loc9_10: type = tuple_type ()
+// CHECK:STDOUT:   %.loc9_14: type = ptr_type [(); 5]
+// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ())
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "base.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -53,14 +63,4 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init %.loc9_36.1, ()
 // CHECK:STDOUT:   %.loc9_38.2: init [(); 5] = array_init %.loc9_38.1, (%.loc9_20.2, %.loc9_24.2, %.loc9_28.2, %.loc9_32.2, %.loc9_36.2) to %c.var
 // CHECK:STDOUT:   assign %c.var, %.loc9_38.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
-// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc8_15: type = ptr_type [f64; 2]
-// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64)
-// CHECK:STDOUT:   %.loc9_10: type = tuple_type ()
-// CHECK:STDOUT:   %.loc9_14: type = ptr_type [(); 5]
-// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ())
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -10,40 +10,34 @@ var c: [(); 5] = ((), (), (), (), (),);
 
 // CHECK:STDOUT: file "base.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_22.2: (i32,) = tuple_literal (%.loc7_20)
-// CHECK:STDOUT:   %.loc7_22.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_22.4: ref i32 = array_index %a.var, %.loc7_22.3
-// CHECK:STDOUT:   %.loc7_22.5: init i32 = initialize_from %.loc7_20 to %.loc7_22.4
-// CHECK:STDOUT:   %.loc7_22.6: init [i32; 1] = array_init %.loc7_22.2, (%.loc7_22.5) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_22.6
+// CHECK:STDOUT:   %.loc7_22.1: (i32,) = tuple_literal (%.loc7_20)
+// CHECK:STDOUT:   %.loc7_22.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_22.3: ref i32 = array_index %a.var, %.loc7_22.2
+// CHECK:STDOUT:   %.loc7_22.4: init i32 = initialize_from %.loc7_20 to %.loc7_22.3
+// CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init %.loc7_22.1, (%.loc7_22.4) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_22.5
 // CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, f64
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [f64; 2]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64
 // CHECK:STDOUT:   %b.var: ref [f64; 2] = var "b"
 // CHECK:STDOUT:   %b: ref [f64; 2] = bind_name "b", %b.var
 // CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1
 // CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1
-// CHECK:STDOUT:   %.loc8_30.1: type = tuple_type (f64, f64)
-// CHECK:STDOUT:   %.loc8_30.2: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
-// CHECK:STDOUT:   %.loc8_30.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc8_30.4: ref f64 = array_index %b.var, %.loc8_30.3
-// CHECK:STDOUT:   %.loc8_30.5: init f64 = initialize_from %.loc8_20 to %.loc8_30.4
-// CHECK:STDOUT:   %.loc8_30.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc8_30.7: ref f64 = array_index %b.var, %.loc8_30.6
-// CHECK:STDOUT:   %.loc8_30.8: init f64 = initialize_from %.loc8_26 to %.loc8_30.7
-// CHECK:STDOUT:   %.loc8_30.9: init [f64; 2] = array_init %.loc8_30.2, (%.loc8_30.5, %.loc8_30.8) to %b.var
-// CHECK:STDOUT:   assign %b.var, %.loc8_30.9
-// CHECK:STDOUT:   %.loc9_10.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc9_10.2: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc8_30.1: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
+// CHECK:STDOUT:   %.loc8_30.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc8_30.3: ref f64 = array_index %b.var, %.loc8_30.2
+// CHECK:STDOUT:   %.loc8_30.4: init f64 = initialize_from %.loc8_20 to %.loc8_30.3
+// CHECK:STDOUT:   %.loc8_30.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc8_30.6: ref f64 = array_index %b.var, %.loc8_30.5
+// CHECK:STDOUT:   %.loc8_30.7: init f64 = initialize_from %.loc8_26 to %.loc8_30.6
+// CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init %.loc8_30.1, (%.loc8_30.4, %.loc8_30.7) to %b.var
+// CHECK:STDOUT:   assign %b.var, %.loc8_30.8
+// CHECK:STDOUT:   %.loc9_10: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5
-// CHECK:STDOUT:   %.loc9_14.1: type = array_type %.loc9_13, ()
-// CHECK:STDOUT:   %.loc9_14.2: type = ptr_type [(); 5]
+// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, ()
 // CHECK:STDOUT:   %c.var: ref [(); 5] = var "c"
 // CHECK:STDOUT:   %c: ref [(); 5] = bind_name "c", %c.var
 // CHECK:STDOUT:   %.loc9_20.1: () = tuple_literal ()
@@ -51,13 +45,22 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc9_28.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_32.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_36.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_38.1: type = tuple_type ((), (), (), (), ())
-// CHECK:STDOUT:   %.loc9_38.2: ((), (), (), (), ()) = tuple_literal (%.loc9_20.1, %.loc9_24.1, %.loc9_28.1, %.loc9_32.1, %.loc9_36.1)
+// CHECK:STDOUT:   %.loc9_38.1: ((), (), (), (), ()) = tuple_literal (%.loc9_20.1, %.loc9_24.1, %.loc9_28.1, %.loc9_32.1, %.loc9_36.1)
 // CHECK:STDOUT:   %.loc9_20.2: init () = tuple_init %.loc9_20.1, ()
 // CHECK:STDOUT:   %.loc9_24.2: init () = tuple_init %.loc9_24.1, ()
 // CHECK:STDOUT:   %.loc9_28.2: init () = tuple_init %.loc9_28.1, ()
 // CHECK:STDOUT:   %.loc9_32.2: init () = tuple_init %.loc9_32.1, ()
 // CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init %.loc9_36.1, ()
-// CHECK:STDOUT:   %.loc9_38.3: init [(); 5] = array_init %.loc9_38.2, (%.loc9_20.2, %.loc9_24.2, %.loc9_28.2, %.loc9_32.2, %.loc9_36.2) to %c.var
-// CHECK:STDOUT:   assign %c.var, %.loc9_38.3
+// CHECK:STDOUT:   %.loc9_38.2: init [(); 5] = array_init %.loc9_38.1, (%.loc9_20.2, %.loc9_24.2, %.loc9_28.2, %.loc9_32.2, %.loc9_36.2) to %c.var
+// CHECK:STDOUT:   assign %c.var, %.loc9_38.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc8_15: type = ptr_type [f64; 2]
+// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64)
+// CHECK:STDOUT:   %.loc9_10: type = tuple_type ()
+// CHECK:STDOUT:   %.loc9_14: type = ptr_type [(); 5]
+// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ())
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -19,6 +19,10 @@ var a: [Incomplete; 1];
 // CHECK:STDERR:                           ^
 var p: Incomplete* = &a[0];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_incomplete_element.carbon" {
 // CHECK:STDOUT:   class_declaration @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
@@ -35,10 +39,6 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -33,9 +33,12 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name "p", %p.var
 // CHECK:STDOUT:   %a.ref: ref <error> = name_reference "a", %a
 // CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc20_22.1: type = ptr_type <error>
-// CHECK:STDOUT:   %.loc20_22.2: <error>* = address_of <error>
+// CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -12,8 +12,11 @@ var a: [1; 1];
 // CHECK:STDOUT: file "fail_invalid_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_13.1: type = array_type %.loc10_12, <error>
-// CHECK:STDOUT:   %.loc10_13.2: type = ptr_type [<error>; 1]
+// CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error>
 // CHECK:STDOUT:   %a.var: ref [<error>; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [<error>; 1] = bind_name "a", %a.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = ptr_type [<error>; 1]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -9,14 +9,14 @@
 // CHECK:STDERR:             ^
 var a: [1; 1];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = ptr_type [<error>; 1]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_invalid_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error>
 // CHECK:STDOUT:   %a.var: ref [<error>; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [<error>; 1] = bind_name "a", %a.var
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = ptr_type [<error>; 1]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -9,6 +9,11 @@
 // CHECK:STDERR:                           ^
 var a: [i32; 1] = (1, 2, 3);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_out_of_bound.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
@@ -19,9 +24,4 @@ var a: [i32; 1] = (1, 2, 3);
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3
 // CHECK:STDOUT:   %.loc10_27: (i32, i32, i32) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_26)
 // CHECK:STDOUT:   assign %a.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 1]
-// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -11,14 +11,17 @@ var a: [i32; 1] = (1, 2, 3);
 
 // CHECK:STDOUT: file "fail_out_of_bound.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc10_27.1: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_27.2: (i32, i32, i32) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_26)
+// CHECK:STDOUT:   %.loc10_27: (i32, i32, i32) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_26)
 // CHECK:STDOUT:   assign %a.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -28,24 +28,18 @@ var d: [i32; 3] = t2;
 
 // CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello"
 // CHECK:STDOUT:   %.loc10_32: String = string_literal "World"
-// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String)
-// CHECK:STDOUT:   %.loc10_39.2: (i32, String, String) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_32)
-// CHECK:STDOUT:   %.loc10_39.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc10_39.4: ref i32 = array_index %a.var, %.loc10_39.3
-// CHECK:STDOUT:   %.loc10_39.5: init i32 = initialize_from %.loc10_20 to %.loc10_39.4
+// CHECK:STDOUT:   %.loc10_39.1: (i32, String, String) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_32)
+// CHECK:STDOUT:   %.loc10_39.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc10_39.3: ref i32 = array_index %a.var, %.loc10_39.2
+// CHECK:STDOUT:   %.loc10_39.4: init i32 = initialize_from %.loc10_20 to %.loc10_39.3
 // CHECK:STDOUT:   assign %a.var, <error>
-// CHECK:STDOUT:   %.loc12_29.1: type = tuple_type (type, type, type)
-// CHECK:STDOUT:   %.loc12_29.2: (type, type, type) = tuple_literal (i32, String, String)
-// CHECK:STDOUT:   %.loc10_39.6: type = tuple_type (i32, String*, String*)
-// CHECK:STDOUT:   %.loc10_39.7: type = ptr_type (i32, String*, String*)
+// CHECK:STDOUT:   %.loc12: (type, type, type) = tuple_literal (i32, String, String)
 // CHECK:STDOUT:   %t1.var: ref (i32, String, String) = var "t1"
 // CHECK:STDOUT:   %t1: ref (i32, String, String) = bind_name "t1", %t1.var
 // CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3
@@ -66,12 +60,9 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %c: ref [i32; 3] = bind_name "c", %c.var
 // CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc21_24.2: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
+// CHECK:STDOUT:   %.loc21_24: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT:   %.loc23_18.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc23_18.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc21_24.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc23: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %t2.var: ref (i32, i32) = var "t2"
 // CHECK:STDOUT:   %t2: ref (i32, i32) = bind_name "t2", %t2.var
 // CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3
@@ -80,4 +71,16 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %d: ref [i32; 3] = bind_name "d", %d.var
 // CHECK:STDOUT:   %t2.ref: ref (i32, i32) = name_reference "t2", %t2
 // CHECK:STDOUT:   assign %d.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String)
+// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*)
+// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*)
+// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -26,6 +26,18 @@ var t2: (i32, i32);
 // CHECK:STDERR:                   ^
 var d: [i32; 3] = t2;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String)
+// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*)
+// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*)
+// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
@@ -71,16 +83,4 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %d: ref [i32; 3] = bind_name "d", %d.var
 // CHECK:STDOUT:   %t2.ref: ref (i32, i32) = name_reference "t2", %t2
 // CHECK:STDOUT:   assign %d.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_15: type = ptr_type [i32; 3]
-// CHECK:STDOUT:   %.1: type = ptr_type String
-// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String)
-// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type)
-// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*)
-// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*)
-// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -17,9 +17,13 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.loc12: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%arr: [i32; 3], %i: i32) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT:   %arr.ref: [i32; 3] = name_reference "arr", %arr
 // CHECK:STDOUT:   %i.ref: i32 = name_reference "i", %i
 // CHECK:STDOUT:   %.loc8_15.1: ref [i32; 3] = value_as_reference %arr.ref
@@ -34,23 +38,22 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc12_20.1: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc12_20.2: (i32, i32, i32) = tuple_literal (%.loc12_13, %.loc12_16, %.loc12_19)
+// CHECK:STDOUT:   %.loc12_20.1: (i32, i32, i32) = tuple_literal (%.loc12_13, %.loc12_16, %.loc12_19)
 // CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc12_20.3: ref [i32; 3] = temporary_storage
-// CHECK:STDOUT:   %.loc12_20.4: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc12_20.5: ref i32 = array_index %.loc12_20.3, %.loc12_20.4
-// CHECK:STDOUT:   %.loc12_20.6: init i32 = initialize_from %.loc12_13 to %.loc12_20.5
-// CHECK:STDOUT:   %.loc12_20.7: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc12_20.8: ref i32 = array_index %.loc12_20.3, %.loc12_20.7
-// CHECK:STDOUT:   %.loc12_20.9: init i32 = initialize_from %.loc12_16 to %.loc12_20.8
-// CHECK:STDOUT:   %.loc12_20.10: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc12_20.11: ref i32 = array_index %.loc12_20.3, %.loc12_20.10
-// CHECK:STDOUT:   %.loc12_20.12: init i32 = initialize_from %.loc12_19 to %.loc12_20.11
-// CHECK:STDOUT:   %.loc12_20.13: init [i32; 3] = array_init %.loc12_20.2, (%.loc12_20.6, %.loc12_20.9, %.loc12_20.12) to %.loc12_20.3
-// CHECK:STDOUT:   %.loc12_20.14: ref [i32; 3] = temporary %.loc12_20.3, %.loc12_20.13
-// CHECK:STDOUT:   %.loc12_20.15: [i32; 3] = bind_value %.loc12_20.14
-// CHECK:STDOUT:   %.loc12_11: init i32 = call %F.ref(%.loc12_20.15, %.loc12_23)
+// CHECK:STDOUT:   %.loc12_20.2: ref [i32; 3] = temporary_storage
+// CHECK:STDOUT:   %.loc12_20.3: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc12_20.4: ref i32 = array_index %.loc12_20.2, %.loc12_20.3
+// CHECK:STDOUT:   %.loc12_20.5: init i32 = initialize_from %.loc12_13 to %.loc12_20.4
+// CHECK:STDOUT:   %.loc12_20.6: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc12_20.7: ref i32 = array_index %.loc12_20.2, %.loc12_20.6
+// CHECK:STDOUT:   %.loc12_20.8: init i32 = initialize_from %.loc12_16 to %.loc12_20.7
+// CHECK:STDOUT:   %.loc12_20.9: i32 = int_literal 2
+// CHECK:STDOUT:   %.loc12_20.10: ref i32 = array_index %.loc12_20.2, %.loc12_20.9
+// CHECK:STDOUT:   %.loc12_20.11: init i32 = initialize_from %.loc12_19 to %.loc12_20.10
+// CHECK:STDOUT:   %.loc12_20.12: init [i32; 3] = array_init %.loc12_20.1, (%.loc12_20.5, %.loc12_20.8, %.loc12_20.11) to %.loc12_20.2
+// CHECK:STDOUT:   %.loc12_20.13: ref [i32; 3] = temporary %.loc12_20.2, %.loc12_20.12
+// CHECK:STDOUT:   %.loc12_20.14: [i32; 3] = bind_value %.loc12_20.13
+// CHECK:STDOUT:   %.loc12_11: init i32 = call %F.ref(%.loc12_20.14, %.loc12_23)
 // CHECK:STDOUT:   %.loc12_25: i32 = value_of_initializer %.loc12_11
 // CHECK:STDOUT:   return %.loc12_25
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -12,14 +12,14 @@ fn G() -> i32 {
   return F((1, 2, 3), 1);
 }
 
-// CHECK:STDOUT: file "function_param.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT:   %.loc12: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "function_param.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%arr: [i32; 3], %i: i32) -> i32 {

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -6,6 +6,11 @@
 
 var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 9]
+// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "nine_elements.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -50,9 +55,4 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.loc7_45.28: init i32 = initialize_from %.loc7_44 to %.loc7_45.27
 // CHECK:STDOUT:   %.loc7_45.29: init [i32; 9] = array_init %.loc7_45.1, (%.loc7_45.4, %.loc7_45.7, %.loc7_45.10, %.loc7_45.13, %.loc7_45.16, %.loc7_45.19, %.loc7_45.22, %.loc7_45.25, %.loc7_45.28) to %a.var
 // CHECK:STDOUT:   assign %a.var, %.loc7_45.29
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 9]
-// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -8,8 +8,7 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 
 // CHECK:STDOUT: file "nine_elements.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 9]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 9] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 9] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1
@@ -21,35 +20,39 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7
 // CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8
 // CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9
-// CHECK:STDOUT:   %.loc7_45.1: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_45.2: (i32, i32, i32, i32, i32, i32, i32, i32, i32) = tuple_literal (%.loc7_20, %.loc7_23, %.loc7_26, %.loc7_29, %.loc7_32, %.loc7_35, %.loc7_38, %.loc7_41, %.loc7_44)
-// CHECK:STDOUT:   %.loc7_45.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_45.4: ref i32 = array_index %a.var, %.loc7_45.3
-// CHECK:STDOUT:   %.loc7_45.5: init i32 = initialize_from %.loc7_20 to %.loc7_45.4
-// CHECK:STDOUT:   %.loc7_45.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_45.7: ref i32 = array_index %a.var, %.loc7_45.6
-// CHECK:STDOUT:   %.loc7_45.8: init i32 = initialize_from %.loc7_23 to %.loc7_45.7
-// CHECK:STDOUT:   %.loc7_45.9: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc7_45.10: ref i32 = array_index %a.var, %.loc7_45.9
-// CHECK:STDOUT:   %.loc7_45.11: init i32 = initialize_from %.loc7_26 to %.loc7_45.10
-// CHECK:STDOUT:   %.loc7_45.12: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc7_45.13: ref i32 = array_index %a.var, %.loc7_45.12
-// CHECK:STDOUT:   %.loc7_45.14: init i32 = initialize_from %.loc7_29 to %.loc7_45.13
-// CHECK:STDOUT:   %.loc7_45.15: i32 = int_literal 4
-// CHECK:STDOUT:   %.loc7_45.16: ref i32 = array_index %a.var, %.loc7_45.15
-// CHECK:STDOUT:   %.loc7_45.17: init i32 = initialize_from %.loc7_32 to %.loc7_45.16
-// CHECK:STDOUT:   %.loc7_45.18: i32 = int_literal 5
-// CHECK:STDOUT:   %.loc7_45.19: ref i32 = array_index %a.var, %.loc7_45.18
-// CHECK:STDOUT:   %.loc7_45.20: init i32 = initialize_from %.loc7_35 to %.loc7_45.19
-// CHECK:STDOUT:   %.loc7_45.21: i32 = int_literal 6
-// CHECK:STDOUT:   %.loc7_45.22: ref i32 = array_index %a.var, %.loc7_45.21
-// CHECK:STDOUT:   %.loc7_45.23: init i32 = initialize_from %.loc7_38 to %.loc7_45.22
-// CHECK:STDOUT:   %.loc7_45.24: i32 = int_literal 7
-// CHECK:STDOUT:   %.loc7_45.25: ref i32 = array_index %a.var, %.loc7_45.24
-// CHECK:STDOUT:   %.loc7_45.26: init i32 = initialize_from %.loc7_41 to %.loc7_45.25
-// CHECK:STDOUT:   %.loc7_45.27: i32 = int_literal 8
-// CHECK:STDOUT:   %.loc7_45.28: ref i32 = array_index %a.var, %.loc7_45.27
-// CHECK:STDOUT:   %.loc7_45.29: init i32 = initialize_from %.loc7_44 to %.loc7_45.28
-// CHECK:STDOUT:   %.loc7_45.30: init [i32; 9] = array_init %.loc7_45.2, (%.loc7_45.5, %.loc7_45.8, %.loc7_45.11, %.loc7_45.14, %.loc7_45.17, %.loc7_45.20, %.loc7_45.23, %.loc7_45.26, %.loc7_45.29) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_45.30
+// CHECK:STDOUT:   %.loc7_45.1: (i32, i32, i32, i32, i32, i32, i32, i32, i32) = tuple_literal (%.loc7_20, %.loc7_23, %.loc7_26, %.loc7_29, %.loc7_32, %.loc7_35, %.loc7_38, %.loc7_41, %.loc7_44)
+// CHECK:STDOUT:   %.loc7_45.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_45.3: ref i32 = array_index %a.var, %.loc7_45.2
+// CHECK:STDOUT:   %.loc7_45.4: init i32 = initialize_from %.loc7_20 to %.loc7_45.3
+// CHECK:STDOUT:   %.loc7_45.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc7_45.6: ref i32 = array_index %a.var, %.loc7_45.5
+// CHECK:STDOUT:   %.loc7_45.7: init i32 = initialize_from %.loc7_23 to %.loc7_45.6
+// CHECK:STDOUT:   %.loc7_45.8: i32 = int_literal 2
+// CHECK:STDOUT:   %.loc7_45.9: ref i32 = array_index %a.var, %.loc7_45.8
+// CHECK:STDOUT:   %.loc7_45.10: init i32 = initialize_from %.loc7_26 to %.loc7_45.9
+// CHECK:STDOUT:   %.loc7_45.11: i32 = int_literal 3
+// CHECK:STDOUT:   %.loc7_45.12: ref i32 = array_index %a.var, %.loc7_45.11
+// CHECK:STDOUT:   %.loc7_45.13: init i32 = initialize_from %.loc7_29 to %.loc7_45.12
+// CHECK:STDOUT:   %.loc7_45.14: i32 = int_literal 4
+// CHECK:STDOUT:   %.loc7_45.15: ref i32 = array_index %a.var, %.loc7_45.14
+// CHECK:STDOUT:   %.loc7_45.16: init i32 = initialize_from %.loc7_32 to %.loc7_45.15
+// CHECK:STDOUT:   %.loc7_45.17: i32 = int_literal 5
+// CHECK:STDOUT:   %.loc7_45.18: ref i32 = array_index %a.var, %.loc7_45.17
+// CHECK:STDOUT:   %.loc7_45.19: init i32 = initialize_from %.loc7_35 to %.loc7_45.18
+// CHECK:STDOUT:   %.loc7_45.20: i32 = int_literal 6
+// CHECK:STDOUT:   %.loc7_45.21: ref i32 = array_index %a.var, %.loc7_45.20
+// CHECK:STDOUT:   %.loc7_45.22: init i32 = initialize_from %.loc7_38 to %.loc7_45.21
+// CHECK:STDOUT:   %.loc7_45.23: i32 = int_literal 7
+// CHECK:STDOUT:   %.loc7_45.24: ref i32 = array_index %a.var, %.loc7_45.23
+// CHECK:STDOUT:   %.loc7_45.25: init i32 = initialize_from %.loc7_41 to %.loc7_45.24
+// CHECK:STDOUT:   %.loc7_45.26: i32 = int_literal 8
+// CHECK:STDOUT:   %.loc7_45.27: ref i32 = array_index %a.var, %.loc7_45.26
+// CHECK:STDOUT:   %.loc7_45.28: init i32 = initialize_from %.loc7_44 to %.loc7_45.27
+// CHECK:STDOUT:   %.loc7_45.29: init [i32; 9] = array_init %.loc7_45.1, (%.loc7_45.4, %.loc7_45.7, %.loc7_45.10, %.loc7_45.13, %.loc7_45.16, %.loc7_45.19, %.loc7_45.22, %.loc7_45.25, %.loc7_45.28) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_45.29
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 9]
+// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -7,8 +7,11 @@
 let t: type = (i32, i32) as type;
 
 // CHECK:STDOUT: file "as_type.carbon" {
-// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_24.2: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %t: type = bind_name "t", constants.%.loc7_26
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_24: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %t: type = bind_name "t", %.loc7_26
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -6,12 +6,12 @@
 
 let t: type = (i32, i32) as type;
 
-// CHECK:STDOUT: file "as_type.carbon" {
-// CHECK:STDOUT:   %.loc7: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %t: type = bind_name "t", constants.%.loc7_26
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_24: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "as_type.carbon" {
+// CHECK:STDOUT:   %.loc7: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %t: type = bind_name "t", constants.%.loc7_26
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -9,15 +9,15 @@
 // CHECK:STDERR:                       ^
 let n: (i32, i32) = 1 as (i32, i32);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_no_conversion.carbon" {
 // CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_35: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %n: (i32, i32) = bind_name "n", <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -10,11 +10,14 @@
 let n: (i32, i32) = 1 as (i32, i32);
 
 // CHECK:STDOUT: file "fail_no_conversion.carbon" {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_35: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %n: (i32, i32) = bind_name "n", <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/identity.carbon
+++ b/toolchain/check/testdata/as/identity.carbon
@@ -27,11 +27,16 @@ fn Initializing() {
 // CHECK:STDOUT: file "identity.carbon" {
 // CHECK:STDOUT:   class_declaration @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT:   %Value: <function> = fn_decl @Value
 // CHECK:STDOUT:   %Reference: <function> = fn_decl @Reference
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %Initializing: <function> = fn_decl @Initializing
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc9: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -41,8 +46,6 @@ fn Initializing() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Value(%n: X) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: type = tuple_type ()
-// CHECK:STDOUT:   %.loc9: type = ptr_type {}
 // CHECK:STDOUT:   %X.ref.loc14_10: type = name_reference "X", file.%X
 // CHECK:STDOUT:   %n.ref: X = name_reference "n", %n
 // CHECK:STDOUT:   %X.ref.loc14_19: type = name_reference "X", file.%X

--- a/toolchain/check/testdata/as/identity.carbon
+++ b/toolchain/check/testdata/as/identity.carbon
@@ -24,6 +24,12 @@ fn Initializing() {
   var x: X = (Make() as X);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc9: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "identity.carbon" {
 // CHECK:STDOUT:   class_declaration @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
@@ -31,12 +37,6 @@ fn Initializing() {
 // CHECK:STDOUT:   %Reference: <function> = fn_decl @Reference
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %Initializing: <function> = fn_decl @Initializing
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc9: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -23,12 +23,19 @@ fn Var() {
 // CHECK:STDOUT: file "tuple.carbon" {
 // CHECK:STDOUT:   class_declaration @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %Let: <function> = fn_decl @Let
 // CHECK:STDOUT:   %Var: <function> = fn_decl @Var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT:   %.loc15_15.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc15_15.2: type = tuple_type (X, X)
+// CHECK:STDOUT:   %.loc15_15.3: type = tuple_type ({}*, {}*)
+// CHECK:STDOUT:   %.loc15_15.4: type = ptr_type ({}*, {}*)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -42,11 +49,7 @@ fn Var() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %X.ref.loc15_11: type = name_reference "X", file.%X
 // CHECK:STDOUT:   %X.ref.loc15_14: type = name_reference "X", file.%X
-// CHECK:STDOUT:   %.loc15_15.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc15_15.2: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
-// CHECK:STDOUT:   %.loc15_15.3: type = tuple_type (X, X)
-// CHECK:STDOUT:   %.loc15_15.4: type = tuple_type ({}*, {}*)
-// CHECK:STDOUT:   %.loc15_15.5: type = ptr_type ({}*, {}*)
+// CHECK:STDOUT:   %.loc15_15: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
 // CHECK:STDOUT:   %Make.ref.loc15_20: <function> = name_reference "Make", file.%Make
 // CHECK:STDOUT:   %.loc15_24.1: ref X = temporary_storage
 // CHECK:STDOUT:   %.loc15_24.2: init X = call %Make.ref.loc15_20() to %.loc15_24.1

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -20,14 +20,6 @@ fn Var() {
   var b: (X, X) = (Make(), Make()) as (X, X);
 }
 
-// CHECK:STDOUT: file "tuple.carbon" {
-// CHECK:STDOUT:   class_declaration @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make
-// CHECK:STDOUT:   %Let: <function> = fn_decl @Let
-// CHECK:STDOUT:   %Var: <function> = fn_decl @Var
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
@@ -36,6 +28,14 @@ fn Var() {
 // CHECK:STDOUT:   %.loc15_15.2: type = tuple_type (X, X)
 // CHECK:STDOUT:   %.loc15_15.3: type = tuple_type ({}*, {}*)
 // CHECK:STDOUT:   %.loc15_15.4: type = ptr_type ({}*, {}*)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "tuple.carbon" {
+// CHECK:STDOUT:   class_declaration @X, ()
+// CHECK:STDOUT:   %X: type = class_type @X
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make
+// CHECK:STDOUT:   %Let: <function> = fn_decl @Let
+// CHECK:STDOUT:   %Var: <function> = fn_decl @Var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -9,6 +9,10 @@ var test_f64: f64 = 0.1;
 let test_str: String = "Test";
 var test_type: type = i32;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "builtin_types.carbon" {
 // CHECK:STDOUT:   %test_i32.var: ref i32 = var "test_i32"
 // CHECK:STDOUT:   %test_i32: ref i32 = bind_name "test_i32", %test_i32.var
@@ -23,8 +27,4 @@ var test_type: type = i32;
 // CHECK:STDOUT:   %test_type.var: ref type = var "test_type"
 // CHECK:STDOUT:   %test_type: ref type = bind_name "test_type", %test_type.var
 // CHECK:STDOUT:   assign %test_type.var, i32
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -18,10 +18,13 @@ var test_type: type = i32;
 // CHECK:STDOUT:   %test_f64: ref f64 = bind_name "test_f64", %test_f64.var
 // CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1
 // CHECK:STDOUT:   assign %test_f64.var, %.loc8
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc9: String = string_literal "Test"
 // CHECK:STDOUT:   %test_str: String = bind_name "test_str", %.loc9
 // CHECK:STDOUT:   %test_type.var: ref type = var "test_type"
 // CHECK:STDOUT:   %test_type: ref type = bind_name "test_type", %test_type.var
 // CHECK:STDOUT:   assign %test_type.var, i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -12,13 +12,13 @@
 // CHECK:STDERR:                     ^
 fn Run() -> String {}
 
-// CHECK:STDOUT: file "fail_bad_run.carbon" {
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc13: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_bad_run.carbon" {
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> %return: String {

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -13,8 +13,11 @@
 fn Run() -> String {}
 
 // CHECK:STDOUT: file "fail_bad_run.carbon" {
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc13: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -25,15 +25,15 @@ fn F() {
   );
 }
 
-// CHECK:STDOUT: file "numeric_literals.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10: type = ptr_type [i32; 5]
 // CHECK:STDOUT:   %.loc16: type = tuple_type (i32, i32, i32, i32, i32)
 // CHECK:STDOUT:   %.loc17: type = ptr_type [f64; 7]
 // CHECK:STDOUT:   %.loc25: type = tuple_type (f64, f64, f64, f64, f64, f64, f64)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "numeric_literals.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -29,11 +29,17 @@ fn F() {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = ptr_type [i32; 5]
+// CHECK:STDOUT:   %.loc16: type = tuple_type (i32, i32, i32, i32, i32)
+// CHECK:STDOUT:   %.loc17: type = ptr_type [f64; 7]
+// CHECK:STDOUT:   %.loc25: type = tuple_type (f64, f64, f64, f64, f64, f64, f64)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5
-// CHECK:STDOUT:   %.loc10_20.1: type = array_type %.loc10_19, i32
-// CHECK:STDOUT:   %.loc10_20.2: type = ptr_type [i32; 5]
+// CHECK:STDOUT:   %.loc10_20: type = array_type %.loc10_19, i32
 // CHECK:STDOUT:   %ints.var: ref [i32; 5] = var "ints"
 // CHECK:STDOUT:   %ints: ref [i32; 5] = bind_name "ints", %ints.var
 // CHECK:STDOUT:   %.loc11: i32 = int_literal 8
@@ -41,28 +47,26 @@ fn F() {
 // CHECK:STDOUT:   %.loc13: i32 = int_literal 8
 // CHECK:STDOUT:   %.loc14: i32 = int_literal 8
 // CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993
-// CHECK:STDOUT:   %.loc16_3.1: type = tuple_type (i32, i32, i32, i32, i32)
-// CHECK:STDOUT:   %.loc16_3.2: (i32, i32, i32, i32, i32) = tuple_literal (%.loc11, %.loc12, %.loc13, %.loc14, %.loc15)
-// CHECK:STDOUT:   %.loc16_3.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc16_3.4: ref i32 = array_index %ints.var, %.loc16_3.3
-// CHECK:STDOUT:   %.loc16_3.5: init i32 = initialize_from %.loc11 to %.loc16_3.4
-// CHECK:STDOUT:   %.loc16_3.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc16_3.7: ref i32 = array_index %ints.var, %.loc16_3.6
-// CHECK:STDOUT:   %.loc16_3.8: init i32 = initialize_from %.loc12 to %.loc16_3.7
-// CHECK:STDOUT:   %.loc16_3.9: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc16_3.10: ref i32 = array_index %ints.var, %.loc16_3.9
-// CHECK:STDOUT:   %.loc16_3.11: init i32 = initialize_from %.loc13 to %.loc16_3.10
-// CHECK:STDOUT:   %.loc16_3.12: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc16_3.13: ref i32 = array_index %ints.var, %.loc16_3.12
-// CHECK:STDOUT:   %.loc16_3.14: init i32 = initialize_from %.loc14 to %.loc16_3.13
-// CHECK:STDOUT:   %.loc16_3.15: i32 = int_literal 4
-// CHECK:STDOUT:   %.loc16_3.16: ref i32 = array_index %ints.var, %.loc16_3.15
-// CHECK:STDOUT:   %.loc16_3.17: init i32 = initialize_from %.loc15 to %.loc16_3.16
-// CHECK:STDOUT:   %.loc16_3.18: init [i32; 5] = array_init %.loc16_3.2, (%.loc16_3.5, %.loc16_3.8, %.loc16_3.11, %.loc16_3.14, %.loc16_3.17) to %ints.var
-// CHECK:STDOUT:   assign %ints.var, %.loc16_3.18
+// CHECK:STDOUT:   %.loc16_3.1: (i32, i32, i32, i32, i32) = tuple_literal (%.loc11, %.loc12, %.loc13, %.loc14, %.loc15)
+// CHECK:STDOUT:   %.loc16_3.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc16_3.3: ref i32 = array_index %ints.var, %.loc16_3.2
+// CHECK:STDOUT:   %.loc16_3.4: init i32 = initialize_from %.loc11 to %.loc16_3.3
+// CHECK:STDOUT:   %.loc16_3.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc16_3.6: ref i32 = array_index %ints.var, %.loc16_3.5
+// CHECK:STDOUT:   %.loc16_3.7: init i32 = initialize_from %.loc12 to %.loc16_3.6
+// CHECK:STDOUT:   %.loc16_3.8: i32 = int_literal 2
+// CHECK:STDOUT:   %.loc16_3.9: ref i32 = array_index %ints.var, %.loc16_3.8
+// CHECK:STDOUT:   %.loc16_3.10: init i32 = initialize_from %.loc13 to %.loc16_3.9
+// CHECK:STDOUT:   %.loc16_3.11: i32 = int_literal 3
+// CHECK:STDOUT:   %.loc16_3.12: ref i32 = array_index %ints.var, %.loc16_3.11
+// CHECK:STDOUT:   %.loc16_3.13: init i32 = initialize_from %.loc14 to %.loc16_3.12
+// CHECK:STDOUT:   %.loc16_3.14: i32 = int_literal 4
+// CHECK:STDOUT:   %.loc16_3.15: ref i32 = array_index %ints.var, %.loc16_3.14
+// CHECK:STDOUT:   %.loc16_3.16: init i32 = initialize_from %.loc15 to %.loc16_3.15
+// CHECK:STDOUT:   %.loc16_3.17: init [i32; 5] = array_init %.loc16_3.1, (%.loc16_3.4, %.loc16_3.7, %.loc16_3.10, %.loc16_3.13, %.loc16_3.16) to %ints.var
+// CHECK:STDOUT:   assign %ints.var, %.loc16_3.17
 // CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7
-// CHECK:STDOUT:   %.loc17_22.1: type = array_type %.loc17_21, f64
-// CHECK:STDOUT:   %.loc17_22.2: type = ptr_type [f64; 7]
+// CHECK:STDOUT:   %.loc17_22: type = array_type %.loc17_21, f64
 // CHECK:STDOUT:   %floats.var: ref [f64; 7] = var "floats"
 // CHECK:STDOUT:   %floats: ref [f64; 7] = bind_name "floats", %floats.var
 // CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1
@@ -72,30 +76,29 @@ fn F() {
 // CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7
 // CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9
 // CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992
-// CHECK:STDOUT:   %.loc25_3.1: type = tuple_type (f64, f64, f64, f64, f64, f64, f64)
-// CHECK:STDOUT:   %.loc25_3.2: (f64, f64, f64, f64, f64, f64, f64) = tuple_literal (%.loc18, %.loc19, %.loc20, %.loc21, %.loc22, %.loc23, %.loc24)
-// CHECK:STDOUT:   %.loc25_3.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc25_3.4: ref f64 = array_index %floats.var, %.loc25_3.3
-// CHECK:STDOUT:   %.loc25_3.5: init f64 = initialize_from %.loc18 to %.loc25_3.4
-// CHECK:STDOUT:   %.loc25_3.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc25_3.7: ref f64 = array_index %floats.var, %.loc25_3.6
-// CHECK:STDOUT:   %.loc25_3.8: init f64 = initialize_from %.loc19 to %.loc25_3.7
-// CHECK:STDOUT:   %.loc25_3.9: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc25_3.10: ref f64 = array_index %floats.var, %.loc25_3.9
-// CHECK:STDOUT:   %.loc25_3.11: init f64 = initialize_from %.loc20 to %.loc25_3.10
-// CHECK:STDOUT:   %.loc25_3.12: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc25_3.13: ref f64 = array_index %floats.var, %.loc25_3.12
-// CHECK:STDOUT:   %.loc25_3.14: init f64 = initialize_from %.loc21 to %.loc25_3.13
-// CHECK:STDOUT:   %.loc25_3.15: i32 = int_literal 4
-// CHECK:STDOUT:   %.loc25_3.16: ref f64 = array_index %floats.var, %.loc25_3.15
-// CHECK:STDOUT:   %.loc25_3.17: init f64 = initialize_from %.loc22 to %.loc25_3.16
-// CHECK:STDOUT:   %.loc25_3.18: i32 = int_literal 5
-// CHECK:STDOUT:   %.loc25_3.19: ref f64 = array_index %floats.var, %.loc25_3.18
-// CHECK:STDOUT:   %.loc25_3.20: init f64 = initialize_from %.loc23 to %.loc25_3.19
-// CHECK:STDOUT:   %.loc25_3.21: i32 = int_literal 6
-// CHECK:STDOUT:   %.loc25_3.22: ref f64 = array_index %floats.var, %.loc25_3.21
-// CHECK:STDOUT:   %.loc25_3.23: init f64 = initialize_from %.loc24 to %.loc25_3.22
-// CHECK:STDOUT:   %.loc25_3.24: init [f64; 7] = array_init %.loc25_3.2, (%.loc25_3.5, %.loc25_3.8, %.loc25_3.11, %.loc25_3.14, %.loc25_3.17, %.loc25_3.20, %.loc25_3.23) to %floats.var
-// CHECK:STDOUT:   assign %floats.var, %.loc25_3.24
+// CHECK:STDOUT:   %.loc25_3.1: (f64, f64, f64, f64, f64, f64, f64) = tuple_literal (%.loc18, %.loc19, %.loc20, %.loc21, %.loc22, %.loc23, %.loc24)
+// CHECK:STDOUT:   %.loc25_3.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc25_3.3: ref f64 = array_index %floats.var, %.loc25_3.2
+// CHECK:STDOUT:   %.loc25_3.4: init f64 = initialize_from %.loc18 to %.loc25_3.3
+// CHECK:STDOUT:   %.loc25_3.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc25_3.6: ref f64 = array_index %floats.var, %.loc25_3.5
+// CHECK:STDOUT:   %.loc25_3.7: init f64 = initialize_from %.loc19 to %.loc25_3.6
+// CHECK:STDOUT:   %.loc25_3.8: i32 = int_literal 2
+// CHECK:STDOUT:   %.loc25_3.9: ref f64 = array_index %floats.var, %.loc25_3.8
+// CHECK:STDOUT:   %.loc25_3.10: init f64 = initialize_from %.loc20 to %.loc25_3.9
+// CHECK:STDOUT:   %.loc25_3.11: i32 = int_literal 3
+// CHECK:STDOUT:   %.loc25_3.12: ref f64 = array_index %floats.var, %.loc25_3.11
+// CHECK:STDOUT:   %.loc25_3.13: init f64 = initialize_from %.loc21 to %.loc25_3.12
+// CHECK:STDOUT:   %.loc25_3.14: i32 = int_literal 4
+// CHECK:STDOUT:   %.loc25_3.15: ref f64 = array_index %floats.var, %.loc25_3.14
+// CHECK:STDOUT:   %.loc25_3.16: init f64 = initialize_from %.loc22 to %.loc25_3.15
+// CHECK:STDOUT:   %.loc25_3.17: i32 = int_literal 5
+// CHECK:STDOUT:   %.loc25_3.18: ref f64 = array_index %floats.var, %.loc25_3.17
+// CHECK:STDOUT:   %.loc25_3.19: init f64 = initialize_from %.loc23 to %.loc25_3.18
+// CHECK:STDOUT:   %.loc25_3.20: i32 = int_literal 6
+// CHECK:STDOUT:   %.loc25_3.21: ref f64 = array_index %floats.var, %.loc25_3.20
+// CHECK:STDOUT:   %.loc25_3.22: init f64 = initialize_from %.loc24 to %.loc25_3.21
+// CHECK:STDOUT:   %.loc25_3.23: init [f64; 7] = array_init %.loc25_3.1, (%.loc25_3.4, %.loc25_3.7, %.loc25_3.10, %.loc25_3.13, %.loc25_3.16, %.loc25_3.19, %.loc25_3.22) to %floats.var
+// CHECK:STDOUT:   assign %floats.var, %.loc25_3.23
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -85,14 +85,14 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       0:               inst+6
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
-// CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc11_28.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc11_28.2: type = tuple_type (i32, f64)
 // CHECK:STDOUT:   %.loc11_28.3: type = ptr_type (i32, f64)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -61,10 +61,8 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       1:               instFloatingPointType
 // CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
-// CHECK:STDOUT:       2:               inst+2
-// CHECK:STDOUT:       3:               inst+3
-// CHECK:STDOUT:       4:               inst+4
+// CHECK:STDOUT:       1:               inst+2
+// CHECK:STDOUT:       2:               inst+4
 // CHECK:STDOUT:     block4:
 // CHECK:STDOUT:       0:               inst+7
 // CHECK:STDOUT:       1:               inst+8
@@ -84,13 +82,17 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       0:               inst+13
 // CHECK:STDOUT:       1:               inst+15
 // CHECK:STDOUT:     block7:
-// CHECK:STDOUT:       0:               inst+5
-// CHECK:STDOUT:       1:               inst+6
+// CHECK:STDOUT:       0:               inst+6
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: file "raw_and_textual_ir.carbon" {
-// CHECK:STDOUT:   %.loc11: type = ptr_type (i32, f64)
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11_28.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc11_28.2: type = tuple_type (i32, f64)
+// CHECK:STDOUT:   %.loc11_28.3: type = ptr_type (i32, f64)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -61,10 +61,8 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       1:               instFloatingPointType
 // CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+1
-// CHECK:STDOUT:       2:               inst+2
-// CHECK:STDOUT:       3:               inst+3
-// CHECK:STDOUT:       4:               inst+4
+// CHECK:STDOUT:       1:               inst+2
+// CHECK:STDOUT:       2:               inst+4
 // CHECK:STDOUT:     block4:
 // CHECK:STDOUT:       0:               inst+7
 // CHECK:STDOUT:       1:               inst+8
@@ -84,6 +82,5 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT:       0:               inst+13
 // CHECK:STDOUT:       1:               inst+15
 // CHECK:STDOUT:     block7:
-// CHECK:STDOUT:       0:               inst+5
-// CHECK:STDOUT:       1:               inst+6
+// CHECK:STDOUT:       0:               inst+6
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -12,14 +12,14 @@ fn Foo(n: i32) -> (i32, f64) {
   return (n + 2, 3.4);
 }
 
-// CHECK:STDOUT: file "textual_ir.carbon" {
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc11_28.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc11_28.2: type = tuple_type (i32, f64)
 // CHECK:STDOUT:   %.loc11_28.3: type = ptr_type (i32, f64)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "textual_ir.carbon" {
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -13,8 +13,13 @@ fn Foo(n: i32) -> (i32, f64) {
 }
 
 // CHECK:STDOUT: file "textual_ir.carbon" {
-// CHECK:STDOUT:   %.loc11: type = ptr_type (i32, f64)
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11_28.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc11_28.2: type = tuple_type (i32, f64)
+// CHECK:STDOUT:   %.loc11_28.3: type = ptr_type (i32, f64)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, f64) {

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -25,9 +25,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT: file "basic.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -22,15 +22,15 @@ fn Run() -> i32 {
   return Class.F(4);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "basic.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -19,6 +19,9 @@ class Class {
 // CHECK:STDOUT: file "fail_addr_not_self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc17: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -16,13 +16,13 @@ class Class {
   fn G(addr b: Class*);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc17: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_addr_not_self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -41,8 +41,13 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT: file "fail_addr_self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -60,8 +65,6 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%c: Class, %p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %c.ref.loc19: Class = name_reference "c", %c
 // CHECK:STDOUT:   %.loc19_4: <bound method> = bound_method %c.ref.loc19, @Class.%F
 // CHECK:STDOUT:   %.loc19_6: init () = call %.loc19_4(<invalid>)

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -38,16 +38,16 @@ fn F(c: Class, p: Class*) {
   (*p).G();
 }
 
-// CHECK:STDOUT: file "fail_addr_self.carbon" {
-// CHECK:STDOUT:   class_declaration @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc10_1.2: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_addr_self.carbon" {
+// CHECK:STDOUT:   class_declaration @Class, ()
+// CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -133,6 +133,11 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:   %CallReturnIncomplete: <function> = fn_decl @CallReturnIncomplete
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc41: type = struct_type {}
+// CHECK:STDOUT:   %.loc100: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: class @Class;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1() {
@@ -149,8 +154,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertFromStruct() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc41_43.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc41_43.2: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc41: {} = struct_literal ()
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -186,8 +190,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:   %TakeIncomplete.ref.loc100: <function> = name_reference "TakeIncomplete", file.%TakeIncomplete
 // CHECK:STDOUT:   %p.ref: Class* = name_reference "p", %p
 // CHECK:STDOUT:   %.loc100_18: ref Class = dereference %p.ref
-// CHECK:STDOUT:   %.loc100_17.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc100_17.2: init () = call %TakeIncomplete.ref.loc100(<invalid>)
+// CHECK:STDOUT:   %.loc100_17: init () = call %TakeIncomplete.ref.loc100(<invalid>)
 // CHECK:STDOUT:   %TakeIncomplete.ref.loc111: <function> = name_reference "TakeIncomplete", file.%TakeIncomplete
 // CHECK:STDOUT:   %.loc111_19: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc111_17: init () = call %TakeIncomplete.ref.loc111(<invalid>)

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -115,6 +115,11 @@ fn CallReturnIncomplete() {
   ReturnIncomplete();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc41: type = struct_type {}
+// CHECK:STDOUT:   %.loc100: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_incomplete.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
@@ -131,11 +136,6 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:   %ReturnIncomplete: <function> = fn_decl @ReturnIncomplete
 // CHECK:STDOUT:   %CallTakeIncomplete: <function> = fn_decl @CallTakeIncomplete
 // CHECK:STDOUT:   %CallReturnIncomplete: <function> = fn_decl @CallReturnIncomplete
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc41: type = struct_type {}
-// CHECK:STDOUT:   %.loc100: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class;

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -24,18 +24,18 @@ fn F() {
   {.a = 1, .b = 2, .c = 3} as Class;
 }
 
-// CHECK:STDOUT: file "fail_init.carbon" {
-// CHECK:STDOUT:   class_declaration @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc20: type = struct_type {.a: i32, .c: i32}
 // CHECK:STDOUT:   %.loc24: type = struct_type {.a: i32, .b: i32, .c: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_init.carbon" {
+// CHECK:STDOUT:   class_declaration @Class, ()
+// CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -27,8 +27,15 @@ fn F() {
 // CHECK:STDOUT: file "fail_init.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc16: type = struct_type {.a: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc20: type = struct_type {.a: i32, .c: i32}
+// CHECK:STDOUT:   %.loc24: type = struct_type {.a: i32, .b: i32, .c: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -47,28 +54,24 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc16_10.1: type = struct_type {.a: i32}
-// CHECK:STDOUT:   %.loc16_10.2: {.a: i32} = struct_literal (%.loc16_9)
+// CHECK:STDOUT:   %.loc16_10.1: {.a: i32} = struct_literal (%.loc16_9)
 // CHECK:STDOUT:   %Class.ref.loc16: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc16_10.3: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc16_10.4: ref Class = temporary %.loc16_10.3, <error>
+// CHECK:STDOUT:   %.loc16_10.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc16_10.3: ref Class = temporary %.loc16_10.2, <error>
 // CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc20_18.1: type = struct_type {.a: i32, .c: i32}
-// CHECK:STDOUT:   %.loc20_18.2: {.a: i32, .c: i32} = struct_literal (%.loc20_9, %.loc20_17)
+// CHECK:STDOUT:   %.loc20_18.1: {.a: i32, .c: i32} = struct_literal (%.loc20_9, %.loc20_17)
 // CHECK:STDOUT:   %Class.ref.loc20: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc20_18.3: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc20_18.4: ref i32 = class_field_access %.loc20_18.3, member0
-// CHECK:STDOUT:   %.loc20_18.5: init i32 = initialize_from %.loc20_9 to %.loc20_18.4
-// CHECK:STDOUT:   %.loc20_18.6: ref Class = temporary %.loc20_18.3, <error>
+// CHECK:STDOUT:   %.loc20_18.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc20_18.3: ref i32 = class_field_access %.loc20_18.2, member0
+// CHECK:STDOUT:   %.loc20_18.4: init i32 = initialize_from %.loc20_9 to %.loc20_18.3
+// CHECK:STDOUT:   %.loc20_18.5: ref Class = temporary %.loc20_18.2, <error>
 // CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc24_26.1: type = struct_type {.a: i32, .b: i32, .c: i32}
-// CHECK:STDOUT:   %.loc24_26.2: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc24_9, %.loc24_17, %.loc24_25)
+// CHECK:STDOUT:   %.loc24_26.1: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc24_9, %.loc24_17, %.loc24_25)
 // CHECK:STDOUT:   %Class.ref.loc24: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc24_26.3: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc24_26.4: ref Class = temporary %.loc24_26.3, <error>
+// CHECK:STDOUT:   %.loc24_26.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc24_26.3: ref Class = temporary %.loc24_26.2, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -25,9 +25,14 @@ fn F() {
 // CHECK:STDOUT: file "fail_init_as_inplace.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc22: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -48,7 +53,6 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref.loc21_10: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %c.var: ref Class = var "c"
 // CHECK:STDOUT:   %c: ref Class = bind_name "c", %c.var
 // CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1
@@ -67,7 +71,6 @@ fn F() {
 // CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %c.ref: ref Class = name_reference "c", %c
 // CHECK:STDOUT:   %.loc22_5: Class* = address_of %c.ref
-// CHECK:STDOUT:   %.loc22_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc22_4.2: init () = call %G.ref(%.loc22_5)
+// CHECK:STDOUT:   %.loc22_4: init () = call %G.ref(%.loc22_5)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -22,17 +22,17 @@ fn F() {
   G(&c);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc22: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_init_as_inplace.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc22: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -33,14 +33,6 @@ fn F(s: {.a: A}, b: B) {
   b.a.F();
 }
 
-// CHECK:STDOUT: file "fail_memaccess_category.carbon" {
-// CHECK:STDOUT:   class_declaration @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A
-// CHECK:STDOUT:   class_declaration @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
@@ -48,6 +40,14 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:   %.loc13_1.1: type = struct_type {.a: A}
 // CHECK:STDOUT:   %.loc13_1.2: type = struct_type {.a: {}*}
 // CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_memaccess_category.carbon" {
+// CHECK:STDOUT:   class_declaration @A, ()
+// CHECK:STDOUT:   %A: type = class_type @A
+// CHECK:STDOUT:   class_declaration @B, ()
+// CHECK:STDOUT:   %B: type = class_type @B
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -36,11 +36,18 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: file "fail_memaccess_category.carbon" {
 // CHECK:STDOUT:   class_declaration @A, ()
 // CHECK:STDOUT:   %A: type = class_type @A
-// CHECK:STDOUT:   %.loc9: type = struct_type {}
 // CHECK:STDOUT:   class_declaration @B, ()
 // CHECK:STDOUT:   %B: type = class_type @B
-// CHECK:STDOUT:   %.loc13: type = struct_type {.a: A}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT:   %.loc13_1.1: type = struct_type {.a: A}
+// CHECK:STDOUT:   %.loc13_1.2: type = struct_type {.a: {}*}
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
@@ -52,8 +59,6 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_reference "A", file.%A
-// CHECK:STDOUT:   %.loc9: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %.loc12_8.1: type = unbound_field_type B, A
 // CHECK:STDOUT:   %.loc12_8.2: <unbound field of class B> = field "a", member0
 // CHECK:STDOUT:   %a: <unbound field of class B> = bind_name "a", %.loc12_8.2
@@ -66,8 +71,6 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%s: {.a: A}, %b: B) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13: type = struct_type {.a: {}*}
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A}
 // CHECK:STDOUT:   %s.ref: {.a: A} = name_reference "s", %s
 // CHECK:STDOUT:   %.loc23_4: A = struct_access %s.ref, member0
 // CHECK:STDOUT:   %.loc23_6: <bound method> = bound_method %.loc23_4, @A.%F

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -21,16 +21,16 @@ let T: type = Class;
 // CHECK:STDERR:    ^
 fn T.F() {}
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_member_of_let.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Class.ref: type = name_reference "Class", %Class
 // CHECK:STDOUT:   %T: type = bind_name "T", %Class.ref
 // CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -24,10 +24,13 @@ fn T.F() {}
 // CHECK:STDOUT: file "fail_member_of_let.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc9: type = struct_type {}
 // CHECK:STDOUT:   %Class.ref: type = name_reference "Class", %Class
 // CHECK:STDOUT:   %T: type = bind_name "T", %Class.ref
 // CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -30,16 +30,16 @@ fn F(c: Class) {
   Class.WithSelf(c);
 }
 
-// CHECK:STDOUT: file "fail_method.carbon" {
-// CHECK:STDOUT:   class_declaration @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc10_1.2: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_method.carbon" {
+// CHECK:STDOUT:   class_declaration @Class, ()
+// CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -33,8 +33,13 @@ fn F(c: Class) {
 // CHECK:STDOUT: file "fail_method.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -52,8 +57,6 @@ fn F(c: Class) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%c: Class) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %c.ref.loc13: Class = name_reference "c", %c
 // CHECK:STDOUT:   %NoSelf.ref.loc13: <function> = name_reference "NoSelf", @Class.%NoSelf
 // CHECK:STDOUT:   %.loc13: init () = call %NoSelf.ref.loc13()

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -27,11 +27,14 @@ fn Class.H() {}
 // CHECK:STDOUT: file "fail_redefinition.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -24,6 +24,10 @@ fn Class.F() {}
 fn Class.G() {}
 fn Class.H() {}
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_redefinition.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
@@ -31,10 +35,6 @@ fn Class.H() {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -25,13 +25,13 @@ class Class {
   }
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc26: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_reorder.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc26: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -28,6 +28,9 @@ class Class {
 // CHECK:STDOUT: file "fail_reorder.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc26: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -18,13 +18,13 @@ class Class {
   }
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc19: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_scope.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc19: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -21,6 +21,9 @@ class Class {
 // CHECK:STDOUT: file "fail_scope.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc19: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -53,12 +53,17 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: file "fail_self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc20: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   class_declaration @WrongSelf, ()
 // CHECK:STDOUT:   %WrongSelf: type = class_type @WrongSelf
 // CHECK:STDOUT:   %CallWrongSelf: <function> = fn_decl @CallWrongSelf
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -79,8 +84,6 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1(%self: Class) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc20: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -50,6 +50,12 @@ fn CallWrongSelf(ws: WrongSelf) {
   ws.F();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
@@ -58,12 +64,6 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:   class_declaration @WrongSelf, ()
 // CHECK:STDOUT:   %WrongSelf: type = class_type @WrongSelf
 // CHECK:STDOUT:   %CallWrongSelf: <function> = fn_decl @CallWrongSelf
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -25,8 +25,11 @@ fn G() -> i32 {
 // CHECK:STDOUT: file "fail_unbound_field.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc16: type = struct_type {.field: i32}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc16: type = struct_type {.field: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -22,14 +22,14 @@ fn G() -> i32 {
   return Class.field;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc16: type = struct_type {.field: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_unbound_field.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: type = struct_type {.field: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -16,15 +16,15 @@ fn G(c: Class) -> i32 {
   return c.something;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_unknown_member.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32}
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -19,8 +19,12 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT: file "fail_unknown_member.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -34,7 +38,6 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%c: Class) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT:   %c.ref: Class = name_reference "c", %c
 // CHECK:STDOUT:   %something.ref: <error> = name_reference "something", <error>
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -19,8 +19,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT: file "field_access.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.j: i32, .k: i32}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -39,7 +43,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT:   %c.var: ref Class = var "c"
 // CHECK:STDOUT:   %c: ref Class = bind_name "c", %c.var
 // CHECK:STDOUT:   %c.ref.loc14: ref Class = name_reference "c", %c

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -16,15 +16,15 @@ fn Run() -> i32 {
   return c.j + c.k;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "field_access.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -20,8 +20,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT: file "field_access_in_value.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.j: i32, .k: i32}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -40,7 +44,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref.loc13: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT:   %cv.var: ref Class = var "cv"
 // CHECK:STDOUT:   %cv: ref Class = bind_name "cv", %cv.var
 // CHECK:STDOUT:   %cv.ref.loc14: ref Class = name_reference "cv", %cv

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -17,15 +17,15 @@ fn Run() -> i32 {
   return c.j + c.k;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "field_access_in_value.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -17,17 +17,17 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
   return {.next = next, .n = n};
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*}
+// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "init.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %MakeReorder: <function> = fn_decl @MakeReorder
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*}
-// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -20,10 +20,14 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: file "init.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*}
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %MakeReorder: <function> = fn_decl @MakeReorder
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*}
+// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -58,12 +62,11 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %next.ref: Class* = name_reference "next", %next
 // CHECK:STDOUT:   %n.ref: i32 = name_reference "n", %n
-// CHECK:STDOUT:   %.loc17_31.1: type = struct_type {.next: Class*, .n: i32}
-// CHECK:STDOUT:   %.loc17_31.2: {.next: Class*, .n: i32} = struct_literal (%next.ref, %n.ref)
-// CHECK:STDOUT:   %.loc17_31.3: ref i32 = class_field_access %return, member1
-// CHECK:STDOUT:   %.loc17_31.4: init i32 = initialize_from %n.ref to %.loc17_31.3
-// CHECK:STDOUT:   %.loc17_31.5: ref Class* = class_field_access %return, member0
-// CHECK:STDOUT:   %.loc17_31.6: init Class* = initialize_from %next.ref to %.loc17_31.5
-// CHECK:STDOUT:   %.loc17_31.7: init Class = class_init %.loc17_31.2, (%.loc17_31.4, %.loc17_31.6)
-// CHECK:STDOUT:   return %.loc17_31.7
+// CHECK:STDOUT:   %.loc17_31.1: {.next: Class*, .n: i32} = struct_literal (%next.ref, %n.ref)
+// CHECK:STDOUT:   %.loc17_31.2: ref i32 = class_field_access %return, member1
+// CHECK:STDOUT:   %.loc17_31.3: init i32 = initialize_from %n.ref to %.loc17_31.2
+// CHECK:STDOUT:   %.loc17_31.4: ref Class* = class_field_access %return, member0
+// CHECK:STDOUT:   %.loc17_31.5: init Class* = initialize_from %next.ref to %.loc17_31.4
+// CHECK:STDOUT:   %.loc17_31.6: init Class = class_init %.loc17_31.1, (%.loc17_31.3, %.loc17_31.5)
+// CHECK:STDOUT:   return %.loc17_31.6
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -13,15 +13,15 @@ fn F() -> i32 {
   return ({.a = 1, .b = 2} as Class).a;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "init_as.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -16,8 +16,12 @@ fn F() -> i32 {
 // CHECK:STDOUT: file "init_as.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -39,7 +43,6 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc13_26.1: {.a: i32, .b: i32} = struct_literal (%.loc13_17, %.loc13_25)
 // CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc13_26.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc13_26.3: ref i32 = class_field_access %.loc13_26.2, member0
 // CHECK:STDOUT:   %.loc13_26.4: init i32 = initialize_from %.loc13_17 to %.loc13_26.3

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -23,16 +23,19 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: file "init_nested.carbon" {
 // CHECK:STDOUT:   class_declaration @Inner, ()
 // CHECK:STDOUT:   %Inner: type = class_type @Inner
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner
 // CHECK:STDOUT:   class_declaration @Outer, ()
 // CHECK:STDOUT:   %Outer: type = class_type @Outer
+// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.c: Inner, .d: Inner}
 // CHECK:STDOUT:   %.loc17_1.2: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}
 // CHECK:STDOUT:   %.loc17_1.3: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}
 // CHECK:STDOUT:   %.loc14: type = ptr_type {.c: Inner, .d: Inner}
-// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -20,15 +20,6 @@ fn MakeOuter() -> Outer {
   return {.c = MakeInner(), .d = MakeInner()};
 }
 
-// CHECK:STDOUT: file "init_nested.carbon" {
-// CHECK:STDOUT:   class_declaration @Inner, ()
-// CHECK:STDOUT:   %Inner: type = class_type @Inner
-// CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner
-// CHECK:STDOUT:   class_declaration @Outer, ()
-// CHECK:STDOUT:   %Outer: type = class_type @Outer
-// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}
@@ -36,6 +27,15 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:   %.loc17_1.2: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}
 // CHECK:STDOUT:   %.loc17_1.3: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}
 // CHECK:STDOUT:   %.loc14: type = ptr_type {.c: Inner, .d: Inner}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "init_nested.carbon" {
+// CHECK:STDOUT:   class_declaration @Inner, ()
+// CHECK:STDOUT:   %Inner: type = class_type @Inner
+// CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner
+// CHECK:STDOUT:   class_declaration @Outer, ()
+// CHECK:STDOUT:   %Outer: type = class_type @Outer
+// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -44,6 +44,11 @@ fn CallGOnInitializingExpression() -> i32 {
   return Make().G();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "method.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
@@ -55,11 +60,6 @@ fn CallGOnInitializingExpression() -> i32 {
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %CallFOnInitializingExpression: <function> = fn_decl @CallFOnInitializingExpression
 // CHECK:STDOUT:   %CallGOnInitializingExpression: <function> = fn_decl @CallGOnInitializingExpression
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32}
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -47,7 +47,6 @@ fn CallGOnInitializingExpression() -> i32 {
 // CHECK:STDOUT: file "method.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Call: <function> = fn_decl @Call
 // CHECK:STDOUT:   %CallWithAddr: <function> = fn_decl @CallWithAddr
@@ -56,6 +55,11 @@ fn CallGOnInitializingExpression() -> i32 {
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make
 // CHECK:STDOUT:   %CallFOnInitializingExpression: <function> = fn_decl @CallFOnInitializingExpression
 // CHECK:STDOUT:   %CallGOnInitializingExpression: <function> = fn_decl @CallGOnInitializingExpression
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -73,7 +77,6 @@ fn CallGOnInitializingExpression() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32}
 // CHECK:STDOUT:   %self.ref: Class = name_reference "self", %self
 // CHECK:STDOUT:   %.loc15_14.1: ref i32 = class_field_access %self.ref, member0
 // CHECK:STDOUT:   %.loc15_14.2: i32 = bind_value %.loc15_14.1

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -18,19 +18,19 @@ fn G(o: Outer) {
   var i: o.Inner;
 }
 
-// CHECK:STDOUT: file "nested_name.carbon" {
-// CHECK:STDOUT:   class_declaration @Outer, ()
-// CHECK:STDOUT:   %Outer: type = class_type @Outer
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32}
 // CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32}
 // CHECK:STDOUT:   %.loc11_1.2: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "nested_name.carbon" {
+// CHECK:STDOUT:   class_declaration @Outer, ()
+// CHECK:STDOUT:   %Outer: type = class_type @Outer
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -21,15 +21,21 @@ fn G(o: Outer) {
 // CHECK:STDOUT: file "nested_name.carbon" {
 // CHECK:STDOUT:   class_declaration @Outer, ()
 // CHECK:STDOUT:   %Outer: type = class_type @Outer
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32}
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32}
+// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
 // CHECK:STDOUT:   class_declaration @Inner, ()
 // CHECK:STDOUT:   %Inner: type = class_type @Inner
-// CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Inner = <unexpected instref 11>
@@ -46,7 +52,6 @@ fn G(o: Outer) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%oi: Inner) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32}
 // CHECK:STDOUT:   %oi.ref: Inner = name_reference "oi", %oi
 // CHECK:STDOUT:   %.loc14_12.1: ref i32 = class_field_access %oi.ref, member0
 // CHECK:STDOUT:   %.loc14_12.2: i32 = bind_value %.loc14_12.1
@@ -55,8 +60,6 @@ fn G(o: Outer) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%o: Outer) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %o.ref: Outer = name_reference "o", %o
 // CHECK:STDOUT:   %Inner.ref: type = name_reference "Inner", @Outer.%Inner
 // CHECK:STDOUT:   %i.var: ref Inner = var "i"

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -12,15 +12,15 @@ class Class {
 
 fn Class.F() {}
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "redeclaration.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -16,8 +16,11 @@ fn Class.F() {}
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   class_declaration @Class, ()
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -18,15 +18,15 @@ fn Run() -> i32 {
   return F() + Class.F();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "scope.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -21,9 +21,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT: file "scope.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = struct_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -19,16 +19,16 @@ fn Class.G[addr self: Class*]() -> i32 {
   return (*self).n;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32}
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -22,9 +22,13 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT: file "self.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -42,7 +46,6 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}
 // CHECK:STDOUT:   %self.ref: Class = name_reference "self", %self
 // CHECK:STDOUT:   %.loc15_14.1: ref i32 = class_field_access %self.ref, member0
 // CHECK:STDOUT:   %.loc15_14.2: i32 = bind_value %.loc15_14.1

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -16,15 +16,15 @@ fn Class.F[self: Class]() -> i32 {
   return (*self.p).F();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "self_type.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*}
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -19,8 +19,12 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT: file "self_type.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*}
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -38,7 +42,6 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*}
 // CHECK:STDOUT:   %self.ref: Class = name_reference "self", %self
 // CHECK:STDOUT:   %.loc16_16.1: ref Class* = class_field_access %self.ref, member0
 // CHECK:STDOUT:   %.loc16_16.2: Class* = bind_value %.loc16_16.1

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -13,16 +13,16 @@ fn Run() -> i32 {
   return c.F();
 }
 
-// CHECK:STDOUT: file "static_method.carbon" {
-// CHECK:STDOUT:   class_declaration @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "static_method.carbon" {
+// CHECK:STDOUT:   class_declaration @Class, ()
+// CHECK:STDOUT:   %Class: type = class_type @Class
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -16,8 +16,13 @@ fn Run() -> i32 {
 // CHECK:STDOUT: file "static_method.carbon" {
 // CHECK:STDOUT:   class_declaration @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
-// CHECK:STDOUT:   %.loc9: type = struct_type {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
@@ -32,8 +37,6 @@ fn Run() -> i32 {
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_reference "Class", file.%Class
-// CHECK:STDOUT:   %.loc9: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %c.var: ref Class = var "c"
 // CHECK:STDOUT:   %c: ref Class = bind_name "c", %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_reference "c", %c

--- a/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
+++ b/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
@@ -16,16 +16,16 @@ fn H() -> i32 {
   return G()[0];
 }
 
-// CHECK:STDOUT: file "in_place_tuple_initialization.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT:   %H: <function> = fn_decl @H
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_20.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc7_20.2: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc7_20.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "in_place_tuple_initialization.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32);

--- a/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
+++ b/toolchain/check/testdata/expression_category/in_place_tuple_initialization.carbon
@@ -17,10 +17,15 @@ fn H() -> i32 {
 }
 
 // CHECK:STDOUT: file "in_place_tuple_initialization.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type (i32, i32)
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_20.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_20.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_20.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32);

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -13,9 +13,13 @@ fn Main() {
 }
 
 // CHECK:STDOUT: file "empty_struct.carbon" {
-// CHECK:STDOUT:   %.loc7: type = tuple_type ()
 // CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: {}) -> {} {

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -12,14 +12,14 @@ fn Main() {
   Echo({});
 }
 
-// CHECK:STDOUT: file "empty_struct.carbon" {
-// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_13.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_13.2: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "empty_struct.carbon" {
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: {}) -> {} {

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -12,13 +12,13 @@ fn Main() {
   Echo(());
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "empty_tuple.carbon" {
 // CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: ()) -> () {

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -17,6 +17,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: ()) -> () {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: () = name_reference "a", %a

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -15,11 +15,14 @@ fn Run() {
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var "x"
 // CHECK:STDOUT:   %x: ref i32 = bind_name "x", %x.var
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc11: String = string_literal "hello"
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -11,12 +11,12 @@ fn Run() {
   var x: i32 = "hello"();
 }
 
-// CHECK:STDOUT: file "fail_not_callable.carbon" {
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_not_callable.carbon" {
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -62,6 +62,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc18: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run0() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -81,8 +85,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_reference "Run0", file.%Run0
 // CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc18_7.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc18_7.2: init () = call %Run0.ref.loc18(<invalid>)
+// CHECK:STDOUT:   %.loc18_7: init () = call %Run0.ref.loc18(<invalid>)
 // CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_reference "Run0", file.%Run0
 // CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -55,15 +55,15 @@ fn Main() {
   Run2(0);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc18: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_param_count.carbon" {
 // CHECK:STDOUT:   %Run0: <function> = fn_decl @Run0
 // CHECK:STDOUT:   %Run1: <function> = fn_decl @Run1
 // CHECK:STDOUT:   %Run2: <function> = fn_decl @Run2
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc18: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run0() {

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -16,13 +16,13 @@ fn F() {
   G(1.0);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc16: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_param_type.carbon" {
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%a: i32) {

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -21,6 +21,10 @@ fn F() {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc16: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%a: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -30,7 +34,6 @@ fn F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %G.ref: <function> = name_reference "G", file.%G
 // CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1
-// CHECK:STDOUT:   %.loc16_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc16_4.2: init () = call %G.ref(<invalid>)
+// CHECK:STDOUT:   %.loc16_4: init () = call %G.ref(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -11,13 +11,13 @@ fn Main() {
   Foo(1 + 2 + 3, 4 + 5, 6);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "more_param_ir.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32, %c: i32) {

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -16,6 +16,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32, %c: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -33,7 +37,6 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_22: i32 = int_literal 5
 // CHECK:STDOUT:   %.loc11_20: i32 = add %.loc11_18, %.loc11_22
 // CHECK:STDOUT:   %.loc11_25: i32 = int_literal 6
-// CHECK:STDOUT:   %.loc11_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc11_6.2: init () = call %Foo.ref(%.loc11_13, %.loc11_20, %.loc11_25)
+// CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref(%.loc11_13, %.loc11_20, %.loc11_25)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -10,13 +10,13 @@ fn Main() {
   Foo(1);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "params_one.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -15,6 +15,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -24,7 +28,6 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref(%.loc10_7)
+// CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -11,13 +11,13 @@ fn Main() {
   Foo(1,);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "params_one_comma.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -16,6 +16,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -25,8 +29,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref.loc10(%.loc10_7)
+// CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7)
 // CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7)

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -10,13 +10,13 @@ fn Main() {
   Foo(1, 2);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "params_two.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -15,6 +15,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -25,7 +29,6 @@ fn Main() {
 // CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref(%.loc10_7, %.loc10_10)
+// CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7, %.loc10_10)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -16,6 +16,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -26,8 +30,7 @@ fn Main() {
 // CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref.loc10(%.loc10_7, %.loc10_10)
+// CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7, %.loc10_10)
 // CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_reference "Foo", file.%Foo
 // CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -11,13 +11,13 @@ fn Main() {
   Foo(1, 2,);
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "params_two_comma.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -15,6 +15,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -23,7 +27,6 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <function> = name_reference "Foo", file.%Foo
-// CHECK:STDOUT:   %.loc10_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_6.2: init () = call %Foo.ref()
+// CHECK:STDOUT:   %.loc10: init () = call %Foo.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -10,13 +10,13 @@ fn Main() {
   Foo();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "params_zero.carbon" {
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -16,6 +16,10 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeImplicitEmptyTuple() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -23,8 +27,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_11.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc11_11.2: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc11_11: () = tuple_literal ()
 // CHECK:STDOUT:   %b.var: ref () = var "b"
 // CHECK:STDOUT:   %b: ref () = bind_name "b", %b.var
 // CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_reference "MakeImplicitEmptyTuple", file.%MakeImplicitEmptyTuple

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -11,13 +11,13 @@ fn Main() {
   var b: () = MakeImplicitEmptyTuple();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "return_implicit.carbon" {
 // CHECK:STDOUT:   %MakeImplicitEmptyTuple: <function> = fn_decl @MakeImplicitEmptyTuple
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeImplicitEmptyTuple() {

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -8,13 +8,13 @@ fn F();
 
 fn G() { F(); }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "simple.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -13,12 +13,15 @@ fn G() { F(); }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc9_11.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc9_11.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc9: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -17,15 +17,15 @@ fn If(b: bool) {
   H();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc13: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "else.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT:   %If: <function> = fn_decl @If
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -24,6 +24,10 @@ fn If(b: bool) {
 // CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc13: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -46,8 +50,7 @@ fn If(b: bool) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc13_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc13_6.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc13: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -14,14 +14,14 @@ fn If(b: bool) {
   G();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "no_else.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %If: <function> = fn_decl @If
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -20,6 +20,10 @@ fn If(b: bool) {
 // CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc12: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -37,8 +41,7 @@ fn If(b: bool) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc12_6.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc12_6.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc12: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:

--- a/toolchain/check/testdata/if_expression/struct.carbon
+++ b/toolchain/check/testdata/if_expression/struct.carbon
@@ -11,14 +11,14 @@ fn F(cond: bool) {
   G(if cond then a else a);
 }
 
-// CHECK:STDOUT: file "struct.carbon" {
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "struct.carbon" {
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%s: {.a: i32, .b: i32});

--- a/toolchain/check/testdata/if_expression/struct.carbon
+++ b/toolchain/check/testdata/if_expression/struct.carbon
@@ -16,12 +16,16 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%s: {.a: i32, .b: i32});
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%cond: bool) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %a.var: ref {.a: i32, .b: i32} = var "a"
 // CHECK:STDOUT:   %a: ref {.a: i32, .b: i32} = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1
@@ -57,7 +61,6 @@ fn F(cond: bool) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_5: {.a: i32, .b: i32} = block_arg !if.expr.result
-// CHECK:STDOUT:   %.loc11_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc11_4.2: init () = call %G.ref(%.loc11_5)
+// CHECK:STDOUT:   %.loc11_4: init () = call %G.ref(%.loc11_5)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -11,22 +11,20 @@ var d: i32 = a[b];
 
 // CHECK:STDOUT: file "array_element_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 2]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 2] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 2] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12
 // CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24
-// CHECK:STDOUT:   %.loc7_26.1: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_26.2: (i32, i32) = tuple_literal (%.loc7_20, %.loc7_24)
-// CHECK:STDOUT:   %.loc7_26.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_26.4: ref i32 = array_index %a.var, %.loc7_26.3
-// CHECK:STDOUT:   %.loc7_26.5: init i32 = initialize_from %.loc7_20 to %.loc7_26.4
-// CHECK:STDOUT:   %.loc7_26.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_26.7: ref i32 = array_index %a.var, %.loc7_26.6
-// CHECK:STDOUT:   %.loc7_26.8: init i32 = initialize_from %.loc7_24 to %.loc7_26.7
-// CHECK:STDOUT:   %.loc7_26.9: init [i32; 2] = array_init %.loc7_26.2, (%.loc7_26.5, %.loc7_26.8) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_26.9
+// CHECK:STDOUT:   %.loc7_26.1: (i32, i32) = tuple_literal (%.loc7_20, %.loc7_24)
+// CHECK:STDOUT:   %.loc7_26.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_26.3: ref i32 = array_index %a.var, %.loc7_26.2
+// CHECK:STDOUT:   %.loc7_26.4: init i32 = initialize_from %.loc7_20 to %.loc7_26.3
+// CHECK:STDOUT:   %.loc7_26.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc7_26.6: ref i32 = array_index %a.var, %.loc7_26.5
+// CHECK:STDOUT:   %.loc7_26.7: init i32 = initialize_from %.loc7_24 to %.loc7_26.6
+// CHECK:STDOUT:   %.loc7_26.8: init [i32; 2] = array_init %.loc7_26.1, (%.loc7_26.4, %.loc7_26.7) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_26.8
 // CHECK:STDOUT:   %b.var: ref i32 = var "b"
 // CHECK:STDOUT:   %b: ref i32 = bind_name "b", %b.var
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 1
@@ -46,4 +44,9 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   %.loc10_17.1: ref i32 = array_index %a.ref.loc10, %.loc10_16
 // CHECK:STDOUT:   %.loc10_17.2: i32 = bind_value %.loc10_17.1
 // CHECK:STDOUT:   assign %d.var, %.loc10_17.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 2]
+// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -9,6 +9,11 @@ var b: i32 = 1;
 var c: i32 = a[0];
 var d: i32 = a[b];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 2]
+// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "array_element_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -44,9 +49,4 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   %.loc10_17.1: ref i32 = array_index %a.ref.loc10, %.loc10_16
 // CHECK:STDOUT:   %.loc10_17.2: i32 = bind_value %.loc10_17.1
 // CHECK:STDOUT:   assign %d.var, %.loc10_17.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 2]
-// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/expression_category.carbon
+++ b/toolchain/check/testdata/index/expression_category.carbon
@@ -25,10 +25,14 @@ fn ValueBinding(b: [i32; 3]) {
 }
 
 // CHECK:STDOUT: file "expression_category.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.loc10: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];
@@ -42,19 +46,18 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc10_29.1: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_29.2: (i32, i32, i32) = tuple_literal (%.loc10_22, %.loc10_25, %.loc10_28)
-// CHECK:STDOUT:   %.loc10_29.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc10_29.4: ref i32 = array_index %a.var, %.loc10_29.3
-// CHECK:STDOUT:   %.loc10_29.5: init i32 = initialize_from %.loc10_22 to %.loc10_29.4
-// CHECK:STDOUT:   %.loc10_29.6: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_29.7: ref i32 = array_index %a.var, %.loc10_29.6
-// CHECK:STDOUT:   %.loc10_29.8: init i32 = initialize_from %.loc10_25 to %.loc10_29.7
-// CHECK:STDOUT:   %.loc10_29.9: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc10_29.10: ref i32 = array_index %a.var, %.loc10_29.9
-// CHECK:STDOUT:   %.loc10_29.11: init i32 = initialize_from %.loc10_28 to %.loc10_29.10
-// CHECK:STDOUT:   %.loc10_29.12: init [i32; 3] = array_init %.loc10_29.2, (%.loc10_29.5, %.loc10_29.8, %.loc10_29.11) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc10_29.12
+// CHECK:STDOUT:   %.loc10_29.1: (i32, i32, i32) = tuple_literal (%.loc10_22, %.loc10_25, %.loc10_28)
+// CHECK:STDOUT:   %.loc10_29.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc10_29.3: ref i32 = array_index %a.var, %.loc10_29.2
+// CHECK:STDOUT:   %.loc10_29.4: init i32 = initialize_from %.loc10_22 to %.loc10_29.3
+// CHECK:STDOUT:   %.loc10_29.5: i32 = int_literal 1
+// CHECK:STDOUT:   %.loc10_29.6: ref i32 = array_index %a.var, %.loc10_29.5
+// CHECK:STDOUT:   %.loc10_29.7: init i32 = initialize_from %.loc10_25 to %.loc10_29.6
+// CHECK:STDOUT:   %.loc10_29.8: i32 = int_literal 2
+// CHECK:STDOUT:   %.loc10_29.9: ref i32 = array_index %a.var, %.loc10_29.8
+// CHECK:STDOUT:   %.loc10_29.10: init i32 = initialize_from %.loc10_28 to %.loc10_29.9
+// CHECK:STDOUT:   %.loc10_29.11: init [i32; 3] = array_init %.loc10_29.1, (%.loc10_29.4, %.loc10_29.7, %.loc10_29.10) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc10_29.11
 // CHECK:STDOUT:   %.loc13_14: type = ptr_type i32
 // CHECK:STDOUT:   %pa.var: ref i32* = var "pa"
 // CHECK:STDOUT:   %pa: ref i32* = bind_name "pa", %pa.var

--- a/toolchain/check/testdata/index/expression_category.carbon
+++ b/toolchain/check/testdata/index/expression_category.carbon
@@ -24,15 +24,15 @@ fn ValueBinding(b: [i32; 3]) {
   F()[0];
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
+// CHECK:STDOUT:   %.loc10: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "expression_category.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
-// CHECK:STDOUT:   %.loc10: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -10,6 +10,11 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                                   ^
 var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_array_large_index.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -29,9 +34,4 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc11_35.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_35.2: i32 = bind_value %.loc11_35.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_35.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -12,18 +12,16 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 
 // CHECK:STDOUT: file "fail_array_large_index.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12
-// CHECK:STDOUT:   %.loc7_23.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_23.2: (i32,) = tuple_literal (%.loc7_20)
-// CHECK:STDOUT:   %.loc7_23.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_23.4: ref i32 = array_index %a.var, %.loc7_23.3
-// CHECK:STDOUT:   %.loc7_23.5: init i32 = initialize_from %.loc7_20 to %.loc7_23.4
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = array_init %.loc7_23.2, (%.loc7_23.5) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
+// CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
+// CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init %.loc7_23.1, (%.loc7_23.4) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_23.5
 // CHECK:STDOUT:   %b.var: ref i32 = var "b"
 // CHECK:STDOUT:   %b: ref i32 = bind_name "b", %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_reference "a", %a
@@ -31,4 +29,9 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc11_35.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_35.2: i32 = bind_value %.loc11_35.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_35.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -10,6 +10,11 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                ^
 var b: i32 = a[2.6];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_array_non_int_indexing.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -29,9 +34,4 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_19.2: i32 = bind_value %.loc11_19.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_19.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -12,18 +12,16 @@ var b: i32 = a[2.6];
 
 // CHECK:STDOUT: file "fail_array_non_int_indexing.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12
-// CHECK:STDOUT:   %.loc7_23.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_23.2: (i32,) = tuple_literal (%.loc7_20)
-// CHECK:STDOUT:   %.loc7_23.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_23.4: ref i32 = array_index %a.var, %.loc7_23.3
-// CHECK:STDOUT:   %.loc7_23.5: init i32 = initialize_from %.loc7_20 to %.loc7_23.4
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = array_init %.loc7_23.2, (%.loc7_23.5) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
+// CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
+// CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init %.loc7_23.1, (%.loc7_23.4) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_23.5
 // CHECK:STDOUT:   %b.var: ref i32 = var "b"
 // CHECK:STDOUT:   %b: ref i32 = bind_name "b", %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_reference "a", %a
@@ -31,4 +29,9 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_19.2: i32 = bind_value %.loc11_19.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_19.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -10,6 +10,11 @@ var a: [i32; 1] = (12,);
 // CHECK:STDERR:                 ^
 var b: i32 = a[2];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_array_out_of_bound_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
@@ -29,9 +34,4 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc11_17.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_17.2: i32 = bind_value %.loc11_17.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_17.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -12,18 +12,16 @@ var b: i32 = a[2];
 
 // CHECK:STDOUT: file "fail_array_out_of_bound_access.carbon" {
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var "a"
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12
-// CHECK:STDOUT:   %.loc7_23.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_23.2: (i32,) = tuple_literal (%.loc7_20)
-// CHECK:STDOUT:   %.loc7_23.3: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc7_23.4: ref i32 = array_index %a.var, %.loc7_23.3
-// CHECK:STDOUT:   %.loc7_23.5: init i32 = initialize_from %.loc7_20 to %.loc7_23.4
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = array_init %.loc7_23.2, (%.loc7_23.5) to %a.var
-// CHECK:STDOUT:   assign %a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
+// CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
+// CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
+// CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init %.loc7_23.1, (%.loc7_23.4) to %a.var
+// CHECK:STDOUT:   assign %a.var, %.loc7_23.5
 // CHECK:STDOUT:   %b.var: ref i32 = var "b"
 // CHECK:STDOUT:   %b: ref i32 = bind_name "b", %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_reference "a", %a
@@ -31,4 +29,9 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc11_17.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_17.2: i32 = bind_value %.loc11_17.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_17.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type [i32; 1]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -18,6 +18,10 @@ fn Run() {
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc13: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -26,11 +30,10 @@ fn Run() {
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc13_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc13_4.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc13_4.1: init () = call %F.ref()
 // CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc13_4.3: ref () = temporary_storage
-// CHECK:STDOUT:   %.loc13_4.4: ref () = temporary %.loc13_4.3, %.loc13_4.2
-// CHECK:STDOUT:   %.loc13_8: ref <error> = tuple_index %.loc13_4.4, <error>
+// CHECK:STDOUT:   %.loc13_4.2: ref () = temporary_storage
+// CHECK:STDOUT:   %.loc13_4.3: ref () = temporary %.loc13_4.2, %.loc13_4.1
+// CHECK:STDOUT:   %.loc13_8: ref <error> = tuple_index %.loc13_4.3, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -13,13 +13,13 @@ fn Run() {
   F()[0];
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc13: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_empty_tuple_access.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/index/fail_expression_category.carbon
+++ b/toolchain/check/testdata/index/fail_expression_category.carbon
@@ -29,13 +29,13 @@ fn G(b: [i32; 3]) {
   F()[0] = 4;
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_expression_category.carbon" {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];

--- a/toolchain/check/testdata/index/fail_expression_category.carbon
+++ b/toolchain/check/testdata/index/fail_expression_category.carbon
@@ -30,9 +30,12 @@ fn G(b: [i32; 3]) {
 }
 
 // CHECK:STDOUT: file "fail_expression_category.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type [i32; 3]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -47,17 +47,20 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %c: ref i32 = bind_name "c", %c.var
 // CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_literal (%.loc26_20, %.loc26_28)
+// CHECK:STDOUT:   %.loc26_29.1: {.a: i32, .b: i32} = struct_literal (%.loc26_20, %.loc26_28)
 // CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc26_29.3: type = ptr_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc26_29.4: {.a: i32, .b: i32} = struct_value %.loc26_29.2, (%.loc26_20, %.loc26_28)
+// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value %.loc26_29.1, (%.loc26_20, %.loc26_28)
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %d.var: ref i32 = var "d"
 // CHECK:STDOUT:   %d: ref i32 = bind_name "d", %d.var
 // CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0
 // CHECK:STDOUT:   assign %d.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -30,6 +30,11 @@ var c: i32 = {.a = 1, .b = 2}[0];
 // CHECK:STDERR:                                  ^
 var d: i32 = {.a: i32, .b: i32}[0];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_invalid_base.carbon" {
 // CHECK:STDOUT:   %.loc11: <namespace> = namespace {}
 // CHECK:STDOUT:   %a.var: ref i32 = var "a"
@@ -56,11 +61,6 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0
 // CHECK:STDOUT:   assign %d.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -12,3 +12,9 @@ var b: i32 = a[-10];
 
 // CHECK:STDOUT: file "fail_negative_indexing.carbon" {
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -10,11 +10,11 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                ^
 var b: i32 = a[-10];
 
-// CHECK:STDOUT: file "fail_negative_indexing.carbon" {
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_negative_indexing.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -11,6 +11,12 @@ var b: i32 = 0;
 // CHECK:STDERR:                 ^
 var c: i32 = a[b];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_non_deterministic_type.carbon" {
 // CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
@@ -34,10 +40,4 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %b.ref: ref i32 = name_reference "b", %b
 // CHECK:STDOUT:   %.loc12: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -12,10 +12,7 @@ var b: i32 = 0;
 var c: i32 = a[b];
 
 // CHECK:STDOUT: file "fail_non_deterministic_type.carbon" {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2
@@ -37,4 +34,10 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %b.ref: ref i32 = name_reference "b", %b
 // CHECK:STDOUT:   %.loc12: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -11,10 +11,7 @@ var a: (i32, i32) = (12, 6);
 var b: i32 = a[oops];
 
 // CHECK:STDOUT: file "fail_tuple_index_error.carbon" {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12
@@ -32,4 +29,10 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   %oops.ref: <error> = name_reference "oops", <error>
 // CHECK:STDOUT:   %.loc11: ref <error> = tuple_index %a.ref, %oops.ref
 // CHECK:STDOUT:   assign %b.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -10,6 +10,12 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                ^
 var b: i32 = a[oops];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_tuple_index_error.carbon" {
 // CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
@@ -29,10 +35,4 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   %oops.ref: <error> = name_reference "oops", <error>
 // CHECK:STDOUT:   %.loc11: ref <error> = tuple_index %a.ref, %oops.ref
 // CHECK:STDOUT:   assign %b.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -11,6 +11,11 @@ var b: (i32,) = a;
 // CHECK:STDERR:                                   ^
 var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_tuple_large_index.carbon" {
 // CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %a.var: ref (i32,) = var "a"
@@ -33,9 +38,4 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855
 // CHECK:STDOUT:   %.loc12_35: ref <error> = tuple_index %b.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -12,9 +12,7 @@ var b: (i32,) = a;
 var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 
 // CHECK:STDOUT: file "fail_tuple_large_index.carbon" {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %a.var: ref (i32,) = var "a"
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12
@@ -35,4 +33,9 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855
 // CHECK:STDOUT:   %.loc12_35: ref <error> = tuple_index %b.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -10,6 +10,12 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                   ^
 var b: i32 = a[2.6];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_tuple_non_int_indexing.carbon" {
 // CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
@@ -29,10 +35,4 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -11,10 +11,7 @@ var a: (i32, i32) = (12, 6);
 var b: i32 = a[2.6];
 
 // CHECK:STDOUT: file "fail_tuple_non_int_indexing.carbon" {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12
@@ -32,4 +29,10 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -10,6 +10,12 @@ var a: (i32, i32) = (12, 6);
 // CHECK:STDERR:                 ^
 var b: i32 = a[2];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_tuple_out_of_bound_access.carbon" {
 // CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
@@ -29,10 +35,4 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -11,10 +11,7 @@ var a: (i32, i32) = (12, 6);
 var b: i32 = a[2];
 
 // CHECK:STDOUT: file "fail_tuple_out_of_bound_access.carbon" {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var "a"
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12
@@ -32,4 +29,10 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -9,9 +9,7 @@ var b: (i32,) = a;
 var c: i32 = b[0];
 
 // CHECK:STDOUT: file "tuple_element_access.carbon" {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %a.var: ref (i32,) = var "a"
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name "a", %a.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12
@@ -33,4 +31,9 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -8,6 +8,11 @@ var a: (i32,) = (12,);
 var b: (i32,) = a;
 var c: i32 = b[0];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "tuple_element_access.carbon" {
 // CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %a.var: ref (i32,) = var "a"
@@ -31,9 +36,4 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -10,14 +10,14 @@ fn Run() -> i32 {
   return F()[0];
 }
 
-// CHECK:STDOUT: file "tuple_return_value_access.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "tuple_return_value_access.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -15,6 +15,11 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -15,12 +15,15 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc8_24.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc8_24.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type)
-// CHECK:STDOUT:   %.loc8_24.2: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.3: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.4: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc8_24: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %v.var: ref (i32, i32, i32) = var "v"
 // CHECK:STDOUT:   %v: ref (i32, i32, i32) = bind_name "v", %v.var
 // CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -11,14 +11,14 @@ fn F() -> i32 {
   return w[1];
 }
 
-// CHECK:STDOUT: file "convert.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type)
 // CHECK:STDOUT:   %.loc8_24.2: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT:   %.loc8_24.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "convert.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -24,6 +24,10 @@ fn Bar() {
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc17: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz.1() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -38,7 +42,6 @@ fn Bar() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", file.%.loc7
 // CHECK:STDOUT:   %Baz.ref: <function> = name_reference "Baz", file.%Baz.loc13
-// CHECK:STDOUT:   %.loc17_10.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc17_10.2: init () = call %Baz.ref()
+// CHECK:STDOUT:   %.loc17: init () = call %Baz.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -17,15 +17,15 @@ fn Bar() {
   Foo.Baz();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc17: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "function.carbon" {
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Baz = %Baz.loc13}
 // CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1
 // CHECK:STDOUT:   %Baz.loc13: <function> = fn_decl @Baz.2
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz.1() {

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -14,15 +14,15 @@ fn Foo.Bar.Baz() {
   Foo.Bar.Wiz();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "nested.carbon" {
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Bar = %.loc8}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace {.Wiz = %Wiz, .Baz = %Baz}
 // CHECK:STDOUT:   %Wiz: <function> = fn_decl @Wiz
 // CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Wiz() {

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -21,6 +21,10 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Wiz() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
@@ -31,7 +35,6 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:   %Foo.ref: <namespace> = name_reference "Foo", file.%.loc7
 // CHECK:STDOUT:   %Bar.ref: <namespace> = name_reference "Bar", file.%.loc8
 // CHECK:STDOUT:   %Wiz.ref: <function> = name_reference "Wiz", file.%Wiz
-// CHECK:STDOUT:   %.loc14_14.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc14_14.2: init () = call %Wiz.ref()
+// CHECK:STDOUT:   %.loc14: init () = call %Wiz.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -22,15 +22,15 @@ fn Main() {
   *(if true then p else &a) = 10;
 }
 
-// CHECK:STDOUT: file "assignment.carbon" {
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc11_19.2: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc11_19.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT:   %.loc15: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "assignment.carbon" {
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -26,6 +26,13 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc11_19.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc11_19.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc15: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var "a"
@@ -35,10 +42,7 @@ fn Main() {
 // CHECK:STDOUT:   %a.ref.loc9: ref i32 = name_reference "a", %a
 // CHECK:STDOUT:   %.loc9: i32 = int_literal 9
 // CHECK:STDOUT:   assign %a.ref.loc9, %.loc9
-// CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc11_19.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc11_19.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc11_19.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc11_19: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %b.var: ref (i32, i32) = var "b"
 // CHECK:STDOUT:   %b: ref (i32, i32) = bind_name "b", %b.var
 // CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1
@@ -60,8 +64,7 @@ fn Main() {
 // CHECK:STDOUT:   %.loc13_6: ref i32 = tuple_index %b.ref.loc13, %.loc13_5
 // CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4
 // CHECK:STDOUT:   assign %.loc13_6, %.loc13_10
-// CHECK:STDOUT:   %.loc15_27.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc15_27.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %c.var: ref {.a: i32, .b: i32} = var "c"
 // CHECK:STDOUT:   %c: ref {.a: i32, .b: i32} = bind_name "c", %c.var
 // CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -50,6 +50,13 @@ fn Main() {
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc21_8.2: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32}
+// CHECK:STDOUT:   %.loc34_18.2: type = ptr_type {.x: i32, .y: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
@@ -63,19 +70,17 @@ fn Main() {
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
 // CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_literal (%.loc21_4, %.loc21_7)
+// CHECK:STDOUT:   %.loc21_8.1: (i32, i32) = tuple_literal (%.loc21_4, %.loc21_7)
 // CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3
 // CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4
 // CHECK:STDOUT:   %.loc21_17.1: (i32, i32) = tuple_literal (%.loc21_13, %.loc21_16)
-// CHECK:STDOUT:   %.loc21_8.3: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc21_17.2: i32 = tuple_access %.loc21_8.2, member0
+// CHECK:STDOUT:   %.loc21_17.2: i32 = tuple_access %.loc21_8.1, member0
 // CHECK:STDOUT:   %.loc21_17.3: init i32 = initialize_from %.loc21_13 to %.loc21_17.2
-// CHECK:STDOUT:   %.loc21_17.4: i32 = tuple_access %.loc21_8.2, member1
+// CHECK:STDOUT:   %.loc21_17.4: i32 = tuple_access %.loc21_8.1, member1
 // CHECK:STDOUT:   %.loc21_17.5: init i32 = initialize_from %.loc21_16 to %.loc21_17.4
 // CHECK:STDOUT:   %.loc21_17.6: init (i32, i32) = tuple_init %.loc21_17.1, (%.loc21_17.3, %.loc21_17.5)
-// CHECK:STDOUT:   assign %.loc21_8.2, %.loc21_17.6
-// CHECK:STDOUT:   %.loc21_8.4: (i32, i32) = tuple_value %.loc21_8.2, (%.loc21_4, %.loc21_7)
+// CHECK:STDOUT:   assign %.loc21_8.1, %.loc21_17.6
+// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value %.loc21_8.1, (%.loc21_4, %.loc21_7)
 // CHECK:STDOUT:   %n.var: ref i32 = var "n"
 // CHECK:STDOUT:   %n: ref i32 = bind_name "n", %n.var
 // CHECK:STDOUT:   %.loc22: i32 = int_literal 0
@@ -99,19 +104,17 @@ fn Main() {
 // CHECK:STDOUT:   assign i32, %.loc30
 // CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32}
-// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_literal (%.loc34_9, %.loc34_17)
+// CHECK:STDOUT:   %.loc34_18.1: {.x: i32, .y: i32} = struct_literal (%.loc34_9, %.loc34_17)
 // CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3
 // CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4
 // CHECK:STDOUT:   %.loc34_37.1: {.x: i32, .y: i32} = struct_literal (%.loc34_28, %.loc34_36)
-// CHECK:STDOUT:   %.loc34_18.3: type = ptr_type {.x: i32, .y: i32}
-// CHECK:STDOUT:   %.loc34_37.2: i32 = struct_access %.loc34_18.2, member0
+// CHECK:STDOUT:   %.loc34_37.2: i32 = struct_access %.loc34_18.1, member0
 // CHECK:STDOUT:   %.loc34_37.3: init i32 = initialize_from %.loc34_28 to %.loc34_37.2
-// CHECK:STDOUT:   %.loc34_37.4: i32 = struct_access %.loc34_18.2, member1
+// CHECK:STDOUT:   %.loc34_37.4: i32 = struct_access %.loc34_18.1, member1
 // CHECK:STDOUT:   %.loc34_37.5: init i32 = initialize_from %.loc34_36 to %.loc34_37.4
 // CHECK:STDOUT:   %.loc34_37.6: init {.x: i32, .y: i32} = struct_init %.loc34_37.1, (%.loc34_37.3, %.loc34_37.5)
-// CHECK:STDOUT:   assign %.loc34_18.2, %.loc34_37.6
-// CHECK:STDOUT:   %.loc34_18.4: {.x: i32, .y: i32} = struct_value %.loc34_18.2, (%.loc34_9, %.loc34_17)
+// CHECK:STDOUT:   assign %.loc34_18.1, %.loc34_37.6
+// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value %.loc34_18.1, (%.loc34_9, %.loc34_17)
 // CHECK:STDOUT:   %.loc38_7: bool = bool_literal true
 // CHECK:STDOUT:   if %.loc38_7 br !if.expr.then.loc38 else br !if.expr.else.loc38
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -45,16 +45,16 @@ fn Main() {
   (if true then a else a) = 10;
 }
 
-// CHECK:STDOUT: file "fail_assignment_to_non_assignable.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc21_8.2: type = ptr_type (i32, i32)
 // CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32}
 // CHECK:STDOUT:   %.loc34_18.2: type = ptr_type {.x: i32, .y: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_assignment_to_non_assignable.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32;

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -9,12 +9,12 @@ fn F() -> i32 {
   return *&*&n;
 }
 
-// CHECK:STDOUT: file "address_of_deref.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc9: type = ptr_type i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "address_of_deref.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -13,6 +13,10 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc9: type = ptr_type i32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.var: ref i32 = var "n"
@@ -20,9 +24,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 0
 // CHECK:STDOUT:   assign %n.var, %.loc8
 // CHECK:STDOUT:   %n.ref: ref i32 = name_reference "n", %n
-// CHECK:STDOUT:   %.loc9_13.1: type = ptr_type i32
-// CHECK:STDOUT:   %.loc9_13.2: i32* = address_of %n.ref
-// CHECK:STDOUT:   %.loc9_12: ref i32 = dereference %.loc9_13.2
+// CHECK:STDOUT:   %.loc9_13: i32* = address_of %n.ref
+// CHECK:STDOUT:   %.loc9_12: ref i32 = dereference %.loc9_13
 // CHECK:STDOUT:   %.loc9_11: i32* = address_of %.loc9_12
 // CHECK:STDOUT:   %.loc9_10.1: ref i32 = dereference %.loc9_11
 // CHECK:STDOUT:   %.loc9_10.2: i32 = bind_value %.loc9_10.1

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -16,15 +16,15 @@ fn F() {
   var t1: i32* = &t[1];
 }
 
-// CHECK:STDOUT: file "address_of_lvalue.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc8: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc14_19.2: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc14_19.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "address_of_lvalue.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -20,10 +20,16 @@ fn F() {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc8: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc14_19.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc14_19.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_27.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc8_27.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc8_27: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %s.var: ref {.a: i32, .b: i32} = var "s"
 // CHECK:STDOUT:   %s: ref {.a: i32, .b: i32} = bind_name "s", %s.var
 // CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1
@@ -56,10 +62,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_19: ref i32 = struct_access %s.ref.loc12, member1
 // CHECK:STDOUT:   %.loc12_17: i32* = address_of %.loc12_19
 // CHECK:STDOUT:   assign %r.var, %.loc12_17
-// CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc14_19.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc14_19.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc14_19.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc14_19: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %t.var: ref (i32, i32) = var "t"
 // CHECK:STDOUT:   %t: ref (i32, i32) = bind_name "t", %t.var
 // CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -18,13 +18,13 @@ fn Test() {
   &(&undeclared);
 }
 
-// CHECK:STDOUT: file "fail_address_of_error.carbon" {
-// CHECK:STDOUT:   %Test: <function> = fn_decl @Test
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc11: type = ptr_type <error>
 // CHECK:STDOUT:   %.loc18: type = ptr_type <error>*
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_address_of_error.carbon" {
+// CHECK:STDOUT:   %Test: <function> = fn_decl @Test
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -22,14 +22,17 @@ fn Test() {
 // CHECK:STDOUT:   %Test: <function> = fn_decl @Test
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc11: type = ptr_type <error>
+// CHECK:STDOUT:   %.loc18: type = ptr_type <error>*
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %undeclared.ref.loc11: <error> = name_reference "undeclared", <error>
-// CHECK:STDOUT:   %.loc11_3.1: type = ptr_type <error>
-// CHECK:STDOUT:   %.loc11_3.2: <error>* = address_of %undeclared.ref.loc11
+// CHECK:STDOUT:   %.loc11: <error>* = address_of %undeclared.ref.loc11
 // CHECK:STDOUT:   %undeclared.ref.loc18: <error> = name_reference "undeclared", <error>
 // CHECK:STDOUT:   %.loc18_5: <error>* = address_of %undeclared.ref.loc18
-// CHECK:STDOUT:   %.loc18_3.1: type = ptr_type <error>*
-// CHECK:STDOUT:   %.loc18_3.2: <error>** = address_of %.loc18_5
+// CHECK:STDOUT:   %.loc18_3: <error>** = address_of %.loc18_5
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -93,6 +93,17 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:   %AddressOfParameter: <function> = fn_decl @AddressOfParameter
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15: type = ptr_type i32
+// CHECK:STDOUT:   %.loc19: type = ptr_type bool
+// CHECK:STDOUT:   %.loc23: type = ptr_type f64
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT:   %.loc31_9: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc31_3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc35: type = ptr_type {.a: i32}
+// CHECK:STDOUT:   %.loc64: type = ptr_type type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() -> {.a: i32};
@@ -100,27 +111,20 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT: fn @AddressOfLiteral() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0
-// CHECK:STDOUT:   %.loc15_3.1: type = ptr_type i32
-// CHECK:STDOUT:   %.loc15_3.2: i32* = address_of %.loc15_4
+// CHECK:STDOUT:   %.loc15_3: i32* = address_of %.loc15_4
 // CHECK:STDOUT:   %.loc19_4: bool = bool_literal true
-// CHECK:STDOUT:   %.loc19_3.1: type = ptr_type bool
-// CHECK:STDOUT:   %.loc19_3.2: bool* = address_of %.loc19_4
+// CHECK:STDOUT:   %.loc19_3: bool* = address_of %.loc19_4
 // CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1
-// CHECK:STDOUT:   %.loc23_3.1: type = ptr_type f64
-// CHECK:STDOUT:   %.loc23_3.2: f64* = address_of %.loc23_4
-// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT:   %.loc23_3: f64* = address_of %.loc23_4
 // CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello"
 // CHECK:STDOUT:   %.loc27_3: String* = address_of %.loc27_4
 // CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc31_9.1: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc31_9.2: (i32, i32) = tuple_literal (%.loc31_5, %.loc31_8)
-// CHECK:STDOUT:   %.loc31_3.1: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc31_3.2: (i32, i32)* = address_of %.loc31_9.2
+// CHECK:STDOUT:   %.loc31_9: (i32, i32) = tuple_literal (%.loc31_5, %.loc31_8)
+// CHECK:STDOUT:   %.loc31_3: (i32, i32)* = address_of %.loc31_9
 // CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5
 // CHECK:STDOUT:   %.loc35_11: {.a: i32} = struct_literal (%.loc35_10)
-// CHECK:STDOUT:   %.loc35_3.1: type = ptr_type {.a: i32}
-// CHECK:STDOUT:   %.loc35_3.2: {.a: i32}* = address_of %.loc35_11
+// CHECK:STDOUT:   %.loc35_3: {.a: i32}* = address_of %.loc35_11
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -152,8 +156,7 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfType() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc64_3.1: type = ptr_type type
-// CHECK:STDOUT:   %.loc64_3.2: type* = address_of i32
+// CHECK:STDOUT:   %.loc64: type* = address_of i32
 // CHECK:STDOUT:   %.loc68_5: type = const_type i32
 // CHECK:STDOUT:   %.loc68_14: type = ptr_type const i32
 // CHECK:STDOUT:   %.loc68_3: type* = address_of %.loc68_14

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -82,17 +82,6 @@ fn AddressOfParameter(param: i32) {
   var param_addr: i32* = &param;
 }
 
-// CHECK:STDOUT: file "fail_address_of_value.carbon" {
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT:   %H: <function> = fn_decl @H
-// CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral
-// CHECK:STDOUT:   %AddressOfOperator: <function> = fn_decl @AddressOfOperator
-// CHECK:STDOUT:   %AddressOfCall: <function> = fn_decl @AddressOfCall
-// CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType
-// CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue
-// CHECK:STDOUT:   %AddressOfParameter: <function> = fn_decl @AddressOfParameter
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc15: type = ptr_type i32
 // CHECK:STDOUT:   %.loc19: type = ptr_type bool
@@ -102,6 +91,17 @@ fn AddressOfParameter(param: i32) {
 // CHECK:STDOUT:   %.loc31_3: type = ptr_type (i32, i32)
 // CHECK:STDOUT:   %.loc35: type = ptr_type {.a: i32}
 // CHECK:STDOUT:   %.loc64: type = ptr_type type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_address_of_value.carbon" {
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral
+// CHECK:STDOUT:   %AddressOfOperator: <function> = fn_decl @AddressOfOperator
+// CHECK:STDOUT:   %AddressOfCall: <function> = fn_decl @AddressOfCall
+// CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType
+// CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue
+// CHECK:STDOUT:   %AddressOfParameter: <function> = fn_decl @AddressOfParameter
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;

--- a/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
@@ -23,17 +23,20 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15: type = tuple_type ()
+// CHECK:STDOUT:   %.loc19: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: i32 = name_reference "n", %n
 // CHECK:STDOUT:   %.loc11: ref <error> = dereference %n.ref
-// CHECK:STDOUT:   %.loc15_5.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc15_5.2: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_5.3: () = tuple_value %.loc15_5.2, ()
-// CHECK:STDOUT:   %.loc15_3: ref <error> = dereference %.loc15_5.3
-// CHECK:STDOUT:   %.loc19_5.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc19_5.2: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc19_5.3: {} = struct_value %.loc19_5.2, ()
-// CHECK:STDOUT:   %.loc19_3: ref <error> = dereference %.loc19_5.3
+// CHECK:STDOUT:   %.loc15_5.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value %.loc15_5.1, ()
+// CHECK:STDOUT:   %.loc15_3: ref <error> = dereference %.loc15_5.2
+// CHECK:STDOUT:   %.loc19_5.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value %.loc19_5.1, ()
+// CHECK:STDOUT:   %.loc19_3: ref <error> = dereference %.loc19_5.2
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_dereference_not_pointer.carbon
@@ -19,13 +19,13 @@ fn Deref(n: i32) {
   *{};
 }
 
-// CHECK:STDOUT: file "fail_dereference_not_pointer.carbon" {
-// CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc15: type = tuple_type ()
 // CHECK:STDOUT:   %.loc19: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_dereference_not_pointer.carbon" {
+// CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n: i32) {

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -11,12 +11,12 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
   return p;
 }
 
-// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
-// CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_type_mismatch.carbon" {
+// CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConstMismatch(%p: const {}*) -> const ({}*) {

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -15,6 +15,10 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConstMismatch(%p: const {}*) -> const ({}*) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: const {}* = name_reference "p", %p

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -14,6 +14,10 @@ fn F() -> () {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> () {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -10,12 +10,12 @@ fn F() -> () {
 // CHECK:STDERR: ^
 }
 
-// CHECK:STDOUT: file "fail_missing_return_empty_tuple.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_missing_return_empty_tuple.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> () {

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -9,14 +9,14 @@ fn Main() -> (i32, i32) {
   return (15, 35);
 }
 
-// CHECK:STDOUT: file "tuple.carbon" {
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc8_23.1: type = tuple_type (type, type)
 // CHECK:STDOUT:   %.loc8_23.2: type = tuple_type (i32, i32)
 // CHECK:STDOUT:   %.loc8_23.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "tuple.carbon" {
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %return: (i32, i32) {

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -10,8 +10,13 @@ fn Main() -> (i32, i32) {
 }
 
 // CHECK:STDOUT: file "tuple.carbon" {
-// CHECK:STDOUT:   %.loc8: type = ptr_type (i32, i32)
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc8_23.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc8_23.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc8_23.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %return: (i32, i32) {

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -8,9 +8,7 @@ var x: {} = {};
 var y: {} = x;
 
 // CHECK:STDOUT: file "empty.carbon" {
-// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc7_9.2: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_9.3: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7_9: {} = struct_literal ()
 // CHECK:STDOUT:   %x.var: ref {} = var "x"
 // CHECK:STDOUT:   %x: ref {} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
@@ -22,4 +20,9 @@ var y: {} = x;
 // CHECK:STDOUT:   %x.ref: ref {} = name_reference "x", %x
 // CHECK:STDOUT:   %.loc8_13: init {} = struct_init %x.ref, ()
 // CHECK:STDOUT:   assign %y.var, %.loc8_13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -7,6 +7,11 @@
 var x: {} = {};
 var y: {} = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "empty.carbon" {
 // CHECK:STDOUT:   %.loc7_9: {} = struct_literal ()
 // CHECK:STDOUT:   %x.var: ref {} = var "x"
@@ -20,9 +25,4 @@ var y: {} = x;
 // CHECK:STDOUT:   %x.ref: ref {} = name_reference "x", %x
 // CHECK:STDOUT:   %.loc8_13: init {} = struct_init %x.ref, ()
 // CHECK:STDOUT:   assign %y.var, %.loc8_13
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -9,14 +9,14 @@
 // CHECK:STDERR:                     ^
 var x: {.a: i32} = {};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_21: {} = struct_literal ()
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -13,7 +13,10 @@ var x: {.a: i32} = {};
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name "x", %x.var
-// CHECK:STDOUT:   %.loc10_21.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc10_21.2: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc10_21: {} = struct_literal ()
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -10,15 +10,18 @@
 var x: {.a: {}} = {.b = {}};
 
 // CHECK:STDOUT: file "fail_assign_nested.carbon" {
-// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc10_14.2: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_15.1: type = struct_type {.a: {}}
-// CHECK:STDOUT:   %.loc10_14.3: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_15.2: type = struct_type {.a: ()}
+// CHECK:STDOUT:   %.loc10_14: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}}
 // CHECK:STDOUT:   %x.var: ref {.a: {}} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: {}} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_26: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_27.1: type = struct_type {.b: {}}
-// CHECK:STDOUT:   %.loc10_27.2: {.b: {}} = struct_literal (%.loc10_26)
+// CHECK:STDOUT:   %.loc10_27: {.b: {}} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()}
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -9,6 +9,13 @@
 // CHECK:STDERR:                           ^
 var x: {.a: {}} = {.b = {}};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()}
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_nested.carbon" {
 // CHECK:STDOUT:   %.loc10_14: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}}
@@ -17,11 +24,4 @@ var x: {.a: {}} = {.b = {}};
 // CHECK:STDOUT:   %.loc10_26: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_27: {.b: {}} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()}
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -10,13 +10,16 @@
 var x: {} = {.a = 1};
 
 // CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
-// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc10_9.2: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_9.3: type = tuple_type ()
+// CHECK:STDOUT:   %.loc10_9: {} = struct_literal ()
 // CHECK:STDOUT:   %x.var: ref {} = var "x"
 // CHECK:STDOUT:   %x: ref {} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_20.1: type = struct_type {.a: i32}
-// CHECK:STDOUT:   %.loc10_20.2: {.a: i32} = struct_literal (%.loc10_19)
+// CHECK:STDOUT:   %.loc10_20: {.a: i32} = struct_literal (%.loc10_19)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -9,6 +9,12 @@
 // CHECK:STDERR:                    ^
 var x: {} = {.a = 1};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_9: {} = struct_literal ()
 // CHECK:STDOUT:   %x.var: ref {} = var "x"
@@ -16,10 +22,4 @@ var x: {} = {.a = 1};
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_20: {.a: i32} = struct_literal (%.loc10_19)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}
-// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -19,12 +19,15 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_27.1: type = struct_type {.b: i32}
-// CHECK:STDOUT:   %.loc10_27.2: {.b: i32} = struct_literal (%.loc10_26)
+// CHECK:STDOUT:   %.loc10_27: {.b: i32} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   %.loc15: type = struct_type {.b: i32}
 // CHECK:STDOUT:   %y.var: ref {.b: i32} = var "y"
 // CHECK:STDOUT:   %y: ref {.b: i32} = bind_name "y", %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_reference "x", %x
 // CHECK:STDOUT:   assign %y.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -14,6 +14,10 @@ var x: {.a: i32} = {.b = 1};
 // CHECK:STDERR:                    ^
 var y: {.b: i32} = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_field_name_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
@@ -26,8 +30,4 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT:   %y: ref {.b: i32} = bind_name "y", %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_reference "x", %x
 // CHECK:STDOUT:   assign %y.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -9,6 +9,10 @@
 // CHECK:STDERR:                             ^
 var x: {.a: i32} = {.b = 1.0};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.b: f64}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_field_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
@@ -16,8 +20,4 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1
 // CHECK:STDOUT:   %.loc10_29: {.b: f64} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.b: f64}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -14,7 +14,10 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1
-// CHECK:STDOUT:   %.loc10_29.1: type = struct_type {.b: f64}
-// CHECK:STDOUT:   %.loc10_29.2: {.b: f64} = struct_literal (%.loc10_26)
+// CHECK:STDOUT:   %.loc10_29: {.b: f64} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.b: f64}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -19,6 +19,10 @@ var s: {.a: Incomplete};
 // CHECK:STDERR:                          ^
 var p: Incomplete* = &s.a;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_nested_incomplete.carbon" {
 // CHECK:STDOUT:   class_declaration @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
@@ -33,10 +37,6 @@ var p: Incomplete* = &s.a;
 // CHECK:STDOUT:   %s.ref: ref <error> = name_reference "s", %s
 // CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -31,9 +31,12 @@ var p: Incomplete* = &s.a;
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var "p"
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name "p", %p.var
 // CHECK:STDOUT:   %s.ref: ref <error> = name_reference "s", %s
-// CHECK:STDOUT:   %.loc20_22.1: type = ptr_type <error>
-// CHECK:STDOUT:   %.loc20_22.2: <error>* = address_of <error>
+// CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -9,6 +9,11 @@
 // CHECK:STDERR:                                    ^
 var x: {.a: i32, .b: i32} = {.a = 1};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_too_few_values.carbon" {
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var "x"
@@ -16,9 +21,4 @@ var x: {.a: i32, .b: i32} = {.a = 1};
 // CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_36: {.a: i32} = struct_literal (%.loc10_35)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -10,12 +10,15 @@
 var x: {.a: i32, .b: i32} = {.a = 1};
 
 // CHECK:STDOUT: file "fail_too_few_values.carbon" {
-// CHECK:STDOUT:   %.loc10_25.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc10_25.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_36.1: type = struct_type {.a: i32}
-// CHECK:STDOUT:   %.loc10_36.2: {.a: i32} = struct_literal (%.loc10_35)
+// CHECK:STDOUT:   %.loc10_36: {.a: i32} = struct_literal (%.loc10_35)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -11,8 +11,11 @@ var x: {.a = 1};
 
 // CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_15.1: type = struct_type {.a: i32}
-// CHECK:STDOUT:   %.loc10_15.2: {.a: i32} = struct_literal (%.loc10_14)
+// CHECK:STDOUT:   %.loc10_15: {.a: i32} = struct_literal (%.loc10_14)
 // CHECK:STDOUT:   %x.var: ref <error> = var "x"
 // CHECK:STDOUT:   %x: ref <error> = bind_name "x", %x.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -9,13 +9,13 @@
 // CHECK:STDERR:               ^
 var x: {.a = 1};
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_15: {.a: i32} = struct_literal (%.loc10_14)
 // CHECK:STDOUT:   %x.var: ref <error> = var "x"
 // CHECK:STDOUT:   %x: ref <error> = bind_name "x", %x.var
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -10,16 +10,16 @@ fn F() -> i32 {
   return {.a = 1, .b = G(), .c = 3}.b.y;
 }
 
-// CHECK:STDOUT: file "literal_member_access.carbon" {
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32}
 // CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32}
 // CHECK:STDOUT:   %.loc10_35.2: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
 // CHECK:STDOUT:   %.loc10_35.3: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "literal_member_access.carbon" {
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: {.x: i32, .y: i32, .z: i32};

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -11,9 +11,15 @@ fn F() -> i32 {
 }
 
 // CHECK:STDOUT: file "literal_member_access.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32}
+// CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32}
+// CHECK:STDOUT:   %.loc10_35.2: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
+// CHECK:STDOUT:   %.loc10_35.3: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: {.x: i32, .y: i32, .z: i32};
@@ -25,10 +31,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_25.1: ref {.x: i32, .y: i32, .z: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc10_25.2: init {.x: i32, .y: i32, .z: i32} = call %G.ref() to %.loc10_25.1
 // CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32}
-// CHECK:STDOUT:   %.loc10_35.2: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_literal (%.loc10_16, %.loc10_25.2, %.loc10_34)
-// CHECK:STDOUT:   %.loc10_35.3: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
-// CHECK:STDOUT:   %.loc10_35.4: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}
+// CHECK:STDOUT:   %.loc10_35.1: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_literal (%.loc10_16, %.loc10_25.2, %.loc10_34)
 // CHECK:STDOUT:   %.loc10_25.3: ref {.x: i32, .y: i32, .z: i32} = temporary %.loc10_25.1, %.loc10_25.2
 // CHECK:STDOUT:   %.loc10_25.4: ref i32 = struct_access %.loc10_25.3, member0
 // CHECK:STDOUT:   %.loc10_25.5: i32 = bind_value %.loc10_25.4
@@ -37,8 +40,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_25.8: ref i32 = struct_access %.loc10_25.3, member2
 // CHECK:STDOUT:   %.loc10_25.9: i32 = bind_value %.loc10_25.8
 // CHECK:STDOUT:   %.loc10_25.10: {.x: i32, .y: i32, .z: i32} = struct_value %.loc10_25.3, (%.loc10_25.5, %.loc10_25.7, %.loc10_25.9)
-// CHECK:STDOUT:   %.loc10_35.5: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value %.loc10_35.2, (%.loc10_16, %.loc10_25.10, %.loc10_34)
-// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.5, member1
+// CHECK:STDOUT:   %.loc10_35.2: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value %.loc10_35.1, (%.loc10_16, %.loc10_25.10, %.loc10_34)
+// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.2, member1
 // CHECK:STDOUT:   %.loc10_38: i32 = struct_access %.loc10_36, member1
 // CHECK:STDOUT:   return %.loc10_38
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -9,8 +9,7 @@ var y: i32 = x.b;
 var z: i32 = y;
 
 // CHECK:STDOUT: file "member_access.carbon" {
-// CHECK:STDOUT:   %.loc7_25.1: type = struct_type {.a: f64, .b: i32}
-// CHECK:STDOUT:   %.loc7_25.2: type = ptr_type {.a: f64, .b: i32}
+// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: f64, .b: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: f64, .b: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1
@@ -33,4 +32,8 @@ var z: i32 = y;
 // CHECK:STDOUT:   %y.ref: ref i32 = name_reference "y", %y
 // CHECK:STDOUT:   %.loc9: i32 = bind_value %y.ref
 // CHECK:STDOUT:   assign %z.var, %.loc9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: f64, .b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -8,6 +8,10 @@ var x: {.a: f64, .b: i32} = {.a = 0.0, .b = 1};
 var y: i32 = x.b;
 var z: i32 = y;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: f64, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "member_access.carbon" {
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: f64, .b: i32} = var "x"
@@ -32,8 +36,4 @@ var z: i32 = y;
 // CHECK:STDOUT:   %y.ref: ref i32 = name_reference "y", %y
 // CHECK:STDOUT:   %.loc9: i32 = bind_value %y.ref
 // CHECK:STDOUT:   assign %z.var, %.loc9
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: f64, .b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -11,9 +11,16 @@ fn G() {
 }
 
 // CHECK:STDOUT: file "nested_struct_in_place.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type (i32, i32, i32)
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
+// CHECK:STDOUT:   %.loc10_51.2: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -22,9 +29,7 @@ fn G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_29: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_50: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)}
-// CHECK:STDOUT:   %.loc10_51.2: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
-// CHECK:STDOUT:   %.loc10_51.3: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
+// CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)}
 // CHECK:STDOUT:   %v.var: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var "v"
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = bind_name "v", %v.var
 // CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_reference "F", file.%F

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -10,17 +10,17 @@ fn G() {
   var v: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = {.a = F(), .b = F()};
 }
 
-// CHECK:STDOUT: file "nested_struct_in_place.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
 // CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
 // CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
 // CHECK:STDOUT:   %.loc10_51.2: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "nested_struct_in_place.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -16,8 +16,13 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: file "reorder_fields.carbon" {
 // CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32
 // CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64}
+// CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32}
+// CHECK:STDOUT:   %.loc11_62.2: type = ptr_type {.b: f64, .a: i32}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeI32() -> i32;
@@ -31,14 +36,12 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT:   %.loc11_44: init f64 = call %MakeF64.ref()
 // CHECK:STDOUT:   %MakeI32.ref: <function> = name_reference "MakeI32", file.%MakeI32
 // CHECK:STDOUT:   %.loc11_60: init i32 = call %MakeI32.ref()
-// CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32}
-// CHECK:STDOUT:   %.loc11_62.2: {.b: f64, .a: i32} = struct_literal (%.loc11_44, %.loc11_60)
-// CHECK:STDOUT:   %.loc11_62.3: i32 = value_of_initializer %.loc11_60
-// CHECK:STDOUT:   %.loc11_62.4: f64 = value_of_initializer %.loc11_44
-// CHECK:STDOUT:   %.loc11_62.5: {.a: i32, .b: f64} = struct_value %.loc11_62.2, (%.loc11_62.3, %.loc11_62.4)
-// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name "x", %.loc11_62.5
+// CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44, %.loc11_60)
+// CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60
+// CHECK:STDOUT:   %.loc11_62.3: f64 = value_of_initializer %.loc11_44
+// CHECK:STDOUT:   %.loc11_62.4: {.a: i32, .b: f64} = struct_value %.loc11_62.1, (%.loc11_62.2, %.loc11_62.3)
+// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name "x", %.loc11_62.4
 // CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32}
-// CHECK:STDOUT:   %.loc11_62.6: type = ptr_type {.b: f64, .a: i32}
 // CHECK:STDOUT:   %x.ref: {.a: i32, .b: f64} = name_reference "x", %x
 // CHECK:STDOUT:   %.loc12_31.1: f64 = struct_access %x.ref, member1
 // CHECK:STDOUT:   %.loc12_31.2: i32 = struct_access %x.ref, member0

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -13,16 +13,16 @@ fn F() -> {.a: i32, .b: f64} {
   return y;
 }
 
-// CHECK:STDOUT: file "reorder_fields.carbon" {
-// CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32
-// CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64}
 // CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32}
 // CHECK:STDOUT:   %.loc11_62.2: type = ptr_type {.b: f64, .a: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "reorder_fields.carbon" {
+// CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32
+// CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeI32() -> i32;

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -8,11 +8,8 @@ var x: {.a: i32, .b: (i32,)} = {.a = 1, .b = (2,)};
 var y: {.a: i32, .b: (i32,)} = x;
 
 // CHECK:STDOUT: file "tuple_as_element.carbon" {
-// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_27.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_27.3: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_28.1: type = struct_type {.a: i32, .b: (i32,)}
-// CHECK:STDOUT:   %.loc7_28.2: type = ptr_type {.a: i32, .b: (i32,)}
+// CHECK:STDOUT:   %.loc7_27: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: (i32,)} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: (i32,)} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1
@@ -43,4 +40,10 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc8_32.10: init (i32,) = initialize_from %.loc8_32.8 to %.loc8_32.9
 // CHECK:STDOUT:   %.loc8_32.11: init {.a: i32, .b: (i32,)} = struct_init %x.ref, (%.loc8_32.4, %.loc8_32.10)
 // CHECK:STDOUT:   assign %y.var, %.loc8_32.11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -7,6 +7,12 @@
 var x: {.a: i32, .b: (i32,)} = {.a = 1, .b = (2,)};
 var y: {.a: i32, .b: (i32,)} = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "tuple_as_element.carbon" {
 // CHECK:STDOUT:   %.loc7_27: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)}
@@ -40,10 +46,4 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc8_32.10: init (i32,) = initialize_from %.loc8_32.8 to %.loc8_32.9
 // CHECK:STDOUT:   %.loc8_32.11: init {.a: i32, .b: (i32,)} = struct_init %x.ref, (%.loc8_32.4, %.loc8_32.10)
 // CHECK:STDOUT:   assign %y.var, %.loc8_32.11
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -8,8 +8,7 @@ var x: {.a: i32, .b: i32} = {.a = 1, .b = 2};
 var y: {.a: i32, .b: i32} = x;
 
 // CHECK:STDOUT: file "two_entries.carbon" {
-// CHECK:STDOUT:   %.loc7_25.1: type = struct_type {.a: i32, .b: i32}
-// CHECK:STDOUT:   %.loc7_25.2: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var "x"
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1
@@ -35,4 +34,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc8_29.8: init i32 = initialize_from %.loc8_29.6 to %.loc8_29.7
 // CHECK:STDOUT:   %.loc8_29.9: init {.a: i32, .b: i32} = struct_init %x.ref, (%.loc8_29.4, %.loc8_29.8)
 // CHECK:STDOUT:   assign %y.var, %.loc8_29.9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -7,6 +7,10 @@
 var x: {.a: i32, .b: i32} = {.a = 1, .b = 2};
 var y: {.a: i32, .b: i32} = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "two_entries.carbon" {
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var "x"
@@ -34,8 +38,4 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc8_29.8: init i32 = initialize_from %.loc8_29.6 to %.loc8_29.7
 // CHECK:STDOUT:   %.loc8_29.9: init {.a: i32, .b: i32} = struct_init %x.ref, (%.loc8_29.4, %.loc8_29.8)
 // CHECK:STDOUT:   assign %y.var, %.loc8_29.9
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -8,8 +8,7 @@ var x: () = ();
 var y: () = x;
 
 // CHECK:STDOUT: file "empty.carbon" {
-// CHECK:STDOUT:   %.loc7_9.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_9.2: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc7_9: () = tuple_literal ()
 // CHECK:STDOUT:   %x.var: ref () = var "x"
 // CHECK:STDOUT:   %x: ref () = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
@@ -21,4 +20,8 @@ var y: () = x;
 // CHECK:STDOUT:   %x.ref: ref () = name_reference "x", %x
 // CHECK:STDOUT:   %.loc8_13: init () = tuple_init %x.ref, ()
 // CHECK:STDOUT:   assign %y.var, %.loc8_13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -7,6 +7,10 @@
 var x: () = ();
 var y: () = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "empty.carbon" {
 // CHECK:STDOUT:   %.loc7_9: () = tuple_literal ()
 // CHECK:STDOUT:   %x.var: ref () = var "x"
@@ -20,8 +24,4 @@ var y: () = x;
 // CHECK:STDOUT:   %x.ref: ref () = name_reference "x", %x
 // CHECK:STDOUT:   %.loc8_13: init () = tuple_init %x.ref, ()
 // CHECK:STDOUT:   assign %y.var, %.loc8_13
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -9,16 +9,16 @@
 // CHECK:STDERR:                  ^
 var x: (i32,) = ();
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_18: () = tuple_literal ()
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -10,12 +10,15 @@
 var x: (i32,) = ();
 
 // CHECK:STDOUT: file "fail_assign_empty.carbon" {
-// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc10_13.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_13.3: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name "x", %x.var
-// CHECK:STDOUT:   %.loc10_18.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_18.2: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc10_18: () = tuple_literal ()
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -9,6 +9,18 @@
 // CHECK:STDERR:                                            ^
 var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type))
+// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32))
+// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*)
+// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*)
+// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_nested.carbon" {
 // CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
@@ -25,16 +37,4 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT:   %.loc10_55: (i32, i32, i32) = tuple_literal (%.loc10_48, %.loc10_51, %.loc10_54)
 // CHECK:STDOUT:   %.loc10_56: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_44, %.loc10_55)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type))
-// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32))
-// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*)
-// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*)
-// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -10,28 +10,31 @@
 var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 
 // CHECK:STDOUT: file "fail_assign_nested.carbon" {
-// CHECK:STDOUT:   %.loc10_18.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_18.2: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type))
-// CHECK:STDOUT:   %.loc10_31.2: ((type, type), (type, type)) = tuple_literal (%.loc10_18.2, %.loc10_30)
-// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.4: type = tuple_type ((i32, i32), (i32, i32))
-// CHECK:STDOUT:   %.loc10_31.5: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.6: type = tuple_type ((i32, i32)*, (i32, i32)*)
-// CHECK:STDOUT:   %.loc10_31.7: type = ptr_type ((i32, i32)*, (i32, i32)*)
+// CHECK:STDOUT:   %.loc10_31: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), (i32, i32)) = var "x"
 // CHECK:STDOUT:   %x: ref ((i32, i32), (i32, i32)) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3
-// CHECK:STDOUT:   %.loc10_44.1: type = tuple_type (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_44.2: (i32, i32, i32) = tuple_literal (%.loc10_37, %.loc10_40, %.loc10_43)
+// CHECK:STDOUT:   %.loc10_44: (i32, i32, i32) = tuple_literal (%.loc10_37, %.loc10_40, %.loc10_43)
 // CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4
 // CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5
 // CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6
 // CHECK:STDOUT:   %.loc10_55: (i32, i32, i32) = tuple_literal (%.loc10_48, %.loc10_51, %.loc10_54)
-// CHECK:STDOUT:   %.loc10_56.1: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
-// CHECK:STDOUT:   %.loc10_56.2: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_44.2, %.loc10_55)
+// CHECK:STDOUT:   %.loc10_56: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_44, %.loc10_55)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type))
+// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32))
+// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*)
+// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*)
+// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -10,10 +10,13 @@
 var x: () = (66);
 
 // CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
-// CHECK:STDOUT:   %.loc10_9.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc10_9.2: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc10_9: () = tuple_literal ()
 // CHECK:STDOUT:   %x.var: ref () = var "x"
 // CHECK:STDOUT:   %x: ref () = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -9,14 +9,14 @@
 // CHECK:STDERR:                 ^
 var x: () = (66);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_assign_to_empty.carbon" {
 // CHECK:STDOUT:   %.loc10_9: () = tuple_literal ()
 // CHECK:STDOUT:   %x.var: ref () = var "x"
 // CHECK:STDOUT:   %x: ref () = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -9,6 +9,13 @@
 // CHECK:STDERR:                              ^
 var x: (i32, i32) = (2, 65.89);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_element_type_mismatch.carbon" {
 // CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
@@ -19,11 +26,4 @@ var x: (i32, i32) = (2, 65.89);
 // CHECK:STDOUT:   %.loc10_30.2: ref i32 = tuple_access %x.var, member0
 // CHECK:STDOUT:   %.loc10_30.3: init i32 = initialize_from %.loc10_22 to %.loc10_30.2
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -10,17 +10,20 @@
 var x: (i32, i32) = (2, 65.89);
 
 // CHECK:STDOUT: file "fail_element_type_mismatch.carbon" {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2
-// CHECK:STDOUT:   %.loc10_30.1: type = tuple_type (i32, f64)
-// CHECK:STDOUT:   %.loc10_30.2: (i32, f64) = tuple_literal (%.loc10_22, %.loc10_25)
-// CHECK:STDOUT:   %.loc10_30.3: ref i32 = tuple_access %x.var, member0
-// CHECK:STDOUT:   %.loc10_30.4: init i32 = initialize_from %.loc10_22 to %.loc10_30.3
+// CHECK:STDOUT:   %.loc10_30.1: (i32, f64) = tuple_literal (%.loc10_22, %.loc10_25)
+// CHECK:STDOUT:   %.loc10_30.2: ref i32 = tuple_access %x.var, member0
+// CHECK:STDOUT:   %.loc10_30.3: init i32 = initialize_from %.loc10_22 to %.loc10_30.2
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -23,9 +23,7 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   class_declaration @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_reference "Incomplete", %Incomplete
-// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc15_24.2: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
-// CHECK:STDOUT:   %.loc15_24.3: type = tuple_type (i32, Incomplete)
+// CHECK:STDOUT:   %.loc15: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
 // CHECK:STDOUT:   %t.var: ref <error> = var "t"
 // CHECK:STDOUT:   %t: ref <error> = bind_name "t", %t.var
 // CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_reference "Incomplete", %Incomplete
@@ -34,9 +32,14 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name "p", %p.var
 // CHECK:STDOUT:   %t.ref: ref <error> = name_reference "t", %t
 // CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc20_22.1: type = ptr_type <error>
-// CHECK:STDOUT:   %.loc20_22.2: <error>* = address_of <error>
+// CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete)
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -19,6 +19,12 @@ var t: (i32, Incomplete);
 // CHECK:STDERR:                           ^
 var p: Incomplete* = &t[1];
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete)
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_nested_incomplete.carbon" {
 // CHECK:STDOUT:   class_declaration @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
@@ -34,12 +40,6 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc20_22: <error>* = address_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete)
-// CHECK:STDOUT:   %.loc20: type = ptr_type <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Incomplete;

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -10,14 +10,17 @@
 var x: (i32, i32) = (2, );
 
 // CHECK:STDOUT: file "fail_too_few_element.carbon" {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2
-// CHECK:STDOUT:   %.loc10_25.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc10_25.2: (i32,) = tuple_literal (%.loc10_22)
+// CHECK:STDOUT:   %.loc10_25: (i32,) = tuple_literal (%.loc10_22)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -9,6 +9,13 @@
 // CHECK:STDERR:                         ^
 var x: (i32, i32) = (2, );
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_too_few_element.carbon" {
 // CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
@@ -16,11 +23,4 @@ var x: (i32, i32) = (2, );
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc10_25: (i32,) = tuple_literal (%.loc10_22)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -10,11 +10,14 @@
 var x: (i32, ) = (i32, );
 
 // CHECK:STDOUT: file "fail_type_assign.carbon" {
-// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc10_14.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_14.3: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_14: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_24: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   assign %x.var, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -9,15 +9,15 @@
 // CHECK:STDERR:                        ^
 var x: (i32, ) = (i32, );
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_type_assign.carbon" {
 // CHECK:STDOUT:   %.loc10_14: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc10_24: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -11,9 +11,12 @@ var x: (1, );
 
 // CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
-// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc10_12.2: (i32,) = tuple_literal (%.loc10_9)
-// CHECK:STDOUT:   %.loc10_12.3: type = tuple_type (<error>)
+// CHECK:STDOUT:   %.loc10_12: (i32,) = tuple_literal (%.loc10_9)
 // CHECK:STDOUT:   %x.var: ref (<error>,) = var "x"
 // CHECK:STDOUT:   %x: ref (<error>,) = bind_name "x", %x.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -9,14 +9,14 @@
 // CHECK:STDERR:            ^
 var x: (1, );
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "fail_value_as_type.carbon" {
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: (i32,) = tuple_literal (%.loc10_9)
 // CHECK:STDOUT:   %x.var: ref (<error>,) = var "x"
 // CHECK:STDOUT:   %x: ref (<error>,) = bind_name "x", %x.var
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32)
-// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -7,15 +7,8 @@
 var x: ((i32, i32), i32) = ((12, 76), 6);
 
 // CHECK:STDOUT: file "nested_tuple.carbon" {
-// CHECK:STDOUT:   %.loc7_18.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_18.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type)
-// CHECK:STDOUT:   %.loc7_24.2: ((type, type), type) = tuple_literal (%.loc7_18.2, i32)
-// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.4: type = tuple_type ((i32, i32), i32)
-// CHECK:STDOUT:   %.loc7_24.5: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.6: type = tuple_type ((i32, i32)*, i32)
-// CHECK:STDOUT:   %.loc7_24.7: type = ptr_type ((i32, i32)*, i32)
+// CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_24: ((type, type), type) = tuple_literal (%.loc7_18, i32)
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), i32) = var "x"
 // CHECK:STDOUT:   %x: ref ((i32, i32), i32) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12
@@ -33,4 +26,14 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:   %.loc7_40.4: init i32 = initialize_from %.loc7_39 to %.loc7_40.3
 // CHECK:STDOUT:   %.loc7_40.5: init ((i32, i32), i32) = tuple_init %.loc7_40.1, (%.loc7_36.6, %.loc7_40.4)
 // CHECK:STDOUT:   assign %x.var, %.loc7_40.5
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type)
+// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32)
+// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32)
+// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -6,6 +6,16 @@
 
 var x: ((i32, i32), i32) = ((12, 76), 6);
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type)
+// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32)
+// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32)
+// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "nested_tuple.carbon" {
 // CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_24: ((type, type), type) = tuple_literal (%.loc7_18, i32)
@@ -26,14 +36,4 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:   %.loc7_40.4: init i32 = initialize_from %.loc7_39 to %.loc7_40.3
 // CHECK:STDOUT:   %.loc7_40.5: init ((i32, i32), i32) = tuple_init %.loc7_40.1, (%.loc7_36.6, %.loc7_40.4)
 // CHECK:STDOUT:   assign %x.var, %.loc7_40.5
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type)
-// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32)
-// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32)
-// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -14,12 +14,6 @@ fn H() {
   var v: (i32, (i32, i32, i32), i32) = (1, F(), 2);
 }
 
-// CHECK:STDOUT: file "nested_tuple_in_place.carbon" {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT:   %G: <function> = fn_decl @G
-// CHECK:STDOUT:   %H: <function> = fn_decl @H
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
 // CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
@@ -32,6 +26,12 @@ fn H() {
 // CHECK:STDOUT:   %.loc14_36.2: type = tuple_type (i32, (i32, i32, i32), i32)
 // CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32)*, i32)
 // CHECK:STDOUT:   %.loc14_36.4: type = ptr_type (i32, (i32, i32, i32)*, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "nested_tuple_in_place.carbon" {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT:   %G: <function> = fn_decl @G
+// CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -15,10 +15,23 @@ fn H() {
 }
 
 // CHECK:STDOUT: file "nested_tuple_in_place.carbon" {
-// CHECK:STDOUT:   %.loc7: type = ptr_type (i32, i32, i32)
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type)
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_43.1: type = tuple_type ((type, type, type), (type, type, type))
+// CHECK:STDOUT:   %.loc10_43.2: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
+// CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*)
+// CHECK:STDOUT:   %.loc10_43.4: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*)
+// CHECK:STDOUT:   %.loc14_36.1: type = tuple_type (type, (type, type, type), type)
+// CHECK:STDOUT:   %.loc14_36.2: type = tuple_type (i32, (i32, i32, i32), i32)
+// CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32)*, i32)
+// CHECK:STDOUT:   %.loc14_36.4: type = ptr_type (i32, (i32, i32, i32)*, i32)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -27,11 +40,7 @@ fn H() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_42: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_43.1: type = tuple_type ((type, type, type), (type, type, type))
-// CHECK:STDOUT:   %.loc10_43.2: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
-// CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32), (i32, i32, i32))
-// CHECK:STDOUT:   %.loc10_43.4: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*)
-// CHECK:STDOUT:   %.loc10_43.5: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*)
+// CHECK:STDOUT:   %.loc10_43: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
 // CHECK:STDOUT:   %v.var: ref ((i32, i32, i32), (i32, i32, i32)) = var "v"
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = bind_name "v", %v.var
 // CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_reference "F", file.%F
@@ -49,11 +58,7 @@ fn H() {
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14_30: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc14_36.1: type = tuple_type (type, (type, type, type), type)
-// CHECK:STDOUT:   %.loc14_36.2: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
-// CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32), i32)
-// CHECK:STDOUT:   %.loc14_36.4: type = tuple_type (i32, (i32, i32, i32)*, i32)
-// CHECK:STDOUT:   %.loc14_36.5: type = ptr_type (i32, (i32, i32, i32)*, i32)
+// CHECK:STDOUT:   %.loc14_36: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
 // CHECK:STDOUT:   %v.var: ref (i32, (i32, i32, i32), i32) = var "v"
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = bind_name "v", %v.var
 // CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -7,6 +7,11 @@
 var x: (i32,) = (4,);
 var y: (i32,) = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "one_element.carbon" {
 // CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
@@ -23,9 +28,4 @@ var y: (i32,) = x;
 // CHECK:STDOUT:   %.loc8_17.2: i32 = bind_value %.loc8_17.1
 // CHECK:STDOUT:   %.loc8_17.3: init (i32,) = tuple_init %x.ref, (%.loc8_17.2)
 // CHECK:STDOUT:   assign %y.var, %.loc8_17.3
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -8,9 +8,7 @@ var x: (i32,) = (4,);
 var y: (i32,) = x;
 
 // CHECK:STDOUT: file "one_element.carbon" {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
-// CHECK:STDOUT:   %.loc7_13.2: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = tuple_type (i32)
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %x.var: ref (i32,) = var "x"
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4
@@ -25,4 +23,9 @@ var y: (i32,) = x;
 // CHECK:STDOUT:   %.loc8_17.2: i32 = bind_value %.loc8_17.1
 // CHECK:STDOUT:   %.loc8_17.3: init (i32,) = tuple_init %x.ref, (%.loc8_17.2)
 // CHECK:STDOUT:   assign %y.var, %.loc8_17.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type)
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -7,6 +7,12 @@
 var x: (i32, i32) = (4, 102);
 var y: (i32, i32) = x;
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "two_elements.carbon" {
 // CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
@@ -34,10 +40,4 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc8_21.8: init i32 = initialize_from %.loc8_21.6 to %.loc8_21.7
 // CHECK:STDOUT:   %.loc8_21.9: init (i32, i32) = tuple_init %x.ref, (%.loc8_21.4, %.loc8_21.8)
 // CHECK:STDOUT:   assign %y.var, %.loc8_21.9
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -8,10 +8,7 @@ var x: (i32, i32) = (4, 102);
 var y: (i32, i32) = x;
 
 // CHECK:STDOUT: file "two_elements.carbon" {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
-// CHECK:STDOUT:   %.loc7_17.2: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = tuple_type (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = ptr_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var "x"
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name "x", %x.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4
@@ -37,4 +34,10 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc8_21.8: init i32 = initialize_from %.loc8_21.6 to %.loc8_21.7
 // CHECK:STDOUT:   %.loc8_21.9: init (i32, i32) = tuple_init %x.ref, (%.loc8_21.4, %.loc8_21.8)
 // CHECK:STDOUT:   assign %y.var, %.loc8_21.9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type)
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -22,17 +22,17 @@ fn F(x: X) {
   var y: X = x;
 }
 
-// CHECK:STDOUT: file "fail_not_copyable.carbon" {
-// CHECK:STDOUT:   class_declaration @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X
-// CHECK:STDOUT:   %F: <function> = fn_decl @F
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc8_1.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc8_1.2: type = tuple_type ()
 // CHECK:STDOUT:   %.loc7: type = ptr_type {}
 // CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_not_copyable.carbon" {
+// CHECK:STDOUT:   class_declaration @X, ()
+// CHECK:STDOUT:   %X: type = class_type @X
+// CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -25,8 +25,14 @@ fn F(x: X) {
 // CHECK:STDOUT: file "fail_not_copyable.carbon" {
 // CHECK:STDOUT:   class_declaration @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
-// CHECK:STDOUT:   %.loc8: type = struct_type {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc8_1.1: type = struct_type {}
+// CHECK:STDOUT:   %.loc8_1.2: type = tuple_type ()
+// CHECK:STDOUT:   %.loc7: type = ptr_type {}
+// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -36,9 +42,6 @@ fn F(x: X) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%x: X) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %s.var: ref String = var "s"
 // CHECK:STDOUT:   %s: ref String = bind_name "s", %s.var
 // CHECK:STDOUT:   %.loc16: String = string_literal "hello"

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -15,12 +15,15 @@ fn While() {
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %.1: type = ptr_type String
 // CHECK:STDOUT:   %.loc11: String = string_literal "Hello"
 // CHECK:STDOUT:   if <error> br !while.body else br !while.done
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -11,12 +11,12 @@ fn While() {
   while ("Hello") {}
 }
 
-// CHECK:STDOUT: file "fail_bad_condition.carbon" {
-// CHECK:STDOUT:   %While: <function> = fn_decl @While
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "fail_bad_condition.carbon" {
+// CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -27,6 +27,10 @@ fn While() {
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -38,8 +42,7 @@ fn While() {
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc14_4.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc14: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -19,16 +19,16 @@ fn While() {
   H();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "unreachable_end.carbon" {
 // CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -18,16 +18,16 @@ fn While() {
   H();
 }
 
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file "while.carbon" {
 // CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -26,6 +26,10 @@ fn While() {
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc14: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -37,8 +41,7 @@ fn While() {
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_reference "F", file.%F
-// CHECK:STDOUT:   %.loc14_4.1: type = tuple_type ()
-// CHECK:STDOUT:   %.loc14_4.2: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc14: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -301,6 +301,8 @@ class File : public Printable<File> {
   auto insts() const -> const InstStore& { return insts_; }
   auto inst_blocks() -> InstBlockStore& { return inst_blocks_; }
   auto inst_blocks() const -> const InstBlockStore& { return inst_blocks_; }
+  auto constants() -> ConstantStore& { return constants_; }
+  auto constants() const -> const ConstantStore& { return constants_; }
 
   // A list of types that were completed in this file, in the order in which
   // they were completed. Earlier types in this list cannot contain instances of
@@ -367,6 +369,10 @@ class File : public Printable<File> {
 
   // The top instruction block ID.
   InstBlockId top_inst_block_id_ = InstBlockId::Invalid;
+
+  // Storage for instructions that represent computed global constants, such as
+  // types.
+  ConstantStore constants_;
 };
 
 // The expression category of a sem_ir instruction. See /docs/design/values.md

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -45,6 +45,19 @@ class InstStore {
   ValueStore<InstId, Inst> values_;
 };
 
+// Provides storage for instructions representing global constants.
+class ConstantStore {
+ public:
+  // Add a constant instruction.
+  auto Add(InstId inst_id) -> void { values_.push_back(inst_id); }
+
+  auto array_ref() const -> llvm::ArrayRef<InstId> { return values_; }
+  auto size() const -> int { return values_.size(); }
+
+ private:
+  llvm::SmallVector<InstId> values_;
+};
+
 // Provides a ValueStore wrapper for an API specific to name scopes.
 class NameScopeStore {
  public:


### PR DESCRIPTION
This moves the instructions generated for type values out of the block in which they happen to first be referenced, and into shared storage.