### PR TITLE
Avoid unnecessary const_cast<>

### DIFF
--- a/explorer/main.cpp
+++ b/explorer/main.cpp
@@ -30,7 +30,7 @@ namespace Carbon {
 namespace cl = llvm::cl;
 namespace path = llvm::sys::path;
 
-auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
+auto ExplorerMain(int argc, const char** argv, void* static_for_main_addr,
                   llvm::StringRef relative_prelude_path) -> int {
   llvm::setBugReportMsg(
       "Please report issues to "
@@ -46,9 +46,9 @@ auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
       llvm::sys::fs::getMainExecutable(argv[0], static_for_main_addr);
   llvm::StringRef install_path = path::parent_path(exe);
 
-  return ExplorerMain(argc, const_cast<const char**>(argv), install_path,
-                      relative_prelude_path, llvm::outs(), llvm::errs(),
-                      llvm::outs(), *llvm::vfs::getRealFileSystem());
+  return ExplorerMain(argc, argv, install_path, relative_prelude_path,
+                      llvm::outs(), llvm::errs(), llvm::outs(),
+                      *llvm::vfs::getRealFileSystem());
 }
 
 auto ExplorerMain(int argc, const char** argv, llvm::StringRef install_path,

--- a/explorer/main.h
+++ b/explorer/main.h
@@ -13,7 +13,7 @@ namespace Carbon {
 
 // Runs explorer. relative_prelude_path must be POSIX-style, not native, and
 // will be translated to native.
-auto ExplorerMain(int argc, char** argv, void* static_for_main_addr,
+auto ExplorerMain(int argc, const char** argv, void* static_for_main_addr,
                   llvm::StringRef relative_prelude_path) -> int;
 
 // Wrapped by the above, but without some process init. This is used directly by

--- a/explorer/main_bin.cpp
+++ b/explorer/main_bin.cpp
@@ -5,7 +5,7 @@
 #include "common/bazel_working_dir.h"
 #include "explorer/main.h"
 
-auto main(int argc, char** argv) -> int {
+auto main(int argc, const char** argv) -> int {
   Carbon::SetWorkingDirForBazel();
 
   static int static_for_main_addr;

--- a/installers/local/carbon.cpp
+++ b/installers/local/carbon.cpp
@@ -5,7 +5,7 @@
 #include "explorer/main.h"
 #include "llvm/Support/Path.h"
 
-auto main(int argc, char** argv) -> int {
+auto main(int argc, const char** argv) -> int {
   llvm::StringRef bin = llvm::sys::path::filename(argv[0]);
   if (bin == "carbon-explorer") {
     static int static_for_main_addr;


### PR DESCRIPTION
I noticed there is an unnecessary `const_cast` in the Explorer. `ExplorerMain(...)` can just receive `argv` as const in my opinion, I apologize if that casting was intended.