### PR TITLE
Ensure the module lockfile doesn't change in tests.yaml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -164,6 +164,9 @@ jobs:
           CACHE_VERSION: 1
         run: |
           cat >user.bazelrc <<EOF
+          # Make MODULE.bazel.lock updates an error in CI.
+          common --lockfile_mode=error
+
           # Enable remote cache for our CI but minimize downloads.
           build --remote_cache=https://storage.googleapis.com/carbon-builds-github-v${CACHE_VERSION}-${{ env.os_for_cache }}
           build --remote_download_minimal


### PR DESCRIPTION
Done separate from #3505 so that the target diff doesn't run bazel 6.0.0 on the "before". (note this will fail tests until #3505 is merged)