### PR TITLE
Add support for 'package' in expressions.

### DIFF
--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -7,6 +7,7 @@
 #include "toolchain/check/convert.h"
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
 
@@ -269,6 +270,15 @@ auto HandleQualifiedDecl(Context& context, Parse::NodeId parse_node) -> bool {
   }
 
   context.decl_name_stack().ApplyNameQualifier(parse_node2, name_id2);
+  return true;
+}
+
+auto HandlePackageExpr(Context& context, Parse::NodeId parse_node) -> bool {
+  context.AddInstAndPush(
+      parse_node,
+      SemIR::NameRef{
+          parse_node, context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
+          SemIR::NameId::PackageNamespace, SemIR::InstId::PackageNamespace});
   return true;
 }
 

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -303,6 +303,7 @@ class NodeStack {
       case Parse::NodeKind::InfixOperator:
       case Parse::NodeKind::MemberAccessExpr:
       case Parse::NodeKind::NameExpr:
+      case Parse::NodeKind::PackageExpr:
       case Parse::NodeKind::ParenExpr:
       case Parse::NodeKind::PostfixOperator:
       case Parse::NodeKind::PrefixOperator:

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -21,6 +21,7 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -19,6 +19,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .Run = %Run}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -17,6 +17,7 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_22.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc7_22.2: type = converted %.loc7_22.1, constants.%.loc7_22.2
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var a

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -21,6 +21,7 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a

--- a/toolchain/check/testdata/array/fail_bound_overflow.carbon
+++ b/toolchain/check/testdata/array/fail_bound_overflow.carbon
@@ -12,6 +12,7 @@ var a: [1; 39999999999999999993];
 // CHECK:STDOUT: --- fail_bound_overflow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a}
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993
 // CHECK:STDOUT:   %a.var: ref <error> = var a

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -26,6 +26,7 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Incomplete = %Incomplete.decl, .a = %a, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -16,6 +16,7 @@ var a: [1; 1];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a}
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error>

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -17,6 +17,7 @@ var a: [i32; 1] = (1, 2, 3);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a}
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -41,6 +41,7 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .t1 = %t1, .b = %b, .c = %c, .t2 = %t2, .d = %d}
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3
 // CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -20,6 +20,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -14,6 +14,7 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 9] = var a

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -14,6 +14,7 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %.loc7_24: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_26: type = converted %.loc7_24, constants.%.loc7_26
 // CHECK:STDOUT:   %t: type = bind_name t, %.loc7_26

--- a/toolchain/check/testdata/as/basic.carbon
+++ b/toolchain/check/testdata/as/basic.carbon
@@ -11,6 +11,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -18,6 +18,7 @@ let n: (i32, i32) = 1 as (i32, i32);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1

--- a/toolchain/check/testdata/as/fail_not_type.carbon
+++ b/toolchain/check/testdata/as/fail_not_type.carbon
@@ -12,6 +12,7 @@ let n: i32 = 1 as 2;
 // CHECK:STDOUT: --- fail_not_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2
 // CHECK:STDOUT:   %n: i32 = bind_name n, <error>

--- a/toolchain/check/testdata/as/identity.carbon
+++ b/toolchain/check/testdata/as/identity.carbon
@@ -33,6 +33,7 @@ fn Initializing() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.X = %X.decl, .Value = %Value, .Reference = %Reference, .Make = %Make, .Initializing = %Initializing}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
 // CHECK:STDOUT:   %Value: <function> = fn_decl @Value

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -33,6 +33,7 @@ fn Var() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.X = %X.decl, .Make = %Make, .Let = %Let, .Var = %Var}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -12,7 +12,8 @@
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:       {}
 // CHECK:STDOUT:   classes:         {}
-// CHECK:STDOUT:   types:           {}
+// CHECK:STDOUT:   types:
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instTypeType:    {kind: CrossRef, arg0: ir0, arg1: instTypeType, type: typeTypeType}
@@ -24,6 +25,9 @@
 // CHECK:STDOUT:     instFunctionType: {kind: CrossRef, arg0: ir0, arg1: instFunctionType, type: typeTypeType}
 // CHECK:STDOUT:     instBoundMethodType: {kind: CrossRef, arg0: ir0, arg1: instBoundMethodType, type: typeTypeType}
 // CHECK:STDOUT:     instNamespaceType: {kind: CrossRef, arg0: ir0, arg1: instNamespaceType, type: typeTypeType}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
+// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -16,6 +16,7 @@ var test_type: type = i32;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.test_i32 = %test_i32, .test_f64 = %test_f64, .test_type = %test_type}
 // CHECK:STDOUT:   %test_i32.var: ref i32 = var test_i32
 // CHECK:STDOUT:   %test_i32: ref i32 = bind_name test_i32, %test_i32.var
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0

--- a/toolchain/check/testdata/basics/empty.carbon
+++ b/toolchain/check/testdata/basics/empty.carbon
@@ -7,5 +7,6 @@
 // CHECK:STDOUT: --- empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/empty_decl.carbon
+++ b/toolchain/check/testdata/basics/empty_decl.carbon
@@ -9,5 +9,6 @@
 // CHECK:STDOUT: --- empty_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -20,6 +20,7 @@ fn Run() -> String {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run = %Run}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_bad_run_2.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run_2.carbon
@@ -12,6 +12,7 @@ fn Run(n: i32) {}
 // CHECK:STDOUT: --- fail_bad_run_2.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run = %Run}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/check/testdata/basics/fail_name_lookup.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_name_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
+++ b/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
@@ -12,6 +12,7 @@ var x: type = 42;
 // CHECK:STDOUT: --- fail_non_type_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %x.var: ref type = var x
 // CHECK:STDOUT:   %x: ref type = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10: i32 = int_literal 42

--- a/toolchain/check/testdata/basics/fail_qualifier_unsupported.carbon
+++ b/toolchain/check/testdata/basics/fail_qualifier_unsupported.carbon
@@ -13,6 +13,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_qualifier_unsupported.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
 // CHECK:STDOUT:   %y.var: ref i32 = var y

--- a/toolchain/check/testdata/basics/multifile.carbon
+++ b/toolchain/check/testdata/basics/multifile.carbon
@@ -17,6 +17,7 @@ fn B() {}
 // CHECK:STDOUT: --- a.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -28,6 +29,7 @@ fn B() {}
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.B = %B}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -26,22 +26,26 @@ fn B() {}
 // CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instFunctionType, value_rep: {kind: copy, type: type1}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: FunctionDecl, arg0: function0, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: Return}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- a.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -58,22 +62,26 @@ fn B() {}
 // CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instFunctionType, value_rep: {kind: copy, type: type1}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: FunctionDecl, arg0: function0, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: Return}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.B = %B}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -26,17 +26,20 @@ fn B() {}
 // CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instFunctionType, value_rep: {kind: copy, type: type1}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: FunctionDecl, arg0: function0, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: Return}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
@@ -46,15 +49,18 @@ fn B() {}
 // CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instFunctionType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instFunctionType, value_rep: {kind: copy, type: type1}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: FunctionDecl, arg0: function0, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: Return}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       0:               inst+2
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -35,6 +35,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/parens.carbon
+++ b/toolchain/check/testdata/basics/parens.carbon
@@ -9,6 +9,7 @@ var test_i32: i32 = ((1) + (2));
 // CHECK:STDOUT: --- parens.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.test_i32 = %test_i32}
 // CHECK:STDOUT:   %test_i32.var: ref i32 = var test_i32
 // CHECK:STDOUT:   %test_i32: ref i32 = bind_name test_i32, %test_i32.var
 // CHECK:STDOUT:   %.loc7_23: i32 = int_literal 1

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -17,76 +17,79 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type3, return_slot: inst+5, body: [block4]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type4, return_slot: inst+6, body: [block4]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instIntType, value_rep: {kind: copy, type: type0}}
-// CHECK:STDOUT:     type1:           {inst: inst+1, value_rep: {kind: unknown, type: type<invalid>}}
-// CHECK:STDOUT:     type2:           {inst: instFloatType, value_rep: {kind: copy, type: type2}}
-// CHECK:STDOUT:     type3:           {inst: inst+3, value_rep: {kind: pointer, type: type4}}
-// CHECK:STDOUT:     type4:           {inst: inst+6, value_rep: {kind: copy, type: type4}}
-// CHECK:STDOUT:     type5:           {inst: instFunctionType, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instIntType, value_rep: {kind: copy, type: type1}}
+// CHECK:STDOUT:     type2:           {inst: inst+2, value_rep: {kind: unknown, type: type<invalid>}}
+// CHECK:STDOUT:     type3:           {inst: instFloatType, value_rep: {kind: copy, type: type3}}
+// CHECK:STDOUT:     type4:           {inst: inst+4, value_rep: {kind: pointer, type: type5}}
+// CHECK:STDOUT:     type5:           {inst: inst+7, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type6:           {inst: instFunctionType, value_rep: {kind: copy, type: type6}}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     typeBlock0:
 // CHECK:STDOUT:       0:               typeTypeType
 // CHECK:STDOUT:       1:               typeTypeType
 // CHECK:STDOUT:     typeBlock1:
