### PR TITLE
Clarify name bindings in namespaces.

### DIFF
--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -699,7 +699,7 @@ namespace NS.MemberNS;
 class NS.MemberNS.MemberClassT {}
 ```
 
-When there are multiple declared names in binding patterns, particularly `var`
+When there are multiple declared names in binding patterns in the same pattern, particularly `var`
 and `let`, all names must be in the same namespace. For example:
 
 ```carbon

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -1032,6 +1032,7 @@ should be part of a larger testing plan.
     -   [Scoped namespaces](/proposals/p0107.md#scoped-namespaces)
     -   [Allow prefixing a tuple binding pattern with a namespace](/proposals/p3407.md#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
     -   [Allow mixing namespaces within a binding pattern](/proposals/p3407.md#allow-mixing-namespaces-within-a-binding-pattern)
+    -   [Disallow declaring namespaces other than the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
 
 ## References
 

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -699,8 +699,11 @@ namespace NS.MemberNS;
 class NS.MemberNS.MemberClassT {}
 ```
 
-When there are multiple declared names in binding patterns in the same pattern, particularly `var`
-and `let`, all names must be in the same namespace. For example:
+When there are multiple declared names in binding patterns in the same pattern,
+all names must be in the same namespace. Because namespace members can only be
+declared in the same scope as the namespace, a namespace-qualified pattern
+binding can only be used in the pattern of a `var` or `let` declaration. For
+example:
 
 ```carbon
 namespace NS;

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -729,7 +729,7 @@ patterns.
 
 ```
 // ✅ Allowed: not a binding pattern.
-(NS.namespace_var, local_var) = (0, 1);
+case (NS.namespace_var, local_var) => ...;
 ```
 
 #### Aliasing

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -1031,8 +1031,9 @@ should be part of a larger testing plan.
     -   [File-level namespaces](/proposals/p0107.md#file-level-namespaces)
     -   [Scoped namespaces](/proposals/p0107.md#scoped-namespaces)
     -   [Allow prefixing a tuple binding pattern with a namespace](/proposals/p3407.md#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
-    -   [Allow mixing namespaces within a binding pattern](/proposals/p3407.md#allow-using-namespaces-in-unrelated-scopes-or-mixing-them-within-a-binding-pattern)
-    -   [Disallow declaring namespaces outside the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
+    -   [Allow binding patterns to declare names in multiple namespaces](/proposals/p3407.md#allow-binding-patterns-to-declare-names-in-multiple-namespaces)
+    -   [Allow declaring names in namespaces not owned by the current scope](/proposals/p3407.md#allow-declaring-names-in-namespaces-not-owned-by-the-current-scope)
+    -   [Disallow declaring namespaces other than the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
 
 ## References
 

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -699,8 +699,8 @@ namespace NS.MemberNS;
 class NS.MemberNS.MemberClassT {}
 ```
 
-When there are multiple declared names in binding patterns in the same pattern,
-all names must be in the same namespace. Because namespace members can only be
+When multiple names are declared by binding patterns in the same pattern, all
+names must be in the same namespace. Because namespace members can only be
 declared in the same scope as the namespace, a namespace-qualified pattern
 binding can only be used in the pattern of a `var` or `let` declaration. For
 example:

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -1031,8 +1031,8 @@ should be part of a larger testing plan.
     -   [File-level namespaces](/proposals/p0107.md#file-level-namespaces)
     -   [Scoped namespaces](/proposals/p0107.md#scoped-namespaces)
     -   [Allow prefixing a tuple binding pattern with a namespace](/proposals/p3407.md#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
-    -   [Allow mixing namespaces within a binding pattern](/proposals/p3407.md#allow-mixing-namespaces-within-a-binding-pattern)
-    -   [Disallow declaring namespaces other than the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
+    -   [Allow mixing namespaces within a binding pattern](/proposals/p3407.md#allow-using-namespaces-in-unrelated-scopes-or-mixing-them-within-a-binding-pattern)
+    -   [Disallow declaring namespaces outside the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
 
 ## References
 

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -715,7 +715,8 @@ var (NS.c: i32, NS.d: i32) = (3, 4);
 var (e: i32, NS.f: i32) = (5, 6);
 ```
 
-This restriction only applies to binding patterns, not other patterns.
+This restriction only applies when declaring names in binding patterns, not
+other name uses in patterns.
 
 #### Aliasing
 

--- a/docs/design/code_and_name_organization/README.md
+++ b/docs/design/code_and_name_organization/README.md
@@ -619,10 +619,11 @@ fn GetArea(c: Circle) { ... }
 
 ### Namespaces
 
-Namespaces offer named paths for entities. Namespaces may be nested. Multiple
-libraries may contribute to the same namespace. In practice, packages may have
-namespaces such as `Testing` containing entities that benefit from an isolated
-space but are present in many libraries.
+Namespaces offer named paths for entities. Namespaces must be declared at file
+scope, and may be nested. Multiple libraries may contribute to the same
+namespace. In practice, packages may have namespaces such as `Testing`
+containing entities that benefit from an isolated space but are present in many
+libraries.
 
 The `namespace` keyword's syntax may loosely be expressed as a regular
 expression:
@@ -689,16 +690,6 @@ class NS.ClassT {
 fn Function() {
   // ❌ Error: A function body has its own name scope.
   var NS.b: i32 = 1;
-
-  namespace FunctionNS;
-  // ✅ Allowed: Both `FunctionNS` and `FunctionNS.c` are defined in the same
-  // name scope.
-  var FunctionNS.c: i32 = 2;
-
-  if (true) {
-    // ❌ Error: This is a separate name scope from `FunctionNS`.
-    var FunctionNS.d: i32 = 3;
-  }
 }
 
 // ✅ Allowed: declaration is in file scope, which also declared `NS`.
@@ -724,13 +715,7 @@ var (NS.c: i32, NS.d: i32) = (3, 4);
 var (e: i32, NS.f: i32) = (5, 6);
 ```
 
-This restriction only applies to binding patterns, not more general uses of
-patterns.
-
-```
-// ✅ Allowed: not a binding pattern.
-case (NS.namespace_var, local_var) => ...;
-```
+This restriction only applies to binding patterns, not other patterns.
 
 #### Aliasing
 
@@ -1033,7 +1018,7 @@ should be part of a larger testing plan.
     -   [Allow prefixing a tuple binding pattern with a namespace](/proposals/p3407.md#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
     -   [Allow binding patterns to declare names in multiple namespaces](/proposals/p3407.md#allow-binding-patterns-to-declare-names-in-multiple-namespaces)
     -   [Allow declaring names in namespaces not owned by the current scope](/proposals/p3407.md#allow-declaring-names-in-namespaces-not-owned-by-the-current-scope)
-    -   [Disallow declaring namespaces other than the file scope](/proposals/p3407.md#disallow-declaring-namespaces-other-than-the-file-scope)
+    -   [Allow declaring namespaces in scopes other than the file scope](/proposals/p3407.md#allow-declaring-namespaces-in-scopes-other-than-the-file-scope)
 
 ## References
 

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -37,7 +37,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 While the trivial case of `var NS.a` seems to be supported as a consequence of
 proposal
 [#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107),
-there are a couple syntactic options when binding multiple names.
+it lacks detail. For example, there are a couple syntactic options when binding
+multiple names.
 
 Also, there's no clear decision around code such as:
 
@@ -79,9 +80,7 @@ for reference.
 -   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
 
     -   Only allowing binding patterns to declare variables in the same
-        namespace allows for a guarantee that the memory can be sequentially
-        allocated. This allows for copy elision on initializers with function
-        calls.
+        namespace allows for consistency with other name scope designs.
 
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
 

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -164,7 +164,8 @@ builds consistency in name scope boundaries across declarations.
 We could allow declaring namespaces in scopes other than the file scope. It's
 ambiguous what path should have resulted from proposal
 [#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107),
-although some p
+although examples all focus on file scope, so other scopes weren't carefully
+considered.
 
 It might prove useful in some situations. For example, perhaps a complex class
 would find a member namespace useful:

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -67,8 +67,8 @@ variables.
 ## Proposal
 
 When used to declare names in binding patterns, as in `var` or `let`, all names
-must be in the same namespace. Declaring members of a namespace inside of an
-unrelated scope is invalid.
+must be in the same namespace. `namespace` members must be declared from within
+the same scope that declared the `namespace`.
 
 See the changes to
 [code and name organization](/docs/design/code_and_name_organization/#namespaces)

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -32,7 +32,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   Declaring namespaces outside file scope is disallowed, so this means
         only at file scope.
 -   Allow binding patterns to directly declare names in namespaces.
--   Disallow using different namespaces in the same binding pattern.
+-   Disallow introducing bindings in different namespaces in the same pattern.
 
 ## Problem
 

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -19,7 +19,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Rationale](#rationale)
 -   [Alternatives considered](#alternatives-considered)
     -   [Allow prefixing a tuple binding pattern with a namespace](#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
-    -   [Allow mixing namespaces within a binding pattern](#allow-mixing-namespaces-within-a-binding-pattern)
+    -   [Allow binding patterns to declare names in multiple namespaces](#allow-binding-patterns-to-declare-names-in-multiple-namespaces)
+    -   [Allow declaring names in namespaces not owned by the current scope](#allow-declaring-names-in-namespaces-not-owned-by-the-current-scope)
     -   [Disallow declaring namespaces other than the file scope](#disallow-declaring-namespaces-other-than-the-file-scope)
 
 <!-- tocstop -->
@@ -40,7 +41,7 @@ there are a couple syntactic options when binding multiple names.
 
 Also, there's no clear decision around code such as:
 
-```
+```carbon
 namespace NS;
 class ClassT {
   // Is this a class member accessed through `NS`, or a file scope member inside
@@ -104,46 +105,60 @@ consequence, the separation of the namespace qualifier from the declared
 identifier might end up unique to this syntax. In that context, we prefer `NS.a`
 for consistency with other cases, such as `class NS.class`.
 
-### Allow mixing namespaces within a binding pattern
+### Allow binding patterns to declare names in multiple namespaces
 
-We could allow mixing namespaces in a binding pattern. For example:
-
-```carbon
-var (e: i32, NS.f: i32) = (5, 6);
-var (FirstNS.g: i32, SecondNS.h: i32) = (7, 8);
-```
-
-The mixture of two different prefixes in a single declaration alone seems likely
-to be confusing, and doesn't have much motivation.
-
-If we allow namespaced names within unrelated scopes, it would also imply the
-possibility of mixing use inside _class_ scopes:
+We could allow binding patterns to declare names in multiple namespaces. For
+example:
 
 ```carbon
 namespace NS;
+var (NS.a: i32, b: i32) = InitData();
+```
 
+Mixing namespaces could be confusing: for example, `b` could be misunderstood to
+be declared in `NS`. We lack data that would demonstrate benefits to offset
+that.
+
+We disallow mixing namespaces in a single declaration for simplicity.
+
+### Allow declaring names in namespaces not owned by the current scope
+
+We could allow declaring names in namespaces not owned by the current scope. For
+example:
+
+```carbon
+namespace NS;
 class ClassT {
-  var (class_member: i32,
-       NS.namespace_member: i32,
-       package.package_member: i32);
+  var NS.val: i32;
+
+  class NS.ChildT {}
 }
 ```
 
-Either these are all instance members, which would be surprising in terms of the
-naming conventions for example members (for example requiring looking up the
-namespace name after the object in `x.NS.namespace_member`), or it would require
-the qualified names to be _static_ members (in C++ terminology).
+Here, `package.NS.val` would be a global, but `ClassT.NS.val` looks more like an
+instance member. It's also unclear whether `ClassT.NS.val` (or
+`instance.NS.val`) could be used to reference the produced variable, since `NS`
+is not inside `ClassT`'s name scope. These problems extend to non-binding
+declarations such as `NS.ChildT`, too.
 
-Mixing static and non-static members in a single declaration seems fundamentally
-problematic due to lifetimes.
+Disallowing using namespaces to cross name scopes is consistent with rules that
+generally prevent declaring names in other name scopes, such as:
 
-We don't have a design for static class members like this yet, and it doesn't
-seem like we should introduce or motivate them with namespacing within scopes.
+```carbon
+class A {
+    class B {
+        // `C` must be declared directly inside `A`.
+        class A.C;
+    }
+}
 
-For now, we just disallow the mixing namespaces in single declarations for
-simplicity and to avoid having to resolve these issues. And we disallow
-namespaced names within unrelated scopes to avoid the name lookup complexity and
-any potential confusion over C++-style-`static` or other semantics.
+// `D` must be declared within `A`, even if separately defined.
+class A.D {}
+```
+
+Both the `namespace` declaration and names declared within the `namespace` must
+be written in the same name scope. This avoids name lookup ambiguities, and
+builds consistency in name scope boundaries across declarations.
 
 ### Disallow declaring namespaces other than the file scope
 
@@ -156,7 +171,7 @@ doesn't actively interfere with Carbon, and it could prove useful in some
 situations. For example, perhaps a complex class would find a member namespace
 useful:
 
-```
+```carbon
 class Complex {
    namespace OptionSet1;
    class OptionSet1.MemberClassA;

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [Allow prefixing a tuple binding pattern with a namespace](#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
     -   [Allow binding patterns to declare names in multiple namespaces](#allow-binding-patterns-to-declare-names-in-multiple-namespaces)
     -   [Allow declaring names in namespaces not owned by the current scope](#allow-declaring-names-in-namespaces-not-owned-by-the-current-scope)
-    -   [Disallow declaring namespaces other than the file scope](#disallow-declaring-namespaces-other-than-the-file-scope)
+    -   [Allow declaring namespaces in scopes other than the file scope](#allow-declaring-namespaces-in-scopes-other-than-the-file-scope)
 
 <!-- tocstop -->
 
@@ -29,6 +29,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 -   Require namespace members be declared in the same name scope as the
     namespace is declared.
+    -   Declaring namespaces outside file scope is disallowed, so this means
+        only at file scope.
 -   Allow binding patterns to directly declare names in namespaces.
 -   Disallow using different namespaces in the same binding pattern.
 
@@ -47,11 +49,11 @@ namespace NS;
 class ClassT {
   // Is this a class member accessed through `NS`, or a file scope member inside
   // `NS`? What is its lifetime?
-  var NS.a = 0;
+  var NS.a: i32 = 0;
 }
 ```
 
-This proposal mainly aims to remove these ambiguities.
+This proposal mainly aims to remove ambiguities.
 
 ## Background
 
@@ -71,16 +73,14 @@ When used to declare names in binding patterns, as in `var` or `let`, all names
 must be in the same namespace. `namespace` members must be declared from within
 the same scope that declared the `namespace`.
 
+There was uncertainty about whether namespaces could be declared outside of file
+scopes; for now, disallow it.
+
 See the changes to
 [code and name organization](/docs/design/code_and_name_organization/#namespaces)
 for reference.
 
 ## Rationale
-
--   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
-
-    -   Only allowing binding patterns to declare variables in the same
-        namespace allows for consistency with other name scope designs.
 
 -   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
 
@@ -159,16 +159,15 @@ Both the `namespace` declaration and names declared within the `namespace` must
 be written in the same name scope. This avoids name lookup ambiguities, and
 builds consistency in name scope boundaries across declarations.
 
-### Disallow declaring namespaces other than the file scope
+### Allow declaring namespaces in scopes other than the file scope
 
-We could disallow declaring namespaces in scopes other than the file scope.
-Combined with requiring members of namespaces to only be declared at the file
-scope, this would prevent their use in other contexts.
+We could allow declaring namespaces in scopes other than the file scope. It's
+ambiguous what path should have resulted from proposal
+[#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107),
+although some p
 
-This would be consistent with C++. However, we believe the current design
-doesn't actively interfere with Carbon, and it could prove useful in some
-situations. For example, perhaps a complex class would find a member namespace
-useful:
+It might prove useful in some situations. For example, perhaps a complex class
+would find a member namespace useful:
 
 ```carbon
 class Complex {
@@ -179,12 +178,23 @@ class Complex {
    namespace OptionSet2;
    class OptionSet2.MemberClassC;
    class OptionSet2.MemberClassD;
+
+   namespace Vars;
+   var Vars.a;
 }
 ```
 
-This would be easy to work around if disallowed (for example, combine names for
-`OptionSet1MemberClassA`). This is both good and bad; disallowing it would be
-cheap, but it may mask friction from not providing the feature.
+This proposal takes a stance against declaring namespaces other than the file
+scope because:
 
-Although we're not sure how useful this will prove to be, we will allow the
-syntax and may reevaluate in the future.
+-   Proposal
+    [#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107)
+    only mentions file scope namespaces, implicitly disallowing it in other
+    scopes.
+-   Disallowing namespaces in other scopes is consistent with C++.
+
+If allowed, it would be necessary to decide whether `Complex.Vars.a` would have
+instance or global lifetime.
+
+For now, namespaces may only be declared at file scope, which gives consistency
+with C++. This decision may be reevaluated in a future proposal.

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -138,7 +138,7 @@ class ClassT {
 Here, `package.NS.val` would be a global, but `ClassT.NS.val` looks more like an
 instance member. It's also unclear whether `ClassT.NS.val` (or
 `instance.NS.val`) could be used to reference the produced variable, since `NS`
-is not inside `ClassT`'s name scope. These problems extend to non-binding
+is not inside `ClassT`'s name scope. The naming problems extend to non-binding
 declarations such as `NS.ChildT`, too.
 
 Disallowing using namespaces to cross name scopes is consistent with rules that

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -36,7 +36,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Problem
 
-While the trivial case of `var NS.a` seems to be supported as a consequence of
+While the trivial case of `class NS.C` seems to be supported as a consequence of
 proposal
 [#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107),
 it lacks detail. For example, there are a couple syntactic options when binding

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -1,0 +1,168 @@
+# Clarify name bindings in namespaces.
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/3407)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Background](#background)
+-   [Proposal](#proposal)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Allow prefixing a tuple binding pattern with a namespace](#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
+    -   [Allow mixing namespaces within a binding pattern](#allow-mixing-namespaces-within-a-binding-pattern)
+
+<!-- tocstop -->
+
+## Abstract
+
+-   Require namespace members be declared in the same name scope as the
+    namespace is declared.
+-   Allow binding patterns to directly declare names in namespaces.
+-   Disallow using different namespaces in the same binding pattern.
+
+## Problem
+
+While the trivial case of `var NS.a` seems to be supported as a consequence of
+proposal
+[#107: Code and name organization](https://github.com/carbon-language/carbon-lang/pull/107),
+there are a couple syntactic options when binding multiple names.
+
+Also, there's no clear decision around code such as:
+
+```
+namespace NS;
+class ClassT {
+  // Is this a class member accessed through `NS`, or a file scope member inside
+  // `NS`? What is its lifetime?
+  var NS.a = 0;
+}
+```
+
+This proposal mainly aims to remove these ambiguities.
+
+## Background
+
+Namespaces are covered in
+[code and name organization](/docs/design/code_and_name_organization/#namespaces).
+Binding patterns are covered in
+[pattern matching](/docs/design/pattern_matching.md#binding-patterns).
+
+There's some discussion of `var` in
+[values, variables, and pointers](/docs/design/values.md), but it's specific to
+locals. That doesn't address other use cases, such as globals or member
+variables.
+
+## Proposal
+
+When used to declare names in binding patterns, as in `var` or `let`, all names
+must be in the same namespace. Declaring members of a namespace inside of an
+unrelated scope is invalid.
+
+See the changes to
+[code and name organization](/docs/design/code_and_name_organization/#namespaces)
+for reference.
+
+## Rationale
+
+-   [Performance-critical software](/docs/project/goals.md#performance-critical-software)
+
+    -   Only allowing binding patterns to declare variables in the same
+        namespace allows for a guarantee that the memory can be sequentially
+        allocated. This allows for copy elision on initializers with function
+        calls.
+
+-   [Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write)
+
+    -   Requiring that declarations of multiple names use `NS.a` syntax is
+        consistent with the single variable case.
+    -   Requiring namespace members be declared while in the same name scope as
+        the namespace itself makes lifetimes clearer.
+
+## Alternatives considered
+
+### Allow prefixing a tuple binding pattern with a namespace
+
+We could use the namespace to prefix the binding tuple. For example:
+
+```carbon
+var NS.(a: i32, b: i32) = (3, 4);
+```
+
+It's rare that we would have a single statement declare multiple names. As a
+consequence, the separation of the namespace qualifier from the declared
+identifier might end up unique to this syntax. In that context, we prefer `NS.a`
+for consistency with other cases, such as `class NS.class`.
+
+### Allow mixing namespaces within a binding pattern
+
+We could allow mixing namespaces in a binding pattern. For example:
+
+```carbon
+var (e: i32, NS.f: i32) = (5, 6);
+var (FirstNS.g: i32, SecondNS.h: i32) = (7, 8);
+```
+
+That would offer the possibility of mixing use inside scopes:
+
+```carbon
+namespace NS;
+
+class ClassT {
+  var (static class_member: i32,
+       NS.namespace_member: i32,
+       package.package_member: i32) = InitData();
+}
+```
+
+Note here that static syntax for class members is not defined: I'm assuming for
+argument's sake that we expect something similar, but this could also be:
+
+```
+  let (class_member: i32,
+       var NS.namespace_member: i32,
+       var package.package_member: i32) = InitData();
+```
+
+It's not obvious how memory for the above should be allocated. There are two
+options:
+
+-   The three values are sequentially allocated, even though they belong to
+    different name scopes. This allows for return value optimizations to work,
+    but may cause issues for how we consider name scopes and lifetimes.
+-   The three values are separately allocated, grouping allocations by name
+    scope. This breaks return value optimizations, but simplifies requirements
+    around name scopes and lifetimes.
+
+Both options have issues; it would likely prove difficult to set this up such
+that return value optimizations would consistently work, across all potential
+uses of this syntax. That would introduce some variability in performance based
+on unclear context, something we would like to avoid.
+
+Without mixing namespaces, static initialization case can still be addressed,
+albeit with more work. For example:
+
+```carbon
+namespace NS;
+
+let init_data: auto = InitData();
+
+class ClassT {
+  var static class_member: i32 = init_data[0];
+}
+
+var NS.namespace_member: i32 = init_data[1];
+var package_member: i32 = init_data[2];
+```
+
+Rather than forcing a choice, this alternative is discarded in order to require
+syntax -- and resulting performance -- be clearer.

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -113,60 +113,37 @@ var (e: i32, NS.f: i32) = (5, 6);
 var (FirstNS.g: i32, SecondNS.h: i32) = (7, 8);
 ```
 
-That would offer the possibility of mixing use inside scopes:
+The mixture of two different prefixes in a single declaration alone seems likely
+to be confusing, and doesn't have much motivation.
+
+If we allow namespaced names within unrelated scopes, it would also imply the
+possibility of mixing use inside _class_ scopes:
 
 ```carbon
 namespace NS;
 
 class ClassT {
-  var (static class_member: i32,
+  var (class_member: i32,
        NS.namespace_member: i32,
-       package.package_member: i32) = InitData();
+       package.package_member: i32);
 }
 ```
 
-Note here that static syntax for class members is not defined: I'm assuming for
-argument's sake that we expect something similar, but this could also be:
+Either these are all instance members, which would be surprising in terms of the
+naming conventions for example members (for example requiring looking up the
+namespace name after the object in `x.NS.namespace_member`), or it would require
+the qualified names to be _static_ members (in C++ terminology).
 
-```
-  let (class_member: i32,
-       var NS.namespace_member: i32,
-       var package.package_member: i32) = InitData();
-```
+Mixing static and non-static members in a single declaration seems fundamentally
+problematic due to lifetimes.
 
-It's not obvious how memory for the above should be allocated. There are two
-options:
+We don't have a design for static class members like this yet, and it doesn't
+seem like we should introduce or motivate them with namespacing within scopes.
 
--   The three values are sequentially allocated, even though they belong to
-    different name scopes. This allows for return value optimizations to work,
-    but may cause issues for how we consider name scopes and lifetimes.
--   The three values are separately allocated, grouping allocations by name
-    scope. This breaks return value optimizations, but simplifies requirements
-    around name scopes and lifetimes.
-
-Both options have issues; it would likely prove difficult to set this up such
-that return value optimizations would consistently work, across all potential
-uses of this syntax. That would introduce some variability in performance based
-on unclear context, something we would like to avoid.
-
-Without mixing namespaces, static initialization case can still be addressed,
-albeit with more work. For example:
-
-```carbon
-namespace NS;
-
-let init_data: auto = InitData();
-
-class ClassT {
-  var static class_member: i32 = init_data[0];
-}
-
-var NS.namespace_member: i32 = init_data[1];
-var package_member: i32 = init_data[2];
-```
-
-Rather than forcing a choice, this alternative is discarded in order to require
-syntax -- and resulting performance -- be clearer.
+For now, we just disallow the mixing namespaces in single declarations for
+simplicity and to avoid having to resolve these issues. And we disallow
+namespaced names within unrelated scopes to avoid the name lookup complexity and
+any potential confusion over C++-style-`static` or other semantics.
 
 ### Disallow declaring namespaces other than the file scope
 

--- a/proposals/p3407.md
+++ b/proposals/p3407.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Alternatives considered](#alternatives-considered)
     -   [Allow prefixing a tuple binding pattern with a namespace](#allow-prefixing-a-tuple-binding-pattern-with-a-namespace)
     -   [Allow mixing namespaces within a binding pattern](#allow-mixing-namespaces-within-a-binding-pattern)
+    -   [Disallow declaring namespaces other than the file scope](#disallow-declaring-namespaces-other-than-the-file-scope)
 
 <!-- tocstop -->
 
@@ -166,3 +167,33 @@ var package_member: i32 = init_data[2];
 
 Rather than forcing a choice, this alternative is discarded in order to require
 syntax -- and resulting performance -- be clearer.
+
+### Disallow declaring namespaces other than the file scope
+
+We could disallow declaring namespaces in scopes other than the file scope.
+Combined with requiring members of namespaces to only be declared at the file
+scope, this would prevent their use in other contexts.
+
+This would be consistent with C++. However, we believe the current design
+doesn't actively interfere with Carbon, and it could prove useful in some
+situations. For example, perhaps a complex class would find a member namespace
+useful:
+
+```
+class Complex {
+   namespace OptionSet1;
+   class OptionSet1.MemberClassA;
+   class OptionSet1.MemberClassB;
+
+   namespace OptionSet2;
+   class OptionSet2.MemberClassC;
+   class OptionSet2.MemberClassD;
+}
+```
+
+This would be easy to work around if disallowed (for example, combine names for
+`OptionSet1MemberClassA`). This is both good and bad; disallowing it would be
+cheap, but it may mask friction from not providing the feature.
+
+Although we're not sure how useful this will prove to be, we will allow the
+syntax and may reevaluate in the future.


### PR DESCRIPTION
-   Require namespace members be declared in the same name scope as the
    namespace is declared.
-   Allow binding patterns to directly declare names in namespaces.
-   Disallow using different namespaces in the same binding pattern.