### PR TITLE
Turn off the lockfile when running target-determinator.

### DIFF
--- a/scripts/target_determinator.py
+++ b/scripts/target_determinator.py
@@ -87,6 +87,7 @@ def main() -> None:
         [
             target_determinator,
             f"--bazel={bazel}",
+            "-bazel-opts=--lockfile_mode=off",
             parsed_args.baseline[0],
         ]
         + parsed_args.args,


### PR DESCRIPTION
My local testing:

```
╚╡./scripts/target_determinator.py trunk
2023/12/18 09:36:47 Processing revision 'before' (trunk, sha: 3fea3dd4015916c8200694d8f1625a6eefaa87cf)
2023/12/18 09:36:47 Running cquery on deps(//...)
2023/12/18 09:36:48 Running cquery on //...
2023/12/18 09:36:49 Finding compatible targets under //...
2023/12/18 09:36:49 Matching labels to configurations
2023/12/18 09:36:50 Hashing targets
2023/12/18 09:36:50 Processing revision 'after' (current working directory state)
2023/12/18 09:36:50 Running cquery on deps(//...)
2023/12/18 09:36:51 Running cquery on //...
2023/12/18 09:36:52 Finding compatible targets under //...
2023/12/18 09:36:53 Matching labels to configurations
2023/12/18 09:36:53 Hashing targets
2023/12/18 09:36:53 Finished after 6.695079561s
Found 0 impacted targets!
```

Note this may not be too effective if other commands result in a lockfile touch.