### PR TITLE
Add Linux AArch64 Bazel support and simplify.

### DIFF
--- a/bazel/cc_toolchains/clang_toolchain.BUILD
+++ b/bazel/cc_toolchains/clang_toolchain.BUILD
@@ -5,125 +5,16 @@
 # This file is symlinked into a configured Clang toolchain repository as the
 # root `BUILD` file for that repository.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain", "cc_toolchain_suite")
-load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load(":cc_toolchain_config.bzl", "cc_local_toolchain_suite")
 
-cc_library(
-    name = "malloc",
-)
-
-filegroup(
-    name = "empty",
-    srcs = [],
-)
-
-cc_toolchain_suite(
+cc_local_toolchain_suite(
     name = "bazel_cc_toolchain",
-    toolchains = {
-        "darwin": ":cc-compiler-darwin",
-        "darwin_arm64": ":cc-compiler-darwin-arm64",
-        "freebsd": "cc-compiler-freebsd",
-        "k8": ":cc-compiler-k8",
-        "x64_windows": ":cc-compiler-x64-windows",
-    },
-)
-
-cc_toolchain(
-    name = "cc-compiler-k8",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local-k8",
-    toolchain_identifier = "local-k8",
-)
-
-cc_toolchain_config(
-    name = "local-k8",
-    target_cpu = "k8",
-)
-
-cc_toolchain(
-    name = "cc-compiler-darwin",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local-darwin",
-    toolchain_identifier = "local-darwin",
-)
-
-cc_toolchain_config(
-    name = "local-darwin",
-    target_cpu = "darwin",
-)
-
-cc_toolchain(
-    name = "cc-compiler-darwin-arm64",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local-darwin-arm64",
-    toolchain_identifier = "local-darwin-arm64",
-)
-
-cc_toolchain_config(
-    name = "local-darwin-arm64",
-    target_cpu = "darwin_arm64",
-)
-
-cc_toolchain(
-    name = "cc-compiler-freebsd",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local-freebsd",
-    toolchain_identifier = "local-freebsd",
-)
-
-cc_toolchain_config(
-    name = "local-freebsd",
-    target_cpu = "freebsd",
-)
-
-cc_toolchain(
-    name = "cc-compiler-x64-windows",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-    toolchain_config = ":local-x64-windows",
-    toolchain_identifier = "local-x64-windows",
-)
-
-cc_toolchain_config(
-    name = "local-x64-windows",
-    target_cpu = "x64_windows",
+    cpus = [
+        "aarch64",
+        "darwin",
+        "darwin_arm64",
+        "freebsd",
+        "k8",
+        "x64_windows",
+    ],
 )

--- a/scripts/scripts_utils.py
+++ b/scripts/scripts_utils.py
@@ -149,6 +149,8 @@ def _get_machine() -> str:
     machine = platform.machine()
     if machine == "x86_64":
         machine = "amd64"
+    elif machine == "aarch64":
+        machine = "arm64"
     return machine
 
 


### PR DESCRIPTION
There was a lot of repetition and unnecessary cruft in our Bazel toolchain support. Switch to generating all of it with a single macro that handles everything. This should make no real difference but dramatically simplifies adding a new CPU.

Use this simplified system and add `aarch64` which is how Arm 64-bit CPU support shows up on a Linux host.

Also teach the basic scripts to map `aarch64` to `arm64` which is used in the released artifact strings.