### PR TITLE
Fix prelude search path for Bazel 7 runfiles layout.

### DIFF
--- a/explorer/main_bin.cpp
+++ b/explorer/main_bin.cpp
@@ -13,5 +13,5 @@ auto main(int argc, char** argv) -> int {
       argc, argv, static_cast<void*>(&static_for_main_addr),
       // This assumes execution from `bazel-bin/explorer`, either directly or
       // with `bazel run`.
-      "explorer.runfiles/carbon/explorer/data/prelude.carbon");
+      "explorer.runfiles/_main/explorer/data/prelude.carbon");
 }


### PR DESCRIPTION
The explorer encoded the old runfiles layout in a string in one place that didn't get updated. This causes our instructions for running the explorer to break. The fix is at least quite simple.

Fixes #3540 
Fixes #3541