### PR TITLE
Pop decl state stack earlier

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -43,6 +43,7 @@ static auto BuildClassDecl(Context& context)
       : !!(modifiers & KeywordModifierSet::Base)   ? SemIR::Class::Base
                                                    : SemIR::Class::Final;
 
+  context.decl_state_stack().Pop(DeclState::Class);
   auto decl_block_id = context.inst_block_stack().Pop();
 
   // Add the class declaration.
@@ -114,7 +115,6 @@ static auto BuildClassDecl(Context& context)
 auto HandleClassDecl(Context& context, Parse::NodeId /*parse_node*/) -> bool {
   BuildClassDecl(context);
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Class);
   return true;
 }
 
@@ -270,7 +270,6 @@ auto HandleClassDefinition(Context& context, Parse::NodeId parse_node) -> bool {
   context.inst_block_stack().Pop();
   context.PopScope();
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Class);
 
   // The class type is now fully defined.
   auto& class_info = context.classes().Get(class_id);

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -105,6 +105,7 @@ static auto BuildFunctionDecl(Context& context, bool is_definition)
     context.TODO(context.decl_state_stack().innermost().saw_decl_modifier,
                  "interface modifier");
   }
+  context.decl_state_stack().Pop(DeclState::Fn);
 
   // Add the function declaration.
   auto function_decl = SemIR::FunctionDecl{
@@ -178,7 +179,6 @@ auto HandleFunctionDecl(Context& context, Parse::NodeId /*parse_node*/)
     -> bool {
   BuildFunctionDecl(context, /*is_definition=*/false);
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Fn);
   return true;
 }
 
@@ -204,7 +204,6 @@ auto HandleFunctionDefinition(Context& context, Parse::NodeId parse_node)
   context.inst_block_stack().Pop();
   context.return_scope_stack().pop_back();
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Fn);
   return true;
 }
 

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -37,6 +37,7 @@ static auto BuildInterfaceDecl(Context& context)
     context.TODO(context.decl_state_stack().innermost().saw_access_modifier,
                  "access modifier");
   }
+  context.decl_state_stack().Pop(DeclState::Interface);
 
   auto decl_block_id = context.inst_block_stack().Pop();
 
@@ -87,7 +88,6 @@ auto HandleInterfaceDecl(Context& context, Parse::NodeId /*parse_node*/)
     -> bool {
   BuildInterfaceDecl(context);
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Interface);
   return true;
 }
 
@@ -142,7 +142,6 @@ auto HandleInterfaceDefinition(Context& context, Parse::NodeId /*parse_node*/)
   context.inst_block_stack().Pop();
   context.PopScope();
   context.decl_name_stack().PopScope();
-  context.decl_state_stack().Pop(DeclState::Interface);
 
   // The interface type is now fully defined.
   auto& interface_info = context.interfaces().Get(interface_id);


### PR DESCRIPTION
Since we switched to using the scope stack instead of the decl state stack to hold information about the containing definition in #3460 , we can now pop the decl state at the end of the declaration instead of the end of the body of the definition.