### PR TITLE
Rename `Carbon::StringLiteralId` -> `Carbon::StringLiteralValueId`.

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -97,17 +97,18 @@ struct IdentifierId : public IdBase, public Printable<IdentifierId> {
 };
 constexpr IdentifierId IdentifierId::Invalid(IdentifierId::InvalidIndex);
 
-// Adapts StringId for string literals.
-struct StringLiteralId : public IdBase, public Printable<StringLiteralId> {
-  static const StringLiteralId Invalid;
+// Adapts StringId for values of string literals.
+struct StringLiteralValueId : public IdBase,
+                              public Printable<StringLiteralValueId> {
+  static const StringLiteralValueId Invalid;
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "strLit";
     IdBase::Print(out);
   }
 };
-constexpr StringLiteralId StringLiteralId::Invalid(
-    StringLiteralId::InvalidIndex);
+constexpr StringLiteralValueId StringLiteralValueId::Invalid(
+    StringLiteralValueId::InvalidIndex);
 
 namespace Internal {
 // Used as a parent class for non-printable types. This is just for
@@ -257,10 +258,11 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
   auto ints() const -> const ValueStore<IntId>& { return ints_; }
   auto reals() -> ValueStore<RealId>& { return reals_; }
   auto reals() const -> const ValueStore<RealId>& { return reals_; }
-  auto string_literals() -> StringStoreWrapper<StringLiteralId>& {
+  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
     return string_literals_;
   }
-  auto string_literals() const -> const StringStoreWrapper<StringLiteralId>& {
+  auto string_literals() const
+      -> const StringStoreWrapper<StringLiteralValueId>& {
     return string_literals_;
   }
 
@@ -285,7 +287,7 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
 
   ValueStore<StringId> strings_;
   StringStoreWrapper<IdentifierId> identifiers_;
-  StringStoreWrapper<StringLiteralId> string_literals_;
+  StringStoreWrapper<StringLiteralValueId> string_literals_;
 };
 
 }  // namespace Carbon

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -242,7 +242,7 @@ class StringStoreWrapper : public Printable<StringStoreWrapper<IdT>> {
 class SharedValueStores : public Yaml::Printable<SharedValueStores> {
  public:
   explicit SharedValueStores()
-      : identifiers_(&strings_), string_literals_(&strings_) {}
+      : identifiers_(&strings_), string_literal_values_(&strings_) {}
 
   // Not copyable or movable.
   SharedValueStores(const SharedValueStores&) = delete;
@@ -258,12 +258,12 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
   auto ints() const -> const ValueStore<IntId>& { return ints_; }
   auto reals() -> ValueStore<RealId>& { return reals_; }
   auto reals() const -> const ValueStore<RealId>& { return reals_; }
-  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
-    return string_literals_;
+  auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {
+    return string_literal_values_;
   }
-  auto string_literals() const
+  auto string_literal_values() const
       -> const StringStoreWrapper<StringLiteralValueId>& {
-    return string_literals_;
+    return string_literal_values_;
   }
 
   auto OutputYaml(std::optional<llvm::StringRef> filename = std::nullopt) const
@@ -287,7 +287,7 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
 
   ValueStore<StringId> strings_;
   StringStoreWrapper<IdentifierId> identifiers_;
-  StringStoreWrapper<StringLiteralValueId> string_literals_;
+  StringStoreWrapper<StringLiteralValueId> string_literal_values_;
 };
 
 }  // namespace Carbon

--- a/toolchain/base/value_store_test.cpp
+++ b/toolchain/base/value_store_test.cpp
@@ -64,18 +64,19 @@ TEST(ValueStore, String) {
   std::string b = "b";
   SharedValueStores value_stores;
   auto a_id = value_stores.identifiers().Add(a);
-  auto b_id = value_stores.string_literals().Add(b);
+  auto b_id = value_stores.string_literal_values().Add(b);
 
   ASSERT_TRUE(a_id.is_valid());
   ASSERT_TRUE(b_id.is_valid());
 
   EXPECT_THAT(a_id.index, Not(Eq(b_id.index)));
   EXPECT_THAT(value_stores.identifiers().Get(a_id), Eq(a));
-  EXPECT_THAT(value_stores.string_literals().Get(b_id), Eq(b));
+  EXPECT_THAT(value_stores.string_literal_values().Get(b_id), Eq(b));
 
   // Adding the same string again, even with a different Id type, should return
   // the same id.
-  EXPECT_THAT(value_stores.string_literals().Add(a).index, Eq(a_id.index));
+  EXPECT_THAT(value_stores.string_literal_values().Add(a).index,
+              Eq(a_id.index));
   EXPECT_THAT(value_stores.identifiers().Add(b).index, Eq(b_id.index));
 }
 
