### PR TITLE
handle missing addr in self pointer pattern

### DIFF
--- a/explorer/interpreter/type_checker.h
+++ b/explorer/interpreter/type_checker.h
@@ -182,10 +182,10 @@ class TypeChecker {
   // Checks a member access that might be accessing a function taking `addr
   // self: Self*`. If it does, this function marks the member access accordingly
   // and ensures the object argument is a reference expression.
-  auto CheckAddrMeAccess(Nonnull<MemberAccessExpression*> access,
-                         Nonnull<const FunctionDeclaration*> func_decl,
-                         const Bindings& bindings, const ImplScope& impl_scope)
-      -> ErrorOr<Success>;
+  auto CheckAddrSelfAccess(Nonnull<MemberAccessExpression*> access,
+                           Nonnull<const FunctionDeclaration*> func_decl,
+                           const Bindings& bindings,
+                           const ImplScope& impl_scope) -> ErrorOr<Success>;
 
   // Traverses the AST rooted at `e`, populating the static_type() of all nodes
   // and ensuring they follow Carbon's typing rules.

--- a/explorer/testdata/addr/fail_missing_addr.carbon
+++ b/explorer/testdata/addr/fail_missing_addr.carbon
@@ -1,0 +1,21 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+package ExplorerTest api;
+
+class Foo {
+    fn Bar[self: Foo*]() {
+        self->x += 1;
+    }
+    var x: i32;
+}
+
+fn Main() -> i32 {
+  var foo: Foo = {.x = 0};
+  // CHECK:STDERR: COMPILATION ERROR: fail_missing_addr.carbon:[[@LINE+1]]: method foo.Bar does not match the target function's self pattern (did you forget an `addr`?)
+  foo.Bar();
+  return 0;
+}


### PR DESCRIPTION
Add validation to `CheckAddrSelfAccess` to additionally check for situations where `addr` is potentially missing. I also updated the name of the function since `me` was renamed to `self`.

Closes #3367