-// CHECK:STDOUT:       0:               type0
-// CHECK:STDOUT:       1:               type2
+// CHECK:STDOUT:       0:               type1
+// CHECK:STDOUT:       1:               type3
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: Param, arg0: name1, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
-// CHECK:STDOUT:     inst+2:          {kind: TupleLiteral, arg0: block2, type: type1}
-// CHECK:STDOUT:     inst+3:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
-// CHECK:STDOUT:     inst+4:          {kind: Converted, arg0: inst+2, arg1: inst+3, type: typeTypeType}
-// CHECK:STDOUT:     inst+5:          {kind: VarStorage, arg0: nameReturnSlot, type: type3}
-// CHECK:STDOUT:     inst+6:          {kind: PointerType, arg0: type3, type: typeTypeType}
-// CHECK:STDOUT:     inst+7:          {kind: FunctionDecl, arg0: function0, type: type5}
-// CHECK:STDOUT:     inst+8:          {kind: NameRef, arg0: name1, arg1: inst+0, type: type0}
-// CHECK:STDOUT:     inst+9:          {kind: IntLiteral, arg0: int3, type: type0}
-// CHECK:STDOUT:     inst+10:         {kind: BinaryOperatorAdd, arg0: inst+8, arg1: inst+9, type: type0}
-// CHECK:STDOUT:     inst+11:         {kind: RealLiteral, arg0: real0, type: type2}
-// CHECK:STDOUT:     inst+12:         {kind: TupleLiteral, arg0: block5, type: type3}
-// CHECK:STDOUT:     inst+13:         {kind: TupleAccess, arg0: inst+5, arg1: element0, type: type0}
-// CHECK:STDOUT:     inst+14:         {kind: InitializeFrom, arg0: inst+10, arg1: inst+13, type: type0}
-// CHECK:STDOUT:     inst+15:         {kind: TupleAccess, arg0: inst+5, arg1: element1, type: type2}
-// CHECK:STDOUT:     inst+16:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+15, type: type2}
-// CHECK:STDOUT:     inst+17:         {kind: TupleInit, arg0: block6, arg1: inst+5, type: type3}
-// CHECK:STDOUT:     inst+18:         {kind: Converted, arg0: inst+12, arg1: inst+17, type: type3}
-// CHECK:STDOUT:     inst+19:         {kind: ReturnExpr, arg0: inst+18}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: Param, arg0: name1, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     inst+3:          {kind: TupleLiteral, arg0: block2, type: type2}
+// CHECK:STDOUT:     inst+4:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:     inst+5:          {kind: Converted, arg0: inst+3, arg1: inst+4, type: typeTypeType}
+// CHECK:STDOUT:     inst+6:          {kind: VarStorage, arg0: nameReturnSlot, type: type4}
+// CHECK:STDOUT:     inst+7:          {kind: PointerType, arg0: type4, type: typeTypeType}
+// CHECK:STDOUT:     inst+8:          {kind: FunctionDecl, arg0: function0, type: type6}
+// CHECK:STDOUT:     inst+9:          {kind: NameRef, arg0: name1, arg1: inst+1, type: type1}
+// CHECK:STDOUT:     inst+10:         {kind: IntLiteral, arg0: int3, type: type1}
+// CHECK:STDOUT:     inst+11:         {kind: BinaryOperatorAdd, arg0: inst+9, arg1: inst+10, type: type1}
+// CHECK:STDOUT:     inst+12:         {kind: RealLiteral, arg0: real0, type: type3}
+// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block5, type: type4}
+// CHECK:STDOUT:     inst+14:         {kind: TupleAccess, arg0: inst+6, arg1: element0, type: type1}
+// CHECK:STDOUT:     inst+15:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+14, type: type1}
+// CHECK:STDOUT:     inst+16:         {kind: TupleAccess, arg0: inst+6, arg1: element1, type: type3}
+// CHECK:STDOUT:     inst+17:         {kind: InitializeFrom, arg0: inst+12, arg1: inst+16, type: type3}
+// CHECK:STDOUT:     inst+18:         {kind: TupleInit, arg0: block6, arg1: inst+6, type: type4}
+// CHECK:STDOUT:     inst+19:         {kind: Converted, arg0: inst+13, arg1: inst+18, type: type4}
+// CHECK:STDOUT:     inst+20:         {kind: ReturnExpr, arg0: inst+19}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               instIntType
 // CHECK:STDOUT:       1:               instFloatType
 // CHECK:STDOUT:     block3:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+2
-// CHECK:STDOUT:       2:               inst+4
-// CHECK:STDOUT:       3:               inst+5
+// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       1:               inst+3
+// CHECK:STDOUT:       2:               inst+5
+// CHECK:STDOUT:       3:               inst+6
 // CHECK:STDOUT:     block4:
-// CHECK:STDOUT:       0:               inst+8
-// CHECK:STDOUT:       1:               inst+9
-// CHECK:STDOUT:       2:               inst+10
-// CHECK:STDOUT:       3:               inst+11
-// CHECK:STDOUT:       4:               inst+12
-// CHECK:STDOUT:       5:               inst+13
-// CHECK:STDOUT:       6:               inst+14
-// CHECK:STDOUT:       7:               inst+15
-// CHECK:STDOUT:       8:               inst+16
-// CHECK:STDOUT:       9:               inst+17
-// CHECK:STDOUT:       10:              inst+18
-// CHECK:STDOUT:       11:              inst+19
+// CHECK:STDOUT:       0:               inst+9
+// CHECK:STDOUT:       1:               inst+10
+// CHECK:STDOUT:       2:               inst+11
+// CHECK:STDOUT:       3:               inst+12
+// CHECK:STDOUT:       4:               inst+13
+// CHECK:STDOUT:       5:               inst+14
+// CHECK:STDOUT:       6:               inst+15
+// CHECK:STDOUT:       7:               inst+16
+// CHECK:STDOUT:       8:               inst+17
+// CHECK:STDOUT:       9:               inst+18
+// CHECK:STDOUT:       10:              inst+19
+// CHECK:STDOUT:       11:              inst+20
 // CHECK:STDOUT:     block5:
-// CHECK:STDOUT:       0:               inst+10
-// CHECK:STDOUT:       1:               inst+11
+// CHECK:STDOUT:       0:               inst+11
+// CHECK:STDOUT:       1:               inst+12
 // CHECK:STDOUT:     block6:
-// CHECK:STDOUT:       0:               inst+14
-// CHECK:STDOUT:       1:               inst+16
+// CHECK:STDOUT:       0:               inst+15
+// CHECK:STDOUT:       1:               inst+17
 // CHECK:STDOUT:     block7:
