### PR TITLE
Add a `MemberName` parse node category for member access expressions

### DIFF
--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -99,6 +99,7 @@ struct Extractable<NodeIdInCategory<Category>> {
   }
       CARBON_NODE_CATEGORY(Decl);
       CARBON_NODE_CATEGORY(Expr);
+      CARBON_NODE_CATEGORY(MemberName);
       CARBON_NODE_CATEGORY(Modifier);
       CARBON_NODE_CATEGORY(NameComponent);
       CARBON_NODE_CATEGORY(Pattern);

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -60,6 +60,7 @@ constexpr NodeIdInCategory<Category> NodeIdInCategory<Category>::Invalid =
 // Aliases for `NodeIdInCategory` to describe particular categories of nodes.
 using AnyDeclId = NodeIdInCategory<NodeCategory::Decl>;
 using AnyExprId = NodeIdInCategory<NodeCategory::Expr>;
+using AnyMemberNameId = NodeIdInCategory<NodeCategory::MemberName>;
 using AnyModifierId = NodeIdInCategory<NodeCategory::Modifier>;
 using AnyNameComponentId = NodeIdInCategory<NodeCategory::NameComponent>;
 using AnyPatternId = NodeIdInCategory<NodeCategory::Pattern>;

--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -23,6 +23,7 @@ auto operator<<(llvm::raw_ostream& output, NodeCategory category)
   }
     CARBON_NODE_CATEGORY(Decl);
     CARBON_NODE_CATEGORY(Expr);
+    CARBON_NODE_CATEGORY(MemberName);
     CARBON_NODE_CATEGORY(Modifier);
     CARBON_NODE_CATEGORY(NameComponent);
     CARBON_NODE_CATEGORY(Pattern);

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -22,10 +22,11 @@ LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 enum class NodeCategory : uint32_t {
   Decl = 1 << 0,
   Expr = 1 << 1,
-  Modifier = 1 << 2,
-  NameComponent = 1 << 3,
-  Pattern = 1 << 4,
-  Statement = 1 << 5,
+  MemberName = 1 << 2,
+  Modifier = 1 << 3,
+  NameComponent = 1 << 4,
+  Pattern = 1 << 5,
+  Statement = 1 << 6,
   None = 0,
 
   LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/Statement)

--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -108,7 +108,8 @@ using EmptyDecl =
 
 // A name in a non-expression context, such as a declaration.
 using IdentifierName =
-    LeafNode<NodeKind::IdentifierName, NodeCategory::NameComponent>;
+    LeafNode<NodeKind::IdentifierName,
+             NodeCategory::NameComponent | NodeCategory::MemberName>;
 
 // A name in an expression context.
 using IdentifierNameExpr =
@@ -125,7 +126,7 @@ using SelfTypeNameExpr =
 // The `base` value keyword, introduced by `base: B`. Typically referenced in
 // an expression, as in `x.base` or `{.base = ...}`, but can also be used as a
 // declared name, as in `{.base: partial B}`.
-using BaseName = LeafNode<NodeKind::BaseName>;
+using BaseName = LeafNode<NodeKind::BaseName, NodeCategory::MemberName>;
 
 // A qualified name: `A.B`.
 struct QualifiedName {
@@ -564,8 +565,7 @@ struct MemberAccessExpr {
       NodeKind::MemberAccessExpr.Define(NodeCategory::Expr);
 
   AnyExprId lhs;
-  // TODO: Figure out which nodes can appear here
-  NodeId rhs;
+  AnyMemberNameId rhs;
 };
 
 // A simple indirect member access expression: `a->b`.
@@ -574,8 +574,7 @@ struct PointerMemberAccessExpr {
       NodeKind::PointerMemberAccessExpr.Define(NodeCategory::Expr);
 
   AnyExprId lhs;
-  // TODO: Figure out which nodes can appear here
-  NodeId rhs;
+  AnyMemberNameId rhs;
 };
 
 // A prefix operator expression.

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -240,7 +240,7 @@ Aggregate [^:]*: success
   EXPECT_THAT(err2.message(), testing::MatchesRegex(
                                   R"Trace(Aggregate [^:]*: begin
 2-tuple: begin
-NodeId: IdentifierName consumed
+NodeIdInCategory MemberName: kind IdentifierName consumed
 NodeIdInCategory Expr: kind PointerMemberAccessExpr consumed
 2-tuple: success
 Aggregate [^:]*: success


### PR DESCRIPTION
Use this new category to replace the unconstrained `NodeId` child of `MemberAccessExpr ` and `PointerMemberAccessExpr`. For now this new category matches `IdentifierName` and `BaseName`, but later this will be expanded to support `a.(b.c)` and `p->(b.c)` syntactic forms.

QUESTION: Is it time to make a `node_category.def` x-macro file?
ANSWER: Not yet.