### PR TITLE
Switch clang::fallthrough to fallthrough

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -365,7 +365,7 @@ auto Driver::ValidateCompileOptions(const CompileOptions& options) const
                       << options.phase << "'.\n";
         return false;
       }
-      [[clang::fallthrough]];
+      [[fallthrough]];
     case Phase::Parse:
       if (options.dump_sem_ir) {
         error_stream_ << "ERROR: Requested dumping the SemIR but compile phase "
@@ -373,7 +373,7 @@ auto Driver::ValidateCompileOptions(const CompileOptions& options) const
                       << options.phase << "'.\n";
         return false;
       }
-      [[clang::fallthrough]];
+      [[fallthrough]];
     case Phase::Check:
       if (options.dump_llvm_ir) {
         error_stream_ << "ERROR: Requested dumping the LLVM IR but compile "
@@ -381,7 +381,7 @@ auto Driver::ValidateCompileOptions(const CompileOptions& options) const
                       << options.phase << "'.\n";
         return false;
       }
-      [[clang::fallthrough]];
+      [[fallthrough]];
     case Phase::Lower:
     case Phase::CodeGen:
       // Everything can be dumped in these phases.

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -168,7 +168,7 @@ auto HandleImport(Context& context) -> void {
     case Context::PackagingState::FileStart:
       // `package` is no longer allowed, but `import` may repeat.
       context.set_packaging_state(Context::PackagingState::InImports);
-      [[clang::fallthrough]];
+      [[fallthrough]];
 
     case Context::PackagingState::InImports:
       HandleDirectiveContent(context, state, directive, on_parse_error);


### PR DESCRIPTION
Preferring the C+11 name, [reflecting old discussion](https://discord.com/channels/655572317891461132/655578254970716160/1171977169556230164)