@@ -103,7 +104,7 @@ TEST(ValueStore, PrintVals) {
   value_stores.ints().Add(apint);
   value_stores.reals().Add(
       Real{.mantissa = apint, .exponent = apint, .is_decimal = true});
-  value_stores.string_literals().Add("foo'\"baz");
+  value_stores.string_literal_values().Add("foo'\"baz");
   TestRawOstream out;
   value_stores.Print(out);
 

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -225,7 +225,7 @@ static auto GetImportKey(UnitInfo& unit_info, IdentifierId file_package_id,
                                    : "";
   llvm::StringRef library_name =
       names.library_id.is_valid()
-          ? stores->string_literals().Get(names.library_id)
+          ? stores->string_literal_values().Get(names.library_id)
           : "";
   return {package_name, library_name};
 }

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -340,8 +340,8 @@ class Context {
   }
   auto ints() -> ValueStore<IntId>& { return sem_ir().ints(); }
   auto reals() -> ValueStore<RealId>& { return sem_ir().reals(); }
-  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
-    return sem_ir().string_literals();
+  auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {
+    return sem_ir().string_literal_values();
   }
   auto functions() -> ValueStore<SemIR::FunctionId>& {
     return sem_ir().functions();

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -340,7 +340,7 @@ class Context {
   }
   auto ints() -> ValueStore<IntId>& { return sem_ir().ints(); }
   auto reals() -> ValueStore<RealId>& { return sem_ir().reals(); }
-  auto string_literals() -> StringStoreWrapper<StringLiteralId>& {
+  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
     return sem_ir().string_literals();
   }
   auto functions() -> ValueStore<SemIR::FunctionId>& {

--- a/toolchain/check/handle_literal.cpp
+++ b/toolchain/check/handle_literal.cpp
@@ -50,7 +50,7 @@ auto HandleStringLiteral(Context& context, Parse::NodeId parse_node) -> bool {
       parse_node,
       SemIR::StringLiteral{
           parse_node, context.GetBuiltinType(SemIR::BuiltinKind::StringType),
-          context.tokens().GetStringLiteral(
+          context.tokens().GetStringLiteralValue(
               context.parse_tree().node_token(parse_node))});
   return true;
 }

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -952,7 +952,7 @@ auto Lexer::LexStringLiteral(llvm::StringRef source_text, ssize_t& position)
   }
 
   if (literal->is_terminated()) {
-    auto string_id = buffer_.value_stores_->string_literals().Add(
+    auto string_id = buffer_.value_stores_->string_literal_values().Add(
         literal->ComputeValue(buffer_.allocator_, emitter_));
     auto token = buffer_.AddToken({.kind = TokenKind::StringLiteral,
                                    .token_line = string_line,

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -109,7 +109,7 @@ auto TokenizedBuffer::GetRealLiteral(TokenIndex token) const -> RealId {
 }
 
 auto TokenizedBuffer::GetStringLiteral(TokenIndex token) const
-    -> StringLiteralId {
+    -> StringLiteralValueId {
   const auto& token_info = GetTokenInfo(token);
   CARBON_CHECK(token_info.kind == TokenKind::StringLiteral) << token_info.kind;
   return token_info.string_literal_id;

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -108,7 +108,7 @@ auto TokenizedBuffer::GetRealLiteral(TokenIndex token) const -> RealId {
   return token_info.real_id;
 }
 
-auto TokenizedBuffer::GetStringLiteral(TokenIndex token) const
+auto TokenizedBuffer::GetStringLiteralValue(TokenIndex token) const
     -> StringLiteralValueId {
   const auto& token_info = GetTokenInfo(token);
   CARBON_CHECK(token_info.kind == TokenKind::StringLiteral) << token_info.kind;
@@ -270,8 +270,8 @@ auto TokenizedBuffer::PrintToken(llvm::raw_ostream& output_stream,
       break;
     case TokenKind::StringLiteral:
       output_stream << ", value: `"
-                    << value_stores_->string_literals().Get(
-                           GetStringLiteral(token))
+                    << value_stores_->string_literal_values().Get(
+                           GetStringLiteralValue(token))
                     << "`";
       break;
     default:

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -158,7 +158,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   auto GetRealLiteral(TokenIndex token) const -> RealId;
 
   // Returns the value of a `StringLiteral()` token.
-  auto GetStringLiteral(TokenIndex token) const -> StringLiteralId;
+  auto GetStringLiteral(TokenIndex token) const -> StringLiteralValueId;
 
   // Returns the size specified in a `*TypeLiteral()` token.
   auto GetTypeLiteralSize(TokenIndex token) const -> const llvm::APInt&;
@@ -293,7 +293,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
           "Unable to pack token and identifier index into the same space!");
 
       IdentifierId ident_id = IdentifierId::Invalid;
-      StringLiteralId string_literal_id;
+      StringLiteralValueId string_literal_id;
       IntId int_id;
       RealId real_id;
       TokenIndex closing_token;

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -158,7 +158,7 @@ class TokenizedBuffer : public Printable<TokenizedBuffer> {
   auto GetRealLiteral(TokenIndex token) const -> RealId;
 
   // Returns the value of a `StringLiteral()` token.
-  auto GetStringLiteral(TokenIndex token) const -> StringLiteralValueId;
+  auto GetStringLiteralValue(TokenIndex token) const -> StringLiteralValueId;
 
   // Returns the size specified in a `*TypeLiteral()` token.
   auto GetTypeLiteralSize(TokenIndex token) const -> const llvm::APInt&;

--- a/toolchain/lex/tokenized_buffer_test_helpers.h
+++ b/toolchain/lex/tokenized_buffer_test_helpers.h
@@ -124,8 +124,8 @@ MATCHER_P(HasTokens, raw_all_expected, "") {
     if (expected.string_contents &&
         actual_kind == Lex::TokenKind::StringLiteral) {
       llvm::StringRef actual_contents =
-          expected.value_stores->string_literals().Get(
-              buffer.GetStringLiteral(token));
+          expected.value_stores->string_literal_values().Get(
+              buffer.GetStringLiteralValue(token));
       if (actual_contents != *expected.string_contents) {
         *result_listener << "\nToken " << index << " has contents `"
                          << actual_contents.str() << "`, expected `"

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -23,7 +23,7 @@ static auto HandleLibraryName(Context& context, bool accept_default)
   if (auto library_name_token =
           context.ConsumeIf(Lex::TokenKind::StringLiteral)) {
     context.AddLeafNode(NodeKind::LibraryName, *library_name_token);
-    return context.tokens().GetStringLiteral(*library_name_token);
+    return context.tokens().GetStringLiteralValue(*library_name_token);
   }
 
   if (accept_default) {

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -19,7 +19,7 @@ static auto OnParseError(Context& context, Context::StateStackEntry state,
 // Handles parsing of the library name. Returns the name's ID on success, which
 // may be invalid for `default`.
 static auto HandleLibraryName(Context& context, bool accept_default)
-    -> std::optional<StringLiteralId> {
+    -> std::optional<StringLiteralValueId> {
   if (auto library_name_token =
           context.ConsumeIf(Lex::TokenKind::StringLiteral)) {
     context.AddLeafNode(NodeKind::LibraryName, *library_name_token);
@@ -29,7 +29,7 @@ static auto HandleLibraryName(Context& context, bool accept_default)
   if (accept_default) {
     if (auto default_token = context.ConsumeIf(Lex::TokenKind::Default)) {
       context.AddLeafNode(NodeKind::DefaultLibrary, *default_token);
-      return StringLiteralId::Invalid;
+      return StringLiteralValueId::Invalid;
     }
   }
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -69,7 +69,7 @@ class Tree : public Printable<Tree> {
   struct PackagingNames {
     NodeId node;
     IdentifierId package_id = IdentifierId::Invalid;
-    StringLiteralId library_id = StringLiteralId::Invalid;
+    StringLiteralValueId library_id = StringLiteralValueId::Invalid;
   };
 
   // The file's packaging.

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -225,12 +225,12 @@ class File : public Printable<File> {
   auto reals() const -> const ValueStore<RealId>& {
     return value_stores_->reals();
   }
-  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
-    return value_stores_->string_literals();
+  auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {
+    return value_stores_->string_literal_values();
   }
-  auto string_literals() const
+  auto string_literal_values() const
       -> const StringStoreWrapper<StringLiteralValueId>& {
-    return value_stores_->string_literals();
+    return value_stores_->string_literal_values();
   }
 
   auto functions() -> ValueStore<FunctionId>& { return functions_; }

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -225,10 +225,11 @@ class File : public Printable<File> {
   auto reals() const -> const ValueStore<RealId>& {
     return value_stores_->reals();
   }
-  auto string_literals() -> StringStoreWrapper<StringLiteralId>& {
+  auto string_literals() -> StringStoreWrapper<StringLiteralValueId>& {
     return value_stores_->string_literals();
   }
-  auto string_literals() const -> const StringStoreWrapper<StringLiteralId>& {
+  auto string_literals() const
+      -> const StringStoreWrapper<StringLiteralValueId>& {
     return value_stores_->string_literals();
   }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1021,7 +1021,7 @@ class Formatter {
     out_ << (real.is_decimal ? 'e' : 'p') << real.exponent;
   }
 
-  auto FormatArg(StringLiteralId id) -> void {
+  auto FormatArg(StringLiteralValueId id) -> void {
     out_ << '"';
     out_.write_escaped(sem_ir_.string_literals().Get(id),
                        /*UseHexEscapes=*/true);

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1023,7 +1023,7 @@ class Formatter {
 
   auto FormatArg(StringLiteralValueId id) -> void {
     out_ << '"';
-    out_.write_escaped(sem_ir_.string_literals().Get(id),
+    out_.write_escaped(sem_ir_.string_literal_values().Get(id),
                        /*UseHexEscapes=*/true);
     out_ << '"';
   }

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -443,7 +443,7 @@ struct StringLiteral {
 
   Parse::NodeId parse_node;
   TypeId type_id;
-  StringLiteralId string_literal_id;
+  StringLiteralValueId string_literal_id;
 };
 
 struct StructAccess {


### PR DESCRIPTION
We have `StringLiteral`s in multiple other `Carbon` sub-namespaces. Rename to a more specific name to avoid collisions.

We should likely also rename `Carbon::IntId` -> `Carbon::IntValueId` and `Carbon::RealId` -> `Carbon::RealValueId`, but this collision is prioritized because it was blocking work on typed parse nodes which introduces a `Carbon::Parse::StringLiteralId`.