### PR TITLE
Underline the complete declaration in diagnostics

### DIFF
--- a/toolchain/check/decl_state.h
+++ b/toolchain/check/decl_state.h
@@ -62,8 +62,7 @@ struct DeclState {
     Var
   };
 
-  explicit DeclState(DeclKind decl_kind, Parse::NodeId parse_node)
-      : kind(decl_kind), first_node(parse_node) {}
+  explicit DeclState(DeclKind decl_kind) : kind(decl_kind) {}
 
   DeclKind kind;
 
@@ -75,9 +74,6 @@ struct DeclState {
   // Invariant: contains just the modifiers represented by `saw_access_modifier`
   // and `saw_other_modifier`.
   KeywordModifierSet modifier_set = KeywordModifierSet::None;
-
-  // Node corresponding to the first token of the declaration.
-  Parse::NodeId first_node;
 };
 
 // Stack of `DeclState` values, representing all the declarations we are
@@ -85,15 +81,10 @@ struct DeclState {
 // Invariant: Bottom of the stack always has a "DeclState::FileScope" entry.
 class DeclStateStack {
  public:
-  DeclStateStack() {
-    stack_.emplace_back(DeclState::FileScope, Parse::NodeId::Invalid);
-  }
+  DeclStateStack() { stack_.emplace_back(DeclState::FileScope); }
 
-  // Enters a declaration of kind `k`, with `parse_node` for the introducer
-  // token.
-  auto Push(DeclState::DeclKind k, Parse::NodeId parse_node) -> void {
-    stack_.push_back(DeclState(k, parse_node));
-  }
+  // Enters a declaration of kind `k`.
+  auto Push(DeclState::DeclKind k) -> void { stack_.emplace_back(k); }
 
   // Gets the state of declaration at the top of the stack -- the innermost
   // declaration currently being processed.

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -183,8 +183,7 @@ auto HandleBaseDecl(Context& context, Parse::NodeId parse_node) -> bool {
   if (!(modifiers & KeywordModifierSet::Extend)) {
     CARBON_DIAGNOSTIC(BaseMissingExtend, Error,
                       "Missing `extend` before `base` declaration in class.");
-    context.emitter().Emit(context.decl_state_stack().innermost().first_node,
-                           BaseMissingExtend);
+    context.emitter().Emit(parse_node, BaseMissingExtend);
   }
   context.decl_state_stack().Pop(DeclState::Base);
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -15,7 +15,7 @@ auto HandleClassIntroducer(Context& context, Parse::NodeId parse_node) -> bool {
   // Push the bracketing node.
   context.node_stack().Push(parse_node);
   // Optional modifiers and the name follow.
-  context.decl_state_stack().Push(DeclState::Class, parse_node);
+  context.decl_state_stack().Push(DeclState::Class);
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }
@@ -163,8 +163,9 @@ auto HandleClassDefinitionStart(Context& context, Parse::NodeId parse_node)
   return true;
 }
 
-auto HandleBaseIntroducer(Context& context, Parse::NodeId parse_node) -> bool {
-  context.decl_state_stack().Push(DeclState::Base, parse_node);
+auto HandleBaseIntroducer(Context& context, Parse::NodeId /*parse_node*/)
+    -> bool {
+  context.decl_state_stack().Push(DeclState::Base);
   return true;
 }
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -276,7 +276,7 @@ auto HandleFunctionIntroducer(Context& context, Parse::NodeId parse_node)
   // Push the bracketing node.
   context.node_stack().Push(parse_node);
   // Optional modifiers and the name follow.
-  context.decl_state_stack().Push(DeclState::Fn, parse_node);
+  context.decl_state_stack().Push(DeclState::Fn);
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -43,7 +43,8 @@ static auto DiagnoseModifiers(Context& context) -> KeywordModifierSet {
 // Build a FunctionDecl describing the signature of a function. This
 // handles the common logic shared by function declaration syntax and function
 // definition syntax.
-static auto BuildFunctionDecl(Context& context, bool is_definition)
+static auto BuildFunctionDecl(Context& context, Parse::NodeId parse_node,
+                              bool is_definition)
     -> std::pair<SemIR::FunctionId, SemIR::InstId> {
   // TODO: This contains the IR block for the parameters and return type. At
   // present, it's just loose, but it's not strictly required for parameter
@@ -88,8 +89,6 @@ static auto BuildFunctionDecl(Context& context, bool is_definition)
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::FunctionIntroducer>();
 
-  auto first_node = context.decl_state_stack().innermost().first_node;
-
   // Process modifiers.
   auto modifiers = DiagnoseModifiers(context);
   if (!!(modifiers & KeywordModifierSet::Access)) {
@@ -110,7 +109,7 @@ static auto BuildFunctionDecl(Context& context, bool is_definition)
 
   // Add the function declaration.
   auto function_decl = SemIR::FunctionDecl{
-      first_node, context.GetBuiltinType(SemIR::BuiltinKind::FunctionType),
+      parse_node, context.GetBuiltinType(SemIR::BuiltinKind::FunctionType),
       SemIR::FunctionId::Invalid};
   auto function_decl_id = context.AddInst(function_decl);
 
@@ -165,20 +164,19 @@ static auto BuildFunctionDecl(Context& context, bool is_definition)
         (return_slot_id.is_valid() &&
          return_type_id !=
              context.GetBuiltinType(SemIR::BuiltinKind::BoolType) &&
-         return_type_id != context.CanonicalizeTupleType(first_node, {}))) {
+         return_type_id != context.CanonicalizeTupleType(parse_node, {}))) {
       CARBON_DIAGNOSTIC(InvalidMainRunSignature, Error,
                         "Invalid signature for `Main.Run` function. Expected "
                         "`fn ()` or `fn () -> i32`.");
-      context.emitter().Emit(first_node, InvalidMainRunSignature);
+      context.emitter().Emit(parse_node, InvalidMainRunSignature);
     }
   }
 
   return {function_decl.function_id, function_decl_id};
 }
 
-auto HandleFunctionDecl(Context& context, Parse::NodeId /*parse_node*/)
-    -> bool {
-  BuildFunctionDecl(context, /*is_definition=*/false);
+auto HandleFunctionDecl(Context& context, Parse::NodeId parse_node) -> bool {
+  BuildFunctionDecl(context, parse_node, /*is_definition=*/false);
   context.decl_name_stack().PopScope();
   return true;
 }
@@ -212,7 +210,7 @@ auto HandleFunctionDefinitionStart(Context& context, Parse::NodeId parse_node)
     -> bool {
   // Process the declaration portion of the function.
   auto [function_id, decl_id] =
-      BuildFunctionDecl(context, /*is_definition=*/true);
+      BuildFunctionDecl(context, parse_node, /*is_definition=*/true);
   auto& function = context.functions().Get(function_id);
 
   // Track that this declaration is the definition.

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -15,7 +15,7 @@ auto HandleInterfaceIntroducer(Context& context, Parse::NodeId parse_node)
   // Push the bracketing node.
   context.node_stack().Push(parse_node);
   // Optional modifiers and the name follow.
-  context.decl_state_stack().Push(DeclState::Interface, parse_node);
+  context.decl_state_stack().Push(DeclState::Interface);
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -20,12 +20,11 @@ auto HandleInterfaceIntroducer(Context& context, Parse::NodeId parse_node)
   return true;
 }
 
-static auto BuildInterfaceDecl(Context& context)
+static auto BuildInterfaceDecl(Context& context, Parse::NodeId parse_node)
     -> std::tuple<SemIR::InterfaceId, SemIR::InstId> {
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::InterfaceIntroducer>();
-  auto first_node = context.decl_state_stack().innermost().first_node;
 
   // Process modifiers.
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Interface);
@@ -43,7 +42,7 @@ static auto BuildInterfaceDecl(Context& context)
 
   // Add the interface declaration.
   auto interface_decl = SemIR::InterfaceDecl{
-      first_node, SemIR::InterfaceId::Invalid, decl_block_id};
+      parse_node, SemIR::InterfaceId::Invalid, decl_block_id};
   auto interface_decl_id = context.AddInst(interface_decl);
 
   // Check whether this is a redeclaration.
@@ -84,16 +83,16 @@ static auto BuildInterfaceDecl(Context& context)
   return {interface_decl.interface_id, interface_decl_id};
 }
 
-auto HandleInterfaceDecl(Context& context, Parse::NodeId /*parse_node*/)
-    -> bool {
-  BuildInterfaceDecl(context);
+auto HandleInterfaceDecl(Context& context, Parse::NodeId parse_node) -> bool {
+  BuildInterfaceDecl(context, parse_node);
   context.decl_name_stack().PopScope();
   return true;
 }
 
 auto HandleInterfaceDefinitionStart(Context& context, Parse::NodeId parse_node)
     -> bool {
-  auto [interface_id, interface_decl_id] = BuildInterfaceDecl(context);
+  auto [interface_id, interface_decl_id] =
+      BuildInterfaceDecl(context, parse_node);
   auto& interface_info = context.interfaces().Get(interface_id);
 
   // Track that this declaration is the definition.

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -57,7 +57,7 @@ auto HandleLetDecl(Context& context, Parse::NodeId parse_node) -> bool {
 }
 
 auto HandleLetIntroducer(Context& context, Parse::NodeId parse_node) -> bool {
-  context.decl_state_stack().Push(DeclState::Let, parse_node);
+  context.decl_state_stack().Push(DeclState::Let);
   // Push a bracketing node to establish the pattern context.
   context.node_stack().Push(parse_node);
   return true;

--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -57,9 +57,6 @@ static auto HandleModifier(Context& context, Parse::NodeId parse_node,
   } else {
     s.modifier_set |= keyword;
     saw_modifier = parse_node;
-    if (is_access || !s.saw_access_modifier.is_valid()) {
-      s.first_node = parse_node;
-    }
   }
   return true;
 }

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -9,9 +9,10 @@
 
 namespace Carbon::Check {
 
-auto HandleNamespaceStart(Context& context, Parse::NodeId parse_node) -> bool {
+auto HandleNamespaceStart(Context& context, Parse::NodeId /*parse_node*/)
+    -> bool {
   // Optional modifiers and the name follow.
-  context.decl_state_stack().Push(DeclState::Namespace, parse_node);
+  context.decl_state_stack().Push(DeclState::Namespace);
   context.decl_name_stack().PushScopeAndStartName();
   return true;
 }

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -16,13 +16,12 @@ auto HandleNamespaceStart(Context& context, Parse::NodeId parse_node) -> bool {
   return true;
 }
 
-auto HandleNamespace(Context& context, Parse::NodeId /*parse_node*/) -> bool {
+auto HandleNamespace(Context& context, Parse::NodeId parse_node) -> bool {
   auto name_context = context.decl_name_stack().FinishName();
-  auto first_node = context.decl_state_stack().innermost().first_node;
   LimitModifiersOnDecl(context, KeywordModifierSet::None,
                        Lex::TokenKind::Namespace);
   auto namespace_id = context.AddInst(SemIR::Namespace{
-      first_node, context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
+      parse_node, context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
       context.name_scopes().Add()});
   context.decl_name_stack().AddNameToLookup(name_context, namespace_id);
 

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -13,7 +13,7 @@ auto HandleVariableIntroducer(Context& context, Parse::NodeId parse_node)
     -> bool {
   // No action, just a bracketing node.
   context.node_stack().Push(parse_node);
-  context.decl_state_stack().Push(DeclState::Var, parse_node);
+  context.decl_state_stack().Push(DeclState::Var);
   return true;
 }
 

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -11,7 +11,7 @@ class Incomplete;
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_incomplete_element.carbon:[[@LINE-5]]:1: Class was forward declared here.
 // CHECK:STDERR: class Incomplete;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 var a: [Incomplete; 1];
 
 // CHECK:STDERR: fail_incomplete_element.carbon:[[@LINE+3]]:1: ERROR: Cannot implicitly convert from `<error>*` to `Incomplete*`.

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -6,7 +6,7 @@
 
 // CHECK:STDERR: fail_bad_run.carbon:[[@LINE+6]]:1: ERROR: Invalid signature for `Main.Run` function. Expected `fn ()` or `fn () -> i32`.
 // CHECK:STDERR: fn Run() -> String {}
-// CHECK:STDERR: ^~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_bad_run.carbon:[[@LINE+3]]:21: ERROR: Missing `return` at end of function with declared return type.
 // CHECK:STDERR: fn Run() -> String {}
 // CHECK:STDERR:                     ^

--- a/toolchain/check/testdata/basics/fail_bad_run_2.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run_2.carbon
@@ -6,7 +6,7 @@
 
 // CHECK:STDERR: fail_bad_run_2.carbon:[[@LINE+3]]:1: ERROR: Invalid signature for `Main.Run` function. Expected `fn ()` or `fn () -> i32`.
 // CHECK:STDERR: fn Run(n: i32) {}
-// CHECK:STDERR: ^~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
 fn Run(n: i32) {}
 
 // CHECK:STDOUT: --- fail_bad_run_2.carbon

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -53,7 +53,7 @@ class DeriveFromIncomplete {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE-6]]:1: Class was forward declared here.
   // CHECK:STDERR: base class Incomplete;
-  // CHECK:STDERR: ^~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
   extend base: Incomplete;
 }
 
@@ -81,7 +81,7 @@ fn ConvertToBadBaseFinal(p: DeriveFromFinal*) -> Final* { return p; }
 // CHECK:STDOUT:   %.loc32_22: type = tuple_type (type)
 // CHECK:STDOUT:   %.loc32_23.1: type = tuple_type (Base)
 // CHECK:STDOUT:   %.loc7_18.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_1: type = ptr_type {}
+// CHECK:STDOUT:   %.loc7_17: type = ptr_type {}
 // CHECK:STDOUT:   %.loc32_23.2: type = tuple_type ({}*)
 // CHECK:STDOUT:   %.loc33_1.1: type = struct_type {.base: (Base,)}
 // CHECK:STDOUT:   %.loc33_1.2: type = struct_type {.base: ({}*,)}

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -48,7 +48,7 @@ class C4 {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_15.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_1: type = ptr_type {}
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}
 // CHECK:STDOUT:   %.loc14: type = struct_type {.base: B}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -19,7 +19,7 @@ class C2 {
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+3]]:3: ERROR: Missing `extend` before `base` declaration in class.
   // CHECK:STDERR:   abstract base: B;
-  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
   abstract base: B;
 }
 

--- a/toolchain/check/testdata/class/fail_base_no_extend.carbon
+++ b/toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -9,7 +9,7 @@ base class B {}
 class C {
   // CHECK:STDERR: fail_base_no_extend.carbon:[[@LINE+3]]:3: ERROR: Missing `extend` before `base` declaration in class.
   // CHECK:STDERR:   base: B;
-  // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR:   ^~~~~~~~
   base: B;
 }
 

--- a/toolchain/check/testdata/class/fail_base_no_extend.carbon
+++ b/toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -18,7 +18,7 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_15.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_1: type = ptr_type {}
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}
 // CHECK:STDOUT:   %.loc14: type = struct_type {.base: B}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_repeated.carbon
+++ b/toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -35,7 +35,7 @@ class D {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_16.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_16.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_1: type = ptr_type {}
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type {}
 // CHECK:STDOUT:   %.loc19: type = struct_type {.base: B1}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_unbound.carbon
+++ b/toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -20,7 +20,7 @@ let b: B = C.base;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}
 // CHECK:STDOUT:   %.loc7_15.2: type = tuple_type ()
-// CHECK:STDOUT:   %.loc7_1: type = ptr_type {}
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}
 // CHECK:STDOUT:   %.loc11: type = struct_type {.base: B}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -11,7 +11,7 @@ class Class;
 // CHECK:STDERR:    ^~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-5]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 fn Class.Function() {}
 
 fn CallClassFunction() {
@@ -20,7 +20,7 @@ fn CallClassFunction() {
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-14]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~
   Class.Function();
 }
 
