### PR TITLE
Form a struct value directly in tree extraction.

### DIFF
--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -249,7 +249,8 @@ template <typename T, typename... U, std::size_t... Index>
 static auto ExtractTupleLikeType(const Tree* tree, Tree::SiblingIterator& it,
                                  Tree::SiblingIterator end, ErrorBuilder* trace,
                                  std::index_sequence<Index...> /*indices*/,
-                                 std::tuple<U...>* /*type*/) -> std::optional<T> {
+                                 std::tuple<U...>* /*type*/)
+    -> std::optional<T> {
   std::tuple<std::optional<U>...> fields;
   if (trace) {
     *trace << typeid(T).name() << ": begin\n";

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -253,7 +253,7 @@ static auto ExtractTupleLikeType(const Tree* tree, Tree::SiblingIterator& it,
     -> std::optional<T> {
   std::tuple<std::optional<U>...> fields;
   if (trace) {
-    *trace << typeid(T).name() << ": begin\n";
+    *trace << "Aggregate " << typeid(T).name() << ": begin\n";
   }
   // Use a fold over the `=` operator to parse fields from right to left.
   [[maybe_unused]] int unused;
@@ -265,13 +265,13 @@ static auto ExtractTupleLikeType(const Tree* tree, Tree::SiblingIterator& it,
         unused) = ... = 0));
   if (!ok) {
     if (trace) {
-      *trace << typeid(T).name() << ": error\n";
+      *trace << "Aggregate " << typeid(T).name() << ": error\n";
     }
     return std::nullopt;
   }
 
   if (trace) {
-    *trace << typeid(T).name() << ": success\n";
+    *trace << "Aggregate " << typeid(T).name() << ": success\n";
   }
   return T{std::move(std::get<Index>(fields).value())...};
 }

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -213,8 +213,8 @@ struct Extractable<std::optional<T>> {
 template <typename T, typename... U, std::size_t... Index>
 static auto ExtractTupleLikeType(const Tree* tree, Tree::SiblingIterator& it,
                                  Tree::SiblingIterator end, ErrorBuilder* trace,
-                                 std::index_sequence<Index...>,
-                                 std::tuple<U...>*) -> std::optional<T> {
+                                 std::index_sequence<Index...> /*indices*/,
+                                 std::tuple<U...>* /*type*/) -> std::optional<T> {
   std::tuple<std::optional<U>...> fields;
   if (trace) {
     *trace << typeid(T).name() << ": begin\n";

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -151,11 +151,9 @@ TEST_F(TypedNodeTest, VerifyExtractTraceLibrary) {
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
   EXPECT_THAT(err.message(), testing::MatchesRegex(
                                  R"Trace(Aggregate [^:]*: begin
-3-tuple: begin
 NodeIdOneOf PackageApi or PackageImpl: PackageImpl consumed
 NodeIdOneOf LibraryName or DefaultLibrary: DefaultLibrary consumed
 NodeIdForKind: LibraryIntroducer consumed
-3-tuple: success
 Aggregate [^:]*: success
 )Trace"));
 }
@@ -174,12 +172,9 @@ TEST_F(TypedNodeTest, VerifyExtractTraceVarNoInit) {
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
   EXPECT_THAT(err.message(), testing::MatchesRegex(
                                  R"Trace(Aggregate [^:]*: begin
-5-tuple: begin
 Optional [^:]*: begin
 Aggregate [^:]*: begin
-2-tuple: begin
 NodeIdInCategory Expr error: kind BindingPattern doesn't match
-2-tuple: error
 Aggregate [^:]*: error
 Optional [^:]*: missing
 NodeIdInCategory Pattern: kind BindingPattern consumed
@@ -190,7 +185,6 @@ Vector: begin
 NodeIdInCategory Modifier error: kind VariableIntroducer doesn't match
 Vector: end
 NodeIdForKind: VariableIntroducer consumed
-5-tuple: success
 Aggregate [^:]*: success
 )Trace"));
 }
@@ -209,13 +203,10 @@ TEST_F(TypedNodeTest, VerifyExtractTraceExpression) {
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
   EXPECT_THAT(err1.message(), testing::MatchesRegex(
                                   R"Trace(Aggregate [^:]*: begin
-5-tuple: begin
 Optional [^:]*leDecl11InitializerE: begin
 Aggregate [^:]*: begin
-2-tuple: begin
 NodeIdInCategory Expr: kind MemberAccessExpr consumed
 NodeIdForKind: VariableInitializer consumed
-2-tuple: success
 Aggregate [^:]*: success
 Optional [^:]*: found
 NodeIdInCategory Pattern: kind BindingPattern consumed
@@ -226,7 +217,6 @@ Vector: begin
 NodeIdInCategory Modifier error: kind VariableIntroducer doesn't match
 Vector: end
 NodeIdForKind: VariableIntroducer consumed
-5-tuple: success
 Aggregate [^:]*: success
 )Trace"));
 
@@ -239,10 +229,8 @@ Aggregate [^:]*: success
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
   EXPECT_THAT(err2.message(), testing::MatchesRegex(
                                   R"Trace(Aggregate [^:]*: begin
-2-tuple: begin
 NodeIdInCategory MemberName: kind IdentifierName consumed
 NodeIdInCategory Expr: kind PointerMemberAccessExpr consumed
-2-tuple: success
 Aggregate [^:]*: success
 )Trace"));
 }
@@ -261,7 +249,6 @@ TEST_F(TypedNodeTest, VerifyExtractTraceClassDecl) {
   // Use Regex matching to avoid hard-coding the result of `typeinfo(T).name()`.
   EXPECT_THAT(err.message(), testing::MatchesRegex(
                                  R"Trace(Aggregate [^:]*: begin
-5-tuple: begin
 Optional [^:]*: begin
 NodeIdForKind: TuplePattern consumed
 Optional [^:]*: found
@@ -275,7 +262,6 @@ NodeIdInCategory Modifier: kind PrivateModifier consumed
 NodeIdInCategory Modifier error: kind ClassIntroducer doesn't match
 Vector: end
 NodeIdForKind: ClassIntroducer consumed
-5-tuple: success
 Aggregate [^:]*: success
 )Trace"));
 }


### PR DESCRIPTION
Don't first form a `std::tuple` and then convert it to a struct. Speeds up compilation of extract.cpp by 15-20%.