### PR TITLE
Split out context targets for check and parse.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -29,23 +29,16 @@ cc_library(
 )
 
 cc_library(
-    name = "check",
+    name = "context",
     srcs = [
-        "check.cpp",
         "context.cpp",
         "convert.cpp",
         "decl_name_stack.cpp",
         "inst_block_stack.cpp",
         "modifiers.cpp",
         "return.cpp",
-        "return.h",
-    ] +
-    # Glob handler files to avoid missing any.
-    glob([
-        "handle*.cpp",
-    ]),
+    ],
     hdrs = [
-        "check.h",
         "context.h",
         "convert.h",
         "decl_name_stack.h",
@@ -53,22 +46,44 @@ cc_library(
         "inst_block_stack.h",
         "modifiers.h",
         "pending_block.h",
+        "return.h",
     ],
     deps = [
         ":node_stack",
         "//common:check",
-        "//common:ostream",
         "//common:vlog",
+        "//toolchain/lex:tokenized_buffer",
+        "//toolchain/parse:node_kind",
+        "//toolchain/parse:tree",
+        "//toolchain/parse:tree_node_location_translator",
+        "//toolchain/sem_ir:file",
+        "//toolchain/sem_ir:ids",
+        "//toolchain/sem_ir:inst",
+        "//toolchain/sem_ir:inst_kind",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "check",
+    srcs = ["check.cpp"] +
+    # Glob handler files to avoid missing any.
+    glob([
+        "handle_*.cpp",
+    ]),
+    hdrs = ["check.h"],
+    deps = [
+        ":context",
+        "//common:check",
+        "//common:ostream",
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
-        "//toolchain/diagnostics:diagnostic_kind",
         "//toolchain/lex:token_kind",
         "//toolchain/lex:tokenized_buffer",
         "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",
         "//toolchain/parse:tree_node_location_translator",
-        "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:entry_point",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:ids",

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -18,6 +18,11 @@
 
 namespace Carbon::Check {
 
+// Parse node handlers. Returns false for unrecoverable errors.
+#define CARBON_PARSE_NODE_KIND(Name) \
+  auto Handle##Name(Context& context, Parse::Name##Id parse_node) -> bool;
+#include "toolchain/parse/node_kind.def"
+
 struct UnitInfo {
   // A given import within the file, with its destination.
   struct Import {

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -543,11 +543,6 @@ class Context {
   llvm::SmallVector<SemIR::InstId> exports_;
 };
 
-// Parse node handlers. Returns false for unrecoverable errors.
-#define CARBON_PARSE_NODE_KIND(Name) \
-  auto Handle##Name(Context& context, Parse::Name##Id parse_node) -> bool;
-#include "toolchain/parse/node_kind.def"
-
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_CONTEXT_H_

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -49,17 +49,9 @@ cc_test(
 )
 
 cc_library(
-    name = "parse",
-    srcs = [
-        "context.cpp",
-        "context.h",
-        "parse.cpp",
-    ] +
-    # Glob handler files to avoid missing any.
-    glob([
-        "handle_*.cpp",
-    ]),
-    hdrs = ["parse.h"],
+    name = "context",
+    srcs = ["context.cpp"],
+    hdrs = ["context.h"],
     deps = [
         ":node_kind",
         ":precedence",
@@ -68,12 +60,32 @@ cc_library(
         "//common:check",
         "//common:ostream",
         "//common:vlog",
+        "//toolchain/lex:token_kind",
+        "//toolchain/lex:tokenized_buffer",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "parse",
+    srcs = ["parse.cpp"] +
+    # Glob handler files to avoid missing any.
+    glob([
+        "handle_*.cpp",
+    ]),
+    hdrs = ["parse.h"],
+    deps = [
+        ":context",
+        ":node_kind",
+        ":state",
+        ":tree",
+        "//common:check",
+        "//common:ostream",
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lex:token_kind",
         "//toolchain/lex:tokenized_buffer",
-        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -365,9 +365,6 @@ class Context {
   Lex::TokenIndex first_non_packaging_token_ = Lex::TokenIndex::Invalid;
 };
 
-#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
-#include "toolchain/parse/state.def"
-
 }  // namespace Carbon::Parse
 
 #endif  // CARBON_TOOLCHAIN_PARSE_CONTEXT_H_

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -10,6 +10,10 @@
 
 namespace Carbon::Parse {
 
+// Declare handlers for each parse state.
+#define CARBON_PARSE_STATE(Name) auto Handle##Name(Context& context) -> void;
+#include "toolchain/parse/state.def"
+
 auto HandleInvalid(Context& context) -> void {
   CARBON_FATAL() << "The Invalid state shouldn't be on the stack: "
                  << context.PopState();


### PR DESCRIPTION
Per request on #3556.

Note, I'm assuming handlers should remain in the same target as the caller for longer-term performance reasons.