@@ -29,7 +29,7 @@ fn CallClassFunction() {
 // CHECK:STDERR:                 ^~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-23]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 var global_var: Class;
 
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:24: ERROR: Function returns incomplete type `Class`.
@@ -37,7 +37,7 @@ var global_var: Class;
 // CHECK:STDERR:                        ^~~~~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-31]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 fn ConvertFromStruct() -> Class { return {}; }
 
 // TODO: Once the `->` operator is supported:
@@ -51,7 +51,7 @@ fn MemberAccess(p: Class*) -> i32 {
   // CHECK:STDERR:           ^~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-45]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~
   return (*p).n;
 }
 
@@ -60,7 +60,7 @@ fn MemberAccess(p: Class*) -> i32 {
 // CHECK:STDERR:                    ^~~~~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-54]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 fn Copy(p: Class*) -> Class {
   return *p;
 }
@@ -71,7 +71,7 @@ fn Let(p: Class*) {
   // CHECK:STDERR:          ^~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-65]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~
   let c: Class = *p;
 }
 
@@ -84,7 +84,7 @@ fn TakeIncomplete(c: Class);
 // CHECK:STDERR:                       ^~~~~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-78]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 fn ReturnIncomplete() -> Class;
 
 fn CallTakeIncomplete(p: Class*) {
@@ -93,10 +93,10 @@ fn CallTakeIncomplete(p: Class*) {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-87]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-19]]:1: Initializing parameter 1 of function declared here.
   // CHECK:STDERR: fn TakeIncomplete(c: Class);
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
   TakeIncomplete(*p);
 
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+9]]:3: ERROR: Forming value of incomplete type `Class`.
@@ -104,10 +104,10 @@ fn CallTakeIncomplete(p: Class*) {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-98]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-30]]:1: Initializing parameter 1 of function declared here.
   // CHECK:STDERR: fn TakeIncomplete(c: Class);
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
   TakeIncomplete({});
 }
 

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -19,14 +19,14 @@ fn F(c: Class) {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_method.carbon:[[@LINE-11]]:3: Calling function declared here.
   // CHECK:STDERR:   fn WithSelf[self: Class]();
-  // CHECK:STDERR:   ^~
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   Class.WithSelf();
   // CHECK:STDERR: fail_method.carbon:[[@LINE+6]]:3: ERROR: 1 argument(s) passed to function expecting 0 argument(s).
   // CHECK:STDERR:   Class.WithSelf(c);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_method.carbon:[[@LINE-18]]:3: Calling function declared here.
   // CHECK:STDERR:   fn WithSelf[self: Class]();
-  // CHECK:STDERR:   ^~
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   Class.WithSelf(c);
 }
 

