### PR TITLE
`startswith` -> `starts_with` to match upstream

### DIFF
--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -755,7 +755,7 @@ auto Lexer::LexCommentOrSlash(llvm::StringRef source_text, ssize_t& position)
 }
 
 auto Lexer::LexComment(llvm::StringRef source_text, ssize_t& position) -> void {
-  CARBON_DCHECK(source_text.substr(position).startswith("//"));
+  CARBON_DCHECK(source_text.substr(position).starts_with("//"));
 
   // Any comment must be the only non-whitespace on the line.
   const auto* line_info = current_line_info();

--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -387,7 +387,7 @@ auto NumericLiteral::Parser::CheckDigitSeparatorPlacement(
 
 // Check that we don't have a '0' prefix on a non-zero decimal integer.
 auto NumericLiteral::Parser::CheckLeadingZero() -> bool {
-  if (radix_ == Radix::Decimal && int_part_.startswith("0") &&
+  if (radix_ == Radix::Decimal && int_part_.starts_with("0") &&
       int_part_ != "0") {
     CARBON_DIAGNOSTIC(UnknownBaseSpecifier, Error,
                       "Unknown base specifier in numeric literal.");

--- a/toolchain/lex/string_literal.cpp
+++ b/toolchain/lex/string_literal.cpp
@@ -40,10 +40,10 @@ auto StringLiteral::Introducer::Lex(llvm::StringRef source_text)
     -> std::optional<Introducer> {
   MultiLineKind kind = NotMultiLine;
   llvm::StringRef indicator;
-  if (source_text.startswith(MultiLineIndicator)) {
+  if (source_text.starts_with(MultiLineIndicator)) {
     kind = MultiLine;
     indicator = llvm::StringRef(MultiLineIndicator);
-  } else if (source_text.startswith(DoubleQuotedMultiLineIndicator)) {
+  } else if (source_text.starts_with(DoubleQuotedMultiLineIndicator)) {
     kind = MultiLineWithDoubleQuotes;
     indicator = llvm::StringRef(DoubleQuotedMultiLineIndicator);
   }
@@ -135,7 +135,7 @@ auto StringLiteral::Lex(llvm::StringRef source_text)
         break;
       case '\\':
         if (escape.size() == 1 ||
-            source_text.substr(cursor + 1).startswith(escape.substr(1))) {
+            source_text.substr(cursor + 1).starts_with(escape.substr(1))) {
           content_needs_validation = true;
           cursor += escape.size();
           // If there's either not a character following the escape, or it's a
@@ -162,7 +162,7 @@ auto StringLiteral::Lex(llvm::StringRef source_text)
         break;
       case '"':
       case '\'':
-        if (source_text.substr(cursor).startswith(terminator)) {
+        if (source_text.substr(cursor).starts_with(terminator)) {
           llvm::StringRef text =
               source_text.substr(0, cursor + terminator.size());
           llvm::StringRef content =
@@ -379,7 +379,7 @@ static auto ExpandEscapeSequencesAndRemoveIndent(
     if (!contents.consume_front(indent)) {
       const char* line_start = contents.begin();
       contents = contents.drop_while(IsHorizontalWhitespace);
-      if (!contents.startswith("\n")) {
+      if (!contents.starts_with("\n")) {
         CARBON_DIAGNOSTIC(
             MismatchedIndentInString, Error,
             "Indentation does not match that of the closing `'''` in "


### PR DESCRIPTION
This matches the change to upstream `llvm::StringRef`, see https://github.com/llvm/llvm-project/pull/75491 .