### PR TITLE
Update the deps test to use the new spellings.

### DIFF
--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -40,8 +40,8 @@ for dep in deps:
     # These are stubs wrapping system libraries for LLVM. They aren't
     # distributed and so should be fine.
     if repo in (
-        "@@_main~_repo_rules~llvm_zlib",
-        "@@_main~_repo_rules~llvm_zstd",
+        "@@zlib~1.3",
+        "@@zstd~1.5.5",
     ):
         continue
     if repo == "@@_main~llvm_project~llvm-project":


### PR DESCRIPTION
Now that both zlib and zstd are handled with bzlmod stuff, they use their own repository names rather than the repo-rules spelling.

Sadly, the target determinator tool didn't detect that this test could be impacted so this slipped past our merge queue.