### PR TITLE
Drop yash from vscode recommendations, and add black

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,9 @@
   "recommendations": [
     "bazelbuild.vscode-bazel",
     "bierner.github-markdown-preview",
-    "daohong-emilio.yash",
     "esbenp.prettier-vscode",
     "llvm-vs-code-extensions.vscode-clangd",
+    "ms-python.black-formatter",
     "ms-python.python"
   ]
 }


### PR DESCRIPTION
yash is mainly for flex/bison formatting, which was for explorer: we're refocusing away from that, so it doesn't make as much sense to include now.

black I think is relatively new, it was previously part of the python plugin. I'm hoping inclusion helps with setup.