### PR TITLE
Fix test to use a single test suite with multiple tests.

### DIFF
--- a/explorer/ast/ast_test_matchers_test.cpp
+++ b/explorer/ast/ast_test_matchers_test.cpp
@@ -23,7 +23,7 @@ using ::testing::Not;
 
 static constexpr SourceLocation DummyLoc("dummy", 0, FileKind::Main);
 
-TEST(BlockContentsAreTest, BasicUsage) {
+TEST(ASTTestMatchers, BlockContentsAreTest) {
   Block empty_block(DummyLoc, {});
   EXPECT_THAT(empty_block, BlockContentsAre(IsEmpty()));
   EXPECT_THAT(&empty_block, BlockContentsAre(IsEmpty()));
@@ -35,7 +35,7 @@ TEST(BlockContentsAreTest, BasicUsage) {
   EXPECT_THAT(break_block, Not(BlockContentsAre(IsEmpty())));
 }
 
-TEST(MatchesLiteralTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesLiteralTest) {
   IntLiteral literal(DummyLoc, 42);
   EXPECT_THAT(literal, MatchesLiteral(42));
   EXPECT_THAT(&literal, MatchesLiteral(42));
@@ -43,7 +43,7 @@ TEST(MatchesLiteralTest, BasicUsage) {
   EXPECT_THAT(StringLiteral(DummyLoc, "foo"), Not(MatchesLiteral(42)));
 }
 
-TEST(MatchesMulTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesMulTest) {
   IntLiteral two(DummyLoc, 2);
   IntLiteral three(DummyLoc, 3);
   OperatorExpression mul(DummyLoc, Operator::Mul, {&two, &three});
@@ -61,7 +61,7 @@ TEST(MatchesMulTest, BasicUsage) {
                          MatchesMul(MatchesLiteral(2), MatchesLiteral(3))));
 }
 
-TEST(MatchesBinaryOpTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesBinaryOpTest) {
   IntLiteral two(DummyLoc, 2);
   IntLiteral three(DummyLoc, 3);
 
@@ -80,7 +80,7 @@ TEST(MatchesBinaryOpTest, BasicUsage) {
               MatchesSub(MatchesLiteral(2), MatchesLiteral(3)));
 }
 
-TEST(MatchesReturnTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesReturnTest) {
   TupleLiteral unit(DummyLoc);
   ReturnExpression empty_return(DummyLoc, &unit,
                                 /*is_omitted_expression=*/true);
@@ -98,7 +98,7 @@ TEST(MatchesReturnTest, BasicUsage) {
   EXPECT_THAT(int_val, Not(MatchesReturn(_)));
 }
 
-TEST(MatchesFunctionDeclarationTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesFunctionDeclarationTest) {
   TuplePattern params(DummyLoc, {});
   Block body(DummyLoc, {});
   FunctionDeclaration decl(DummyLoc, DeclaredName(DummyLoc, "Foo"), {},
@@ -124,7 +124,7 @@ TEST(MatchesFunctionDeclarationTest, BasicUsage) {
   EXPECT_THAT(body, Not(MatchesFunctionDeclaration()));
 }
 
-TEST(MatchesUnimplementedExpressionTest, BasicUsage) {
+TEST(ASTTestMatchers, MatchesUnimplementedExpressionTest) {
   IntLiteral two(DummyLoc, 2);
   IntLiteral three(DummyLoc, 3);
   UnimplementedExpression unimplemented(DummyLoc, "DummyLabel", &two, &three);
@@ -146,7 +146,7 @@ TEST(MatchesUnimplementedExpressionTest, BasicUsage) {
               Not(MatchesUnimplementedExpression("DummyLabel", IsEmpty())));
 }
 
-TEST(ASTDeclarationsTest, BasicUsage) {
+TEST(ASTTestMatchers, ASTDeclarationsTest) {
   TuplePattern params(DummyLoc, {});
   Block body(DummyLoc, {});
   FunctionDeclaration decl(DummyLoc, DeclaredName(DummyLoc, "Foo"), {},


### PR DESCRIPTION
Previously it had a bunch of test suites, each with a test named BasicUsage.