### PR TITLE
Change LexicalLookup to not resize, due to lack of current need.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -348,12 +348,9 @@ class Context {
 
   // Directly expose SemIR::File data accessors for brevity in calls.
 
-  // Use `lexical_lookup().AddIdentifier` to add entries. `identifiers()` is
-  // const to discourage misuse.
-  auto identifiers() -> const StringStoreWrapper<IdentifierId>& {
+  auto identifiers() -> StringStoreWrapper<IdentifierId>& {
     return sem_ir().identifiers();
   }
-
   auto ints() -> ValueStore<IntId>& { return sem_ir().ints(); }
   auto reals() -> ValueStore<RealId>& { return sem_ir().reals(); }
   auto string_literal_values() -> StringStoreWrapper<StringLiteralValueId>& {

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -57,8 +57,7 @@ static auto CopyNameFromImportIR(Context& context,
   if (auto import_identifier_id = import_name_id.AsIdentifierId();
       import_identifier_id.is_valid()) {
     auto name = import_sem_ir.identifiers().Get(import_identifier_id);
-    return SemIR::NameId::ForIdentifier(
-        context.lexical_lookup().AddIdentifier(name));
+    return SemIR::NameId::ForIdentifier(context.identifiers().Add(name));
   }
   return import_name_id;
 }

--- a/toolchain/check/lexical_lookup.h
+++ b/toolchain/check/lexical_lookup.h
@@ -29,35 +29,26 @@ class LexicalLookup {
     ScopeIndex scope_index;
   };
 
-  explicit LexicalLookup(StringStoreWrapper<IdentifierId>& identifiers)
-      : identifiers_(&identifiers),
-        lookup_(identifiers_->size() + SemIR::NameId::NonIndexValueCount) {}
-
-  ~LexicalLookup() {
-    CARBON_CHECK(lookup_.size() ==
-                 identifiers_->size() + SemIR::NameId::NonIndexValueCount)
-        << lookup_.size() << " must match " << identifiers_->size() << " + "
-        << SemIR::NameId::NonIndexValueCount
-        << "; something may have been added incorrectly";
-  }
-
-  // Handles both adding the identifier and resizing lookup_ to accommodate the
-  // new entry. `identifiers().Add` must not be called directly once checking
-  // has begun.
-  auto AddIdentifier(llvm::StringRef name) -> IdentifierId {
-    auto id = identifiers_->Add(name);
-    // Bear in mind that Add was not guaranteed to actually change the size.
-    lookup_.resize(identifiers_->size() + SemIR::NameId::NonIndexValueCount);
-    return id;
-  }
+  explicit LexicalLookup(const StringStoreWrapper<IdentifierId>& identifiers)
+      : original_identifiers_size_(identifiers.size()),
+        lookup_(identifiers.size() + SemIR::NameId::NonIndexValueCount) {}
 
   // Returns the lexical lookup results for a name.
   auto Get(SemIR::NameId name_id) -> llvm::SmallVector<Result, 2>& {
+    CARBON_CHECK(name_id.index < original_identifiers_size_)
+        << "An identifier was added after the Context was initialized. "
+           "Currently, we expect that new identifiers will never be used with "
+           "lexical lookup (they're added for things like detecting name "
+           "collisions in imports). That might change with metaprogramming: if "
+           "it does, we may need to start resizing `lookup_`, either on each "
+           "identifier addition or in Get` where this CHECK currently fires.";
     return lookup_[name_id.index + SemIR::NameId::NonIndexValueCount];
   }
 
  private:
-  StringStoreWrapper<IdentifierId>* identifiers_;
+  // Track the original size of identifiers_ to assist with identifier
+  // validation.
+  const int32_t original_identifiers_size_;
 
   // Maps identifiers to name lookup results.
   // TODO: Consider TinyPtrVector<Result> or similar. For now, use a small size

--- a/toolchain/check/lexical_lookup.h
+++ b/toolchain/check/lexical_lookup.h
@@ -30,26 +30,22 @@ class LexicalLookup {
   };
 
   explicit LexicalLookup(const StringStoreWrapper<IdentifierId>& identifiers)
-      : original_identifiers_size_(identifiers.size()),
-        lookup_(identifiers.size() + SemIR::NameId::NonIndexValueCount) {}
+      : lookup_(identifiers.size() + SemIR::NameId::NonIndexValueCount) {}
 
   // Returns the lexical lookup results for a name.
   auto Get(SemIR::NameId name_id) -> llvm::SmallVector<Result, 2>& {
-    CARBON_CHECK(name_id.index + SemIR::NameID::NonIndexValueCount < lookup_.size())
+    size_t index = name_id.index + SemIR::NameId::NonIndexValueCount;
+    CARBON_CHECK(index < lookup_.size())
         << "An identifier was added after the Context was initialized. "
            "Currently, we expect that new identifiers will never be used with "
            "lexical lookup (they're added for things like detecting name "
            "collisions in imports). That might change with metaprogramming: if "
            "it does, we may need to start resizing `lookup_`, either on each "
            "identifier addition or in Get` where this CHECK currently fires.";
-    return lookup_[name_id.index + SemIR::NameId::NonIndexValueCount];
+    return lookup_[index];
   }
 
  private:
-  // Track the original size of identifiers_ to assist with identifier
-  // validation.
-  const int32_t original_identifiers_size_;
-
   // Maps identifiers to name lookup results.
   // TODO: Consider TinyPtrVector<Result> or similar. For now, use a small size
   // of 2 to cover the common case.

--- a/toolchain/check/lexical_lookup.h
+++ b/toolchain/check/lexical_lookup.h
@@ -35,7 +35,7 @@ class LexicalLookup {
 
   // Returns the lexical lookup results for a name.
   auto Get(SemIR::NameId name_id) -> llvm::SmallVector<Result, 2>& {
-    CARBON_CHECK(name_id.index < original_identifiers_size_)
+    CARBON_CHECK(name_id.index + SemIR::NameID::NonIndexValueCount < lookup_.size())
         << "An identifier was added after the Context was initialized. "
            "Currently, we expect that new identifiers will never be used with "
            "lexical lookup (they're added for things like detecting name "


### PR DESCRIPTION
Per discussion, unqualified lookup should only occur on identifiers that existed at the time Context was initialized. As a consequence, the resize logic in LexicalLookup may not be necessary. Even considering metaprogramming, if metaprogramming is restricted to qualified name lookup, it may not be necessary in the future. Support should be easy to add if we need it. Trying to clearly document in the CHECK message what the rationale is.