### PR TITLE
Add support to decl/init globals of primitive types

### DIFF
--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -24,6 +24,12 @@ class FileContext {
   // the main execution loop.
   auto Run() -> std::unique_ptr<llvm::Module>;
 
+  auto SetGlobal(SemIR::InstId inst_id, llvm::Value* value) {
+    bool added = globals_.insert({inst_id, value}).second;
+    CARBON_CHECK(added) << "Duplicate global insert: " << inst_id << " "
+                        << sem_ir().insts().Get(inst_id);
+  }
+
   // Gets a callable's function.
   auto GetFunction(SemIR::FunctionId function_id) -> llvm::Function* {
     CARBON_CHECK(functions_[function_id.index] != nullptr) << function_id;
@@ -65,6 +71,8 @@ class FileContext {
   // Builds the type for the given instruction, which should then be cached by
   // the caller.
   auto BuildType(SemIR::InstId inst_id) -> llvm::Type*;
+
+  auto LowerTopInstBlock() -> void;
 
   // Returns the empty LLVM struct type used to represent the type `type`.
   auto GetTypeType() -> llvm::StructType* {

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -59,6 +59,10 @@ class FunctionContext {
                         << sem_ir().insts().Get(inst_id);
   }
 
+  auto SetGlobal(SemIR::InstId inst_id, llvm::Value* value) {
+    file_context_->SetGlobal(inst_id, value);
+  }
+
   // Gets a callable's function.
   auto GetFunction(SemIR::FunctionId function_id) -> llvm::Function* {
     return file_context_->GetFunction(function_id);
@@ -73,6 +77,8 @@ class FunctionContext {
   auto GetTypeAsValue() -> llvm::Value* {
     return file_context_->GetTypeAsValue();
   }
+
+  auto GetFuncName() -> llvm::StringRef { return function_->getName(); }
 
   // Create a synthetic block that corresponds to no SemIR::InstBlockId. Such
   // a block should only ever have a single predecessor, and is used when we
@@ -98,6 +104,8 @@ class FunctionContext {
   auto llvm_module() -> llvm::Module& { return file_context_->llvm_module(); }
   auto builder() -> llvm::IRBuilder<>& { return builder_; }
   auto sem_ir() -> const SemIR::File& { return file_context_->sem_ir(); }
+
+  static constexpr llvm::StringLiteral GlobInitFunc = "__global_init";
 
  private:
   // Emits a value copy for type `type_id` from `source_id` to `dest_id`.

--- a/toolchain/lower/testdata/global/decl.carbon
+++ b/toolchain/lower/testdata/global/decl.carbon
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+var globl: i32;
+
+// CHECK:STDOUT: ; ModuleID = 'decl.carbon'
+// CHECK:STDOUT: source_filename = "decl.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @globl = internal global i32 0

--- a/toolchain/lower/testdata/global/decl_with_init.carbon
+++ b/toolchain/lower/testdata/global/decl_with_init.carbon
@@ -1,0 +1,18 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+var globl: i32 = 5;
+
+// CHECK:STDOUT: ; ModuleID = 'decl_with_init.carbon'
+// CHECK:STDOUT: source_filename = "decl_with_init.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @globl = internal global i32 0
+// CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__global_init, ptr null }]
+// CHECK:STDOUT:
+// CHECK:STDOUT: define internal void @__global_init() section ".text.startup" {
+// CHECK:STDOUT:   store i32 5, ptr @globl, align 4
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }


### PR DESCRIPTION
This is an experimental strategy to implement globals.

It's only handled in the lowering phase.
I added a new function named `__global_init` and lowered the top_inst_blck with that function. That way I was able to  override the behaviors of some handle functions, only 3 of them at the moment:

- VarStorage  → Creates a global
- BindName   → Sets a global value
- Assign          → Adds an initialization instruction to the init_function

The initialization function is very much like what `clang` generates but only simpler, instead of seperate functions for each global, there is only one for all of them. So llvm.global_ctors "only" points to that.