### PR TITLE
Switch gnu::unused to maybe_unused

### DIFF
--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -590,17 +590,17 @@ void BM_GroupingSymbols(benchmark::State& state) {
       os.indent(j * 2) << "{\n";
     }
     os.indent(curly_brace_depth * 2);
-    for ([[gnu::unused]] int j : llvm::seq(paren_depth)) {
+    for ([[maybe_unused]] int j : llvm::seq(paren_depth)) {
       os << "(";
     }
-    for ([[gnu::unused]] int j : llvm::seq(square_bracket_depth)) {
+    for ([[maybe_unused]] int j : llvm::seq(square_bracket_depth)) {
       os << "[";
     }
     os << ids[(i * 2) % NumTokens];
-    for ([[gnu::unused]] int j : llvm::seq(square_bracket_depth)) {
+    for ([[maybe_unused]] int j : llvm::seq(square_bracket_depth)) {
       os << "]";
     }
-    for ([[gnu::unused]] int j : llvm::seq(paren_depth)) {
+    for ([[maybe_unused]] int j : llvm::seq(paren_depth)) {
       os << ")";
     }
     for (int j : llvm::reverse(llvm::seq(curly_brace_depth))) {


### PR DESCRIPTION
Preferring the C+11 name, [reflecting old discussion](https://discord.com/channels/655572317891461132/655578254970716160/1171977169556230164)