### PR TITLE
Shift handler loops to use a dispatch table.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -181,8 +181,6 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
 // Structure for the core handler dispatch.
 using DispatchFunctionT = auto(Context& context, Parse::NodeId parse_node)
     -> bool;
-using DispatchTableT =
-    std::array<DispatchFunctionT*, Parse::NodeKind::EnumCount>;
 
 // Transforms a parse node ID to a typed parse node, which is then passed to the
 // handler.
@@ -194,7 +192,7 @@ using DispatchTableT =
 
 // The main dispatch table. This is used instead of a switch in order to
 // optimize for common functionality.
-static constexpr DispatchTableT DispatchTable = {
+static constexpr std::array DispatchTable = {
 #define CARBON_PARSE_NODE_KIND(Name) &Dispatch##Name,
 #include "toolchain/parse/node_kind.def"
 };

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -43,10 +43,10 @@ using DispatchFunctionT = auto(FunctionContext& context, SemIR::InstId inst_id,
 
 // Transforms a parse node ID to a typed parse node, which is then passed to the
 // handler.
-#define CARBON_SEM_IR_INST_KIND(Name)                                  \
-  auto Dispatch##Name(FunctionContext& context, SemIR::InstId inst_id, \
-                      SemIR::Inst inst) -> void {                      \
-    return Handle##Name(context, inst_id, inst.As<SemIR::Name>());     \
+#define CARBON_SEM_IR_INST_KIND(Name)                                         \
+  static auto Dispatch##Name(FunctionContext& context, SemIR::InstId inst_id, \
+                             SemIR::Inst inst) -> void {                      \
+    return Handle##Name(context, inst_id, inst.As<SemIR::Name>());            \
   }
 #include "toolchain/sem_ir/inst_kind.def"
 

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -40,8 +40,6 @@ auto FunctionContext::TryToReuseBlock(SemIR::InstBlockId block_id,
 // Structure for the core handler dispatch.
 using DispatchFunctionT = auto(FunctionContext& context, SemIR::InstId inst_id,
                                SemIR::Inst inst) -> void;
-using DispatchTableT =
-    std::array<DispatchFunctionT*, SemIR::InstKind::EnumCount>;
 
 // Transforms a parse node ID to a typed parse node, which is then passed to the
 // handler.
@@ -54,7 +52,7 @@ using DispatchTableT =
 
 // The main dispatch table. This is used instead of a switch in order to
 // optimize for common functionality.
-static constexpr DispatchTableT DispatchTable = {
+static constexpr std::array DispatchTable = {
 #define CARBON_SEM_IR_INST_KIND(Name) &Dispatch##Name,
 #include "toolchain/sem_ir/inst_kind.def"
 };

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -53,13 +53,6 @@ class NodeKind : public CARBON_ENUM_BASE(NodeKind) {
 
   class Definition;
 
-  // Provide the size of the enum, for use in array sizing.
-  static constexpr UnderlyingType EnumCount = 0
-  // NOLINTNEXTLINE(bugprone-macro-parentheses)
-#define CARBON_PARSE_NODE_KIND(Name) +1
-#include "toolchain/parse/node_kind.def"
-      ;
-
   using EnumBase::Create;
 
   // Support use as array indices.

--- a/toolchain/parse/node_kind.h
+++ b/toolchain/parse/node_kind.h
@@ -51,6 +51,20 @@ class NodeKind : public CARBON_ENUM_BASE(NodeKind) {
 #define CARBON_PARSE_NODE_KIND(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/parse/node_kind.def"
 
+  class Definition;
+
+  // Provide the size of the enum, for use in array sizing.
+  static constexpr UnderlyingType EnumCount = 0
+  // NOLINTNEXTLINE(bugprone-macro-parentheses)
+#define CARBON_PARSE_NODE_KIND(Name) +1
+#include "toolchain/parse/node_kind.def"
+      ;
+
+  using EnumBase::Create;
+
+  // Support use as array indices.
+  using EnumBase::AsInt;
+
   // Validates that a `parse_node_kind` parser node can be generated for a
   // `lex_token_kind` lexer token.
   auto CheckMatchesTokenKind(Lex::TokenKind lex_token_kind, bool has_error)
@@ -69,10 +83,6 @@ class NodeKind : public CARBON_ENUM_BASE(NodeKind) {
 
   // Returns which categories this node kind is in.
   auto category() const -> NodeCategory;
-
-  using EnumBase::Create;
-
-  class Definition;
 
   // Provides a definition for this parse node kind. Should only be called
   // once, to construct the kind as part of defining it in `typed_nodes.h`.

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -17,11 +17,10 @@ auto HandleInvalid(Context& context) -> void {
 
 // Structure for the core handler dispatch.
 using DispatchFunctionT = auto(Context& context) -> void;
-using DispatchTableT = std::array<DispatchFunctionT*, State::EnumCount>;
 
 // The main dispatch table. This is used instead of a switch in order to
 // optimize for common functionality.
-static constexpr DispatchTableT DispatchTable = {
+static constexpr std::array DispatchTable = {
 #define CARBON_PARSE_STATE(Name) &Handle##Name,
 #include "toolchain/parse/state.def"
 };

--- a/toolchain/parse/state.h
+++ b/toolchain/parse/state.h
@@ -21,13 +21,6 @@ class State : public CARBON_ENUM_BASE(State) {
 #define CARBON_PARSE_STATE(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/parse/state.def"
 
-  // Provide the size of the enum, for use in array sizing.
-  static constexpr UnderlyingType EnumCount = 0
-  // NOLINTNEXTLINE(bugprone-macro-parentheses)
-#define CARBON_PARSE_STATE(Name) +1
-#include "toolchain/parse/state.def"
-      ;
-
   // Support use as array indices.
   using EnumBase::AsInt;
 };

--- a/toolchain/parse/state.h
+++ b/toolchain/parse/state.h
@@ -20,6 +20,16 @@ class State : public CARBON_ENUM_BASE(State) {
  public:
 #define CARBON_PARSE_STATE(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/parse/state.def"
+
+  // Provide the size of the enum, for use in array sizing.
+  static constexpr UnderlyingType EnumCount = 0
+  // NOLINTNEXTLINE(bugprone-macro-parentheses)
+#define CARBON_PARSE_STATE(Name) +1
+#include "toolchain/parse/state.def"
+      ;
+
+  // Support use as array indices.
+  using EnumBase::AsInt;
 };
 
 #define CARBON_PARSE_STATE(Name) CARBON_ENUM_CONSTANT_DEFINITION(State, Name)

--- a/toolchain/sem_ir/builtin_kind.h
+++ b/toolchain/sem_ir/builtin_kind.h
@@ -24,9 +24,6 @@ class BuiltinKind : public CARBON_ENUM_BASE(BuiltinKind) {
   auto label() -> llvm::StringRef;
 
   // The count of enum values excluding Invalid.
-  //
-  // Note that we *define* this as `constexpr` making it a true compile-time
-  // constant.
   static const uint8_t ValidCount;
 
   // Support conversion to and from an int32_t for SemIR instruction storage.

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -48,7 +48,17 @@ class InstKind : public CARBON_ENUM_BASE(InstKind) {
 #define CARBON_SEM_IR_INST_KIND(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/sem_ir/inst_kind.def"
 
+  // Provide the size of the enum, for use in array sizing.
+  static constexpr UnderlyingType EnumCount = 0
+  // NOLINTNEXTLINE(bugprone-macro-parentheses)
+#define CARBON_SEM_IR_INST_KIND(Name) +1
+#include "toolchain/sem_ir/inst_kind.def"
+      ;
+
   using EnumBase::Create;
+
+  // Support use as array indices.
+  using EnumBase::AsInt;
 
   // Returns the name to use for this instruction kind in Semantics IR.
   auto ir_name() const -> llvm::StringLiteral;

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -48,13 +48,6 @@ class InstKind : public CARBON_ENUM_BASE(InstKind) {
 #define CARBON_SEM_IR_INST_KIND(Name) CARBON_ENUM_CONSTANT_DECL(Name)
 #include "toolchain/sem_ir/inst_kind.def"
 
-  // Provide the size of the enum, for use in array sizing.
-  static constexpr UnderlyingType EnumCount = 0
-  // NOLINTNEXTLINE(bugprone-macro-parentheses)
-#define CARBON_SEM_IR_INST_KIND(Name) +1
-#include "toolchain/sem_ir/inst_kind.def"
-      ;
-
   using EnumBase::Create;
 
   // Support use as array indices.


### PR DESCRIPTION
The intent here is that while the optimizer may optimize a large switch to a similar construct, it may get a little confused by the code structure. The switch to an array offers a stronger guarantee of how the code structure will execute.

This is intended to mirror the path of lex, minus `[[clang::musttail]]`: mainly, I wasn't sure if we should be restructuring code for `[[clang::musttail]]`.