### PR TITLE
Fix clang-tidy issues in common and testing

### DIFF
--- a/common/struct_reflection.h
+++ b/common/struct_reflection.h
@@ -36,8 +36,11 @@ namespace Internal {
 template <typename T>
 struct AnyField {
   template <typename FieldT>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator FieldT&() const;
+
   template <typename FieldT>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator FieldT&&() const;
 
   // Don't allow conversion to T itself. This ensures we don't match against a
@@ -52,11 +55,11 @@ struct AnyField {
 
 // Detector for whether we can list-initialize T from the given list of fields.
 template <typename T, typename... Fields>
-constexpr bool CanListInitialize(decltype(T{Fields()...})*) {
+constexpr auto CanListInitialize(decltype(T{Fields()...})* /*unused*/) -> bool {
   return true;
 }
 template <typename T, typename... Fields>
-constexpr bool CanListInitialize(...) {
+constexpr auto CanListInitialize(...) -> bool {
   return false;
 }
 

--- a/common/struct_reflection_test.cpp
+++ b/common/struct_reflection_test.cpp
@@ -25,7 +25,7 @@ struct ReferenceField {
 };
 
 struct NoDefaultConstructor {
-  NoDefaultConstructor(int n) : v(n) {}
+  explicit NoDefaultConstructor(int n) : v(n) {}
   int v;
 };
 
@@ -42,8 +42,8 @@ TEST(StructReflectionTest, CanListInitialize) {
   {
     using Type = OneField;
     using Field = Internal::AnyField<Type>;
-    static_assert(Internal::CanListInitialize<Type>(0));
-    static_assert(Internal::CanListInitialize<Type, Field>(0));
+    static_assert(Internal::CanListInitialize<Type>(nullptr));
+    static_assert(Internal::CanListInitialize<Type, Field>(nullptr));
     static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
   }
 
@@ -51,7 +51,7 @@ TEST(StructReflectionTest, CanListInitialize) {
     using Type = OneFieldNoDefaultConstructor;
     using Field = Internal::AnyField<Type>;
     static_assert(!Internal::CanListInitialize<Type>(0));
-    static_assert(Internal::CanListInitialize<Type, Field>(0));
+    static_assert(Internal::CanListInitialize<Type, Field>(nullptr));
     static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
   }
 }
@@ -82,7 +82,8 @@ TEST(StructReflectionTest, TwoField) {
 
 TEST(StructReflectionTest, NoDefaultConstructor) {
   std::tuple<NoDefaultConstructor, NoDefaultConstructor> fields =
-      AsTuple(TwoFieldsNoDefaultConstructor{.x = 1, .y = 2});
+      AsTuple(TwoFieldsNoDefaultConstructor{.x = NoDefaultConstructor(1),
+                                            .y = NoDefaultConstructor(2)});
   EXPECT_EQ(std::get<0>(fields).v, 1);
   EXPECT_EQ(std::get<1>(fields).v, 2);
 }

--- a/testing/file_test/line.h
+++ b/testing/file_test/line.h
@@ -15,7 +15,7 @@ class FileTestLineBase : public Printable<FileTestLineBase> {
  public:
   explicit FileTestLineBase(int file_number, int line_number)
       : file_number_(file_number), line_number_(line_number) {}
-  virtual ~FileTestLineBase() {}
+  virtual ~FileTestLineBase() = default;
 
   // Prints the autoupdated line.
   virtual auto Print(llvm::raw_ostream& out) const -> void = 0;


### PR DESCRIPTION
Choosing to make the constructor explicit in the test, rather than NOLINT, because it seems to better reflect how our code is usually written (and may be more likely to trip an issue).