### PR TITLE
Style note for explicit constructors.

### DIFF
--- a/docs/project/cpp_style_guide.md
+++ b/docs/project/cpp_style_guide.md
@@ -135,6 +135,8 @@ these.
     -   Use `{}` initialization without the `=` only if the above options don't
         compile.
     -   Never mix `{}` initialization and `auto`.
+-   Always mark constructors `explicit` unless there's a specific reason to
+    support implicit or `{}` initialization.
 -   Always use braces for conditional, `switch`, and loop statements, even when
     the body is a single statement.
     -   Within a `switch` statement, use braces after a `case` label when


### PR DESCRIPTION
This stems from an [old discussion](https://discord.com/channels/655572317891461132/821113559755784242/1070759074112741447), I think this is the resolution that never got added here.