### PR TITLE
Implement a list of exported names for imports.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -13,6 +13,7 @@
 #include "toolchain/parse/tree.h"
 #include "toolchain/parse/tree_node_location_translator.h"
 #include "toolchain/sem_ir/file.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -68,6 +69,32 @@ struct UnitInfo {
   llvm::SmallVector<UnitInfo*> incoming_imports;
 };
 
+// Returns the NameId for the entity. May return Invalid for a TODO.
+// TODO: This will need to handle enclosing namespaces.
+static auto GetImportNameId(Parse::NodeId parse_node, Context& context,
+                            const SemIR::File& import_sem_ir,
+                            SemIR::InstId import_inst_id) -> SemIR::NameId {
+  auto import_inst = import_sem_ir.insts().Get(import_inst_id);
+
+  switch (import_inst.kind()) {
+    case SemIR::InstKind::BindName: {
+      auto bind_name = import_inst.As<SemIR::BindName>();
+      return bind_name.name_id;
+    }
+
+    case SemIR::InstKind::FunctionDecl: {
+      auto bind_name = import_inst.As<SemIR::FunctionDecl>();
+      return import_sem_ir.functions().Get(bind_name.function_id).name_id;
+    }
+
+    default:
+      context.TODO(parse_node, (llvm::Twine("Support GetImportNameId of ") +
+                                import_inst.kind().name())
+                                   .str());
+      return SemIR::NameId::Invalid;
+  }
+}
+
 // Add imports to the root block.
 static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
     -> void {
@@ -92,33 +119,38 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
 
     for (const auto& import : self_import->second.imports) {
       const auto& import_sem_ir = **import.unit_info->unit->sem_ir;
-      const auto& import_scope =
-          import_sem_ir.name_scopes().Get(SemIR::NameScopeId::Package);
 
       // If an import of the current package caused an error for the imported
       // file, it transitively affects the current file too.
-      package_scope.has_error |= import_scope.has_error;
+      package_scope.has_error |= import_sem_ir.name_scopes()
+                                     .Get(SemIR::NameScopeId::Package)
+                                     .has_error;
 
       auto ir_id = context.sem_ir().cross_ref_irs().Add(&import_sem_ir);
 
-      for (const auto& [import_name_id, import_inst_id] : import_scope.names) {
-        // Translate the name to the current IR.
-        auto name_id = SemIR::NameId::Invalid;
-        if (auto import_identifier_id = import_name_id.AsIdentifierId();
+      for (const auto import_inst_id :
+           import_sem_ir.inst_blocks().Get(SemIR::InstBlockId::Exports)) {
+        // TODO: Handle enclosing namespaces.
+        auto name_id = GetImportNameId(self_import->second.node, context,
+                                       import_sem_ir, import_inst_id);
+
+        // Translate the name to the current IR. It will usually be an
+        // identifier, but could also be a builtin name ID which is
+        // equivalent cross-IR.
+        if (auto import_identifier_id = name_id.AsIdentifierId();
             import_identifier_id.is_valid()) {
           auto name = import_sem_ir.identifiers().Get(import_identifier_id);
           name_id =
               SemIR::NameId::ForIdentifier(context.identifiers().Add(name));
-        } else {
-          // A builtin name ID which is equivalent cross-IR.
-          name_id = import_name_id;
         }
 
         // Leave a placeholder that the inst comes from the other IR.
         auto target_id = context.AddInst(
             SemIR::LazyImportRef{.ir_id = ir_id, .inst_id = import_inst_id});
-        // TODO: The scope's names should be changed to allow for ambiguous
-        // names.
+        // TODO: When importing from other packages, the scope's names should be
+        // changed to allow for ambiguous names. When importing from the current
+        // package, as is currently being done, we should issue a diagnostic on
+        // conflicts.
         package_scope.names.insert({name_id, target_id});
       }
     }
@@ -198,6 +230,7 @@ static auto CheckParseTree(const SemIR::File& builtin_ir, UnitInfo& unit_info,
   // Pop information for the file-level scope.
   sem_ir.set_top_inst_block_id(context.inst_block_stack().Pop());
   context.PopScope();
+  context.FinalizeExports();
 
   context.VerifyOnFinish();
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -294,6 +294,14 @@ class Context {
     params_or_args_stack_.AddInstId(inst_id);
   }
 
+  // Adds an exported name.
+  auto AddExport(SemIR::InstId inst_id) -> void { exports_.push_back(inst_id); }
+
+  // Finalizes the list of exports on the IR.
+  auto FinalizeExports() -> void {
+    inst_blocks().Set(SemIR::InstBlockId::Exports, exports_);
+  }
+
   // Prints information for a stack dump.
   auto PrintForStackDump(llvm::raw_ostream& output) const -> void;
 
@@ -530,6 +538,9 @@ class Context {
   // Storage for the nodes in canonical_type_nodes_. This stores in pointers so
   // that FoldingSet can have stable pointers.
   llvm::SmallVector<std::unique_ptr<TypeNode>> type_node_storage_;
+
+  // The list which will form NodeBlockId::Exports.
+  llvm::SmallVector<SemIR::InstId> exports_;
 };
 
 // Parse node handlers. Returns false for unrecoverable errors.

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/decl_name_stack.h"
 
 #include "toolchain/check/context.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
 
@@ -83,6 +84,7 @@ auto DeclNameStack::LookupOrAddName(NameContext name_context,
                                      QualifiedDeclOutsideScopeEntity);
           }
         }
+        context_->AddExport(target_id);
         auto [_, success] = name_scope.names.insert(
             {name_context.unresolved_name_id, target_id});
         CARBON_CHECK(success)

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -28,6 +28,7 @@
 // CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     block1:          {}
+// CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -23,7 +23,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -36,8 +36,10 @@ fn B() {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...
@@ -59,7 +61,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -72,8 +74,10 @@ fn B() {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -23,7 +23,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -36,8 +36,10 @@ fn B() {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...
@@ -46,7 +48,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block1]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -59,8 +61,10 @@ fn B() {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+1
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -17,7 +17,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type4, return_slot: inst+7, body: [block4]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block2, return_type: type4, return_slot: inst+7, body: [block5]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -41,7 +41,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+1:          {kind: Param, arg0: name1, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: BindName, arg0: name1, arg1: inst+1, type: type1}
 // CHECK:STDOUT:     inst+3:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
-// CHECK:STDOUT:     inst+4:          {kind: TupleLiteral, arg0: block2, type: type2}
+// CHECK:STDOUT:     inst+4:          {kind: TupleLiteral, arg0: block3, type: type2}
 // CHECK:STDOUT:     inst+5:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
 // CHECK:STDOUT:     inst+6:          {kind: Converted, arg0: inst+4, arg1: inst+5, type: typeTypeType}
 // CHECK:STDOUT:     inst+7:          {kind: VarStorage, arg0: nameReturnSlot, type: type4}
@@ -50,31 +50,33 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+10:         {kind: NameRef, arg0: name1, arg1: inst+2, type: type1}
 // CHECK:STDOUT:     inst+11:         {kind: IntLiteral, arg0: int4, type: type1}
 // CHECK:STDOUT:     inst+12:         {kind: RealLiteral, arg0: real0, type: type3}
-// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block5, type: type4}
+// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block6, type: type4}
 // CHECK:STDOUT:     inst+14:         {kind: TupleAccess, arg0: inst+7, arg1: element0, type: type1}
 // CHECK:STDOUT:     inst+15:         {kind: InitializeFrom, arg0: inst+10, arg1: inst+14, type: type1}
 // CHECK:STDOUT:     inst+16:         {kind: TupleAccess, arg0: inst+7, arg1: element1, type: type1}
 // CHECK:STDOUT:     inst+17:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+16, type: type1}
 // CHECK:STDOUT:     inst+18:         {kind: TupleAccess, arg0: inst+7, arg1: element2, type: type3}
 // CHECK:STDOUT:     inst+19:         {kind: InitializeFrom, arg0: inst+12, arg1: inst+18, type: type3}
-// CHECK:STDOUT:     inst+20:         {kind: TupleInit, arg0: block6, arg1: inst+7, type: type4}
+// CHECK:STDOUT:     inst+20:         {kind: TupleInit, arg0: block7, arg1: inst+7, type: type4}
 // CHECK:STDOUT:     inst+21:         {kind: Converted, arg0: inst+13, arg1: inst+20, type: type4}
 // CHECK:STDOUT:     inst+22:         {kind: ReturnExpr, arg0: inst+21}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+9
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               instIntType
 // CHECK:STDOUT:       1:               instIntType
 // CHECK:STDOUT:       2:               instFloatType
-// CHECK:STDOUT:     block3:
+// CHECK:STDOUT:     block4:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:       1:               inst+2
 // CHECK:STDOUT:       2:               inst+4
 // CHECK:STDOUT:       3:               inst+6
 // CHECK:STDOUT:       4:               inst+7
-// CHECK:STDOUT:     block4:
+// CHECK:STDOUT:     block5:
 // CHECK:STDOUT:       0:               inst+10
 // CHECK:STDOUT:       1:               inst+11
 // CHECK:STDOUT:       2:               inst+12
@@ -88,15 +90,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:       10:              inst+20
 // CHECK:STDOUT:       11:              inst+21
 // CHECK:STDOUT:       12:              inst+22
-// CHECK:STDOUT:     block5:
+// CHECK:STDOUT:     block6:
 // CHECK:STDOUT:       0:               inst+10
 // CHECK:STDOUT:       1:               inst+11
 // CHECK:STDOUT:       2:               inst+12
-// CHECK:STDOUT:     block6:
+// CHECK:STDOUT:     block7:
 // CHECK:STDOUT:       0:               inst+15
 // CHECK:STDOUT:       1:               inst+17
 // CHECK:STDOUT:       2:               inst+19
-// CHECK:STDOUT:     block7:
+// CHECK:STDOUT:     block8:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+9
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -17,7 +17,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block1, return_type: type4, return_slot: inst+7, body: [block4]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: block2, return_type: type4, return_slot: inst+7, body: [block5]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -41,7 +41,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+1:          {kind: Param, arg0: name1, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: BindName, arg0: name1, arg1: inst+1, type: type1}
 // CHECK:STDOUT:     inst+3:          {kind: TupleType, arg0: typeBlock0, type: typeTypeType}
-// CHECK:STDOUT:     inst+4:          {kind: TupleLiteral, arg0: block2, type: type2}
+// CHECK:STDOUT:     inst+4:          {kind: TupleLiteral, arg0: block3, type: type2}
 // CHECK:STDOUT:     inst+5:          {kind: TupleType, arg0: typeBlock1, type: typeTypeType}
 // CHECK:STDOUT:     inst+6:          {kind: Converted, arg0: inst+4, arg1: inst+5, type: typeTypeType}
 // CHECK:STDOUT:     inst+7:          {kind: VarStorage, arg0: nameReturnSlot, type: type4}
@@ -50,31 +50,33 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+10:         {kind: NameRef, arg0: name1, arg1: inst+2, type: type1}
 // CHECK:STDOUT:     inst+11:         {kind: IntLiteral, arg0: int4, type: type1}
 // CHECK:STDOUT:     inst+12:         {kind: RealLiteral, arg0: real0, type: type3}
-// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block5, type: type4}
+// CHECK:STDOUT:     inst+13:         {kind: TupleLiteral, arg0: block6, type: type4}
 // CHECK:STDOUT:     inst+14:         {kind: TupleAccess, arg0: inst+7, arg1: element0, type: type1}
 // CHECK:STDOUT:     inst+15:         {kind: InitializeFrom, arg0: inst+10, arg1: inst+14, type: type1}
 // CHECK:STDOUT:     inst+16:         {kind: TupleAccess, arg0: inst+7, arg1: element1, type: type1}
 // CHECK:STDOUT:     inst+17:         {kind: InitializeFrom, arg0: inst+11, arg1: inst+16, type: type1}
 // CHECK:STDOUT:     inst+18:         {kind: TupleAccess, arg0: inst+7, arg1: element2, type: type3}
 // CHECK:STDOUT:     inst+19:         {kind: InitializeFrom, arg0: inst+12, arg1: inst+18, type: type3}
-// CHECK:STDOUT:     inst+20:         {kind: TupleInit, arg0: block6, arg1: inst+7, type: type4}
+// CHECK:STDOUT:     inst+20:         {kind: TupleInit, arg0: block7, arg1: inst+7, type: type4}
 // CHECK:STDOUT:     inst+21:         {kind: Converted, arg0: inst+13, arg1: inst+20, type: type4}
 // CHECK:STDOUT:     inst+22:         {kind: ReturnExpr, arg0: inst+21}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     block0:          {}
 // CHECK:STDOUT:     block1:
-// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:       0:               inst+9
 // CHECK:STDOUT:     block2:
+// CHECK:STDOUT:       0:               inst+2
+// CHECK:STDOUT:     block3:
 // CHECK:STDOUT:       0:               instIntType
 // CHECK:STDOUT:       1:               instIntType
 // CHECK:STDOUT:       2:               instFloatType
-// CHECK:STDOUT:     block3:
+// CHECK:STDOUT:     block4:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:       1:               inst+2
 // CHECK:STDOUT:       2:               inst+4
 // CHECK:STDOUT:       3:               inst+6
 // CHECK:STDOUT:       4:               inst+7
-// CHECK:STDOUT:     block4:
+// CHECK:STDOUT:     block5:
 // CHECK:STDOUT:       0:               inst+10
 // CHECK:STDOUT:       1:               inst+11
 // CHECK:STDOUT:       2:               inst+12
@@ -88,15 +90,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:       10:              inst+20
 // CHECK:STDOUT:       11:              inst+21
 // CHECK:STDOUT:       12:              inst+22
-// CHECK:STDOUT:     block5:
+// CHECK:STDOUT:     block6:
 // CHECK:STDOUT:       0:               inst+10
 // CHECK:STDOUT:       1:               inst+11
 // CHECK:STDOUT:       2:               inst+12
-// CHECK:STDOUT:     block6:
+// CHECK:STDOUT:     block7:
 // CHECK:STDOUT:       0:               inst+15
 // CHECK:STDOUT:       1:               inst+17
 // CHECK:STDOUT:       2:               inst+19
-// CHECK:STDOUT:     block7:
+// CHECK:STDOUT:     block8:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT:       1:               inst+9
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -40,7 +40,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   %.loc17: i32 = block_arg <unexpected instblockref block4>
+// CHECK:STDOUT:   %.loc17: i32 = block_arg <unexpected instblockref block5>
 // CHECK:STDOUT:   %x: i32 = bind_name x, %.loc17
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
 // CHECK:STDOUT:   %C: type = class_type @C

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -69,9 +69,6 @@ File::File(SharedValueStores& value_stores)
   CARBON_CHECK(builtins_id == CrossRefIRId::Builtins)
       << "Builtins must be the first IR, even if self-referential";
 
-  // Default entry for InstBlockId::Empty.
-  inst_blocks_.AddDefaultValue();
-
   insts_.Reserve(BuiltinKind::ValidCount);
 
   // Error uses a self-referential type so that it's not accidentally treated as
@@ -99,9 +96,6 @@ File::File(SharedValueStores& value_stores, std::string filename,
   auto builtins_id = cross_ref_irs_.Add(builtins);
   CARBON_CHECK(builtins_id == CrossRefIRId::Builtins)
       << "Builtins must be the first IR";
-
-  // Default entry for InstBlockId::Empty.
-  inst_blocks_.AddDefaultValue();
 
   // Copy builtins over.
   insts_.Reserve(BuiltinKind::ValidCount);

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -241,7 +241,8 @@ struct InstBlockId : public IdBase, public Printable<InstBlockId> {
   // 0-index block.
   static const InstBlockId Empty;
 
-  // Exported instructions. Always the 1-index block.
+  // Exported instructions. Always the 1-index block. Empty until the File is
+  // fully checked; intermediate state is in the Check::Context.
   static const InstBlockId Exports;
 
   // An explicitly invalid ID.

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -237,8 +237,12 @@ struct InstBlockId : public IdBase, public Printable<InstBlockId> {
   using ElementType = InstId;
   using ValueType = llvm::MutableArrayRef<ElementType>;
 
-  // All File instances must provide the 0th instruction block as empty.
+  // An empty block, reused to avoid allocating empty vectors. Always the
+  // 0-index block.
   static const InstBlockId Empty;
+
+  // Exported instructions. Always the 1-index block.
+  static const InstBlockId Exports;
 
   // An explicitly invalid ID.
   static const InstBlockId Invalid;
@@ -258,6 +262,7 @@ struct InstBlockId : public IdBase, public Printable<InstBlockId> {
 };
 
 constexpr InstBlockId InstBlockId::Empty = InstBlockId(0);
+constexpr InstBlockId InstBlockId::Exports = InstBlockId(1);
 constexpr InstBlockId InstBlockId::Invalid =
     InstBlockId(InstBlockId::InvalidIndex);
 constexpr InstBlockId InstBlockId::Unreachable =

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -330,7 +330,14 @@ class InstBlockStore : public BlockValueStore<InstBlockId> {
 
   using BaseType::AddDefaultValue;
   using BaseType::AddUninitialized;
-  using BaseType::BaseType;
+
+  explicit InstBlockStore(llvm::BumpPtrAllocator& allocator)
+      : BaseType(allocator) {
+    auto empty_id = AddDefaultValue();
+    CARBON_CHECK(empty_id == InstBlockId::Empty);
+    auto exports_id = AddDefaultValue();
+    CARBON_CHECK(exports_id == InstBlockId::Exports);
+  }
 
   auto Set(InstBlockId block_id, llvm::ArrayRef<InstId> content) -> void {
     CARBON_CHECK(block_id != InstBlockId::Unreachable);

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -76,7 +76,7 @@ TEST(SemIRTest, YAML) {
       Pair("inst_blocks",
            Yaml::Mapping(ElementsAre(
                Pair("block0", Yaml::Mapping(IsEmpty())),
-               Pair("block1", Yaml::Mapping(IsEmpty())),
+               Pair("block1", Yaml::Mapping(Each(Pair(_, inst_id)))),
                Pair("block2", Yaml::Mapping(Each(Pair(_, inst_id)))),
                Pair("block3", Yaml::Mapping(Each(Pair(_, inst_id)))))))));
 

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -76,8 +76,9 @@ TEST(SemIRTest, YAML) {
       Pair("inst_blocks",
            Yaml::Mapping(ElementsAre(
                Pair("block0", Yaml::Mapping(IsEmpty())),
-               Pair("block1", Yaml::Mapping(Each(Pair(_, inst_id)))),
-               Pair("block2", Yaml::Mapping(Each(Pair(_, inst_id)))))))));
+               Pair("block1", Yaml::Mapping(IsEmpty())),
+               Pair("block2", Yaml::Mapping(Each(Pair(_, inst_id)))),
+               Pair("block3", Yaml::Mapping(Each(Pair(_, inst_id)))))))));
 
   auto root = Yaml::Sequence(ElementsAre(Yaml::Mapping(
       ElementsAre(Pair("filename", "test.carbon"), Pair("sem_ir", file)))));


### PR DESCRIPTION
This adds a block for exported InstIds, rather than scanning the package scope. This working down a path discussed last month, which we'll need to add enclosing namespaces to the Inst in order to complete import of something like `namespace NS; var NS.a;`

Exports could've been a separate `vector<InstId>` on `SemIR::File`, but using an entry in `inst_blocks` felt more consistent.