### PR TITLE
Correct accepted-proposal link

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ## Proposal lists
 
 -   [All proposals](https://github.com/carbon-language/carbon-lang/pulls?q=is%3Apr+label%3Aproposal)
--   [Accepted proposals](https://github.com/carbon-language/carbon-lang/pulls?q=is%3Apr+label%3A%22proposal+accepted%22)
+-   [Accepted proposals](https://github.com/carbon-language/carbon-lang/pulls?q=is%3Apr+label%3A%22proposal%22+is%3Amerged)
 
 ## Directory structure
 


### PR DESCRIPTION
It looks like we haven't used the "proposal accepted" label in about a year.
