### PR TITLE
Refactor ValueStore to reduce template type repetition.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -302,24 +302,19 @@ class Context {
   auto string_literals() -> StringStoreWrapper<StringLiteralId>& {
     return sem_ir().string_literals();
   }
-  auto functions() -> ValueStore<SemIR::FunctionId, SemIR::Function>& {
+  auto functions() -> ValueStore<SemIR::FunctionId>& {
     return sem_ir().functions();
   }
-  auto classes() -> ValueStore<SemIR::ClassId, SemIR::Class>& {
-    return sem_ir().classes();
-  }
-  auto cross_ref_irs() -> ValueStore<SemIR::CrossRefIRId, const SemIR::File*>& {
+  auto classes() -> ValueStore<SemIR::ClassId>& { return sem_ir().classes(); }
+  auto cross_ref_irs() -> ValueStore<SemIR::CrossRefIRId>& {
     return sem_ir().cross_ref_irs();
   }
   auto names() -> SemIR::NameStoreWrapper { return sem_ir().names(); }
   auto name_scopes() -> SemIR::NameScopeStore& {
     return sem_ir().name_scopes();
   }
-  auto types() -> ValueStore<SemIR::TypeId, SemIR::TypeInfo>& {
-    return sem_ir().types();
-  }
-  auto type_blocks()
-      -> SemIR::BlockValueStore<SemIR::TypeBlockId, SemIR::TypeId>& {
+  auto types() -> ValueStore<SemIR::TypeId>& { return sem_ir().types(); }
+  auto type_blocks() -> SemIR::BlockValueStore<SemIR::TypeBlockId>& {
     return sem_ir().type_blocks();
   }
   auto insts() -> SemIR::InstStore& { return sem_ir().insts(); }

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -289,16 +289,12 @@ class File : public Printable<File> {
     return value_stores_->string_literals();
   }
 
-  auto functions() -> ValueStore<FunctionId, Function>& { return functions_; }
-  auto functions() const -> const ValueStore<FunctionId, Function>& {
-    return functions_;
-  }
-  auto classes() -> ValueStore<ClassId, Class>& { return classes_; }
-  auto classes() const -> const ValueStore<ClassId, Class>& { return classes_; }
-  auto cross_ref_irs() -> ValueStore<CrossRefIRId, const File*>& {
-    return cross_ref_irs_;
-  }
-  auto cross_ref_irs() const -> const ValueStore<CrossRefIRId, const File*>& {
+  auto functions() -> ValueStore<FunctionId>& { return functions_; }
+  auto functions() const -> const ValueStore<FunctionId>& { return functions_; }
+  auto classes() -> ValueStore<ClassId>& { return classes_; }
+  auto classes() const -> const ValueStore<ClassId>& { return classes_; }
+  auto cross_ref_irs() -> ValueStore<CrossRefIRId>& { return cross_ref_irs_; }
+  auto cross_ref_irs() const -> const ValueStore<CrossRefIRId>& {
     return cross_ref_irs_;
   }
   auto names() const -> NameStoreWrapper {
@@ -306,12 +302,10 @@ class File : public Printable<File> {
   }
   auto name_scopes() -> NameScopeStore& { return name_scopes_; }
   auto name_scopes() const -> const NameScopeStore& { return name_scopes_; }
-  auto types() -> ValueStore<TypeId, TypeInfo>& { return types_; }
-  auto types() const -> const ValueStore<TypeId, TypeInfo>& { return types_; }
-  auto type_blocks() -> BlockValueStore<TypeBlockId, TypeId>& {
-    return type_blocks_;
-  }
-  auto type_blocks() const -> const BlockValueStore<TypeBlockId, TypeId>& {
+  auto types() -> ValueStore<TypeId>& { return types_; }
+  auto types() const -> const ValueStore<TypeId>& { return types_; }
+  auto type_blocks() -> BlockValueStore<TypeBlockId>& { return type_blocks_; }
+  auto type_blocks() const -> const BlockValueStore<TypeBlockId>& {
     return type_blocks_;
   }
   auto insts() -> InstStore& { return insts_; }
@@ -353,28 +347,28 @@ class File : public Printable<File> {
   std::string filename_;
 
   // Storage for callable objects.
-  ValueStore<FunctionId, Function> functions_;
+  ValueStore<FunctionId> functions_;
 
   // Storage for classes.
-  ValueStore<ClassId, Class> classes_;
+  ValueStore<ClassId> classes_;
 
   // Related IRs. There will always be at least 2 entries, the builtin IR (used
   // for references of builtins) followed by the current IR (used for references
   // crossing instruction blocks).
-  ValueStore<CrossRefIRId, const File*> cross_ref_irs_;
+  ValueStore<CrossRefIRId> cross_ref_irs_;
 
   // Storage for name scopes.
   NameScopeStore name_scopes_;
 
   // Descriptions of types used in this file.
-  ValueStore<TypeId, TypeInfo> types_;
+  ValueStore<TypeId> types_;
 
   // Types that were completed in this file.
   llvm::SmallVector<TypeId> complete_types_;
 
   // Type blocks within the IR. These reference entries in types_. Storage for
   // the data is provided by allocator_.
-  BlockValueStore<TypeBlockId, TypeId> type_blocks_;
+  BlockValueStore<TypeBlockId> type_blocks_;
 
   // All instructions. The first entries will always be cross-references to
   // builtins, at indices matching BuiltinKind ordering.

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -13,8 +13,17 @@
 
 namespace Carbon::SemIR {
 
+// Forward declare indexed types, for integration with ValueStore.
+class File;
+class Inst;
+struct Class;
+struct Function;
+struct TypeInfo;
+
 // The ID of an instruction.
 struct InstId : public IdBase, public Printable<InstId> {
+  using IndexedType = Inst;
+
   // An explicitly invalid instruction ID.
   static const InstId Invalid;
 
@@ -52,6 +61,8 @@ constexpr InstId InstId::Invalid = InstId(InstId::InvalidIndex);
 
 // The ID of a function.
 struct FunctionId : public IdBase, public Printable<FunctionId> {
+  using IndexedType = Function;
+
   // An explicitly invalid function ID.
   static const FunctionId Invalid;
 
@@ -66,6 +77,8 @@ constexpr FunctionId FunctionId::Invalid = FunctionId(FunctionId::InvalidIndex);
 
 // The ID of a class.
 struct ClassId : public IdBase, public Printable<ClassId> {
+  using IndexedType = Class;
+
   // An explicitly invalid class ID.
   static const ClassId Invalid;
 
@@ -80,6 +93,8 @@ constexpr ClassId ClassId::Invalid = ClassId(ClassId::InvalidIndex);
 
 // The ID of a cross-referenced IR.
 struct CrossRefIRId : public IdBase, public Printable<CrossRefIRId> {
+  using IndexedType = const File*;
+
   static const CrossRefIRId Builtins;
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
@@ -164,6 +179,8 @@ constexpr NameId NameId::ReturnSlot = NameId(NameId::InvalidIndex - 3);
 
 // The ID of a name scope.
 struct NameScopeId : public IdBase, public Printable<NameScopeId> {
+  using IndexedType = llvm::DenseMap<NameId, InstId>;
+
   // An explicitly invalid ID.
   static const NameScopeId Invalid;
 
@@ -179,6 +196,9 @@ constexpr NameScopeId NameScopeId::Invalid =
 
 // The ID of an instruction block.
 struct InstBlockId : public IdBase, public Printable<InstBlockId> {
+  using ValueType = InstId;
+  using IndexedType = llvm::MutableArrayRef<ValueType>;
+
   // All File instances must provide the 0th instruction block as empty.
   static const InstBlockId Empty;
 
@@ -207,6 +227,8 @@ constexpr InstBlockId InstBlockId::Unreachable =
 
 // The ID of a type.
 struct TypeId : public IdBase, public Printable<TypeId> {
+  using IndexedType = TypeInfo;
+
   // The builtin TypeType.
   static const TypeId TypeType;
 
@@ -235,6 +257,9 @@ constexpr TypeId TypeId::Invalid = TypeId(TypeId::InvalidIndex);
 
 // The ID of a type block.
 struct TypeBlockId : public IdBase, public Printable<TypeBlockId> {
+  using ValueType = TypeId;
+  using IndexedType = llvm::MutableArrayRef<ValueType>;
+
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "typeBlock";

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -22,7 +22,7 @@ struct TypeInfo;
 
 // The ID of an instruction.
 struct InstId : public IdBase, public Printable<InstId> {
-  using IndexedType = Inst;
+  using ValueType = Inst;
 
   // An explicitly invalid instruction ID.
   static const InstId Invalid;
@@ -61,7 +61,7 @@ constexpr InstId InstId::Invalid = InstId(InstId::InvalidIndex);
 
 // The ID of a function.
 struct FunctionId : public IdBase, public Printable<FunctionId> {
-  using IndexedType = Function;
+  using ValueType = Function;
 
   // An explicitly invalid function ID.
   static const FunctionId Invalid;
@@ -77,7 +77,7 @@ constexpr FunctionId FunctionId::Invalid = FunctionId(FunctionId::InvalidIndex);
 
 // The ID of a class.
 struct ClassId : public IdBase, public Printable<ClassId> {
-  using IndexedType = Class;
+  using ValueType = Class;
 
   // An explicitly invalid class ID.
   static const ClassId Invalid;
@@ -93,7 +93,7 @@ constexpr ClassId ClassId::Invalid = ClassId(ClassId::InvalidIndex);
 
 // The ID of a cross-referenced IR.
 struct CrossRefIRId : public IdBase, public Printable<CrossRefIRId> {
-  using IndexedType = const File*;
+  using ValueType = const File*;
 
   static const CrossRefIRId Builtins;
   using IdBase::IdBase;
@@ -179,7 +179,7 @@ constexpr NameId NameId::ReturnSlot = NameId(NameId::InvalidIndex - 3);
 
 // The ID of a name scope.
 struct NameScopeId : public IdBase, public Printable<NameScopeId> {
-  using IndexedType = llvm::DenseMap<NameId, InstId>;
+  using ValueType = llvm::DenseMap<NameId, InstId>;
 
   // An explicitly invalid ID.
   static const NameScopeId Invalid;
@@ -196,8 +196,8 @@ constexpr NameScopeId NameScopeId::Invalid =
 
 // The ID of an instruction block.
 struct InstBlockId : public IdBase, public Printable<InstBlockId> {
-  using ValueType = InstId;
-  using IndexedType = llvm::MutableArrayRef<ValueType>;
+  using ElementType = InstId;
+  using ValueType = llvm::MutableArrayRef<ElementType>;
 
   // All File instances must provide the 0th instruction block as empty.
   static const InstBlockId Empty;
@@ -227,7 +227,7 @@ constexpr InstBlockId InstBlockId::Unreachable =
 
 // The ID of a type.
 struct TypeId : public IdBase, public Printable<TypeId> {
-  using IndexedType = TypeInfo;
+  using ValueType = TypeInfo;
 
   // The builtin TypeType.
   static const TypeId TypeType;
@@ -257,8 +257,8 @@ constexpr TypeId TypeId::Invalid = TypeId(TypeId::InvalidIndex);
 
 // The ID of a type block.
 struct TypeBlockId : public IdBase, public Printable<TypeBlockId> {
-  using ValueType = TypeId;
-  using IndexedType = llvm::MutableArrayRef<ValueType>;
+  using ElementType = TypeId;
+  using ValueType = llvm::MutableArrayRef<ElementType>;
 
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {


### PR DESCRIPTION
There's a trade-off here of explicitness in the use versus repetition, but I'm hoping the Id offers sufficient info (also, some Ids already relied on this, so this builds consistency). The forward declarations I'm mixed on, but they are difficult to avoid if heading down this route due to interdependencies between ids and types which contain ids.