-// CHECK:STDOUT:       0:               inst+7
+// CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+8
 // CHECK:STDOUT: ...
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- raw_and_textual_ir.carbon
@@ -98,6 +101,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/raw_identifier.carbon
+++ b/toolchain/check/testdata/basics/raw_identifier.carbon
@@ -23,6 +23,7 @@ fn C(r#if: i32) -> i32 {
 // CHECK:STDOUT: --- raw_identifier.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A, .B = %B, .C = %C}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT:   %C: <function> = fn_decl @C

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -17,74 +17,77 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type3, return_slot: inst+5, body: [block4]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type4, return_slot: inst+6, body: [block4]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
-// CHECK:STDOUT:     type0:           {inst: instIntType, value_rep: {kind: copy, type: type0}}
-// CHECK:STDOUT:     type1:           {inst: inst+1, value_rep: {kind: unknown, type: type<invalid>}}
-// CHECK:STDOUT:     type2:           {inst: instFloatType, value_rep: {kind: copy, type: type2}}
-// CHECK:STDOUT:     type3:           {inst: inst+3, value_rep: {kind: pointer, type: type4}}
-// CHECK:STDOUT:     type4:           {inst: inst+6, value_rep: {kind: copy, type: type4}}
-// CHECK:STDOUT:     type5:           {inst: instFunctionType, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
+// CHECK:STDOUT:     type1:           {inst: instIntType, value_rep: {kind: copy, type: type1}}
+// CHECK:STDOUT:     type2:           {inst: inst+2, value_rep: {kind: unknown, type: type<invalid>}}
+// CHECK:STDOUT:     type3:           {inst: instFloatType, value_rep: {kind: copy, type: type3}}
+// CHECK:STDOUT:     type4:           {inst: inst+4, value_rep: {kind: pointer, type: type5}}
+// CHECK:STDOUT:     type5:           {inst: inst+7, value_rep: {kind: copy, type: type5}}
+// CHECK:STDOUT:     type6:           {inst: instFunctionType, value_rep: {kind: copy, type: type6}}
 // CHECK:STDOUT:   type_blocks:
 // CHECK:STDOUT:     typeBlock0:
 // CHECK:STDOUT:       0:               typeTypeType
 // CHECK:STDOUT:       1:               typeTypeType
 // CHECK:STDOUT:     typeBlock1:
-// CHECK:STDOUT:       0:               type0
-// CHECK:STDOUT:       1:               type2
+// CHECK:STDOUT:       0:               type1
+// CHECK:STDOUT:       1:               type3
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     inst+0:          {kind: Param, arg0: name1, type: type0}
-// CHECK:STDOUT:     inst+1:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
-// CHECK:STDOUT:     inst+2:          {kind: TupleLiteral, arg0: block2, type: type1}
-// CHECK:STDOUT:     inst+3:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
-// CHECK:STDOUT:     inst+4:          {kind: Converted, arg0: inst+2, arg1: inst+3, type: typeTypeType}
-// CHECK:STDOUT:     inst+5:          {kind: VarStorage, arg0: nameReturnSlot, type: type3}
-// CHECK:STDOUT:     inst+6:          {kind: PointerType, arg0: type3, type: typeTypeType}
-// CHECK:STDOUT:     inst+7:          {kind: FunctionDecl, arg0: function0, type: type5}
-// CHECK:STDOUT:     inst+8:          {kind: NameRef, arg0: name1, arg1: inst+0, type: type0}
-// CHECK:STDOUT:     inst+9:          {kind: IntLiteral, arg0: int3, type: type0}
-// CHECK:STDOUT:     inst+10:         {kind: BinaryOperatorAdd, arg0: inst+8, arg1: inst+9, type: type0}
-// CHECK:STDOUT:     inst+11:         {kind: RealLiteral, arg0: real0, type: type2}
-// CHECK:STDOUT:     inst+12:         {kind: TupleLiteral, arg0: block5, type: type3}
-// CHECK:STDOUT:     inst+13:         {kind: TupleAccess, arg0: inst+5, arg1: element0, type: type0}
-// CHECK:STDOUT:     inst+14:         {kind: InitializeFrom, arg0: inst+10, arg1: inst+13, type: type0}
-// CHECK:STDOUT:     inst+15:         {kind: TupleAccess, arg0: inst+5, arg1: element1, type: type2}
-// CHECK:STDOUT:     inst+16:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+15, type: type2}
-// CHECK:STDOUT:     inst+17:         {kind: TupleInit, arg0: block6, arg1: inst+5, type: type3}
-// CHECK:STDOUT:     inst+18:         {kind: Converted, arg0: inst+12, arg1: inst+17, type: type3}
-// CHECK:STDOUT:     inst+19:         {kind: ReturnExpr, arg0: inst+18}
+// CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
+// CHECK:STDOUT:     inst+1:          {kind: Param, arg0: name1, type: type1}
+// CHECK:STDOUT:     inst+2:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
+// CHECK:STDOUT:     inst+3:          {kind: TupleLiteral, arg0: block2, type: type2}
+// CHECK:STDOUT:     inst+4:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
+// CHECK:STDOUT:     inst+5:          {kind: Converted, arg0: inst+3, arg1: inst+4, type: typeTypeType}
+// CHECK:STDOUT:     inst+6:          {kind: VarStorage, arg0: nameReturnSlot, type: type4}
+// CHECK:STDOUT:     inst+7:          {kind: PointerType, arg0: type4, type: typeTypeType}
+// CHECK:STDOUT:     inst+8:          {kind: FunctionDecl, arg0: function0, type: type6}
+// CHECK:STDOUT:     inst+9:          {kind: NameRef, arg0: name1, arg1: inst+1, type: type1}
+// CHECK:STDOUT:     inst+10:         {kind: IntLiteral, arg0: int3, type: type1}
+// CHECK:STDOUT:     inst+11:         {kind: BinaryOperatorAdd, arg0: inst+9, arg1: inst+10, type: type1}
+// CHECK:STDOUT:     inst+12:         {kind: RealLiteral, arg0: real0, type: type3}
+// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block5, type: type4}
+// CHECK:STDOUT:     inst+14:         {kind: TupleAccess, arg0: inst+6, arg1: element0, type: type1}
+// CHECK:STDOUT:     inst+15:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+14, type: type1}
+// CHECK:STDOUT:     inst+16:         {kind: TupleAccess, arg0: inst+6, arg1: element1, type: type3}
+// CHECK:STDOUT:     inst+17:         {kind: InitializeFrom, arg0: inst+12, arg1: inst+16, type: type3}
+// CHECK:STDOUT:     inst+18:         {kind: TupleInit, arg0: block6, arg1: inst+6, type: type4}
+// CHECK:STDOUT:     inst+19:         {kind: Converted, arg0: inst+13, arg1: inst+18, type: type4}
+// CHECK:STDOUT:     inst+20:         {kind: ReturnExpr, arg0: inst+19}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               instIntType
 // CHECK:STDOUT:       1:               instFloatType
 // CHECK:STDOUT:     block3:
-// CHECK:STDOUT:       0:               inst+0
-// CHECK:STDOUT:       1:               inst+2
-// CHECK:STDOUT:       2:               inst+4
-// CHECK:STDOUT:       3:               inst+5
+// CHECK:STDOUT:       0:               inst+1
+// CHECK:STDOUT:       1:               inst+3
+// CHECK:STDOUT:       2:               inst+5
+// CHECK:STDOUT:       3:               inst+6
 // CHECK:STDOUT:     block4:
-// CHECK:STDOUT:       0:               inst+8
-// CHECK:STDOUT:       1:               inst+9
-// CHECK:STDOUT:       2:               inst+10
-// CHECK:STDOUT:       3:               inst+11
-// CHECK:STDOUT:       4:               inst+12
-// CHECK:STDOUT:       5:               inst+13
-// CHECK:STDOUT:       6:               inst+14
-// CHECK:STDOUT:       7:               inst+15
-// CHECK:STDOUT:       8:               inst+16
-// CHECK:STDOUT:       9:               inst+17
-// CHECK:STDOUT:       10:              inst+18
-// CHECK:STDOUT:       11:              inst+19
+// CHECK:STDOUT:       0:               inst+9
+// CHECK:STDOUT:       1:               inst+10
+// CHECK:STDOUT:       2:               inst+11
+// CHECK:STDOUT:       3:               inst+12
+// CHECK:STDOUT:       4:               inst+13
+// CHECK:STDOUT:       5:               inst+14
+// CHECK:STDOUT:       6:               inst+15
+// CHECK:STDOUT:       7:               inst+16
+// CHECK:STDOUT:       8:               inst+17
+// CHECK:STDOUT:       9:               inst+18
+// CHECK:STDOUT:       10:              inst+19
+// CHECK:STDOUT:       11:              inst+20
 // CHECK:STDOUT:     block5:
-// CHECK:STDOUT:       0:               inst+10
-// CHECK:STDOUT:       1:               inst+11
+// CHECK:STDOUT:       0:               inst+11
+// CHECK:STDOUT:       1:               inst+12
 // CHECK:STDOUT:     block6:
-// CHECK:STDOUT:       0:               inst+14
-// CHECK:STDOUT:       1:               inst+16
+// CHECK:STDOUT:       0:               inst+15
+// CHECK:STDOUT:       1:               inst+17
 // CHECK:STDOUT:     block7:
-// CHECK:STDOUT:       0:               inst+7
+// CHECK:STDOUT:       0:               inst+0
+// CHECK:STDOUT:       1:               inst+8
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/run.carbon
+++ b/toolchain/check/testdata/basics/run.carbon
@@ -9,6 +9,7 @@ fn Run() {}
 // CHECK:STDOUT: --- run.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run = %Run}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/run_i32.carbon
+++ b/toolchain/check/testdata/basics/run_i32.carbon
@@ -9,6 +9,7 @@ fn Run() -> i32 { return 0; }
 // CHECK:STDOUT: --- run_i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run = %Run}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -21,6 +21,7 @@ fn Foo(n: i32) -> (i32, f64) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -29,6 +29,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -23,6 +23,7 @@ fn Make() -> Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Make = %Make}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -23,6 +23,7 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -47,6 +47,7 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -123,6 +123,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .CallClassFunction = %CallClassFunction, .global_var = %global_var, .ConvertFromStruct = %ConvertFromStruct, .MemberAccess = %MemberAccess, .Copy = %Copy, .Let = %Let, .TakeIncomplete = %TakeIncomplete, .ReturnIncomplete = %ReturnIncomplete, .CallTakeIncomplete = %CallTakeIncomplete, .CallReturnIncomplete = %CallReturnIncomplete}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -35,6 +35,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -31,6 +31,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .G = %G, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -45,6 +45,7 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A.decl, .B = %B.decl, .F = %F}
 // CHECK:STDOUT:   %A.decl = class_decl @A, ()
 // CHECK:STDOUT:   %A: type = class_type @A
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -13,10 +13,7 @@ let T: type = Class;
 
 // The class name is required to be written in the same way as in the class
 // declaration. An expression that evaluates to the class name is not accepted.
-// CHECK:STDERR: fail_member_of_let.carbon:[[@LINE+6]]:6: ERROR: Declaration qualifiers are only allowed for entities that provide a scope.
-// CHECK:STDERR: fn T.F() {}
-// CHECK:STDERR:      ^
-// CHECK:STDERR: fail_member_of_let.carbon:[[@LINE+3]]:4: Non-scope entity referenced here.
+// CHECK:STDERR: fail_member_of_let.carbon:[[@LINE+3]]:4: ERROR: Name `T` not found.
 // CHECK:STDERR: fn T.F() {}
 // CHECK:STDERR:    ^
 fn T.F() {}
@@ -28,11 +25,12 @@ fn T.F() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, %Class
 // CHECK:STDOUT:   %T: type = bind_name T, %Class.ref
-// CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1
+// CHECK:STDOUT:   %.loc19: <function> = fn_decl @.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -39,6 +39,7 @@ fn F(c: Class) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
@@ -81,6 +81,7 @@ base class G;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A.decl.loc7, .B = %B.decl.loc16, .C = %C.decl.loc25, .D = %D.decl.loc34, .E = %E.decl.loc43, .F = %F.decl.loc52, .G = %G.decl.loc61}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A, ()
 // CHECK:STDOUT:   %A: type = class_type @A
 // CHECK:STDOUT:   %A.decl.loc14 = class_decl @A, ()

