### PR TITLE
Split build keys so that a read-write key is only used for merged PRs, and read-only is used otherwise.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -132,24 +132,23 @@ jobs:
           which clang++
           clang++ --version
 
-      # Extract our access key for our build cache.
-      - name: Extract access key (read-only)
+      # Disable uploads when the remote cache is read-only.
+      - name: Set up remote cache access (read-only)
         if:
           steps.filter.outputs.ignore == 'false' && github.event_name ==
           'pull_request'
         run: |
-          # Disable uploads when the remote cache is read-only.
           echo "remote_cache_upload=--remote_upload_local_results=false" \
               >> $GITHUB_ENV
 
-      - name: Extract access key (read-write)
+      # Provide a cache key when the remote cache is read-write.
+      - name: Set up remote cache access (read-write)
         if:
           steps.filter.outputs.ignore == 'false' && github.event_name !=
           'pull_request'
         env:
-          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS }}
+          REMOTE_CACHE_KEY: ${{ secrets.CARBON_BUILDS_GITHUB }}
         run: |
-          # Provide a cache key when the remote cache is read-write.
           echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json
           echo "remote_cache_upload=--google_credentials=$HOME/remote_cache_key.json" \
               >> $GITHUB_ENV

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,8 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [action-test]
+    #branches: [trunk]
   pull_request_target:
   merge_group:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [trunk]
+    branches: [action-test]
   pull_request_target:
   merge_group:
 
@@ -138,11 +138,10 @@ jobs:
           steps.filter.outputs.ignore == 'false' && github.event_name ==
           'pull_request_target'
         env:
-          CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_ONLY }}
+          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS_READ_ONLY }}
         run: |
-          echo "$CARBON_GITHUB_BUILDS" \
-            | base64 -d > $HOME/gcp-builds-service-account.json
-          echo "bazelrc_upload=build --remote_upload_local_results=false" \
+          echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json
+          echo "remote_cache_upload=build --remote_upload_local_results=false" \
               >> $GITHUB_ENV
 
       - name: Extract access key (read-write)
@@ -150,11 +149,10 @@ jobs:
           steps.filter.outputs.ignore == 'false' && github.event_name !=
           'pull_request_target'
         env:
-          CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
+          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
         run: |
-          echo "$CARBON_GITHUB_BUILDS" \
-            | base64 -d > $HOME/gcp-builds-service-account.json
-          echo "bazelrc_upload=# read-write cache" >> $GITHUB_ENV
+          echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json
+          echo "remote_cache_upload=# read-write cache" >> $GITHUB_ENV
 
       # We need to replace the `.` with a `_` for the build cache.
       - name: Setup LLVM and Clang (macOS)
@@ -178,11 +176,11 @@ jobs:
           cat >user.bazelrc <<EOF
           # Enable remote cache for our CI but minimize downloads.
           build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ env.os_for_cache }}
-          build --google_credentials=$HOME/gcp-builds-service-account.json
+          build --google_credentials=$HOME/remote_cache_key.json
           build --remote_download_minimal
 
           # Disable uploads if the remote cache is read-only.
-          ${{ env.bazelrc_upload }}
+          ${{ env.remote_cache_upload }}
 
           # Set an artificially high jobs count. This flag controls the number
           # of concurrency Bazel itself uses, which is essential for actions

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -133,13 +133,28 @@ jobs:
           clang++ --version
 
       # Extract our access key for our build cache.
-      - name: Extract access key
-        if: steps.filter.outputs.ignore == 'false'
+      - name: Extract access key (read-only)
+        if:
+          steps.filter.outputs.ignore == 'false' &&
+          github.event_name == 'pull_request_target'
         env:
-          GCP_BUILDS_SERVICE_ACCOUNT: ${{ secrets.GCP_BUILDS_SERVICE_ACCOUNT }}
+          CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_ONLY }}
         run: |
-          echo "$GCP_BUILDS_SERVICE_ACCOUNT" \
+          echo "$CARBON_GITHUB_BUILDS" \
             | base64 -d > $HOME/gcp-builds-service-account.json
+          echo "bazelrc_upload=build --remote_upload_local_results=false" \
+              >> $GITHUB_ENV
+
+      - name: Extract access key (read-write)
+        if:
+          steps.filter.outputs.ignore == 'false' &&
+          github.event_name != 'pull_request_target'
+        env:
+          CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
+        run: |
+          echo "$CARBON_GITHUB_BUILDS" \
+            | base64 -d > $HOME/gcp-builds-service-account.json
+          echo "bazelrc_upload=# read-write cache" >> $GITHUB_ENV
 
       # We need to replace the `.` with a `_` for the build cache.
       - name: Setup LLVM and Clang (macOS)
@@ -165,6 +180,9 @@ jobs:
           build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ env.os_for_cache }}
           build --google_credentials=$HOME/gcp-builds-service-account.json
           build --remote_download_minimal
+
+          # Set when determining whether the cache is read-write.
+          ${{ env.bazelrc_upload }}
 
           # Set an artificially high jobs count. This flag controls the number
           # of concurrency Bazel itself uses, which is essential for actions

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ name: test
 on:
   push:
     branches: [trunk]
