### PR TITLE
Test trace output of `Tree::VerifyExtractAs`, fix found bugs

### DIFF
--- a/toolchain/parse/tree.cpp
+++ b/toolchain/parse/tree.cpp
@@ -248,8 +248,8 @@ auto Tree::Verify() const -> ErrorOr<Success> {
     }
     // Should extract successfully if node not marked as having an error.
     // Without this code, a 10 mloc test case of lex & parse takes
-    // 4.129 s ±  0.041 s. With this additional verification, it takes
-    // 5.768 s ±  0.036 s.
+    // 4.129 s ± 0.041 s. With this additional verification, it takes
+    // 5.768 s ± 0.036 s.
     if (!n_impl.has_error && !TestExtract(this, n, n_impl.kind, nullptr)) {
       ErrorBuilder trace;
       trace << llvm::formatv(
@@ -309,6 +309,14 @@ auto Tree::Verify() const -> ErrorOr<Success> {
                         n, n_impl.kind, n_impl.subtree_size, prev_index));
     }
     prev_index = n.index;
+  }
+
+  // Validate the roots, ensures Tree::ExtractFile() doesn't CHECK-fail.
+  if (!TryExtractNodeFromChildren<File>(roots(), nullptr)) {
+    ErrorBuilder trace;
+    trace << "Roots of tree couldn't be extracted as a `File`. Trace:\n";
+    TryExtractNodeFromChildren<File>(roots(), &trace);
+    return trace;
   }
 
   if (!has_errors_ && static_cast<int32_t>(node_impls_.size()) !=

--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -165,7 +165,8 @@ struct LibrarySpecifier {
 // First line of the file, such as:
 //   `package MyPackage library "MyLibrary" impl;`
 struct PackageDirective {
-  static constexpr auto Kind = NodeKind::PackageDirective.Define();
+  static constexpr auto Kind =
+      NodeKind::PackageDirective.Define(NodeCategory::Decl);
 
   PackageIntroducerId introducer;
   std::optional<PackageNameId> name;
@@ -176,7 +177,8 @@ struct PackageDirective {
 // `import TheirPackage library "TheirLibrary";`
 using ImportIntroducer = LeafNode<NodeKind::ImportIntroducer>;
 struct ImportDirective {
-  static constexpr auto Kind = NodeKind::ImportDirective.Define();
+  static constexpr auto Kind =
+      NodeKind::ImportDirective.Define(NodeCategory::Decl);
 
   ImportIntroducerId introducer;
   std::optional<PackageNameId> name;
@@ -186,7 +188,8 @@ struct ImportDirective {
 // `library` as directive.
 using LibraryIntroducer = LeafNode<NodeKind::LibraryIntroducer>;
 struct LibraryDirective {
-  static constexpr auto Kind = NodeKind::LibraryDirective.Define();
+  static constexpr auto Kind =
+      NodeKind::LibraryDirective.Define(NodeCategory::Decl);
 
   LibraryIntroducerId introducer;
   NodeIdOneOf<LibraryName, DefaultLibrary> library_name;


### PR DESCRIPTION
Tests previously uncovered code. Fix uncovered problems:
* formatting of trace output
* package & import directives need to be classified as declarations
* the problem that meant the previous problem wasn't caught by existing tests (since `Tree::Verify` didn't check that top-level declarations match `AnyDeclId`, as required by `Tree::ExtractFile()`).
