### PR TITLE
Refactor checking flow to allow for ordering based on import/package.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -125,9 +125,8 @@ static auto TrackImport(
   if (package_key.first == ExplicitMainName) {
     // Implicit imports will have already warned.
     if (explicit_import_map) {
-      CARBON_DIAGNOSTIC(
-          ImportMainPackage, Error,
-          "Cannot import the `Main` package from another package.");
+      CARBON_DIAGNOSTIC(ImportMainPackage, Error,
+                        "Cannot import `Main` from other packages.");
       unit_info.emitter.Emit(import.node, ImportMainPackage);
     }
     return;
@@ -139,8 +138,8 @@ static auto TrackImport(
             explicit_import_map->insert({package_key, import.node});
         !success) {
       CARBON_DIAGNOSTIC(RepeatedImport, Error,
-                        "Library is imported more than once.");
-      CARBON_DIAGNOSTIC(FirstImported, Note, "First imported here.");
+                        "Library imported more than once.");
+      CARBON_DIAGNOSTIC(FirstImported, Note, "First import here.");
       unit_info.emitter.Build(import.node, RepeatedImport)
           .Note(insert_it->second, FirstImported)
           .Emit();
@@ -153,9 +152,8 @@ static auto TrackImport(
         import.package_id == package_directive->package.package_id &&
         import.library_id == package_directive->package.library_id) {
       CARBON_DIAGNOSTIC(ExplicitImportApi, Error,
-                        "The `impl` for a library implicitly imports the `api` "
-                        "and must not do so explicitly.");
-      CARBON_DIAGNOSTIC(ImportSelf, Error, "A file must not import itself.");
+                        "Omit import of library `api`.");
+      CARBON_DIAGNOSTIC(ImportSelf, Error, "Library cannot import itself.");
       unit_info.emitter.Emit(import.node, package_directive->api_or_impl ==
                                                   Parse::Tree::ApiOrImpl::Impl
                                               ? ExplicitImportApi
@@ -200,14 +198,13 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
       // APIs.
       if (package_key.first == ExplicitMainName) {
         if (package_key.second.empty()) {
-          CARBON_DIAGNOSTIC(
-              ExplicitMainPackage, Error,
-              "Omit the `package` directive to define the `Main` package.");
+          CARBON_DIAGNOSTIC(ExplicitMainPackage, Error,
+                            "Omit `package` directive for `Main` package.");
           unit_info.emitter.Emit(package->package.node, ExplicitMainPackage);
         } else {
-          CARBON_DIAGNOSTIC(ExplicitMainLibrary, Error,
-                            "Use the `library` directive to define libraries "
-                            "in the `Main` package.");
+          CARBON_DIAGNOSTIC(
+              ExplicitMainLibrary, Error,
+              "Use `library` directive in `Main` package libraries.");
           unit_info.emitter.Emit(package->package.node, ExplicitMainLibrary);
         }
         continue;
@@ -221,7 +218,7 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
       if (!success) {
         // TODO: Cross-reference the source, deal with library, etc.
         CARBON_DIAGNOSTIC(DuplicateLibraryApi, Error,
-                          "Multiple files declare the same library's API.");
+                          "Library's API declared in more than one file.");
         unit_info.emitter.Emit(package->package.node, DuplicateLibraryApi);
       }
     }
@@ -278,9 +275,9 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
           if (*import_unit->sem_ir) {
             ++import_it;
           } else {
-            CARBON_DIAGNOSTIC(ImportCycleDetected, Error,
-                              "Import is part of a cycle. The cycle must be "
-                              "fixed before the import can be used.");
+            CARBON_DIAGNOSTIC(
+                ImportCycleDetected, Error,
+                "Import is in cycle. Cycle must be fixed to import.");
             unit_info.emitter.Emit(import_it->first, ImportCycleDetected);
             import_it = unit_info.imports.erase(import_it);
           }

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -154,8 +154,8 @@ static auto TrackImport(
     if (packaging && import.package_id == packaging->names.package_id &&
         import.library_id == packaging->names.library_id) {
       CARBON_DIAGNOSTIC(ExplicitImportApi, Error,
-                        "Explicit import of `api` from `impl` file is redundant "
-                        "with implicit import.");
+                        "Explicit import of `api` from `impl` file is "
+                        "redundant with implicit import.");
       CARBON_DIAGNOSTIC(ImportSelf, Error, "File cannot import itself.");
       unit_info.emitter.Emit(
           import.node, packaging->api_or_impl == Parse::Tree::ApiOrImpl::Impl

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -97,7 +97,7 @@ static auto CheckParseTree(const SemIR::File& builtin_ir, UnitInfo& unit_info,
 #endif
 }
 
-// The package and library names, used as map keys
+// The package and library names, used as map keys.
 using ImportKey = std::pair<llvm::StringRef, llvm::StringRef>;
 
 // Returns a key form of the package object.

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -2,27 +2,56 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "common/check.h"
+#include "toolchain/check/check.h"
 
+#include "common/check.h"
 #include "toolchain/base/pretty_stack_trace_function.h"
+#include "toolchain/base/value_store.h"
 #include "toolchain/check/context.h"
 #include "toolchain/parse/tree_node_location_translator.h"
 #include "toolchain/sem_ir/file.h"
 
 namespace Carbon::Check {
 
-auto CheckParseTree(SharedValueStores& value_stores,
-                    const SemIR::File& builtin_ir,
-                    const Lex::TokenizedBuffer& tokens,
-                    const Parse::Tree& parse_tree, DiagnosticConsumer& consumer,
-                    llvm::raw_ostream* vlog_stream) -> SemIR::File {
-  auto sem_ir = SemIR::File(value_stores, tokens.filename().str(), &builtin_ir);
+struct UnitInfo {
+  explicit UnitInfo(Unit& unit)
+      : unit(&unit),
+        translator(unit.tokens, unit.parse_tree),
+        err_tracker(*unit.consumer),
+        emitter(translator, err_tracker) {}
 
-  Parse::NodeLocationTranslator translator(&tokens, &parse_tree);
-  ErrorTrackingDiagnosticConsumer err_tracker(consumer);
-  DiagnosticEmitter<Parse::Node> emitter(translator, err_tracker);
+  Unit* unit;
 
-  Check::Context context(tokens, emitter, parse_tree, sem_ir, vlog_stream);
+  // Emitter information.
+  Parse::NodeLocationTranslator translator;
+  ErrorTrackingDiagnosticConsumer err_tracker;
+  DiagnosticEmitter<Parse::Node> emitter;
+
+  // A list of outgoing imports.
+  llvm::SmallVector<std::pair<Parse::Node, UnitInfo*>> imports;
+
+  // The remaining number of imports which must be checked before this unit can
+  // be processed.
+  int32_t imports_remaining = 0;
+
+  // A list of incoming imports. This will be empty for `impl` files, because
+  // imports only touch `api` files.
+  llvm::SmallVector<UnitInfo*> incoming_imports;
+};
+
+// Produces and checks the IR for the provided Parse::Tree.
+static auto CheckParseTree(const SemIR::File& builtin_ir, UnitInfo& unit_info,
+                           llvm::raw_ostream* vlog_stream) -> void {
+  unit_info.unit->sem_ir->emplace(*unit_info.unit->value_stores,
+                                  unit_info.unit->tokens->filename().str(),
+                                  &builtin_ir);
+
+  // For ease-of-access.
+  SemIR::File& sem_ir = **unit_info.unit->sem_ir;
+  const Parse::Tree& parse_tree = *unit_info.unit->parse_tree;
+
+  Check::Context context(*unit_info.unit->tokens, unit_info.emitter, parse_tree,
+                         sem_ir, vlog_stream);
   PrettyStackTraceFunction context_dumper(
       [&](llvm::raw_ostream& output) { context.PrintForStackDump(output); });
 
@@ -39,10 +68,10 @@ auto CheckParseTree(SharedValueStores& value_stores,
 #define CARBON_PARSE_NODE_KIND(Name)                                         \
   case Parse::NodeKind::Name: {                                              \
     if (!Check::Handle##Name(context, parse_node)) {                         \
-      CARBON_CHECK(err_tracker.seen_error())                                 \
+      CARBON_CHECK(unit_info.err_tracker.seen_error())                       \
           << "Handle" #Name " returned false without printing a diagnostic"; \
       sem_ir.set_has_errors(true);                                           \
-      return sem_ir;                                                         \
+      return;                                                                \
     }                                                                        \
     break;                                                                   \
   }
@@ -56,7 +85,7 @@ auto CheckParseTree(SharedValueStores& value_stores,
 
   context.VerifyOnFinish();
 
-  sem_ir.set_has_errors(err_tracker.seen_error());
+  sem_ir.set_has_errors(unit_info.err_tracker.seen_error());
 
 #ifndef NDEBUG
   if (auto verify = sem_ir.Verify(); !verify.ok()) {
@@ -64,8 +93,210 @@ auto CheckParseTree(SharedValueStores& value_stores,
                    << "\n";
   }
 #endif
+}
 
-  return sem_ir;
+// Returns a key form of the package object.
+static auto PackageKey(UnitInfo& unit_info, Parse::Tree::Package package)
+    -> std::pair<llvm::StringRef, llvm::StringRef> {
+  auto* stores = unit_info.unit->value_stores;
+  return {package.package_id.is_valid()
+              ? stores->identifiers().Get(package.package_id)
+              : "",
+          package.library_id.is_valid()
+              ? stores->string_literals().Get(package.library_id)
+              : ""};
+}
+
+static constexpr llvm::StringLiteral ExplicitMainName = "Main";
+
+// Marks an import as required on both the source and target file. seen_imports
+// is optional, and will be omitted for implicit imports (which are disallowed
+// when explicit).
+static auto TrackImport(
+    llvm::DenseMap<std::pair<llvm::StringRef, llvm::StringRef>, UnitInfo*>&
+        api_map,
+    llvm::DenseMap<std::pair<llvm::StringRef, llvm::StringRef>, Parse::Node>*
+        explicit_import_map,
+    UnitInfo& unit_info, Parse::Tree::Package import) -> void {
+  auto package_key = PackageKey(unit_info, import);
+
+  // Specialize the error for imports from `Main`.
+  if (package_key.first == ExplicitMainName) {
+    // Implicit imports will have already warned.
+    if (explicit_import_map) {
+      CARBON_DIAGNOSTIC(ImportMainPackage, Error,
+                        "The `Main` package cannot be mentioned explicitly on "
+                        "imports; it can only be imported implicitly");
+      unit_info.emitter.Emit(import.node, ImportMainPackage);
+    }
+    return;
+  }
+
+  if (explicit_import_map) {
+    // Check for redundant imports.
+    if (auto [insert_it, success] =
+            explicit_import_map->insert({package_key, import.node});
+        !success) {
+      CARBON_DIAGNOSTIC(RepeatedImport, Error,
+                        "Import matches an earlier import");
+      CARBON_DIAGNOSTIC(FirstImported, Note, "First imported here");
+      unit_info.emitter.Build(import.node, RepeatedImport)
+          .Note(insert_it->second, FirstImported)
+          .Emit();
+      return;
+    }
+
+    // Check for explicit imports of the same library.
+    auto package_directive = unit_info.unit->parse_tree->package();
+    if (package_directive &&
+        import.package_id == package_directive->package.package_id &&
+        import.library_id == package_directive->package.library_id) {
+      CARBON_DIAGNOSTIC(ExplicitImportApi, Error,
+                        "The `impl` for a library implicitly imports the `api` "
+                        "and must not do so explicitly");
+      CARBON_DIAGNOSTIC(ImportSelf, Error, "A file must not import itself");
+      unit_info.emitter.Emit(import.node, package_directive->api_or_impl ==
+                                                  Parse::Tree::ApiOrImpl::Impl
+                                              ? ExplicitImportApi
+                                              : ImportSelf);
+      return;
+    }
+  }
+
+  if (auto api = api_map.find(package_key); api != api_map.end()) {
+    unit_info.imports.push_back({import.node, api->second});
+    ++unit_info.imports_remaining;
+    api->second->incoming_imports.push_back(&unit_info);
+  } else {
+    CARBON_DIAGNOSTIC(LibraryApiNotFound, Error, "Corresponding API not found");
+    CARBON_DIAGNOSTIC(ImportNotFound, Error, "Imported API not found");
+    unit_info.emitter.Emit(
+        import.node, explicit_import_map ? ImportNotFound : LibraryApiNotFound);
+  }
+}
+
+auto CheckParseTrees(const SemIR::File& builtin_ir,
+                     llvm::MutableArrayRef<Unit> units,
+                     llvm::raw_ostream* vlog_stream) -> void {
+  // Prepare diagnostic emitters in case we run into issues during package
+  // checking.
+  //
+  // UnitInfo is big due to its SmallVectors, so we default to 0 on the stack.
+  llvm::SmallVector<UnitInfo, 0> unit_infos;
+  unit_infos.reserve(units.size());
+  for (auto& unit : units) {
+    unit_infos.emplace_back(unit);
+  }
+
+  // Create a map of APIs which might be imported.
+  llvm::DenseMap<std::pair<llvm::StringRef, llvm::StringRef>, UnitInfo*>
+      api_map;
+  for (auto& unit_info : unit_infos) {
+    const auto& package = unit_info.unit->parse_tree->package();
+    if (package) {
+      auto package_key = PackageKey(unit_info, package->package);
+      // Catch explicit `Main` errors before they become marked as possible
+      // APIs.
+      if (package_key.first == ExplicitMainName) {
+        if (package_key.second.empty()) {
+          CARBON_DIAGNOSTIC(ExplicitMainPackage, Error,
+                            "The `Main` package is implicit and not allowed in "
+                            "the `package` directive");
+          unit_info.emitter.Emit(package->package.node, ExplicitMainPackage);
+        } else {
+          CARBON_DIAGNOSTIC(ExplicitMainLibrary, Error,
+                            "The `Main` package is implicit; libraries should "
+                            "omit `package Main`",
+                            std::string);
+          unit_info.emitter.Emit(package->package.node, ExplicitMainLibrary,
+                                 package_key.second.str());
+        }
+        continue;
+      }
+
+      if (package->api_or_impl == Parse::Tree::ApiOrImpl::Impl) {
+        continue;
+      }
+
+      auto [entry, success] = api_map.insert({package_key, &unit_info});
+      if (!success) {
+        // TODO: Cross-reference the source, deal with library, etc.
+        CARBON_DIAGNOSTIC(DuplicateLibraryApi, Error,
+                          "Multiple files declare the same library's API");
+        unit_info.emitter.Emit(package->package.node, DuplicateLibraryApi);
+      }
+    }
+  }
+
+  // TODO: Detect self import, explicit import of api
+  // Mark down imports for all files.
+  llvm::SmallVector<UnitInfo*> ready_to_check;
+  ready_to_check.reserve(units.size());
+  for (auto& unit_info : unit_infos) {
+    const auto& package = unit_info.unit->parse_tree->package();
+    if (package && package->api_or_impl == Parse::Tree::ApiOrImpl::Impl) {
+      // An `impl` has an implicit import of its `api`.
+      TrackImport(api_map, nullptr, unit_info, package->package);
+    }
+
+    llvm::DenseMap<std::pair<llvm::StringRef, llvm::StringRef>, Parse::Node>
+        explicit_import_map;
+    for (const auto& import : unit_info.unit->parse_tree->imports()) {
+      TrackImport(api_map, &explicit_import_map, unit_info, import);
+    }
+
+    if (unit_info.imports_remaining == 0) {
+      ready_to_check.push_back(&unit_info);
+    }
+  }
+
+  // Check everything with no dependencies. Earlier entries with dependencies
+  // will be checked as soon as all their dependencies have been checked.
+  for (int check_index = 0;
+       check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
+    auto* unit_info = ready_to_check[check_index];
+    CheckParseTree(builtin_ir, *unit_info, vlog_stream);
+    for (auto* incoming_import : unit_info->incoming_imports) {
+      --incoming_import->imports_remaining;
+      if (incoming_import->imports_remaining == 0) {
+        ready_to_check.push_back(incoming_import);
+      }
+    }
+  }
+
+  // If there are still units with remaining imports, it means there's a
+  // dependency loop.
+  if (ready_to_check.size() < unit_infos.size()) {
+    // Go through units and mask out unevaluated imports. This breaks everything
+    // associated with a loop equivalently, whether it's part of it or depending
+    // on a part of it.
+    // TODO: Better identify cycles, maybe try to untangle them.
+    for (auto& unit_info : unit_infos) {
+      if (unit_info.imports_remaining > 0) {
+        for (auto* import_it = unit_info.imports.begin();
+             import_it != unit_info.imports.end();) {
+          auto* import_unit = import_it->second->unit;
+          if (*import_unit->sem_ir) {
+            ++import_it;
+          } else {
+            CARBON_DIAGNOSTIC(
+                ImportCycleDetected, Error,
+                "Import is part of a cycle which could not be resolved");
+            unit_info.emitter.Emit(import_it->first, ImportCycleDetected);
+            import_it = unit_info.imports.erase(import_it);
+          }
+        }
+      }
+    }
+
+    // Check the remaining file contents, which are probably broken due to
+    // incomplete imports.
+    for (auto& unit_info : unit_infos) {
+      if (unit_info.imports_remaining > 0) {
+        CheckParseTree(builtin_ir, unit_info, vlog_stream);
+      }
+    }
+  }
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -224,7 +224,7 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
     }
   }
 
-  // TODO: Detect self import, explicit import of api
+  // TODO: Detect self import.
   // Mark down imports for all files.
   llvm::SmallVector<UnitInfo*> ready_to_check;
   ready_to_check.reserve(units.size());

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -154,7 +154,7 @@ static auto TrackImport(
     if (packaging && import.package_id == packaging->names.package_id &&
         import.library_id == packaging->names.library_id) {
       CARBON_DIAGNOSTIC(ExplicitImportApi, Error,
-                        "Explicit import `api` of `impl` file is redundant "
+                        "Explicit import of `api` from `impl` file is redundant "
                         "with implicit import.");
       CARBON_DIAGNOSTIC(ImportSelf, Error, "File cannot import itself.");
       unit_info.emitter.Emit(

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -20,13 +20,21 @@ inline auto MakeBuiltins(SharedValueStores& value_stores) -> SemIR::File {
   return SemIR::File(value_stores);
 }
 
-// Produces and checks the IR for the provided Parse::Tree.
-extern auto CheckParseTree(SharedValueStores& value_stores,
-                           const SemIR::File& builtin_ir,
-                           const Lex::TokenizedBuffer& tokens,
-                           const Parse::Tree& parse_tree,
-                           DiagnosticConsumer& consumer,
-                           llvm::raw_ostream* vlog_stream) -> SemIR::File;
+// Checking information that's tracked per file.
+struct Unit {
+  SharedValueStores* value_stores;
+  const Lex::TokenizedBuffer* tokens;
+  const Parse::Tree* parse_tree;
+  DiagnosticConsumer* consumer;
+  // The generated IR. Unset on input, set on output.
+  std::optional<SemIR::File>* sem_ir;
+};
+
+// Checks a group of parse trees. This will use imports to decide the order of
+// checking.
+auto CheckParseTrees(const SemIR::File& builtin_ir,
+                     llvm::MutableArrayRef<Unit> units,
+                     llvm::raw_ostream* vlog_stream) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/handle_import_and_package.cpp
+++ b/toolchain/check/handle_import_and_package.cpp
@@ -6,32 +6,47 @@
 
 namespace Carbon::Check {
 
-auto HandleImportIntroducer(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandleImportIntroducer");
+// `import` and `package` are structured by parsing. As a consequence, no
+// checking logic is needed here.
+
+auto HandleImportIntroducer(Context& /*context*/, Parse::Node /*parse_node*/)
+    -> bool {
+  return true;
 }
 
-auto HandlePackageIntroducer(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandlePackageIntroducer");
+auto HandlePackageIntroducer(Context& /*context*/, Parse::Node /*parse_node*/)
+    -> bool {
+  return true;
 }
 
-auto HandleLibrary(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandleLibrary");
+auto HandleLibrary(Context& context, Parse::Node /*parse_node*/) -> bool {
+  // Pop and discard the library name from the node stack.
+  context.node_stack().Pop<Parse::NodeKind::Literal>();
+  return true;
 }
 
-auto HandlePackageApi(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandlePackageApi");
+auto HandlePackageApi(Context& /*context*/, Parse::Node /*parse_node*/)
+    -> bool {
+  return true;
 }
 
-auto HandlePackageImpl(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandlePackageImpl");
+auto HandlePackageImpl(Context& /*context*/, Parse::Node /*parse_node*/)
+    -> bool {
+  return true;
 }
 
-auto HandleImportDirective(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandleImportDirective");
+auto HandleImportDirective(Context& context, Parse::Node /*parse_node*/)
+    -> bool {
+  // Pop and discard the identifier from the node stack.
+  context.node_stack().Pop<Parse::NodeKind::Name>();
+  return true;
 }
 
-auto HandlePackageDirective(Context& context, Parse::Node parse_node) -> bool {
-  return context.TODO(parse_node, "HandlePackageDirective");
+auto HandlePackageDirective(Context& context, Parse::Node /*parse_node*/)
+    -> bool {
+  // Pop and discard the identifier from the node stack.
+  context.node_stack().Pop<Parse::NodeKind::Name>();
+  return true;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/testdata/packages/explicit_imports.carbon
+++ b/toolchain/check/testdata/packages/explicit_imports.carbon
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- api.carbon
+
+package Api api;
+
+// --- api_lib.carbon
+
+package Api library "lib" api;
+
+// --- import_api.carbon
+
+import Api;
+import Api library "lib";
+
+// CHECK:STDOUT: file "api.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "api_lib.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "import_api.carbon" {
+// CHECK:STDOUT:   %.loc3: String = string_literal "lib"
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -6,14 +6,14 @@
 
 // --- no_api.carbon
 
-// CHECK:STDERR: no_api.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found
+// CHECK:STDERR: no_api.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
 // CHECK:STDERR: package Foo impl;
 // CHECK:STDERR: ^
 package Foo impl;
 
 // --- no_api_lib.carbon
 
-// CHECK:STDERR: no_api_lib.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found
+// CHECK:STDERR: no_api_lib.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
 // CHECK:STDERR: package Foo library "Bar" impl;
 // CHECK:STDERR: ^
 package Foo library "Bar" impl;

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -1,0 +1,29 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- no_api.carbon
+
+// CHECK:STDERR: no_api.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found
+// CHECK:STDERR: package Foo impl;
+// CHECK:STDERR: ^
+package Foo impl;
+
+// --- no_api_lib.carbon
+
+// CHECK:STDERR: no_api_lib.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found
+// CHECK:STDERR: package Foo library "Bar" impl;
+// CHECK:STDERR: ^
+package Foo library "Bar" impl;
+
+// CHECK:STDOUT: file "no_api.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "no_api_lib.carbon" {
+// CHECK:STDOUT:   %.loc5: String = string_literal "Bar"
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -1,0 +1,50 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- a.carbon
+
+package A api;
+
+// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: import B;
+// CHECK:STDERR: ^
+import B;
+
+// --- b.carbon
+
+package B api;
+
+// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: import C;
+// CHECK:STDERR: ^
+import C;
+
+// --- c.carbon
+
+package C api;
+
+// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: import A;
+// CHECK:STDERR: ^
+import A;
+
+// --- cycle_child.carbon
+
+package CycleChild api;
+
+// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: import B;
+// CHECK:STDERR: ^
+import B;
+
+// CHECK:STDOUT: file "a.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "b.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "c.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "cycle_child.carbon" {
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -8,7 +8,7 @@
 
 package A api;
 
-// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;
@@ -17,7 +17,7 @@ import B;
 
 package B api;
 
-// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
 // CHECK:STDERR: import C;
 // CHECK:STDERR: ^
 import C;
@@ -26,16 +26,23 @@ import C;
 
 package C api;
 
-// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
 // CHECK:STDERR: import A;
 // CHECK:STDERR: ^
 import A;
+
+// --- c_impl.carbon
+
+// CHECK:STDERR: c_impl.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: package C impl;
+// CHECK:STDERR: ^
+package C impl;
 
 // --- cycle_child.carbon
 
 package CycleChild api;
 
-// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle which could not be resolved
+// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;
@@ -45,6 +52,8 @@ import B;
 // CHECK:STDOUT: file "b.carbon" {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: file "c.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "c_impl.carbon" {
 // CHECK:STDOUT: }
 // CHECK:STDOUT: file "cycle_child.carbon" {
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -8,7 +8,7 @@
 
 package A api;
 
-// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;
@@ -17,7 +17,7 @@ import B;
 
 package B api;
 
-// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import C;
 // CHECK:STDERR: ^
 import C;
@@ -26,14 +26,14 @@ import C;
 
 package C api;
 
-// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import A;
 // CHECK:STDERR: ^
 import A;
 
 // --- c_impl.carbon
 
-// CHECK:STDERR: c_impl.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: c_impl.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
 // CHECK:STDERR: package C impl;
 // CHECK:STDERR: ^
 package C impl;
@@ -42,7 +42,7 @@ package C impl;
 
 package CycleChild api;
 
-// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is part of a cycle. The cycle must be fixed before the import can be used.
+// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -8,7 +8,7 @@
 
 package A api;
 
-// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
+// CHECK:STDERR: a.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;
@@ -17,7 +17,7 @@ import B;
 
 package B api;
 
-// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
+// CHECK:STDERR: b.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import C;
 // CHECK:STDERR: ^
 import C;
@@ -26,14 +26,14 @@ import C;
 
 package C api;
 
-// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
+// CHECK:STDERR: c.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import A;
 // CHECK:STDERR: ^
 import A;
 
 // --- c_impl.carbon
 
-// CHECK:STDERR: c_impl.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
+// CHECK:STDERR: c_impl.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: package C impl;
 // CHECK:STDERR: ^
 package C impl;
@@ -42,7 +42,7 @@ package C impl;
 
 package CycleChild api;
 
-// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import is in cycle. Cycle must be fixed to import.
+// CHECK:STDERR: cycle_child.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^
 import B;

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -22,7 +22,7 @@ import Main library "lib";
 
 package This api;
 
-// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: Library cannot import itself.
+// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: File cannot import itself.
 // CHECK:STDERR: import This;
 // CHECK:STDERR: ^
 import This;
@@ -31,7 +31,7 @@ import This;
 
 package This library "lib" api;
 
-// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: Library cannot import itself.
+// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: File cannot import itself.
 // CHECK:STDERR: import This library "lib";
 // CHECK:STDERR: ^
 import This library "lib";
@@ -44,7 +44,7 @@ package Implicit api;
 
 package Implicit impl;
 
-// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: Omit import of library `api`.
+// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import `api` of `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit;
 // CHECK:STDERR: ^
 import Implicit;
@@ -57,7 +57,7 @@ package Implicit library "lib" api;
 
 package Implicit library "lib" impl;
 
-// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: Omit import of library `api`.
+// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import `api` of `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit library "lib";
 // CHECK:STDERR: ^
 import Implicit library "lib";

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -6,14 +6,14 @@
 
 // --- main.carbon
 
-// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Cannot import the `Main` package from another package.
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Cannot import `Main` from other packages.
 // CHECK:STDERR: import Main;
 // CHECK:STDERR: ^
 import Main;
 
 // --- main_lib.carbon
 
-// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Cannot import the `Main` package from another package.
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Cannot import `Main` from other packages.
 // CHECK:STDERR: import Main library "lib";
 // CHECK:STDERR: ^
 import Main library "lib";
@@ -22,7 +22,7 @@ import Main library "lib";
 
 package This api;
 
-// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself.
+// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: Library cannot import itself.
 // CHECK:STDERR: import This;
 // CHECK:STDERR: ^
 import This;
@@ -31,7 +31,7 @@ import This;
 
 package This library "lib" api;
 
-// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself.
+// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: Library cannot import itself.
 // CHECK:STDERR: import This library "lib";
 // CHECK:STDERR: ^
 import This library "lib";
@@ -44,7 +44,7 @@ package Implicit api;
 
 package Implicit impl;
 
-// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly.
+// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: Omit import of library `api`.
 // CHECK:STDERR: import Implicit;
 // CHECK:STDERR: ^
 import Implicit;
@@ -57,7 +57,7 @@ package Implicit library "lib" api;
 
 package Implicit library "lib" impl;
 
-// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly.
+// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: Omit import of library `api`.
 // CHECK:STDERR: import Implicit library "lib";
 // CHECK:STDERR: ^
 import Implicit library "lib";

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -44,7 +44,7 @@ package Implicit api;
 
 package Implicit impl;
 
-// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import `api` of `impl` file is redundant with implicit import.
+// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit;
 // CHECK:STDERR: ^
 import Implicit;
@@ -57,7 +57,7 @@ package Implicit library "lib" api;
 
 package Implicit library "lib" impl;
 
-// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import `api` of `impl` file is redundant with implicit import.
+// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit library "lib";
 // CHECK:STDERR: ^
 import Implicit library "lib";

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -6,14 +6,14 @@
 
 // --- main.carbon
 
-// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package cannot be mentioned explicitly on imports; it can only be imported implicitly
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Cannot import the `Main` package from another package.
 // CHECK:STDERR: import Main;
 // CHECK:STDERR: ^
 import Main;
 
 // --- main_lib.carbon
 
-// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: The `Main` package cannot be mentioned explicitly on imports; it can only be imported implicitly
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Cannot import the `Main` package from another package.
 // CHECK:STDERR: import Main library "lib";
 // CHECK:STDERR: ^
 import Main library "lib";
@@ -22,7 +22,7 @@ import Main library "lib";
 
 package This api;
 
-// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself
+// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself.
 // CHECK:STDERR: import This;
 // CHECK:STDERR: ^
 import This;
@@ -31,7 +31,7 @@ import This;
 
 package This library "lib" api;
 
-// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself
+// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself.
 // CHECK:STDERR: import This library "lib";
 // CHECK:STDERR: ^
 import This library "lib";
@@ -44,7 +44,7 @@ package Implicit api;
 
 package Implicit impl;
 
-// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly
+// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly.
 // CHECK:STDERR: import Implicit;
 // CHECK:STDERR: ^
 import Implicit;
@@ -57,14 +57,14 @@ package Implicit library "lib" api;
 
 package Implicit library "lib" impl;
 
-// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly
+// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly.
 // CHECK:STDERR: import Implicit library "lib";
 // CHECK:STDERR: ^
 import Implicit library "lib";
 
 // --- unknown.carbon
 
-// CHECK:STDERR: unknown.carbon:[[@LINE+3]]:1: ERROR: Imported API not found
+// CHECK:STDERR: unknown.carbon:[[@LINE+3]]:1: ERROR: Imported API not found.
 // CHECK:STDERR: import Unknown;
 // CHECK:STDERR: ^
 import Unknown;

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -1,0 +1,111 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- main.carbon
+
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package cannot be mentioned explicitly on imports; it can only be imported implicitly
+// CHECK:STDERR: import Main;
+// CHECK:STDERR: ^
+import Main;
+
+// --- main_lib.carbon
+
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: The `Main` package cannot be mentioned explicitly on imports; it can only be imported implicitly
+// CHECK:STDERR: import Main library "lib";
+// CHECK:STDERR: ^
+import Main library "lib";
+
+// --- this.carbon
+
+package This api;
+
+// CHECK:STDERR: this.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself
+// CHECK:STDERR: import This;
+// CHECK:STDERR: ^
+import This;
+
+// --- this_lib.carbon
+
+package This library "lib" api;
+
+// CHECK:STDERR: this_lib.carbon:[[@LINE+3]]:1: ERROR: A file must not import itself
+// CHECK:STDERR: import This library "lib";
+// CHECK:STDERR: ^
+import This library "lib";
+
+// --- implicit_api.carbon
+
+package Implicit api;
+
+// --- implicit_impl.carbon
+
+package Implicit impl;
+
+// CHECK:STDERR: implicit_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly
+// CHECK:STDERR: import Implicit;
+// CHECK:STDERR: ^
+import Implicit;
+
+// --- implicit_lib_api.carbon
+
+package Implicit library "lib" api;
+
+// --- implicit_lib_impl.carbon
+
+package Implicit library "lib" impl;
+
+// CHECK:STDERR: implicit_lib_impl.carbon:[[@LINE+3]]:1: ERROR: The `impl` for a library implicitly imports the `api` and must not do so explicitly
+// CHECK:STDERR: import Implicit library "lib";
+// CHECK:STDERR: ^
+import Implicit library "lib";
+
+// --- unknown.carbon
+
+// CHECK:STDERR: unknown.carbon:[[@LINE+3]]:1: ERROR: Imported API not found
+// CHECK:STDERR: import Unknown;
+// CHECK:STDERR: ^
+import Unknown;
+
+// CHECK:STDOUT: file "main.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "main_lib.carbon" {
+// CHECK:STDOUT:   %.loc5: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "this.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "this_lib.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT:   %.loc7: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "implicit_api.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "implicit_impl.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "implicit_lib_api.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "implicit_lib_impl.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT:   %.loc7: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "unknown.carbon" {
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -15,18 +15,18 @@ package Api library "lib" api;
 // --- import_api.carbon
 
 import Api;
-// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Import matches an earlier import
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library is imported more than once.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^
-// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^
 import Api;
 import Api library "lib";
-// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Import matches an earlier import
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library is imported more than once.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^
-// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^
 import Api library "lib";

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -1,0 +1,50 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- api.carbon
+
+package Api api;
+
+// --- api_lib.carbon
+
+package Api library "lib" api;
+
+// --- import_api.carbon
+
+import Api;
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Import matches an earlier import
+// CHECK:STDERR: import Api;
+// CHECK:STDERR: ^
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here
+// CHECK:STDERR: import Api;
+// CHECK:STDERR: ^
+import Api;
+import Api library "lib";
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Import matches an earlier import
+// CHECK:STDERR: import Api library "lib";
+// CHECK:STDERR: ^
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here
+// CHECK:STDERR: import Api library "lib";
+// CHECK:STDERR: ^
+import Api library "lib";
+
+// CHECK:STDOUT: file "api.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "api_lib.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "import_api.carbon" {
+// CHECK:STDOUT:   %.loc10: String = string_literal "lib"
+// CHECK:STDOUT:   %.loc17: String = string_literal "lib"
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -15,18 +15,18 @@ package Api library "lib" api;
 // --- import_api.carbon
 
 import Api;
-// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library is imported more than once.
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library imported more than once.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^
-// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here.
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First import here.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^
 import Api;
 import Api library "lib";
-// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library is imported more than once.
+// CHECK:STDERR: import_api.carbon:[[@LINE+6]]:1: ERROR: Library imported more than once.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^
-// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First imported here.
+// CHECK:STDERR: import_api.carbon:[[@LINE-4]]:1: First import here.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^
 import Api library "lib";

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -6,14 +6,14 @@
 
 // --- main.carbon
 
-// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
 // CHECK:STDERR: package Main api;
 // CHECK:STDERR: ^
 package Main api;
 
 // --- main_impl.carbon
 
-// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
 // CHECK:STDERR: package Main impl;
 // CHECK:STDERR: ^
 package Main impl;
@@ -21,14 +21,14 @@ package Main impl;
 // --- raw_main.carbon
 
 // `Main` isn't a keyword, so this fails the same way.
-// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
 // CHECK:STDERR: package r#Main api;
 // CHECK:STDERR: ^
 package r#Main api;
 
 // --- main_lib.carbon
 
-// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit; libraries should omit `package Main`
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Use the `library` directive to define libraries in the `Main` package.
 // CHECK:STDERR: package Main library "lib" api;
 // CHECK:STDERR: ^
 package Main library "lib" api;

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -6,14 +6,14 @@
 
 // --- main.carbon
 
-// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
 // CHECK:STDERR: package Main api;
 // CHECK:STDERR: ^
 package Main api;
 
 // --- main_impl.carbon
 
-// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
+// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
 // CHECK:STDERR: package Main impl;
 // CHECK:STDERR: ^
 package Main impl;
@@ -21,14 +21,14 @@ package Main impl;
 // --- raw_main.carbon
 
 // `Main` isn't a keyword, so this fails the same way.
-// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: Omit the `package` directive to define the `Main` package.
+// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
 // CHECK:STDERR: package r#Main api;
 // CHECK:STDERR: ^
 package r#Main api;
 
 // --- main_lib.carbon
 
-// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Use the `library` directive to define libraries in the `Main` package.
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: Use `library` directive in `Main` package libraries.
 // CHECK:STDERR: package Main library "lib" api;
 // CHECK:STDERR: ^
 package Main library "lib" api;

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- main.carbon
+
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: package Main api;
+// CHECK:STDERR: ^
+package Main api;
+
+// --- main_impl.carbon
+
+// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: package Main impl;
+// CHECK:STDERR: ^
+package Main impl;
+
+// --- raw_main.carbon
+
+// `Main` isn't a keyword, so this fails the same way.
+// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit and not allowed in the `package` directive
+// CHECK:STDERR: package r#Main api;
+// CHECK:STDERR: ^
+package r#Main api;
+
+// --- main_lib.carbon
+
+// CHECK:STDERR: main_lib.carbon:[[@LINE+3]]:1: ERROR: The `Main` package is implicit; libraries should omit `package Main`
+// CHECK:STDERR: package Main library "lib" api;
+// CHECK:STDERR: ^
+package Main library "lib" api;
+
+// CHECK:STDOUT: file "main.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "main_impl.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "raw_main.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "main_lib.carbon" {
+// CHECK:STDOUT:   %.loc5: String = string_literal "lib"
+// CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -6,14 +6,14 @@
 
 // --- main.carbon
 
-// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
+// CHECK:STDERR: main.carbon:[[@LINE+3]]:1: ERROR: Default `Main` library must omit `package` directive.
 // CHECK:STDERR: package Main api;
 // CHECK:STDERR: ^
 package Main api;
 
 // --- main_impl.carbon
 
-// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
+// CHECK:STDERR: main_impl.carbon:[[@LINE+3]]:1: ERROR: Default `Main` library must omit `package` directive.
 // CHECK:STDERR: package Main impl;
 // CHECK:STDERR: ^
 package Main impl;
@@ -21,7 +21,7 @@ package Main impl;
 // --- raw_main.carbon
 
 // `Main` isn't a keyword, so this fails the same way.
-// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: Omit `package` directive for `Main` package.
+// CHECK:STDERR: raw_main.carbon:[[@LINE+3]]:1: ERROR: Default `Main` library must omit `package` directive.
 // CHECK:STDERR: package r#Main api;
 // CHECK:STDERR: ^
 package r#Main api;

--- a/toolchain/check/testdata/packages/implicit_imports.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports.carbon
@@ -1,0 +1,64 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- api_only.carbon
+
+package ApiOnly api;
+
+// --- api_only_lib.carbon
+
+package ApiOnly library "lib" api;
+
+// --- with_impl_api.carbon
+
+package WithImpl api;
+
+// --- with_impl_impl.carbon
+
+package WithImpl impl;
+
+// --- with_impl_impl_extra.carbon
+
+// Multiple impls are allowed.
+package WithImpl impl;
+
+// --- with_impl_lib_api.carbon
+
+package WithImpl library "lib" api;
+
+// --- with_impl_lib_impl.carbon
+
+package WithImpl library "lib" impl;
+
+// CHECK:STDOUT: file "api_only.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "api_only_lib.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "with_impl_api.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "with_impl_impl.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: file "with_impl_impl_extra.carbon" {
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "with_impl_lib_api.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type String
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file "with_impl_lib_impl.carbon" {
+// CHECK:STDOUT:   %.loc2: String = string_literal "lib"
+// CHECK:STDOUT: }

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -114,6 +114,19 @@ CARBON_DIAGNOSTIC_KIND(ParamsRequiredByIntroducer)
 
 CARBON_DIAGNOSTIC_KIND(SemanticsTodo)
 
+// Package/import checking diagnostics.
+CARBON_DIAGNOSTIC_KIND(DuplicateLibraryApi)
+CARBON_DIAGNOSTIC_KIND(LibraryApiNotFound)
+CARBON_DIAGNOSTIC_KIND(ImportNotFound)
+CARBON_DIAGNOSTIC_KIND(ImportCycleDetected)
+CARBON_DIAGNOSTIC_KIND(ExplicitMainPackage)
+CARBON_DIAGNOSTIC_KIND(ExplicitMainLibrary)
+CARBON_DIAGNOSTIC_KIND(ImportMainPackage)
+CARBON_DIAGNOSTIC_KIND(ImportSelf)
+CARBON_DIAGNOSTIC_KIND(ExplicitImportApi)
+CARBON_DIAGNOSTIC_KIND(RepeatedImport)
+CARBON_DIAGNOSTIC_KIND(FirstImported)
+
 // Function call checking.
 CARBON_DIAGNOSTIC_KIND(AddrSelfIsNonReference)
 CARBON_DIAGNOSTIC_KIND(CallArgCountMismatch)

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -54,6 +54,7 @@ cc_library(
         "//common:ostream",
         "//common:vlog",
         "//toolchain/base:pretty_stack_trace_function",
+        "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lex:token_kind",
         "//toolchain/lex:tokenized_buffer",

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -287,6 +287,17 @@ class Context {
   auto RecoverFromDeclError(StateStackEntry state, NodeKind parse_node_kind,
                             bool skip_past_likely_end) -> void;
 
+  // Sets the package directive information. Called at most once.
+  auto SetPackage(Tree::Package package, Tree::ApiOrImpl api_or_impl) -> void {
+    CARBON_CHECK(!tree_->package_);
+    tree_->package_ = {.package = package, .api_or_impl = api_or_impl};
+  }
+
+  // Adds an import.
+  auto AddImport(Tree::Package package) -> void {
+    tree_->imports_.push_back(package);
+  }
+
   // Prints information for a stack dump.
   auto PrintForStackDump(llvm::raw_ostream& output) const -> void;
 

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -288,13 +288,14 @@ class Context {
                             bool skip_past_likely_end) -> void;
 
   // Sets the package directive information. Called at most once.
-  auto SetPackage(Tree::Package package, Tree::ApiOrImpl api_or_impl) -> void {
+  auto SetPackage(Tree::PackagingNames package, Tree::ApiOrImpl api_or_impl)
+      -> void {
     CARBON_CHECK(!tree_->package_);
     tree_->package_ = {.package = package, .api_or_impl = api_or_impl};
   }
 
   // Adds an import.
-  auto AddImport(Tree::Package package) -> void {
+  auto AddImport(Tree::PackagingNames package) -> void {
     tree_->imports_.push_back(package);
   }
 

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -288,10 +288,11 @@ class Context {
                             bool skip_past_likely_end) -> void;
 
   // Sets the package directive information. Called at most once.
-  auto SetPackage(Tree::PackagingNames package, Tree::ApiOrImpl api_or_impl)
-      -> void {
-    CARBON_CHECK(!tree_->package_);
-    tree_->package_ = {.package = package, .api_or_impl = api_or_impl};
+  auto set_packaging_directive(Tree::PackagingNames packaging_names,
+                               Tree::ApiOrImpl api_or_impl) -> void {
+    CARBON_CHECK(!tree_->packaging_directive_);
+    tree_->packaging_directive_ = {.names = packaging_names,
+                                   .api_or_impl = api_or_impl};
   }
 
   // Adds an import.

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -23,9 +23,9 @@ static auto HandleImportAndPackage(Context& context,
                                    Context::StateStackEntry state,
                                    NodeKind directive, bool is_package)
     -> void {
-  Tree::PackagingNames package{.node = Node(state.subtree_start)};
+  Tree::PackagingNames names{.node = Node(state.subtree_start)};
   if (auto package_name_token = context.ConsumeIf(Lex::TokenKind::Identifier)) {
-    package.package_id = context.tokens().GetIdentifier(*package_name_token);
+    names.package_id = context.tokens().GetIdentifier(*package_name_token);
     context.AddLeafNode(NodeKind::Name, *package_name_token);
   } else {
     CARBON_DIAGNOSTIC(ExpectedIdentifierAfterKeyword, Error,
@@ -41,7 +41,7 @@ static auto HandleImportAndPackage(Context& context,
 
     if (auto library_name_token =
             context.ConsumeIf(Lex::TokenKind::StringLiteral)) {
-      package.library_id =
+      names.library_id =
           context.tokens().GetStringLiteral(*library_name_token);
       context.AddLeafNode(NodeKind::Literal, *library_name_token);
     } else {
@@ -58,7 +58,7 @@ static auto HandleImportAndPackage(Context& context,
   }
 
   auto next_kind = context.PositionKind();
-  if (!package.library_id.is_valid() &&
+  if (!names.library_id.is_valid() &&
       next_kind == Lex::TokenKind::StringLiteral) {
     // If we come acroess a string literal and we didn't parse `library
     // "..."` yet, then most probably the user forgot to add `library`
@@ -100,9 +100,9 @@ static auto HandleImportAndPackage(Context& context,
   }
 
   if (is_package) {
-    context.SetPackage(package, api_or_impl);
+    context.set_packaging_directive(names, api_or_impl);
   } else {
-    context.AddImport(package);
+    context.AddImport(names);
   }
 
   context.AddNode(directive, context.Consume(), state.subtree_start,

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -23,7 +23,7 @@ static auto HandleImportAndPackage(Context& context,
                                    Context::StateStackEntry state,
                                    NodeKind directive, bool is_package)
     -> void {
-  Tree::Package package{.node = Node(state.subtree_start)};
+  Tree::PackagingNames package{.node = Node(state.subtree_start)};
   if (auto package_name_token = context.ConsumeIf(Lex::TokenKind::Identifier)) {
     package.package_id = context.tokens().GetIdentifier(*package_name_token);
     context.AddLeafNode(NodeKind::Name, *package_name_token);

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -41,8 +41,7 @@ static auto HandleImportAndPackage(Context& context,
 
     if (auto library_name_token =
             context.ConsumeIf(Lex::TokenKind::StringLiteral)) {
-      names.library_id =
-          context.tokens().GetStringLiteral(*library_name_token);
+      names.library_id = context.tokens().GetStringLiteral(*library_name_token);
       context.AddLeafNode(NodeKind::Literal, *library_name_token);
     } else {
       CARBON_DIAGNOSTIC(

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -77,7 +77,7 @@ class Tree : public Printable<Tree> {
 
   // `package` information.
   struct PackagingDirective {
-    PackagingNames package;
+    PackagingNames names;
     ApiOrImpl api_or_impl;
   };
 
@@ -126,8 +126,8 @@ class Tree : public Printable<Tree> {
 
   [[nodiscard]] auto node_subtree_size(Node n) const -> int32_t;
 
-  auto package() const -> const std::optional<PackagingDirective>& {
-    return package_;
+  auto packaging_directive() const -> const std::optional<PackagingDirective>& {
+    return packaging_directive_;
   }
   auto imports() const -> llvm::ArrayRef<PackagingNames> { return imports_; }
 
@@ -266,7 +266,7 @@ class Tree : public Printable<Tree> {
   // nodes as some tokens may have been skipped.
   bool has_errors_ = false;
 
-  std::optional<PackagingDirective> package_;
+  std::optional<PackagingDirective> packaging_directive_;
   llvm::SmallVector<PackagingNames> imports_;
 };
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -10,7 +10,6 @@
 #include "common/error.h"
 #include "common/ostream.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
@@ -70,15 +69,15 @@ class Tree : public Printable<Tree> {
 
   // Used for both `package` and `import`. Links back to the node for
   // diagnostics.
-  struct Package {
+  struct PackagingNames {
     Node node;
     IdentifierId package_id = IdentifierId::Invalid;
     StringLiteralId library_id = StringLiteralId::Invalid;
   };
 
   // `package` information.
-  struct PackageDirective {
-    Package package;
+  struct PackagingDirective {
+    PackagingNames package;
     ApiOrImpl api_or_impl;
   };
 
@@ -127,10 +126,10 @@ class Tree : public Printable<Tree> {
 
   [[nodiscard]] auto node_subtree_size(Node n) const -> int32_t;
 
-  auto package() const -> const std::optional<PackageDirective>& {
+  auto package() const -> const std::optional<PackagingDirective>& {
     return package_;
   }
-  auto imports() const -> llvm::ArrayRef<Package> { return imports_; }
+  auto imports() const -> llvm::ArrayRef<PackagingNames> { return imports_; }
 
   // See the other Print comments.
   auto Print(llvm::raw_ostream& output) const -> void;
@@ -267,8 +266,8 @@ class Tree : public Printable<Tree> {
   // nodes as some tokens may have been skipped.
   bool has_errors_ = false;
 
-  std::optional<PackageDirective> package_;
-  llvm::SmallVector<Package> imports_;
+  std::optional<PackagingDirective> package_;
+  llvm::SmallVector<PackagingNames> imports_;
 };
 
 // A random-access iterator to the depth-first postorder sequence of parse nodes

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -61,21 +61,21 @@ class Tree : public Printable<Tree> {
   class PostorderIterator;
   class SiblingIterator;
 
-  // For `package`.
+  // For PackagingDirective.
   enum class ApiOrImpl : uint8_t {
     Api,
     Impl,
   };
 
-  // Used for both `package` and `import`. Links back to the node for
-  // diagnostics.
+  // Names in packaging, whether the file's packaging or an import. Links back
+  // to the node for diagnostics.
   struct PackagingNames {
     Node node;
     IdentifierId package_id = IdentifierId::Invalid;
     StringLiteralId library_id = StringLiteralId::Invalid;
   };
 
-  // `package` information.
+  // The file's packaging.
   struct PackagingDirective {
     PackagingNames names;
     ApiOrImpl api_or_impl;


### PR DESCRIPTION
As I was working on this, I noticed `import` and `library` syntax needs to be fixed for how it imports the current package, and for `Main` libraries. This mostly reflects the current state in its testing.

Otherwise, this should handle most of the errors I could think of: dependency cycles, redundant imports, etc.

It does not actually deal with the nuances of cross-IR references.