### PR TITLE
Distribute autoupdate across threads.

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -728,7 +728,7 @@ static auto Main(int argc, char** argv) -> int {
   // Tests might try to read from stdin. Ensure those reads fail by closing
   // stdin and reopening it as /dev/null. Note that STDIN_FILENO doesn't exist
   // on Windows, but POSIX requires it to be 0.
-  llvm::sys::Process::SafelyCloseFileDescriptor(/*STDIN_FILENO*/ 0);
+  llvm::sys::Process::SafelyCloseFileDescriptor(0);
   llvm::sys::Process::FixupStandardFileDescriptors();
 
   llvm::SmallVector<std::string> tests = GetTests();

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -726,8 +726,9 @@ static auto Main(int argc, char** argv) -> int {
   }
 
   // Tests might try to read from stdin. Ensure those reads fail by closing
-  // stdin and reopening it as /dev/null.
-  llvm::sys::Process::SafelyCloseFileDescriptor(0);
+  // stdin and reopening it as /dev/null. Note that STDIN_FILENO doesn't exist
+  // on Windows, but POSIX requires it to be 0.
+  llvm::sys::Process::SafelyCloseFileDescriptor(/*STDIN_FILENO*/ 0);
   llvm::sys::Process::FixupStandardFileDescriptors();
 
   llvm::SmallVector<std::string> tests = GetTests();

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -575,7 +575,7 @@ static auto Main(int argc, char** argv) -> int {
               auto result = test->Autoupdate();
 
               // Guard access to llvm::errs, which is not thread-safe.
-              std::unique_lock lock(errs_mutex);
+              std::unique_lock<std::mutex> lock(errs_mutex);
               llvm::errs() << (result.ok() ? (*result ? "!" : ".")
                                            : "\n" + result.error().message());
             }

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -4,7 +4,11 @@
 
 #include "testing/file_test/file_test_base.h"
 
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <fcntl.h>
+#endif
 
 #include <filesystem>
 #include <fstream>

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -540,8 +540,15 @@ static auto Main(int argc, char** argv) -> int {
   }
 
   // Tests might try to read from stdin. Ensure those reads fail.
-  // TODO: This won't work on Windows.
-  int dev_null = open("/dev/null", O_RDONLY);
+  // TODO: Windows support here is untested.
+  int dev_null = open(
+#ifdef _WIN32
+      "nul"
+#else
+      "/dev/null"
+#endif
+      ,
+      O_RDONLY);
   if (dev_null == -1) {
     llvm::errs() << "Failed to open /dev/null.\n";
     return EXIT_FAILURE;

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -43,7 +43,7 @@ def main() -> None:
         argv.append("--file_tests=" + ",".join(file_tests))
     # Provide an empty stdin so that the driver tests that read from stdin
     # don't block waiting for input. This matches the behavior of `bazel test`.
-    subprocess.run(argv, check=True, stdin=subprocess.DEVNULL)
+    subprocess.run(argv, check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also switch how we ensure that stdin is closed for tests, so that `bazel run` doesn't hang if invoked manually.