--- a/toolchain/check/testdata/class/fail_method_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_method_modifiers.carbon
@@ -11,7 +11,7 @@ class FinalClass {
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-5]]:1: Containing definition here.
   // CHECK:STDERR: class FinalClass {
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
   abstract fn Abstract[self: Self]();
 
   // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+6]]:3: ERROR: `virtual` not allowed on `fn` declaration in a non-abstract non-base `class` definition.
@@ -19,7 +19,7 @@ class FinalClass {
   // CHECK:STDERR:   ^~~~~~~
   // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-13]]:1: Containing definition here.
   // CHECK:STDERR: class FinalClass {
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
   virtual fn Virtual[self: Self]();
 }
 
@@ -43,7 +43,7 @@ base class BaseClass {
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-5]]:1: Containing definition here.
   // CHECK:STDERR: base class BaseClass {
-  // CHECK:STDERR: ^~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
   abstract fn Abstract[self: Self]();
 }
 

--- a/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
@@ -7,71 +7,71 @@
 class A;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class A {}
-// CHECK:STDERR: ^~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class A;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~
 base class A {}
 
 class B;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class B {}
-// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class B;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~
 abstract class B {}
 
 base class C;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: class C {}
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: base class C;
-// CHECK:STDERR: ^~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 class C {}
 
 base class D;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class D {}
-// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: base class D;
-// CHECK:STDERR: ^~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 abstract class D {}
 
 abstract class E;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: class E {}
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: abstract class E;
-// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 class E {}
 
 abstract class F;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class F {}
-// CHECK:STDERR: ^~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: abstract class F;
-// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 base class F {}
 
 class G {}
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class G;
-// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class G {}
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~
 abstract class G;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class G;
-// CHECK:STDERR: ^~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-11]]:1: Previously declared here.
 // CHECK:STDERR: class G {}
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~
 base class G;
 
 // CHECK:STDOUT: --- fail_redeclaration_introducer.carbon

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -14,7 +14,7 @@ class Class {
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-8]]:1: Previous definition was here.
 // CHECK:STDERR: class Class {
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~
 class Class {
   fn G();
   fn H();

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -13,7 +13,7 @@ class Class {
     // CHECK:STDERR:            ^~~~~
     // CHECK:STDERR: fail_reorder.carbon:[[@LINE-7]]:1: Class is incomplete within its definition.
     // CHECK:STDERR: class Class {
-    // CHECK:STDERR: ^~~~~
+    // CHECK:STDERR: ^~~~~~~~~~~~~
     // CHECK:STDERR: fail_reorder.carbon:[[@LINE+3]]:12: ERROR: Name `F` not found.
     // CHECK:STDERR:     return Class.F();
     // CHECK:STDERR:            ^~~~~~~

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -15,7 +15,7 @@ class Class {
   // CHECK:STDERR:          ^~~~~~~~
   // CHECK:STDERR: fail_self.carbon:[[@LINE-9]]:1: Class is incomplete within its definition.
   // CHECK:STDERR: class Class {
-  // CHECK:STDERR: ^~~~~
+  // CHECK:STDERR: ^~~~~~~~~~~~~
   fn G() -> Class;
 }
 

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -14,14 +14,14 @@ fn Main() {
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-8]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run0() {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~
   Run0(1);
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 2 argument(s) passed to function expecting 0 argument(s).
   // CHECK:STDERR:   Run0(0, 1);
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-15]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run0() {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~
   Run0(0, 1);
 
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 0 argument(s) passed to function expecting 1 argument(s).
@@ -29,14 +29,14 @@ fn Main() {
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-22]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run1(a: i32) {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
   Run1();
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 2 argument(s) passed to function expecting 1 argument(s).
   // CHECK:STDERR:   Run1(0, 1);
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-29]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run1(a: i32) {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
   Run1(0, 1);
 
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 0 argument(s) passed to function expecting 2 argument(s).
@@ -44,14 +44,14 @@ fn Main() {
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-36]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run2(a: i32, b: i32) {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   Run2();
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 1 argument(s) passed to function expecting 2 argument(s).
   // CHECK:STDERR:   Run2(0);
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-43]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run2(a: i32, b: i32) {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   Run2(0);
 }
 

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -12,7 +12,7 @@ fn F() {
   // CHECK:STDERR:   ^~
   // CHECK:STDERR: fail_param_type.carbon:[[@LINE-6]]:1: Initializing parameter 1 of function declared here.
   // CHECK:STDERR: fn G(a: i32) {}
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~
   G(1.0);
 }
 

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -11,7 +11,7 @@ interface Interface { }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-5]]:1: Previous definition was here.
 // CHECK:STDERR: interface Interface { }
-// CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 interface Interface {
   fn F();
 }

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -23,7 +23,7 @@ fn Function();
 // CHECK:STDERR:           ^~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: fn Function();
-// CHECK:STDERR: ^~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 interface Function;
 
 class Class;
@@ -33,7 +33,7 @@ class Class;
 // CHECK:STDERR:           ^~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: class Class;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~
 interface Class { }
 
 // CHECK:STDOUT: --- fail_duplicate.carbon

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -14,7 +14,7 @@ fn Foo.Baz() {
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-6]]:1: Previous definition was here.
 // CHECK:STDERR: fn Foo.Baz() {
