### PR TITLE
Make ID formatting consistently use *this for special cases

### DIFF
--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -27,8 +27,8 @@
 // CHECK:STDOUT:     instNamespaceType: {kind: CrossRef, arg0: ir0, arg1: instNamespaceType, type: typeTypeType}
 // CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, type: type0}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:          {}
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:         {}
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+0
 // CHECK:STDOUT: ...

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -23,7 +23,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: empty, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -34,8 +34,8 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2
@@ -61,7 +61,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: empty, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -72,8 +72,8 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -23,7 +23,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: empty, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -34,8 +34,8 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2
@@ -48,7 +48,7 @@ fn B() {}
 // CHECK:STDOUT: sem_ir:
 // CHECK:STDOUT:   cross_ref_irs_size: 1
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function0:       {name: name0, param_refs: block0, body: [block2]}
+// CHECK:STDOUT:     function0:       {name: name0, param_refs: empty, body: [block2]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     type0:           {inst: instNamespaceType, value_rep: {kind: copy, type: type0}}
@@ -59,8 +59,8 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+1
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -61,8 +61,8 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+21:         {kind: Converted, arg0: inst+13, arg1: inst+20, type: type4}
 // CHECK:STDOUT:     inst+22:         {kind: ReturnExpr, arg0: inst+21}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+9
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -61,8 +61,8 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+21:         {kind: Converted, arg0: inst+13, arg1: inst+20, type: type4}
 // CHECK:STDOUT:     inst+22:         {kind: ReturnExpr, arg0: inst+21}
 // CHECK:STDOUT:   inst_blocks:
-// CHECK:STDOUT:     block0:          {}
-// CHECK:STDOUT:     block1:
+// CHECK:STDOUT:     empty:           {}
+// CHECK:STDOUT:     exports:
 // CHECK:STDOUT:       0:               inst+9
 // CHECK:STDOUT:     block2:
 // CHECK:STDOUT:       0:               inst+2

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -137,15 +137,12 @@ struct BoolValue : public IdBase, public Printable<BoolValue> {
 
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
-    switch (index) {
-      case 0:
-        out << "false";
-        break;
-      case 1:
-        out << "true";
-        break;
-      default:
-        CARBON_FATAL() << "Invalid bool value " << index;
+    if (*this == False) {
+      out << "false";
+    } else if (*this == True) {
+      out << "true";
+    } else {
+      CARBON_FATAL() << "Invalid bool value " << index;
     }
   }
 };
@@ -253,8 +250,12 @@ struct InstBlockId : public IdBase, public Printable<InstBlockId> {
 
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
-    if (index == Unreachable.index) {
+    if (*this == Unreachable) {
       out << "unreachable";
+    } else if (*this == Empty) {
+      out << "empty";
+    } else if (*this == Exports) {
+      out << "exports";
     } else {
       out << "block";
       IdBase::Print(out);
@@ -285,9 +286,9 @@ struct TypeId : public IdBase, public Printable<TypeId> {
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "type";
-    if (index == TypeType.index) {
+    if (*this == TypeType) {
       out << "TypeType";
-    } else if (index == Error.index) {
+    } else if (*this == Error) {
       out << "Error";
     } else {
       IdBase::Print(out);

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -75,8 +75,8 @@ TEST(SemIRTest, YAML) {
       // This production has only two instruction blocks.
       Pair("inst_blocks",
            Yaml::Mapping(ElementsAre(
-               Pair("block0", Yaml::Mapping(IsEmpty())),
-               Pair("block1", Yaml::Mapping(Each(Pair(_, inst_id)))),
+               Pair("empty", Yaml::Mapping(IsEmpty())),
+               Pair("exports", Yaml::Mapping(Each(Pair(_, inst_id)))),
                Pair("block2", Yaml::Mapping(Each(Pair(_, inst_id)))),
                Pair("block3", Yaml::Mapping(Each(Pair(_, inst_id)))))))));
 


### PR DESCRIPTION
When formatting special values, we currently have `NameId` doing `if (*this == SelfValue)`, `BoolValue` doing `case 0:`, and `TypeId` doing `if (index == TypeType.index)`. I'm suggesting we consolidate onto the `*this == SelfValue` approach for consistency, it seems the easiest to see the mapping of values.

This mixes in #3552 because I'm adding `Exports` there. I'm suggesting reformatting `Empty` and `Exports` consistent with `Unreachable`.