--- a/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
@@ -28,6 +28,7 @@ class Y {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A.decl.loc7, .X = %X.decl, .Y = %Y.decl}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A.1, ()
 // CHECK:STDOUT:   %A: type = class_type @A.1
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -31,6 +31,7 @@ fn Class.H() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl.loc7}
 // CHECK:STDOUT:   %Class.decl.loc7 = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Class.decl.loc18 = class_decl @Class, ()
@@ -44,8 +45,8 @@ fn Class.H() {}
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .F = <unexpected instref inst+2>
-// CHECK:STDOUT:   .H = <unexpected instref inst+3>
+// CHECK:STDOUT:   .F = <unexpected instref inst+3>
+// CHECK:STDOUT:   .H = <unexpected instref inst+4>
 // CHECK:STDOUT:   .G = %G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -32,6 +32,7 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -24,6 +24,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -59,6 +59,7 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .WrongSelf = %WrongSelf.decl, .CallWrongSelf = %CallWrongSelf}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -28,6 +28,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -24,6 +24,7 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -24,6 +24,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -25,6 +25,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run

--- a/toolchain/check/testdata/class/forward_declared.carbon
+++ b/toolchain/check/testdata/class/forward_declared.carbon
@@ -11,6 +11,7 @@ fn F(p: Class*) -> Class* { return p; }
 // CHECK:STDOUT: --- forward_declared.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -26,6 +26,7 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Make = %Make, .MakeReorder = %MakeReorder}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -21,6 +21,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -32,6 +32,7 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Inner = %Inner.decl, .MakeInner = %MakeInner, .Outer = %Outer.decl, .MakeOuter = %MakeOuter}
 // CHECK:STDOUT:   %Inner.decl = class_decl @Inner, ()
 // CHECK:STDOUT:   %Inner: type = class_type @Inner
 // CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -52,6 +52,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Call = %Call, .CallWithAddr = %CallWithAddr, .CallFThroughPointer = %CallFThroughPointer, .CallGThroughPointer = %CallGThroughPointer, .Make = %Make, .CallFOnInitializingExpr = %CallFOnInitializingExpr, .CallGOnInitializingExpr = %CallGOnInitializingExpr}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -38,6 +38,7 @@ fn F(a: Outer*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Outer = %Outer.decl, .F = %F}
 // CHECK:STDOUT:   %Outer.decl = class_decl @Outer, ()
 // CHECK:STDOUT:   %Outer: type = class_type @Outer
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -29,6 +29,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Outer = %Outer.decl, .F = %F, .G = %G}
 // CHECK:STDOUT:   %Outer.decl = class_decl @Outer, ()
 // CHECK:STDOUT:   %Outer: type = class_type @Outer
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -29,6 +29,7 @@ fn Class.G[self: Class](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/raw_self_type.carbon
+++ b/toolchain/check/testdata/class/raw_self_type.carbon
@@ -18,6 +18,7 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -19,6 +19,7 @@ fn Class.F() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl.loc7}
 // CHECK:STDOUT:   %Class.decl.loc7 = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Class.decl.loc9 = class_decl @Class, ()

--- a/toolchain/check/testdata/class/redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/redeclaration_introducer.carbon
@@ -19,6 +19,7 @@ abstract class C {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A.decl.loc7, .B = %B.decl.loc8, .C = %C.decl.loc9}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A, ()
 // CHECK:STDOUT:   %A: type = class_type @A
 // CHECK:STDOUT:   %B.decl.loc8 = class_decl @B, ()

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -20,6 +20,7 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -29,6 +29,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .F = %F, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -27,6 +27,7 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -24,6 +24,7 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -22,6 +22,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class: type = class_type @Class
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run

--- a/toolchain/check/testdata/const/collapse.carbon
+++ b/toolchain/check/testdata/const/collapse.carbon
@@ -15,6 +15,7 @@ fn F(p: const i32**) -> const (const i32)** {
 // CHECK:STDOUT: --- collapse.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -17,6 +17,7 @@ fn G(p: const (const i32)**) -> i32** {
 // CHECK:STDOUT: --- fail_collapse.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.G = %G}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
+++ b/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
@@ -25,6 +25,7 @@ fn H() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .H = %H}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -20,6 +20,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Echo = %Echo, .Main = %Main}
 // CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -19,6 +19,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Echo = %Echo, .Main = %Main}
 // CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -18,6 +18,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run = %Run}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -62,6 +62,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Run0 = %Run0, .Run1 = %Run1, .Run2 = %Run2, .Main = %Main}
 // CHECK:STDOUT:   %Run0: <function> = fn_decl @Run0
 // CHECK:STDOUT:   %Run1: <function> = fn_decl @Run1
 // CHECK:STDOUT:   %Run2: <function> = fn_decl @Run2

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -23,6 +23,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.G = %G, .F = %F}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -16,6 +16,7 @@ fn Run() {
 // CHECK:STDOUT: --- fail_return_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Run = %Run}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -15,6 +15,7 @@ fn Main() {
 // CHECK:STDOUT: --- i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Echo = %Echo, .Main = %Main}
 // CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -18,6 +18,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -17,6 +17,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -18,6 +18,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -17,6 +17,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -18,6 +18,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -17,6 +17,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Main = %Main}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -18,6 +18,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.MakeImplicitEmptyTuple = %MakeImplicitEmptyTuple, .Main = %Main}
 // CHECK:STDOUT:   %MakeImplicitEmptyTuple: <function> = fn_decl @MakeImplicitEmptyTuple
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -15,6 +15,7 @@ fn G() { F(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
@@ -15,6 +15,7 @@ fn Bar(a: i32, a: i32) {}
 // CHECK:STDOUT: --- fail_param_name_conflict.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Bar = %Bar}
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/order.carbon
+++ b/toolchain/check/testdata/function/definition/order.carbon
@@ -11,6 +11,7 @@ fn Baz() {}
 // CHECK:STDOUT: --- order.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Bar = %Bar, .Baz = %Baz}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz

--- a/toolchain/check/testdata/function/definition/params_one.carbon
+++ b/toolchain/check/testdata/function/definition/params_one.carbon
@@ -9,6 +9,7 @@ fn Foo(a: i32) {}
 // CHECK:STDOUT: --- params_one.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_one_comma.carbon
@@ -9,6 +9,7 @@ fn Foo(a: i32,) {}
 // CHECK:STDOUT: --- params_one_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_two.carbon
+++ b/toolchain/check/testdata/function/definition/params_two.carbon
@@ -9,6 +9,7 @@ fn Foo(a: i32, b: i32) {}
 // CHECK:STDOUT: --- params_two.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_two_comma.carbon
@@ -9,6 +9,7 @@ fn Foo(a: i32, b: i32,) {}
 // CHECK:STDOUT: --- params_two_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/params_zero.carbon
+++ b/toolchain/check/testdata/function/definition/params_zero.carbon
@@ -9,6 +9,7 @@ fn Foo() {}
 // CHECK:STDOUT: --- params_zero.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/same_param_name.carbon
+++ b/toolchain/check/testdata/function/definition/same_param_name.carbon
@@ -10,6 +10,7 @@ fn Bar(a: i32) {}
 // CHECK:STDOUT: --- same_param_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %Foo, .Bar = %Bar}
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -24,6 +24,7 @@ fn If(b: bool) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .H = %H, .If = %If}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -36,6 +36,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_reachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.If1 = %If1, .If2 = %If2, .If3 = %If3}
 // CHECK:STDOUT:   %If1: <function> = fn_decl @If1
 // CHECK:STDOUT:   %If2: <function> = fn_decl @If2
 // CHECK:STDOUT:   %If3: <function> = fn_decl @If3

--- a/toolchain/check/testdata/if/fail_scope.carbon
+++ b/toolchain/check/testdata/if/fail_scope.carbon
@@ -18,6 +18,7 @@ fn VarScope(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.VarScope = %VarScope}
 // CHECK:STDOUT:   %VarScope: <function> = fn_decl @VarScope
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -21,6 +21,7 @@ fn If(b: bool) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .If = %If}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %If: <function> = fn_decl @If

--- a/toolchain/check/testdata/if/unreachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/unreachable_fallthrough.carbon
@@ -16,6 +16,7 @@ fn If(b: bool) -> i32 {
 // CHECK:STDOUT: --- unreachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.If = %If}
 // CHECK:STDOUT:   %If: <function> = fn_decl @If
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -11,6 +11,7 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -18,6 +18,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- constant_condition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A, .B = %B, .F = %F, .G = %G}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -14,6 +14,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- control_flow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A, .B = %B, .F = %F}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -51,6 +51,6 @@ class C {
 // CHECK:STDOUT:   if %.loc33 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .n = <unexpected instref inst+20>
+// CHECK:STDOUT:   .n = <unexpected instref inst+21>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/nested.carbon
+++ b/toolchain/check/testdata/if_expr/nested.carbon
@@ -11,6 +11,7 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -19,6 +19,7 @@ fn F(cond: bool) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.G = %G, .F = %F}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -17,6 +17,7 @@ var d: i32 = a[b];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b, .c = %c, .d = %d}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 2] = var a

