### PR TITLE
Add a fallback for target-determinator failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -233,7 +233,12 @@ jobs:
           git fetch --depth=1 origin $GIT_BASE_SHA
 
           # Then use `target-determinator` as wrapped by our script.
-          ./scripts/target_determinator.py $GIT_BASE_SHA >$TARGETS_FILE
+          exit_code=0
+          ./scripts/target_determinator.py $GIT_BASE_SHA >$TARGETS_FILE || exit_code=$?
+          if (( $exit_code != 0 )); then
+            echo "./scripts/target_determinator.py failed! Running all tests."
+            echo "//..." >$TARGETS_FILE
+          fi
 
       # Build and run just the tests impacted by the PR or merge group.
       - name: Test (${{ matrix.build_mode }})


### PR DESCRIPTION
Add a workaround for target-determinator problems to prevent them from blocking changes (e.g., https://github.com/carbon-language/carbon-lang/actions/runs/7225229412/job/19694000744?pr=3514)

I was trying to do this in #3517, but that fails due to a zstd issue. #3514 changes how zstd is set up, but fails due to this issue. So now I'm trying to separate out this workaround to see if things come together.