### PR TITLE
Upgrade clang-format version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,14 +72,14 @@ repos:
         types_or: [c++, proto]
         language: python
         args: ['-i']
-        additional_dependencies: ['clang-format==16.0.6']
+        additional_dependencies: ['clang-format==17.0.1']
       - id: explorer-format-grammar
         name: Format the explorer grammar file
         entry: explorer/syntax/format_grammar.py
         language: python
         files: ^explorer/syntax/(lexer.lpp|parser.ypp)$
         pass_filenames: false
-        additional_dependencies: ['clang-format==16.0.6']
+        additional_dependencies: ['clang-format==17.0.1']
 
   - repo: local
     hooks:

--- a/explorer/syntax/parse_and_lex_context.h
+++ b/explorer/syntax/parse_and_lex_context.h
@@ -65,7 +65,7 @@ class ParseAndLexContext {
 #define YY_DECL                                                             \
   auto yylex(Carbon::Nonnull<Carbon::Arena*> /*arena*/, yyscan_t yyscanner, \
              Carbon::ParseAndLexContext& context)                           \
-      ->Carbon::Parser::symbol_type
+      -> Carbon::Parser::symbol_type
 
 // Declares yylex for the parser's sake.
 YY_DECL;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -170,7 +170,7 @@ extern auto GetFileTestFactory() -> FileTestFactory;
 
 // Provides a standard GetFileTestFactory implementation.
 #define CARBON_FILE_TEST_FACTORY(Name)                                   \
-  auto GetFileTestFactory()->FileTestFactory {                           \
+  auto GetFileTestFactory() -> FileTestFactory {                         \
     return {#Name, [](llvm::StringRef path) { return new Name(path); }}; \
   }
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -499,7 +499,7 @@ class Context {
 
 // Parse node handlers. Returns false for unrecoverable errors.
 #define CARBON_PARSE_NODE_KIND(Name) \
-  auto Handle##Name(Context& context, Parse::NodeId parse_node)->bool;
+  auto Handle##Name(Context& context, Parse::NodeId parse_node) -> bool;
 #include "toolchain/parse/node_kind.def"
 
 }  // namespace Carbon::Check

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -67,7 +67,7 @@ static auto HandleModifier(Context& context, Parse::NodeId parse_node,
 #define CARBON_PARSE_NODE_KIND(...)
 #define CARBON_PARSE_NODE_KIND_TOKEN_MODIFIER(Name, ...)                  \
   auto Handle##Name##Modifier(Context& context, Parse::NodeId parse_node) \
-      ->bool {                                                            \
+      -> bool {                                                           \
     return HandleModifier(context, parse_node, KeywordModifierSet::Name); \
   }
 #include "toolchain/parse/node_kind.def"

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -489,8 +489,7 @@ static auto DispatchNext(Lexer& lexer, llvm::StringRef source_text,
 // and continuing the dispatch.
 #define CARBON_DISPATCH_LEX_TOKEN(LexMethod)                                 \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     Lexer::LexResult result = lexer.LexMethod(source_text, position);        \
     CARBON_CHECK(result) << "Failed to form a token!";                       \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
@@ -503,17 +502,16 @@ CARBON_DISPATCH_LEX_TOKEN(LexNumericLiteral)
 CARBON_DISPATCH_LEX_TOKEN(LexStringLiteral)
 
 // A custom dispatch functions that pre-select the symbol token to lex.
-#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                        \
-  static auto Dispatch##LexMethod##SymbolToken(                            \
-      Lexer& lexer, llvm::StringRef source_text, ssize_t position)         \
-      ->void {                                                             \
-    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                \
-        source_text,                                                       \
-        OneCharTokenKindTable[static_cast<unsigned char>(                  \
-            source_text[position])],                                       \
-        position);                                                         \
-    CARBON_CHECK(result) << "Failed to form a token!";                     \
-    [[clang::musttail]] return DispatchNext(lexer, source_text, position); \
+#define CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexMethod)                          \
+  static auto Dispatch##LexMethod##SymbolToken(                              \
+      Lexer& lexer, llvm::StringRef source_text, ssize_t position) -> void { \
+    Lexer::LexResult result = lexer.LexMethod##SymbolToken(                  \
+        source_text,                                                         \
+        OneCharTokenKindTable[static_cast<unsigned char>(                    \
+            source_text[position])],                                         \
+        position);                                                           \
+    CARBON_CHECK(result) << "Failed to form a token!";                       \
+    [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOneChar)
 CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexOpening)
@@ -523,8 +521,7 @@ CARBON_DISPATCH_LEX_SYMBOL_TOKEN(LexClosing)
 // whitespace and comments.
 #define CARBON_DISPATCH_LEX_NON_TOKEN(LexMethod)                             \
   static auto Dispatch##LexMethod(Lexer& lexer, llvm::StringRef source_text, \
-                                  ssize_t position)                          \
-      ->void {                                                               \
+                                  ssize_t position) -> void {                \
     lexer.LexMethod(source_text, position);                                  \
     [[clang::musttail]] return DispatchNext(lexer, source_text, position);   \
   }

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -131,8 +131,7 @@ class FunctionContext {
 // Declare handlers for each SemIR::File instruction.
 #define CARBON_SEM_IR_INST_KIND(Name)                                \
   auto Handle##Name(FunctionContext& context, SemIR::InstId inst_id, \
-                    SemIR::Name inst)                                \
-      ->void;
+                    SemIR::Name inst) -> void;
 #include "toolchain/sem_ir/inst_kind.def"
 
 }  // namespace Carbon::Lower

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -401,9 +401,7 @@ class Context {
   Lex::TokenIndex first_non_packaging_token_ = Lex::TokenIndex::Invalid;
 };
 
-// `clang-format` has a bug with spacing around `->` returns in macros. See
-// https://bugs.llvm.org/show_bug.cgi?id=48320 for details.
-#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context)->void;
+#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
 #include "toolchain/parse/state.def"
 
 }  // namespace Carbon::Parse


### PR DESCRIPTION
This apparently includes a fix for https://github.com/llvm/llvm-project/issues/47664 (previously https://bugs.llvm.org/show_bug.cgi?id=48320)

Note this continues with a clang-format version that's different from the compiler versions we're often using, but the differences in formatting seem worthwhile.