--- a/toolchain/check/testdata/index/expr_category.carbon
+++ b/toolchain/check/testdata/index/expr_category.carbon
@@ -32,6 +32,7 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .ValueBinding = %ValueBinding}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -18,6 +18,7 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -18,6 +18,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -18,6 +18,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -20,6 +20,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .Run = %Run}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_expr_category.carbon
+++ b/toolchain/check/testdata/index/fail_expr_category.carbon
@@ -36,6 +36,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -38,6 +38,7 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.N = %.loc11, .a = %a, .F = %F, .b = %b, .c = %c, .d = %d}
 // CHECK:STDOUT:   %.loc11: <namespace> = namespace {}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var

--- a/toolchain/check/testdata/index/fail_name_not_found.carbon
+++ b/toolchain/check/testdata/index/fail_name_not_found.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_name_not_found.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -20,6 +20,7 @@ var c: i32 = a[b];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a

--- a/toolchain/check/testdata/index/fail_non_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_non_tuple_access.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_non_tuple_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -19,6 +19,7 @@ var b: i32 = a[oops];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -19,6 +19,7 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -19,6 +19,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -19,6 +19,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -16,6 +16,7 @@ var c: i32 = b[0];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -18,6 +18,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .Run = %Run}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
@@ -9,6 +9,7 @@ fn A() { if (true) { var n: i32 = 1; } if (true) { var n: i32 = 2; } }
 // CHECK:STDOUT: --- duplicate_name_same_line.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -20,6 +20,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -17,6 +17,7 @@ fn F(a: i32) {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_use_in_init.carbon
+++ b/toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -14,6 +14,7 @@ fn F() {
 // CHECK:STDOUT: --- fail_use_in_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -11,6 +11,7 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT: --- global.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 1
 // CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/let/local.carbon
+++ b/toolchain/check/testdata/let/local.carbon
@@ -12,6 +12,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: --- local.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -21,6 +21,7 @@ fn Foo.Baz() {
 // CHECK:STDOUT: --- fail_duplicate.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %.loc7}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Baz = %Baz.loc9}
 // CHECK:STDOUT:   %Baz.loc9: <function> = fn_decl @Baz
 // CHECK:STDOUT:   %Baz.loc18: <function> = fn_decl @Baz

--- a/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
+++ b/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
@@ -13,6 +13,7 @@ fn Foo.Baz() {
 // CHECK:STDOUT: --- fail_unresolved_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %.loc10: <function> = fn_decl @.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -24,6 +24,7 @@ fn Bar() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %.loc7, .Baz = %Baz.loc10, .Bar = %Bar}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Baz = %Baz.loc13}
 // CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1
 // CHECK:STDOUT:   %Baz.loc13: <function> = fn_decl @Baz.2

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -21,6 +21,7 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Foo = %.loc7}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.Bar = %.loc8}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace {.Wiz = %Wiz, .Baz = %Baz}
 // CHECK:STDOUT:   %Wiz: <function> = fn_decl @Wiz

--- a/toolchain/check/testdata/namespace/shadow.carbon
+++ b/toolchain/check/testdata/namespace/shadow.carbon
@@ -30,6 +30,7 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A.loc7, .N = %.loc9}
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A.1
 // CHECK:STDOUT:   %.loc9: <namespace> = namespace {.A = %A.loc10, .M = %.loc12}
 // CHECK:STDOUT:   %A.loc10: <function> = fn_decl @A.2

