### PR TITLE
Tidy up lint issues.

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -11,7 +11,6 @@
 #include "common/ostream.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -45,7 +45,7 @@ class Context {
   // Stores references for work.
   explicit Context(const Lex::TokenizedBuffer& tokens,
                    DiagnosticEmitter& emitter, const Parse::Tree& parse_tree,
-                   SemIR::File& semantics, llvm::raw_ostream* vlog_stream);
+                   SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
   auto TODO(Parse::NodeId parse_node, std::string label) -> bool;
@@ -136,7 +136,7 @@ class Context {
   // If there is no `returned var` in scope, sets the given instruction to be
   // the current `returned var` and returns an invalid instruction ID. If there
   // is already a `returned var`, returns it instead.
-  auto SetReturnedVarOrGetExisting(SemIR::InstId bind_id) -> SemIR::InstId;
+  auto SetReturnedVarOrGetExisting(SemIR::InstId inst_id) -> SemIR::InstId;
 
   // Follows NameRef instructions to find the value named by a given
   // instruction.
@@ -178,8 +178,8 @@ class Context {
   // corresponding result values are the elements of `block_args`. Returns an
   // instruction referring to the result value.
   auto AddConvergenceBlockWithArgAndPush(
-      Parse::NodeId parse_node,
-      std::initializer_list<SemIR::InstId> blocks_and_args) -> SemIR::InstId;
+      Parse::NodeId parse_node, std::initializer_list<SemIR::InstId> block_args)
+      -> SemIR::InstId;
 
   // Add the current code block to the enclosing function.
   // TODO: The parse_node is taken for expressions, which can occur in

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -10,11 +10,8 @@
 #include "common/check.h"
 #include "llvm/ADT/STLExtras.h"
 #include "toolchain/check/context.h"
-#include "toolchain/diagnostics/diagnostic_kind.h"
-#include "toolchain/parse/node_kind.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::Check {
 
@@ -213,7 +210,7 @@ class CopyOnWriteBlock {
     }
   }
 
