### PR TITLE
Restore interface declaration parse test

### DIFF
--- a/toolchain/parse/testdata/generics/interface/declaration.carbon
+++ b/toolchain/parse/testdata/generics/interface/declaration.carbon
@@ -4,15 +4,13 @@
 //
 // AUTOUPDATE
 
-interface Foo {
-}
+interface Foo;
 
 // CHECK:STDOUT: - filename: declaration.carbon
 // CHECK:STDOUT:   parse_tree: [
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
-// CHECK:STDOUT:         {kind: 'InterfaceIntroducer', text: 'interface'},
-// CHECK:STDOUT:         {kind: 'Name', text: 'Foo'},
-// CHECK:STDOUT:       {kind: 'InterfaceDefinitionStart', text: '{', subtree_size: 3},
-// CHECK:STDOUT:     {kind: 'InterfaceDefinition', text: '}', subtree_size: 4},
+// CHECK:STDOUT:       {kind: 'InterfaceIntroducer', text: 'interface'},
+// CHECK:STDOUT:       {kind: 'Name', text: 'Foo'},
+// CHECK:STDOUT:     {kind: 'InterfaceDecl', text: ';', subtree_size: 3},
 // CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT:   ]

--- a/toolchain/parse/testdata/generics/interface/empty_body.carbon
+++ b/toolchain/parse/testdata/generics/interface/empty_body.carbon
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
+
 interface Foo {
 }
 


### PR DESCRIPTION
The declaration test was made the same as the empty body test in #2649. This change restores it to test parsing a forward declaration of an interface.