### PR TITLE
Refactor state construction and change how the decl loop makes state.

### DIFF
--- a/toolchain/parse/handle_binding_pattern.cpp
+++ b/toolchain/parse/handle_binding_pattern.cpp
@@ -12,15 +12,15 @@ auto HandleBindingPattern(Context& context) -> void {
   // Parameters may have keywords prefixing the pattern. They become the parent
   // for the full BindingPattern.
   if (auto token = context.ConsumeIf(Lex::TokenKind::Template)) {
-    context.PushState(Context::StateStackEntry(
-        State::BindingPatternTemplate, PrecedenceGroup::ForTopLevelExpr(),
-        PrecedenceGroup::ForTopLevelExpr(), *token, state.subtree_start));
+    context.PushState({.state = State::BindingPatternTemplate,
+                       .token = *token,
+                       .subtree_start = state.subtree_start});
   }
 
   if (auto token = context.ConsumeIf(Lex::TokenKind::Addr)) {
-    context.PushState(Context::StateStackEntry(
-        State::BindingPatternAddress, PrecedenceGroup::ForTopLevelExpr(),
-        PrecedenceGroup::ForTopLevelExpr(), *token, state.subtree_start));
+    context.PushState({.state = State::BindingPatternAddress,
+                       .token = *token,
+                       .subtree_start = state.subtree_start});
   }
 
   // Handle an invalid pattern introducer for parameters and variables.

--- a/toolchain/parse/state.def
+++ b/toolchain/parse/state.def
@@ -53,6 +53,10 @@
   CARBON_PARSE_STATE_VARIANT(State, Variant1)                             \
   CARBON_PARSE_STATE_VARIANTS3(State, Variant2, Variant3, Variant4)
 
+// Used as a default for StateStackEntry initialization in some cases. Should
+// not be put on the state stack.
+CARBON_PARSE_STATE(Invalid)
+
 // Handles an index expression:
 //
 // a[0]
@@ -1039,7 +1043,8 @@ CARBON_PARSE_STATE_VARIANTS3(TypeDefinitionFinish, Class, Interface,
 //                           ^
 //   1. DeclNameAndParamsAsOptional
 //   2. TypeAfterParamsAs(Class|Interface|NamedConstraint)
-CARBON_PARSE_STATE_VARIANTS3(TypeAfterIntroducer, Class, Interface, NamedConstraint)
+CARBON_PARSE_STATE_VARIANTS3(TypeAfterIntroducer, Class, Interface,
+                             NamedConstraint)
 
 // Handles processing of a type after its optional parameters.
 //

--- a/toolchain/parse/tree.cpp
+++ b/toolchain/parse/tree.cpp
@@ -15,6 +15,11 @@
 
 namespace Carbon::Parse {
 
+auto HandleInvalid(Context& context) -> void {
+  CARBON_FATAL() << "The Invalid state shouldn't be on the stack: "
+                 << context.PopState();
+}
+
 auto Tree::Parse(Lex::TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
                  llvm::raw_ostream* vlog_stream) -> Tree {
   Lex::TokenLocationTranslator translator(&tokens);


### PR DESCRIPTION
Building on #3463. The PushState+PopState to construct a state feels worth cleanup. The rest is just kind of making it easier to do without adding another PushState overload.