--- a/toolchain/check/testdata/namespace/unqualified_lookup.carbon
+++ b/toolchain/check/testdata/namespace/unqualified_lookup.carbon
@@ -33,6 +33,7 @@ fn OuterN.InnerN.CallABC() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.OuterN = %.loc7, .A = %A, .CallA = %CallA}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {.InnerN = %.loc8, .B = %B, .CallAB = %CallAB}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace {.C = %C, .CallABC = %CallABC}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -14,6 +14,7 @@ fn And() -> bool {
 // CHECK:STDOUT: --- and.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .And = %And}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %And: <function> = fn_decl @And

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -32,6 +32,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/binary_op.carbon
+++ b/toolchain/check/testdata/operators/binary_op.carbon
@@ -11,6 +11,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- binary_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
@@ -18,6 +18,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_assignment_to_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -55,6 +55,7 @@ fn Main() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .Main = %Main}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch.carbon
@@ -14,6 +14,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
@@ -15,6 +15,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_type_mismatch_assignment.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
@@ -16,6 +16,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch_once.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -14,6 +14,7 @@ fn Or() -> bool {
 // CHECK:STDOUT: --- or.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .Or = %Or}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %Or: <function> = fn_decl @Or

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -11,6 +11,7 @@ fn Not(b: bool) -> bool {
 // CHECK:STDOUT: --- unary_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Not = %Not}
 // CHECK:STDOUT:   %Not: <function> = fn_decl @Not
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/package_expr/fail_not_found.carbon
+++ b/toolchain/check/testdata/package_expr/fail_not_found.carbon
@@ -1,0 +1,30 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn Main() {
+  // CHECK:STDERR: fail_not_found.carbon:[[@LINE+3]]:23: ERROR: Name `x` not found.
+  // CHECK:STDERR:   var y: i32 = package.x;
+  // CHECK:STDERR:                       ^
+  var y: i32 = package.x;
+}
+
+// CHECK:STDOUT: --- fail_not_found.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Main() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %y.var: ref i32 = var y
+// CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
+// CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
+// CHECK:STDOUT:   %x.ref: <error> = name_ref x, <error>
+// CHECK:STDOUT:   assign %y.var, <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/package_expr/syntax.carbon
+++ b/toolchain/check/testdata/package_expr/syntax.carbon
@@ -1,0 +1,133 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- global.carbon
+
+package Global api;
+
+var x: i32 = 0;
+
+fn Main() {
+  var x: i32 = 1;
+
+  var y: i32 = package.x;
+}
+
+// --- inside_fn.carbon
+
+package InsideFn api;
+
+var x: i32 = 0;
+
+fn Main() {
+  var x: i32 = 1;
+
+  var y: i32 = package.x;
+}
+
+// --- namespace.carbon
+
+package Namespace api;
+
+namespace NS;
+
+class NS.C {
+  fn Foo() {}
+};
+
+fn Main() {
+  package.NS.C.Foo();
+}
+
+// CHECK:STDOUT: --- global.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .Main = %Main}
+// CHECK:STDOUT:   %x.var: ref i32 = var x
+// CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0
+// CHECK:STDOUT:   assign %x.var, %.loc4
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Main() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %x.var: ref i32 = var x
+// CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1
+// CHECK:STDOUT:   assign %x.var, %.loc7
+// CHECK:STDOUT:   %y.var: ref i32 = var y
+// CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
+// CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
+// CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, file.%x
+// CHECK:STDOUT:   %.loc9: i32 = bind_value %x.ref
+// CHECK:STDOUT:   assign %y.var, %.loc9
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- inside_fn.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .Main = %Main}
+// CHECK:STDOUT:   %x.var: ref i32 = var x
+// CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0
+// CHECK:STDOUT:   assign %x.var, %.loc4
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Main() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %x.var: ref i32 = var x
+// CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1
+// CHECK:STDOUT:   assign %x.var, %.loc7
+// CHECK:STDOUT:   %y.var: ref i32 = var y
+// CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
+// CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
+// CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, file.%x
+// CHECK:STDOUT:   %.loc9: i32 = bind_value %x.ref
+// CHECK:STDOUT:   assign %y.var, %.loc9
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- namespace.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.loc8: type = struct_type {}
+// CHECK:STDOUT:   %.loc11: type = tuple_type ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.NS = %.loc4, .Main = %Main}
+// CHECK:STDOUT:   %.loc4: <namespace> = namespace {.C = %C.decl}
+// CHECK:STDOUT:   %C.decl = class_decl @C, ()
+// CHECK:STDOUT:   %C: type = class_type @C
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Foo = %Foo
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Foo() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Main() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
+// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%.loc4
+// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, @C.%Foo
+// CHECK:STDOUT:   %.loc11: init () = call %Foo.ref()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/explicit_imports.carbon
+++ b/toolchain/check/testdata/packages/explicit_imports.carbon
@@ -37,22 +37,26 @@ import library "lib";
 // CHECK:STDOUT: --- api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- api_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- same_package.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- different_package.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir2
 // CHECK:STDOUT:   %Api: <namespace> = bind_name Api, %import
 // CHECK:STDOUT: }
@@ -60,11 +64,13 @@ import library "lib";
 // CHECK:STDOUT: --- main_lib_api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -28,6 +28,7 @@ library "Bar" impl;
 // CHECK:STDOUT: --- no_api.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Foo: <namespace> = bind_name Foo, %import
 // CHECK:STDOUT: }
@@ -35,6 +36,7 @@ library "Bar" impl;
 // CHECK:STDOUT: --- no_api_lib.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Foo: <namespace> = bind_name Foo, %import
 // CHECK:STDOUT: }
@@ -42,6 +44,7 @@ library "Bar" impl;
 // CHECK:STDOUT: --- no_api_main_lib.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -50,6 +50,7 @@ import B;
 // CHECK:STDOUT: --- a.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %B: <namespace> = bind_name B, %import
 // CHECK:STDOUT: }
@@ -57,6 +58,7 @@ import B;
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %C: <namespace> = bind_name C, %import
 // CHECK:STDOUT: }
@@ -64,6 +66,7 @@ import B;
 // CHECK:STDOUT: --- c.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %A: <namespace> = bind_name A, %import
 // CHECK:STDOUT: }
@@ -71,6 +74,7 @@ import B;
 // CHECK:STDOUT: --- c.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %C: <namespace> = bind_name C, %import
 // CHECK:STDOUT: }
@@ -78,6 +82,7 @@ import B;
 // CHECK:STDOUT: --- cycle_child.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %B: <namespace> = bind_name B, %import
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_duplicate_api.carbon
+++ b/toolchain/check/testdata/packages/fail_duplicate_api.carbon
@@ -45,40 +45,48 @@ package Package library "lib" api;
 // CHECK:STDOUT: --- main1.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main2.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib1.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib2.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package1.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package2.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package_lib1.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package_lib2.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_extension.carbon
+++ b/toolchain/check/testdata/packages/fail_extension.carbon
@@ -73,32 +73,38 @@ package SwappedExt impl;
 // CHECK:STDOUT: --- main.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_redundant_with_swapped_ext.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib_impl.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package_impl.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Package: <namespace> = bind_name Package, %import
 // CHECK:STDOUT: }
@@ -106,11 +112,13 @@ package SwappedExt impl;
 // CHECK:STDOUT: --- package_lib.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- package_lib_impl.incorrect
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Package: <namespace> = bind_name Package, %import
 // CHECK:STDOUT: }
@@ -118,11 +126,13 @@ package SwappedExt impl;
 // CHECK:STDOUT: --- swapped_ext.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- swapped_ext.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %SwappedExt: <namespace> = bind_name SwappedExt, %import
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_import_default.carbon
+++ b/toolchain/check/testdata/packages/fail_import_default.carbon
@@ -41,11 +41,13 @@ import library default;
 // CHECK:STDOUT: --- default_api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- default.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %A: <namespace> = bind_name A, %import
 // CHECK:STDOUT: }
@@ -53,10 +55,12 @@ import library default;
 // CHECK:STDOUT: --- main_import_default.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib_import_default.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -85,31 +85,37 @@ import ImportNotFound;
 // CHECK:STDOUT: --- main.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- not_main.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- this.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- this_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit_api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Implicit: <namespace> = bind_name Implicit, %import
 // CHECK:STDOUT: }
@@ -117,11 +123,13 @@ import ImportNotFound;
 // CHECK:STDOUT: --- implicit_lib_api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit_lib.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %Implicit: <namespace> = bind_name Implicit, %import
 // CHECK:STDOUT: }
@@ -129,6 +137,7 @@ import ImportNotFound;
 // CHECK:STDOUT: --- not_found.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %ImportNotFound: <namespace> = bind_name ImportNotFound, %import
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -61,21 +61,25 @@ import library default;
 // CHECK:STDOUT: --- api.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- api_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import.loc2: <namespace> = import ir1, ir2
 // CHECK:STDOUT:   %Api: <namespace> = bind_name Api, %import.loc2
 // CHECK:STDOUT:   %import.loc20: <namespace> = import ir3, ir3
@@ -84,6 +88,7 @@ import library default;
 // CHECK:STDOUT: --- default_import.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -36,20 +36,24 @@ package Main library "lib" api;
 // CHECK:STDOUT: --- main.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- raw_main.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/implicit_imports.carbon
+++ b/toolchain/check/testdata/packages/implicit_imports.carbon
@@ -46,21 +46,25 @@ library "lib" impl;
 // CHECK:STDOUT: --- api_only.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- api_only_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- with_impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- with_impl.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %WithImpl: <namespace> = bind_name WithImpl, %import
 // CHECK:STDOUT: }
@@ -68,6 +72,7 @@ library "lib" impl;
 // CHECK:STDOUT: --- with_impl_extra.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %WithImpl: <namespace> = bind_name WithImpl, %import
 // CHECK:STDOUT: }
@@ -75,11 +80,13 @@ library "lib" impl;
 // CHECK:STDOUT: --- with_impl_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- with_impl_lib.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT:   %WithImpl: <namespace> = bind_name WithImpl, %import
 // CHECK:STDOUT: }
@@ -87,16 +94,19 @@ library "lib" impl;
 // CHECK:STDOUT: --- main.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- main_lib.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %import: <namespace> = import ir1, ir1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -16,6 +16,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -26,6 +26,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -14,6 +14,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -26,6 +26,7 @@ fn Test() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Test = %Test}
 // CHECK:STDOUT:   %Test: <function> = fn_decl @Test
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -96,6 +96,7 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.G = %G, .H = %H, .AddressOfLiteral = %AddressOfLiteral, .AddressOfOperator = %AddressOfOperator, .AddressOfCall = %AddressOfCall, .AddressOfType = %AddressOfType, .AddressOfTupleElementValue = %AddressOfTupleElementValue, .AddressOfParam = %AddressOfParam}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H
 // CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral

--- a/toolchain/check/testdata/pointer/fail_deref_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_error.carbon
@@ -12,6 +12,7 @@ let n: i32 = *undeclared;
 // CHECK:STDOUT: --- fail_deref_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error>
 // CHECK:STDOUT:   %.loc10: ref <error> = deref <error>
 // CHECK:STDOUT:   %n: i32 = bind_name n, <error>

--- a/toolchain/check/testdata/pointer/fail_deref_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_function.carbon
@@ -14,6 +14,7 @@ fn A() {
 // CHECK:STDOUT: --- fail_deref_function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -16,6 +16,7 @@ fn F() {
 // CHECK:STDOUT: --- fail_deref_namespace.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %.loc7, .F = %F}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -27,6 +27,7 @@ fn Deref(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Deref = %Deref}
 // CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_type.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_type.carbon
@@ -15,6 +15,7 @@ var p: *i32;
 // CHECK:STDOUT: --- fail_deref_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.p = %p}
 // CHECK:STDOUT:   %.loc13: ref <error> = deref i32
 // CHECK:STDOUT:   %p.var: ref <error> = var p
 // CHECK:STDOUT:   %p: ref <error> = bind_name p, %p.var

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -18,6 +18,7 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.ConstMismatch = %ConstMismatch}
 // CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/nested_const.carbon
+++ b/toolchain/check/testdata/pointer/nested_const.carbon
@@ -12,6 +12,7 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
 // CHECK:STDOUT: --- nested_const.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/types.carbon
+++ b/toolchain/check/testdata/pointer/types.carbon
@@ -15,6 +15,7 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
 // CHECK:STDOUT: --- types.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Ptr = %Ptr, .ConstPtr = %ConstPtr}
 // CHECK:STDOUT:   %Ptr: <function> = fn_decl @Ptr
 // CHECK:STDOUT:   %ConstPtr: <function> = fn_decl @ConstPtr
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/code_after_return.carbon
+++ b/toolchain/check/testdata/return/code_after_return.carbon
@@ -12,6 +12,7 @@ fn Main() {
 // CHECK:STDOUT: --- code_after_return.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/code_after_return_value.carbon
+++ b/toolchain/check/testdata/return/code_after_return_value.carbon
@@ -19,6 +19,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- code_after_return_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_call_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_call_in_type.carbon
@@ -15,6 +15,7 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT: --- fail_call_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.ReturnType = %ReturnType, .Six = %Six}
 // CHECK:STDOUT:   %ReturnType: <function> = fn_decl @ReturnType
 // CHECK:STDOUT:   %Six: <function> = fn_decl @Six
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_error_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_error_in_type.carbon
@@ -12,6 +12,7 @@ fn Six() -> x;
 // CHECK:STDOUT: --- fail_error_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Six = %Six}
 // CHECK:STDOUT:   %Six: <function> = fn_decl @Six
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -14,6 +14,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_let_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Six = %Six}
 // CHECK:STDOUT:   %x: type = bind_name x, i32
 // CHECK:STDOUT:   %Six: <function> = fn_decl @Six
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_missing_return.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return.carbon
@@ -13,6 +13,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_missing_return.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -17,6 +17,7 @@ fn F() -> () {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_return_var_no_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_var_no_returned_var.carbon
@@ -14,6 +14,7 @@ fn Procedure() -> i32 {
 // CHECK:STDOUT: --- fail_return_var_no_returned_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Procedure = %Procedure}
 // CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -35,6 +35,7 @@ fn G() -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .C = %C.decl, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
 // CHECK:STDOUT:   %C: type = class_type @C

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -22,6 +22,7 @@ fn Procedure() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Procedure = %Procedure}
 // CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
@@ -37,6 +37,7 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.SameScope = %SameScope, .DifferentScopes = %DifferentScopes}
 // CHECK:STDOUT:   %SameScope: <function> = fn_decl @SameScope
 // CHECK:STDOUT:   %DifferentScopes: <function> = fn_decl @DifferentScopes
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_returned_var_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_type.carbon
@@ -18,6 +18,7 @@ fn Mismatch() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Mismatch = %Mismatch}
 // CHECK:STDOUT:   %Mismatch: <function> = fn_decl @Mismatch
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/return/fail_type_mismatch.carbon
@@ -14,6 +14,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -17,6 +17,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_value_disallowed.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_missing.carbon
+++ b/toolchain/check/testdata/return/fail_value_missing.carbon
@@ -17,6 +17,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_value_missing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_var_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_var_in_type.carbon
@@ -13,6 +13,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_var_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .Six = %Six}
 // CHECK:STDOUT:   %x.var: ref type = var x
 // CHECK:STDOUT:   %x: ref type = bind_name x, %x.var
 // CHECK:STDOUT:   assign %x.var, i32

