### PR TITLE
Update setup instructions for recent debian / ubuntu

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -50,7 +50,10 @@ sudo apt install \
   libc++-dev \
   lld \
   python3 \
-  pre-commit
+  pipx
+
+# Install pre-commit.
+pipx install pre-commit
 
 # Set up git.
 # If you don't already have a fork:

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -49,10 +49,8 @@ sudo apt install \
   gh \
   libc++-dev \
   lld \
-  python3
-
-# Install pre-commit.
-pip3 install pre-commit
+  python3 \
+  pre-commit
 
 # Set up git.
 # If you don't already have a fork:


### PR DESCRIPTION
`pip3 install` refuses to perform a system-wide installation, but we can install `pre-commit` with `apt` instead.