### PR TITLE
Use typed parse node ids in SemIR instruction types

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -66,6 +66,40 @@ auto operator!=(IndexType lhs, IndexType rhs) -> bool {
   return lhs.index != rhs.index;
 }
 
+template <
+    typename IndexType, typename RHSType,
+    typename std::enable_if_t<std::is_base_of_v<IdBase, IndexType>>* = nullptr,
+    typename std::enable_if_t<std::is_convertible_v<RHSType, IndexType>>* =
+        nullptr>
+auto operator==(IndexType lhs, RHSType rhs) -> bool {
+  return lhs.index == IndexType(rhs).index;
+}
+template <
+    typename IndexType, typename RHSType,
+    typename std::enable_if_t<std::is_base_of_v<IdBase, IndexType>>* = nullptr,
+    typename std::enable_if_t<std::is_convertible_v<RHSType, IndexType>>* =
+        nullptr>
+auto operator!=(IndexType lhs, RHSType rhs) -> bool {
+  return lhs.index != IndexType(rhs).index;
+}
+
+template <
+    typename LHSType, typename IndexType,
+    typename std::enable_if_t<std::is_base_of_v<IdBase, IndexType>>* = nullptr,
+    typename std::enable_if_t<std::is_convertible_v<LHSType, IndexType>>* =
+        nullptr>
+auto operator==(LHSType lhs, IndexType rhs) -> bool {
+  return IndexType(lhs).index == rhs.index;
+}
+template <
+    typename LHSType, typename IndexType,
+    typename std::enable_if_t<std::is_base_of_v<IdBase, IndexType>>* = nullptr,
+    typename std::enable_if_t<std::is_convertible_v<LHSType, IndexType>>* =
+        nullptr>
+auto operator!=(LHSType lhs, IndexType rhs) -> bool {
+  return IndexType(lhs).index != rhs.index;
+}
+
 // The < and > comparisons for only IndexBase.
 template <typename IndexType,
           typename std::enable_if_t<std::is_base_of_v<IndexBase, IndexType>>* =

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -78,7 +78,7 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
   CARBON_CHECK(package_scope_id == SemIR::NameScopeId::Package);
 
   auto package_inst = context.AddInst(SemIR::Namespace{
-      Parse::NodeId::Invalid,
+      Parse::NamespaceId::Invalid,
       context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
       SemIR::NameScopeId::Package});
   CARBON_CHECK(package_inst == SemIR::InstId::PackageNamespace);

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -78,7 +78,7 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
   CARBON_CHECK(package_scope_id == SemIR::NameScopeId::Package);
 
   auto package_inst = context.AddInst(SemIR::Namespace{
-      Parse::NamespaceId::Invalid,
+      Parse::NodeId::Invalid,
       context.GetBuiltinType(SemIR::BuiltinKind::NamespaceType),
       SemIR::NameScopeId::Package});
   CARBON_CHECK(package_inst == SemIR::InstId::PackageNamespace);

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -23,7 +23,7 @@ auto HandleClassIntroducer(Context& context,
 
 static auto BuildClassDecl(
     Context& context,
-    Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart>
+    Parse::NodeIdOneOf<Parse::ClassDeclId, Parse::ClassDefinitionStartId>
         parse_node) -> std::tuple<SemIR::ClassId, SemIR::InstId> {
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -21,8 +21,10 @@ auto HandleClassIntroducer(Context& context,
   return true;
 }
 
-static auto BuildClassDecl(Context& context, Parse::NodeId parse_node)
-    -> std::tuple<SemIR::ClassId, SemIR::InstId> {
+static auto BuildClassDecl(
+    Context& context,
+    Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart>
+        parse_node) -> std::tuple<SemIR::ClassId, SemIR::InstId> {
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::ClassIntroducer>();

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -43,9 +43,11 @@ static auto DiagnoseModifiers(Context& context) -> KeywordModifierSet {
 // Build a FunctionDecl describing the signature of a function. This
 // handles the common logic shared by function declaration syntax and function
 // definition syntax.
-static auto BuildFunctionDecl(Context& context, Parse::NodeId parse_node,
-                              bool is_definition)
-    -> std::pair<SemIR::FunctionId, SemIR::InstId> {
+static auto BuildFunctionDecl(
+    Context& context,
+    Parse::NodeIdOneOf<Parse::FunctionDecl, Parse::FunctionDefinitionStart>
+        parse_node,
+    bool is_definition) -> std::pair<SemIR::FunctionId, SemIR::InstId> {
   // TODO: This contains the IR block for the parameters and return type. At
   // present, it's just loose, but it's not strictly required for parameter
   // refs; we should either stop constructing it completely or, if it turns out

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -45,7 +45,7 @@ static auto DiagnoseModifiers(Context& context) -> KeywordModifierSet {
 // definition syntax.
 static auto BuildFunctionDecl(
     Context& context,
-    Parse::NodeIdOneOf<Parse::FunctionDecl, Parse::FunctionDefinitionStart>
+    Parse::NodeIdOneOf<Parse::FunctionDeclId, Parse::FunctionDefinitionStartId>
         parse_node,
     bool is_definition) -> std::pair<SemIR::FunctionId, SemIR::InstId> {
   // TODO: This contains the IR block for the parameters and return type. At

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -22,9 +22,10 @@ auto HandleInterfaceIntroducer(Context& context,
 }
 
 static auto BuildInterfaceDecl(
-    Context& context,
-    Parse::NodeIdOneOf<Parse::InterfaceDecl, Parse::InterfaceDefinitionStart>
-        parse_node) -> std::tuple<SemIR::InterfaceId, SemIR::InstId> {
+    Context& context, Parse::NodeIdOneOf<Parse::InterfaceDeclId,
+                                         Parse::InterfaceDefinitionStartId>
+                          parse_node)
+    -> std::tuple<SemIR::InterfaceId, SemIR::InstId> {
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::InterfaceIntroducer>();

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -21,8 +21,10 @@ auto HandleInterfaceIntroducer(Context& context,
   return true;
 }
 
-static auto BuildInterfaceDecl(Context& context, Parse::NodeId parse_node)
-    -> std::tuple<SemIR::InterfaceId, SemIR::InstId> {
+static auto BuildInterfaceDecl(
+    Context& context,
+    Parse::NodeIdOneOf<Parse::InterfaceDecl, Parse::InterfaceDefinitionStart>
+        parse_node) -> std::tuple<SemIR::InterfaceId, SemIR::InstId> {
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()
       .PopAndDiscardSoloParseNode<Parse::NodeKind::InterfaceIntroducer>();

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -144,40 +144,45 @@ class NodeStack {
   template <const Parse::NodeKind& RequiredParseKind>
   auto PopWithParseNode() -> auto {
     constexpr IdKind RequiredIdKind = ParseNodeKindToIdKind(RequiredParseKind);
+    auto NodeIdCast = [&](auto back) {
+      using NodeIdT = Parse::NodeIdForKind<RequiredParseKind>;
+      return std::pair<NodeIdT, decltype(back.second)>(back);
+    };
+
     if constexpr (RequiredIdKind == IdKind::InstId) {
       auto back = PopWithParseNode<SemIR::InstId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::InstBlockId) {
       auto back = PopWithParseNode<SemIR::InstBlockId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::FunctionId) {
       auto back = PopWithParseNode<SemIR::FunctionId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::ClassId) {
       auto back = PopWithParseNode<SemIR::ClassId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::InterfaceId) {
       auto back = PopWithParseNode<SemIR::InterfaceId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::NameId) {
       auto back = PopWithParseNode<SemIR::NameId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     if constexpr (RequiredIdKind == IdKind::TypeId) {
       auto back = PopWithParseNode<SemIR::TypeId>();
       RequireParseKind<RequiredParseKind>(back.first);
-      return back;
+      return NodeIdCast(back);
     }
     CARBON_FATAL() << "Unpoppable IdKind for parse kind: " << RequiredParseKind
                    << "; see value in ParseNodeKindToIdKind";

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -108,7 +108,8 @@ auto RegisterReturnedVar(Context& context, SemIR::InstId bind_id) -> void {
   }
 }
 
-auto BuildReturnWithNoExpr(Context& context, Parse::NodeId parse_node) -> void {
+auto BuildReturnWithNoExpr(Context& context,
+                           Parse::ReturnStatementId parse_node) -> void {
   const auto& function = GetCurrentFunction(context);
 
   if (function.return_type_id.is_valid()) {
@@ -122,7 +123,7 @@ auto BuildReturnWithNoExpr(Context& context, Parse::NodeId parse_node) -> void {
   context.AddInst(SemIR::Return{parse_node});
 }
 
-auto BuildReturnWithExpr(Context& context, Parse::NodeId parse_node,
+auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId parse_node,
                          SemIR::InstId expr_id) -> void {
   const auto& function = GetCurrentFunction(context);
   auto returned_var_id = GetCurrentReturnedVar(context);
@@ -154,7 +155,8 @@ auto BuildReturnWithExpr(Context& context, Parse::NodeId parse_node,
   context.AddInst(SemIR::ReturnExpr{parse_node, expr_id});
 }
 
-auto BuildReturnVar(Context& context, Parse::NodeId parse_node) -> void {
+auto BuildReturnVar(Context& context, Parse::ReturnStatementId parse_node)
+    -> void {
   const auto& function = GetCurrentFunction(context);
   auto returned_var_id = GetCurrentReturnedVar(context);
 

--- a/toolchain/check/return.h
+++ b/toolchain/check/return.h
@@ -22,14 +22,16 @@ auto CheckReturnedVar(Context& context, Parse::NodeId returned_node,
 auto RegisterReturnedVar(Context& context, SemIR::InstId bind_id) -> void;
 
 // Checks and builds SemIR for a `return;` statement.
-auto BuildReturnWithNoExpr(Context& context, Parse::NodeId parse_node) -> void;
+auto BuildReturnWithNoExpr(Context& context,
+                           Parse::ReturnStatementId parse_node) -> void;
 
 // Checks and builds SemIR for a `return <expression>;` statement.
-auto BuildReturnWithExpr(Context& context, Parse::NodeId parse_node,
+auto BuildReturnWithExpr(Context& context, Parse::ReturnStatementId parse_node,
                          SemIR::InstId expr_id) -> void;
 
 // Checks and builds SemIR for a `return var;` statement.
-auto BuildReturnVar(Context& context, Parse::NodeId parse_node) -> void;
+auto BuildReturnVar(Context& context, Parse::ReturnStatementId parse_node)
+    -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -32,11 +32,14 @@ struct NodeForId;
 
 // `<KindName>Id` is a typed version of `NodeId` that references a node of kind
 // `<KindName>`:
-template <const NodeKind&>
+template <const NodeKind& K>
 struct NodeIdForKind : public NodeId {
+  static const NodeKind& Kind;
   constexpr explicit NodeIdForKind(NodeId node_id) : NodeId(node_id) {}
   constexpr NodeIdForKind(InvalidNodeId) : NodeId(NodeId::InvalidIndex) {}
 };
+template <const NodeKind& K>
+const NodeKind& NodeIdForKind<K>::Kind = K;
 
 #define CARBON_PARSE_NODE_KIND(KindName) \
   using KindName##Id = NodeIdForKind<NodeKind::KindName>;

--- a/toolchain/parse/tree_node_location_translator.h
+++ b/toolchain/parse/tree_node_location_translator.h
@@ -16,6 +16,9 @@ class NodeLocation {
   NodeLocation(NodeId node_id) : NodeLocation(node_id, false) {}
   NodeLocation(NodeId node_id, bool token_only)
       : node_id_(node_id), token_only_(token_only) {}
+  // TODO: Have some other way of representing diagnostic that applies to a file
+  // as a whole.
+  NodeLocation(InvalidNodeId node_id) : NodeLocation(node_id, false) {}
 
   auto node_id() const -> NodeId { return node_id_; }
   auto token_only() const -> bool { return token_only_; }

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -36,6 +36,7 @@ cc_library(
     textual_hdrs = ["inst_kind.def"],
     deps = [
         "//common:enum_base",
+        "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",
         "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:ids",

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -101,7 +101,8 @@ class Inst : public Printable<Inst> {
                                   << " to wrong kind " << TypedInst::Kind;
     auto build_with_type_id_and_args = [&](auto... type_id_and_args) {
       if constexpr (HasParseNodeMember<TypedInst>) {
-        return TypedInst{parse_node(), type_id_and_args...};
+        return TypedInst{decltype(TypedInst::parse_node)(parse_node()),
+                         type_id_and_args...};
       } else {
         return TypedInst{type_id_and_args...};
       }

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -326,6 +326,7 @@ struct FunctionDecl {
 struct Import {
   static constexpr auto Kind = InstKind::Import.Define("import");
 
+  // TODO: Should always be an ImportDirectiveId?
   Parse::NodeId parse_node;
   TypeId type_id;
   CrossRefIRId first_cross_ref_ir_id;
@@ -349,7 +350,8 @@ struct InitializeFrom {
 struct InterfaceDecl {
   static constexpr auto Kind = InstKind::InterfaceDecl.Define("interface_decl");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::InterfaceDecl, Parse::InterfaceDefinitionStart>
+      parse_node;
   // No type: an interface declaration is not itself a value. The name of an
   // interface declaration becomes a facet type value.
   // TODO: For a generic interface declaration, the name of the interface

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -5,8 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_TYPED_INSTS_H_
 #define CARBON_TOOLCHAIN_SEM_IR_TYPED_INSTS_H_
 
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/tree.h"
-#include "toolchain/parse/typed_nodes.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_kind.h"
@@ -94,7 +94,8 @@ struct ArrayType {
 struct Assign {
   static constexpr auto Kind = InstKind::Assign.Define("assign");
 
-  Parse::NodeIdOneOf<Parse::InfixOperatorEqual, Parse::VariableDecl> parse_node;
+  Parse::NodeIdOneOf<Parse::InfixOperatorEqualId, Parse::VariableDeclId>
+      parse_node;
   // Assignments are statements, and so have no type.
   InstId lhs_id;
   InstId rhs_id;
@@ -219,7 +220,8 @@ struct Call {
 struct ClassDecl {
   static constexpr auto Kind = InstKind::ClassDecl.Define("class_decl");
 
-  Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart> parse_node;
+  Parse::NodeIdOneOf<Parse::ClassDeclId, Parse::ClassDefinitionStartId>
+      parse_node;
   // No type: a class declaration is not itself a value. The name of a class
   // declaration becomes a class type value.
   // TODO: For a generic class declaration, the name of the class declaration
@@ -254,7 +256,8 @@ struct ClassInit {
 struct ClassType {
   static constexpr auto Kind = InstKind::ClassType.Define("class_type");
 
-  Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart> parse_node;
+  Parse::NodeIdOneOf<Parse::ClassDeclId, Parse::ClassDefinitionStartId>
+      parse_node;
   TypeId type_id;
   ClassId class_id;
   // TODO: Once we support generic classes, include the class's arguments here.
@@ -313,7 +316,7 @@ struct FieldDecl {
 struct FunctionDecl {
   static constexpr auto Kind = InstKind::FunctionDecl.Define("fn_decl");
 
-  Parse::NodeIdOneOf<Parse::FunctionDecl, Parse::FunctionDefinitionStart>
+  Parse::NodeIdOneOf<Parse::FunctionDeclId, Parse::FunctionDefinitionStartId>
       parse_node;
   TypeId type_id;
   FunctionId function_id;
@@ -350,7 +353,7 @@ struct InitializeFrom {
 struct InterfaceDecl {
   static constexpr auto Kind = InstKind::InterfaceDecl.Define("interface_decl");
 
-  Parse::NodeIdOneOf<Parse::InterfaceDecl, Parse::InterfaceDefinitionStart>
+  Parse::NodeIdOneOf<Parse::InterfaceDeclId, Parse::InterfaceDefinitionStartId>
       parse_node;
   // No type: an interface declaration is not itself a value. The name of an
   // interface declaration becomes a facet type value.
@@ -441,7 +444,7 @@ struct Return {
   static constexpr auto Kind =
       InstKind::Return.Define("return", TerminatorKind::Terminator);
 
-  Parse::NodeIdOneOf<Parse::FunctionDefinition, Parse::ReturnStatement>
+  Parse::NodeIdOneOf<Parse::FunctionDefinitionId, Parse::ReturnStatementId>
       parse_node;
   // This is a statement, so has no type.
 };
@@ -458,6 +461,7 @@ struct ReturnExpr {
 struct SpliceBlock {
   static constexpr auto Kind = InstKind::SpliceBlock.Define("splice_block");
 
+  // TODO: Can we make this more specific?
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId block_id;
@@ -495,7 +499,7 @@ struct StructInit {
 struct StructLiteral {
   static constexpr auto Kind = InstKind::StructLiteral.Define("struct_literal");
 
-  Parse::NodeId parse_node;
+  Parse::StructLiteralId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
 };
@@ -503,6 +507,8 @@ struct StructLiteral {
 struct StructType {
   static constexpr auto Kind = InstKind::StructType.Define("struct_type");
 
+  // TODO: Make this more specific. It can be one of: ClassDefinitionId,
+  // StructLiteralId, StructTypeLiteralId
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId fields_id;
@@ -619,7 +625,7 @@ struct UnboundElementType {
   static constexpr auto Kind =
       InstKind::UnboundElementType.Define("unbound_element_type");
 
-  Parse::NodeIdOneOf<Parse::BaseDecl, Parse::BindingPattern> parse_node;
+  Parse::NodeIdOneOf<Parse::BaseDeclId, Parse::BindingPatternId> parse_node;
   TypeId type_id;
   // The class that a value of this type is an element of.
   TypeId class_type_id;

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -41,7 +41,7 @@ namespace Carbon::SemIR {
 struct AddressOf {
   static constexpr auto Kind = InstKind::AddressOf.Define("address_of");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId lvalue_id;
@@ -59,7 +59,7 @@ struct AddrPattern {
 struct ArrayIndex {
   static constexpr auto Kind = InstKind::ArrayIndex.Define("array_index");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId array_id;
@@ -72,7 +72,7 @@ struct ArrayIndex {
 struct ArrayInit {
   static constexpr auto Kind = InstKind::ArrayInit.Define("array_init");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId inits_id;
@@ -116,7 +116,7 @@ struct BaseDecl {
 struct BindName {
   static constexpr auto Kind = InstKind::BindName.Define("bind_name");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -126,7 +126,7 @@ struct BindName {
 struct BindValue {
   static constexpr auto Kind = InstKind::BindValue.Define("bind_value");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId value_id;
@@ -135,7 +135,7 @@ struct BindValue {
 struct BlockArg {
   static constexpr auto Kind = InstKind::BlockArg.Define("block_arg");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId block_id;
@@ -144,7 +144,7 @@ struct BlockArg {
 struct BoolLiteral {
   static constexpr auto Kind = InstKind::BoolLiteral.Define("bool_literal");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   BoolValue value;
@@ -168,7 +168,7 @@ struct Branch {
   static constexpr auto Kind =
       InstKind::Branch.Define("br", TerminatorKind::Terminator);
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -178,7 +178,7 @@ struct BranchIf {
   static constexpr auto Kind =
       InstKind::BranchIf.Define("br", TerminatorKind::TerminatorSequence);
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -189,7 +189,7 @@ struct BranchWithArg {
   static constexpr auto Kind =
       InstKind::BranchWithArg.Define("br", TerminatorKind::Terminator);
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -236,7 +236,7 @@ struct ClassElementAccess {
   static constexpr auto Kind =
       InstKind::ClassElementAccess.Define("class_element_access");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId base_id;
@@ -246,7 +246,7 @@ struct ClassElementAccess {
 struct ClassInit {
   static constexpr auto Kind = InstKind::ClassInit.Define("class_init");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -274,7 +274,7 @@ struct ConstType {
 struct Converted {
   static constexpr auto Kind = InstKind::Converted.Define("converted");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId original_id;
@@ -296,7 +296,7 @@ struct CrossRef {
 struct Deref {
   static constexpr auto Kind = InstKind::Deref.Define("deref");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId pointer_id;
@@ -343,7 +343,7 @@ struct InitializeFrom {
   static constexpr auto Kind =
       InstKind::InitializeFrom.Define("initialize_from");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId src_id;
@@ -368,7 +368,7 @@ struct InterfaceDecl {
 struct IntLiteral {
   static constexpr auto Kind = InstKind::IntLiteral.Define("int_literal");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   IntId int_id;
@@ -391,7 +391,7 @@ struct LazyImportRef {
 struct NameRef {
   static constexpr auto Kind = InstKind::NameRef.Define("name_ref");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -417,7 +417,7 @@ struct NoOp {
 struct Param {
   static constexpr auto Kind = InstKind::Param.Define("param");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -426,7 +426,7 @@ struct Param {
 struct PointerType {
   static constexpr auto Kind = InstKind::PointerType.Define("ptr_type");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   TypeId pointee_id;
@@ -479,7 +479,7 @@ struct StringLiteral {
 struct StructAccess {
   static constexpr auto Kind = InstKind::StructAccess.Define("struct_access");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId struct_id;
@@ -489,7 +489,7 @@ struct StructAccess {
 struct StructInit {
   static constexpr auto Kind = InstKind::StructInit.Define("struct_init");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -518,7 +518,7 @@ struct StructTypeField {
   static constexpr auto Kind =
       InstKind::StructTypeField.Define("struct_type_field");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   // This instruction is an implementation detail of `StructType`, and doesn't
   // produce a value, so has no type, even though it declares a field with a
@@ -530,7 +530,7 @@ struct StructTypeField {
 struct StructValue {
   static constexpr auto Kind = InstKind::StructValue.Define("struct_value");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -539,7 +539,7 @@ struct StructValue {
 struct Temporary {
   static constexpr auto Kind = InstKind::Temporary.Define("temporary");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId storage_id;
@@ -550,7 +550,7 @@ struct TemporaryStorage {
   static constexpr auto Kind =
       InstKind::TemporaryStorage.Define("temporary_storage");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
 };
@@ -558,7 +558,7 @@ struct TemporaryStorage {
 struct TupleAccess {
   static constexpr auto Kind = InstKind::TupleAccess.Define("tuple_access");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId tuple_id;
@@ -577,7 +577,7 @@ struct TupleIndex {
 struct TupleInit {
   static constexpr auto Kind = InstKind::TupleInit.Define("tuple_init");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -595,7 +595,7 @@ struct TupleLiteral {
 struct TupleType {
   static constexpr auto Kind = InstKind::TupleType.Define("tuple_type");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   TypeBlockId elements_id;
@@ -604,7 +604,7 @@ struct TupleType {
 struct TupleValue {
   static constexpr auto Kind = InstKind::TupleValue.Define("tuple_value");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -613,7 +613,7 @@ struct TupleValue {
 struct UnaryOperatorNot {
   static constexpr auto Kind = InstKind::UnaryOperatorNot.Define("not");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId operand_id;
@@ -646,7 +646,7 @@ struct ValueOfInitializer {
   static constexpr auto Kind =
       InstKind::ValueOfInitializer.Define("value_of_initializer");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId init_id;
@@ -655,7 +655,7 @@ struct ValueOfInitializer {
 struct VarStorage {
   static constexpr auto Kind = InstKind::VarStorage.Define("var");
 
-  // TODO: make this more specific
+  // TODO: Make this more specific.
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -377,7 +377,7 @@ struct NameRef {
 struct Namespace {
   static constexpr auto Kind = InstKind::Namespace.Define("namespace");
 
-  Parse::NodeId parse_node;
+  Parse::NamespaceId parse_node;
   TypeId type_id;
   NameScopeId name_scope_id;
 };
@@ -617,11 +617,13 @@ struct VarStorage {
   NameId name_id;
 };
 
-// HasParseNodeMember<T> is true if T has a `Parse::NodeId parse_node` field.
-template <typename T, typename ParseNodeType = Parse::NodeId T::*>
+// HasParseNodeMember<T> is true if T has a `U parse_node` field,
+// where `U` extends `Parse::NodeId`.
+template <typename T, typename NodeIdType = Parse::NodeId>
 inline constexpr bool HasParseNodeMember = false;
 template <typename T>
-inline constexpr bool HasParseNodeMember<T, decltype(&T::parse_node)> = true;
+inline constexpr bool HasParseNodeMember<
+    T, decltype(Parse::NodeId((static_cast<T*>(nullptr))->parse_node))> = true;
 
 // HasTypeIdMember<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -667,7 +667,7 @@ template <typename T, typename NodeIdType = Parse::NodeId>
 inline constexpr bool HasParseNodeMember = false;
 template <typename T>
 inline constexpr bool HasParseNodeMember<
-    T, decltype(Parse::NodeId(std::declval<T>().parse_node))> = true;
+    T, std::is_base_of_v<Parse::NodeId, decltype(T::parse_node)>> = true;
 
 // HasTypeIdMember<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -154,7 +154,7 @@ struct BoolLiteral {
 struct BoundMethod {
   static constexpr auto Kind = InstKind::BoundMethod.Define("bound_method");
 
-  Parse::NodeId parse_node;
+  Parse::MemberAccessExprId parse_node;
   TypeId type_id;
   // The object argument in the bound method, which will be used to initialize
   // `self`, or whose address will be used to initialize `self` for an `addr
@@ -167,6 +167,7 @@ struct Branch {
   static constexpr auto Kind =
       InstKind::Branch.Define("br", TerminatorKind::Terminator);
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -176,6 +177,7 @@ struct BranchIf {
   static constexpr auto Kind =
       InstKind::BranchIf.Define("br", TerminatorKind::TerminatorSequence);
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -204,7 +206,7 @@ struct Builtin {
 struct Call {
   static constexpr auto Kind = InstKind::Call.Define("call");
 
-  Parse::NodeId parse_node;
+  Parse::CallExprStartId parse_node;
   TypeId type_id;
   InstId callee_id;
   // The arguments block contains IDs for the following arguments, in order:
@@ -217,7 +219,7 @@ struct Call {
 struct ClassDecl {
   static constexpr auto Kind = InstKind::ClassDecl.Define("class_decl");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart> parse_node;
   // No type: a class declaration is not itself a value. The name of a class
   // declaration becomes a class type value.
   // TODO: For a generic class declaration, the name of the class declaration
@@ -252,7 +254,7 @@ struct ClassInit {
 struct ClassType {
   static constexpr auto Kind = InstKind::ClassType.Define("class_type");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::ClassDecl, Parse::ClassDefinitionStart> parse_node;
   TypeId type_id;
   ClassId class_id;
   // TODO: Once we support generic classes, include the class's arguments here.
@@ -383,6 +385,7 @@ struct LazyImportRef {
 struct NameRef {
   static constexpr auto Kind = InstKind::NameRef.Define("name_ref");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -504,6 +507,7 @@ struct StructTypeField {
   static constexpr auto Kind =
       InstKind::StructTypeField.Define("struct_type_field");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   // This instruction is an implementation detail of `StructType`, and doesn't
   // produce a value, so has no type, even though it declares a field with a

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -6,6 +6,7 @@
 #define CARBON_TOOLCHAIN_SEM_IR_TYPED_INSTS_H_
 
 #include "toolchain/parse/tree.h"
+#include "toolchain/parse/typed_nodes.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_kind.h"
@@ -40,6 +41,7 @@ namespace Carbon::SemIR {
 struct AddressOf {
   static constexpr auto Kind = InstKind::AddressOf.Define("address_of");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId lvalue_id;
@@ -48,7 +50,7 @@ struct AddressOf {
 struct AddrPattern {
   static constexpr auto Kind = InstKind::AddrPattern.Define("addr_pattern");
 
-  Parse::NodeId parse_node;
+  Parse::AddressId parse_node;
   TypeId type_id;
   // The `self` parameter.
   InstId inner_id;
@@ -57,6 +59,7 @@ struct AddrPattern {
 struct ArrayIndex {
   static constexpr auto Kind = InstKind::ArrayIndex.Define("array_index");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId array_id;
@@ -69,6 +72,7 @@ struct ArrayIndex {
 struct ArrayInit {
   static constexpr auto Kind = InstKind::ArrayInit.Define("array_init");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId inits_id;
@@ -78,7 +82,7 @@ struct ArrayInit {
 struct ArrayType {
   static constexpr auto Kind = InstKind::ArrayType.Define("array_type");
 
-  Parse::NodeId parse_node;
+  Parse::ArrayExprId parse_node;
   TypeId type_id;
   InstId bound_id;
   TypeId element_type_id;
@@ -90,7 +94,7 @@ struct ArrayType {
 struct Assign {
   static constexpr auto Kind = InstKind::Assign.Define("assign");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::InfixOperatorEqual, Parse::VariableDecl> parse_node;
   // Assignments are statements, and so have no type.
   InstId lhs_id;
   InstId rhs_id;
@@ -102,7 +106,7 @@ struct Assign {
 struct BaseDecl {
   static constexpr auto Kind = InstKind::BaseDecl.Define("base_decl");
 
-  Parse::NodeId parse_node;
+  Parse::BaseDeclId parse_node;
   TypeId type_id;
   TypeId base_type_id;
   ElementIndex index;
@@ -111,6 +115,7 @@ struct BaseDecl {
 struct BindName {
   static constexpr auto Kind = InstKind::BindName.Define("bind_name");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -120,6 +125,7 @@ struct BindName {
 struct BindValue {
   static constexpr auto Kind = InstKind::BindValue.Define("bind_value");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId value_id;
@@ -128,6 +134,7 @@ struct BindValue {
 struct BlockArg {
   static constexpr auto Kind = InstKind::BlockArg.Define("block_arg");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId block_id;
@@ -136,6 +143,7 @@ struct BlockArg {
 struct BoolLiteral {
   static constexpr auto Kind = InstKind::BoolLiteral.Define("bool_literal");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   BoolValue value;
@@ -178,6 +186,7 @@ struct BranchWithArg {
   static constexpr auto Kind =
       InstKind::BranchWithArg.Define("br", TerminatorKind::Terminator);
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   // Branches don't produce a value, so have no type.
   InstBlockId target_id;
@@ -223,6 +232,7 @@ struct ClassElementAccess {
   static constexpr auto Kind =
       InstKind::ClassElementAccess.Define("class_element_access");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId base_id;
@@ -232,6 +242,7 @@ struct ClassElementAccess {
 struct ClassInit {
   static constexpr auto Kind = InstKind::ClassInit.Define("class_init");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -250,7 +261,7 @@ struct ClassType {
 struct ConstType {
   static constexpr auto Kind = InstKind::ConstType.Define("const_type");
 
-  Parse::NodeId parse_node;
+  Parse::PrefixOperatorConstId parse_node;
   TypeId type_id;
   TypeId inner_id;
 };
@@ -258,6 +269,7 @@ struct ConstType {
 struct Converted {
   static constexpr auto Kind = InstKind::Converted.Define("converted");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId original_id;
@@ -279,6 +291,7 @@ struct CrossRef {
 struct Deref {
   static constexpr auto Kind = InstKind::Deref.Define("deref");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId pointer_id;
@@ -289,7 +302,7 @@ struct Deref {
 struct FieldDecl {
   static constexpr auto Kind = InstKind::FieldDecl.Define("field_decl");
 
-  Parse::NodeId parse_node;
+  Parse::BindingPatternId parse_node;
   TypeId type_id;
   NameId name_id;
   ElementIndex index;
@@ -323,6 +336,7 @@ struct InitializeFrom {
   static constexpr auto Kind =
       InstKind::InitializeFrom.Define("initialize_from");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId src_id;
@@ -346,6 +360,7 @@ struct InterfaceDecl {
 struct IntLiteral {
   static constexpr auto Kind = InstKind::IntLiteral.Define("int_literal");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   IntId int_id;
@@ -392,6 +407,7 @@ struct NoOp {
 struct Param {
   static constexpr auto Kind = InstKind::Param.Define("param");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -400,6 +416,7 @@ struct Param {
 struct PointerType {
   static constexpr auto Kind = InstKind::PointerType.Define("ptr_type");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   TypeId pointee_id;
@@ -450,6 +467,7 @@ struct StringLiteral {
 struct StructAccess {
   static constexpr auto Kind = InstKind::StructAccess.Define("struct_access");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId struct_id;
@@ -459,6 +477,7 @@ struct StructAccess {
 struct StructInit {
   static constexpr auto Kind = InstKind::StructInit.Define("struct_init");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -496,6 +515,7 @@ struct StructTypeField {
 struct StructValue {
   static constexpr auto Kind = InstKind::StructValue.Define("struct_value");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -504,6 +524,7 @@ struct StructValue {
 struct Temporary {
   static constexpr auto Kind = InstKind::Temporary.Define("temporary");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId storage_id;
@@ -514,6 +535,7 @@ struct TemporaryStorage {
   static constexpr auto Kind =
       InstKind::TemporaryStorage.Define("temporary_storage");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
 };
@@ -521,6 +543,7 @@ struct TemporaryStorage {
 struct TupleAccess {
   static constexpr auto Kind = InstKind::TupleAccess.Define("tuple_access");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId tuple_id;
@@ -530,7 +553,7 @@ struct TupleAccess {
 struct TupleIndex {
   static constexpr auto Kind = InstKind::TupleIndex.Define("tuple_index");
 
-  Parse::NodeId parse_node;
+  Parse::IndexExprId parse_node;
   TypeId type_id;
   InstId tuple_id;
   InstId index_id;
@@ -539,6 +562,7 @@ struct TupleIndex {
 struct TupleInit {
   static constexpr auto Kind = InstKind::TupleInit.Define("tuple_init");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -564,6 +588,7 @@ struct TupleType {
 struct TupleValue {
   static constexpr auto Kind = InstKind::TupleValue.Define("tuple_value");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
@@ -572,6 +597,7 @@ struct TupleValue {
 struct UnaryOperatorNot {
   static constexpr auto Kind = InstKind::UnaryOperatorNot.Define("not");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId operand_id;
@@ -584,7 +610,7 @@ struct UnboundElementType {
   static constexpr auto Kind =
       InstKind::UnboundElementType.Define("unbound_element_type");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::BaseDecl, Parse::BindingPattern> parse_node;
   TypeId type_id;
   // The class that a value of this type is an element of.
   TypeId class_type_id;
@@ -595,7 +621,7 @@ struct UnboundElementType {
 struct ValueAsRef {
   static constexpr auto Kind = InstKind::ValueAsRef.Define("value_as_ref");
 
-  Parse::NodeId parse_node;
+  Parse::IndexExprId parse_node;
   TypeId type_id;
   InstId value_id;
 };
@@ -604,6 +630,7 @@ struct ValueOfInitializer {
   static constexpr auto Kind =
       InstKind::ValueOfInitializer.Define("value_of_initializer");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   InstId init_id;
@@ -612,6 +639,7 @@ struct ValueOfInitializer {
 struct VarStorage {
   static constexpr auto Kind = InstKind::VarStorage.Define("var");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   NameId name_id;
@@ -623,7 +651,7 @@ template <typename T, typename NodeIdType = Parse::NodeId>
 inline constexpr bool HasParseNodeMember = false;
 template <typename T>
 inline constexpr bool HasParseNodeMember<
-    T, decltype(Parse::NodeId((static_cast<T*>(nullptr))->parse_node))> = true;
+    T, decltype(Parse::NodeId(std::declval<T>().parse_node))> = true;
 
 // HasTypeIdMember<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -587,7 +587,7 @@ struct TupleInit {
 struct TupleLiteral {
   static constexpr auto Kind = InstKind::TupleLiteral.Define("tuple_literal");
 
-  Parse::NodeId parse_node;
+  Parse::TupleLiteralId parse_node;
   TypeId type_id;
   InstBlockId elements_id;
 };

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -313,7 +313,8 @@ struct FieldDecl {
 struct FunctionDecl {
   static constexpr auto Kind = InstKind::FunctionDecl.Define("fn_decl");
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::FunctionDecl, Parse::FunctionDefinitionStart>
+      parse_node;
   TypeId type_id;
   FunctionId function_id;
 };
@@ -437,7 +438,8 @@ struct Return {
   static constexpr auto Kind =
       InstKind::Return.Define("return", TerminatorKind::Terminator);
 
-  Parse::NodeId parse_node;
+  Parse::NodeIdOneOf<Parse::FunctionDefinition, Parse::ReturnStatement>
+      parse_node;
   // This is a statement, so has no type.
 };
 

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -595,6 +595,7 @@ struct TupleLiteral {
 struct TupleType {
   static constexpr auto Kind = InstKind::TupleType.Define("tuple_type");
 
+  // TODO: make this more specific
   Parse::NodeId parse_node;
   TypeId type_id;
   TypeBlockId elements_id;

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -663,11 +663,11 @@ struct VarStorage {
 
 // HasParseNodeMember<T> is true if T has a `U parse_node` field,
 // where `U` extends `Parse::NodeId`.
-template <typename T, typename NodeIdType = Parse::NodeId>
+template <typename T, bool Enabled = true>
 inline constexpr bool HasParseNodeMember = false;
 template <typename T>
 inline constexpr bool HasParseNodeMember<
-    T, std::is_base_of_v<Parse::NodeId, decltype(T::parse_node)>> = true;
+    T, bool(std::is_base_of_v<Parse::NodeId, decltype(T::parse_node)>)> = true;
 
 // HasTypeIdMember<T> is true if T has a `TypeId type_id` field.
 template <typename T, typename TypeIdType = TypeId T::*>

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -406,6 +406,7 @@ struct Namespace {
 struct NoOp {
   static constexpr auto Kind = InstKind::NoOp.Define("no_op");
 
+  // TODO: Delete since now unused.
   Parse::NodeId parse_node;
   // This instruction doesn't produce a value, so has no type.
 };
@@ -431,7 +432,7 @@ struct PointerType {
 struct RealLiteral {
   static constexpr auto Kind = InstKind::RealLiteral.Define("real_literal");
 
-  Parse::NodeId parse_node;
+  Parse::RealLiteralId parse_node;
   TypeId type_id;
   RealId real_id;
 };
@@ -466,7 +467,7 @@ struct SpliceBlock {
 struct StringLiteral {
   static constexpr auto Kind = InstKind::StringLiteral.Define("string_literal");
 
-  Parse::NodeId parse_node;
+  Parse::StringLiteralId parse_node;
   TypeId type_id;
   StringLiteralValueId string_literal_id;
 };

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -450,7 +450,7 @@ struct ReturnExpr {
   static constexpr auto Kind =
       InstKind::ReturnExpr.Define("return", TerminatorKind::Terminator);
 
-  Parse::NodeId parse_node;
+  Parse::ReturnStatementId parse_node;
   // This is a statement, so has no type.
   InstId expr_id;
 };

--- a/toolchain/sem_ir/typed_insts_test.cpp
+++ b/toolchain/sem_ir/typed_insts_test.cpp
@@ -44,7 +44,8 @@ auto CommonFieldOrder() -> void {
   Inst inst = MakeInstWithNumberedFields(TypedInst::Kind);
   auto typed = inst.As<TypedInst>();
   if constexpr (HasParseNodeMember<TypedInst>) {
-    EXPECT_EQ(typed.parse_node, Parse::NodeId(1));
+    EXPECT_EQ(typed.parse_node,
+              decltype(TypedInst::parse_node)(Parse::NodeId(1)));
   }
   if constexpr (HasTypeIdMember<TypedInst>) {
     EXPECT_EQ(typed.type_id, TypeId(2));


### PR DESCRIPTION
This involves a number of supporting changes:
* The `parse_node;` member of instruction types may now have any type derived from `Parse::NodeId` and is no longer required to have that exact type.
* `Parse::Node::Invalid` is now a singleton object of a separate type that is convertible to `Parse::NodeId` and its descendants. This replaces the `Invalid` member of its descendants, and avoids having to write long `NodeIdOneOf<...>` types when initializing variables to invalid.
* `IndexBase` now allows `==` and `!=` comparisons between its derived classes and types that are convertible to those types.
* A number of functions in the check stage have been changed to preserve more type information instead of using `Parse::NodeId`.
* `NodeIdForKind<K>` (also known as `KId`) now has a `Kind` member so it may be used to declare `NodeIdOneOf<T, U>` types without #including `parse/typed_nodes.h`.
* `NodeIdForKind<K>` (also known as `KId`) may be implicitly converted to `NodeIdOneOf<T, U>` if `T::Kind == K` or `U::Kind == K` (executing a TODO).

Many of the `parse_node` members were not converted since they would have required more extensive changes. They have been marked with "TODO" comments.