--- a/toolchain/check/testdata/return/missing_return_no_return_type.carbon
+++ b/toolchain/check/testdata/return/missing_return_no_return_type.carbon
@@ -10,6 +10,7 @@ fn F() {
 // CHECK:STDOUT: --- missing_return_no_return_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/no_value.carbon
+++ b/toolchain/check/testdata/return/no_value.carbon
@@ -11,6 +11,7 @@ fn Main() {
 // CHECK:STDOUT: --- no_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -27,6 +27,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.C = %C.decl, .F = %F, .G = %G}
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
 // CHECK:STDOUT:   %C: type = class_type @C
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/return/returned_var_scope.carbon
+++ b/toolchain/check/testdata/return/returned_var_scope.carbon
@@ -26,6 +26,7 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: --- returned_var_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.UnrelatedScopes = %UnrelatedScopes, .EnclosingButAfter = %EnclosingButAfter}
 // CHECK:STDOUT:   %UnrelatedScopes: <function> = fn_decl @UnrelatedScopes
 // CHECK:STDOUT:   %EnclosingButAfter: <function> = fn_decl @EnclosingButAfter
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -11,6 +11,7 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT: --- struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -18,6 +18,7 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/value.carbon
+++ b/toolchain/check/testdata/return/value.carbon
@@ -11,6 +11,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -15,6 +15,7 @@ var y: {} = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_9.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7_9.1
 // CHECK:STDOUT:   %x.var: ref {} = var x

--- a/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
+++ b/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
@@ -13,6 +13,7 @@ fn F() { a.b; }
 // CHECK:STDOUT: --- fail_access_into_invalid.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -16,6 +16,7 @@ var x: {.a: i32} = {};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -19,6 +19,7 @@ var x: {.a: {}} = {.b = {}};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_14.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.1
 // CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}}

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -18,6 +18,7 @@ var x: {} = {.a = 1};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_9.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9.1
 // CHECK:STDOUT:   %x.var: ref {} = var x

--- a/toolchain/check/testdata/struct/fail_duplicate_name.carbon
+++ b/toolchain/check/testdata/struct/fail_duplicate_name.carbon
@@ -52,6 +52,7 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .x = %x, .y = %y}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc21_36: {.a: i32} = struct_literal (%.loc21_35)

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -21,6 +21,7 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -16,6 +16,7 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -13,6 +13,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_member_access_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: f64}
 // CHECK:STDOUT:   %x.var: ref {.a: f64} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_member_of_function.carbon
+++ b/toolchain/check/testdata/struct/fail_member_of_function.carbon
@@ -14,6 +14,7 @@ fn A() {
 // CHECK:STDOUT: --- fail_member_of_function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -26,6 +26,7 @@ var p: Incomplete* = &s.a;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Incomplete = %Incomplete.decl, .s = %s, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -13,6 +13,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_non_member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -17,6 +17,7 @@ var x: {.a: i32, .b: i32} = {.a = 1};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/check/testdata/struct/fail_type_assign.carbon
@@ -12,6 +12,7 @@ var x: {.a: i32} = {.a: i32};
 // CHECK:STDOUT: --- fail_type_assign.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -16,6 +16,7 @@ var x: {.a = 1};
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_15: {.a: i32} = struct_literal (%.loc10_14)
 // CHECK:STDOUT:   %x.var: ref <error> = var x

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -20,6 +20,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.G = %G, .F = %F}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -15,6 +15,7 @@ var z: i32 = y;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y, .z = %z}
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: f64, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64, .b: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -21,6 +21,7 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -10,6 +10,7 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT: --- one_entry.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -22,6 +22,7 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.MakeI32 = %MakeI32, .MakeF64 = %MakeF64, .F = %F}
 // CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32
 // CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -16,6 +16,7 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_27.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%.loc7_27.2
 // CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)}

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -14,6 +14,7 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32}
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -14,6 +14,7 @@ var y: () = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7
 // CHECK:STDOUT:   %x.var: ref () = var x

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -18,6 +18,7 @@ var x: (i32,) = ();
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_13.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_13.1, constants.%.loc10_13.2
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -24,6 +24,7 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -16,6 +16,7 @@ var x: () = (66);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10
 // CHECK:STDOUT:   %x.var: ref () = var x

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -19,6 +19,7 @@ var x: (i32, i32) = (2, 65.89);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -28,6 +28,7 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Incomplete = %Incomplete.decl, .t = %t, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -19,6 +19,7 @@ var x: (i32, i32) = (2, );
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -17,6 +17,7 @@ var x: (i32, ) = (i32, );
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_14.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.2
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -17,6 +17,7 @@ var x: (1, );
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1
 // CHECK:STDOUT:   %.loc10_12.1: (i32,) = tuple_literal (%.loc10_9)
 // CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, constants.%.loc10_12.2

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -19,6 +19,7 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18, i32)
 // CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_18, constants.%.loc7_24.2

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -31,6 +31,7 @@ fn H() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.F = %F, .G = %G, .H = %H}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G
 // CHECK:STDOUT:   %H: <function> = fn_decl @H

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -15,6 +15,7 @@ var y: (i32,) = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -16,6 +16,7 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x