-  pull_request_target:
+  pull_request:
   merge_group:
 
 # Cancel previous workflows on the PR when there are multiple fast commits.
@@ -46,13 +46,13 @@ jobs:
 
       # Checkout the pull request head or the branch.
       - name: Checkout pull request
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout branch
-        if: github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v3
 
       # Tests should only run on applicable paths, but we still need to have an
@@ -136,23 +136,23 @@ jobs:
       - name: Extract access key (read-only)
         if:
           steps.filter.outputs.ignore == 'false' && github.event_name ==
-          'pull_request_target'
-        env:
-          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS_READ_ONLY }}
+          'pull_request'
         run: |
-          echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json
-          echo "remote_cache_upload=build --remote_upload_local_results=false" \
+          # Disable uploads when the remote cache is read-only.
+          echo "remote_cache_upload=--remote_upload_local_results=false" \
               >> $GITHUB_ENV
 
       - name: Extract access key (read-write)
         if:
           steps.filter.outputs.ignore == 'false' && github.event_name !=
-          'pull_request_target'
+          'pull_request'
         env:
           REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
         run: |
+          # Provide a cache key when the remote cache is read-write.
           echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json
-          echo "remote_cache_upload=# read-write cache" >> $GITHUB_ENV
+          echo "remote_cache_upload=--google_credentials=$HOME/remote_cache_key.json" \
+              >> $GITHUB_ENV
 
       # We need to replace the `.` with a `_` for the build cache.
       - name: Setup LLVM and Clang (macOS)
@@ -176,11 +176,9 @@ jobs:
           cat >user.bazelrc <<EOF
           # Enable remote cache for our CI but minimize downloads.
           build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ env.os_for_cache }}
-          build --google_credentials=$HOME/remote_cache_key.json
           build --remote_download_minimal
 
-          # Disable uploads if the remote cache is read-only.
-          ${{ env.remote_cache_upload }}
+          build ${{ env.remote_cache_upload }}
 
           # Set an artificially high jobs count. This flag controls the number
           # of concurrency Bazel itself uses, which is essential for actions
@@ -238,7 +236,7 @@ jobs:
         env:
           # Compute the base SHA from the different event structures.
           GIT_BASE_SHA:
-            ${{ github.event_name == 'pull_request_target' &&
+            ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.sha ||
             github.event.merge_group.base_sha }}
           TARGETS_FILE: ${{ runner.temp }}/targets

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -147,7 +147,7 @@ jobs:
           steps.filter.outputs.ignore == 'false' && github.event_name !=
           'pull_request'
         env:
-          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
+          REMOTE_CACHE_KEY: ${{ secrets.CARBON_GITHUB_BUILDS }}
         run: |
           # Provide a cache key when the remote cache is read-write.
           echo "$REMOTE_CACHE_KEY" | base64 -d > $HOME/remote_cache_key.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: [action-test]
+    branches: [trunk]
   pull_request_target:
   merge_group:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,7 @@ name: test
 
 on:
   push:
-    branches: [action-test]
-    #branches: [trunk]
+    branches: [trunk]
   pull_request_target:
   merge_group:
 
@@ -136,8 +135,8 @@ jobs:
       # Extract our access key for our build cache.
       - name: Extract access key (read-only)
         if:
-          steps.filter.outputs.ignore == 'false' &&
-          github.event_name == 'pull_request_target'
+          steps.filter.outputs.ignore == 'false' && github.event_name ==
+          'pull_request_target'
         env:
           CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_ONLY }}
         run: |
@@ -148,8 +147,8 @@ jobs:
 
       - name: Extract access key (read-write)
         if:
-          steps.filter.outputs.ignore == 'false' &&
-          github.event_name != 'pull_request_target'
+          steps.filter.outputs.ignore == 'false' && github.event_name !=
+          'pull_request_target'
         env:
           CARBON_GITHUB_BUILDS: ${{ secrets.CARBON_GITHUB_BUILDS_READ_WRITE }}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -181,7 +181,7 @@ jobs:
           build --google_credentials=$HOME/gcp-builds-service-account.json
           build --remote_download_minimal
 
-          # Set when determining whether the cache is read-write.
+          # Disable uploads if the remote cache is read-only.
           ${{ env.bazelrc_upload }}
 
           # Set an artificially high jobs count. This flag controls the number

--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -2,7 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Blah
 #include "toolchain/lex/numeric_literal.h"
 
 #include <bitset>

--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/lex/numeric_literal.h"
+#include  "toolchain/lex/numeric_literal.h"
 
 #include <bitset>
 

--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -2,7 +2,8 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include  "toolchain/lex/numeric_literal.h"
+// Blah
+#include "toolchain/lex/numeric_literal.h"
 
 #include <bitset>
 


### PR DESCRIPTION
The final test commit has an example of the push run:
https://github.com/carbon-language/carbon-lang/actions/runs/6748256043/job/18346225812

But pull request runs require merging to trunk, AFAIK. Unfortunately that means the remote upload disabling isn't really tested in full.