### PR TITLE
Remove `llvm::StringRef` from diagnostic example

### DIFF
--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -35,7 +35,7 @@ enum class DiagnosticLevel : int8_t {
 // Provides a definition of a diagnostic. For example:
 //   CARBON_DIAGNOSTIC(MyDiagnostic, Error, "Invalid code!");
 //   CARBON_DIAGNOSTIC(MyDiagnostic, Warning, "Found {0}, expected {1}.",
-//              llvm::StringRef, llvm::StringRef);
+//                     std::string, std::string);
 //
 // Arguments are passed to llvm::formatv; see:
 // https://llvm.org/doxygen/FormatVariadic_8h_source.html


### PR DESCRIPTION
To match new guidance to avoid lifetime issues (now documented at https://docs.google.com/document/d/1RRYMm42osyqhI2LyjrjockYCutQ5dOf8Abu50kTrkX0/edit?resourcekey=0-kHyqOESbOHmzZphUbtLrTw#heading=h.nlcon9stg5pg )