--- a/toolchain/check/testdata/var/decl.carbon
+++ b/toolchain/check/testdata/var/decl.carbon
@@ -11,6 +11,7 @@ fn Main() {
 // CHECK:STDOUT: --- decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/decl_with_init.carbon
@@ -11,6 +11,7 @@ fn Main() {
 // CHECK:STDOUT: --- decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/fail_duplicate_decl.carbon
@@ -19,6 +19,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_init_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/check/testdata/var/fail_init_with_self.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_init_with_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
@@ -16,6 +16,7 @@ var y: i32 = x;
 // CHECK:STDOUT: --- fail_lookup_outside_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main, .y = %y}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -32,6 +32,7 @@ fn F(x: X) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.X = %X.decl, .F = %F}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
 // CHECK:STDOUT:   %X: type = class_type @X
 // CHECK:STDOUT:   %F: <function> = fn_decl @F

--- a/toolchain/check/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/check/testdata/var/fail_storage_is_literal.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_storage_is_literal.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/global_decl.carbon
+++ b/toolchain/check/testdata/var/global_decl.carbon
@@ -9,6 +9,7 @@ var x: i32;
 // CHECK:STDOUT: --- global_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/check/testdata/var/global_decl_with_init.carbon
@@ -9,6 +9,7 @@ var x: i32 = 0;
 // CHECK:STDOUT: --- global_decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0

--- a/toolchain/check/testdata/var/global_lookup.carbon
+++ b/toolchain/check/testdata/var/global_lookup.carbon
@@ -10,6 +10,7 @@ var y: i32 = x;
 // CHECK:STDOUT: --- global_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .y = %y}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -13,6 +13,7 @@ fn Main() {
 // CHECK:STDOUT: --- global_lookup_in_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 0

--- a/toolchain/check/testdata/var/lookup.carbon
+++ b/toolchain/check/testdata/var/lookup.carbon
@@ -12,6 +12,7 @@ fn Main() {
 // CHECK:STDOUT: --- lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/shadowing.carbon
+++ b/toolchain/check/testdata/var/shadowing.carbon
@@ -17,6 +17,7 @@ fn Main() {
 // CHECK:STDOUT: --- shadowing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -29,6 +29,7 @@ fn While() {
 // CHECK:STDOUT: --- break_continue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %A, .B = %B, .C = %C, .D = %D, .E = %E, .F = %F, .G = %G, .H = %H, .While = %While}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A
 // CHECK:STDOUT:   %B: <function> = fn_decl @B
 // CHECK:STDOUT:   %C: <function> = fn_decl @C

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -18,6 +18,7 @@ fn While() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.While = %While}
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/fail_break_continue.carbon
+++ b/toolchain/check/testdata/while/fail_break_continue.carbon
@@ -30,6 +30,7 @@ fn While() {
 // CHECK:STDOUT: --- fail_break_continue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.While = %While}
 // CHECK:STDOUT:   %While: <function> = fn_decl @While
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -26,6 +26,7 @@ fn While() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Cond = %Cond, .F = %F, .G = %G, .H = %H, .While = %While}
 // CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -25,6 +25,7 @@ fn While() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.Cond = %Cond, .F = %F, .G = %G, .H = %H, .While = %While}
 // CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond
 // CHECK:STDOUT:   %F: <function> = fn_decl @F
 // CHECK:STDOUT:   %G: <function> = fn_decl @G

--- a/toolchain/driver/testdata/stdin.carbon
+++ b/toolchain/driver/testdata/stdin.carbon
@@ -9,5 +9,6 @@
 // CHECK:STDOUT: --- <stdin>
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/parse/handle_expr.cpp
+++ b/toolchain/parse/handle_expr.cpp
@@ -147,6 +147,11 @@ auto HandleExprInPostfix(Context& context) -> void {
       context.PushState(State::ArrayExpr);
       break;
     }
+    case Lex::TokenKind::Package: {
+      context.AddLeafNode(NodeKind::PackageExpr, context.Consume());
+      context.PushState(state);
+      break;
+    }
     case Lex::TokenKind::SelfValueIdentifier: {
       context.AddLeafNode(NodeKind::SelfValueNameExpr, context.Consume());
       context.PushState(state);

--- a/toolchain/parse/node_kind.def
+++ b/toolchain/parse/node_kind.def
@@ -638,6 +638,9 @@ CARBON_PARSE_NODE_KIND_CHILD_COUNT(SelfValueNameExpr, 0,
 CARBON_PARSE_NODE_KIND_CHILD_COUNT(SelfTypeNameExpr, 0,
                                    CARBON_TOKEN(SelfTypeIdentifier))
 
+// The `package` keyword in an expression.
+CARBON_PARSE_NODE_KIND_CHILD_COUNT(PackageExpr, 0, CARBON_TOKEN(Package))
+
 #undef CARBON_PARSE_NODE_KIND
 #undef CARBON_PARSE_NODE_KIND_BRACKET
 #undef CARBON_PARSE_NODE_KIND_CHILD_COUNT

--- a/toolchain/parse/testdata/package_expr/basic.carbon
+++ b/toolchain/parse/testdata/package_expr/basic.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+var x: package.Foo = package.Bar;
+
+// CHECK:STDOUT: - filename: basic.carbon
+// CHECK:STDOUT:   parse_tree: [
+// CHECK:STDOUT:     {kind: 'FileStart', text: ''},
+// CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},
+// CHECK:STDOUT:         {kind: 'Name', text: 'x'},
+// CHECK:STDOUT:           {kind: 'PackageExpr', text: 'package'},
+// CHECK:STDOUT:           {kind: 'Name', text: 'Foo'},
+// CHECK:STDOUT:         {kind: 'MemberAccessExpr', text: '.', subtree_size: 3},
+// CHECK:STDOUT:       {kind: 'BindingPattern', text: ':', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'VariableInitializer', text: '='},
+// CHECK:STDOUT:         {kind: 'PackageExpr', text: 'package'},
+// CHECK:STDOUT:         {kind: 'Name', text: 'Bar'},
+// CHECK:STDOUT:       {kind: 'MemberAccessExpr', text: '.', subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'VariableDecl', text: ';', subtree_size: 11},
+// CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT:   ]

--- a/toolchain/parse/testdata/package_expr/fail_in_name.carbon
+++ b/toolchain/parse/testdata/package_expr/fail_in_name.carbon
@@ -1,0 +1,38 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:5: ERROR: Expected pattern in `var` declaration.
+// CHECK:STDERR: var package.val: i32;
+// CHECK:STDERR:     ^~~~~~~
+var package.val: i32;
+
+// CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: namespace package.NS;
+// CHECK:STDERR:           ^~~~~~~
+namespace package.NS;
+
+// CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:7: ERROR: `class` introducer should be followed by a name.
+// CHECK:STDERR: class package.C {
+// CHECK:STDERR:       ^~~~~~~
+class package.C {
+}
+
+// CHECK:STDOUT: - filename: fail_in_name.carbon
+// CHECK:STDOUT:   parse_tree: [
+// CHECK:STDOUT:     {kind: 'FileStart', text: ''},
+// CHECK:STDOUT:       {kind: 'VariableIntroducer', text: 'var'},
+// CHECK:STDOUT:         {kind: 'Name', text: 'package', has_error: yes},
+// CHECK:STDOUT:         {kind: 'InvalidParse', text: 'package', has_error: yes},
+// CHECK:STDOUT:       {kind: 'BindingPattern', text: 'package', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'VariableDecl', text: ';', subtree_size: 5},
+// CHECK:STDOUT:       {kind: 'NamespaceStart', text: 'namespace'},
+// CHECK:STDOUT:       {kind: 'InvalidParse', text: 'package', has_error: yes},
+// CHECK:STDOUT:     {kind: 'Namespace', text: ';', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:       {kind: 'ClassIntroducer', text: 'class'},
+// CHECK:STDOUT:       {kind: 'InvalidParse', text: 'package', has_error: yes},
+// CHECK:STDOUT:     {kind: 'ClassDecl', text: 'class', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT:   ]

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -146,9 +146,6 @@ class InstNamer {
     auto& [inst_scope, inst_name] = insts[inst_id.index];
     if (!inst_name) {
       // This should not happen in valid IR.
-      // TODO: This is encountered for names in namespaces: the namespace is
-      // declared before the name, and then the formatter prints the name scope
-      // for the name before it's been added.
       std::string str;
       llvm::raw_string_ostream(str) << "<unexpected instref " << inst_id << ">";
       return str;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -139,9 +139,16 @@ class InstNamer {
       return BuiltinKind::FromInt(inst_id.index).label().str();
     }
 
+    if (inst_id == InstId::PackageNamespace) {
+      return "package";
+    }
+
     auto& [inst_scope, inst_name] = insts[inst_id.index];
     if (!inst_name) {
       // This should not happen in valid IR.
+      // TODO: This is encountered for names in namespaces: the namespace is
+      // declared before the name, and then the formatter prints the name scope
+      // for the name before it's been added.
       std::string str;
       llvm::raw_string_ostream(str) << "<unexpected instref " << inst_id << ">";
       return str;

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -31,6 +31,9 @@ struct InstId : public IdBase, public Printable<InstId> {
 #define CARBON_SEM_IR_BUILTIN_KIND_NAME(Name) static const InstId Builtin##Name;
 #include "toolchain/sem_ir/builtin_kind.def"
 
+  // The namespace for a `package` expression.
+  static const InstId PackageNamespace;
+
   // Returns the cross-reference instruction ID for a builtin. This relies on
   // File guarantees for builtin cross-reference placement.
   static constexpr auto ForBuiltin(BuiltinKind kind) -> InstId {
@@ -58,6 +61,9 @@ constexpr InstId InstId::Invalid = InstId(InstId::InvalidIndex);
   constexpr InstId InstId::Builtin##Name =    \
       InstId::ForBuiltin(BuiltinKind::Name);
 #include "toolchain/sem_ir/builtin_kind.def"
+
+// The package namespace will be the instruction after builtins.
+constexpr InstId InstId::PackageNamespace = InstId(BuiltinKind::ValidCount);
 
 // The ID of a function.
 struct FunctionId : public IdBase, public Printable<FunctionId> {
@@ -139,6 +145,8 @@ struct NameId : public IdBase, public Printable<NameId> {
   static const NameId SelfType;
   // The name of the return slot in a function.
   static const NameId ReturnSlot;
+  // The name of `package`.
+  static const NameId PackageNamespace;
 
   // Returns the NameId corresponding to a particular IdentifierId.
   static auto ForIdentifier(IdentifierId id) -> NameId {
@@ -165,6 +173,8 @@ struct NameId : public IdBase, public Printable<NameId> {
       out << "SelfType";
     } else if (*this == ReturnSlot) {
       out << "ReturnSlot";
+    } else if (*this == PackageNamespace) {
+      out << "PackageNamespace";
     } else {
       CARBON_CHECK(index >= 0) << "Unknown index";
       IdBase::Print(out);
@@ -176,6 +186,7 @@ constexpr NameId NameId::Invalid = NameId(NameId::InvalidIndex);
 constexpr NameId NameId::SelfValue = NameId(NameId::InvalidIndex - 1);
 constexpr NameId NameId::SelfType = NameId(NameId::InvalidIndex - 2);
 constexpr NameId NameId::ReturnSlot = NameId(NameId::InvalidIndex - 3);
+constexpr NameId NameId::PackageNamespace = NameId(NameId::InvalidIndex - 4);
 
 // The ID of a name scope.
 struct NameScopeId : public IdBase, public Printable<NameScopeId> {

--- a/toolchain/sem_ir/value_stores.cpp
+++ b/toolchain/sem_ir/value_stores.cpp
@@ -19,6 +19,8 @@ static auto GetSpecialName(NameId name_id, bool for_ir) -> llvm::StringRef {
       return "Self";
     case NameId::ReturnSlot.index:
       return for_ir ? "return" : "<return slot>";
+    case NameId::PackageNamespace.index:
+      return "package";
     default:
       CARBON_FATAL() << "Unknown special name";
   }


### PR DESCRIPTION
This creates a namespace for `package` scope.

It looks like names of class_decls in namespaces lead to an unexpected instref. This is already true, as best as I can tell. I'm not sure if there's a preferred approach to address that, so I've left a TODO for now.