### PR TITLE
Make `Parse::NodeCategory` printable

### DIFF
--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -87,38 +87,20 @@ struct Extractable<NodeIdInCategory<Category>> {
   static auto Extract(const Tree* tree, Tree::SiblingIterator& it,
                       Tree::SiblingIterator end, ErrorBuilder* trace)
       -> std::optional<NodeIdInCategory<Category>> {
-    if (trace) {
-      *trace << "NodeIdInCategory";
-      // TODO: Make NodeCategory printable instead.
-      if (!Category) {
-        *trace << " <none>";
-      }
-#define CARBON_NODE_CATEGORY(Name)         \
-  if (!!(Category & NodeCategory::Name)) { \
-    *trace << " " #Name;                   \
-  }
-      CARBON_NODE_CATEGORY(Decl);
-      CARBON_NODE_CATEGORY(Expr);
-      CARBON_NODE_CATEGORY(Modifier);
-      CARBON_NODE_CATEGORY(NameComponent);
-      CARBON_NODE_CATEGORY(Pattern);
-      CARBON_NODE_CATEGORY(Statement);
-#undef CARBON_NODE_CATEGORY
-    }
-
     if (it == end || !(tree->node_kind(*it).category() & Category)) {
       if (trace) {
+        *trace << "NodeIdInCategory " << Category << " error: ";
         if (it == end) {
-          *trace << " error: no more children\n";
+          *trace << "no more children\n";
         } else {
-          *trace << " error: kind " << tree->node_kind(*it)
-                 << " doesn't match\n";
+          *trace << "kind " << tree->node_kind(*it) << " doesn't match\n";
         }
       }
       return std::nullopt;
     }
     if (trace) {
-      *trace << ": kind " << tree->node_kind(*it) << " consumed\n";
+      *trace << "NodeIdInCategory " << Category << ": kind "
+             << tree->node_kind(*it) << " consumed\n";
     }
     return NodeIdInCategory<Category>(*it++);
   }

--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -5,9 +5,32 @@
 #include "toolchain/parse/node_kind.h"
 
 #include "common/check.h"
+#include "llvm/ADT/StringExtras.h"
 #include "toolchain/parse/typed_nodes.h"
 
 namespace Carbon::Parse {
+
+auto operator<<(llvm::raw_ostream& output, NodeCategory category)
+    -> llvm::raw_ostream& {
+  if (!category) {
+    output << "<none>";
+  } else {
+    llvm::ListSeparator sep("|");
+
+#define CARBON_NODE_CATEGORY(Name)         \
+  if (!!(category & NodeCategory::Name)) { \
+    output << sep << #Name;                \
+  }
+    CARBON_NODE_CATEGORY(Decl);
+    CARBON_NODE_CATEGORY(Expr);
+    CARBON_NODE_CATEGORY(Modifier);
+    CARBON_NODE_CATEGORY(NameComponent);
+    CARBON_NODE_CATEGORY(Pattern);
+    CARBON_NODE_CATEGORY(Statement);
+#undef CARBON_NODE_CATEGORY
+  }
+  return output;
+}
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(NodeKind) = {
 #define CARBON_PARSE_NODE_KIND(Name) CARBON_ENUM_CLASS_NAME_STRING(Name)

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -35,6 +35,9 @@ inline auto operator!(NodeCategory k) -> bool {
   return !static_cast<uint32_t>(k);
 }
 
+auto operator<<(llvm::raw_ostream& output, NodeCategory category)
+    -> llvm::raw_ostream&;
+
 CARBON_DEFINE_RAW_ENUM_CLASS(NodeKind, uint8_t) {
 #define CARBON_PARSE_NODE_KIND(Name) CARBON_RAW_ENUM_ENUMERATOR(Name)
 #include "toolchain/parse/node_kind.def"


### PR DESCRIPTION
Completes TODO in `parse/extract.cpp`, moving the printing code for `NodeCategory` out of the implementation of `Extractable<NodeIdInCategory<T>>`.