-// CHECK:STDERR: ^~
+// CHECK:STDERR: ^~~~~~~~~~~~~~
 fn Foo.Baz() {
 }
 

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -10,7 +10,7 @@ fn Procedure() {
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_returned_var_no_return_type.carbon:[[@LINE-4]]:1: There was no return type provided.
   // CHECK:STDERR: fn Procedure() {
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~
   returned var v: () = ();
   return;
 }

--- a/toolchain/check/testdata/return/fail_returned_var_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_type.carbon
@@ -10,7 +10,7 @@ fn Mismatch() -> i32 {
   // CHECK:STDERR:                   ^~~
   // CHECK:STDERR: fail_returned_var_type.carbon:[[@LINE-4]]:1: Return type of function is `i32`.
   // CHECK:STDERR: fn Mismatch() -> i32 {
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
   returned var v: f64 = 0.0;
   return var;
 }

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -10,7 +10,7 @@ fn Main() {
   // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR: fail_value_disallowed.carbon:[[@LINE-4]]:1: There was no return type provided.
   // CHECK:STDERR: fn Main() {
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~
   return 0;
 }
 

--- a/toolchain/check/testdata/return/fail_value_missing.carbon
+++ b/toolchain/check/testdata/return/fail_value_missing.carbon
@@ -10,7 +10,7 @@ fn Main() -> i32 {
   // CHECK:STDERR:   ^~~~~~~
   // CHECK:STDERR: fail_value_missing.carbon:[[@LINE-4]]:1: Return type of function is `i32`.
   // CHECK:STDERR: fn Main() -> i32 {
-  // CHECK:STDERR: ^~
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
   return;
 }
 

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -11,7 +11,7 @@ class Incomplete;
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: Class was forward declared here.
 // CHECK:STDERR: class Incomplete;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 var s: {.a: Incomplete};
 
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE+3]]:1: ERROR: Cannot implicitly convert from `<error>*` to `Incomplete*`.

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -11,7 +11,7 @@ class Incomplete;
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: Class was forward declared here.
 // CHECK:STDERR: class Incomplete;
-// CHECK:STDERR: ^~~~~
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 var t: (i32, Incomplete);
 
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE+3]]:1: ERROR: Cannot implicitly convert from `<error>*` to `Incomplete*`.


### PR DESCRIPTION
Builds upon @domisterwoozy 's excellent #3442 . Removes the need to store the first node of a declaration in the declaration state stack.