-  auto id() -> SemIR::InstBlockId const { return id_; }
+  auto id() const -> SemIR::InstBlockId { return id_; }
 
   auto Set(int i, SemIR::InstId value) -> void {
     if (source_id_.is_valid() && file_.inst_blocks().Get(id_)[i] == value) {
@@ -579,8 +576,8 @@ static auto ConvertStructToClass(Context& context, SemIR::StructType src_type,
 // Returns whether `category` is a valid expression category to produce as a
 // result of a conversion with kind `target_kind`, or at most needs a temporary
 // to be materialized.
-static bool IsValidExprCategoryForConversionTarget(
-    SemIR::ExprCategory category, ConversionTarget::Kind target_kind) {
+static auto IsValidExprCategoryForConversionTarget(
+    SemIR::ExprCategory category, ConversionTarget::Kind target_kind) -> bool {
   switch (target_kind) {
     case ConversionTarget::Value:
       return category == SemIR::ExprCategory::Value;
@@ -720,8 +717,7 @@ static auto PerformBuiltinConversion(Context& context, Parse::NodeId parse_node,
         // iterative approach.
         type_ids.push_back(ExprAsType(context, parse_node, tuple_inst_id));
       }
-      auto tuple_type_id =
-          context.CanonicalizeTupleType(parse_node, std::move(type_ids));
+      auto tuple_type_id = context.CanonicalizeTupleType(parse_node, type_ids);
       return sem_ir.GetTypeAllowBuiltinTypes(tuple_type_id);
     }
 

--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -8,13 +8,12 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/pending_block.h"
 #include "toolchain/parse/tree.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 
 // Description of the target of a conversion.
 struct ConversionTarget {
-  enum Kind {
+  enum Kind : int8_t {
     // Convert to a value of type `type`.
     Value,
     // Convert to either a value or a reference of type `type`.
@@ -46,13 +45,13 @@ struct ConversionTarget {
   PendingBlock* init_block = nullptr;
 
   // Are we converting this value into an initializer for an object?
-  bool is_initializer() const {
+  auto is_initializer() const -> bool {
     return kind == Initializer || kind == FullInitializer;
   }
 };
 
 // Convert a value to another type and expression category.
-auto Convert(Context& context, Parse::NodeId parse_node, SemIR::InstId value_id,
+auto Convert(Context& context, Parse::NodeId parse_node, SemIR::InstId expr_id,
              ConversionTarget target) -> SemIR::InstId;
 
 // Performs initialization of `target_id` from `value_id`. Returns the

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -7,7 +7,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/parse/tree.h"
-#include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -6,7 +6,6 @@
 #include "toolchain/check/convert.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/context.h"
-#include "toolchain/lex/token_kind.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -6,7 +6,6 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -2,8 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <utility>
-
 #include "toolchain/check/context.h"
 
 namespace Carbon::Check {
@@ -46,7 +44,7 @@ auto HandleTupleLiteral(Context& context, Parse::NodeId parse_node) -> bool {
   for (auto inst : inst_block) {
     type_ids.push_back(context.insts().Get(inst).type_id());
   }
-  auto type_id = context.CanonicalizeTupleType(parse_node, std::move(type_ids));
+  auto type_id = context.CanonicalizeTupleType(parse_node, type_ids);
 
   auto value_id =
       context.AddInst(SemIR::TupleLiteral{parse_node, type_id, refs_id});

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -14,10 +14,10 @@ namespace Carbon::Check {
 // that haven't been inserted yet.
 class PendingBlock {
  public:
-  PendingBlock(Context& context) : context_(context) {}
+  explicit PendingBlock(Context& context) : context_(context) {}
 
   PendingBlock(const PendingBlock&) = delete;
-  PendingBlock& operator=(const PendingBlock&) = delete;
+  auto operator=(const PendingBlock&) -> PendingBlock& = delete;
 
   // A scope in which we will tentatively add instructions to a pending block.
   // If we leave the scope without inserting or merging the block, instructions
@@ -26,7 +26,7 @@ class PendingBlock {
    public:
     // If `block` is not null, enters the scope. If `block` is null, this object
     // has no effect.
-    DiscardUnusedInstsScope(PendingBlock* block)
+    explicit DiscardUnusedInstsScope(PendingBlock* block)
         : block_(block), size_(block ? block->insts_.size() : 0) {}
     ~DiscardUnusedInstsScope() {
       if (block_ && block_->insts_.size() > size_) {

--- a/toolchain/diagnostics/mocks.h
+++ b/toolchain/diagnostics/mocks.h
@@ -16,6 +16,7 @@ class MockDiagnosticConsumer : public DiagnosticConsumer {
   MOCK_METHOD(void, HandleDiagnostic, (Diagnostic diagnostic), (override));
 };
 
+// NOLINTNEXTLINE(modernize-use-trailing-return-type): From the macro.
 MATCHER_P(IsDiagnosticMessage, matcher, "") {
   const Diagnostic& diag = arg;
   return testing::ExplainMatchResult(

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -11,7 +11,6 @@
 #include "toolchain/sem_ir/entry_point.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::Lower {
 

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -10,7 +10,6 @@
 #include "llvm/IR/Module.h"
 #include "toolchain/lower/file_context.h"
 #include "toolchain/sem_ir/file.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Lower {
 
@@ -91,7 +90,7 @@ class FunctionContext {
   // initialization was performed in-place, and otherwise performs a store or a
   // copy.
   auto FinishInit(SemIR::TypeId type_id, SemIR::InstId dest_id,
-                  SemIR::InstId init_id) -> void;
+                  SemIR::InstId source_id) -> void;
 
   auto llvm_context() -> llvm::LLVMContext& {
     return file_context_->llvm_context();

--- a/toolchain/lower/handle_aggregates.cpp
+++ b/toolchain/lower/handle_aggregates.cpp
@@ -9,7 +9,6 @@
 #include "llvm/IR/Value.h"
 #include "toolchain/lower/function_context.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/inst_kind.h"
 
 namespace Carbon::Lower {
 
@@ -113,7 +112,7 @@ auto HandleClassFieldAccess(FunctionContext& context, SemIR::InstId inst_id,
           .GetAs<SemIR::ClassType>(
               context.sem_ir().GetTypeAllowBuiltinTypes(class_type_id))
           .class_id;
-  auto& class_info = context.sem_ir().classes().Get(class_id);
+  const auto& class_info = context.sem_ir().classes().Get(class_id);
 
   // Translate the class field access into a struct access on the object
   // representation.

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -24,6 +24,7 @@ enum class RelativeLocation : int8_t {
 };
 
 // Adapts RelativeLocation for use with formatv.
+// TODO: Investigate for approaches that clangd is happier with.
 static auto operator<<(llvm::raw_ostream& out, RelativeLocation loc)
     -> llvm::raw_ostream& {
   switch (loc) {

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -22,6 +22,8 @@ namespace Carbon::Parse {
 // used sparingly, and unbounded lookahead should be avoided.
 //
 // TODO: Decide whether we want to avoid lookahead altogether.
+//
+// NOLINTNEXTLINE(performance-enum-size): Deliberately matches index size.
 enum class Lookahead : int32_t {
   CurrentToken = 0,
   NextToken = 1,

--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -47,6 +47,7 @@ auto NodeKind::child_count() const -> int32_t {
   return child_count;
 }
 
+// NOLINTNEXTLINE(readability-function-size): It's hard to extract macros.
 void CheckNodeMatchesLexerToken(NodeKind node_kind, Lex::TokenKind token_kind,
                                 bool has_error) {
   switch (node_kind) {
@@ -69,9 +70,9 @@ void CheckNodeMatchesLexerToken(NodeKind node_kind, Lex::TokenKind token_kind,
     MatchActions                      \
   }
 
-#define CARBON_CASE(Name, MatchActions) \
-  case NodeKind::Name:                  \
-    MatchActions;                       \
+#define CARBON_CASE(Name, MatchActions)                    \
+  case NodeKind::Name:                                     \
+    MatchActions; /* NOLINT(bugprone-macro-parentheses) */ \
     break;
 
 #define CARBON_PARSE_NODE_KIND_BRACKET(Name, BracketName, MatchActions) \

--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -48,8 +48,8 @@ auto NodeKind::child_count() const -> int32_t {
 }
 
 // NOLINTNEXTLINE(readability-function-size): It's hard to extract macros.
-void CheckNodeMatchesLexerToken(NodeKind node_kind, Lex::TokenKind token_kind,
-                                bool has_error) {
+auto CheckNodeMatchesLexerToken(NodeKind node_kind, Lex::TokenKind token_kind,
+                                bool has_error) -> void {
   switch (node_kind) {
     // Use `CARBON_LOG CARBON_ANY_TOKEN` to discover which combinations happen
     // in practice.

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -12,7 +12,6 @@
 #include "toolchain/base/value_store.h"
 #include "toolchain/base/yaml.h"
 #include "toolchain/sem_ir/ids.h"
-#include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/value_stores.h"
 
 namespace Carbon::SemIR {
@@ -63,7 +62,7 @@ struct Function : public Printable<Function> {
 
 // A class.
 struct Class : public Printable<Class> {
-  enum InheritanceKind {
+  enum InheritanceKind : int8_t {
     // `abstract class`
     Abstract,
     // `base class`
@@ -79,7 +78,9 @@ struct Class : public Printable<Class> {
 
   // Determines whether this class has been fully defined. This is false until
   // we reach the `}` of the class definition.
-  bool is_defined() const { return object_representation_id.is_valid(); }
+  auto is_defined() const -> bool {
+    return object_representation_id.is_valid();
+  }
 
   // The following members always have values, and do not change throughout the
   // lifetime of the class.

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_IDS_H_
 #define CARBON_TOOLCHAIN_SEM_IR_IDS_H_
 
-#include <cstdint>
-
 #include "common/check.h"
 #include "common/ostream.h"
 #include "toolchain/base/index_base.h"
@@ -129,6 +127,7 @@ struct NameId : public IndexBase, public Printable<NameId> {
 
   // Returns the NameId corresponding to a particular IdentifierId.
   static auto ForIdentifier(IdentifierId id) -> NameId {
+    // NOLINTNEXTLINE(misc-redundant-expression): Asserting to be sure.
     static_assert(NameId::InvalidIndex == IdentifierId::InvalidIndex);
     CARBON_CHECK(id.index >= 0 || id.index == InvalidIndex)
         << "Unexpected identifier ID";

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -191,7 +191,8 @@ static_assert(sizeof(Inst) == 20, "Unexpected Inst size");
 
 // Typed instructions can be printed by converting them to instructions.
 template <typename TypedInst, typename = TypedInstArgsInfo<TypedInst>>
-inline llvm::raw_ostream& operator<<(llvm::raw_ostream& out, TypedInst inst) {
+inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
+    -> llvm::raw_ostream& {
   Inst(inst).Print(out);
   return out;
 }

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -94,6 +94,10 @@ static_assert(sizeof(InstKind) == 1, "Kind objects include padding!");
 // thin wrapper around an instruction kind index.
 class InstKind::Definition : public InstKind {
  public:
+  // Not copyable.
+  Definition(const Definition&) = delete;
+  auto operator=(const Definition&) -> Definition& = delete;
+
   // Returns the name to use for this instruction kind in Semantics IR.
   constexpr auto ir_name() const -> llvm::StringLiteral { return ir_name_; }
 
@@ -109,10 +113,6 @@ class InstKind::Definition : public InstKind {
   constexpr Definition(InstKind kind, llvm::StringLiteral ir_name,
                        TerminatorKind terminator_kind)
       : InstKind(kind), ir_name_(ir_name), terminator_kind_(terminator_kind) {}
-
-  // Not copyable.
-  Definition(const Definition&) = delete;
-  Definition& operator=(const Definition&) = delete;
 
   llvm::StringLiteral ir_name_;
   TerminatorKind terminator_kind_;

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -587,15 +587,15 @@ struct VarStorage {
 
 // HasParseNode<T> is true if T has a `Parse::NodeId parse_node` field.
 template <typename T, typename ParseNodeType = Parse::NodeId T::*>
-static constexpr bool HasParseNode = false;
+inline constexpr bool HasParseNode = false;
 template <typename T>
-static constexpr bool HasParseNode<T, decltype(&T::parse_node)> = true;
+inline constexpr bool HasParseNode<T, decltype(&T::parse_node)> = true;
 
 // HasTypeId<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>
-static constexpr bool HasTypeId = false;
+inline constexpr bool HasTypeId = false;
 template <typename T>
-static constexpr bool HasTypeId<T, decltype(&T::type_id)> = true;
+inline constexpr bool HasTypeId<T, decltype(&T::type_id)> = true;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -587,15 +587,15 @@ struct VarStorage {
 
 // HasParseNode<T> is true if T has a `Parse::NodeId parse_node` field.
 template <typename T, typename ParseNodeType = Parse::NodeId T::*>
-constexpr bool HasParseNode = false;
+static constexpr bool HasParseNode = false;
 template <typename T>
-constexpr bool HasParseNode<T, decltype(&T::parse_node)> = true;
+static constexpr bool HasParseNode<T, decltype(&T::parse_node)> = true;
 
 // HasTypeId<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>
-constexpr bool HasTypeId = false;
+static constexpr bool HasTypeId = false;
 template <typename T>
-constexpr bool HasTypeId<T, decltype(&T::type_id)> = true;
+static constexpr bool HasTypeId<T, decltype(&T::type_id)> = true;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/typed_insts_test.cpp
+++ b/toolchain/sem_ir/typed_insts_test.cpp
@@ -42,7 +42,7 @@ auto MakeInstWithNumberedFields(InstKind kind) -> Inst {
 template <typename TypedInst>
 auto CommonFieldOrder() -> void {
   Inst inst = MakeInstWithNumberedFields(TypedInst::Kind);
-  TypedInst typed = inst.As<TypedInst>();
+  auto typed = inst.As<TypedInst>();
   if constexpr (HasParseNode<TypedInst>) {
     EXPECT_EQ(typed.parse_node, Parse::NodeId(1));
   }
@@ -74,14 +74,14 @@ auto ExpectEqInsts(const Inst& inst1, const Inst& inst2,
 template <typename TypedInst>
 auto RoundTrip() -> void {
   Inst inst1 = MakeInstWithNumberedFields(TypedInst::Kind);
-  TypedInst typed1 = inst1.As<TypedInst>();
+  auto typed1 = inst1.As<TypedInst>();
   Inst inst2 = typed1;
 
   ExpectEqInsts(inst1, inst2, HasParseNode<TypedInst>, HasTypeId<TypedInst>);
 
   // If the typed instruction has no padding, we should get exactly the same
   // thing if we convert back from an instruction.
-  TypedInst typed2 = inst2.As<TypedInst>();
+  auto typed2 = inst2.As<TypedInst>();
   if constexpr (std::has_unique_object_representations_v<TypedInst>) {
     EXPECT_EQ(std::memcmp(&typed1, &typed2, sizeof(TypedInst)), 0);
   }
@@ -127,7 +127,7 @@ template <typename TypedInst>
 auto StructLayout() -> void {
   // We can only do this check if the typed instruction has no padding.
   if constexpr (std::has_unique_object_representations_v<TypedInst>) {
-    TypedInst typed =
+    auto typed =
         MakeInstWithNumberedFields(TypedInst::Kind).template As<TypedInst>();
     StructLayoutHelper(&typed, sizeof(typed), HasParseNode<TypedInst>,
                        HasTypeId<TypedInst>);


### PR DESCRIPTION
These are manual fixes; mostly from clang-tidy, some from clangd (which notes unused includes).

In typed_insts, adding inlline due to misc-definitions-in-headers. Per discussion, clang-tidy is wrong, but inline silences it.

For parameter name skew in definition versus declaration, I'm just using the name from the definition.