### PR TITLE
Distinguish between template constants and symbolic constants.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -60,7 +60,7 @@ class Context {
   auto AddInst(SemIR::Inst inst) -> SemIR::InstId;
 
   // Adds an instruction to the constants block, returning the produced ID.
-  auto AddConstantInst(SemIR::Inst inst) -> SemIR::InstId;
+  auto AddConstant(SemIR::Inst inst, bool is_symbolic) -> SemIR::ConstantId;
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
   // result.

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -13,19 +13,21 @@ namespace Carbon::Check {
 // Overloads are provided for different kinds of ID.
 
 // If the given instruction is constant, returns its constant value.
-static auto GetConstantValue(Context& context, SemIR::InstId inst_id)
-    -> SemIR::InstId {
-  return context.constant_values().Get(inst_id);
+static auto GetConstantValue(Context& context, SemIR::InstId inst_id,
+                             bool* is_symbolic) -> SemIR::InstId {
+  auto const_id = context.constant_values().Get(inst_id);
+  *is_symbolic |= const_id.is_symbolic();
+  return const_id.inst_id();
 }
 
 // If the given instruction block contains only constants, returns a
 // corresponding block of those values.
-static auto GetConstantValue(Context& context, SemIR::InstBlockId inst_block_id)
-    -> SemIR::InstBlockId {
+static auto GetConstantValue(Context& context, SemIR::InstBlockId inst_block_id,
+                             bool* is_symbolic) -> SemIR::InstBlockId {
   auto insts = context.inst_blocks().Get(inst_block_id);
   llvm::SmallVector<SemIR::InstId> const_insts;
   for (auto inst_id : insts) {
-    auto const_inst_id = GetConstantValue(context, inst_id);
+    auto const_inst_id = GetConstantValue(context, inst_id, is_symbolic);
     if (!const_inst_id.is_valid()) {
       return SemIR::InstBlockId::Invalid;
     }
@@ -49,8 +51,9 @@ static auto GetConstantValue(Context& context, SemIR::InstBlockId inst_block_id)
 // has runtime phase.
 template <typename InstT, typename FieldIdT>
 static auto ReplaceFieldWithConstantValue(Context& context, InstT* inst,
-                                          FieldIdT InstT::*field) -> bool {
-  auto unwrapped = GetConstantValue(context, inst->*field);
+                                          FieldIdT InstT::*field,
+                                          bool* is_symbolic) -> bool {
+  auto unwrapped = GetConstantValue(context, inst->*field, is_symbolic);
   if (!unwrapped.is_valid()) {
     return false;
   }
@@ -64,19 +67,21 @@ static auto ReplaceFieldWithConstantValue(Context& context, InstT* inst,
 template <typename InstT, typename... EachFieldIdT>
 static auto RebuildIfFieldsAreConstant(Context& context, SemIR::Inst inst,
                                        EachFieldIdT InstT::*... each_field_id)
-    -> SemIR::InstId {
+    -> SemIR::ConstantId {
   // Build a constant instruction by replacing each non-constant operand with
   // its constant value.
   auto typed_inst = inst.As<InstT>();
-  if ((ReplaceFieldWithConstantValue(context, &typed_inst, each_field_id) &&
+  bool is_symbolic = false;
+  if ((ReplaceFieldWithConstantValue(context, &typed_inst, each_field_id,
+                                     &is_symbolic) &&
        ...)) {
-    return context.AddConstantInst(typed_inst);
+    return context.AddConstant(typed_inst, is_symbolic);
   }
-  return SemIR::InstId::Invalid;
+  return SemIR::ConstantId::NotConstant;
 }
 
 auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
-    -> SemIR::InstId {
+    -> SemIR::ConstantId {
   // clang warns on unhandled enum values; clang-tidy is incorrect here.
   // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
   switch (inst.kind()) {
@@ -111,22 +116,24 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     case SemIR::ConstType::Kind:
     case SemIR::PointerType::Kind:
     case SemIR::StructType::Kind:
+    case SemIR::StructTypeField::Kind:
     case SemIR::TupleType::Kind:
     case SemIR::UnboundElementType::Kind:
-      return inst_id;
+      // TODO: Propagate symbolic / template nature from operands.
+      return SemIR::ConstantId::ForTemplateConstant(inst_id);
 
     case SemIR::BaseDecl::Kind:
     case SemIR::FieldDecl::Kind:
     case SemIR::FunctionDecl::Kind:
       // TODO: Consider adding a corresponding `Value` inst.
-      return inst_id;
+      return SemIR::ConstantId::ForTemplateConstant(inst_id);
 
     case SemIR::BoolLiteral::Kind:
     case SemIR::IntLiteral::Kind:
     case SemIR::RealLiteral::Kind:
     case SemIR::StringLiteral::Kind:
       // Promote literals to the constant block.
-      return context.AddConstantInst(inst);
+      return context.AddConstant(inst, /*is_symbolic=*/false);
 
     // TODO: These need special handling.
     case SemIR::StructInit::Kind:
@@ -149,32 +156,34 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     case SemIR::ValueOfInitializer::Kind:
       break;
 
-    case SemIR::BindName::Kind:
-    case SemIR::BindSymbolicName::Kind: {
-      // TODO: Should we really be looking through runtime and symbolic `let`
-      // bindings?
-      return GetConstantValue(context, inst.As<SemIR::AnyBindName>().value_id);
-    }
+    case SemIR::BindSymbolicName::Kind:
+      // TODO: Consider forming a constant value here using a de Bruijn index or
+      // similar, so that corresponding symbolic parameters in redeclarations
+      // are treated as the same value.
+      return SemIR::ConstantId::ForSymbolicConstant(inst_id);
 
-    case SemIR::NameRef::Kind: {
-      return GetConstantValue(context, inst.As<SemIR::NameRef>().value_id);
-    }
+    case SemIR::BindName::Kind:
+      // TODO: We need to look through `BindName`s for member accesses naming
+      // fields, where the member name is a `BindName`. Should we really be
+      // creating a `BindName` in that case?
+      return context.constant_values().Get(inst.As<SemIR::BindName>().value_id);
+
+    case SemIR::NameRef::Kind:
+      return context.constant_values().Get(inst.As<SemIR::NameRef>().value_id);
 
     case SemIR::UnaryOperatorNot::Kind: {
-      auto const_id = GetConstantValue(
-          context, inst.As<SemIR::UnaryOperatorNot>().operand_id);
-      if (!const_id.is_valid()) {
+      auto const_id = context.constant_values().Get(
+          inst.As<SemIR::UnaryOperatorNot>().operand_id);
+      if (!const_id.is_template()) {
         break;
       }
-      auto value = context.insts().TryGetAs<SemIR::BoolLiteral>(const_id);
-      if (!value) {
-        // TODO: Can we CHECK this instead?
-        break;
-      }
-      value->value =
-          (value->value == SemIR::BoolValue::False ? SemIR::BoolValue::True
-                                                   : SemIR::BoolValue::False);
-      return context.AddConstantInst(*value);
+      // A template constant of bool type is always a bool literal.
+      auto value =
+          context.insts().GetAs<SemIR::BoolLiteral>(const_id.inst_id());
+      value.value =
+          (value.value == SemIR::BoolValue::False ? SemIR::BoolValue::True
+                                                  : SemIR::BoolValue::False);
+      return context.AddConstant(value, /*is_symbolic=*/false);
     }
 
     // These cases are either not expressions or not constant.
@@ -193,12 +202,11 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     case SemIR::ReturnExpr::Kind:
     case SemIR::Return::Kind:
     case SemIR::StructLiteral::Kind:
-    case SemIR::StructTypeField::Kind:
     case SemIR::TupleLiteral::Kind:
     case SemIR::VarStorage::Kind:
       break;
   }
-  return SemIR::InstId::Invalid;
+  return SemIR::ConstantId::NotConstant;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -13,11 +13,11 @@ namespace Carbon::Check {
 
 // Determines the phase of the instruction `inst`, and returns its constant
 // value if it has constant phase. If it has runtime phase, returns
-// `SemIR::InstId::Invalid`.
+// `SemIR::ConstantId::NotConstant`.
 //
 // TODO: Support symbolic phase.
 auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
-    -> SemIR::InstId;
+    -> SemIR::ConstantId;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/handle_call_expr.cpp
+++ b/toolchain/check/handle_call_expr.cpp
@@ -57,11 +57,12 @@ auto HandleCallExpr(Context& context, Parse::CallExprId parse_node) -> bool {
 
   // Identify the function we're calling.
   auto function_decl_id = context.constant_values().Get(function_callee_id);
-  if (!function_decl_id.is_valid()) {
+  if (!function_decl_id.is_constant()) {
     return diagnose_not_callable();
   }
-  auto function_decl =
-      context.insts().Get(function_decl_id).TryAs<SemIR::FunctionDecl>();
+  auto function_decl = context.insts()
+                           .Get(function_decl_id.inst_id())
+                           .TryAs<SemIR::FunctionDecl>();
   if (!function_decl) {
     return diagnose_not_callable();
   }

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -155,10 +155,10 @@ auto HandleMemberAccessExpr(Context& context,
         // Find the specified element, which could be either a field or a base
         // class, and build an element access expression.
         auto element_id = context.constant_values().Get(member_id);
-        CARBON_CHECK(element_id.is_valid())
+        CARBON_CHECK(element_id.is_constant())
             << "Non-constant value " << context.insts().Get(member_id)
             << " of unbound element type";
-        auto index = GetClassElementIndex(context, element_id);
+        auto index = GetClassElementIndex(context, element_id.inst_id());
         auto access_id = context.AddInst(SemIR::ClassElementAccess{
             parse_node, unbound_element_type->element_type_id, base_id, index});
         if (SemIR::GetExprCategory(context.sem_ir(), base_id) ==
@@ -179,13 +179,15 @@ auto HandleMemberAccessExpr(Context& context,
           context.GetBuiltinType(SemIR::BuiltinKind::FunctionType)) {
         // Find the named function and check whether it's an instance method.
         auto function_name_id = context.constant_values().Get(member_id);
-        CARBON_CHECK(function_name_id.is_valid())
+        CARBON_CHECK(function_name_id.is_constant())
             << "Non-constant value " << context.insts().Get(member_id)
             << " of function type";
-        auto function_decl =
-            context.insts().Get(function_name_id).TryAs<SemIR::FunctionDecl>();
+        auto function_decl = context.insts()
+                                 .Get(function_name_id.inst_id())
+                                 .TryAs<SemIR::FunctionDecl>();
         CARBON_CHECK(function_decl)
-            << "Unexpected value " << context.insts().Get(function_name_id)
+            << "Unexpected value "
+            << context.insts().Get(function_name_id.inst_id())
             << " of function type";
         if (IsInstanceMethod(context.sem_ir(), function_decl->function_id)) {
           context.AddInstAndPush(

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -13,19 +13,19 @@ fn G() {
 // CHECK:STDOUT: --- array_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_29.1: type = array_type %.loc10_28, (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc10_29.2: type = ptr_type [(i32, i32, i32); 2], const
-// CHECK:STDOUT:   %.loc10_42: type = tuple_type ((i32, i32, i32), (i32, i32, i32)), const
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_29.1: type = array_type %.loc10_28, (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_29.2: type = ptr_type [(i32, i32, i32); 2] [template]
+// CHECK:STDOUT:   %.loc10_42: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -33,18 +33,18 @@ fn G() {
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2, const = constants.%.loc10_28
-// CHECK:STDOUT:   %.loc7: type = converted %.loc10_25, constants.%.loc7_25.2, const = constants.%.loc7_25.2
-// CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32), const = constants.%.loc10_29.1
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template = constants.%.loc10_28]
+// CHECK:STDOUT:   %.loc7: type = converted %.loc10_25, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32) [template = constants.%.loc10_29.1]
 // CHECK:STDOUT:   %v.var: ref [(i32, i32, i32); 2] = var v
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = bind_name v, %v.var
-// CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_42.3: ref (i32, i32, i32) = splice_block %.loc10_42.2 {
 // CHECK:STDOUT:     %.loc10_42.1: i32 = int_literal 0
 // CHECK:STDOUT:     %.loc10_42.2: ref (i32, i32, i32) = array_index %v.var, %.loc10_42.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_35: init (i32, i32, i32) = call %F.ref.loc10_34() to %.loc10_42.3
-// CHECK:STDOUT:   %F.ref.loc10_39: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_39: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_42.6: ref (i32, i32, i32) = splice_block %.loc10_42.5 {
 // CHECK:STDOUT:     %.loc10_42.4: i32 = int_literal 1
 // CHECK:STDOUT:     %.loc10_42.5: ref (i32, i32, i32) = array_index %v.var, %.loc10_42.4

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -13,37 +13,37 @@ fn Run() {
 // CHECK:STDOUT: --- assign_return_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28), const
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_17.1: type = array_type %.loc10_16, i32, const
-// CHECK:STDOUT:   %.loc10_17.2: type = ptr_type [i32; 1], const
+// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28) [template]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_17.1: type = array_type %.loc10_16, i32 [template]
+// CHECK:STDOUT:   %.loc10_17.2: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .Run = %Run}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0, const = constants.%.loc7_28
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.loc7_28]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28), const = constants.%.loc7_30
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2, const = constants.%.loc7_30
+// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.loc7_30]
 // CHECK:STDOUT:   return %.loc7_30.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1, const = constants.%.loc10_16
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32, const = constants.%.loc10_17.1
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.loc10_16]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.loc10_17.1]
 // CHECK:STDOUT:   %t.var: ref [i32; 1] = var t
 // CHECK:STDOUT:   %t: ref [i32; 1] = bind_name t, %t.var
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_22.1: init (i32,) = call %F.ref()
 // CHECK:STDOUT:   %.loc10_22.2: ref (i32,) = temporary_storage
 // CHECK:STDOUT:   %.loc10_22.3: ref (i32,) = temporary %.loc10_22.2, %.loc10_22.1

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -10,26 +10,26 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT: --- assign_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, i32, const
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [i32; 3], const
+// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, i32 [template]
+// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [i32; 3] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_22.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_22.2: type = converted %.loc7_22.1, constants.%.loc7_22.2, const = constants.%.loc7_22.2
+// CHECK:STDOUT:   %.loc7_22.2: type = converted %.loc7_22.1, constants.%.loc7_22.2 [template = constants.%.loc7_22.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1, const = constants.%.loc7_27
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2, const = constants.%.loc7_30
-// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3, const = constants.%.loc7_33
+// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template = constants.%.loc7_27]
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2 [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3 [template = constants.%.loc7_33]
 // CHECK:STDOUT:   %.loc7_34.1: (i32, i32, i32) = tuple_literal (%.loc7_27, %.loc7_30, %.loc7_33)
 // CHECK:STDOUT:   %.loc7_34.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_34.3: init i32 = initialize_from %.loc7_27 to %.loc7_34.2
@@ -40,8 +40,8 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7) to %a.var
 // CHECK:STDOUT:   %.loc7_34.9: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8
 // CHECK:STDOUT:   assign %a.var, %.loc7_34.9
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3, const = constants.%.loc8_14
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32, const = constants.%.loc8_15.1
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template = constants.%.loc8_14]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32 [template = constants.%.loc8_15.1]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32, i32) = name_ref a, %a

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -11,31 +11,31 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT: --- base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, f64, const
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [f64; 2], const
-// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1, const
-// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1, const
-// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64), const
-// CHECK:STDOUT:   %.loc9_10: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc9_14.1: type = array_type %.loc9_13, (), const
-// CHECK:STDOUT:   %.loc9_14.2: type = ptr_type [(); 5], const
-// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ()), const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, f64 [template]
+// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [f64; 2] [template]
+// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template]
+// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template]
+// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64) [template]
+// CHECK:STDOUT:   %.loc9_10: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc9_14.1: type = array_type %.loc9_13, () [template]
+// CHECK:STDOUT:   %.loc9_14.2: type = ptr_type [(); 5] [template]
+// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ()) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1, const = constants.%.loc7_20
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.loc7_20]
 // CHECK:STDOUT:   %.loc7_22.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_22.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_22.3: ref i32 = array_index %a.var, %.loc7_22.2
@@ -43,12 +43,12 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init (%.loc7_22.4) to %a.var
 // CHECK:STDOUT:   %.loc7_22.6: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5
 // CHECK:STDOUT:   assign %a.var, %.loc7_22.6
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2, const = constants.%.loc8_14
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64, const = constants.%.loc8_15.1
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template = constants.%.loc8_14]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64 [template = constants.%.loc8_15.1]
 // CHECK:STDOUT:   %b.var: ref [f64; 2] = var b
 // CHECK:STDOUT:   %b: ref [f64; 2] = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1, const = constants.%.loc8_20
-// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1, const = constants.%.loc8_26
+// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template = constants.%.loc8_20]
+// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template = constants.%.loc8_26]
 // CHECK:STDOUT:   %.loc8_30.1: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
 // CHECK:STDOUT:   %.loc8_30.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc8_30.3: ref f64 = array_index %b.var, %.loc8_30.2
@@ -60,9 +60,9 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc8_30.9: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8
 // CHECK:STDOUT:   assign %b.var, %.loc8_30.9
 // CHECK:STDOUT:   %.loc9_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5, const = constants.%.loc9_13
-// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.loc9_10, const = constants.%.loc9_10
-// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, (), const = constants.%.loc9_14.1
+// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.loc9_13]
+// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.loc9_10 [template = constants.%.loc9_10]
+// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.loc9_14.1]
 // CHECK:STDOUT:   %c.var: ref [(); 5] = var c
 // CHECK:STDOUT:   %c: ref [(); 5] = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc9_20.1: () = tuple_literal ()

--- a/toolchain/check/testdata/array/fail_bound_overflow.carbon
+++ b/toolchain/check/testdata/array/fail_bound_overflow.carbon
@@ -12,14 +12,14 @@ var a: [1; 39999999999999999993];
 // CHECK:STDOUT: --- fail_bound_overflow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993, const
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const = constants.%.loc10_9
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993, const = constants.%.loc10_12
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993 [template = constants.%.loc10_12]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -22,27 +22,27 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT: --- fail_incomplete_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete, const
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error>, const
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete [template]
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Incomplete = %Incomplete.decl, .a = %a, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
-// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete, const
-// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete, const = %Incomplete
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1, const = constants.%.loc15_21
-// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete, const = constants.%.loc15_22
+// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
+// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1 [template = constants.%.loc15_21]
+// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete [template = constants.%.loc15_22]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
-// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete, const = %Incomplete
-// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete, const
+// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
+// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete [template]
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var p
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name p, %p.var
 // CHECK:STDOUT:   %a.ref: ref <error> = name_ref a, %a
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0, const = constants.%.loc20_25
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0 [template = constants.%.loc20_25]
 // CHECK:STDOUT:   %.loc20_22: <error>* = addr_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -12,17 +12,17 @@ var a: [1; 1];
 // CHECK:STDOUT: --- fail_invalid_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_13.1: type = array_type %.loc10_12, <error>, const
-// CHECK:STDOUT:   %.loc10_13.2: type = ptr_type [<error>; 1], const
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_13.1: type = array_type %.loc10_12, <error> [template]
+// CHECK:STDOUT:   %.loc10_13.2: type = ptr_type [<error>; 1] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const = constants.%.loc10_9
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1, const = constants.%.loc10_12
-// CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error>, const = constants.%.loc10_13.1
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1 [template = constants.%.loc10_12]
+// CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error> [template = constants.%.loc10_13.1]
 // CHECK:STDOUT:   %a.var: ref [<error>; 1] = var a
 // CHECK:STDOUT:   %a: ref [<error>; 1] = bind_name a, %a.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -12,24 +12,24 @@ var a: [i32; 1] = (1, 2, 3);
 // CHECK:STDOUT: --- fail_out_of_bound.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32, const
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32), const
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32 [template]
+// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const = constants.%.loc10_14
-// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32, const = constants.%.loc10_15.1
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.loc10_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const = constants.%.loc10_20
-// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2, const = constants.%.loc10_23
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3, const = constants.%.loc10_26
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
+// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2 [template = constants.%.loc10_23]
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3 [template = constants.%.loc10_26]
 // CHECK:STDOUT:   %.loc10_27: (i32, i32, i32) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_26)
 // CHECK:STDOUT:   assign %a.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -29,50 +29,50 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32, const
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 3], const
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello", const
-// CHECK:STDOUT:   %.loc10_32: String = string_literal "World", const
-// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String), const
-// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*), const
-// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*), const
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32, const
-// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32, const
-// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32, const
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32 [template]
+// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template]
+// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template]
+// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String) [template]
+// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*) [template]
+// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*) [template]
+// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template]
+// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template]
+// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .t1 = %t1, .b = %b, .c = %c, .t2 = %t2, .d = %d}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3, const = constants.%.loc10_14
-// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32, const = constants.%.loc10_15.1
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template = constants.%.loc10_14]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.loc10_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const = constants.%.loc10_20
-// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello", const = constants.%.loc10_23
-// CHECK:STDOUT:   %.loc10_32: String = string_literal "World", const = constants.%.loc10_32
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
+// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template = constants.%.loc10_23]
+// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template = constants.%.loc10_32]
 // CHECK:STDOUT:   %.loc10_39.1: (i32, String, String) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_32)
 // CHECK:STDOUT:   %.loc10_39.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_39.3: ref i32 = array_index %a.var, %.loc10_39.2
 // CHECK:STDOUT:   %.loc10_39.4: init i32 = initialize_from %.loc10_20 to %.loc10_39.3
 // CHECK:STDOUT:   assign %a.var, <error>
 // CHECK:STDOUT:   %.loc12: (type, type, type) = tuple_literal (i32, String, String)
-// CHECK:STDOUT:   %.loc10_39.5: type = converted %.loc12, constants.%.loc10_39.1, const = constants.%.loc10_39.1
+// CHECK:STDOUT:   %.loc10_39.5: type = converted %.loc12, constants.%.loc10_39.1 [template = constants.%.loc10_39.1]
 // CHECK:STDOUT:   %t1.var: ref (i32, String, String) = var t1
 // CHECK:STDOUT:   %t1: ref (i32, String, String) = bind_name t1, %t1.var
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3, const = constants.%.loc16_14
-// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32, const = constants.%.loc16_15
+// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template = constants.%.loc16_14]
+// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template = constants.%.loc16_15]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
 // CHECK:STDOUT:   %t1.ref: ref (i32, String, String) = name_ref t1, %t1
@@ -83,20 +83,20 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %.loc16_19.5: init i32 = initialize_from %.loc16_19.2 to %.loc16_19.4
 // CHECK:STDOUT:   %.loc16_19.6: ref String = tuple_access %t1.ref, element1
 // CHECK:STDOUT:   assign %b.var, <error>
-// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3, const = constants.%.loc21_14
-// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32, const = constants.%.loc21_15
+// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template = constants.%.loc21_14]
+// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template = constants.%.loc21_15]
 // CHECK:STDOUT:   %c.var: ref [i32; 3] = var c
 // CHECK:STDOUT:   %c: ref [i32; 3] = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1, const = constants.%.loc21_20
-// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2, const = constants.%.loc21_23
+// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template = constants.%.loc21_20]
+// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template = constants.%.loc21_23]
 // CHECK:STDOUT:   %.loc21_24.1: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %.loc23: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc21_24.2: type = converted %.loc23, constants.%.loc21_24.1, const = constants.%.loc21_24.1
+// CHECK:STDOUT:   %.loc21_24.2: type = converted %.loc23, constants.%.loc21_24.1 [template = constants.%.loc21_24.1]
 // CHECK:STDOUT:   %t2.var: ref (i32, i32) = var t2
 // CHECK:STDOUT:   %t2: ref (i32, i32) = bind_name t2, %t2.var
-// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3, const = constants.%.loc27_14
-// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32, const = constants.%.loc27_15
+// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template = constants.%.loc27_14]
+// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template = constants.%.loc27_15]
 // CHECK:STDOUT:   %d.var: ref [i32; 3] = var d
 // CHECK:STDOUT:   %d: ref [i32; 3] = bind_name d, %d.var
 // CHECK:STDOUT:   %t2.ref: ref (i32, i32) = name_ref t2, %t2

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -15,20 +15,20 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- function_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32, const
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3], const
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc12_20: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
+// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc12_20: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%arr: [i32; 3], %i: i32) -> i32 {
@@ -43,12 +43,12 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1, const = constants.%.loc12_13
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2, const = constants.%.loc12_16
-// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3, const = constants.%.loc12_19
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1 [template = constants.%.loc12_13]
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2 [template = constants.%.loc12_16]
+// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3 [template = constants.%.loc12_19]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, i32) = tuple_literal (%.loc12_13, %.loc12_16, %.loc12_19)
-// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1, const = constants.%.loc12_23
+// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1 [template = constants.%.loc12_23]
 // CHECK:STDOUT:   %.loc12_20.2: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc12_20.3: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc12_20.4: ref i32 = array_index %.loc12_20.2, %.loc12_20.3

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -9,36 +9,36 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT: --- nine_elements.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 9], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7, const
-// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8, const
-// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9, const
-// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32), const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 9] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 9] = var a
 // CHECK:STDOUT:   %a: ref [i32; 9] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1, const = constants.%.loc7_20
-// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2, const = constants.%.loc7_23
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3, const = constants.%.loc7_26
-// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4, const = constants.%.loc7_29
-// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5, const = constants.%.loc7_32
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6, const = constants.%.loc7_35
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7, const = constants.%.loc7_38
-// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8, const = constants.%.loc7_41
-// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9, const = constants.%.loc7_44
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2 [template = constants.%.loc7_23]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3 [template = constants.%.loc7_26]
+// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4 [template = constants.%.loc7_29]
+// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5 [template = constants.%.loc7_32]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6 [template = constants.%.loc7_35]
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7 [template = constants.%.loc7_38]
+// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8 [template = constants.%.loc7_41]
+// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9 [template = constants.%.loc7_44]
 // CHECK:STDOUT:   %.loc7_45.1: (i32, i32, i32, i32, i32, i32, i32, i32, i32) = tuple_literal (%.loc7_20, %.loc7_23, %.loc7_26, %.loc7_29, %.loc7_32, %.loc7_35, %.loc7_38, %.loc7_41, %.loc7_44)
 // CHECK:STDOUT:   %.loc7_45.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_45.3: ref i32 = array_index %a.var, %.loc7_45.2

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -9,14 +9,14 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT: --- as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_24: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32), const
+// CHECK:STDOUT:   %.loc7_24: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
 // CHECK:STDOUT:   %.loc7_24: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_26: type = converted %.loc7_24, constants.%.loc7_26, const = constants.%.loc7_26
+// CHECK:STDOUT:   %.loc7_26: type = converted %.loc7_24, constants.%.loc7_26 [template = constants.%.loc7_26]
 // CHECK:STDOUT:   %t: type = bind_name t, %.loc7_26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/basic.carbon
+++ b/toolchain/check/testdata/as/basic.carbon
@@ -11,17 +11,17 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -12,19 +12,19 @@ let n: (i32, i32) = 1 as (i32, i32);
 // CHECK:STDOUT: --- fail_no_conversion.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2, const = constants.%.loc10_17.2
-// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1, const = constants.%.loc10_21
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
+// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template = constants.%.loc10_21]
 // CHECK:STDOUT:   %.loc10_35: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = converted %.loc10_35, constants.%.loc10_17.2, const = constants.%.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17.3: type = converted %.loc10_35, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
 // CHECK:STDOUT:   %n: (i32, i32) = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_not_type.carbon
+++ b/toolchain/check/testdata/as/fail_not_type.carbon
@@ -12,14 +12,14 @@ let n: i32 = 1 as 2;
 // CHECK:STDOUT: --- fail_not_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const = constants.%.loc10_14
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2, const = constants.%.loc10_19
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template = constants.%.loc10_19]
 // CHECK:STDOUT:   %n: i32 = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/identity.carbon
+++ b/toolchain/check/testdata/as/identity.carbon
@@ -27,19 +27,19 @@ fn Initializing() {
 // CHECK:STDOUT: --- identity.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc9: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc9: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.X = %X.decl, .Value = %Value, .Reference = %Reference, .Make = %Make, .Initializing = %Initializing}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X, const
-// CHECK:STDOUT:   %Value: <function> = fn_decl @Value, const
-// CHECK:STDOUT:   %Reference: <function> = fn_decl @Reference, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %Initializing: <function> = fn_decl @Initializing, const
+// CHECK:STDOUT:   %X: type = class_type @X [template]
+// CHECK:STDOUT:   %Value: <function> = fn_decl @Value [template]
+// CHECK:STDOUT:   %Reference: <function> = fn_decl @Reference [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %Initializing: <function> = fn_decl @Initializing [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -49,20 +49,20 @@ fn Initializing() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Value(%n: X) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %X.ref.loc14_10: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc14_10: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %n.ref: X = name_ref n, %n
-// CHECK:STDOUT:   %X.ref.loc14_19: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc14_19: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %m: X = bind_name m, %n.ref
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Reference(%p: X*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %X.ref.loc18_10: type = name_ref X, file.%X, const = file.%X
-// CHECK:STDOUT:   %.loc18_11: type = ptr_type X, const
+// CHECK:STDOUT:   %X.ref.loc18_10: type = name_ref X, file.%X [template = file.%X]
+// CHECK:STDOUT:   %.loc18_11: type = ptr_type X [template]
 // CHECK:STDOUT:   %p.ref: X* = name_ref p, %p
 // CHECK:STDOUT:   %.loc18_17: ref X = deref %p.ref
-// CHECK:STDOUT:   %X.ref.loc18_23: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc18_23: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc18_15: X* = addr_of %.loc18_17
 // CHECK:STDOUT:   %q: X* = bind_name q, %.loc18_15
 // CHECK:STDOUT:   return
@@ -72,13 +72,13 @@ fn Initializing() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Initializing() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %X.ref.loc24_10: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc24_10: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %x.var: ref X = var x
 // CHECK:STDOUT:   %x: ref X = bind_name x, %x.var
-// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc24_7: ref X = splice_block %x.var {}
 // CHECK:STDOUT:   %.loc24_19: init X = call %Make.ref() to %.loc24_7
-// CHECK:STDOUT:   %X.ref.loc24_25: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc24_25: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   assign %x.var, %.loc24_19
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -23,22 +23,22 @@ fn Var() {
 // CHECK:STDOUT: --- tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc15_15.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc15_15.2: type = tuple_type (X, X), const
-// CHECK:STDOUT:   %.loc15_15.3: type = tuple_type ({}*, {}*), const
-// CHECK:STDOUT:   %.loc15_15.4: type = ptr_type ({}*, {}*), const
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc15_15.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc15_15.2: type = tuple_type (X, X) [template]
+// CHECK:STDOUT:   %.loc15_15.3: type = tuple_type ({}*, {}*) [template]
+// CHECK:STDOUT:   %.loc15_15.4: type = ptr_type ({}*, {}*) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.X = %X.decl, .Make = %Make, .Let = %Let, .Var = %Var}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %Let: <function> = fn_decl @Let, const
-// CHECK:STDOUT:   %Var: <function> = fn_decl @Var, const
+// CHECK:STDOUT:   %X: type = class_type @X [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %Let: <function> = fn_decl @Let [template]
+// CHECK:STDOUT:   %Var: <function> = fn_decl @Var [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -50,21 +50,21 @@ fn Var() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Let() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %X.ref.loc15_11: type = name_ref X, file.%X, const = file.%X
-// CHECK:STDOUT:   %X.ref.loc15_14: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc15_11: type = name_ref X, file.%X [template = file.%X]
+// CHECK:STDOUT:   %X.ref.loc15_14: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc15_15.1: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
-// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc15_15.1, constants.%.loc15_15.2, const = constants.%.loc15_15.2
-// CHECK:STDOUT:   %Make.ref.loc15_20: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc15_15.1, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
+// CHECK:STDOUT:   %Make.ref.loc15_20: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc15_24.1: ref X = temporary_storage
 // CHECK:STDOUT:   %.loc15_24.2: init X = call %Make.ref.loc15_20() to %.loc15_24.1
-// CHECK:STDOUT:   %Make.ref.loc15_28: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref.loc15_28: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc15_32.1: ref X = temporary_storage
 // CHECK:STDOUT:   %.loc15_32.2: init X = call %Make.ref.loc15_28() to %.loc15_32.1
 // CHECK:STDOUT:   %.loc15_34.1: (X, X) = tuple_literal (%.loc15_24.2, %.loc15_32.2)
-// CHECK:STDOUT:   %X.ref.loc15_40: type = name_ref X, file.%X, const = file.%X
-// CHECK:STDOUT:   %X.ref.loc15_43: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc15_40: type = name_ref X, file.%X [template = file.%X]
+// CHECK:STDOUT:   %X.ref.loc15_43: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc15_44: (type, type) = tuple_literal (%X.ref.loc15_40, %X.ref.loc15_43)
-// CHECK:STDOUT:   %.loc15_15.3: type = converted %.loc15_44, constants.%.loc15_15.2, const = constants.%.loc15_15.2
+// CHECK:STDOUT:   %.loc15_15.3: type = converted %.loc15_44, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
 // CHECK:STDOUT:   %.loc15_24.3: ref X = temporary %.loc15_24.1, %.loc15_24.2
 // CHECK:STDOUT:   %.loc15_24.4: X = bind_value %.loc15_24.3
 // CHECK:STDOUT:   %.loc15_32.3: ref X = temporary %.loc15_32.1, %.loc15_32.2
@@ -77,23 +77,23 @@ fn Var() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Var() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %X.ref.loc20_11: type = name_ref X, file.%X, const = file.%X
-// CHECK:STDOUT:   %X.ref.loc20_14: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc20_11: type = name_ref X, file.%X [template = file.%X]
+// CHECK:STDOUT:   %X.ref.loc20_14: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc20_15: (type, type) = tuple_literal (%X.ref.loc20_11, %X.ref.loc20_14)
-// CHECK:STDOUT:   %.loc15_15.1: type = converted %.loc20_15, constants.%.loc15_15.2, const = constants.%.loc15_15.2
+// CHECK:STDOUT:   %.loc15_15.1: type = converted %.loc20_15, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
 // CHECK:STDOUT:   %b.var: ref (X, X) = var b
 // CHECK:STDOUT:   %b: ref (X, X) = bind_name b, %b.var
-// CHECK:STDOUT:   %Make.ref.loc20_20: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref.loc20_20: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc20_34.1: ref X = tuple_access %b.var, element0
 // CHECK:STDOUT:   %.loc20_24: init X = call %Make.ref.loc20_20() to %.loc20_34.1
-// CHECK:STDOUT:   %Make.ref.loc20_28: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref.loc20_28: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc20_34.2: ref X = tuple_access %b.var, element1
 // CHECK:STDOUT:   %.loc20_32: init X = call %Make.ref.loc20_28() to %.loc20_34.2
 // CHECK:STDOUT:   %.loc20_34.3: (X, X) = tuple_literal (%.loc20_24, %.loc20_32)
-// CHECK:STDOUT:   %X.ref.loc20_40: type = name_ref X, file.%X, const = file.%X
-// CHECK:STDOUT:   %X.ref.loc20_43: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref.loc20_40: type = name_ref X, file.%X [template = file.%X]
+// CHECK:STDOUT:   %X.ref.loc20_43: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc20_44: (type, type) = tuple_literal (%X.ref.loc20_40, %X.ref.loc20_43)
-// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc20_44, constants.%.loc15_15.2, const = constants.%.loc15_15.2
+// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc20_44, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
 // CHECK:STDOUT:   %.loc20_34.4: init (X, X) = tuple_init (%.loc20_24, %.loc20_32) to %b.var
 // CHECK:STDOUT:   %.loc20_34.5: init (X, X) = converted %.loc20_34.3, %.loc20_34.4
 // CHECK:STDOUT:   assign %b.var, %.loc20_34.5

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -12,23 +12,23 @@ var test_type: type = i32;
 // CHECK:STDOUT: --- builtin_types.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1, const
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc9: String = string_literal "Test", const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.test_i32 = %test_i32, .test_f64 = %test_f64, .test_type = %test_type}
 // CHECK:STDOUT:   %test_i32.var: ref i32 = var test_i32
 // CHECK:STDOUT:   %test_i32: ref i32 = bind_name test_i32, %test_i32.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %test_i32.var, %.loc7
 // CHECK:STDOUT:   %test_f64.var: ref f64 = var test_f64
 // CHECK:STDOUT:   %test_f64: ref f64 = bind_name test_f64, %test_f64.var
-// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %test_f64.var, %.loc8
-// CHECK:STDOUT:   %.loc9: String = string_literal "Test", const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template = constants.%.loc9]
 // CHECK:STDOUT:   %test_str: String = bind_name test_str, %.loc9
 // CHECK:STDOUT:   %test_type.var: ref type = var test_type
 // CHECK:STDOUT:   %test_type: ref type = bind_name test_type, %test_type.var

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -15,13 +15,13 @@ fn Run() -> String {}
 // CHECK:STDOUT: --- fail_bad_run.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc13: type = tuple_type (), const
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc13: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run = %Run}
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> %return: String {

--- a/toolchain/check/testdata/basics/fail_bad_run_2.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run_2.carbon
@@ -13,7 +13,7 @@ fn Run(n: i32) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run = %Run}
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run(%n: i32) {

--- a/toolchain/check/testdata/basics/fail_name_lookup.carbon
+++ b/toolchain/check/testdata/basics/fail_name_lookup.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
+++ b/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
@@ -12,14 +12,14 @@ var x: type = 42;
 // CHECK:STDOUT: --- fail_non_type_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 42, const
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 42 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %x.var: ref type = var x
 // CHECK:STDOUT:   %x: ref type = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 42, const = constants.%.loc10
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 42 [template = constants.%.loc10]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/multifile.carbon
+++ b/toolchain/check/testdata/basics/multifile.carbon
@@ -18,7 +18,7 @@ fn B() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
@@ -30,7 +30,7 @@ fn B() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B}
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() {

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          !inst+1
+// CHECK:STDOUT:     inst+1:          const inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -80,7 +80,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          !inst+1
+// CHECK:STDOUT:     inst+1:          const inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          inst+1
+// CHECK:STDOUT:     inst+1:          !inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -80,7 +80,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          inst+1
+// CHECK:STDOUT:     inst+1:          !inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          const inst+1
+// CHECK:STDOUT:     inst+1:          template inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -80,7 +80,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          const inst+1
+// CHECK:STDOUT:     inst+1:          template inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -53,7 +53,7 @@ fn B() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
@@ -96,7 +96,7 @@ fn B() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B}
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() {

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          inst+1
+// CHECK:STDOUT:     inst+1:          !inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -67,7 +67,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          inst+1
+// CHECK:STDOUT:     inst+1:          !inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          !inst+1
+// CHECK:STDOUT:     inst+1:          const inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -67,7 +67,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          !inst+1
+// CHECK:STDOUT:     inst+1:          const inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -37,7 +37,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          const inst+1
+// CHECK:STDOUT:     inst+1:          template inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:
@@ -67,7 +67,7 @@ fn B() {}
 // CHECK:STDOUT:     inst+1:          {kind: FunctionDecl, arg0: function0, type: type1}
 // CHECK:STDOUT:     inst+2:          {kind: Return}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+1:          const inst+1
+// CHECK:STDOUT:     inst+1:          template inst+1
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -28,44 +28,44 @@ fn F() {
 // CHECK:STDOUT: --- numeric_literals.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc10_20.1: type = array_type %.loc10_19, i32, const
-// CHECK:STDOUT:   %.loc10_20.2: type = ptr_type [i32; 5], const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 8, const
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 9, const
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 8, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 8, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993, const
-// CHECK:STDOUT:   %.loc16: type = tuple_type (i32, i32, i32, i32, i32), const
-// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7, const
-// CHECK:STDOUT:   %.loc17_22.1: type = array_type %.loc17_21, f64, const
-// CHECK:STDOUT:   %.loc17_22.2: type = ptr_type [f64; 7], const
-// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1, const
-// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1, const
-// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1, const
-// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6, const
-// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7, const
-// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9, const
-// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992, const
-// CHECK:STDOUT:   %.loc25: type = tuple_type (f64, f64, f64, f64, f64, f64, f64), const
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc10_20.1: type = array_type %.loc10_19, i32 [template]
+// CHECK:STDOUT:   %.loc10_20.2: type = ptr_type [i32; 5] [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993 [template]
+// CHECK:STDOUT:   %.loc16: type = tuple_type (i32, i32, i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.loc17_22.1: type = array_type %.loc17_21, f64 [template]
+// CHECK:STDOUT:   %.loc17_22.2: type = ptr_type [f64; 7] [template]
+// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1 [template]
+// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1 [template]
+// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1 [template]
+// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6 [template]
+// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7 [template]
+// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9 [template]
+// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992 [template]
+// CHECK:STDOUT:   %.loc25: type = tuple_type (f64, f64, f64, f64, f64, f64, f64) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5, const = constants.%.loc10_19
-// CHECK:STDOUT:   %.loc10_20: type = array_type %.loc10_19, i32, const = constants.%.loc10_20.1
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5 [template = constants.%.loc10_19]
+// CHECK:STDOUT:   %.loc10_20: type = array_type %.loc10_19, i32 [template = constants.%.loc10_20.1]
 // CHECK:STDOUT:   %ints.var: ref [i32; 5] = var ints
 // CHECK:STDOUT:   %ints: ref [i32; 5] = bind_name ints, %ints.var
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 8, const = constants.%.loc11
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 9, const = constants.%.loc12
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 8, const = constants.%.loc13
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 8, const = constants.%.loc14
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 8 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 9 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 8 [template = constants.%.loc13]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 8 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993 [template = constants.%.loc15]
 // CHECK:STDOUT:   %.loc16_3.1: (i32, i32, i32, i32, i32) = tuple_literal (%.loc11, %.loc12, %.loc13, %.loc14, %.loc15)
 // CHECK:STDOUT:   %.loc16_3.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc16_3.3: ref i32 = array_index %ints.var, %.loc16_3.2
@@ -85,17 +85,17 @@ fn F() {
 // CHECK:STDOUT:   %.loc16_3.17: init [i32; 5] = array_init (%.loc16_3.4, %.loc16_3.7, %.loc16_3.10, %.loc16_3.13, %.loc16_3.16) to %ints.var
 // CHECK:STDOUT:   %.loc16_3.18: init [i32; 5] = converted %.loc16_3.1, %.loc16_3.17
 // CHECK:STDOUT:   assign %ints.var, %.loc16_3.18
-// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7, const = constants.%.loc17_21
-// CHECK:STDOUT:   %.loc17_22: type = array_type %.loc17_21, f64, const = constants.%.loc17_22.1
+// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7 [template = constants.%.loc17_21]
+// CHECK:STDOUT:   %.loc17_22: type = array_type %.loc17_21, f64 [template = constants.%.loc17_22.1]
 // CHECK:STDOUT:   %floats.var: ref [f64; 7] = var floats
 // CHECK:STDOUT:   %floats: ref [f64; 7] = bind_name floats, %floats.var
-// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1, const = constants.%.loc18
-// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1, const = constants.%.loc19
-// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1, const = constants.%.loc20
-// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6, const = constants.%.loc21
-// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7, const = constants.%.loc22
-// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9, const = constants.%.loc23
-// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992, const = constants.%.loc24
+// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1 [template = constants.%.loc18]
+// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1 [template = constants.%.loc19]
+// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1 [template = constants.%.loc20]
+// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6 [template = constants.%.loc21]
+// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9 [template = constants.%.loc23]
+// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992 [template = constants.%.loc24]
 // CHECK:STDOUT:   %.loc25_3.1: (f64, f64, f64, f64, f64, f64, f64) = tuple_literal (%.loc18, %.loc19, %.loc20, %.loc21, %.loc22, %.loc23, %.loc24)
 // CHECK:STDOUT:   %.loc25_3.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc25_3.3: ref f64 = array_index %floats.var, %.loc25_3.2

--- a/toolchain/check/testdata/basics/parens.carbon
+++ b/toolchain/check/testdata/basics/parens.carbon
@@ -10,19 +10,19 @@ var b: i32 = ((2));
 // CHECK:STDOUT: --- parens.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %a.var, %.loc7
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -67,14 +67,14 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          inst+3
-// CHECK:STDOUT:     inst+5:          inst+5
-// CHECK:STDOUT:     inst+8:          inst+8
-// CHECK:STDOUT:     inst+9:          inst+9
-// CHECK:STDOUT:     inst+11:         inst+12
-// CHECK:STDOUT:     inst+12:         inst+12
-// CHECK:STDOUT:     inst+13:         inst+14
-// CHECK:STDOUT:     inst+14:         inst+14
+// CHECK:STDOUT:     inst+3:          !inst+3
+// CHECK:STDOUT:     inst+5:          !inst+5
+// CHECK:STDOUT:     inst+8:          !inst+8
+// CHECK:STDOUT:     inst+9:          !inst+9
+// CHECK:STDOUT:     inst+11:         !inst+12
+// CHECK:STDOUT:     inst+12:         !inst+12
+// CHECK:STDOUT:     inst+13:         !inst+14
+// CHECK:STDOUT:     inst+14:         !inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -67,15 +67,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          !inst+3
-// CHECK:STDOUT:     inst+5:          !inst+5
-// CHECK:STDOUT:     inst+6:          !inst+5
-// CHECK:STDOUT:     inst+8:          !inst+8
-// CHECK:STDOUT:     inst+9:          !inst+9
-// CHECK:STDOUT:     inst+11:         !inst+12
-// CHECK:STDOUT:     inst+12:         !inst+12
-// CHECK:STDOUT:     inst+13:         !inst+14
-// CHECK:STDOUT:     inst+14:         !inst+14
+// CHECK:STDOUT:     inst+3:          const inst+3
+// CHECK:STDOUT:     inst+5:          const inst+5
+// CHECK:STDOUT:     inst+6:          const inst+5
+// CHECK:STDOUT:     inst+8:          const inst+8
+// CHECK:STDOUT:     inst+9:          const inst+9
+// CHECK:STDOUT:     inst+11:         const inst+12
+// CHECK:STDOUT:     inst+12:         const inst+12
+// CHECK:STDOUT:     inst+13:         const inst+14
+// CHECK:STDOUT:     inst+14:         const inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -122,23 +122,23 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: --- raw_and_textual_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64), const
-// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64), const
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1, const
+// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, i32, f64) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2, const = constants.%.loc12_14
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1, const = constants.%.loc12_17
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.loc12_14]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.loc12_17]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, f64) = tuple_literal (%n.ref, %.loc12_14, %.loc12_17)
 // CHECK:STDOUT:   %.loc12_20.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc12_20.3: init i32 = initialize_from %n.ref to %.loc12_20.2

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -67,15 +67,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          const inst+3
-// CHECK:STDOUT:     inst+5:          const inst+5
-// CHECK:STDOUT:     inst+6:          const inst+5
-// CHECK:STDOUT:     inst+8:          const inst+8
-// CHECK:STDOUT:     inst+9:          const inst+9
-// CHECK:STDOUT:     inst+11:         const inst+12
-// CHECK:STDOUT:     inst+12:         const inst+12
-// CHECK:STDOUT:     inst+13:         const inst+14
-// CHECK:STDOUT:     inst+14:         const inst+14
+// CHECK:STDOUT:     inst+3:          template inst+3
+// CHECK:STDOUT:     inst+5:          template inst+5
+// CHECK:STDOUT:     inst+6:          template inst+5
+// CHECK:STDOUT:     inst+8:          template inst+8
+// CHECK:STDOUT:     inst+9:          template inst+9
+// CHECK:STDOUT:     inst+11:         template inst+12
+// CHECK:STDOUT:     inst+12:         template inst+12
+// CHECK:STDOUT:     inst+13:         template inst+14
+// CHECK:STDOUT:     inst+14:         template inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/raw_identifier.carbon
+++ b/toolchain/check/testdata/basics/raw_identifier.carbon
@@ -24,9 +24,9 @@ fn C(r#if: i32) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A, .B = %B, .C = %C}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
-// CHECK:STDOUT:   %C: <function> = fn_decl @C, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
+// CHECK:STDOUT:   %C: <function> = fn_decl @C [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A(%n: i32) -> i32 {

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -67,14 +67,14 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          inst+3
-// CHECK:STDOUT:     inst+5:          inst+5
-// CHECK:STDOUT:     inst+8:          inst+8
-// CHECK:STDOUT:     inst+9:          inst+9
-// CHECK:STDOUT:     inst+11:         inst+12
-// CHECK:STDOUT:     inst+12:         inst+12
-// CHECK:STDOUT:     inst+13:         inst+14
-// CHECK:STDOUT:     inst+14:         inst+14
+// CHECK:STDOUT:     inst+3:          !inst+3
+// CHECK:STDOUT:     inst+5:          !inst+5
+// CHECK:STDOUT:     inst+8:          !inst+8
+// CHECK:STDOUT:     inst+9:          !inst+9
+// CHECK:STDOUT:     inst+11:         !inst+12
+// CHECK:STDOUT:     inst+12:         !inst+12
+// CHECK:STDOUT:     inst+13:         !inst+14
+// CHECK:STDOUT:     inst+14:         !inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -67,15 +67,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          !inst+3
-// CHECK:STDOUT:     inst+5:          !inst+5
-// CHECK:STDOUT:     inst+6:          !inst+5
-// CHECK:STDOUT:     inst+8:          !inst+8
-// CHECK:STDOUT:     inst+9:          !inst+9
-// CHECK:STDOUT:     inst+11:         !inst+12
-// CHECK:STDOUT:     inst+12:         !inst+12
-// CHECK:STDOUT:     inst+13:         !inst+14
-// CHECK:STDOUT:     inst+14:         !inst+14
+// CHECK:STDOUT:     inst+3:          const inst+3
+// CHECK:STDOUT:     inst+5:          const inst+5
+// CHECK:STDOUT:     inst+6:          const inst+5
+// CHECK:STDOUT:     inst+8:          const inst+8
+// CHECK:STDOUT:     inst+9:          const inst+9
+// CHECK:STDOUT:     inst+11:         const inst+12
+// CHECK:STDOUT:     inst+12:         const inst+12
+// CHECK:STDOUT:     inst+13:         const inst+14
+// CHECK:STDOUT:     inst+14:         const inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -67,15 +67,15 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT:     inst+23:         {kind: Converted, arg0: inst+15, arg1: inst+22, type: type4}
 // CHECK:STDOUT:     inst+24:         {kind: ReturnExpr, arg0: inst+23}
 // CHECK:STDOUT:   constant_values:
-// CHECK:STDOUT:     inst+3:          const inst+3
-// CHECK:STDOUT:     inst+5:          const inst+5
-// CHECK:STDOUT:     inst+6:          const inst+5
-// CHECK:STDOUT:     inst+8:          const inst+8
-// CHECK:STDOUT:     inst+9:          const inst+9
-// CHECK:STDOUT:     inst+11:         const inst+12
-// CHECK:STDOUT:     inst+12:         const inst+12
-// CHECK:STDOUT:     inst+13:         const inst+14
-// CHECK:STDOUT:     inst+14:         const inst+14
+// CHECK:STDOUT:     inst+3:          template inst+3
+// CHECK:STDOUT:     inst+5:          template inst+5
+// CHECK:STDOUT:     inst+6:          template inst+5
+// CHECK:STDOUT:     inst+8:          template inst+8
+// CHECK:STDOUT:     inst+9:          template inst+9
+// CHECK:STDOUT:     inst+11:         template inst+12
+// CHECK:STDOUT:     inst+12:         template inst+12
+// CHECK:STDOUT:     inst+13:         template inst+14
+// CHECK:STDOUT:     inst+14:         template inst+14
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     empty:           {}
 // CHECK:STDOUT:     exports:

--- a/toolchain/check/testdata/basics/run.carbon
+++ b/toolchain/check/testdata/basics/run.carbon
@@ -10,7 +10,7 @@ fn Run() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run = %Run}
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/basics/run_i32.carbon
+++ b/toolchain/check/testdata/basics/run_i32.carbon
@@ -9,17 +9,17 @@ fn Run() -> i32 { return 0; }
 // CHECK:STDOUT: --- run_i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run = %Run}
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -15,23 +15,23 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: --- textual_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64), const
-// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64), const
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1, const
+// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, i32, f64) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2, const = constants.%.loc12_14
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1, const = constants.%.loc12_17
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.loc12_14]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.loc12_17]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, f64) = tuple_literal (%n.ref, %.loc12_14, %.loc12_17)
 // CHECK:STDOUT:   %.loc12_20.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc12_20.3: init i32 = initialize_from %n.ref to %.loc12_20.2

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -25,46 +25,46 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: --- base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.b: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.b: i32}, const
-// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Base, .d: i32}, const
-// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.b: i32}*, .d: i32}, const
-// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.b: i32}*, .d: i32}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base, .d: i32}, const
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7, const
-// CHECK:STDOUT:   %.loc18_35: type = struct_type {.base: {.b: i32}, .d: i32}, const
-// CHECK:STDOUT:   %.loc21_35.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc21_35.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc21_35.3: type = ptr_type (i32, i32), const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.b: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.b: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Base, .d: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.b: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.b: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base, .d: i32} [template]
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.loc18_35: type = struct_type {.base: {.b: i32}, .d: i32} [template]
+// CHECK:STDOUT:   %.loc21_35.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc21_35.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc21_35.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Derived = %Derived.decl, .Make = %Make, .Access = %Access}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %Access: <function> = fn_decl @Access, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %Access: <function> = fn_decl @Access [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl b, element0, const
-// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl b, element0 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .b = %b
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
-// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base, const
-// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0, const
-// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Derived, i32, const
-// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Derived> = field_decl d, element1, const
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14_8.2, const = %.loc14_8.2
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
+// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0 [template]
+// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Derived, i32 [template]
+// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Derived> = field_decl d, element1 [template]
+// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14_8.2 [template = %.loc14_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_20.2
@@ -74,9 +74,9 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return: Derived {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4, const = constants.%.loc18_25
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4 [template = constants.%.loc18_25]
 // CHECK:STDOUT:   %.loc18_26.1: {.b: i32} = struct_literal (%.loc18_25)
-// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7, const = constants.%.loc18_34
+// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7 [template = constants.%.loc18_34]
 // CHECK:STDOUT:   %.loc18_35.1: {.base: {.b: i32}, .d: i32} = struct_literal (%.loc18_26.1, %.loc18_34)
 // CHECK:STDOUT:   %.loc18_35.2: ref Base = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc18_26.2: ref i32 = class_element_access %.loc18_35.2, element0

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -24,33 +24,33 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: --- base_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {.a: i32, .b: i32, .c: i32}, const
-// CHECK:STDOUT:   %.loc11_1.2: type = ptr_type {.a: i32, .b: i32, .c: i32}, const
-// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: Base, .d: i32, .e: i32}, const
-// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32}, const
-// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32}, const
-// CHECK:STDOUT:   %.loc13: type = ptr_type {.base: Base, .d: i32, .e: i32}, const
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.loc11_1.2: type = ptr_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: Base, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.loc13: type = ptr_type {.base: Base, .d: i32, .e: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Derived = %Derived.decl, .Access = %Access}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %Access: <function> = fn_decl @Access, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %Access: <function> = fn_decl @Access [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Base> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
-// CHECK:STDOUT:   %.loc10_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc10_8.2: <unbound element of class Base> = field_decl c, element2, const
-// CHECK:STDOUT:   %c: <unbound element of class Base> = bind_name c, %.loc10_8.2, const = %.loc10_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Base> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
+// CHECK:STDOUT:   %.loc10_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc10_8.2: <unbound element of class Base> = field_decl c, element2 [template]
+// CHECK:STDOUT:   %c: <unbound element of class Base> = bind_name c, %.loc10_8.2 [template = %.loc10_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -59,15 +59,15 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
-// CHECK:STDOUT:   %.loc14_20.1: type = unbound_element_type Derived, Base, const
-// CHECK:STDOUT:   %.loc14_20.2: <unbound element of class Derived> = base_decl Base, element0, const
-// CHECK:STDOUT:   %.loc16_8.1: type = unbound_element_type Derived, i32, const
-// CHECK:STDOUT:   %.loc16_8.2: <unbound element of class Derived> = field_decl d, element1, const
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc16_8.2, const = %.loc16_8.2
-// CHECK:STDOUT:   %.loc17_8.1: type = unbound_element_type Derived, i32, const
-// CHECK:STDOUT:   %.loc17_8.2: <unbound element of class Derived> = field_decl e, element2, const
-// CHECK:STDOUT:   %e: <unbound element of class Derived> = bind_name e, %.loc17_8.2, const = %.loc17_8.2
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
+// CHECK:STDOUT:   %.loc14_20.1: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.loc14_20.2: <unbound element of class Derived> = base_decl Base, element0 [template]
+// CHECK:STDOUT:   %.loc16_8.1: type = unbound_element_type Derived, i32 [template]
+// CHECK:STDOUT:   %.loc16_8.2: <unbound element of class Derived> = field_decl d, element1 [template]
+// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc16_8.2 [template = %.loc16_8.2]
+// CHECK:STDOUT:   %.loc17_8.1: type = unbound_element_type Derived, i32 [template]
+// CHECK:STDOUT:   %.loc17_8.2: <unbound element of class Derived> = field_decl e, element2 [template]
+// CHECK:STDOUT:   %e: <unbound element of class Derived> = bind_name e, %.loc17_8.2 [template = %.loc17_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc14_20.2

--- a/toolchain/check/testdata/class/base_function_unqualified.carbon
+++ b/toolchain/check/testdata/class/base_function_unqualified.carbon
@@ -22,34 +22,34 @@ fn Derived.H() {
 // CHECK:STDOUT: --- base_function_unqualified.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc16: type = struct_type {.base: Base}, const
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc16: type = struct_type {.base: Base} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Derived = %Derived.decl}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
-// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base, const
-// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
+// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0 [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_20.2
@@ -62,14 +62,14 @@ fn Derived.H() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F, const = @Base.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
 // CHECK:STDOUT:   %.loc14: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F, const = @Base.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
 // CHECK:STDOUT:   %.loc19: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -25,30 +25,30 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: --- base_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: Base}, const
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.a: i32}*}, const
-// CHECK:STDOUT:   %.loc17: type = ptr_type {.base: Base}, const
-// CHECK:STDOUT:   %.loc22: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc11: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.loc17: type = ptr_type {.base: Base} [template]
+// CHECK:STDOUT:   %.loc22: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Derived = %Derived.decl, .Call = %Call}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %Call: <function> = fn_decl @Call, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %Call: <function> = fn_decl @Call [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -56,9 +56,9 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
-// CHECK:STDOUT:   %.loc18_20.1: type = unbound_element_type Derived, Base, const
-// CHECK:STDOUT:   %.loc18_20.2: <unbound element of class Derived> = base_decl Base, element0, const
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
+// CHECK:STDOUT:   %.loc18_20.1: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.loc18_20.2: <unbound element of class Derived> = base_decl Base, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc18_20.2
@@ -70,7 +70,7 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc14_4: ref Base = deref %self.ref
 // CHECK:STDOUT:   %.loc14_10: ref i32 = class_element_access %.loc14_4, element0
-// CHECK:STDOUT:   %.loc14_15: i32 = int_literal 1, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14_15: i32 = int_literal 1 [template = constants.%.loc14]
 // CHECK:STDOUT:   assign %.loc14_10, %.loc14_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -32,42 +32,42 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: --- base_method_shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A}, const
-// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {}*}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A}, const
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B}, const
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A}*}, const
-// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B}, const
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A} [template]
+// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {}*} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A} [template]
+// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A}*} [template]
+// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl, .B = %B.decl, .C = %C.decl, .D = %D.decl, .Call = %Call}
 // CHECK:STDOUT:   %A.decl = class_decl @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A, const
+// CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %D.decl = class_decl @D, ()
-// CHECK:STDOUT:   %D: type = class_type @D, const
-// CHECK:STDOUT:   %Call: <function> = fn_decl @Call, const
+// CHECK:STDOUT:   %D: type = class_type @D [template]
+// CHECK:STDOUT:   %Call: <function> = fn_decl @Call [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
-// CHECK:STDOUT:   %.loc12_17.1: type = unbound_element_type B, A, const
-// CHECK:STDOUT:   %.loc12_17.2: <unbound element of class B> = base_decl A, element0, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc12_17.1: type = unbound_element_type B, A [template]
+// CHECK:STDOUT:   %.loc12_17.2: <unbound element of class B> = base_decl A, element0 [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_17.2
@@ -76,10 +76,10 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc17_17.1: type = unbound_element_type C, B, const
-// CHECK:STDOUT:   %.loc17_17.2: <unbound element of class C> = base_decl B, element0, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.3, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc17_17.1: type = unbound_element_type C, B [template]
+// CHECK:STDOUT:   %.loc17_17.2: <unbound element of class C> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc17_17.2
@@ -88,9 +88,9 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc22_17.1: type = unbound_element_type D, B, const
-// CHECK:STDOUT:   %.loc22_17.2: <unbound element of class D> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc22_17.1: type = unbound_element_type D, B [template]
+// CHECK:STDOUT:   %.loc22_17.2: <unbound element of class D> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc22_17.2

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -25,24 +25,24 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32}, const
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32} [template]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Class> = field_decl k, element0, const
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc14_8.2, const = %.loc14_8.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Class> = field_decl k, element0 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc14_8.2 [template = %.loc14_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -64,9 +64,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F, const = @Class.%F
-// CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4, const = constants.%.loc22
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4 [template = constants.%.loc22]
 // CHECK:STDOUT:   %.loc22_17: init i32 = call %F.ref(%.loc22_18)
 // CHECK:STDOUT:   %.loc22_20.1: i32 = value_of_initializer %.loc22_17
 // CHECK:STDOUT:   %.loc22_20.2: i32 = converted %.loc22_17, %.loc22_20.1

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -37,55 +37,55 @@ fn ConvertInit() {
 // CHECK:STDOUT: --- derived_to_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A, .b: i32}, const
-// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {.a: i32}*, .b: i32}, const
-// CHECK:STDOUT:   %.loc14_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A, .b: i32}, const
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B, .c: i32}, const
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A, .b: i32}*, .c: i32}, const
-// CHECK:STDOUT:   %.loc19_1.3: type = ptr_type {.base: {.base: A, .b: i32}*, .c: i32}, const
-// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B, .c: i32}, const
-// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc34_48: type = struct_type {.base: {.a: i32}, .b: i32}, const
-// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc34_57: type = struct_type {.base: {.base: {.a: i32}, .b: i32}, .c: i32}, const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A, .b: i32} [template]
+// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.loc14_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A, .b: i32} [template]
+// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B, .c: i32} [template]
+// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.loc19_1.3: type = ptr_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B, .c: i32} [template]
+// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc34_48: type = struct_type {.base: {.a: i32}, .b: i32} [template]
+// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc34_57: type = struct_type {.base: {.base: {.a: i32}, .b: i32}, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl, .B = %B.decl, .C = %C.decl, .ConvertCToB = %ConvertCToB, .ConvertBToA = %ConvertBToA, .ConvertCToA = %ConvertCToA, .ConvertValue = %ConvertValue, .ConvertRef = %ConvertRef, .ConvertInit = %ConvertInit}
 // CHECK:STDOUT:   %A.decl = class_decl @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A, const
+// CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %ConvertCToB: <function> = fn_decl @ConvertCToB, const
-// CHECK:STDOUT:   %ConvertBToA: <function> = fn_decl @ConvertBToA, const
-// CHECK:STDOUT:   %ConvertCToA: <function> = fn_decl @ConvertCToA, const
-// CHECK:STDOUT:   %ConvertValue: <function> = fn_decl @ConvertValue, const
-// CHECK:STDOUT:   %ConvertRef: <function> = fn_decl @ConvertRef, const
-// CHECK:STDOUT:   %ConvertInit: <function> = fn_decl @ConvertInit, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %ConvertCToB: <function> = fn_decl @ConvertCToB [template]
+// CHECK:STDOUT:   %ConvertBToA: <function> = fn_decl @ConvertBToA [template]
+// CHECK:STDOUT:   %ConvertCToA: <function> = fn_decl @ConvertCToA [template]
+// CHECK:STDOUT:   %ConvertValue: <function> = fn_decl @ConvertValue [template]
+// CHECK:STDOUT:   %ConvertRef: <function> = fn_decl @ConvertRef [template]
+// CHECK:STDOUT:   %ConvertInit: <function> = fn_decl @ConvertInit [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type A, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class A> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class A> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type A, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class A> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class A> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
-// CHECK:STDOUT:   %.loc12_17.1: type = unbound_element_type B, A, const
-// CHECK:STDOUT:   %.loc12_17.2: <unbound element of class B> = base_decl A, element0, const
-// CHECK:STDOUT:   %.loc13_8.1: type = unbound_element_type B, i32, const
-// CHECK:STDOUT:   %.loc13_8.2: <unbound element of class B> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class B> = bind_name b, %.loc13_8.2, const = %.loc13_8.2
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc12_17.1: type = unbound_element_type B, A [template]
+// CHECK:STDOUT:   %.loc12_17.2: <unbound element of class B> = base_decl A, element0 [template]
+// CHECK:STDOUT:   %.loc13_8.1: type = unbound_element_type B, i32 [template]
+// CHECK:STDOUT:   %.loc13_8.2: <unbound element of class B> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class B> = bind_name b, %.loc13_8.2 [template = %.loc13_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_17.2
@@ -94,12 +94,12 @@ fn ConvertInit() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc17_17.1: type = unbound_element_type C, B, const
-// CHECK:STDOUT:   %.loc17_17.2: <unbound element of class C> = base_decl B, element0, const
-// CHECK:STDOUT:   %.loc18_8.1: type = unbound_element_type C, i32, const
-// CHECK:STDOUT:   %.loc18_8.2: <unbound element of class C> = field_decl c, element1, const
-// CHECK:STDOUT:   %c: <unbound element of class C> = bind_name c, %.loc18_8.2, const = %.loc18_8.2
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc17_17.1: type = unbound_element_type C, B [template]
+// CHECK:STDOUT:   %.loc17_17.2: <unbound element of class C> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %.loc18_8.1: type = unbound_element_type C, i32 [template]
+// CHECK:STDOUT:   %.loc18_8.2: <unbound element of class C> = field_decl c, element1 [template]
+// CHECK:STDOUT:   %c: <unbound element of class C> = bind_name c, %.loc18_8.2 [template = %.loc18_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc17_17.2
@@ -140,7 +140,7 @@ fn ConvertInit() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertValue(%c: C) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %c.ref: C = name_ref c, %c
 // CHECK:STDOUT:   %.loc26_15.1: ref B = class_element_access %c.ref, element0
 // CHECK:STDOUT:   %.loc26_15.2: ref A = class_element_access %.loc26_15.1, element0
@@ -154,7 +154,7 @@ fn ConvertInit() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: C* = name_ref c, %c
 // CHECK:STDOUT:   %.loc30_12: ref C = deref %c.ref
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc30_15.1: ref B = class_element_access %.loc30_12, element0
 // CHECK:STDOUT:   %.loc30_15.2: ref A = class_element_access %.loc30_15.1, element0
 // CHECK:STDOUT:   %.loc30_15.3: ref A = converted %.loc30_12, %.loc30_15.2
@@ -164,14 +164,14 @@ fn ConvertInit() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertInit() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
-// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1, const = constants.%.loc34_38
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1 [template = constants.%.loc34_38]
 // CHECK:STDOUT:   %.loc34_39.1: {.a: i32} = struct_literal (%.loc34_38)
-// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2, const = constants.%.loc34_47
+// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2 [template = constants.%.loc34_47]
 // CHECK:STDOUT:   %.loc34_48.1: {.base: {.a: i32}, .b: i32} = struct_literal (%.loc34_39.1, %.loc34_47)
-// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3, const = constants.%.loc34_56
+// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3 [template = constants.%.loc34_56]
 // CHECK:STDOUT:   %.loc34_57.1: {.base: {.base: {.a: i32}, .b: i32}, .c: i32} = struct_literal (%.loc34_48.1, %.loc34_56)
-// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C, const = file.%C
+// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc34_57.2: ref C = temporary_storage
 // CHECK:STDOUT:   %.loc34_57.3: ref B = class_element_access %.loc34_57.2, element0
 // CHECK:STDOUT:   %.loc34_48.2: ref A = class_element_access %.loc34_57.3, element0

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -29,46 +29,46 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: --- fail_abstract.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Abstract, .d: i32}, const
-// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.a: i32}*, .d: i32}, const
-// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.a: i32}*, .d: i32}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Abstract, .d: i32}, const
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7, const
-// CHECK:STDOUT:   %.loc22_35: type = struct_type {.base: {.a: i32}, .d: i32}, const
-// CHECK:STDOUT:   %.loc25_35.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc25_35.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc25_35.3: type = ptr_type (i32, i32), const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Abstract, .d: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.a: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.a: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Abstract, .d: i32} [template]
+// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.loc22_35: type = struct_type {.base: {.a: i32}, .d: i32} [template]
+// CHECK:STDOUT:   %.loc25_35.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc25_35.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc25_35.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Abstract = %Abstract.decl, .Derived = %Derived.decl, .Make = %Make, .Access = %Access}
 // CHECK:STDOUT:   %Abstract.decl = class_decl @Abstract, ()
-// CHECK:STDOUT:   %Abstract: type = class_type @Abstract, const
+// CHECK:STDOUT:   %Abstract: type = class_type @Abstract [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %Access: <function> = fn_decl @Access, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %Access: <function> = fn_decl @Access [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Abstract {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Abstract, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Abstract> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Abstract> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Abstract, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Abstract> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Abstract> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Abstract.ref: type = name_ref Abstract, file.%Abstract, const = file.%Abstract
-// CHECK:STDOUT:   %.loc12_24.1: type = unbound_element_type Derived, Abstract, const
-// CHECK:STDOUT:   %.loc12_24.2: <unbound element of class Derived> = base_decl Abstract, element0, const
-// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Derived, i32, const
-// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Derived> = field_decl d, element1, const
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14_8.2, const = %.loc14_8.2
+// CHECK:STDOUT:   %Abstract.ref: type = name_ref Abstract, file.%Abstract [template = file.%Abstract]
+// CHECK:STDOUT:   %.loc12_24.1: type = unbound_element_type Derived, Abstract [template]
+// CHECK:STDOUT:   %.loc12_24.2: <unbound element of class Derived> = base_decl Abstract, element0 [template]
+// CHECK:STDOUT:   %.loc14_8.1: type = unbound_element_type Derived, i32 [template]
+// CHECK:STDOUT:   %.loc14_8.2: <unbound element of class Derived> = field_decl d, element1 [template]
+// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14_8.2 [template = %.loc14_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_24.2
@@ -78,9 +78,9 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return: Derived {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1, const = constants.%.loc22_25
+// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.loc22_25]
 // CHECK:STDOUT:   %.loc22_26: {.a: i32} = struct_literal (%.loc22_25)
-// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7, const = constants.%.loc22_34
+// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7 [template = constants.%.loc22_34]
 // CHECK:STDOUT:   %.loc22_35: {.base: {.a: i32}, .d: i32} = struct_literal (%.loc22_26, %.loc22_34)
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -19,18 +19,18 @@ class Class {
 // CHECK:STDOUT: --- fail_addr_not_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc17: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -41,21 +41,21 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT: --- fail_addr_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -120,58 +120,58 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: --- fail_base_bad_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_18.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc17: type = struct_type {.base: <error>}, const
-// CHECK:STDOUT:   %.loc12: type = ptr_type {.base: <error>}, const
-// CHECK:STDOUT:   %.loc26: i32 = int_literal 32, const
-// CHECK:STDOUT:   %.loc51_22: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc51_23.1: type = tuple_type (Base), const
-// CHECK:STDOUT:   %.loc7_18.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7_17: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc51_23.2: type = tuple_type ({}*), const
-// CHECK:STDOUT:   %.loc67: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc8: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc102_1.1: type = struct_type {.base: Final}, const
-// CHECK:STDOUT:   %.loc102_1.2: type = struct_type {.base: {.a: i32}*}, const
-// CHECK:STDOUT:   %.loc97: type = ptr_type {.base: Final}, const
+// CHECK:STDOUT:   %.loc7_18.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc17: type = struct_type {.base: <error>} [template]
+// CHECK:STDOUT:   %.loc12: type = ptr_type {.base: <error>} [template]
+// CHECK:STDOUT:   %.loc26: i32 = int_literal 32 [template]
+// CHECK:STDOUT:   %.loc51_22: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc51_23.1: type = tuple_type (Base) [template]
+// CHECK:STDOUT:   %.loc7_18.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7_17: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc51_23.2: type = tuple_type ({}*) [template]
+// CHECK:STDOUT:   %.loc67: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc8: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc102_1.1: type = struct_type {.base: Final} [template]
+// CHECK:STDOUT:   %.loc102_1.2: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.loc97: type = ptr_type {.base: Final} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Final = %Final.decl, .DeriveFromError = %DeriveFromError.decl, .AccessMemberWithInvalidBaseError = %AccessMemberWithInvalidBaseError, .DeriveFromNonType = %DeriveFromNonType.decl, .AccessMemberWithInvalidBasNonType = %AccessMemberWithInvalidBasNonType, .DeriveFromi32 = %DeriveFromi32.decl, .ConvertToBadBasei32 = %ConvertToBadBasei32, .AccessMemberWithInvalidBasei32 = %AccessMemberWithInvalidBasei32, .DeriveFromTuple = %DeriveFromTuple.decl, .ConvertToBadBaseTuple = %ConvertToBadBaseTuple, .AccessMemberWithInvalidBaseTuple = %AccessMemberWithInvalidBaseTuple, .DeriveFromStruct = %DeriveFromStruct.decl, .ConvertToBadBaseStruct = %ConvertToBadBaseStruct, .AccessMemberWithInvalidBaseStruct = %AccessMemberWithInvalidBaseStruct, .Incomplete = %Incomplete.decl, .DeriveFromIncomplete = %DeriveFromIncomplete.decl, .ConvertToBadBaseIncomplete = %ConvertToBadBaseIncomplete, .AccessMemberWithInvalidBaseIncomplete = %AccessMemberWithInvalidBaseIncomplete, .DeriveFromFinal = %DeriveFromFinal.decl, .ConvertToBadBaseFinal = %ConvertToBadBaseFinal, .AccessMemberWithInvalidBaseFinal_WithMember = %AccessMemberWithInvalidBaseFinal_WithMember, .AccessMemberWithInvalidBaseFinal_NoMember = %AccessMemberWithInvalidBaseFinal_NoMember}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Final.decl = class_decl @Final, ()
-// CHECK:STDOUT:   %Final: type = class_type @Final, const
+// CHECK:STDOUT:   %Final: type = class_type @Final [template]
 // CHECK:STDOUT:   %DeriveFromError.decl = class_decl @DeriveFromError, ()
-// CHECK:STDOUT:   %DeriveFromError: type = class_type @DeriveFromError, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseError: <function> = fn_decl @AccessMemberWithInvalidBaseError, const
+// CHECK:STDOUT:   %DeriveFromError: type = class_type @DeriveFromError [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseError: <function> = fn_decl @AccessMemberWithInvalidBaseError [template]
 // CHECK:STDOUT:   %DeriveFromNonType.decl = class_decl @DeriveFromNonType, ()
-// CHECK:STDOUT:   %DeriveFromNonType: type = class_type @DeriveFromNonType, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBasNonType: <function> = fn_decl @AccessMemberWithInvalidBasNonType, const
+// CHECK:STDOUT:   %DeriveFromNonType: type = class_type @DeriveFromNonType [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBasNonType: <function> = fn_decl @AccessMemberWithInvalidBasNonType [template]
 // CHECK:STDOUT:   %DeriveFromi32.decl = class_decl @DeriveFromi32, ()
-// CHECK:STDOUT:   %DeriveFromi32: type = class_type @DeriveFromi32, const
-// CHECK:STDOUT:   %ConvertToBadBasei32: <function> = fn_decl @ConvertToBadBasei32, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBasei32: <function> = fn_decl @AccessMemberWithInvalidBasei32, const
+// CHECK:STDOUT:   %DeriveFromi32: type = class_type @DeriveFromi32 [template]
+// CHECK:STDOUT:   %ConvertToBadBasei32: <function> = fn_decl @ConvertToBadBasei32 [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBasei32: <function> = fn_decl @AccessMemberWithInvalidBasei32 [template]
 // CHECK:STDOUT:   %DeriveFromTuple.decl = class_decl @DeriveFromTuple, ()
-// CHECK:STDOUT:   %DeriveFromTuple: type = class_type @DeriveFromTuple, const
-// CHECK:STDOUT:   %ConvertToBadBaseTuple: <function> = fn_decl @ConvertToBadBaseTuple, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseTuple: <function> = fn_decl @AccessMemberWithInvalidBaseTuple, const
+// CHECK:STDOUT:   %DeriveFromTuple: type = class_type @DeriveFromTuple [template]
+// CHECK:STDOUT:   %ConvertToBadBaseTuple: <function> = fn_decl @ConvertToBadBaseTuple [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseTuple: <function> = fn_decl @AccessMemberWithInvalidBaseTuple [template]
 // CHECK:STDOUT:   %DeriveFromStruct.decl = class_decl @DeriveFromStruct, ()
-// CHECK:STDOUT:   %DeriveFromStruct: type = class_type @DeriveFromStruct, const
-// CHECK:STDOUT:   %ConvertToBadBaseStruct: <function> = fn_decl @ConvertToBadBaseStruct, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseStruct: <function> = fn_decl @AccessMemberWithInvalidBaseStruct, const
+// CHECK:STDOUT:   %DeriveFromStruct: type = class_type @DeriveFromStruct [template]
+// CHECK:STDOUT:   %ConvertToBadBaseStruct: <function> = fn_decl @ConvertToBadBaseStruct [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseStruct: <function> = fn_decl @AccessMemberWithInvalidBaseStruct [template]
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
-// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete, const
+// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
 // CHECK:STDOUT:   %DeriveFromIncomplete.decl = class_decl @DeriveFromIncomplete, ()
-// CHECK:STDOUT:   %DeriveFromIncomplete: type = class_type @DeriveFromIncomplete, const
-// CHECK:STDOUT:   %ConvertToBadBaseIncomplete: <function> = fn_decl @ConvertToBadBaseIncomplete, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseIncomplete: <function> = fn_decl @AccessMemberWithInvalidBaseIncomplete, const
+// CHECK:STDOUT:   %DeriveFromIncomplete: type = class_type @DeriveFromIncomplete [template]
+// CHECK:STDOUT:   %ConvertToBadBaseIncomplete: <function> = fn_decl @ConvertToBadBaseIncomplete [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseIncomplete: <function> = fn_decl @AccessMemberWithInvalidBaseIncomplete [template]
 // CHECK:STDOUT:   %DeriveFromFinal.decl = class_decl @DeriveFromFinal, ()
-// CHECK:STDOUT:   %DeriveFromFinal: type = class_type @DeriveFromFinal, const
-// CHECK:STDOUT:   %ConvertToBadBaseFinal: <function> = fn_decl @ConvertToBadBaseFinal, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_WithMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_WithMember, const
-// CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_NoMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_NoMember, const
+// CHECK:STDOUT:   %DeriveFromFinal: type = class_type @DeriveFromFinal [template]
+// CHECK:STDOUT:   %ConvertToBadBaseFinal: <function> = fn_decl @ConvertToBadBaseFinal [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_WithMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_WithMember [template]
+// CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_NoMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_NoMember [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
@@ -180,9 +180,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Final {
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Final, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Final> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Final> = bind_name a, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Final, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Final> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Final> = bind_name a, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -190,8 +190,8 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromError {
 // CHECK:STDOUT:   %error.ref: <error> = name_ref error, <error>
-// CHECK:STDOUT:   %.loc16_21.1: type = unbound_element_type DeriveFromError, <error>, const
-// CHECK:STDOUT:   %.loc16_21.2: <unbound element of class DeriveFromError> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %.loc16_21.1: type = unbound_element_type DeriveFromError, <error> [template]
+// CHECK:STDOUT:   %.loc16_21.2: <unbound element of class DeriveFromError> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc16_21.2
@@ -199,9 +199,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromNonType {
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 32, const = constants.%.loc26
-// CHECK:STDOUT:   %.loc26_18.1: type = unbound_element_type DeriveFromNonType, <error>, const
-// CHECK:STDOUT:   %.loc26_18.2: <unbound element of class DeriveFromNonType> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 32 [template = constants.%.loc26]
+// CHECK:STDOUT:   %.loc26_18.1: type = unbound_element_type DeriveFromNonType, <error> [template]
+// CHECK:STDOUT:   %.loc26_18.2: <unbound element of class DeriveFromNonType> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc26_18.2
@@ -209,8 +209,8 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromi32 {
-// CHECK:STDOUT:   %.loc35_19.1: type = unbound_element_type DeriveFromi32, <error>, const
-// CHECK:STDOUT:   %.loc35_19.2: <unbound element of class DeriveFromi32> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %.loc35_19.1: type = unbound_element_type DeriveFromi32, <error> [template]
+// CHECK:STDOUT:   %.loc35_19.2: <unbound element of class DeriveFromi32> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc35_19.2
@@ -218,11 +218,11 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromTuple {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
 // CHECK:STDOUT:   %.loc51_22: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:   %.loc51_23.1: type = converted %.loc51_22, constants.%.loc51_23.1, const = constants.%.loc51_23.1
-// CHECK:STDOUT:   %.loc51_23.2: type = unbound_element_type DeriveFromTuple, <error>, const
-// CHECK:STDOUT:   %.loc51_23.3: <unbound element of class DeriveFromTuple> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %.loc51_23.1: type = converted %.loc51_22, constants.%.loc51_23.1 [template = constants.%.loc51_23.1]
+// CHECK:STDOUT:   %.loc51_23.2: type = unbound_element_type DeriveFromTuple, <error> [template]
+// CHECK:STDOUT:   %.loc51_23.3: <unbound element of class DeriveFromTuple> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc51_23.3
@@ -230,9 +230,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromStruct {
-// CHECK:STDOUT:   %.loc67_33: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc67_34.1: type = unbound_element_type DeriveFromStruct, <error>, const
-// CHECK:STDOUT:   %.loc67_34.2: <unbound element of class DeriveFromStruct> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %.loc67_33: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc67_34.1: type = unbound_element_type DeriveFromStruct, <error> [template]
+// CHECK:STDOUT:   %.loc67_34.2: <unbound element of class DeriveFromStruct> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc67_34.2
@@ -242,9 +242,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: class @Incomplete;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromIncomplete {
-// CHECK:STDOUT:   %Incomplete.ref: type = name_ref Incomplete, file.%Incomplete, const = file.%Incomplete
-// CHECK:STDOUT:   %.loc87_26.1: type = unbound_element_type DeriveFromIncomplete, <error>, const
-// CHECK:STDOUT:   %.loc87_26.2: <unbound element of class DeriveFromIncomplete> = base_decl <error>, element0, const
+// CHECK:STDOUT:   %Incomplete.ref: type = name_ref Incomplete, file.%Incomplete [template = file.%Incomplete]
+// CHECK:STDOUT:   %.loc87_26.1: type = unbound_element_type DeriveFromIncomplete, <error> [template]
+// CHECK:STDOUT:   %.loc87_26.2: <unbound element of class DeriveFromIncomplete> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc87_26.2
@@ -252,9 +252,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromFinal {
-// CHECK:STDOUT:   %Final.ref: type = name_ref Final, file.%Final, const = file.%Final
-// CHECK:STDOUT:   %.loc101_21.1: type = unbound_element_type DeriveFromFinal, Final, const
-// CHECK:STDOUT:   %.loc101_21.2: <unbound element of class DeriveFromFinal> = base_decl Final, element0, const
+// CHECK:STDOUT:   %Final.ref: type = name_ref Final, file.%Final [template = file.%Final]
+// CHECK:STDOUT:   %.loc101_21.1: type = unbound_element_type DeriveFromFinal, Final [template]
+// CHECK:STDOUT:   %.loc101_21.2: <unbound element of class DeriveFromFinal> = base_decl Final, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc101_21.2

--- a/toolchain/check/testdata/class/fail_base_method_define.carbon
+++ b/toolchain/check/testdata/class/fail_base_method_define.carbon
@@ -29,26 +29,26 @@ fn D.C.F() {}
 // CHECK:STDOUT: --- fail_base_method_define.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc12_3.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc17: type = struct_type {.base: B}, const
+// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc12_3.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc17: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B.decl, .D = %D.decl}
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %D.decl = class_decl @D, ()
-// CHECK:STDOUT:   %D: type = class_type @D, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.3, const
-// CHECK:STDOUT:   %.loc27: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %D: type = class_type @D [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template]
+// CHECK:STDOUT:   %.loc27: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -56,16 +56,16 @@ fn D.C.F() {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc16_17.1: type = unbound_element_type D, B, const
-// CHECK:STDOUT:   %.loc16_17.2: <unbound element of class D> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc16_17.1: type = unbound_element_type D, B [template]
+// CHECK:STDOUT:   %.loc16_17.2: <unbound element of class D> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc16_17.2

--- a/toolchain/check/testdata/class/fail_base_misplaced.carbon
+++ b/toolchain/check/testdata/class/fail_base_misplaced.carbon
@@ -24,7 +24,7 @@ fn F() {
 // CHECK:STDOUT: --- fail_base_misplaced.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -46,24 +46,24 @@ class C4 {
 // CHECK:STDOUT: --- fail_base_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B}, const
+// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B.decl, .C1 = %C1.decl, .C2 = %C2.decl, .C3 = %C3.decl, .C4 = %C4.decl}
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C1.decl = class_decl @C1, ()
-// CHECK:STDOUT:   %C1: type = class_type @C1, const
+// CHECK:STDOUT:   %C1: type = class_type @C1 [template]
 // CHECK:STDOUT:   %C2.decl = class_decl @C2, ()
-// CHECK:STDOUT:   %C2: type = class_type @C2, const
+// CHECK:STDOUT:   %C2: type = class_type @C2 [template]
 // CHECK:STDOUT:   %C3.decl = class_decl @C3, ()
-// CHECK:STDOUT:   %C3: type = class_type @C3, const
+// CHECK:STDOUT:   %C3: type = class_type @C3 [template]
 // CHECK:STDOUT:   %C4.decl = class_decl @C4, ()
-// CHECK:STDOUT:   %C4: type = class_type @C4, const
+// CHECK:STDOUT:   %C4: type = class_type @C4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
@@ -72,9 +72,9 @@ class C4 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C1 {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc13_25.1: type = unbound_element_type C1, B, const
-// CHECK:STDOUT:   %.loc13_25.2: <unbound element of class C1> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc13_25.1: type = unbound_element_type C1, B [template]
+// CHECK:STDOUT:   %.loc13_25.2: <unbound element of class C1> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc13_25.2
@@ -82,18 +82,18 @@ class C4 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C2 {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc23_19.1: type = unbound_element_type C2, B, const
-// CHECK:STDOUT:   %.loc23_19.2: <unbound element of class C2> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc23_19.1: type = unbound_element_type C2, B [template]
+// CHECK:STDOUT:   %.loc23_19.2: <unbound element of class C2> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc23_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C3 {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc33_25.1: type = unbound_element_type C3, B, const
-// CHECK:STDOUT:   %.loc33_25.2: <unbound element of class C3> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc33_25.1: type = unbound_element_type C3, B [template]
+// CHECK:STDOUT:   %.loc33_25.2: <unbound element of class C3> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc33_25.2
@@ -101,9 +101,9 @@ class C4 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C4 {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc43_24.1: type = unbound_element_type C4, B, const
-// CHECK:STDOUT:   %.loc43_24.2: <unbound element of class C4> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc43_24.1: type = unbound_element_type C4, B [template]
+// CHECK:STDOUT:   %.loc43_24.2: <unbound element of class C4> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc43_24.2

--- a/toolchain/check/testdata/class/fail_base_no_extend.carbon
+++ b/toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -16,18 +16,18 @@ class C {
 // CHECK:STDOUT: --- fail_base_no_extend.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B}, const
+// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B.decl, .C = %C.decl}
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
@@ -36,9 +36,9 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc13_10.1: type = unbound_element_type C, B, const
-// CHECK:STDOUT:   %.loc13_10.2: <unbound element of class C> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc13_10.1: type = unbound_element_type C, B [template]
+// CHECK:STDOUT:   %.loc13_10.2: <unbound element of class C> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc13_10.2

--- a/toolchain/check/testdata/class/fail_base_repeated.carbon
+++ b/toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -33,22 +33,22 @@ class D {
 // CHECK:STDOUT: --- fail_base_repeated.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc19: type = struct_type {.base: B1}, const
+// CHECK:STDOUT:   %.loc7_16.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7_15: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc19: type = struct_type {.base: B1} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B1 = %B1.decl, .B2 = %B2.decl, .C = %C.decl, .D = %D.decl}
 // CHECK:STDOUT:   %B1.decl = class_decl @B1, ()
-// CHECK:STDOUT:   %B1: type = class_type @B1, const
+// CHECK:STDOUT:   %B1: type = class_type @B1 [template]
 // CHECK:STDOUT:   %B2.decl = class_decl @B2, ()
-// CHECK:STDOUT:   %B2: type = class_type @B2, const
+// CHECK:STDOUT:   %B2: type = class_type @B2 [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %D.decl = class_decl @D, ()
-// CHECK:STDOUT:   %D: type = class_type @D, const
+// CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B1 {
@@ -62,10 +62,10 @@ class D {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B1.ref: type = name_ref B1, file.%B1, const = file.%B1
-// CHECK:STDOUT:   %.loc11_18.1: type = unbound_element_type C, B1, const
-// CHECK:STDOUT:   %.loc11_18.2: <unbound element of class C> = base_decl B1, element0, const
-// CHECK:STDOUT:   %B2.ref: type = name_ref B2, file.%B2, const = file.%B2
+// CHECK:STDOUT:   %B1.ref: type = name_ref B1, file.%B1 [template = file.%B1]
+// CHECK:STDOUT:   %.loc11_18.1: type = unbound_element_type C, B1 [template]
+// CHECK:STDOUT:   %.loc11_18.2: <unbound element of class C> = base_decl B1, element0 [template]
+// CHECK:STDOUT:   %B2.ref: type = name_ref B2, file.%B2 [template = file.%B2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc11_18.2
@@ -73,10 +73,10 @@ class D {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %B1.ref.loc23: type = name_ref B1, file.%B1, const = file.%B1
-// CHECK:STDOUT:   %.loc23_18.1: type = unbound_element_type D, B1, const
-// CHECK:STDOUT:   %.loc23_18.2: <unbound element of class D> = base_decl B1, element0, const
-// CHECK:STDOUT:   %B1.ref.loc30: type = name_ref B1, file.%B1, const = file.%B1
+// CHECK:STDOUT:   %B1.ref.loc23: type = name_ref B1, file.%B1 [template = file.%B1]
+// CHECK:STDOUT:   %.loc23_18.1: type = unbound_element_type D, B1 [template]
+// CHECK:STDOUT:   %.loc23_18.2: <unbound element of class D> = base_decl B1, element0 [template]
+// CHECK:STDOUT:   %B1.ref.loc30: type = name_ref B1, file.%B1 [template = file.%B1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc23_18.2

--- a/toolchain/check/testdata/class/fail_base_unbound.carbon
+++ b/toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -18,21 +18,21 @@ let b: B = C.base;
 // CHECK:STDOUT: --- fail_base_unbound.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc11: type = struct_type {.base: B}, const
+// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc11: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B.decl, .C = %C.decl}
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %B.ref: type = name_ref B, %B, const = %B
-// CHECK:STDOUT:   %C.ref: type = name_ref C, %C, const = %C
-// CHECK:STDOUT:   %base.ref: <unbound element of class C> = name_ref base, @C.%.loc10_17.2, const = @C.%.loc10_17.2
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %B.ref: type = name_ref B, %B [template = %B]
+// CHECK:STDOUT:   %C.ref: type = name_ref C, %C [template = %C]
+// CHECK:STDOUT:   %base.ref: <unbound element of class C> = name_ref base, @C.%.loc10_17.2 [template = @C.%.loc10_17.2]
 // CHECK:STDOUT:   %b: B = bind_name b, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -42,9 +42,9 @@ let b: B = C.base;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B, const = file.%B
-// CHECK:STDOUT:   %.loc10_17.1: type = unbound_element_type C, B, const
-// CHECK:STDOUT:   %.loc10_17.2: <unbound element of class C> = base_decl B, element0, const
+// CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %.loc10_17.1: type = unbound_element_type C, B [template]
+// CHECK:STDOUT:   %.loc10_17.2: <unbound element of class C> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc10_17.2

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -32,53 +32,53 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT: --- fail_derived_to_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: A2, .b: i32}, const
-// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32}*, .b: i32}, const
-// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32}, const
-// CHECK:STDOUT:   %.loc15: type = ptr_type {.base: A2, .b: i32}, const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: A2, .b: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.loc15: type = ptr_type {.base: A2, .b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A1 = %A1.decl, .A2 = %A2.decl, .B2 = %B2.decl, .ConvertUnrelated = %ConvertUnrelated, .Incomplete = %Incomplete.decl, .ConvertIncomplete = %ConvertIncomplete}
 // CHECK:STDOUT:   %A1.decl = class_decl @A1, ()
-// CHECK:STDOUT:   %A1: type = class_type @A1, const
+// CHECK:STDOUT:   %A1: type = class_type @A1 [template]
 // CHECK:STDOUT:   %A2.decl = class_decl @A2, ()
-// CHECK:STDOUT:   %A2: type = class_type @A2, const
+// CHECK:STDOUT:   %A2: type = class_type @A2 [template]
 // CHECK:STDOUT:   %B2.decl = class_decl @B2, ()
-// CHECK:STDOUT:   %B2: type = class_type @B2, const
-// CHECK:STDOUT:   %ConvertUnrelated: <function> = fn_decl @ConvertUnrelated, const
+// CHECK:STDOUT:   %B2: type = class_type @B2 [template]
+// CHECK:STDOUT:   %ConvertUnrelated: <function> = fn_decl @ConvertUnrelated [template]
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
-// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete, const
-// CHECK:STDOUT:   %ConvertIncomplete: <function> = fn_decl @ConvertIncomplete, const
+// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
+// CHECK:STDOUT:   %ConvertIncomplete: <function> = fn_decl @ConvertIncomplete [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A1 {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type A1, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class A1> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class A1> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type A1, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class A1> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class A1> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A2 {
-// CHECK:STDOUT:   %.loc12_8.1: type = unbound_element_type A2, i32, const
-// CHECK:STDOUT:   %.loc12_8.2: <unbound element of class A2> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class A2> = bind_name a, %.loc12_8.2, const = %.loc12_8.2
+// CHECK:STDOUT:   %.loc12_8.1: type = unbound_element_type A2, i32 [template]
+// CHECK:STDOUT:   %.loc12_8.2: <unbound element of class A2> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class A2> = bind_name a, %.loc12_8.2 [template = %.loc12_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B2 {
-// CHECK:STDOUT:   %A2.ref: type = name_ref A2, file.%A2, const = file.%A2
-// CHECK:STDOUT:   %.loc16_18.1: type = unbound_element_type B2, A2, const
-// CHECK:STDOUT:   %.loc16_18.2: <unbound element of class B2> = base_decl A2, element0, const
-// CHECK:STDOUT:   %.loc17_8.1: type = unbound_element_type B2, i32, const
-// CHECK:STDOUT:   %.loc17_8.2: <unbound element of class B2> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class B2> = bind_name b, %.loc17_8.2, const = %.loc17_8.2
+// CHECK:STDOUT:   %A2.ref: type = name_ref A2, file.%A2 [template = file.%A2]
+// CHECK:STDOUT:   %.loc16_18.1: type = unbound_element_type B2, A2 [template]
+// CHECK:STDOUT:   %.loc16_18.2: <unbound element of class B2> = base_decl A2, element0 [template]
+// CHECK:STDOUT:   %.loc17_8.1: type = unbound_element_type B2, i32 [template]
+// CHECK:STDOUT:   %.loc17_8.2: <unbound element of class B2> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class B2> = bind_name b, %.loc17_8.2 [template = %.loc17_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc16_18.2

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -30,27 +30,27 @@ class Class {
 // CHECK:STDOUT: --- fail_field_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc27: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc28: type = struct_type {.j: i32, .k: i32}, const
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc28: type = struct_type {.j: i32, .k: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc12_16.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc12_16.2: <unbound element of class Class> = field_decl j, element0, const
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc12_16.2, const = %.loc12_16.2
-// CHECK:STDOUT:   %.loc17_14.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc17_14.2: <unbound element of class Class> = field_decl k, element1, const
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc17_14.2, const = %.loc17_14.2
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0, const = constants.%.loc22
+// CHECK:STDOUT:   %.loc12_16.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc12_16.2: <unbound element of class Class> = field_decl j, element0 [template]
+// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc12_16.2 [template = %.loc12_16.2]
+// CHECK:STDOUT:   %.loc17_14.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc17_14.2: <unbound element of class Class> = field_decl k, element1 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc17_14.2 [template = %.loc17_14.2]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.loc22]
 // CHECK:STDOUT:   %l: i32 = bind_name l, %.loc22
-// CHECK:STDOUT:   %.loc27: i32 = int_literal 1, const = constants.%.loc27
+// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template = constants.%.loc27]
 // CHECK:STDOUT:   %m: i32 = bind_name m, %.loc27
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -118,27 +118,27 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT: --- fail_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc41: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc100: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc41: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc100: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .CallClassFunction = %CallClassFunction, .global_var = %global_var, .ConvertFromStruct = %ConvertFromStruct, .MemberAccess = %MemberAccess, .Copy = %Copy, .Let = %Let, .TakeIncomplete = %TakeIncomplete, .ReturnIncomplete = %ReturnIncomplete, .CallTakeIncomplete = %CallTakeIncomplete, .CallReturnIncomplete = %CallReturnIncomplete}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1, const
-// CHECK:STDOUT:   %CallClassFunction: <function> = fn_decl @CallClassFunction, const
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, %Class, const = %Class
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template]
+// CHECK:STDOUT:   %CallClassFunction: <function> = fn_decl @CallClassFunction [template]
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, %Class [template = %Class]
 // CHECK:STDOUT:   %global_var.var: ref <error> = var global_var
 // CHECK:STDOUT:   %global_var: ref <error> = bind_name global_var, %global_var.var
-// CHECK:STDOUT:   %ConvertFromStruct: <function> = fn_decl @ConvertFromStruct, const
-// CHECK:STDOUT:   %MemberAccess: <function> = fn_decl @MemberAccess, const
-// CHECK:STDOUT:   %Copy: <function> = fn_decl @Copy, const
-// CHECK:STDOUT:   %Let: <function> = fn_decl @Let, const
-// CHECK:STDOUT:   %TakeIncomplete: <function> = fn_decl @TakeIncomplete, const
-// CHECK:STDOUT:   %ReturnIncomplete: <function> = fn_decl @ReturnIncomplete, const
-// CHECK:STDOUT:   %CallTakeIncomplete: <function> = fn_decl @CallTakeIncomplete, const
-// CHECK:STDOUT:   %CallReturnIncomplete: <function> = fn_decl @CallReturnIncomplete, const
+// CHECK:STDOUT:   %ConvertFromStruct: <function> = fn_decl @ConvertFromStruct [template]
+// CHECK:STDOUT:   %MemberAccess: <function> = fn_decl @MemberAccess [template]
+// CHECK:STDOUT:   %Copy: <function> = fn_decl @Copy [template]
+// CHECK:STDOUT:   %Let: <function> = fn_decl @Let [template]
+// CHECK:STDOUT:   %TakeIncomplete: <function> = fn_decl @TakeIncomplete [template]
+// CHECK:STDOUT:   %ReturnIncomplete: <function> = fn_decl @ReturnIncomplete [template]
+// CHECK:STDOUT:   %CallTakeIncomplete: <function> = fn_decl @CallTakeIncomplete [template]
+// CHECK:STDOUT:   %CallReturnIncomplete: <function> = fn_decl @CallReturnIncomplete [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class;
@@ -150,7 +150,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallClassFunction() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %Function.ref: <error> = name_ref Function, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -177,7 +177,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Let(%p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc75: ref Class = deref %p.ref
 // CHECK:STDOUT:   %c: <error> = bind_name c, <error>
@@ -190,11 +190,11 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallTakeIncomplete(%p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc100: <function> = name_ref TakeIncomplete, file.%TakeIncomplete, const = file.%TakeIncomplete
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc100: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc100_18: ref Class = deref %p.ref
 // CHECK:STDOUT:   %.loc100_17: init () = call %TakeIncomplete.ref.loc100(<invalid>)
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc111: <function> = name_ref TakeIncomplete, file.%TakeIncomplete, const = file.%TakeIncomplete
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc111: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
 // CHECK:STDOUT:   %.loc111_19: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc111_17: init () = call %TakeIncomplete.ref.loc111(<invalid>)
 // CHECK:STDOUT:   return
@@ -202,7 +202,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallReturnIncomplete() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %ReturnIncomplete.ref: <function> = name_ref ReturnIncomplete, file.%ReturnIncomplete, const = file.%ReturnIncomplete
+// CHECK:STDOUT:   %ReturnIncomplete.ref: <function> = name_ref ReturnIncomplete, file.%ReturnIncomplete [template = file.%ReturnIncomplete]
 // CHECK:STDOUT:   %.loc115: init <error> = call %ReturnIncomplete.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -27,33 +27,33 @@ fn F() {
 // CHECK:STDOUT: --- fail_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc16_10: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc20_18: type = struct_type {.a: i32, .c: i32}, const
-// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc24_26: type = struct_type {.a: i32, .b: i32, .c: i32}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc16_10: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc20_18: type = struct_type {.a: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc24_26: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -62,26 +62,26 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1, const = constants.%.loc16_9
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template = constants.%.loc16_9]
 // CHECK:STDOUT:   %.loc16_10.1: {.a: i32} = struct_literal (%.loc16_9)
-// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc16_10.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc16_10.3: ref Class = temporary %.loc16_10.2, <error>
 // CHECK:STDOUT:   %.loc16_10.4: ref Class = converted %.loc16_10.1, %.loc16_10.3
-// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1, const = constants.%.loc20_9
-// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2, const = constants.%.loc20_17
+// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template = constants.%.loc20_9]
+// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template = constants.%.loc20_17]
 // CHECK:STDOUT:   %.loc20_18.1: {.a: i32, .c: i32} = struct_literal (%.loc20_9, %.loc20_17)
-// CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc20_18.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc20_18.3: ref i32 = class_element_access %.loc20_18.2, element0
 // CHECK:STDOUT:   %.loc20_18.4: init i32 = initialize_from %.loc20_9 to %.loc20_18.3
 // CHECK:STDOUT:   %.loc20_18.5: ref Class = temporary %.loc20_18.2, <error>
 // CHECK:STDOUT:   %.loc20_18.6: ref Class = converted %.loc20_18.1, %.loc20_18.5
-// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1, const = constants.%.loc24_9
-// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2, const = constants.%.loc24_17
-// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3, const = constants.%.loc24_25
+// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template = constants.%.loc24_9]
+// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template = constants.%.loc24_17]
+// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template = constants.%.loc24_25]
 // CHECK:STDOUT:   %.loc24_26.1: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc24_9, %.loc24_17, %.loc24_25)
-// CHECK:STDOUT:   %Class.ref.loc24: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc24: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc24_26.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc24_26.3: ref Class = temporary %.loc24_26.2, <error>
 // CHECK:STDOUT:   %.loc24_26.4: ref Class = converted %.loc24_26.1, %.loc24_26.3

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -25,28 +25,28 @@ fn F() {
 // CHECK:STDOUT: --- fail_init_as_inplace.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc22: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc22: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .G = %G, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -57,13 +57,13 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref.loc21_10: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc21_10: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1, const = constants.%.loc21_24
-// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2, const = constants.%.loc21_32
+// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1 [template = constants.%.loc21_24]
+// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2 [template = constants.%.loc21_32]
 // CHECK:STDOUT:   %.loc21_33.1: {.a: i32, .b: i32} = struct_literal (%.loc21_24, %.loc21_32)
-// CHECK:STDOUT:   %Class.ref.loc21_38: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc21_38: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc21_33.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc21_33.3: ref i32 = class_element_access %.loc21_33.2, element0
 // CHECK:STDOUT:   %.loc21_33.4: init i32 = initialize_from %.loc21_24 to %.loc21_33.3
@@ -74,7 +74,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc21_33.9: ref Class = converted %.loc21_33.1, %.loc21_33.8
 // CHECK:STDOUT:   %.loc21_33.10: Class = bind_value %.loc21_33.9
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc22_5: Class* = addr_of %c.ref
 // CHECK:STDOUT:   %.loc22_4: init () = call %G.ref(%.loc22_5)

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -36,35 +36,35 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: --- fail_memaccess_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.loc13_1.1: type = struct_type {.a: A}, const
-// CHECK:STDOUT:   %.loc13_1.2: type = struct_type {.a: {}*}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A}, const
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.loc13_1.1: type = struct_type {.a: A} [template]
+// CHECK:STDOUT:   %.loc13_1.2: type = struct_type {.a: {}*} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl, .B = %B.decl, .F = %F}
 // CHECK:STDOUT:   %A.decl = class_decl @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A, const
+// CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %B.decl = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
-// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A, const = file.%A
-// CHECK:STDOUT:   %.loc12_8.1: type = unbound_element_type B, A, const
-// CHECK:STDOUT:   %.loc12_8.2: <unbound element of class B> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class B> = bind_name a, %.loc12_8.2, const = %.loc12_8.2
+// CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc12_8.1: type = unbound_element_type B, A [template]
+// CHECK:STDOUT:   %.loc12_8.2: <unbound element of class B> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class B> = bind_name a, %.loc12_8.2 [template = %.loc12_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -21,20 +21,20 @@ fn T.F() {}
 // CHECK:STDOUT: --- fail_member_of_let.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc9: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, %Class, const = %Class
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, %Class [template = %Class]
 // CHECK:STDOUT:   %T: type = bind_name T, %Class.ref
-// CHECK:STDOUT:   %.loc19: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %.loc19: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -33,21 +33,21 @@ fn F(c: Class) {
 // CHECK:STDOUT: --- fail_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %NoSelf: <function> = fn_decl @NoSelf, const
-// CHECK:STDOUT:   %WithSelf: <function> = fn_decl @WithSelf, const
+// CHECK:STDOUT:   %NoSelf: <function> = fn_decl @NoSelf [template]
+// CHECK:STDOUT:   %WithSelf: <function> = fn_decl @WithSelf [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .NoSelf = %NoSelf
@@ -61,19 +61,19 @@ fn F(c: Class) {
 // CHECK:STDOUT: fn @F(%c: Class) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref.loc13: Class = name_ref c, %c
-// CHECK:STDOUT:   %NoSelf.ref.loc13: <function> = name_ref NoSelf, @Class.%NoSelf, const = @Class.%NoSelf
+// CHECK:STDOUT:   %NoSelf.ref.loc13: <function> = name_ref NoSelf, @Class.%NoSelf [template = @Class.%NoSelf]
 // CHECK:STDOUT:   %.loc13: init () = call %NoSelf.ref.loc13()
 // CHECK:STDOUT:   %c.ref.loc14: Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc14_4: <bound method> = bound_method %c.ref.loc14, @Class.%WithSelf
 // CHECK:STDOUT:   %.loc14_13: init () = call %.loc14_4(%c.ref.loc14)
-// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %NoSelf.ref.loc16: <function> = name_ref NoSelf, @Class.%NoSelf, const = @Class.%NoSelf
+// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %NoSelf.ref.loc16: <function> = name_ref NoSelf, @Class.%NoSelf [template = @Class.%NoSelf]
 // CHECK:STDOUT:   %.loc16: init () = call %NoSelf.ref.loc16()
-// CHECK:STDOUT:   %Class.ref.loc23: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %WithSelf.ref.loc23: <function> = name_ref WithSelf, @Class.%WithSelf, const = @Class.%WithSelf
+// CHECK:STDOUT:   %Class.ref.loc23: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc23: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
 // CHECK:STDOUT:   %.loc23: init () = call %WithSelf.ref.loc23(<invalid>)
-// CHECK:STDOUT:   %Class.ref.loc30: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %WithSelf.ref.loc30: <function> = name_ref WithSelf, @Class.%WithSelf, const = @Class.%WithSelf
+// CHECK:STDOUT:   %Class.ref.loc30: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc30: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
 // CHECK:STDOUT:   %c.ref.loc30: Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc30: init () = call %WithSelf.ref.loc30(<invalid>)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/fail_method_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_method_modifiers.carbon
@@ -50,22 +50,22 @@ base class BaseClass {
 // CHECK:STDOUT: --- fail_method_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc24: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc24: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.FinalClass = %FinalClass.decl, .AbstractClass = %AbstractClass.decl, .BaseClass = %BaseClass.decl}
 // CHECK:STDOUT:   %FinalClass.decl = class_decl @FinalClass, ()
-// CHECK:STDOUT:   %FinalClass: type = class_type @FinalClass, const
+// CHECK:STDOUT:   %FinalClass: type = class_type @FinalClass [template]
 // CHECK:STDOUT:   %AbstractClass.decl = class_decl @AbstractClass, ()
-// CHECK:STDOUT:   %AbstractClass: type = class_type @AbstractClass, const
+// CHECK:STDOUT:   %AbstractClass: type = class_type @AbstractClass [template]
 // CHECK:STDOUT:   %BaseClass.decl = class_decl @BaseClass, ()
-// CHECK:STDOUT:   %BaseClass: type = class_type @BaseClass, const
+// CHECK:STDOUT:   %BaseClass: type = class_type @BaseClass [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @FinalClass {
-// CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.1, const
-// CHECK:STDOUT:   %Virtual: <function> = fn_decl @Virtual, const
+// CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.1 [template]
+// CHECK:STDOUT:   %Virtual: <function> = fn_decl @Virtual [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Abstract = %Abstract
@@ -73,8 +73,8 @@ base class BaseClass {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @AbstractClass {
-// CHECK:STDOUT:   %Default: <function> = fn_decl @Default, const
-// CHECK:STDOUT:   %Final: <function> = fn_decl @Final, const
+// CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template]
+// CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Default = %Default
@@ -82,7 +82,7 @@ base class BaseClass {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @BaseClass {
-// CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.2, const
+// CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.2 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Abstract = %Abstract

--- a/toolchain/check/testdata/class/fail_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_modifiers.carbon
@@ -67,23 +67,23 @@ abstract base class AbstractAndBase {}
 // CHECK:STDOUT: --- fail_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc27: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc27: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.DuplicatePrivate = %DuplicatePrivate.decl, .TwoAccess = %TwoAccess.decl, .TwoAbstract = %TwoAbstract.decl, .Virtual = %Virtual.decl, .WrongOrder = %WrongOrder.decl, .AbstractAndBase = %AbstractAndBase.decl}
 // CHECK:STDOUT:   %DuplicatePrivate.decl = class_decl @DuplicatePrivate, ()
-// CHECK:STDOUT:   %DuplicatePrivate: type = class_type @DuplicatePrivate, const
+// CHECK:STDOUT:   %DuplicatePrivate: type = class_type @DuplicatePrivate [template]
 // CHECK:STDOUT:   %TwoAccess.decl = class_decl @TwoAccess, ()
-// CHECK:STDOUT:   %TwoAccess: type = class_type @TwoAccess, const
+// CHECK:STDOUT:   %TwoAccess: type = class_type @TwoAccess [template]
 // CHECK:STDOUT:   %TwoAbstract.decl = class_decl @TwoAbstract, ()
-// CHECK:STDOUT:   %TwoAbstract: type = class_type @TwoAbstract, const
+// CHECK:STDOUT:   %TwoAbstract: type = class_type @TwoAbstract [template]
 // CHECK:STDOUT:   %Virtual.decl = class_decl @Virtual, ()
-// CHECK:STDOUT:   %Virtual: type = class_type @Virtual, const
+// CHECK:STDOUT:   %Virtual: type = class_type @Virtual [template]
 // CHECK:STDOUT:   %WrongOrder.decl = class_decl @WrongOrder, ()
-// CHECK:STDOUT:   %WrongOrder: type = class_type @WrongOrder, const
+// CHECK:STDOUT:   %WrongOrder: type = class_type @WrongOrder [template]
 // CHECK:STDOUT:   %AbstractAndBase.decl = class_decl @AbstractAndBase, ()
-// CHECK:STDOUT:   %AbstractAndBase: type = class_type @AbstractAndBase, const
+// CHECK:STDOUT:   %AbstractAndBase: type = class_type @AbstractAndBase [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DuplicatePrivate;

--- a/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
+++ b/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
@@ -14,14 +14,14 @@ fn C.F() {}
 // CHECK:STDOUT: --- fail_out_of_line_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.C = %C.decl}
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
@@ -77,31 +77,31 @@ base class G;
 // CHECK:STDOUT: --- fail_redeclaration_introducer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc14: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl.loc7, .B = %B.decl.loc16, .C = %C.decl.loc25, .D = %D.decl.loc34, .E = %E.decl.loc43, .F = %F.decl.loc52, .G = %G.decl.loc61}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A, const
+// CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %A.decl.loc14 = class_decl @A, ()
 // CHECK:STDOUT:   %B.decl.loc16 = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %B.decl.loc23 = class_decl @B, ()
 // CHECK:STDOUT:   %C.decl.loc25 = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %C.decl.loc32 = class_decl @C, ()
 // CHECK:STDOUT:   %D.decl.loc34 = class_decl @D, ()
-// CHECK:STDOUT:   %D: type = class_type @D, const
+// CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %D.decl.loc41 = class_decl @D, ()
 // CHECK:STDOUT:   %E.decl.loc43 = class_decl @E, ()
-// CHECK:STDOUT:   %E: type = class_type @E, const
+// CHECK:STDOUT:   %E: type = class_type @E [template]
 // CHECK:STDOUT:   %E.decl.loc50 = class_decl @E, ()
 // CHECK:STDOUT:   %F.decl.loc52 = class_decl @F, ()
-// CHECK:STDOUT:   %F: type = class_type @F, const
+// CHECK:STDOUT:   %F: type = class_type @F [template]
 // CHECK:STDOUT:   %F.decl.loc59 = class_decl @F, ()
 // CHECK:STDOUT:   %G.decl.loc61 = class_decl @G, ()
-// CHECK:STDOUT:   %G: type = class_type @G, const
+// CHECK:STDOUT:   %G: type = class_type @G [template]
 // CHECK:STDOUT:   %G.decl.loc68 = class_decl @G, ()
 // CHECK:STDOUT:   %G.decl.loc75 = class_decl @G, ()
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
@@ -24,23 +24,23 @@ class Y {
 // CHECK:STDOUT: --- fail_redeclaration_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl.loc7, .X = %X.decl, .Y = %Y.decl}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A.1, ()
-// CHECK:STDOUT:   %A: type = class_type @A.1, const
+// CHECK:STDOUT:   %A: type = class_type @A.1 [template]
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X, const
+// CHECK:STDOUT:   %X: type = class_type @X [template]
 // CHECK:STDOUT:   %A.decl.loc15 = class_decl @A.1, ()
 // CHECK:STDOUT:   %Y.decl = class_decl @Y, ()
-// CHECK:STDOUT:   %Y: type = class_type @Y, const
+// CHECK:STDOUT:   %Y: type = class_type @Y [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A.1 {
 // CHECK:STDOUT:   %B.decl = class_decl @B.2, ()
-// CHECK:STDOUT:   %B: type = class_type @B.2, const
+// CHECK:STDOUT:   %B: type = class_type @B.2 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .B = %B.decl
@@ -48,7 +48,7 @@ class Y {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
 // CHECK:STDOUT:   %A.decl = class_decl @A.2, ()
-// CHECK:STDOUT:   %A: type = class_type @A.2, const
+// CHECK:STDOUT:   %A: type = class_type @A.2 [template]
 // CHECK:STDOUT:   %B.decl = class_decl @B.1, ()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -57,7 +57,7 @@ class Y {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A.2 {
 // CHECK:STDOUT:   %B.decl = class_decl @B.1, ()
-// CHECK:STDOUT:   %B: type = class_type @B.1, const
+// CHECK:STDOUT:   %B: type = class_type @B.1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .B = %B.decl
@@ -72,7 +72,7 @@ class Y {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Y {
 // CHECK:STDOUT:   %.decl = class_decl @.1, ()
-// CHECK:STDOUT:   %.loc21: type = class_type @.1, const
+// CHECK:STDOUT:   %.loc21: type = class_type @.1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -27,22 +27,22 @@ fn Class.H() {}
 // CHECK:STDOUT: --- fail_redefinition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl.loc7}
 // CHECK:STDOUT:   %Class.decl.loc7 = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %Class.decl.loc18 = class_decl @Class, ()
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = <unexpected instref inst+3>

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -28,19 +28,19 @@ class Class {
 // CHECK:STDOUT: --- fail_reorder.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc26: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc26: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .G = %G
@@ -49,14 +49,14 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %F.ref: <error> = name_ref F, <error>
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 1, const = constants.%.loc24
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template = constants.%.loc24]
 // CHECK:STDOUT:   return %.loc24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -20,19 +20,19 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- fail_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc11: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -40,7 +40,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -53,25 +53,25 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: --- fail_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .WrongSelf = %WrongSelf.decl, .CallWrongSelf = %CallWrongSelf}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %WrongSelf.decl = class_decl @WrongSelf, ()
-// CHECK:STDOUT:   %WrongSelf: type = class_type @WrongSelf, const
-// CHECK:STDOUT:   %CallWrongSelf: <function> = fn_decl @CallWrongSelf, const
+// CHECK:STDOUT:   %WrongSelf: type = class_type @WrongSelf [template]
+// CHECK:STDOUT:   %CallWrongSelf: <function> = fn_decl @CallWrongSelf [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -79,7 +79,7 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @WrongSelf {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -92,7 +92,7 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: Class {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %self.var: ref Class = var self
 // CHECK:STDOUT:   %self: ref Class = bind_name self, %self.var
 // CHECK:STDOUT:   %self.ref: ref Class = name_ref self, %self

--- a/toolchain/check/testdata/class/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_todo_modifiers.carbon
@@ -61,29 +61,29 @@ abstract class Abstract {
 // CHECK:STDOUT: --- fail_todo_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc28: type = struct_type {.k: i32, .l: i32}, const
-// CHECK:STDOUT:   %.loc41: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc28: type = struct_type {.k: i32, .l: i32} [template]
+// CHECK:STDOUT:   %.loc41: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Access = %Access.decl, .Base = %Base.decl, .Abstract = %Abstract.decl}
 // CHECK:STDOUT:   %Access.decl = class_decl @Access, ()
-// CHECK:STDOUT:   %Access: type = class_type @Access, const
+// CHECK:STDOUT:   %Access: type = class_type @Access [template]
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Abstract.decl = class_decl @Abstract, ()
-// CHECK:STDOUT:   %Abstract: type = class_type @Abstract, const
+// CHECK:STDOUT:   %Abstract: type = class_type @Abstract [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Access {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %.loc22_16.1: type = unbound_element_type Access, i32, const
-// CHECK:STDOUT:   %.loc22_16.2: <unbound element of class Access> = field_decl k, element0, const
-// CHECK:STDOUT:   %k: <unbound element of class Access> = bind_name k, %.loc22_16.2, const = %.loc22_16.2
-// CHECK:STDOUT:   %.loc27_18.1: type = unbound_element_type Access, i32, const
-// CHECK:STDOUT:   %.loc27_18.2: <unbound element of class Access> = field_decl l, element1, const
-// CHECK:STDOUT:   %l: <unbound element of class Access> = bind_name l, %.loc27_18.2, const = %.loc27_18.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %.loc22_16.1: type = unbound_element_type Access, i32 [template]
+// CHECK:STDOUT:   %.loc22_16.2: <unbound element of class Access> = field_decl k, element0 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Access> = bind_name k, %.loc22_16.2 [template = %.loc22_16.2]
+// CHECK:STDOUT:   %.loc27_18.1: type = unbound_element_type Access, i32 [template]
+// CHECK:STDOUT:   %.loc27_18.2: <unbound element of class Access> = field_decl l, element1 [template]
+// CHECK:STDOUT:   %l: <unbound element of class Access> = bind_name l, %.loc27_18.2 [template = %.loc27_18.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -93,8 +93,8 @@ abstract class Abstract {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %I: <function> = fn_decl @I, const
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %I: <function> = fn_decl @I [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .H = %H
@@ -102,9 +102,9 @@ abstract class Abstract {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Abstract {
-// CHECK:STDOUT:   %J: <function> = fn_decl @J, const
-// CHECK:STDOUT:   %K: <function> = fn_decl @K, const
-// CHECK:STDOUT:   %L: <function> = fn_decl @L, const
+// CHECK:STDOUT:   %J: <function> = fn_decl @J [template]
+// CHECK:STDOUT:   %K: <function> = fn_decl @K [template]
+// CHECK:STDOUT:   %L: <function> = fn_decl @L [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .J = %J

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -24,21 +24,21 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- fail_unbound_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = struct_type {.field: i32}, const
+// CHECK:STDOUT:   %.loc15: type = struct_type {.field: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_12.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_12.2: <unbound element of class Class> = field_decl field, element0, const
-// CHECK:STDOUT:   %field: <unbound element of class Class> = bind_name field, %.loc8_12.2, const = %.loc8_12.2
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %.loc8_12.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_12.2: <unbound element of class Class> = field_decl field, element0 [template]
+// CHECK:STDOUT:   %field: <unbound element of class Class> = bind_name field, %.loc8_12.2 [template = %.loc8_12.2]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .field = %field
@@ -47,14 +47,14 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field, const = @Class.%.loc8_12.2
+// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field [template = @Class.%.loc8_12.2]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field, const = @Class.%.loc8_12.2
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field [template = @Class.%.loc8_12.2]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -19,21 +19,21 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT: --- fail_unknown_member.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}, const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .G = %G}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl n, element0, const
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl n, element0 [template]
+// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .n = %n

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -20,26 +20,26 @@ fn Run() {
 // CHECK:STDOUT: --- field_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl j, element0, const
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl k, element1, const
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl j, element0 [template]
+// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl k, element1 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .j = %j
@@ -48,16 +48,16 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref.loc14: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc14_4: ref i32 = class_element_access %c.ref.loc14, element0
-// CHECK:STDOUT:   %.loc14_9: i32 = int_literal 1, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14_9: i32 = int_literal 1 [template = constants.%.loc14]
 // CHECK:STDOUT:   assign %.loc14_4, %.loc14_9
 // CHECK:STDOUT:   %c.ref.loc15: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc15_4: ref i32 = class_element_access %c.ref.loc15, element1
-// CHECK:STDOUT:   %.loc15_9: i32 = int_literal 2, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15_9: i32 = int_literal 2 [template = constants.%.loc15]
 // CHECK:STDOUT:   assign %.loc15_4, %.loc15_9
 // CHECK:STDOUT:   %cj.var: ref i32 = var cj
 // CHECK:STDOUT:   %cj: ref i32 = bind_name cj, %cj.var

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -21,26 +21,26 @@ fn Test() {
 // CHECK:STDOUT: --- field_access_in_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32}, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Test = %Test}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %Test: <function> = fn_decl @Test, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %Test: <function> = fn_decl @Test [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl j, element0, const
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl k, element1, const
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl j, element0 [template]
+// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl k, element1 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .j = %j
@@ -49,18 +49,18 @@ fn Test() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref.loc13: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc13: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %cv.var: ref Class = var cv
 // CHECK:STDOUT:   %cv: ref Class = bind_name cv, %cv.var
 // CHECK:STDOUT:   %cv.ref.loc14: ref Class = name_ref cv, %cv
 // CHECK:STDOUT:   %.loc14_5: ref i32 = class_element_access %cv.ref.loc14, element0
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 1, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 1 [template = constants.%.loc14]
 // CHECK:STDOUT:   assign %.loc14_5, %.loc14_10
 // CHECK:STDOUT:   %cv.ref.loc15: ref Class = name_ref cv, %cv
 // CHECK:STDOUT:   %.loc15_5: ref i32 = class_element_access %cv.ref.loc15, element1
-// CHECK:STDOUT:   %.loc15_10: i32 = int_literal 2, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15_10: i32 = int_literal 2 [template = constants.%.loc15]
 // CHECK:STDOUT:   assign %.loc15_5, %.loc15_10
-// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %cv.ref.loc16: ref Class = name_ref cv, %cv
 // CHECK:STDOUT:   %.loc16: Class = bind_value %cv.ref.loc16
 // CHECK:STDOUT:   %c: Class = bind_name c, %.loc16

--- a/toolchain/check/testdata/class/forward_declared.carbon
+++ b/toolchain/check/testdata/class/forward_declared.carbon
@@ -13,8 +13,8 @@ fn F(p: Class*) -> Class* { return p; }
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class;

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -20,28 +20,28 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: --- init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*}, const
-// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*} [template]
+// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Make = %Make, .MakeReorder = %MakeReorder}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %MakeReorder: <function> = fn_decl @MakeReorder, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %MakeReorder: <function> = fn_decl @MakeReorder [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl n, element0, const
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %.loc9_18: type = ptr_type Class, const
-// CHECK:STDOUT:   %.loc9_11.1: type = unbound_element_type Class, Class*, const
-// CHECK:STDOUT:   %.loc9_11.2: <unbound element of class Class> = field_decl next, element1, const
-// CHECK:STDOUT:   %next: <unbound element of class Class> = bind_name next, %.loc9_11.2, const = %.loc9_11.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl n, element0 [template]
+// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %.loc9_18: type = ptr_type Class [template]
+// CHECK:STDOUT:   %.loc9_11.1: type = unbound_element_type Class, Class* [template]
+// CHECK:STDOUT:   %.loc9_11.2: <unbound element of class Class> = field_decl next, element1 [template]
+// CHECK:STDOUT:   %next: <unbound element of class Class> = bind_name next, %.loc9_11.2 [template = %.loc9_11.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .n = %n

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -16,26 +16,26 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- init_as.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Class> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -44,10 +44,10 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1, const = constants.%.loc13_17
-// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2, const = constants.%.loc13_25
+// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1 [template = constants.%.loc13_17]
+// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2 [template = constants.%.loc13_25]
 // CHECK:STDOUT:   %.loc13_26.1: {.a: i32, .b: i32} = struct_literal (%.loc13_17, %.loc13_25)
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc13_26.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc13_26.3: ref i32 = class_element_access %.loc13_26.2, element0
 // CHECK:STDOUT:   %.loc13_26.4: init i32 = initialize_from %.loc13_17 to %.loc13_26.3

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -23,31 +23,31 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: --- init_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.c: Inner, .d: Inner}, const
-// CHECK:STDOUT:   %.loc17_1.2: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}, const
-// CHECK:STDOUT:   %.loc17_1.3: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*}, const
-// CHECK:STDOUT:   %.loc14: type = ptr_type {.c: Inner, .d: Inner}, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.c: Inner, .d: Inner} [template]
+// CHECK:STDOUT:   %.loc17_1.2: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
+// CHECK:STDOUT:   %.loc17_1.3: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
+// CHECK:STDOUT:   %.loc14: type = ptr_type {.c: Inner, .d: Inner} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Inner = %Inner.decl, .MakeInner = %MakeInner, .Outer = %Outer.decl, .MakeOuter = %MakeOuter}
 // CHECK:STDOUT:   %Inner.decl = class_decl @Inner, ()
-// CHECK:STDOUT:   %Inner: type = class_type @Inner, const
-// CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner, const
+// CHECK:STDOUT:   %Inner: type = class_type @Inner [template]
+// CHECK:STDOUT:   %MakeInner: <function> = fn_decl @MakeInner [template]
 // CHECK:STDOUT:   %Outer.decl = class_decl @Outer, ()
-// CHECK:STDOUT:   %Outer: type = class_type @Outer, const
-// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter, const
+// CHECK:STDOUT:   %Outer: type = class_type @Outer [template]
+// CHECK:STDOUT:   %MakeOuter: <function> = fn_decl @MakeOuter [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Inner, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Inner> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Inner> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Inner, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Inner> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class Inner> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Inner, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Inner> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Inner> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Inner, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Inner> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class Inner> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -55,14 +55,14 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
-// CHECK:STDOUT:   %Inner.ref.loc15: type = name_ref Inner, file.%Inner, const = file.%Inner
-// CHECK:STDOUT:   %.loc15_8.1: type = unbound_element_type Outer, Inner, const
-// CHECK:STDOUT:   %.loc15_8.2: <unbound element of class Outer> = field_decl c, element0, const
-// CHECK:STDOUT:   %c: <unbound element of class Outer> = bind_name c, %.loc15_8.2, const = %.loc15_8.2
-// CHECK:STDOUT:   %Inner.ref.loc16: type = name_ref Inner, file.%Inner, const = file.%Inner
-// CHECK:STDOUT:   %.loc16_8.1: type = unbound_element_type Outer, Inner, const
-// CHECK:STDOUT:   %.loc16_8.2: <unbound element of class Outer> = field_decl d, element1, const
-// CHECK:STDOUT:   %d: <unbound element of class Outer> = bind_name d, %.loc16_8.2, const = %.loc16_8.2
+// CHECK:STDOUT:   %Inner.ref.loc15: type = name_ref Inner, file.%Inner [template = file.%Inner]
+// CHECK:STDOUT:   %.loc15_8.1: type = unbound_element_type Outer, Inner [template]
+// CHECK:STDOUT:   %.loc15_8.2: <unbound element of class Outer> = field_decl c, element0 [template]
+// CHECK:STDOUT:   %c: <unbound element of class Outer> = bind_name c, %.loc15_8.2 [template = %.loc15_8.2]
+// CHECK:STDOUT:   %Inner.ref.loc16: type = name_ref Inner, file.%Inner [template = file.%Inner]
+// CHECK:STDOUT:   %.loc16_8.1: type = unbound_element_type Outer, Inner [template]
+// CHECK:STDOUT:   %.loc16_8.2: <unbound element of class Outer> = field_decl d, element1 [template]
+// CHECK:STDOUT:   %d: <unbound element of class Outer> = bind_name d, %.loc16_8.2 [template = %.loc16_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .c = %c
@@ -73,10 +73,10 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeOuter() -> %return: Outer {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %MakeInner.ref.loc20_16: <function> = name_ref MakeInner, file.%MakeInner, const = file.%MakeInner
+// CHECK:STDOUT:   %MakeInner.ref.loc20_16: <function> = name_ref MakeInner, file.%MakeInner [template = file.%MakeInner]
 // CHECK:STDOUT:   %.loc20_45.1: ref Inner = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc20_25: init Inner = call %MakeInner.ref.loc20_16() to %.loc20_45.1
-// CHECK:STDOUT:   %MakeInner.ref.loc20_34: <function> = name_ref MakeInner, file.%MakeInner, const = file.%MakeInner
+// CHECK:STDOUT:   %MakeInner.ref.loc20_34: <function> = name_ref MakeInner, file.%MakeInner [template = file.%MakeInner]
 // CHECK:STDOUT:   %.loc20_45.2: ref Inner = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc20_43: init Inner = call %MakeInner.ref.loc20_34() to %.loc20_45.2
 // CHECK:STDOUT:   %.loc20_45.3: {.c: Inner, .d: Inner} = struct_literal (%.loc20_25, %.loc20_43)

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -51,32 +51,32 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: --- method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32}, const
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32} [template]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Call = %Call, .CallOnConstBoundMethod = %CallOnConstBoundMethod, .CallWithAddr = %CallWithAddr, .CallFThroughPointer = %CallFThroughPointer, .CallGThroughPointer = %CallGThroughPointer, .Make = %Make, .CallFOnInitializingExpr = %CallFOnInitializingExpr, .CallGOnInitializingExpr = %CallGOnInitializingExpr}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Call: <function> = fn_decl @Call, const
-// CHECK:STDOUT:   %CallOnConstBoundMethod: <function> = fn_decl @CallOnConstBoundMethod, const
-// CHECK:STDOUT:   %CallWithAddr: <function> = fn_decl @CallWithAddr, const
-// CHECK:STDOUT:   %CallFThroughPointer: <function> = fn_decl @CallFThroughPointer, const
-// CHECK:STDOUT:   %CallGThroughPointer: <function> = fn_decl @CallGThroughPointer, const
-// CHECK:STDOUT:   %Make: <function> = fn_decl @Make, const
-// CHECK:STDOUT:   %CallFOnInitializingExpr: <function> = fn_decl @CallFOnInitializingExpr, const
-// CHECK:STDOUT:   %CallGOnInitializingExpr: <function> = fn_decl @CallGOnInitializingExpr, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Call: <function> = fn_decl @Call [template]
+// CHECK:STDOUT:   %CallOnConstBoundMethod: <function> = fn_decl @CallOnConstBoundMethod [template]
+// CHECK:STDOUT:   %CallWithAddr: <function> = fn_decl @CallWithAddr [template]
+// CHECK:STDOUT:   %CallFThroughPointer: <function> = fn_decl @CallFThroughPointer [template]
+// CHECK:STDOUT:   %CallGThroughPointer: <function> = fn_decl @CallGThroughPointer [template]
+// CHECK:STDOUT:   %Make: <function> = fn_decl @Make [template]
+// CHECK:STDOUT:   %CallFOnInitializingExpr: <function> = fn_decl @CallFOnInitializingExpr [template]
+// CHECK:STDOUT:   %CallGOnInitializingExpr: <function> = fn_decl @CallGOnInitializingExpr [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %.loc11_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc11_8.2: <unbound element of class Class> = field_decl k, element0, const
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc11_8.2, const = %.loc11_8.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %.loc11_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc11_8.2: <unbound element of class Class> = field_decl k, element0 [template]
+// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc11_8.2 [template = %.loc11_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -106,9 +106,9 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallOnConstBoundMethod() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc25_17: i32 = int_literal 1, const = constants.%.loc25
+// CHECK:STDOUT:   %.loc25_17: i32 = int_literal 1 [template = constants.%.loc25]
 // CHECK:STDOUT:   %.loc25_18.1: {.k: i32} = struct_literal (%.loc25_17)
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc25_18.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc25_18.3: ref i32 = class_element_access %.loc25_18.2, element0
 // CHECK:STDOUT:   %.loc25_18.4: init i32 = initialize_from %.loc25_17 to %.loc25_18.3
@@ -125,7 +125,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallWithAddr() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
@@ -165,7 +165,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallFOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc44_14.1: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc44_14.2: init Class = call %Make.ref() to %.loc44_14.1
 // CHECK:STDOUT:   %.loc44_14.3: ref Class = temporary %.loc44_14.1, %.loc44_14.2
@@ -179,7 +179,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make, const = file.%Make
+// CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc48_14.1: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc48_14.2: init Class = call %Make.ref() to %.loc48_14.1
 // CHECK:STDOUT:   %.loc48_14.3: ref Class = temporary %.loc48_14.1, %.loc48_14.2

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -31,37 +31,37 @@ fn F(a: Outer*) {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {.pi: Inner*, .po: Outer*, .qi: Inner*}, const
-// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.po: Outer*, .qo: Outer*, .pi: Inner*}, const
-// CHECK:STDOUT:   %.loc17_1.2: type = ptr_type {.po: Outer*, .qo: Outer*, .pi: Inner*}, const
-// CHECK:STDOUT:   %.loc12_3.2: type = ptr_type {.pi: Inner*, .po: Outer*, .qi: Inner*}, const
+// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
+// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
+// CHECK:STDOUT:   %.loc17_1.2: type = ptr_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
+// CHECK:STDOUT:   %.loc12_3.2: type = ptr_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Outer = %Outer.decl, .F = %F}
 // CHECK:STDOUT:   %Outer.decl = class_decl @Outer, ()
-// CHECK:STDOUT:   %Outer: type = class_type @Outer, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Outer: type = class_type @Outer [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
 // CHECK:STDOUT:   %Inner.decl = class_decl @Inner, ()
-// CHECK:STDOUT:   %Inner: type = class_type @Inner, const
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Outer, const = file.%Outer
-// CHECK:STDOUT:   %.loc14_15: type = ptr_type Outer, const
-// CHECK:STDOUT:   %.loc14_9.1: type = unbound_element_type Outer, Outer*, const
-// CHECK:STDOUT:   %.loc14_9.2: <unbound element of class Outer> = field_decl po, element0, const
-// CHECK:STDOUT:   %po: <unbound element of class Outer> = bind_name po, %.loc14_9.2, const = %.loc14_9.2
-// CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer, const = file.%Outer
-// CHECK:STDOUT:   %.loc15_16: type = ptr_type Outer, const
-// CHECK:STDOUT:   %.loc15_9.1: type = unbound_element_type Outer, Outer*, const
-// CHECK:STDOUT:   %.loc15_9.2: <unbound element of class Outer> = field_decl qo, element1, const
-// CHECK:STDOUT:   %qo: <unbound element of class Outer> = bind_name qo, %.loc15_9.2, const = %.loc15_9.2
-// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, %Inner, const = %Inner
-// CHECK:STDOUT:   %.loc16_16: type = ptr_type Inner, const
-// CHECK:STDOUT:   %.loc16_9.1: type = unbound_element_type Outer, Inner*, const
-// CHECK:STDOUT:   %.loc16_9.2: <unbound element of class Outer> = field_decl pi, element2, const
-// CHECK:STDOUT:   %pi: <unbound element of class Outer> = bind_name pi, %.loc16_9.2, const = %.loc16_9.2
+// CHECK:STDOUT:   %Inner: type = class_type @Inner [template]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Outer [template = file.%Outer]
+// CHECK:STDOUT:   %.loc14_15: type = ptr_type Outer [template]
+// CHECK:STDOUT:   %.loc14_9.1: type = unbound_element_type Outer, Outer* [template]
+// CHECK:STDOUT:   %.loc14_9.2: <unbound element of class Outer> = field_decl po, element0 [template]
+// CHECK:STDOUT:   %po: <unbound element of class Outer> = bind_name po, %.loc14_9.2 [template = %.loc14_9.2]
+// CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer [template = file.%Outer]
+// CHECK:STDOUT:   %.loc15_16: type = ptr_type Outer [template]
+// CHECK:STDOUT:   %.loc15_9.1: type = unbound_element_type Outer, Outer* [template]
+// CHECK:STDOUT:   %.loc15_9.2: <unbound element of class Outer> = field_decl qo, element1 [template]
+// CHECK:STDOUT:   %qo: <unbound element of class Outer> = bind_name qo, %.loc15_9.2 [template = %.loc15_9.2]
+// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, %Inner [template = %Inner]
+// CHECK:STDOUT:   %.loc16_16: type = ptr_type Inner [template]
+// CHECK:STDOUT:   %.loc16_9.1: type = unbound_element_type Outer, Inner* [template]
+// CHECK:STDOUT:   %.loc16_9.2: <unbound element of class Outer> = field_decl pi, element2 [template]
+// CHECK:STDOUT:   %pi: <unbound element of class Outer> = bind_name pi, %.loc16_9.2 [template = %.loc16_9.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Inner = %Inner.decl
@@ -71,21 +71,21 @@ fn F(a: Outer*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, @Outer.%Inner, const = @Outer.%Inner
-// CHECK:STDOUT:   %.loc9_17: type = ptr_type Inner, const
-// CHECK:STDOUT:   %.loc9_11.1: type = unbound_element_type Inner, Inner*, const
-// CHECK:STDOUT:   %.loc9_11.2: <unbound element of class Inner> = field_decl pi, element0, const
-// CHECK:STDOUT:   %pi: <unbound element of class Inner> = bind_name pi, %.loc9_11.2, const = %.loc9_11.2
-// CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer, const = file.%Outer
-// CHECK:STDOUT:   %.loc10_18: type = ptr_type Outer, const
-// CHECK:STDOUT:   %.loc10_11.1: type = unbound_element_type Inner, Outer*, const
-// CHECK:STDOUT:   %.loc10_11.2: <unbound element of class Inner> = field_decl po, element1, const
-// CHECK:STDOUT:   %po: <unbound element of class Inner> = bind_name po, %.loc10_11.2, const = %.loc10_11.2
-// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, @Outer.%Inner, const = @Outer.%Inner
-// CHECK:STDOUT:   %.loc11_18: type = ptr_type Inner, const
-// CHECK:STDOUT:   %.loc11_11.1: type = unbound_element_type Inner, Inner*, const
-// CHECK:STDOUT:   %.loc11_11.2: <unbound element of class Inner> = field_decl qi, element2, const
-// CHECK:STDOUT:   %qi: <unbound element of class Inner> = bind_name qi, %.loc11_11.2, const = %.loc11_11.2
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, @Outer.%Inner [template = @Outer.%Inner]
+// CHECK:STDOUT:   %.loc9_17: type = ptr_type Inner [template]
+// CHECK:STDOUT:   %.loc9_11.1: type = unbound_element_type Inner, Inner* [template]
+// CHECK:STDOUT:   %.loc9_11.2: <unbound element of class Inner> = field_decl pi, element0 [template]
+// CHECK:STDOUT:   %pi: <unbound element of class Inner> = bind_name pi, %.loc9_11.2 [template = %.loc9_11.2]
+// CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer [template = file.%Outer]
+// CHECK:STDOUT:   %.loc10_18: type = ptr_type Outer [template]
+// CHECK:STDOUT:   %.loc10_11.1: type = unbound_element_type Inner, Outer* [template]
+// CHECK:STDOUT:   %.loc10_11.2: <unbound element of class Inner> = field_decl po, element1 [template]
+// CHECK:STDOUT:   %po: <unbound element of class Inner> = bind_name po, %.loc10_11.2 [template = %.loc10_11.2]
+// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, @Outer.%Inner [template = @Outer.%Inner]
+// CHECK:STDOUT:   %.loc11_18: type = ptr_type Inner [template]
+// CHECK:STDOUT:   %.loc11_11.1: type = unbound_element_type Inner, Inner* [template]
+// CHECK:STDOUT:   %.loc11_11.2: <unbound element of class Inner> = field_decl qi, element2 [template]
+// CHECK:STDOUT:   %qi: <unbound element of class Inner> = bind_name qi, %.loc11_11.2 [template = %.loc11_11.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .pi = %pi

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -21,33 +21,33 @@ fn G(o: Outer) {
 // CHECK:STDOUT: --- nested_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32}, const
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32}, const
-// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32} [template]
+// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Outer = %Outer.decl, .F = %F, .G = %G}
 // CHECK:STDOUT:   %Outer.decl = class_decl @Outer, ()
-// CHECK:STDOUT:   %Outer: type = class_type @Outer, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Outer: type = class_type @Outer [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
 // CHECK:STDOUT:   %Inner.decl = class_decl @Inner, ()
-// CHECK:STDOUT:   %Inner: type = class_type @Inner, const
+// CHECK:STDOUT:   %Inner: type = class_type @Inner [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Inner = %Inner.decl
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
-// CHECK:STDOUT:   %.loc9_10.1: type = unbound_element_type Inner, i32, const
-// CHECK:STDOUT:   %.loc9_10.2: <unbound element of class Inner> = field_decl n, element0, const
-// CHECK:STDOUT:   %n: <unbound element of class Inner> = bind_name n, %.loc9_10.2, const = %.loc9_10.2
+// CHECK:STDOUT:   %.loc9_10.1: type = unbound_element_type Inner, i32 [template]
+// CHECK:STDOUT:   %.loc9_10.2: <unbound element of class Inner> = field_decl n, element0 [template]
+// CHECK:STDOUT:   %n: <unbound element of class Inner> = bind_name n, %.loc9_10.2 [template = %.loc9_10.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .n = %n
@@ -64,7 +64,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT: fn @G(%o: Outer) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %o.ref: Outer = name_ref o, %o
-// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, @Outer.%Inner, const = @Outer.%Inner
+// CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, @Outer.%Inner [template = @Outer.%Inner]
 // CHECK:STDOUT:   %i.var: ref Inner = var i
 // CHECK:STDOUT:   %i: ref Inner = bind_name i, %i.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -21,27 +21,27 @@ fn Class.G[self: Class](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT: --- raw_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_46.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc9_46.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc9_46.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc11: type = struct_type {.n: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}, const
+// CHECK:STDOUT:   %.loc9_46.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc9_46.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc9_46.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc11: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %.loc10_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc10_8.2: <unbound element of class Class> = field_decl n, element0, const
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc10_8.2, const = %.loc10_8.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %.loc10_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc10_8.2: <unbound element of class Class> = field_decl n, element0 [template]
+// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc10_8.2 [template = %.loc10_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/raw_self_type.carbon
+++ b/toolchain/check/testdata/class/raw_self_type.carbon
@@ -14,17 +14,17 @@ class Class {
 // CHECK:STDOUT: --- raw_self_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc12: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -32,12 +32,12 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Self.ref.loc9: type = name_ref Self, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %.loc9: type = ptr_type Class, const
+// CHECK:STDOUT:   %Self.ref.loc9: type = name_ref Self, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %.loc9: type = ptr_type Class [template]
 // CHECK:STDOUT:   %Self.var: ref Class* = var r#Self
 // CHECK:STDOUT:   %Self: ref Class* = bind_name r#Self, %Self.var
-// CHECK:STDOUT:   %Self.ref.loc10_12: type = name_ref Self, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %.loc10_16: type = ptr_type Class, const
+// CHECK:STDOUT:   %Self.ref.loc10_12: type = name_ref Self, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %.loc10_16: type = ptr_type Class [template]
 // CHECK:STDOUT:   %p.var: ref Class* = var p
 // CHECK:STDOUT:   %p: ref Class* = bind_name p, %p.var
 // CHECK:STDOUT:   %Self.ref.loc10_20: ref Class* = name_ref r#Self, %Self

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -15,19 +15,19 @@ fn Class.F() {}
 // CHECK:STDOUT: --- redeclaration.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl.loc7}
 // CHECK:STDOUT:   %Class.decl.loc7 = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %Class.decl.loc9 = class_decl @Class, ()
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/redeclaration_introducer.carbon
@@ -15,17 +15,17 @@ abstract class C {}
 // CHECK:STDOUT: --- redeclaration_introducer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.decl.loc7, .B = %B.decl.loc8, .C = %C.decl.loc9}
 // CHECK:STDOUT:   %A.decl.loc7 = class_decl @A, ()
-// CHECK:STDOUT:   %A: type = class_type @A, const
+// CHECK:STDOUT:   %A: type = class_type @A [template]
 // CHECK:STDOUT:   %B.decl.loc8 = class_decl @B, ()
-// CHECK:STDOUT:   %B: type = class_type @B, const
+// CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C.decl.loc9 = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %A.decl.loc11 = class_decl @A, ()
 // CHECK:STDOUT:   %B.decl.loc12 = class_decl @B, ()
 // CHECK:STDOUT:   %C.decl.loc13 = class_decl @C, ()

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -16,19 +16,19 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT: --- reenter_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -37,7 +37,7 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G, const = @Class.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
 // CHECK:STDOUT:   %.loc13_11: init i32 = call %G.ref()
 // CHECK:STDOUT:   %.loc13_13.1: i32 = value_of_initializer %.loc13_11
 // CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_11, %.loc13_13.1

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -26,22 +26,22 @@ fn Run() {
 // CHECK:STDOUT: --- scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .F = %F, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.2, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F.1, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -50,13 +50,13 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F, const = @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
 // CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
 // CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1
@@ -65,7 +65,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 2, const = constants.%.loc18
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 2 [template = constants.%.loc18]
 // CHECK:STDOUT:   return %.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -73,13 +73,13 @@ fn Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %F.ref.loc22: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc22: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc22: init i32 = call %F.ref.loc22()
 // CHECK:STDOUT:   assign %a.var, %.loc22
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %F.ref.loc23: <function> = name_ref F, @Class.%F, const = @Class.%F
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %F.ref.loc23: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc23: init i32 = call %F.ref.loc23()
 // CHECK:STDOUT:   assign %b.var, %.loc23
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -22,24 +22,24 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT: --- self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32}, const
+// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %.loc11_8.1: type = unbound_element_type Class, i32, const
-// CHECK:STDOUT:   %.loc11_8.2: <unbound element of class Class> = field_decl n, element0, const
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc11_8.2, const = %.loc11_8.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %.loc11_8.1: type = unbound_element_type Class, i32 [template]
+// CHECK:STDOUT:   %.loc11_8.2: <unbound element of class Class> = field_decl n, element0 [template]
+// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc11_8.2 [template = %.loc11_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -31,41 +31,41 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: --- self_conversion.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc16_1.1: type = struct_type {.base: Base}, const
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc16_1.2: type = struct_type {.base: {.a: i32}*}, const
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base}, const
-// CHECK:STDOUT:   %.loc27: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc16_1.1: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc16_1.2: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base} [template]
+// CHECK:STDOUT:   %.loc27: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Base = %Base.decl, .Derived = %Derived.decl, .Call = %Call}
 // CHECK:STDOUT:   %Base.decl = class_decl @Base, ()
-// CHECK:STDOUT:   %Base: type = class_type @Base, const
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
 // CHECK:STDOUT:   %Derived.decl = class_decl @Derived, ()
-// CHECK:STDOUT:   %Derived: type = class_type @Derived, const
-// CHECK:STDOUT:   %SelfBase: <function> = fn_decl @SelfBase, const
-// CHECK:STDOUT:   %AddrSelfBase: <function> = fn_decl @AddrSelfBase, const
-// CHECK:STDOUT:   %Call: <function> = fn_decl @Call, const
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %SelfBase: <function> = fn_decl @SelfBase [template]
+// CHECK:STDOUT:   %AddrSelfBase: <function> = fn_decl @AddrSelfBase [template]
+// CHECK:STDOUT:   %Call: <function> = fn_decl @Call [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class Base> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
-// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base, const = file.%Base
-// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base, const
-// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0, const
-// CHECK:STDOUT:   %SelfBase: <function> = fn_decl @SelfBase, const
-// CHECK:STDOUT:   %AddrSelfBase: <function> = fn_decl @AddrSelfBase, const
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
+// CHECK:STDOUT:   %.loc12_20.1: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.loc12_20.2: <unbound element of class Derived> = base_decl Base, element0 [template]
+// CHECK:STDOUT:   %SelfBase: <function> = fn_decl @SelfBase [template]
+// CHECK:STDOUT:   %AddrSelfBase: <function> = fn_decl @AddrSelfBase [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12_20.2
@@ -87,7 +87,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc23_4: ref Base = deref %self.ref
 // CHECK:STDOUT:   %.loc23_10: ref i32 = class_element_access %.loc23_4, element0
-// CHECK:STDOUT:   %.loc23_15: i32 = int_literal 1, const = constants.%.loc23
+// CHECK:STDOUT:   %.loc23_15: i32 = int_literal 1 [template = constants.%.loc23]
 // CHECK:STDOUT:   assign %.loc23_10, %.loc23_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -19,24 +19,24 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT: --- self_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*}, const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*}, const
+// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*} [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Class, const = file.%Class
-// CHECK:STDOUT:   %.loc9_14: type = ptr_type Class, const
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, Class*, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl p, element0, const
-// CHECK:STDOUT:   %p: <unbound element of class Class> = bind_name p, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Class [template = file.%Class]
+// CHECK:STDOUT:   %.loc9_14: type = ptr_type Class [template]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type Class, Class* [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class Class> = field_decl p, element0 [template]
+// CHECK:STDOUT:   %p: <unbound element of class Class> = bind_name p, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -16,20 +16,20 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- static_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
+// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl, .Run = %Run}
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -39,11 +39,11 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class, const = file.%Class
+// CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F, const = @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
 // CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
 // CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1

--- a/toolchain/check/testdata/const/collapse.carbon
+++ b/toolchain/check/testdata/const/collapse.carbon
@@ -16,7 +16,7 @@ fn F(p: const i32**) -> const (const i32)** {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%p: const i32**) -> const i32** {

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -18,7 +18,7 @@ fn G(p: const (const i32)**) -> i32** {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.G = %G}
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%p: const i32**) -> i32** {

--- a/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
+++ b/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
@@ -19,17 +19,17 @@ fn H() -> i32 {
 // CHECK:STDOUT: --- in_place_tuple_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_20.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_20.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_20.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_20.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_20.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_20.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .H = %H}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32);
@@ -37,19 +37,19 @@ fn H() -> i32 {
 // CHECK:STDOUT: fn @G() -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_19: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7: type = converted %.loc10_19, constants.%.loc7_20.2, const = constants.%.loc7_20.2
+// CHECK:STDOUT:   %.loc7: type = converted %.loc10_19, constants.%.loc7_20.2 [template = constants.%.loc7_20.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32) = bind_name v, %v.var
-// CHECK:STDOUT:   %F.ref.loc10: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_7: ref (i32, i32) = splice_block %v.var {}
 // CHECK:STDOUT:   %.loc10_24: init (i32, i32) = call %F.ref.loc10() to %.loc10_7
 // CHECK:STDOUT:   assign %v.var, %.loc10_24
 // CHECK:STDOUT:   %v.ref: ref (i32, i32) = name_ref v, %v
-// CHECK:STDOUT:   %F.ref.loc11: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc11: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc11_3: ref (i32, i32) = splice_block %v.ref {}
 // CHECK:STDOUT:   %.loc11_8: init (i32, i32) = call %F.ref.loc11() to %.loc11_3
 // CHECK:STDOUT:   assign %v.ref, %.loc11_8
-// CHECK:STDOUT:   %F.ref.loc12: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc12: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc9: ref (i32, i32) = splice_block %return {}
 // CHECK:STDOUT:   %.loc12: init (i32, i32) = call %F.ref.loc12() to %.loc9
 // CHECK:STDOUT:   return %.loc12
@@ -57,10 +57,10 @@ fn H() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc16_11.1: ref (i32, i32) = temporary_storage
 // CHECK:STDOUT:   %.loc16_11.2: init (i32, i32) = call %G.ref() to %.loc16_11.1
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0, const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0 [template = constants.%.loc16]
 // CHECK:STDOUT:   %.loc16_11.3: ref (i32, i32) = temporary %.loc16_11.1, %.loc16_11.2
 // CHECK:STDOUT:   %.loc16_15.1: ref i32 = tuple_index %.loc16_11.3, %.loc16_14
 // CHECK:STDOUT:   %.loc16_15.2: i32 = bind_value %.loc16_15.1

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -15,15 +15,15 @@ fn Main() {
 // CHECK:STDOUT: --- empty_struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc12: {} = struct_value (), const
+// CHECK:STDOUT:   %.loc7_13.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc12: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Echo = %Echo, .Main = %Main}
-// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: {}) -> {} {
@@ -34,10 +34,10 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo, const = file.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: {} = struct_value (), const = constants.%.loc12
-// CHECK:STDOUT:   %.loc12_9.3: {} = converted %.loc12_9.1, %.loc12_9.2, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12_9.2: {} = struct_value () [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_9.3: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.loc12]
 // CHECK:STDOUT:   %.loc12_7: init {} = call %Echo.ref(%.loc12_9.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -15,14 +15,14 @@ fn Main() {
 // CHECK:STDOUT: --- empty_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc12: () = tuple_value (), const
+// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc12: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Echo = %Echo, .Main = %Main}
-// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: ()) -> () {
@@ -33,10 +33,10 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo, const = file.%Echo
+// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: () = tuple_value (), const = constants.%.loc12
-// CHECK:STDOUT:   %.loc12_9.3: () = converted %.loc12_9.1, %.loc12_9.2, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12_9.2: () = tuple_value () [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_9.3: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.loc12]
 // CHECK:STDOUT:   %.loc12_7: init () = call %Echo.ref(%.loc12_9.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -14,20 +14,20 @@ fn Run() {
 // CHECK:STDOUT: --- fail_not_callable.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc11: String = string_literal "hello", const
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc11: String = string_literal "hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run = %Run}
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11: String = string_literal "hello", const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: String = string_literal "hello" [template = constants.%.loc11]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -58,21 +58,21 @@ fn Main() {
 // CHECK:STDOUT: --- fail_param_count.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc18_7: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc55: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc18_7: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc55: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Run0 = %Run0, .Run1 = %Run1, .Run2 = %Run2, .Main = %Main}
-// CHECK:STDOUT:   %Run0: <function> = fn_decl @Run0, const
-// CHECK:STDOUT:   %Run1: <function> = fn_decl @Run1, const
-// CHECK:STDOUT:   %Run2: <function> = fn_decl @Run2, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Run0: <function> = fn_decl @Run0 [template]
+// CHECK:STDOUT:   %Run1: <function> = fn_decl @Run1 [template]
+// CHECK:STDOUT:   %Run2: <function> = fn_decl @Run2 [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run0() {
@@ -92,23 +92,23 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_ref Run0, file.%Run0, const = file.%Run0
-// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1, const = constants.%.loc18_8
+// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
+// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template = constants.%.loc18_8]
 // CHECK:STDOUT:   %.loc18_7: init () = call %Run0.ref.loc18(<invalid>)
-// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_ref Run0, file.%Run0, const = file.%Run0
-// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0, const = constants.%.loc25_8
-// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1, const = constants.%.loc25_11
+// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
+// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template = constants.%.loc25_8]
+// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template = constants.%.loc25_11]
 // CHECK:STDOUT:   %.loc25_7: init () = call %Run0.ref.loc25(<invalid>)
-// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_ref Run1, file.%Run1, const = file.%Run1
+// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
 // CHECK:STDOUT:   %.loc33: init () = call %Run1.ref.loc33(<invalid>)
-// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_ref Run1, file.%Run1, const = file.%Run1
-// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0, const = constants.%.loc40_8
-// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1, const = constants.%.loc40_11
+// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
+// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template = constants.%.loc40_8]
+// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template = constants.%.loc40_11]
 // CHECK:STDOUT:   %.loc40_7: init () = call %Run1.ref.loc40(<invalid>)
-// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_ref Run2, file.%Run2, const = file.%Run2
+// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
 // CHECK:STDOUT:   %.loc48: init () = call %Run2.ref.loc48(<invalid>)
-// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_ref Run2, file.%Run2, const = file.%Run2
-// CHECK:STDOUT:   %.loc55_8: i32 = int_literal 0, const = constants.%.loc55
+// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
+// CHECK:STDOUT:   %.loc55_8: i32 = int_literal 0 [template = constants.%.loc55]
 // CHECK:STDOUT:   %.loc55_7: init () = call %Run2.ref.loc55(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -19,14 +19,14 @@ fn F() {
 // CHECK:STDOUT: --- fail_param_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1, const
-// CHECK:STDOUT:   %.loc16_4: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.loc16_4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.G = %G, .F = %F}
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%a: i32) {
@@ -36,8 +36,8 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
-// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1, const = constants.%.loc16_5
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
+// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1 [template = constants.%.loc16_5]
 // CHECK:STDOUT:   %.loc16_4: init () = call %G.ref(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -16,18 +16,18 @@ fn Run() {
 // CHECK:STDOUT: --- fail_return_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1, const
+// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Run = %Run}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() -> f64 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1 [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -35,7 +35,7 @@ fn Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo, const = file.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %.loc13: init f64 = call %Foo.ref()
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -15,13 +15,13 @@ fn Main() {
 // CHECK:STDOUT: --- i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Echo = %Echo, .Main = %Main}
-// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Echo: <function> = fn_decl @Echo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Echo(%a: i32) -> i32 {
@@ -34,8 +34,8 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo, const = file.%Echo
-// CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1, const = constants.%.loc12
+// CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
+// CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1 [template = constants.%.loc12]
 // CHECK:STDOUT:   %.loc12_20: init i32 = call %Echo.ref(%.loc12_21)
 // CHECK:STDOUT:   assign %b.var, %.loc12_20
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -15,18 +15,18 @@ fn Main() {
 // CHECK:STDOUT: --- more_param_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_15.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc10_15.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc12_6: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10_15.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc10_15.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc12_6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
@@ -37,19 +37,19 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_15.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_15.2: type = converted %.loc10_15.1, constants.%.loc10_15.2, const = constants.%.loc10_15.2
+// CHECK:STDOUT:   %.loc10_15.2: type = converted %.loc10_15.1, constants.%.loc10_15.2 [template = constants.%.loc10_15.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1, const = constants.%.loc10_20
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
 // CHECK:STDOUT:   %.loc10_22.1: (i32,) = tuple_literal (%.loc10_20)
 // CHECK:STDOUT:   %.loc10_22.2: init (i32,) = tuple_init (%.loc10_20) to %x.var
 // CHECK:STDOUT:   %.loc10_22.3: init (i32,) = converted %.loc10_22.1, %.loc10_22.2
 // CHECK:STDOUT:   assign %x.var, %.loc10_22.3
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo, const = file.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x
-// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0, const = constants.%.loc12_9
+// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.loc12_9]
 // CHECK:STDOUT:   %.loc12_10.1: ref i32 = tuple_index %x.ref, %.loc12_9
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6, const = constants.%.loc12_13
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template = constants.%.loc12_13]
 // CHECK:STDOUT:   %.loc12_10.2: i32 = bind_value %.loc12_10.1
 // CHECK:STDOUT:   %.loc12_6: init () = call %Foo.ref(%.loc12_10.2, %.loc12_13)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -13,14 +13,14 @@ fn Main() {
 // CHECK:STDOUT: --- params_one.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const = constants.%.loc10_7
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -14,15 +14,15 @@ fn Main() {
 // CHECK:STDOUT: --- params_one_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {
@@ -32,11 +32,11 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const = constants.%.loc10_7
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7)
-// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1, const = constants.%.loc11
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -13,15 +13,15 @@ fn Main() {
 // CHECK:STDOUT: --- params_two.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
@@ -31,9 +31,9 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const = constants.%.loc10_7
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2, const = constants.%.loc10_10
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.loc10_10]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7, %.loc10_10)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -14,17 +14,17 @@ fn Main() {
 // CHECK:STDOUT: --- params_two_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {
@@ -34,13 +34,13 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1, const = constants.%.loc10_7
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2, const = constants.%.loc10_10
+// CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.loc10_10]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7, %.loc10_10)
-// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo, const = file.%Foo
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1, const = constants.%.loc11_7
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2, const = constants.%.loc11_10
+// CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.loc11_7]
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2 [template = constants.%.loc11_10]
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7, %.loc11_10)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -13,13 +13,13 @@ fn Main() {
 // CHECK:STDOUT: --- params_zero.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Main = %Main}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {
@@ -29,7 +29,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo, const = file.%Foo
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %.loc10: init () = call %Foo.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -14,13 +14,13 @@ fn Main() {
 // CHECK:STDOUT: --- return_implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.MakeImplicitEmptyTuple = %MakeImplicitEmptyTuple, .Main = %Main}
-// CHECK:STDOUT:   %MakeImplicitEmptyTuple: <function> = fn_decl @MakeImplicitEmptyTuple, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %MakeImplicitEmptyTuple: <function> = fn_decl @MakeImplicitEmptyTuple [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeImplicitEmptyTuple() {
@@ -31,10 +31,10 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc11_11.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc11_11.2: type = converted %.loc11_11.1, constants.%.loc11, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_11.2: type = converted %.loc11_11.1, constants.%.loc11 [template = constants.%.loc11]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
-// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_ref MakeImplicitEmptyTuple, file.%MakeImplicitEmptyTuple, const = file.%MakeImplicitEmptyTuple
+// CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_ref MakeImplicitEmptyTuple, file.%MakeImplicitEmptyTuple [template = file.%MakeImplicitEmptyTuple]
 // CHECK:STDOUT:   %.loc11_37: init () = call %MakeImplicitEmptyTuple.ref()
 // CHECK:STDOUT:   assign %b.var, %.loc11_37
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/declaration/fail_modifiers.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_modifiers.carbon
@@ -74,12 +74,12 @@ default final virtual fn ModifiersConflict2() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.WrongOrder = %WrongOrder, .DuplicateVirtual = %DuplicateVirtual, .TwoAccess = %TwoAccess, .ModifiersConflict = %ModifiersConflict, .InvalidModifier = %InvalidModifier, .ModifiersConflict2 = %ModifiersConflict2}
-// CHECK:STDOUT:   %WrongOrder: <function> = fn_decl @WrongOrder, const
-// CHECK:STDOUT:   %DuplicateVirtual: <function> = fn_decl @DuplicateVirtual, const
-// CHECK:STDOUT:   %TwoAccess: <function> = fn_decl @TwoAccess, const
-// CHECK:STDOUT:   %ModifiersConflict: <function> = fn_decl @ModifiersConflict, const
-// CHECK:STDOUT:   %InvalidModifier: <function> = fn_decl @InvalidModifier, const
-// CHECK:STDOUT:   %ModifiersConflict2: <function> = fn_decl @ModifiersConflict2, const
+// CHECK:STDOUT:   %WrongOrder: <function> = fn_decl @WrongOrder [template]
+// CHECK:STDOUT:   %DuplicateVirtual: <function> = fn_decl @DuplicateVirtual [template]
+// CHECK:STDOUT:   %TwoAccess: <function> = fn_decl @TwoAccess [template]
+// CHECK:STDOUT:   %ModifiersConflict: <function> = fn_decl @ModifiersConflict [template]
+// CHECK:STDOUT:   %InvalidModifier: <function> = fn_decl @InvalidModifier [template]
+// CHECK:STDOUT:   %ModifiersConflict2: <function> = fn_decl @ModifiersConflict2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @WrongOrder();

--- a/toolchain/check/testdata/function/declaration/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_todo_modifiers.carbon
@@ -13,7 +13,7 @@ private fn F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -11,20 +11,20 @@ fn G() { F(); }
 // CHECK:STDOUT: --- simple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc9: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc9: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
+++ b/toolchain/check/testdata/function/definition/fail_param_name_conflict.carbon
@@ -16,7 +16,7 @@ fn Bar(a: i32, a: i32) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Bar = %Bar}
-// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar, const
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Bar(%a.loc13_8: i32, %a.loc13_16: i32) {

--- a/toolchain/check/testdata/function/definition/order.carbon
+++ b/toolchain/check/testdata/function/definition/order.carbon
@@ -12,9 +12,9 @@ fn Baz() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Bar = %Bar, .Baz = %Baz}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar, const
-// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template]
+// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {

--- a/toolchain/check/testdata/function/definition/params_one.carbon
+++ b/toolchain/check/testdata/function/definition/params_one.carbon
@@ -10,7 +10,7 @@ fn Foo(a: i32) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/definition/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_one_comma.carbon
@@ -10,7 +10,7 @@ fn Foo(a: i32,) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/definition/params_two.carbon
+++ b/toolchain/check/testdata/function/definition/params_two.carbon
@@ -10,7 +10,7 @@ fn Foo(a: i32, b: i32) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/definition/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/definition/params_two_comma.carbon
@@ -10,7 +10,7 @@ fn Foo(a: i32, b: i32,) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32, %b: i32) {

--- a/toolchain/check/testdata/function/definition/params_zero.carbon
+++ b/toolchain/check/testdata/function/definition/params_zero.carbon
@@ -10,7 +10,7 @@ fn Foo() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() {

--- a/toolchain/check/testdata/function/definition/same_param_name.carbon
+++ b/toolchain/check/testdata/function/definition/same_param_name.carbon
@@ -11,8 +11,8 @@ fn Bar(a: i32) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %Foo, .Bar = %Bar}
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
-// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo(%a: i32) {

--- a/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
@@ -16,16 +16,16 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type, %U: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %T, sym = %T
-// CHECK:STDOUT:   %.loc8: type = ptr_type T, const
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %.loc8: type = ptr_type T [template]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %U.ref: type = name_ref U, %U, sym = %U
+// CHECK:STDOUT:   %U.ref: type = name_ref U, %U [symbolic = %U]
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc12_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc12_14: ref T = deref %.loc12_15

--- a/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
@@ -21,11 +21,11 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type, %U: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %T
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T, sym = %T
 // CHECK:STDOUT:   %.loc8: type = ptr_type T, const
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %U.ref: type = name_ref U, %U
+// CHECK:STDOUT:   %U.ref: type = name_ref U, %U, sym = %U
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc12_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc12_14: ref T = deref %.loc12_15

--- a/toolchain/check/testdata/function/generic/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/type_param.carbon
@@ -13,16 +13,16 @@ fn F(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T, sym = %T
-// CHECK:STDOUT:   %.loc8: type = ptr_type T, const
+// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %.loc8: type = ptr_type T [template]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T, sym = %T
+// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = %T]
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc9_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc9_14.1: ref T = deref %.loc9_15

--- a/toolchain/check/testdata/function/generic/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/type_param.carbon
@@ -18,11 +18,11 @@ fn F(T:! type) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T
+// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T, sym = %T
 // CHECK:STDOUT:   %.loc8: type = ptr_type T, const
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T
+// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T, sym = %T
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc9_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc9_14.1: ref T = deref %.loc9_15

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -20,15 +20,15 @@ fn If(b: bool) {
 // CHECK:STDOUT: --- else.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc13: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .H = %H, .If = %If}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %If: <function> = fn_decl @If, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %If: <function> = fn_decl @If [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -52,17 +52,17 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc13: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc15: init () = call %G.ref()
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H, const = file.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
 // CHECK:STDOUT:   %.loc17: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -36,16 +36,16 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_reachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.If1 = %If1, .If2 = %If2, .If3 = %If3}
-// CHECK:STDOUT:   %If1: <function> = fn_decl @If1, const
-// CHECK:STDOUT:   %If2: <function> = fn_decl @If2, const
-// CHECK:STDOUT:   %If3: <function> = fn_decl @If3, const
+// CHECK:STDOUT:   %If1: <function> = fn_decl @If1 [template]
+// CHECK:STDOUT:   %If2: <function> = fn_decl @If2 [template]
+// CHECK:STDOUT:   %If3: <function> = fn_decl @If3 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @If1(%b: bool) -> i32 {
@@ -54,7 +54,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
@@ -72,7 +72,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 2, const = constants.%.loc20
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template = constants.%.loc20]
 // CHECK:STDOUT:   return %.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
@@ -84,7 +84,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1, const = constants.%.loc29
+// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.loc29]
 // CHECK:STDOUT:   return %.loc29
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:

--- a/toolchain/check/testdata/if/fail_scope.carbon
+++ b/toolchain/check/testdata/if/fail_scope.carbon
@@ -18,12 +18,12 @@ fn VarScope(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.VarScope = %VarScope}
-// CHECK:STDOUT:   %VarScope: <function> = fn_decl @VarScope, const
+// CHECK:STDOUT:   %VarScope: <function> = fn_decl @VarScope [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @VarScope(%b: bool) -> i32 {
@@ -34,7 +34,7 @@ fn VarScope(b: bool) -> i32 {
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 2, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 2 [template = constants.%.loc9]
 // CHECK:STDOUT:   assign %n.var, %.loc9
 // CHECK:STDOUT:   %n.ref.loc10: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc10: i32 = bind_value %n.ref.loc10

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -17,14 +17,14 @@ fn If(b: bool) {
 // CHECK:STDOUT: --- no_else.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc12: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .If = %If}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %If: <function> = fn_decl @If, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %If: <function> = fn_decl @If [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -43,12 +43,12 @@ fn If(b: bool) {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc12: init () = call %F.ref()
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc14: init () = call %G.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if/unreachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/unreachable_fallthrough.carbon
@@ -16,13 +16,13 @@ fn If(b: bool) -> i32 {
 // CHECK:STDOUT: --- unreachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.If = %If}
-// CHECK:STDOUT:   %If: <function> = fn_decl @If, const
+// CHECK:STDOUT:   %If: <function> = fn_decl @If [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @If(%b: bool) -> i32 {
@@ -31,11 +31,11 @@ fn If(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template = constants.%.loc11]
 // CHECK:STDOUT:   return %.loc11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -12,25 +12,25 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8_17.1: type = array_type %.loc8_16, i32, const
-// CHECK:STDOUT:   %.loc8_17.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc8_24: type = tuple_type (i32), const
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8_17.1: type = array_type %.loc8_16, i32 [template]
+// CHECK:STDOUT:   %.loc8_17.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc8_24: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool, %n: i32, %m: i32) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1, const = constants.%.loc8_16
-// CHECK:STDOUT:   %.loc8_17: type = array_type %.loc8_16, i32, const = constants.%.loc8_17.1
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1 [template = constants.%.loc8_16]
+// CHECK:STDOUT:   %.loc8_17: type = array_type %.loc8_16, i32 [template = constants.%.loc8_17.1]
 // CHECK:STDOUT:   %x.var: ref [i32; 1] = var x
 // CHECK:STDOUT:   %x: ref [i32; 1] = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0, const = constants.%.loc8_22
+// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0 [template = constants.%.loc8_22]
 // CHECK:STDOUT:   %.loc8_24.1: (i32,) = tuple_literal (%.loc8_22)
 // CHECK:STDOUT:   %.loc8_24.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc8_24.3: ref i32 = array_index %x.var, %.loc8_24.2

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -18,46 +18,46 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- constant_condition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc15: bool = bool_literal false, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc15: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A, .B = %B, .F = %F, .G = %G}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_13: bool = bool_literal true, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_13: bool = bool_literal true [template = constants.%.loc11]
 // CHECK:STDOUT:   if %.loc11_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc11_24.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc11_24.2: i32 = value_of_initializer %.loc11_24.1
 // CHECK:STDOUT:   %.loc11_24.3: i32 = converted %.loc11_24.1, %.loc11_24.2
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_24.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc11_33: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc11_27.1: i32 = value_of_initializer %.loc11_33
 // CHECK:STDOUT:   %.loc11_27.2: i32 = converted %.loc11_33, %.loc11_27.1
@@ -70,18 +70,18 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc15_13: bool = bool_literal false, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15_13: bool = bool_literal false [template = constants.%.loc15]
 // CHECK:STDOUT:   if %.loc15_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc15_25.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc15_25.2: i32 = value_of_initializer %.loc15_25.1
 // CHECK:STDOUT:   %.loc15_25.3: i32 = converted %.loc15_25.1, %.loc15_25.2
 // CHECK:STDOUT:   br !if.expr.result(%.loc15_25.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc15_34: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc15_28.1: i32 = value_of_initializer %.loc15_34
 // CHECK:STDOUT:   %.loc15_28.2: i32 = converted %.loc15_34, %.loc15_28.1

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -14,26 +14,26 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- control_flow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A, .B = %B, .F = %F}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -43,14 +43,14 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc11_21.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc11_21.2: i32 = value_of_initializer %.loc11_21.1
 // CHECK:STDOUT:   %.loc11_21.3: i32 = converted %.loc11_21.1, %.loc11_21.2
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_21.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc11_30: init i32 = call %B.ref()
 // CHECK:STDOUT:   %.loc11_24.1: i32 = value_of_initializer %.loc11_30
 // CHECK:STDOUT:   %.loc11_24.2: i32 = converted %.loc11_30, %.loc11_24.1

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -36,22 +36,22 @@ class C {
 // CHECK:STDOUT: --- fail_not_in_function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17_17: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc17_27: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc17_34: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc33: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc34: type = struct_type {.n: <error>}, const
+// CHECK:STDOUT:   %.loc17_17: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc17_27: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc17_34: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc34: type = struct_type {.n: <error>} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %.loc17: i32 = block_arg <unexpected instblockref block5>
 // CHECK:STDOUT:   %x: i32 = bind_name x, %.loc17
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc33: bool = bool_literal true, const = constants.%.loc33
+// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template = constants.%.loc33]
 // CHECK:STDOUT:   if %.loc33 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/if_expr/nested.carbon
+++ b/toolchain/check/testdata/if_expr/nested.carbon
@@ -11,15 +11,15 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: bool, %b: bool, %c: bool) -> i32 {
@@ -32,11 +32,11 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.expr.then.loc8_20 else br !if.expr.else.loc8_20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8_20:
-// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1, const = constants.%.loc8_30
+// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template = constants.%.loc8_30]
 // CHECK:STDOUT:   br !if.expr.result.loc8_20(%.loc8_30)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc8_20:
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2, const = constants.%.loc8_37
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2 [template = constants.%.loc8_37]
 // CHECK:STDOUT:   br !if.expr.result.loc8_20(%.loc8_37)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8_20:
@@ -48,11 +48,11 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT:   if %c.ref br !if.expr.then.loc8_44 else br !if.expr.else.loc8_44
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8_44:
-// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3, const = constants.%.loc8_54
+// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3 [template = constants.%.loc8_54]
 // CHECK:STDOUT:   br !if.expr.result.loc8_44(%.loc8_54)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc8_44:
-// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4, const = constants.%.loc8_61
+// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4 [template = constants.%.loc8_61]
 // CHECK:STDOUT:   br !if.expr.result.loc8_44(%.loc8_61)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8_44:

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -14,27 +14,27 @@ fn F(cond: bool) {
 // CHECK:STDOUT: --- struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc11: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.G = %G, .F = %F}
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%s: {.a: i32, .b: i32});
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%cond: bool) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %a.var: ref {.a: i32, .b: i32} = var a
 // CHECK:STDOUT:   %a: ref {.a: i32, .b: i32} = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1, const = constants.%.loc10_37
-// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2, const = constants.%.loc10_45
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.loc10_37]
+// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2 [template = constants.%.loc10_45]
 // CHECK:STDOUT:   %.loc10_46.1: {.a: i32, .b: i32} = struct_literal (%.loc10_37, %.loc10_45)
 // CHECK:STDOUT:   %.loc10_46.2: ref i32 = struct_access %a.var, element0
 // CHECK:STDOUT:   %.loc10_46.3: init i32 = initialize_from %.loc10_37 to %.loc10_46.2
@@ -43,7 +43,7 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init (%.loc10_46.3, %.loc10_46.5) to %a.var
 // CHECK:STDOUT:   %.loc10_46.7: init {.a: i32, .b: i32} = converted %.loc10_46.1, %.loc10_46.6
 // CHECK:STDOUT:   assign %a.var, %.loc10_46.7
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %cond.ref: bool = name_ref cond, %cond
 // CHECK:STDOUT:   if %cond.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -12,24 +12,24 @@ var d: i32 = a[b];
 // CHECK:STDOUT: --- array_element_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 2], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24, const
-// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 2] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24 [template]
+// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c, .d = %d}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 2] = var a
 // CHECK:STDOUT:   %a: ref [i32; 2] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const = constants.%.loc7_20
-// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24, const = constants.%.loc7_24
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24 [template = constants.%.loc7_24]
 // CHECK:STDOUT:   %.loc7_26.1: (i32, i32) = tuple_literal (%.loc7_20, %.loc7_24)
 // CHECK:STDOUT:   %.loc7_26.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_26.3: ref i32 = array_index %a.var, %.loc7_26.2
@@ -42,12 +42,12 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   assign %a.var, %.loc7_26.9
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %a.ref.loc9: ref [i32; 2] = name_ref a, %a
-// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.loc9]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = array_index %a.ref.loc9, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2

--- a/toolchain/check/testdata/index/expr_category.carbon
+++ b/toolchain/check/testdata/index/expr_category.carbon
@@ -27,50 +27,50 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT: --- expr_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32, const
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3], const
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32, const
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32, const
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_29: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc17_26: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc17_27: type = array_type %.loc17_26, i32, const
-// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32, const
-// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
+// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32 [template]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_29: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc17_26: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc17_27: type = array_type %.loc17_26, i32 [template]
+// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32 [template]
+// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .ValueBinding = %ValueBinding}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %ValueBinding: <function> = fn_decl @ValueBinding [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3, const = constants.%.loc10_16
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32, const = constants.%.loc10_17
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3 [template = constants.%.loc10_16]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.loc10_17]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1, const = constants.%.loc10_22
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2, const = constants.%.loc10_25
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3, const = constants.%.loc10_28
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template = constants.%.loc10_22]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2 [template = constants.%.loc10_25]
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3 [template = constants.%.loc10_28]
 // CHECK:STDOUT:   %.loc10_29.1: (i32, i32, i32) = tuple_literal (%.loc10_22, %.loc10_25, %.loc10_28)
 // CHECK:STDOUT:   %.loc10_29.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_29.3: ref i32 = array_index %a.var, %.loc10_29.2
@@ -84,31 +84,31 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc10_29.11: init [i32; 3] = array_init (%.loc10_29.4, %.loc10_29.7, %.loc10_29.10) to %a.var
 // CHECK:STDOUT:   %.loc10_29.12: init [i32; 3] = converted %.loc10_29.1, %.loc10_29.11
 // CHECK:STDOUT:   assign %a.var, %.loc10_29.12
-// CHECK:STDOUT:   %.loc13_14: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc13_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %pa.var: ref i32* = var pa
 // CHECK:STDOUT:   %pa: ref i32* = bind_name pa, %pa.var
 // CHECK:STDOUT:   %a.ref.loc13: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc13_21: i32 = int_literal 0, const = constants.%.loc13
+// CHECK:STDOUT:   %.loc13_21: i32 = int_literal 0 [template = constants.%.loc13]
 // CHECK:STDOUT:   %.loc13_22: ref i32 = array_index %a.ref.loc13, %.loc13_21
 // CHECK:STDOUT:   %.loc13_18: i32* = addr_of %.loc13_22
 // CHECK:STDOUT:   assign %pa.var, %.loc13_18
 // CHECK:STDOUT:   %a.ref.loc14: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0, const = constants.%.loc14_5
+// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template = constants.%.loc14_5]
 // CHECK:STDOUT:   %.loc14_6: ref i32 = array_index %a.ref.loc14, %.loc14_5
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4, const = constants.%.loc14_10
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template = constants.%.loc14_10]
 // CHECK:STDOUT:   assign %.loc14_6, %.loc14_10
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ValueBinding(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3, const = constants.%.loc18_16
-// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32, const = constants.%.loc18_17
+// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3 [template = constants.%.loc18_16]
+// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32 [template = constants.%.loc18_17]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1, const = constants.%.loc18_22
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2, const = constants.%.loc18_25
-// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3, const = constants.%.loc18_28
+// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1 [template = constants.%.loc18_22]
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2 [template = constants.%.loc18_25]
+// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3 [template = constants.%.loc18_28]
 // CHECK:STDOUT:   %.loc18_29.1: (i32, i32, i32) = tuple_literal (%.loc18_22, %.loc18_25, %.loc18_28)
 // CHECK:STDOUT:   %.loc18_29.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc18_29.3: ref i32 = array_index %a.var, %.loc18_29.2
@@ -123,17 +123,17 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc18_29.12: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11
 // CHECK:STDOUT:   assign %a.var, %.loc18_29.12
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0, const = constants.%.loc22
+// CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0 [template = constants.%.loc22]
 // CHECK:STDOUT:   %.loc22_6: ref i32 = array_index %a.ref, %.loc22_5
 // CHECK:STDOUT:   %b.ref: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc23_5: i32 = int_literal 0, const = constants.%.loc23
+// CHECK:STDOUT:   %.loc23_5: i32 = int_literal 0 [template = constants.%.loc23]
 // CHECK:STDOUT:   %.loc23_6.1: ref [i32; 3] = value_as_ref %b.ref
 // CHECK:STDOUT:   %.loc23_6.2: ref i32 = array_index %.loc23_6.1, %.loc23_5
 // CHECK:STDOUT:   %.loc23_6.3: i32 = bind_value %.loc23_6.2
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc24_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc24_4.2: init [i32; 3] = call %F.ref() to %.loc24_4.1
-// CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0, const = constants.%.loc24
+// CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0 [template = constants.%.loc24]
 // CHECK:STDOUT:   %.loc24_4.3: ref [i32; 3] = temporary %.loc24_4.1, %.loc24_4.2
 // CHECK:STDOUT:   %.loc24_8.1: ref i32 = array_index %.loc24_4.3, %.loc24_7
 // CHECK:STDOUT:   %.loc24_8.2: i32 = bind_value %.loc24_8.1

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: --- fail_array_large_index.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 295147905179352825855, const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 295147905179352825855 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const = constants.%.loc7_20
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 295147905179352825855, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 295147905179352825855 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_35.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_35.2: i32 = bind_value %.loc11_35.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_35.2

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: --- fail_array_non_int_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1, const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const = constants.%.loc7_20
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_19.2: i32 = bind_value %.loc11_19.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_19.2

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[2];
 // CHECK:STDOUT: --- fail_array_out_of_bound_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32, const
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1], const
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
+// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1, const = constants.%.loc7_14
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32, const = constants.%.loc7_15.1
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12, const = constants.%.loc7_20
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_17.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_17.2: i32 = bind_value %.loc11_17.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_17.2

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -16,14 +16,14 @@ fn Run() {
 // CHECK:STDOUT: --- fail_empty_tuple_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_4: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc13_4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .Run = %Run}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -33,9 +33,9 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc13_4.1: init () = call %F.ref()
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0, const = constants.%.loc13_7
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0 [template = constants.%.loc13_7]
 // CHECK:STDOUT:   %.loc13_4.2: ref () = temporary_storage
 // CHECK:STDOUT:   %.loc13_4.3: ref () = temporary %.loc13_4.2, %.loc13_4.1
 // CHECK:STDOUT:   %.loc13_8: ref <error> = tuple_index %.loc13_4.3, <error>

--- a/toolchain/check/testdata/index/fail_expr_category.carbon
+++ b/toolchain/check/testdata/index/fail_expr_category.carbon
@@ -32,66 +32,66 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT: --- fail_expr_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32, const
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3], const
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
+// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32 [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: [i32; 3];
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_14: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc14_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %pb.var: ref i32* = var pb
 // CHECK:STDOUT:   %pb: ref i32* = bind_name pb, %pb.var
 // CHECK:STDOUT:   %b.ref.loc14: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc14_21: i32 = int_literal 0, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14_21: i32 = int_literal 0 [template = constants.%.loc14]
 // CHECK:STDOUT:   %.loc14_22.1: ref [i32; 3] = value_as_ref %b.ref.loc14
 // CHECK:STDOUT:   %.loc14_22.2: ref i32 = array_index %.loc14_22.1, %.loc14_21
 // CHECK:STDOUT:   %.loc14_22.3: i32 = bind_value %.loc14_22.2
 // CHECK:STDOUT:   %.loc14_18: i32* = addr_of %.loc14_22.3
 // CHECK:STDOUT:   assign %pb.var, %.loc14_18
 // CHECK:STDOUT:   %b.ref.loc18: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0, const = constants.%.loc18_5
+// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template = constants.%.loc18_5]
 // CHECK:STDOUT:   %.loc18_6.1: ref [i32; 3] = value_as_ref %b.ref.loc18
 // CHECK:STDOUT:   %.loc18_6.2: ref i32 = array_index %.loc18_6.1, %.loc18_5
 // CHECK:STDOUT:   %.loc18_6.3: i32 = bind_value %.loc18_6.2
-// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4, const = constants.%.loc18_10
+// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template = constants.%.loc18_10]
 // CHECK:STDOUT:   assign %.loc18_6.3, %.loc18_10
-// CHECK:STDOUT:   %.loc25_14: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc25_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %pf.var: ref i32* = var pf
 // CHECK:STDOUT:   %pf: ref i32* = bind_name pf, %pf.var
-// CHECK:STDOUT:   %F.ref.loc25: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc25: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc25_20.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc25_20.2: init [i32; 3] = call %F.ref.loc25() to %.loc25_20.1
-// CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0, const = constants.%.loc25
+// CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0 [template = constants.%.loc25]
 // CHECK:STDOUT:   %.loc25_20.3: ref [i32; 3] = temporary %.loc25_20.1, %.loc25_20.2
 // CHECK:STDOUT:   %.loc25_24.1: ref i32 = array_index %.loc25_20.3, %.loc25_23
 // CHECK:STDOUT:   %.loc25_24.2: i32 = bind_value %.loc25_24.1
 // CHECK:STDOUT:   %.loc25_18: i32* = addr_of %.loc25_24.2
 // CHECK:STDOUT:   assign %pf.var, %.loc25_18
-// CHECK:STDOUT:   %F.ref.loc29: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc29: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc29_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc29_4.2: init [i32; 3] = call %F.ref.loc29() to %.loc29_4.1
-// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0, const = constants.%.loc29_7
+// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template = constants.%.loc29_7]
 // CHECK:STDOUT:   %.loc29_4.3: ref [i32; 3] = temporary %.loc29_4.1, %.loc29_4.2
 // CHECK:STDOUT:   %.loc29_8.1: ref i32 = array_index %.loc29_4.3, %.loc29_7
 // CHECK:STDOUT:   %.loc29_8.2: i32 = bind_value %.loc29_8.1
-// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4, const = constants.%.loc29_12
+// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template = constants.%.loc29_12]
 // CHECK:STDOUT:   assign %.loc29_8.2, %.loc29_12
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -33,15 +33,15 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT: --- fail_invalid_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc21: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28), const
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template]
+// CHECK:STDOUT:   %.loc31: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,27 +50,27 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, %.loc11
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.loc15]
 // CHECK:STDOUT:   assign %a.var, <error>
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, %F, const = %F
-// CHECK:STDOUT:   %.loc21: i32 = int_literal 1, const = constants.%.loc21
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, %F [template = %F]
+// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template = constants.%.loc21]
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1, const = constants.%.loc26_20
-// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2, const = constants.%.loc26_28
+// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template = constants.%.loc26_20]
+// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template = constants.%.loc26_28]
 // CHECK:STDOUT:   %.loc26_29.1: {.a: i32, .b: i32} = struct_literal (%.loc26_20, %.loc26_28)
-// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0, const = constants.%.loc26_31
-// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28), const = constants.%.loc26_29.3
-// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = converted %.loc26_29.1, %.loc26_29.2, const = constants.%.loc26_29.3
+// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template = constants.%.loc26_31]
+// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template = constants.%.loc26_29.3]
+// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = converted %.loc26_29.1, %.loc26_29.2 [template = constants.%.loc26_29.3]
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %d.var: ref i32 = var d
 // CHECK:STDOUT:   %d: ref i32 = bind_name d, %d.var
-// CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0, const = constants.%.loc31
+// CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0 [template = constants.%.loc31]
 // CHECK:STDOUT:   assign %d.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_name_not_found.carbon
+++ b/toolchain/check/testdata/index/fail_name_not_found.carbon
@@ -14,12 +14,12 @@ fn Main() {
 // CHECK:STDOUT: --- fail_name_not_found.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
@@ -27,7 +27,7 @@ fn Main() {
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error>
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.loc11]
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -13,12 +13,12 @@ var b: i32 = a[-10];
 // CHECK:STDOUT: --- fail_negative_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 10, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -14,22 +14,22 @@ var c: i32 = a[b];
 // CHECK:STDOUT: --- fail_non_deterministic_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2, const = constants.%.loc7_22
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3, const = constants.%.loc7_25
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template = constants.%.loc7_22]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3 [template = constants.%.loc7_25]
 // CHECK:STDOUT:   %.loc7_26.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
 // CHECK:STDOUT:   %.loc7_26.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_26.3: init i32 = initialize_from %.loc7_22 to %.loc7_26.2
@@ -40,7 +40,7 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   assign %a.var, %.loc7_26.7
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var

--- a/toolchain/check/testdata/index/fail_non_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_non_tuple_access.carbon
@@ -14,19 +14,19 @@ fn Main() {
 // CHECK:STDOUT: --- fail_non_tuple_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0, const = constants.%.loc11_3
-// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1, const = constants.%.loc11_5
+// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0 [template = constants.%.loc11_3]
+// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1 [template = constants.%.loc11_5]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[oops];
 // CHECK:STDOUT: --- fail_tuple_index_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const = constants.%.loc7_22
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const = constants.%.loc7_26
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -14,25 +14,25 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: --- fail_tuple_large_index.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 295147905179352825855, const
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 295147905179352825855 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12, const = constants.%.loc7_18
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.loc7_18]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a
@@ -44,7 +44,7 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, %b
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855 [template = constants.%.loc12]
 // CHECK:STDOUT:   %.loc12_35: ref <error> = tuple_index %b.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -13,22 +13,22 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: --- fail_tuple_non_int_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const = constants.%.loc7_22
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const = constants.%.loc7_26
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2
@@ -40,7 +40,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -13,22 +13,22 @@ var b: i32 = a[2];
 // CHECK:STDOUT: --- fail_tuple_out_of_bound_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12, const = constants.%.loc7_22
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6, const = constants.%.loc7_26
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2
@@ -40,7 +40,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -11,25 +11,25 @@ var c: i32 = b[0];
 // CHECK:STDOUT: --- tuple_element_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12, const = constants.%.loc7_18
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.loc7_18]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a
@@ -41,7 +41,7 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, %b
-// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.loc9]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -13,33 +13,33 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- tuple_return_value_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28), const
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28) [template]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .Run = %Run}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Run: <function> = fn_decl @Run, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0, const = constants.%.loc7_28
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.loc7_28]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28), const = constants.%.loc7_30
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2, const = constants.%.loc7_30
+// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.loc7_30]
 // CHECK:STDOUT:   return %.loc7_30.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_11.1: init (i32,) = call %F.ref()
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0, const = constants.%.loc10
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0 [template = constants.%.loc10]
 // CHECK:STDOUT:   %.loc10_11.2: ref (i32,) = temporary_storage
 // CHECK:STDOUT:   %.loc10_11.3: ref (i32,) = temporary %.loc10_11.2, %.loc10_11.1
 // CHECK:STDOUT:   %.loc10_15.1: ref i32 = tuple_index %.loc10_11.3, %.loc10_14

--- a/toolchain/check/testdata/interface/basic.carbon
+++ b/toolchain/check/testdata/interface/basic.carbon
@@ -28,7 +28,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -42,15 +42,15 @@ interface Class { }
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Interface = %Interface.decl.loc7, .Function = %Function, .Class = %Class.decl}
 // CHECK:STDOUT:   %Interface.decl.loc7 = interface_decl @Interface, ()
 // CHECK:STDOUT:   %Interface.decl.loc15 = interface_decl @Interface, ()
-// CHECK:STDOUT:   %Function: <function> = fn_decl @Function, const
+// CHECK:STDOUT:   %Function: <function> = fn_decl @Function [template]
 // CHECK:STDOUT:   %.decl.loc27 = interface_decl @.1, ()
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
-// CHECK:STDOUT:   %Class: type = class_type @Class, const
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %.decl.loc37 = interface_decl @.2, ()
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
@@ -30,8 +30,8 @@ private interface Private {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Modifiers {
-// CHECK:STDOUT:   %Final: <function> = fn_decl @Final, const
-// CHECK:STDOUT:   %Default: <function> = fn_decl @Default, const
+// CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template]
+// CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Final = %Final

--- a/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
@@ -9,37 +9,37 @@ fn A() { if (true) { var n: i32 = 1; } if (true) { var n: i32 = 2; } }
 // CHECK:STDOUT: --- duplicate_name_same_line.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true, const = constants.%.loc7_14
+// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true [template = constants.%.loc7_14]
 // CHECK:STDOUT:   if %.loc7_14 br !if.then.loc7_18 else br !if.else.loc7_18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc7_18:
 // CHECK:STDOUT:   %n.var.loc7_26: ref i32 = var n
 // CHECK:STDOUT:   %n.loc7_26: ref i32 = bind_name n, %n.var.loc7_26
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1, const = constants.%.loc7_35
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.loc7_35]
 // CHECK:STDOUT:   assign %n.var.loc7_26, %.loc7_35
 // CHECK:STDOUT:   br !if.else.loc7_18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc7_18:
-// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true, const = constants.%.loc7_44
+// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true [template = constants.%.loc7_44]
 // CHECK:STDOUT:   if %.loc7_44 br !if.then.loc7_48 else br !if.else.loc7_48
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc7_48:
 // CHECK:STDOUT:   %n.var.loc7_56: ref i32 = var n
 // CHECK:STDOUT:   %n.loc7_56: ref i32 = bind_name n, %n.var.loc7_56
-// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2, const = constants.%.loc7_65
+// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2 [template = constants.%.loc7_65]
 // CHECK:STDOUT:   assign %n.var.loc7_56, %.loc7_65
 // CHECK:STDOUT:   br !if.else.loc7_48
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -14,29 +14,29 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- convert.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc8_24.2: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc8_24.3: type = ptr_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc8_24.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc8_24.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.2: type = converted %.loc8_24.1, constants.%.loc8_24.2, const = constants.%.loc8_24.2
+// CHECK:STDOUT:   %.loc8_24.2: type = converted %.loc8_24.1, constants.%.loc8_24.2 [template = constants.%.loc8_24.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32, i32) = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1, const = constants.%.loc8_29
-// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2, const = constants.%.loc8_32
-// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3, const = constants.%.loc8_35
+// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template = constants.%.loc8_29]
+// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2 [template = constants.%.loc8_32]
+// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3 [template = constants.%.loc8_35]
 // CHECK:STDOUT:   %.loc8_36.1: (i32, i32, i32) = tuple_literal (%.loc8_29, %.loc8_32, %.loc8_35)
 // CHECK:STDOUT:   %.loc8_36.2: ref i32 = tuple_access %v.var, element0
 // CHECK:STDOUT:   %.loc8_36.3: init i32 = initialize_from %.loc8_29 to %.loc8_36.2
@@ -48,7 +48,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.9: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8
 // CHECK:STDOUT:   assign %v.var, %.loc8_36.9
 // CHECK:STDOUT:   %.loc10_24: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.3: type = converted %.loc10_24, constants.%.loc8_24.2, const = constants.%.loc8_24.2
+// CHECK:STDOUT:   %.loc8_24.3: type = converted %.loc10_24, constants.%.loc8_24.2 [template = constants.%.loc8_24.2]
 // CHECK:STDOUT:   %v.ref: ref (i32, i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %.loc10_28.1: ref i32 = tuple_access %v.ref, element0
 // CHECK:STDOUT:   %.loc10_28.2: i32 = bind_value %.loc10_28.1
@@ -60,7 +60,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_28.8: (i32, i32, i32) = converted %v.ref, %.loc10_28.7
 // CHECK:STDOUT:   %w: (i32, i32, i32) = bind_name w, %.loc10_28.8
 // CHECK:STDOUT:   %w.ref: (i32, i32, i32) = name_ref w, %w
-// CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_13: i32 = tuple_index %w.ref, %.loc11_12
 // CHECK:STDOUT:   return %.loc11_13
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -17,17 +17,17 @@ fn F(a: i32) {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a.loc7: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template = constants.%.loc14]
 // CHECK:STDOUT:   %a.loc14: i32 = bind_name a, %.loc14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -20,19 +20,19 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 5, const
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 5, const = constants.%.loc13
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template = constants.%.loc13]
 // CHECK:STDOUT:   %x: T = bind_name x, <error>
 // CHECK:STDOUT:   %x.ref: T = name_ref x, %x
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/let/fail_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_modifiers.carbon
@@ -71,33 +71,33 @@ protected protected let i: i32 = 1;
 // CHECK:STDOUT: --- fail_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc36: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc47: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc58: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc69: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1, const = constants.%.loc10
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.loc10]
 // CHECK:STDOUT:   %b: i32 = bind_name b, %.loc10
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.loc15]
 // CHECK:STDOUT:   %c: i32 = bind_name c, %.loc15
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 1, const = constants.%.loc20
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template = constants.%.loc20]
 // CHECK:STDOUT:   %d: i32 = bind_name d, %.loc20
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1, const = constants.%.loc25
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.loc25]
 // CHECK:STDOUT:   %e: i32 = bind_name e, %.loc25
-// CHECK:STDOUT:   %.loc36: i32 = int_literal 1, const = constants.%.loc36
+// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template = constants.%.loc36]
 // CHECK:STDOUT:   %f: i32 = bind_name f, %.loc36
-// CHECK:STDOUT:   %.loc47: i32 = int_literal 1, const = constants.%.loc47
+// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template = constants.%.loc47]
 // CHECK:STDOUT:   %g: i32 = bind_name g, %.loc47
-// CHECK:STDOUT:   %.loc58: i32 = int_literal 1, const = constants.%.loc58
+// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template = constants.%.loc58]
 // CHECK:STDOUT:   %h: i32 = bind_name h, %.loc58
-// CHECK:STDOUT:   %.loc69: i32 = int_literal 1, const = constants.%.loc69
+// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template = constants.%.loc69]
 // CHECK:STDOUT:   %i: i32 = bind_name i, %.loc69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_todo_modifiers.carbon
@@ -12,12 +12,12 @@ private let a: i32 = 1;
 // CHECK:STDOUT: --- fail_todo_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1, const = constants.%.loc10
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.loc10]
 // CHECK:STDOUT:   %a: i32 = bind_name a, %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_use_in_init.carbon
+++ b/toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -15,7 +15,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/let/generic.carbon
+++ b/toolchain/check/testdata/let/generic.carbon
@@ -14,14 +14,14 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32
 // CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T
-// CHECK:STDOUT:   %.loc9: type = ptr_type T, const
+// CHECK:STDOUT:   %.loc9: type = ptr_type T [template]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
 // CHECK:STDOUT:   %T.ref.loc10: type = name_ref T, %T

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -11,14 +11,14 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT: --- global.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/let/local.carbon
+++ b/toolchain/check/testdata/let/local.carbon
@@ -13,7 +13,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: i32) -> i32 {

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -28,24 +28,24 @@ var a: i32 = NS.A();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.NS = %.2, .a = %a}
 // CHECK:STDOUT:   %.2: <namespace> = namespace NS, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, %.2
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, %A, const = %A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, %A [template = %A]
 // CHECK:STDOUT:   %.loc6: init i32 = call %A.ref()
 // CHECK:STDOUT:   assign %a.var, %.loc6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
 // CHECK:STDOUT:   return %.loc4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -23,8 +23,8 @@ fn Foo.Baz() {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %.loc7}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace Foo, {.Baz = %Baz.loc9}
-// CHECK:STDOUT:   %Baz.loc9: <function> = fn_decl @Baz, const
-// CHECK:STDOUT:   %Baz.loc18: <function> = fn_decl @Baz, const
+// CHECK:STDOUT:   %Baz.loc9: <function> = fn_decl @Baz [template]
+// CHECK:STDOUT:   %Baz.loc18: <function> = fn_decl @Baz [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz() {

--- a/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
+++ b/toolchain/check/testdata/namespace/fail_unresolved_scope.carbon
@@ -14,7 +14,7 @@ fn Foo.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %.loc10: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1() {

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -20,15 +20,15 @@ fn Bar() {
 // CHECK:STDOUT: --- function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc17: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %.loc7, .Baz = %Baz.loc10, .Bar = %Bar}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace Foo, {.Baz = %Baz.loc13}
-// CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1, const
-// CHECK:STDOUT:   %Baz.loc13: <function> = fn_decl @Baz.2, const
-// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar, const
+// CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1 [template]
+// CHECK:STDOUT:   %Baz.loc13: <function> = fn_decl @Baz.2 [template]
+// CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz.1() {
@@ -44,7 +44,7 @@ fn Bar() {
 // CHECK:STDOUT: fn @Bar() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%.loc7
-// CHECK:STDOUT:   %Baz.ref: <function> = name_ref Baz, file.%Baz.loc13, const = file.%Baz.loc13
+// CHECK:STDOUT:   %Baz.ref: <function> = name_ref Baz, file.%Baz.loc13 [template = file.%Baz.loc13]
 // CHECK:STDOUT:   %.loc17: init () = call %Baz.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -30,8 +30,8 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.NS = %.loc4}
 // CHECK:STDOUT:   %.loc4: <namespace> = namespace NS, {.ChildNS = %.loc5, .A = %A}
 // CHECK:STDOUT:   %.loc5: <namespace> = namespace ChildNS, {.B = %B}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A();
@@ -41,49 +41,49 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.NS = %.2, .a = %a, .b = %b, .package_a = %package_a, .package_b = %package_b}
 // CHECK:STDOUT:   %.2: <namespace> = namespace NS, {.ChildNS = %.3, .A = %.4}
 // CHECK:STDOUT:   %.3: <namespace> = namespace ChildNS, {.B = %.5}
-// CHECK:STDOUT:   %.4: <function> = fn_decl @.1, const
-// CHECK:STDOUT:   %.5: <function> = fn_decl @.2, const
+// CHECK:STDOUT:   %.4: <function> = fn_decl @.1 [template]
+// CHECK:STDOUT:   %.5: <function> = fn_decl @.2 [template]
 // CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %NS.ref.loc4: <namespace> = name_ref NS, %.2
-// CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.4, const = %.4
+// CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.4 [template = %.4]
 // CHECK:STDOUT:   %.loc4_17: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_17
 // CHECK:STDOUT:   %.loc5_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc5_9, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc5_9, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %NS.ref.loc5: <namespace> = name_ref NS, %.2
 // CHECK:STDOUT:   %ChildNS.ref.loc5: <namespace> = name_ref ChildNS, %.3
-// CHECK:STDOUT:   %B.ref.loc5: <function> = name_ref B, %.5, const = %.5
+// CHECK:STDOUT:   %B.ref.loc5: <function> = name_ref B, %.5 [template = %.5]
 // CHECK:STDOUT:   %.loc5_25: init () = call %B.ref.loc5()
 // CHECK:STDOUT:   assign %b.var, %.loc5_25
 // CHECK:STDOUT:   %.loc7_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.4: type = converted %.loc7_17, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.4: type = converted %.loc7_17, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref.loc7: <namespace> = name_ref package, package
 // CHECK:STDOUT:   %NS.ref.loc7: <namespace> = name_ref NS, %.2
-// CHECK:STDOUT:   %A.ref.loc7: <function> = name_ref A, %.4, const = %.4
+// CHECK:STDOUT:   %A.ref.loc7: <function> = name_ref A, %.4 [template = %.4]
 // CHECK:STDOUT:   %.loc7_33: init () = call %A.ref.loc7()
 // CHECK:STDOUT:   assign %package_a.var, %.loc7_33
 // CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.5: type = converted %.loc8_17, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.5: type = converted %.loc8_17, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref.loc8: <namespace> = name_ref package, package
 // CHECK:STDOUT:   %NS.ref.loc8: <namespace> = name_ref NS, %.2
 // CHECK:STDOUT:   %ChildNS.ref.loc8: <namespace> = name_ref ChildNS, %.3
-// CHECK:STDOUT:   %B.ref.loc8: <function> = name_ref B, %.5, const = %.5
+// CHECK:STDOUT:   %B.ref.loc8: <function> = name_ref B, %.5 [template = %.5]
 // CHECK:STDOUT:   %.loc8_41: init () = call %B.ref.loc8()
 // CHECK:STDOUT:   assign %package_b.var, %.loc8_41
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -69,7 +69,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   %.2: <namespace> = namespace A, {.B = %.3}
 // CHECK:STDOUT:   %.3: <namespace> = namespace B, {.C = %.4}
 // CHECK:STDOUT:   %.4: <namespace> = namespace C, {.D = %D}
-// CHECK:STDOUT:   %D: <function> = fn_decl @D, const
+// CHECK:STDOUT:   %D: <function> = fn_decl @D [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @D() {
@@ -80,7 +80,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: --- e.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc5: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc5: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -88,15 +88,15 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   %.2: <namespace> = namespace A, {.B = %.3}
 // CHECK:STDOUT:   %.3: <namespace> = namespace B, {.C = %.4}
 // CHECK:STDOUT:   %.4: <namespace> = namespace C, {.D = %.5}
-// CHECK:STDOUT:   %.5: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %.5: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.loc5, const = constants.%.loc5
+// CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.loc5 [template = constants.%.loc5]
 // CHECK:STDOUT:   %e.var: ref () = var e
 // CHECK:STDOUT:   %e: ref () = bind_name e, %e.var
 // CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, %.2
 // CHECK:STDOUT:   %B.ref: <namespace> = name_ref B, %.3
 // CHECK:STDOUT:   %C.ref: <namespace> = name_ref C, %.4
-// CHECK:STDOUT:   %D.ref: <function> = name_ref D, %.5, const = %.5
+// CHECK:STDOUT:   %D.ref: <function> = name_ref D, %.5 [template = %.5]
 // CHECK:STDOUT:   %.loc5_20: init () = call %D.ref()
 // CHECK:STDOUT:   assign %e.var, %.loc5_20
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -17,15 +17,15 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Foo = %.loc7}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace Foo, {.Bar = %.loc8}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace Bar, {.Wiz = %Wiz, .Baz = %Baz}
-// CHECK:STDOUT:   %Wiz: <function> = fn_decl @Wiz, const
-// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz, const
+// CHECK:STDOUT:   %Wiz: <function> = fn_decl @Wiz [template]
+// CHECK:STDOUT:   %Baz: <function> = fn_decl @Baz [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Wiz() {
@@ -37,7 +37,7 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%.loc7
 // CHECK:STDOUT:   %Bar.ref: <namespace> = name_ref Bar, file.%.loc8
-// CHECK:STDOUT:   %Wiz.ref: <function> = name_ref Wiz, file.%Wiz, const = file.%Wiz
+// CHECK:STDOUT:   %Wiz.ref: <function> = name_ref Wiz, file.%Wiz [template = file.%Wiz]
 // CHECK:STDOUT:   %.loc14: init () = call %Wiz.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/shadow.carbon
+++ b/toolchain/check/testdata/namespace/shadow.carbon
@@ -26,19 +26,19 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT: --- shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc17: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc16: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc17: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A.loc7, .N = %.loc9}
-// CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A.1, const
+// CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A.1 [template]
 // CHECK:STDOUT:   %.loc9: <namespace> = namespace N, {.A = %A.loc10, .M = %.loc12}
-// CHECK:STDOUT:   %A.loc10: <function> = fn_decl @A.2, const
+// CHECK:STDOUT:   %A.loc10: <function> = fn_decl @A.2 [template]
 // CHECK:STDOUT:   %.loc12: <namespace> = namespace M, {.B = %B}
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A.1();
@@ -47,22 +47,22 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref.loc16: <function> = name_ref A, file.%A.loc10, const = file.%A.loc10
+// CHECK:STDOUT:   %A.ref.loc16: <function> = name_ref A, file.%A.loc10 [template = file.%A.loc10]
 // CHECK:STDOUT:   %.loc16: init () = call %A.ref.loc16()
-// CHECK:STDOUT:   %.loc17: bool = bool_literal true, const = constants.%.loc17
+// CHECK:STDOUT:   %.loc17: bool = bool_literal true [template = constants.%.loc17]
 // CHECK:STDOUT:   if %.loc17 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %A.var: ref i32 = var A
 // CHECK:STDOUT:   %A: ref i32 = bind_name A, %A.var
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0, const = constants.%.loc18
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.loc18]
 // CHECK:STDOUT:   assign %A.var, %.loc18
 // CHECK:STDOUT:   %A.ref.loc21: ref i32 = name_ref A, %A
 // CHECK:STDOUT:   %.loc21: i32 = bind_value %A.ref.loc21
 // CHECK:STDOUT:   return %.loc21
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0, const = constants.%.loc23
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.loc23]
 // CHECK:STDOUT:   return %.loc23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/unqualified_lookup.carbon
+++ b/toolchain/check/testdata/namespace/unqualified_lookup.carbon
@@ -29,19 +29,19 @@ fn OuterN.InnerN.CallABC() {
 // CHECK:STDOUT: --- unqualified_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc15: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.OuterN = %.loc7, .A = %A, .CallA = %CallA}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace OuterN, {.InnerN = %.loc8, .B = %B, .CallAB = %CallAB}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace InnerN, {.C = %C, .CallABC = %CallABC}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
-// CHECK:STDOUT:   %C: <function> = fn_decl @C, const
-// CHECK:STDOUT:   %CallA: <function> = fn_decl @CallA, const
-// CHECK:STDOUT:   %CallAB: <function> = fn_decl @CallAB, const
-// CHECK:STDOUT:   %CallABC: <function> = fn_decl @CallABC, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
+// CHECK:STDOUT:   %C: <function> = fn_decl @C [template]
+// CHECK:STDOUT:   %CallA: <function> = fn_decl @CallA [template]
+// CHECK:STDOUT:   %CallAB: <function> = fn_decl @CallAB [template]
+// CHECK:STDOUT:   %CallABC: <function> = fn_decl @CallABC [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A();
@@ -52,27 +52,27 @@ fn OuterN.InnerN.CallABC() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallA() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc15: init () = call %A.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallAB() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc19: init () = call %A.ref()
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc20: init () = call %B.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallABC() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc24: init () = call %A.ref()
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc25: init () = call %B.ref()
-// CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C, const = file.%C
+// CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc26: init () = call %C.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -14,41 +14,41 @@ fn And() -> bool {
 // CHECK:STDOUT: --- and.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc11: bool = bool_literal false, const
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc11: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .And = %And}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %And: <function> = fn_decl @And, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %And: <function> = fn_decl @And [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @And() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
 // CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false [template = constants.%.loc11]
 // CHECK:STDOUT:   if %.loc11_14.2 br !and.rhs else br !and.result(%.loc11_14.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc11_19: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc11_14.4: bool = value_of_initializer %.loc11_19
 // CHECK:STDOUT:   %.loc11_14.5: bool = converted %.loc11_19, %.loc11_14.4

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -25,47 +25,47 @@ fn Main() {
 // CHECK:STDOUT: --- assignment.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 9, const
-// CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc11_19.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc11_19.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc15_27: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc17: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc11_19.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc11_19.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc15_27: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc17: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 12, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 12 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %a.var, %.loc8
 // CHECK:STDOUT:   %a.ref.loc9: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 9, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template = constants.%.loc9]
 // CHECK:STDOUT:   assign %a.ref.loc9, %.loc9
 // CHECK:STDOUT:   %.loc11_19.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc11_19.2: type = converted %.loc11_19.1, constants.%.loc11_19.2, const = constants.%.loc11_19.2
+// CHECK:STDOUT:   %.loc11_19.2: type = converted %.loc11_19.1, constants.%.loc11_19.2 [template = constants.%.loc11_19.2]
 // CHECK:STDOUT:   %b.var: ref (i32, i32) = var b
 // CHECK:STDOUT:   %b: ref (i32, i32) = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1, const = constants.%.loc11_24
-// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2, const = constants.%.loc11_27
+// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.loc11_24]
+// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2 [template = constants.%.loc11_27]
 // CHECK:STDOUT:   %.loc11_28.1: (i32, i32) = tuple_literal (%.loc11_24, %.loc11_27)
 // CHECK:STDOUT:   %.loc11_28.2: ref i32 = tuple_access %b.var, element0
 // CHECK:STDOUT:   %.loc11_28.3: init i32 = initialize_from %.loc11_24 to %.loc11_28.2
@@ -75,20 +75,20 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_28.7: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6
 // CHECK:STDOUT:   assign %b.var, %.loc11_28.7
 // CHECK:STDOUT:   %b.ref.loc12: ref (i32, i32) = name_ref b, %b
-// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0, const = constants.%.loc12_5
+// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.loc12_5]
 // CHECK:STDOUT:   %.loc12_6: ref i32 = tuple_index %b.ref.loc12, %.loc12_5
-// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3, const = constants.%.loc12_10
+// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template = constants.%.loc12_10]
 // CHECK:STDOUT:   assign %.loc12_6, %.loc12_10
 // CHECK:STDOUT:   %b.ref.loc13: ref (i32, i32) = name_ref b, %b
-// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1, const = constants.%.loc13_5
+// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template = constants.%.loc13_5]
 // CHECK:STDOUT:   %.loc13_6: ref i32 = tuple_index %b.ref.loc13, %.loc13_5
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4, const = constants.%.loc13_10
+// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template = constants.%.loc13_10]
 // CHECK:STDOUT:   assign %.loc13_6, %.loc13_10
-// CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %c.var: ref {.a: i32, .b: i32} = var c
 // CHECK:STDOUT:   %c: ref {.a: i32, .b: i32} = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1, const = constants.%.loc15_37
-// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2, const = constants.%.loc15_45
+// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template = constants.%.loc15_37]
+// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2 [template = constants.%.loc15_45]
 // CHECK:STDOUT:   %.loc15_46.1: {.a: i32, .b: i32} = struct_literal (%.loc15_37, %.loc15_45)
 // CHECK:STDOUT:   %.loc15_46.2: ref i32 = struct_access %c.var, element0
 // CHECK:STDOUT:   %.loc15_46.3: init i32 = initialize_from %.loc15_37 to %.loc15_46.2
@@ -99,13 +99,13 @@ fn Main() {
 // CHECK:STDOUT:   assign %c.var, %.loc15_46.7
 // CHECK:STDOUT:   %c.ref.loc16: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc16_4: ref i32 = struct_access %c.ref.loc16, element0
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3, const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.loc16]
 // CHECK:STDOUT:   assign %.loc16_4, %.loc16_9
 // CHECK:STDOUT:   %c.ref.loc17: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc17_4: ref i32 = struct_access %c.ref.loc17, element1
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4, const = constants.%.loc17
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4 [template = constants.%.loc17]
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
-// CHECK:STDOUT:   %.loc19_13: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc19_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %p.var: ref i32* = var p
 // CHECK:STDOUT:   %p: ref i32* = bind_name p, %p.var
 // CHECK:STDOUT:   %a.ref.loc19: ref i32 = name_ref a, %a
@@ -114,9 +114,9 @@ fn Main() {
 // CHECK:STDOUT:   %p.ref.loc20: ref i32* = name_ref p, %p
 // CHECK:STDOUT:   %.loc20_4: i32* = bind_value %p.ref.loc20
 // CHECK:STDOUT:   %.loc20_3: ref i32 = deref %.loc20_4
-// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5, const = constants.%.loc20
+// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5 [template = constants.%.loc20]
 // CHECK:STDOUT:   assign %.loc20_3, %.loc20_8
-// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true, const = constants.%.loc22_8
+// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template = constants.%.loc22_8]
 // CHECK:STDOUT:   if %.loc22_8 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
@@ -132,7 +132,7 @@ fn Main() {
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc22_5: i32* = block_arg !if.expr.result
 // CHECK:STDOUT:   %.loc22_3: ref i32 = deref %.loc22_5
-// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10, const = constants.%.loc22_31
+// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template = constants.%.loc22_31]
 // CHECK:STDOUT:   assign %.loc22_3, %.loc22_31
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
@@ -18,23 +18,23 @@ fn Main() {
 // CHECK:STDOUT: --- fail_assignment_to_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 42, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 42, const
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 42 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error>
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 42, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template = constants.%.loc11]
 // CHECK:STDOUT:   assign %undeclared.ref, <error>
 // CHECK:STDOUT:   %also_undeclared.ref: <error> = name_ref also_undeclared, <error>
 // CHECK:STDOUT:   %.loc15_3: ref <error> = deref <error>
-// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42 [template = constants.%.loc15]
 // CHECK:STDOUT:   assign %.loc15_3, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -48,56 +48,56 @@ fn Main() {
 // CHECK:STDOUT: --- fail_assignment_to_non_assignable.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc17: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc21_8.2: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7), const
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32}, const
-// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc34_18.2: type = ptr_type {.x: i32, .y: i32}, const
-// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17), const
-// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10, const
+// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc17: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc21_8.2: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc34_18.2: type = ptr_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template]
+// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .Main = %Main}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1, const = constants.%.loc13_3
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2, const = constants.%.loc13_7
+// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template = constants.%.loc13_3]
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template = constants.%.loc13_7]
 // CHECK:STDOUT:   assign %.loc13_3, %.loc13_7
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc17_4: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1, const = constants.%.loc17
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1 [template = constants.%.loc17]
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
-// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1, const = constants.%.loc21_4
-// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2, const = constants.%.loc21_7
+// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template = constants.%.loc21_4]
+// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template = constants.%.loc21_7]
 // CHECK:STDOUT:   %.loc21_8.1: (i32, i32) = tuple_literal (%.loc21_4, %.loc21_7)
-// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3, const = constants.%.loc21_13
-// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4, const = constants.%.loc21_16
+// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template = constants.%.loc21_13]
+// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template = constants.%.loc21_16]
 // CHECK:STDOUT:   %.loc21_17.1: (i32, i32) = tuple_literal (%.loc21_13, %.loc21_16)
 // CHECK:STDOUT:   %.loc21_17.2: i32 = tuple_access %.loc21_8.1, element0
 // CHECK:STDOUT:   %.loc21_17.3: init i32 = initialize_from %.loc21_13 to %.loc21_17.2
@@ -106,17 +106,17 @@ fn Main() {
 // CHECK:STDOUT:   %.loc21_17.6: init (i32, i32) = tuple_init (%.loc21_17.3, %.loc21_17.5) to %.loc21_8.1
 // CHECK:STDOUT:   %.loc21_17.7: init (i32, i32) = converted %.loc21_17.1, %.loc21_17.6
 // CHECK:STDOUT:   assign %.loc21_8.1, %.loc21_17.7
-// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7), const = constants.%.loc21_8.3
-// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = converted %.loc21_8.1, %.loc21_8.2, const = constants.%.loc21_8.3
+// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template = constants.%.loc21_8.3]
+// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = converted %.loc21_8.1, %.loc21_8.2 [template = constants.%.loc21_8.3]
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0, const = constants.%.loc22
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.loc22]
 // CHECK:STDOUT:   assign %n.var, %.loc22
 // CHECK:STDOUT:   %n.ref.loc26_4: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %n.ref.loc26_7: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc26_8.1: (i32, i32) = tuple_literal (%n.ref.loc26_4, %n.ref.loc26_7)
-// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1, const = constants.%.loc26_13
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2, const = constants.%.loc26_16
+// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template = constants.%.loc26_13]
+// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template = constants.%.loc26_16]
 // CHECK:STDOUT:   %.loc26_17.1: (i32, i32) = tuple_literal (%.loc26_13, %.loc26_16)
 // CHECK:STDOUT:   %.loc26_17.2: i32 = tuple_access %.loc26_8.1, element0
 // CHECK:STDOUT:   %.loc26_17.3: init i32 = initialize_from %.loc26_13 to %.loc26_17.2
@@ -129,13 +129,13 @@ fn Main() {
 // CHECK:STDOUT:   %.loc26_7: i32 = bind_value %n.ref.loc26_7
 // CHECK:STDOUT:   %.loc26_8.2: (i32, i32) = tuple_value (%.loc26_4, %.loc26_7)
 // CHECK:STDOUT:   %.loc26_8.3: (i32, i32) = converted %.loc26_8.1, %.loc26_8.2
-// CHECK:STDOUT:   %.loc30: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc30: type = ptr_type i32 [template]
 // CHECK:STDOUT:   assign i32, %.loc30
-// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1, const = constants.%.loc34_9
-// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2, const = constants.%.loc34_17
+// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template = constants.%.loc34_9]
+// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template = constants.%.loc34_17]
 // CHECK:STDOUT:   %.loc34_18.1: {.x: i32, .y: i32} = struct_literal (%.loc34_9, %.loc34_17)
-// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3, const = constants.%.loc34_28
-// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4, const = constants.%.loc34_36
+// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template = constants.%.loc34_28]
+// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template = constants.%.loc34_36]
 // CHECK:STDOUT:   %.loc34_37.1: {.x: i32, .y: i32} = struct_literal (%.loc34_28, %.loc34_36)
 // CHECK:STDOUT:   %.loc34_37.2: i32 = struct_access %.loc34_18.1, element0
 // CHECK:STDOUT:   %.loc34_37.3: init i32 = initialize_from %.loc34_28 to %.loc34_37.2
@@ -144,26 +144,26 @@ fn Main() {
 // CHECK:STDOUT:   %.loc34_37.6: init {.x: i32, .y: i32} = struct_init (%.loc34_37.3, %.loc34_37.5) to %.loc34_18.1
 // CHECK:STDOUT:   %.loc34_37.7: init {.x: i32, .y: i32} = converted %.loc34_37.1, %.loc34_37.6
 // CHECK:STDOUT:   assign %.loc34_18.1, %.loc34_37.7
-// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17), const = constants.%.loc34_18.3
-// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = converted %.loc34_18.1, %.loc34_18.2, const = constants.%.loc34_18.3
-// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true, const = constants.%.loc38_7
+// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template = constants.%.loc34_18.3]
+// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = converted %.loc34_18.1, %.loc34_18.2 [template = constants.%.loc34_18.3]
+// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template = constants.%.loc38_7]
 // CHECK:STDOUT:   if %.loc38_7 br !if.expr.then.loc38 else br !if.expr.else.loc38
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc38:
-// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1, const = constants.%.loc38_17
+// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template = constants.%.loc38_17]
 // CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_17)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc38:
-// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2, const = constants.%.loc38_24
+// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template = constants.%.loc38_24]
 // CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_24)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc38:
 // CHECK:STDOUT:   %.loc38_4: i32 = block_arg !if.expr.result.loc38
-// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3, const = constants.%.loc38_29
+// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template = constants.%.loc38_29]
 // CHECK:STDOUT:   assign %.loc38_4, %.loc38_29
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true, const = constants.%.loc45_7
+// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.loc45_7]
 // CHECK:STDOUT:   if %.loc45_7 br !if.expr.then.loc45 else br !if.expr.else.loc45
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc45:
@@ -178,7 +178,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc45:
 // CHECK:STDOUT:   %.loc45_4: i32 = block_arg !if.expr.result.loc45
-// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10, const = constants.%.loc45_29
+// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template = constants.%.loc45_29]
 // CHECK:STDOUT:   assign %.loc45_4, %.loc45_29
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch.carbon
@@ -14,19 +14,19 @@ fn Main() {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 12, const
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref bool = var x
 // CHECK:STDOUT:   %x: ref bool = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11_21: i32 = int_literal 12, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_21: i32 = int_literal 12 [template = constants.%.loc11]
 // CHECK:STDOUT:   %.loc11_17: <error> = not <error>
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
@@ -15,23 +15,23 @@ fn Main() {
 // CHECK:STDOUT: --- fail_type_mismatch_assignment.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 3, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 3 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %a.var, %.loc8
 // CHECK:STDOUT:   %a.ref: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1 [template = constants.%.loc12]
 // CHECK:STDOUT:   assign %a.ref, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
@@ -16,8 +16,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch_once.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc13_15: f64 = real_literal 34e-1, const
+// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc13_15: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/fail_unimplemented_op.carbon
+++ b/toolchain/check/testdata/operators/fail_unimplemented_op.carbon
@@ -14,8 +14,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_unimplemented_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc11_15: i32 = int_literal 34, const
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc11_15: i32 = int_literal 34 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -14,42 +14,42 @@ fn Or() -> bool {
 // CHECK:STDOUT: --- or.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true, const
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .Or = %Or}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %Or: <function> = fn_decl @Or, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %Or: <function> = fn_decl @Or [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.loc7]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Or() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
 // CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
 // CHECK:STDOUT:   %.loc11_14.3: bool = not %.loc11_14.2
-// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true [template = constants.%.loc11]
 // CHECK:STDOUT:   if %.loc11_14.3 br !or.rhs else br !or.result(%.loc11_14.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc11_18: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc11_14.5: bool = value_of_initializer %.loc11_18
 // CHECK:STDOUT:   %.loc11_14.6: bool = converted %.loc11_18, %.loc11_14.5

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -14,20 +14,20 @@ let not_false: bool = not false;
 // CHECK:STDOUT: --- unary_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_26.1: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc11_26.2: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc12_27.1: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc12_27.2: bool = bool_literal true, const
+// CHECK:STDOUT:   %.loc11_26.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc11_26.2: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc12_27.1: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc12_27.2: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Not = %Not}
-// CHECK:STDOUT:   %Not: <function> = fn_decl @Not, const
-// CHECK:STDOUT:   %.loc11_26: bool = bool_literal true, const = constants.%.loc11_26.1
-// CHECK:STDOUT:   %.loc11_22: bool = not %.loc11_26, const = constants.%.loc11_26.2
+// CHECK:STDOUT:   %Not: <function> = fn_decl @Not [template]
+// CHECK:STDOUT:   %.loc11_26: bool = bool_literal true [template = constants.%.loc11_26.1]
+// CHECK:STDOUT:   %.loc11_22: bool = not %.loc11_26 [template = constants.%.loc11_26.2]
 // CHECK:STDOUT:   %not_true: bool = bind_name not_true, %.loc11_22
-// CHECK:STDOUT:   %.loc12_27: bool = bool_literal false, const = constants.%.loc12_27.1
-// CHECK:STDOUT:   %.loc12_23: bool = not %.loc12_27, const = constants.%.loc12_27.2
+// CHECK:STDOUT:   %.loc12_27: bool = bool_literal false [template = constants.%.loc12_27.1]
+// CHECK:STDOUT:   %.loc12_23: bool = not %.loc12_27 [template = constants.%.loc12_27.2]
 // CHECK:STDOUT:   %not_false: bool = bind_name not_false, %.loc12_23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/package_expr/fail_not_found.carbon
+++ b/toolchain/check/testdata/package_expr/fail_not_found.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/package_expr/syntax.carbon
+++ b/toolchain/check/testdata/package_expr/syntax.carbon
@@ -45,24 +45,24 @@ fn Main() {
 // CHECK:STDOUT: --- global.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
 // CHECK:STDOUT:   assign %x.var, %.loc4
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
@@ -76,24 +76,24 @@ fn Main() {
 // CHECK:STDOUT: --- inside_fn.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
 // CHECK:STDOUT:   assign %x.var, %.loc4
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
@@ -107,20 +107,20 @@ fn Main() {
 // CHECK:STDOUT: --- namespace.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc11: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc8: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.NS = %.loc4, .Main = %Main}
 // CHECK:STDOUT:   %.loc4: <namespace> = namespace NS, {.C = %C.decl}
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo, const
+// CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Foo = %Foo
@@ -135,8 +135,8 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%.loc4
-// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C, const = file.%C
-// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, @C.%Foo, const = @C.%Foo
+// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
+// CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, @C.%Foo [template = @C.%Foo]
 // CHECK:STDOUT:   %.loc11: init () = call %Foo.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -16,13 +16,13 @@ var a: () = A();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, has_error}
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7 [template = constants.%.loc7]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %A.ref: <error> = name_ref A, <error>

--- a/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
+++ b/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
@@ -23,28 +23,28 @@ var a: () = a_ref;
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a_ref = %a_ref}
 // CHECK:STDOUT:   %a_ref.var: ref i32 = var a_ref
 // CHECK:STDOUT:   %a_ref: ref i32 = bind_name a_ref, %a_ref.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
 // CHECK:STDOUT:   assign %a_ref.var, %.loc4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a_ref = %package.var, .a = %a}
 // CHECK:STDOUT:   %package.var: ref <error> = var package
 // CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %a_ref.ref: ref <error> = name_ref a_ref, %package.var

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -38,7 +38,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A();
@@ -46,25 +46,25 @@ var package_b: () = package.B();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %.2, .a = %a, .package_a = %package_a}
-// CHECK:STDOUT:   %.2: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
-// CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.2, const = %.2
+// CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc4_14: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_14
 // CHECK:STDOUT:   %.loc6_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc6_17, constants.%.loc4, const = constants.%.loc4
+// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc6_17, constants.%.loc4 [template = constants.%.loc4]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
-// CHECK:STDOUT:   %A.ref.loc6: <function> = name_ref A, %.2, const = %.2
+// CHECK:STDOUT:   %A.ref.loc6: <function> = name_ref A, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc6_30: init () = call %A.ref.loc6()
 // CHECK:STDOUT:   assign %package_a.var, %.loc6_30
 // CHECK:STDOUT: }
@@ -75,7 +75,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %B}
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B();
@@ -83,25 +83,25 @@ var package_b: () = package.B();
 // CHECK:STDOUT: --- same_package_importer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc6: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %.2, .b = %b, .package_b = %package_b}
-// CHECK:STDOUT:   %.2: <function> = fn_decl @.1, const
+// CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.loc6, const = constants.%.loc6
+// CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.loc6 [template = constants.%.loc6]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
-// CHECK:STDOUT:   %B.ref.loc6: <function> = name_ref B, %.2, const = %.2
+// CHECK:STDOUT:   %B.ref.loc6: <function> = name_ref B, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc6_14: init () = call %B.ref.loc6()
 // CHECK:STDOUT:   assign %b.var, %.loc6_14
 // CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc6_9.3: type = converted %.loc8_17, constants.%.loc6, const = constants.%.loc6
+// CHECK:STDOUT:   %.loc6_9.3: type = converted %.loc8_17, constants.%.loc6 [template = constants.%.loc6]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
-// CHECK:STDOUT:   %B.ref.loc8: <function> = name_ref B, %.2, const = %.2
+// CHECK:STDOUT:   %B.ref.loc8: <function> = name_ref B, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc8_30: init () = call %B.ref.loc8()
 // CHECK:STDOUT:   assign %package_b.var, %.loc8_30
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/unused_lazy_import.carbon
+++ b/toolchain/check/testdata/packages/unused_lazy_import.carbon
@@ -18,7 +18,7 @@ package Implicit impl;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A();

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -12,20 +12,20 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- address_of_deref.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc9: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc9: type = ptr_type i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %n.var, %.loc8
 // CHECK:STDOUT:   %n.ref: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc9_13: i32* = addr_of %n.ref

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -19,30 +19,30 @@ fn F() {
 // CHECK:STDOUT: --- address_of_lvalue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_27: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc14_19.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc14_19.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc8_27: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc14_19.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc14_19.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_27: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc8_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %s.var: ref {.a: i32, .b: i32} = var s
 // CHECK:STDOUT:   %s: ref {.a: i32, .b: i32} = bind_name s, %s.var
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1, const = constants.%.loc8_37
-// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2, const = constants.%.loc8_45
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1 [template = constants.%.loc8_37]
+// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2 [template = constants.%.loc8_45]
 // CHECK:STDOUT:   %.loc8_46.1: {.a: i32, .b: i32} = struct_literal (%.loc8_37, %.loc8_45)
 // CHECK:STDOUT:   %.loc8_46.2: ref i32 = struct_access %s.var, element0
 // CHECK:STDOUT:   %.loc8_46.3: init i32 = initialize_from %.loc8_37 to %.loc8_46.2
@@ -51,21 +51,21 @@ fn F() {
 // CHECK:STDOUT:   %.loc8_46.6: init {.a: i32, .b: i32} = struct_init (%.loc8_46.3, %.loc8_46.5) to %s.var
 // CHECK:STDOUT:   %.loc8_46.7: init {.a: i32, .b: i32} = converted %.loc8_46.1, %.loc8_46.6
 // CHECK:STDOUT:   assign %s.var, %.loc8_46.7
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_28: type = ptr_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_28: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %p.var: ref {.a: i32, .b: i32}* = var p
 // CHECK:STDOUT:   %p: ref {.a: i32, .b: i32}* = bind_name p, %p.var
 // CHECK:STDOUT:   %s.ref.loc10: ref {.a: i32, .b: i32} = name_ref s, %s
 // CHECK:STDOUT:   %.loc10_32: {.a: i32, .b: i32}* = addr_of %s.ref.loc10
 // CHECK:STDOUT:   assign %p.var, %.loc10_32
-// CHECK:STDOUT:   %.loc11_13: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc11_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %q.var: ref i32* = var q
 // CHECK:STDOUT:   %q: ref i32* = bind_name q, %q.var
 // CHECK:STDOUT:   %s.ref.loc11: ref {.a: i32, .b: i32} = name_ref s, %s
 // CHECK:STDOUT:   %.loc11_19: ref i32 = struct_access %s.ref.loc11, element0
 // CHECK:STDOUT:   %.loc11_17: i32* = addr_of %.loc11_19
 // CHECK:STDOUT:   assign %q.var, %.loc11_17
-// CHECK:STDOUT:   %.loc12_13: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc12_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %r.var: ref i32* = var r
 // CHECK:STDOUT:   %r: ref i32* = bind_name r, %r.var
 // CHECK:STDOUT:   %s.ref.loc12: ref {.a: i32, .b: i32} = name_ref s, %s
@@ -73,11 +73,11 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_17: i32* = addr_of %.loc12_19
 // CHECK:STDOUT:   assign %r.var, %.loc12_17
 // CHECK:STDOUT:   %.loc14_19.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.loc14_19.2, const = constants.%.loc14_19.2
+// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.loc14_19.2 [template = constants.%.loc14_19.2]
 // CHECK:STDOUT:   %t.var: ref (i32, i32) = var t
 // CHECK:STDOUT:   %t: ref (i32, i32) = bind_name t, %t.var
-// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1, const = constants.%.loc14_24
-// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2, const = constants.%.loc14_27
+// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template = constants.%.loc14_24]
+// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2 [template = constants.%.loc14_27]
 // CHECK:STDOUT:   %.loc14_28.1: (i32, i32) = tuple_literal (%.loc14_24, %.loc14_27)
 // CHECK:STDOUT:   %.loc14_28.2: ref i32 = tuple_access %t.var, element0
 // CHECK:STDOUT:   %.loc14_28.3: init i32 = initialize_from %.loc14_24 to %.loc14_28.2
@@ -86,19 +86,19 @@ fn F() {
 // CHECK:STDOUT:   %.loc14_28.6: init (i32, i32) = tuple_init (%.loc14_28.3, %.loc14_28.5) to %t.var
 // CHECK:STDOUT:   %.loc14_28.7: init (i32, i32) = converted %.loc14_28.1, %.loc14_28.6
 // CHECK:STDOUT:   assign %t.var, %.loc14_28.7
-// CHECK:STDOUT:   %.loc15_14: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc15_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %t0.var: ref i32* = var t0
 // CHECK:STDOUT:   %t0: ref i32* = bind_name t0, %t0.var
 // CHECK:STDOUT:   %t.ref.loc15: ref (i32, i32) = name_ref t, %t
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.loc15]
 // CHECK:STDOUT:   %.loc15_22: ref i32 = tuple_index %t.ref.loc15, %.loc15_21
 // CHECK:STDOUT:   %.loc15_18: i32* = addr_of %.loc15_22
 // CHECK:STDOUT:   assign %t0.var, %.loc15_18
-// CHECK:STDOUT:   %.loc16_14: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc16_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %t1.var: ref i32* = var t1
 // CHECK:STDOUT:   %t1: ref i32* = bind_name t1, %t1.var
 // CHECK:STDOUT:   %t.ref.loc16: ref (i32, i32) = name_ref t, %t
-// CHECK:STDOUT:   %.loc16_21: i32 = int_literal 1, const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16_21: i32 = int_literal 1 [template = constants.%.loc16]
 // CHECK:STDOUT:   %.loc16_22: ref i32 = tuple_index %t.ref.loc16, %.loc16_21
 // CHECK:STDOUT:   %.loc16_18: i32* = addr_of %.loc16_22
 // CHECK:STDOUT:   assign %t1.var, %.loc16_18

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -14,21 +14,21 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %n.var, %.loc8
-// CHECK:STDOUT:   %.loc9_13: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc9_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %p.var: ref i32* = var p
 // CHECK:STDOUT:   %p: ref i32* = bind_name p, %p.var
 // CHECK:STDOUT:   %n.ref: ref i32 = name_ref n, %n

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -21,13 +21,13 @@ fn Test() {
 // CHECK:STDOUT: --- fail_address_of_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = ptr_type <error>, const
-// CHECK:STDOUT:   %.loc18: type = ptr_type <error>*, const
+// CHECK:STDOUT:   %.loc11: type = ptr_type <error> [template]
+// CHECK:STDOUT:   %.loc18: type = ptr_type <error>* [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Test = %Test}
-// CHECK:STDOUT:   %Test: <function> = fn_decl @Test, const
+// CHECK:STDOUT:   %Test: <function> = fn_decl @Test [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -85,48 +85,48 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: --- fail_address_of_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc15_3.1: type = ptr_type i32, const
-// CHECK:STDOUT:   %.loc15_3.2: i32* = addr_of %.loc15_4, const
-// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc19_3.1: type = ptr_type bool, const
-// CHECK:STDOUT:   %.loc19_3.2: bool* = addr_of %.loc19_4, const
-// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1, const
-// CHECK:STDOUT:   %.loc23_3.1: type = ptr_type f64, const
-// CHECK:STDOUT:   %.loc23_3.2: f64* = addr_of %.loc23_4, const
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello", const
-// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4, const
-// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc31_9: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc31_3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc35_3: type = ptr_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc42_10: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc50_9.1: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc50_9.2: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_9.2, const
-// CHECK:STDOUT:   %.loc64: type = ptr_type type, const
-// CHECK:STDOUT:   %.loc68: type* = addr_of @AddressOfType.%.loc68_14, const
-// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc75_10: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9), const
+// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc15_3.1: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.loc15_3.2: i32* = addr_of %.loc15_4 [template]
+// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc19_3.1: type = ptr_type bool [template]
+// CHECK:STDOUT:   %.loc19_3.2: bool* = addr_of %.loc19_4 [template]
+// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.loc23_3.1: type = ptr_type f64 [template]
+// CHECK:STDOUT:   %.loc23_3.2: f64* = addr_of %.loc23_4 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template]
+// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4 [template]
+// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc31_9: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc31_3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc35_3: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc42_10: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc50_9.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc50_9.2: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_9.2 [template]
+// CHECK:STDOUT:   %.loc64: type = ptr_type type [template]
+// CHECK:STDOUT:   %.loc68: type* = addr_of @AddressOfType.%.loc68_14 [template]
+// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc75_10: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.G = %G, .H = %H, .AddressOfLiteral = %AddressOfLiteral, .AddressOfOperator = %AddressOfOperator, .AddressOfCall = %AddressOfCall, .AddressOfType = %AddressOfType, .AddressOfTupleElementValue = %AddressOfTupleElementValue, .AddressOfParam = %AddressOfParam}
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral, const
-// CHECK:STDOUT:   %AddressOfOperator: <function> = fn_decl @AddressOfOperator, const
-// CHECK:STDOUT:   %AddressOfCall: <function> = fn_decl @AddressOfCall, const
-// CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType, const
-// CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue, const
-// CHECK:STDOUT:   %AddressOfParam: <function> = fn_decl @AddressOfParam, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %AddressOfLiteral: <function> = fn_decl @AddressOfLiteral [template]
+// CHECK:STDOUT:   %AddressOfOperator: <function> = fn_decl @AddressOfOperator [template]
+// CHECK:STDOUT:   %AddressOfCall: <function> = fn_decl @AddressOfCall [template]
+// CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType [template]
+// CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue [template]
+// CHECK:STDOUT:   %AddressOfParam: <function> = fn_decl @AddressOfParam [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;
@@ -135,19 +135,19 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfLiteral() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0, const = constants.%.loc15_4
-// CHECK:STDOUT:   %.loc15_3: i32* = addr_of %.loc15_4, const = constants.%.loc15_3.2
-// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true, const = constants.%.loc19_4
-// CHECK:STDOUT:   %.loc19_3: bool* = addr_of %.loc19_4, const = constants.%.loc19_3.2
-// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1, const = constants.%.loc23_4
-// CHECK:STDOUT:   %.loc23_3: f64* = addr_of %.loc23_4, const = constants.%.loc23_3.2
-// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello", const = constants.%.loc27_4
-// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4, const = constants.%.loc27_3
-// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1, const = constants.%.loc31_5
-// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2, const = constants.%.loc31_8
+// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template = constants.%.loc15_4]
+// CHECK:STDOUT:   %.loc15_3: i32* = addr_of %.loc15_4 [template = constants.%.loc15_3.2]
+// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template = constants.%.loc19_4]
+// CHECK:STDOUT:   %.loc19_3: bool* = addr_of %.loc19_4 [template = constants.%.loc19_3.2]
+// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template = constants.%.loc23_4]
+// CHECK:STDOUT:   %.loc23_3: f64* = addr_of %.loc23_4 [template = constants.%.loc23_3.2]
+// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template = constants.%.loc27_4]
+// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4 [template = constants.%.loc27_3]
+// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template = constants.%.loc31_5]
+// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template = constants.%.loc31_8]
 // CHECK:STDOUT:   %.loc31_9: (i32, i32) = tuple_literal (%.loc31_5, %.loc31_8)
 // CHECK:STDOUT:   %.loc31_3: (i32, i32)* = addr_of %.loc31_9
-// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5, const = constants.%.loc35_10
+// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template = constants.%.loc35_10]
 // CHECK:STDOUT:   %.loc35_11: {.a: i32} = struct_literal (%.loc35_10)
 // CHECK:STDOUT:   %.loc35_3: {.a: i32}* = addr_of %.loc35_11
 // CHECK:STDOUT:   return
@@ -155,32 +155,32 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfOperator() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true, const = constants.%.loc42_5
-// CHECK:STDOUT:   %.loc42_10.1: bool = bool_literal false, const = constants.%.loc42_10
+// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template = constants.%.loc42_5]
+// CHECK:STDOUT:   %.loc42_10.1: bool = bool_literal false [template = constants.%.loc42_10]
 // CHECK:STDOUT:   if %.loc42_5 br !and.rhs else br !and.result(%.loc42_10.1)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false, const = constants.%.loc42_14
+// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template = constants.%.loc42_14]
 // CHECK:STDOUT:   br !and.result(%.loc42_14)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
 // CHECK:STDOUT:   %.loc42_10.2: bool = block_arg !and.result
 // CHECK:STDOUT:   %.loc42_3: bool* = addr_of %.loc42_10.2
-// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H, const = file.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
 // CHECK:STDOUT:   %.loc46_5.1: init {.a: i32} = call %H.ref()
 // CHECK:STDOUT:   %.loc46_5.2: ref {.a: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc46_5.3: ref {.a: i32} = temporary %.loc46_5.2, %.loc46_5.1
 // CHECK:STDOUT:   %.loc46_7: ref i32 = struct_access %.loc46_5.3, element0
 // CHECK:STDOUT:   %.loc46_3: i32* = addr_of %.loc46_7
-// CHECK:STDOUT:   %.loc50_9: bool = bool_literal true, const = constants.%.loc50_9.1
-// CHECK:STDOUT:   %.loc50_5: bool = not %.loc50_9, const = constants.%.loc50_9.2
-// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_5, const = constants.%.loc50_3
+// CHECK:STDOUT:   %.loc50_9: bool = bool_literal true [template = constants.%.loc50_9.1]
+// CHECK:STDOUT:   %.loc50_5: bool = not %.loc50_9 [template = constants.%.loc50_9.2]
+// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_5 [template = constants.%.loc50_3]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfCall() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc57_5: init i32 = call %G.ref()
 // CHECK:STDOUT:   %.loc57_3: i32* = addr_of %.loc57_5
 // CHECK:STDOUT:   return
@@ -189,20 +189,20 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: fn @AddressOfType() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc64: type* = addr_of i32
-// CHECK:STDOUT:   %.loc68_5: type = const_type i32, const
-// CHECK:STDOUT:   %.loc68_14: type = ptr_type const i32, const
-// CHECK:STDOUT:   %.loc68_3: type* = addr_of %.loc68_14, const = constants.%.loc68
+// CHECK:STDOUT:   %.loc68_5: type = const_type i32 [template]
+// CHECK:STDOUT:   %.loc68_14: type = ptr_type const i32 [template]
+// CHECK:STDOUT:   %.loc68_3: type* = addr_of %.loc68_14 [template = constants.%.loc68]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfTupleElementValue() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1, const = constants.%.loc75_6
-// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2, const = constants.%.loc75_9
+// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template = constants.%.loc75_6]
+// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template = constants.%.loc75_9]
 // CHECK:STDOUT:   %.loc75_10.1: (i32, i32) = tuple_literal (%.loc75_6, %.loc75_9)
-// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0, const = constants.%.loc75_12
-// CHECK:STDOUT:   %.loc75_10.2: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9), const = constants.%.loc75_10
-// CHECK:STDOUT:   %.loc75_10.3: (i32, i32) = converted %.loc75_10.1, %.loc75_10.2, const = constants.%.loc75_10
+// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template = constants.%.loc75_12]
+// CHECK:STDOUT:   %.loc75_10.2: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template = constants.%.loc75_10]
+// CHECK:STDOUT:   %.loc75_10.3: (i32, i32) = converted %.loc75_10.1, %.loc75_10.2 [template = constants.%.loc75_10]
 // CHECK:STDOUT:   %.loc75_13: i32 = tuple_index %.loc75_10.3, %.loc75_12
 // CHECK:STDOUT:   %.loc75_3: i32* = addr_of %.loc75_13
 // CHECK:STDOUT:   return
@@ -210,7 +210,7 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfParam(%param: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc82_22: type = ptr_type i32, const
+// CHECK:STDOUT:   %.loc82_22: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %param_addr.var: ref i32* = var param_addr
 // CHECK:STDOUT:   %param_addr: ref i32* = bind_name param_addr, %param_addr.var
 // CHECK:STDOUT:   %param.ref: i32 = name_ref param, %param

--- a/toolchain/check/testdata/pointer/fail_deref_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_function.carbon
@@ -15,12 +15,12 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc11: ref <error> = deref <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -18,7 +18,7 @@ fn F() {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %.loc7, .F = %F}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace A, {}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -22,15 +22,15 @@ fn Deref(n: i32) {
 // CHECK:STDOUT: --- fail_deref_not_pointer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_5.1: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value (), const
-// CHECK:STDOUT:   %.loc19_5.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value (), const
+// CHECK:STDOUT:   %.loc15_5.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %.loc19_5.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Deref = %Deref}
-// CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref, const
+// CHECK:STDOUT:   %Deref: <function> = fn_decl @Deref [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n: i32) {
@@ -38,12 +38,12 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc11: ref <error> = deref %n.ref
 // CHECK:STDOUT:   %.loc15_5.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value (), const = constants.%.loc15_5.2
-// CHECK:STDOUT:   %.loc15_5.3: () = converted %.loc15_5.1, %.loc15_5.2, const = constants.%.loc15_5.2
+// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value () [template = constants.%.loc15_5.2]
+// CHECK:STDOUT:   %.loc15_5.3: () = converted %.loc15_5.1, %.loc15_5.2 [template = constants.%.loc15_5.2]
 // CHECK:STDOUT:   %.loc15_3: ref <error> = deref %.loc15_5.3
 // CHECK:STDOUT:   %.loc19_5.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value (), const = constants.%.loc19_5.2
-// CHECK:STDOUT:   %.loc19_5.3: {} = converted %.loc19_5.1, %.loc19_5.2, const = constants.%.loc19_5.2
+// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value () [template = constants.%.loc19_5.2]
+// CHECK:STDOUT:   %.loc19_5.3: {} = converted %.loc19_5.1, %.loc19_5.2 [template = constants.%.loc19_5.2]
 // CHECK:STDOUT:   %.loc19_3: ref <error> = deref %.loc19_5.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -14,12 +14,12 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.ConstMismatch = %ConstMismatch}
-// CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch, const
+// CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConstMismatch(%p: const {}*) -> const ({}*) {

--- a/toolchain/check/testdata/pointer/nested_const.carbon
+++ b/toolchain/check/testdata/pointer/nested_const.carbon
@@ -13,7 +13,7 @@ fn F(p: const (const (const i32*)*)) -> const i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%p: const (const (const i32*)*)) -> const i32 {

--- a/toolchain/check/testdata/pointer/types.carbon
+++ b/toolchain/check/testdata/pointer/types.carbon
@@ -16,8 +16,8 @@ fn ConstPtr(p: const i32*) -> (const i32)* {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Ptr = %Ptr, .ConstPtr = %ConstPtr}
-// CHECK:STDOUT:   %Ptr: <function> = fn_decl @Ptr, const
-// CHECK:STDOUT:   %ConstPtr: <function> = fn_decl @ConstPtr, const
+// CHECK:STDOUT:   %Ptr: <function> = fn_decl @Ptr [template]
+// CHECK:STDOUT:   %ConstPtr: <function> = fn_decl @ConstPtr [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Ptr(%p: i32*) -> i32* {

--- a/toolchain/check/testdata/return/code_after_return.carbon
+++ b/toolchain/check/testdata/return/code_after_return.carbon
@@ -12,12 +12,12 @@ fn Main() {
 // CHECK:STDOUT: --- code_after_return.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/return/code_after_return_value.carbon
+++ b/toolchain/check/testdata/return/code_after_return_value.carbon
@@ -19,21 +19,21 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- code_after_return_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc12_26: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc12_33: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc13_9: bool = bool_literal false, const
-// CHECK:STDOUT:   %.loc13_16: bool = bool_literal true, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc12_26: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc12_33: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc13_9: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.loc13_16: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_call_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_call_in_type.carbon
@@ -15,13 +15,13 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT: --- fail_call_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 6, const
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.ReturnType = %ReturnType, .Six = %Six}
-// CHECK:STDOUT:   %ReturnType: <function> = fn_decl @ReturnType, const
-// CHECK:STDOUT:   %Six: <function> = fn_decl @Six, const
+// CHECK:STDOUT:   %ReturnType: <function> = fn_decl @ReturnType [template]
+// CHECK:STDOUT:   %Six: <function> = fn_decl @Six [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ReturnType() -> type {
@@ -31,7 +31,7 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 6, const = constants.%.loc13
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 6 [template = constants.%.loc13]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_error_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_error_in_type.carbon
@@ -13,7 +13,7 @@ fn Six() -> x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Six = %Six}
-// CHECK:STDOUT:   %Six: <function> = fn_decl @Six, const
+// CHECK:STDOUT:   %Six: <function> = fn_decl @Six [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error>;

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -14,18 +14,18 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_let_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 6, const
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Six = %Six}
 // CHECK:STDOUT:   %x: type = bind_name x, i32
-// CHECK:STDOUT:   %Six: <function> = fn_decl @Six, const
+// CHECK:STDOUT:   %Six: <function> = fn_decl @Six [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 6, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.loc12]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_missing_return.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return.carbon
@@ -14,7 +14,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -13,12 +13,12 @@ fn F() -> () {
 // CHECK:STDOUT: --- fail_missing_return_empty_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> () {

--- a/toolchain/check/testdata/return/fail_return_var_no_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_var_no_returned_var.carbon
@@ -15,7 +15,7 @@ fn Procedure() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Procedure = %Procedure}
-// CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure, const
+// CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Procedure() -> i32 {

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -30,29 +30,29 @@ fn G() -> C {
 // CHECK:STDOUT: --- fail_return_with_returned_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc18_35.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc18_35.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc18_35.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc18_35.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .C = %C.decl, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc18_16.1: type = unbound_element_type C, i32, const
-// CHECK:STDOUT:   %.loc18_16.2: <unbound element of class C> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc18_16.2, const = %.loc18_16.2
-// CHECK:STDOUT:   %.loc18_28.1: type = unbound_element_type C, i32, const
-// CHECK:STDOUT:   %.loc18_28.2: <unbound element of class C> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc18_28.2, const = %.loc18_28.2
+// CHECK:STDOUT:   %.loc18_16.1: type = unbound_element_type C, i32 [template]
+// CHECK:STDOUT:   %.loc18_16.2: <unbound element of class C> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc18_16.2 [template = %.loc18_16.2]
+// CHECK:STDOUT:   %.loc18_28.1: type = unbound_element_type C, i32 [template]
+// CHECK:STDOUT:   %.loc18_28.2: <unbound element of class C> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc18_28.2 [template = %.loc18_28.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -63,18 +63,18 @@ fn G() -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %v.var, %.loc8
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1, const = constants.%.loc15
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.loc15]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C, const = file.%C
+// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %c: ref C = bind_name c, %return
-// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1, const = constants.%.loc20_29
-// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2, const = constants.%.loc20_37
+// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template = constants.%.loc20_29]
+// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template = constants.%.loc20_37]
 // CHECK:STDOUT:   %.loc20_38.1: {.a: i32, .b: i32} = struct_literal (%.loc20_29, %.loc20_37)
 // CHECK:STDOUT:   %.loc20_38.2: ref i32 = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc20_38.3: init i32 = initialize_from %.loc20_29 to %.loc20_38.2

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -18,18 +18,18 @@ fn Procedure() {
 // CHECK:STDOUT: --- fail_returned_var_no_return_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Procedure = %Procedure}
-// CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure, const
+// CHECK:STDOUT:   %Procedure: <function> = fn_decl @Procedure [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Procedure() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14_20.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc14_20.2: type = converted %.loc14_20.1, constants.%.loc14, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14_20.2: type = converted %.loc14_20.1, constants.%.loc14 [template = constants.%.loc14]
 // CHECK:STDOUT:   %v: () = bind_name v, <error>
 // CHECK:STDOUT:   %.loc14_25: () = tuple_literal ()
 // CHECK:STDOUT:   assign <error>, <error>

--- a/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
@@ -37,61 +37,61 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc22: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc24: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc34: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.SameScope = %SameScope, .DifferentScopes = %DifferentScopes}
-// CHECK:STDOUT:   %SameScope: <function> = fn_decl @SameScope, const
-// CHECK:STDOUT:   %DifferentScopes: <function> = fn_decl @DifferentScopes, const
+// CHECK:STDOUT:   %SameScope: <function> = fn_decl @SameScope [template]
+// CHECK:STDOUT:   %DifferentScopes: <function> = fn_decl @DifferentScopes [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @SameScope() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
 // CHECK:STDOUT:   if %.loc8 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
 // CHECK:STDOUT:   assign %v.var, %.loc9
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1, const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template = constants.%.loc16]
 // CHECK:STDOUT:   assign %w.var, %.loc16
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0, const = constants.%.loc18
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.loc18]
 // CHECK:STDOUT:   return %.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @DifferentScopes() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22: bool = bool_literal true, const = constants.%.loc22
+// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template = constants.%.loc22]
 // CHECK:STDOUT:   if %.loc22 br !if.then.loc22 else br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc22:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0, const = constants.%.loc23
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.loc23]
 // CHECK:STDOUT:   assign %v.var, %.loc23
-// CHECK:STDOUT:   %.loc24: bool = bool_literal true, const = constants.%.loc24
+// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template = constants.%.loc24]
 // CHECK:STDOUT:   if %.loc24 br !if.then.loc24 else br !if.else.loc24
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc24:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 1, const = constants.%.loc31
+// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template = constants.%.loc31]
 // CHECK:STDOUT:   assign %w.var, %.loc31
 // CHECK:STDOUT:   br !if.else.loc24
 // CHECK:STDOUT:
@@ -99,7 +99,7 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT:   br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc22:
-// CHECK:STDOUT:   %.loc34: i32 = int_literal 0, const = constants.%.loc34
+// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template = constants.%.loc34]
 // CHECK:STDOUT:   return %.loc34
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_returned_var_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_type.carbon
@@ -18,18 +18,18 @@ fn Mismatch() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1, const
+// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Mismatch = %Mismatch}
-// CHECK:STDOUT:   %Mismatch: <function> = fn_decl @Mismatch, const
+// CHECK:STDOUT:   %Mismatch: <function> = fn_decl @Mismatch [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Mismatch() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %v: f64 = bind_name v, <error>
-// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template = constants.%.loc14]
 // CHECK:STDOUT:   assign <error>, <error>
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/return/fail_type_mismatch.carbon
@@ -14,17 +14,17 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1, const
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.loc11]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -17,17 +17,17 @@ fn Main() {
 // CHECK:STDOUT: --- fail_value_disallowed.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.loc14]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_missing.carbon
+++ b/toolchain/check/testdata/return/fail_value_missing.carbon
@@ -18,7 +18,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {

--- a/toolchain/check/testdata/return/fail_var_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_var_in_type.carbon
@@ -13,7 +13,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_var_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 6, const
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,12 +21,12 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT:   %x.var: ref type = var x
 // CHECK:STDOUT:   %x: ref type = bind_name x, %x.var
 // CHECK:STDOUT:   assign %x.var, i32
-// CHECK:STDOUT:   %Six: <function> = fn_decl @Six, const
+// CHECK:STDOUT:   %Six: <function> = fn_decl @Six [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 6, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template = constants.%.loc11]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/missing_return_no_return_type.carbon
+++ b/toolchain/check/testdata/return/missing_return_no_return_type.carbon
@@ -11,7 +11,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/return/no_value.carbon
+++ b/toolchain/check/testdata/return/no_value.carbon
@@ -12,7 +12,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -22,28 +22,28 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- returned_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.C = %C.decl, .F = %F, .G = %G}
 // CHECK:STDOUT:   %C.decl = class_decl @C, ()
-// CHECK:STDOUT:   %C: type = class_type @C, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type C, i32, const
-// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class C> = field_decl a, element0, const
-// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc8_8.2, const = %.loc8_8.2
-// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type C, i32, const
-// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class C> = field_decl b, element1, const
-// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc9_8.2, const = %.loc9_8.2
+// CHECK:STDOUT:   %.loc8_8.1: type = unbound_element_type C, i32 [template]
+// CHECK:STDOUT:   %.loc8_8.2: <unbound element of class C> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc8_8.2 [template = %.loc8_8.2]
+// CHECK:STDOUT:   %.loc9_8.1: type = unbound_element_type C, i32 [template]
+// CHECK:STDOUT:   %.loc9_8.2: <unbound element of class C> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc9_8.2 [template = %.loc9_8.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .a = %a
@@ -52,10 +52,10 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C, const = file.%C
+// CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %result: ref C = bind_name result, %return
-// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1, const = constants.%.loc13_34
-// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2, const = constants.%.loc13_42
+// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template = constants.%.loc13_34]
+// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2 [template = constants.%.loc13_42]
 // CHECK:STDOUT:   %.loc13_43.1: {.a: i32, .b: i32} = struct_literal (%.loc13_34, %.loc13_42)
 // CHECK:STDOUT:   %.loc13_43.2: ref i32 = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc13_43.3: init i32 = initialize_from %.loc13_34 to %.loc13_43.2
@@ -71,7 +71,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %result.var: ref i32 = var result
 // CHECK:STDOUT:   %result: ref i32 = bind_name result, %result.var
-// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0, const = constants.%.loc18
+// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0 [template = constants.%.loc18]
 // CHECK:STDOUT:   assign %result.var, %.loc18_30
 // CHECK:STDOUT:   %.loc18_16: i32 = bind_value %result
 // CHECK:STDOUT:   return %.loc18_16

--- a/toolchain/check/testdata/return/returned_var_scope.carbon
+++ b/toolchain/check/testdata/return/returned_var_scope.carbon
@@ -26,46 +26,46 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: --- returned_var_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc19: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc19: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.UnrelatedScopes = %UnrelatedScopes, .EnclosingButAfter = %EnclosingButAfter}
-// CHECK:STDOUT:   %UnrelatedScopes: <function> = fn_decl @UnrelatedScopes, const
-// CHECK:STDOUT:   %EnclosingButAfter: <function> = fn_decl @EnclosingButAfter, const
+// CHECK:STDOUT:   %UnrelatedScopes: <function> = fn_decl @UnrelatedScopes [template]
+// CHECK:STDOUT:   %EnclosingButAfter: <function> = fn_decl @EnclosingButAfter [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @UnrelatedScopes() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
 // CHECK:STDOUT:   if %.loc8 br !if.then.loc8 else br !if.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc8:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
 // CHECK:STDOUT:   assign %v.var, %.loc9
 // CHECK:STDOUT:   br !if.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc8:
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template = constants.%.loc11]
 // CHECK:STDOUT:   if %.loc11 br !if.then.loc11 else br !if.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc11:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1, const = constants.%.loc12
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template = constants.%.loc12]
 // CHECK:STDOUT:   assign %w.var, %.loc12
 // CHECK:STDOUT:   br !if.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc11:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0, const = constants.%.loc14
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.loc14]
 // CHECK:STDOUT:   return %.loc14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -77,7 +77,7 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc19_27: i32 = int_literal 0, const = constants.%.loc19
+// CHECK:STDOUT:   %.loc19_27: i32 = int_literal 0 [template = constants.%.loc19]
 // CHECK:STDOUT:   assign %v.var, %.loc19_27
 // CHECK:STDOUT:   %.loc19_18: i32 = bind_value %v
 // CHECK:STDOUT:   return %.loc19_18
@@ -85,7 +85,7 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: !if.else:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1, const = constants.%.loc22
+// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.loc22]
 // CHECK:STDOUT:   assign %w.var, %.loc22_25
 // CHECK:STDOUT:   %.loc22_16: i32 = bind_value %w
 // CHECK:STDOUT:   return %.loc22_16

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -11,21 +11,21 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT: --- struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc8_17: {.a: i32} = struct_value (%.loc8_16), const
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc8_17: {.a: i32} = struct_value (%.loc8_16) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> {.a: i32} {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3, const = constants.%.loc8_16
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template = constants.%.loc8_16]
 // CHECK:STDOUT:   %.loc8_17.1: {.a: i32} = struct_literal (%.loc8_16)
-// CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16), const = constants.%.loc8_17
-// CHECK:STDOUT:   %.loc8_17.3: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2, const = constants.%.loc8_17
+// CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16) [template = constants.%.loc8_17]
+// CHECK:STDOUT:   %.loc8_17.3: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.loc8_17]
 // CHECK:STDOUT:   return %.loc8_17.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -12,22 +12,22 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT: --- tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_23.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc8_23.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc8_23.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15, const
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35, const
+// CHECK:STDOUT:   %.loc8_23.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc8_23.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc8_23.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15 [template]
+// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15, const = constants.%.loc9_11
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35, const = constants.%.loc9_15
+// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15 [template = constants.%.loc9_11]
+// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35 [template = constants.%.loc9_15]
 // CHECK:STDOUT:   %.loc9_17.1: (i32, i32) = tuple_literal (%.loc9_11, %.loc9_15)
 // CHECK:STDOUT:   %.loc9_17.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc9_17.3: init i32 = initialize_from %.loc9_11 to %.loc9_17.2

--- a/toolchain/check/testdata/return/value.carbon
+++ b/toolchain/check/testdata/return/value.carbon
@@ -11,17 +11,17 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -10,14 +10,14 @@ var y: {} = x;
 // CHECK:STDOUT: --- empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7_9.1, const = constants.%.loc7_9.1
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7_9.1 [template = constants.%.loc7_9.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
@@ -25,7 +25,7 @@ var y: {} = x;
 // CHECK:STDOUT:   %.loc7_14.3: init {} = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
 // CHECK:STDOUT:   %.loc8_9: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7_9.1, const = constants.%.loc7_9.1
+// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7_9.1 [template = constants.%.loc7_9.1]
 // CHECK:STDOUT:   %y.var: ref {} = var y
 // CHECK:STDOUT:   %y: ref {} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {} = name_ref x, %x

--- a/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
+++ b/toolchain/check/testdata/struct/fail_access_into_invalid.carbon
@@ -14,7 +14,7 @@ fn F() { a.b; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -12,12 +12,12 @@ var x: {.a: i32} = {};
 // CHECK:STDOUT: --- fail_assign_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {}, const
+// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_21: {} = struct_literal ()

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -12,17 +12,17 @@ var x: {.a: {}} = {.b = {}};
 // CHECK:STDOUT: --- fail_assign_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()}, const
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}}, const
+// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()} [template]
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_14.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.1, const = constants.%.loc10_14.1
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}}, const
+// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.1 [template = constants.%.loc10_14.1]
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: {}} = var x
 // CHECK:STDOUT:   %x: ref {.a: {}} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_26: {} = struct_literal ()

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -12,19 +12,19 @@ var x: {} = {.a = 1};
 // CHECK:STDOUT: --- fail_assign_to_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9.1, const = constants.%.loc10_9.1
+// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9.1 [template = constants.%.loc10_9.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1, const = constants.%.loc10_19
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template = constants.%.loc10_19]
 // CHECK:STDOUT:   %.loc10_20: {.a: i32} = struct_literal (%.loc10_19)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_duplicate_name.carbon
+++ b/toolchain/check/testdata/struct/fail_duplicate_name.carbon
@@ -47,37 +47,37 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT: --- fail_duplicate_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc21_36: type = struct_type {.a: i32}, const
-// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc45_25: type = ptr_type {.b: i32, .c: i32}, const
-// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc21_36: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc45_25: type = ptr_type {.b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .x = %x, .y = %y}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1, const = constants.%.loc21_35
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template = constants.%.loc21_35]
 // CHECK:STDOUT:   %.loc21_36: {.a: i32} = struct_literal (%.loc21_35)
 // CHECK:STDOUT:   %v: <error> = bind_name v, <error>
-// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1, const = constants.%.loc29_22
-// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2, const = constants.%.loc29_32
+// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template = constants.%.loc29_22]
+// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template = constants.%.loc29_32]
 // CHECK:STDOUT:   %w: i32 = bind_name w, <error>
-// CHECK:STDOUT:   %.loc37_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc37_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1, const = constants.%.loc37_26
-// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2, const = constants.%.loc37_34
+// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template = constants.%.loc37_26]
+// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template = constants.%.loc37_34]
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT:   %.loc45_25: type = struct_type {.b: i32, .c: i32}, const
+// CHECK:STDOUT:   %.loc45_25: type = struct_type {.b: i32, .c: i32} [template]
 // CHECK:STDOUT:   %y.var: ref {.b: i32, .c: i32} = var y
 // CHECK:STDOUT:   %y: ref {.b: i32, .c: i32} = bind_name y, %y.var
-// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3, const = constants.%.loc45_35
-// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4, const = constants.%.loc45_43
+// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template = constants.%.loc45_35]
+// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template = constants.%.loc45_43]
 // CHECK:STDOUT:   assign %y.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -17,19 +17,19 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT: --- fail_field_name_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: i32}, const
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1, const = constants.%.loc10_26
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.loc10_26]
 // CHECK:STDOUT:   %.loc10_27: {.b: i32} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT:   %.loc15: type = struct_type {.b: i32}, const
+// CHECK:STDOUT:   %.loc15: type = struct_type {.b: i32} [template]
 // CHECK:STDOUT:   %y.var: ref {.b: i32} = var y
 // CHECK:STDOUT:   %y: ref {.b: i32} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, %x

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -12,16 +12,16 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT: --- fail_field_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1, const
-// CHECK:STDOUT:   %.loc10_29: type = struct_type {.b: f64}, const
+// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.loc10_29: type = struct_type {.b: f64} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1, const = constants.%.loc10_26
+// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1 [template = constants.%.loc10_26]
 // CHECK:STDOUT:   %.loc10_29: {.b: f64} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -13,15 +13,15 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_member_access_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 40e-1, const
+// CHECK:STDOUT:   %.loc7: f64 = real_literal 40e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: f64}, const
+// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: f64} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: f64} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1 [template = constants.%.loc7]
 // CHECK:STDOUT:   %.loc7_29.1: {.a: f64} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_29.2: init {.a: f64} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_29.3: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2

--- a/toolchain/check/testdata/struct/fail_member_of_function.carbon
+++ b/toolchain/check/testdata/struct/fail_member_of_function.carbon
@@ -15,12 +15,12 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -22,19 +22,19 @@ var p: Incomplete* = &s.a;
 // CHECK:STDOUT: --- fail_nested_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20: type = ptr_type <error>, const
+// CHECK:STDOUT:   %.loc20: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Incomplete = %Incomplete.decl, .s = %s, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
-// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete, const
-// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete, const = %Incomplete
-// CHECK:STDOUT:   %.loc15: type = struct_type {.a: Incomplete}, const
+// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
+// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
+// CHECK:STDOUT:   %.loc15: type = struct_type {.a: Incomplete} [template]
 // CHECK:STDOUT:   %s.var: ref <error> = var s
 // CHECK:STDOUT:   %s: ref <error> = bind_name s, %s.var
-// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete, const = %Incomplete
-// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete, const
+// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
+// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete [template]
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var p
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name p, %p.var
 // CHECK:STDOUT:   %s.ref: ref <error> = name_ref s, %s

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -13,15 +13,15 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_non_member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.loc7]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -12,17 +12,17 @@ var x: {.a: i32, .b: i32} = {.a = 1};
 // CHECK:STDOUT: --- fail_too_few_values.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1, const = constants.%.loc10_35
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.loc10_35]
 // CHECK:STDOUT:   %.loc10_36: {.a: i32} = struct_literal (%.loc10_35)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_type_assign.carbon
+++ b/toolchain/check/testdata/struct/fail_type_assign.carbon
@@ -13,10 +13,10 @@ var x: {.a: i32} = {.a: i32};
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_28: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_28: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -12,13 +12,13 @@ var x: {.a = 1};
 // CHECK:STDOUT: --- fail_value_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1, const = constants.%.loc10_14
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
 // CHECK:STDOUT:   %.loc10_15: {.a: i32} = struct_literal (%.loc10_14)
 // CHECK:STDOUT:   %x.var: ref <error> = var x
 // CHECK:STDOUT:   %x: ref <error> = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -13,29 +13,29 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- literal_member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32}, const
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32}, const
-// CHECK:STDOUT:   %.loc10_35.2: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}, const
-// CHECK:STDOUT:   %.loc10_35.3: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32}, const
+// CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32} [template]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} [template]
+// CHECK:STDOUT:   %.loc10_35.2: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.loc10_35.3: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.G = %G, .F = %F}
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: {.x: i32, .y: i32, .z: i32};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1, const = constants.%.loc10_16
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.loc10_16]
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc10_25.1: ref {.x: i32, .y: i32, .z: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc10_25.2: init {.x: i32, .y: i32, .z: i32} = call %G.ref() to %.loc10_25.1
-// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3, const = constants.%.loc10_34
+// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3 [template = constants.%.loc10_34]
 // CHECK:STDOUT:   %.loc10_35.1: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_literal (%.loc10_16, %.loc10_25.2, %.loc10_34)
 // CHECK:STDOUT:   %.loc10_25.3: ref {.x: i32, .y: i32, .z: i32} = temporary %.loc10_25.1, %.loc10_25.2
 // CHECK:STDOUT:   %.loc10_25.4: ref i32 = struct_access %.loc10_25.3, element0

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -11,18 +11,18 @@ var z: i32 = y;
 // CHECK:STDOUT: --- member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: f64, .b: i32}, const
-// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1, const
-// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: f64, .b: i32} [template]
+// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1 [template]
+// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y, .z = %z}
-// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32}, const
+// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: f64, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1, const = constants.%.loc7_35
-// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1, const = constants.%.loc7_45
+// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1 [template = constants.%.loc7_35]
+// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1 [template = constants.%.loc7_45]
 // CHECK:STDOUT:   %.loc7_46.1: {.a: f64, .b: i32} = struct_literal (%.loc7_35, %.loc7_45)
 // CHECK:STDOUT:   %.loc7_46.2: ref f64 = struct_access %x.var, element0
 // CHECK:STDOUT:   %.loc7_46.3: init f64 = initialize_from %.loc7_35 to %.loc7_46.2

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -13,17 +13,17 @@ fn G() {
 // CHECK:STDOUT: --- nested_struct_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}, const
-// CHECK:STDOUT:   %.loc10_51.2: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*}, const
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
+// CHECK:STDOUT:   %.loc10_51.2: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -31,16 +31,16 @@ fn G() {
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_29: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_29, constants.%.loc7_25.2, const = constants.%.loc7_25.2
+// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_29, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
 // CHECK:STDOUT:   %.loc10_50: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_50, constants.%.loc7_25.2, const = constants.%.loc7_25.2
-// CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)}, const
+// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_50, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)} [template]
 // CHECK:STDOUT:   %v.var: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var v
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = bind_name v, %v.var
-// CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_61: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_74.1: ref (i32, i32, i32) = struct_access %v.var, element0
 // CHECK:STDOUT:   %.loc10_62: init (i32, i32, i32) = call %F.ref.loc10_61() to %.loc10_74.1
-// CHECK:STDOUT:   %F.ref.loc10_71: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_71: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_74.2: ref (i32, i32, i32) = struct_access %v.var, element1
 // CHECK:STDOUT:   %.loc10_72: init (i32, i32, i32) = call %F.ref.loc10_71() to %.loc10_74.2
 // CHECK:STDOUT:   %.loc10_74.3: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = struct_literal (%.loc10_62, %.loc10_72)

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -10,20 +10,20 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT: --- one_entry.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.loc7]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_27.3
-// CHECK:STDOUT:   %.loc8_16: type = struct_type {.a: i32}, const
+// CHECK:STDOUT:   %.loc8_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %y.var: ref {.a: i32} = var y
 // CHECK:STDOUT:   %y: ref {.a: i32} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, %x

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -16,16 +16,16 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: --- reorder_fields.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64}, const
-// CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32}, const
-// CHECK:STDOUT:   %.loc11_62.2: type = ptr_type {.b: f64, .a: i32}, const
+// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64} [template]
+// CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32} [template]
+// CHECK:STDOUT:   %.loc11_62.2: type = ptr_type {.b: f64, .a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.MakeI32 = %MakeI32, .MakeF64 = %MakeF64, .F = %F}
-// CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32, const
-// CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %MakeI32: <function> = fn_decl @MakeI32 [template]
+// CHECK:STDOUT:   %MakeF64: <function> = fn_decl @MakeF64 [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeI32() -> i32;
@@ -34,10 +34,10 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: {.a: i32, .b: f64} {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_27: type = struct_type {.a: i32, .b: f64}, const
-// CHECK:STDOUT:   %MakeF64.ref: <function> = name_ref MakeF64, file.%MakeF64, const = file.%MakeF64
+// CHECK:STDOUT:   %.loc11_27: type = struct_type {.a: i32, .b: f64} [template]
+// CHECK:STDOUT:   %MakeF64.ref: <function> = name_ref MakeF64, file.%MakeF64 [template = file.%MakeF64]
 // CHECK:STDOUT:   %.loc11_44: init f64 = call %MakeF64.ref()
-// CHECK:STDOUT:   %MakeI32.ref: <function> = name_ref MakeI32, file.%MakeI32, const = file.%MakeI32
+// CHECK:STDOUT:   %MakeI32.ref: <function> = name_ref MakeI32, file.%MakeI32 [template = file.%MakeI32]
 // CHECK:STDOUT:   %.loc11_60: init i32 = call %MakeI32.ref()
 // CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44, %.loc11_60)
 // CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60
@@ -47,7 +47,7 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT:   %.loc11_62.6: {.a: i32, .b: f64} = struct_value (%.loc11_62.3, %.loc11_62.5)
 // CHECK:STDOUT:   %.loc11_62.7: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.6
 // CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_62.7
-// CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32}, const
+// CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32} [template]
 // CHECK:STDOUT:   %x.ref: {.a: i32, .b: f64} = name_ref x, %x
 // CHECK:STDOUT:   %.loc12_31.1: f64 = struct_access %x.ref, element1
 // CHECK:STDOUT:   %.loc12_31.2: i32 = struct_access %x.ref, element0

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -10,22 +10,22 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT: --- tuple_as_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)}, const
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)} [template]
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_27.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%.loc7_27.2, const = constants.%.loc7_27.2
-// CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)}, const
+// CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%.loc7_27.2 [template = constants.%.loc7_27.2]
+// CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: (i32,)} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: (i32,)} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1, const = constants.%.loc7_38
-// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2, const = constants.%.loc7_47
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template = constants.%.loc7_38]
+// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2 [template = constants.%.loc7_47]
 // CHECK:STDOUT:   %.loc7_49.1: (i32,) = tuple_literal (%.loc7_47)
 // CHECK:STDOUT:   %.loc7_50.1: {.a: i32, .b: (i32,)} = struct_literal (%.loc7_38, %.loc7_49.1)
 // CHECK:STDOUT:   %.loc7_50.2: ref i32 = struct_access %x.var, element0
@@ -38,8 +38,8 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.6
 // CHECK:STDOUT:   assign %x.var, %.loc7_50.7
 // CHECK:STDOUT:   %.loc8_27: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_27.3: type = converted %.loc8_27, constants.%.loc7_27.2, const = constants.%.loc7_27.2
-// CHECK:STDOUT:   %.loc8_28: type = struct_type {.a: i32, .b: (i32,)}, const
+// CHECK:STDOUT:   %.loc7_27.3: type = converted %.loc8_27, constants.%.loc7_27.2 [template = constants.%.loc7_27.2]
+// CHECK:STDOUT:   %.loc8_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %y.var: ref {.a: i32, .b: (i32,)} = var y
 // CHECK:STDOUT:   %y: ref {.a: i32, .b: (i32,)} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: (i32,)} = name_ref x, %x

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -13,31 +13,31 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT: --- two_entries.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc7_44: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43), const
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc7_44: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template]
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32}, const
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1, const = constants.%.loc7_35
-// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2, const = constants.%.loc7_43
+// CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.loc7_35]
+// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template = constants.%.loc7_43]
 // CHECK:STDOUT:   %.loc7_44.1: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
-// CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43), const = constants.%.loc7_44
-// CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2, const = constants.%.loc7_44
+// CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.loc7_44]
+// CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.loc7_44]
 // CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_44.3
-// CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v
 // CHECK:STDOUT:   %w: {.a: i32, .b: i32} = bind_name w, %v.ref
-// CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1, const = constants.%.loc10_35
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2, const = constants.%.loc10_43
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.loc10_35]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2 [template = constants.%.loc10_43]
 // CHECK:STDOUT:   %.loc10_44.1: {.a: i32, .b: i32} = struct_literal (%.loc10_35, %.loc10_43)
 // CHECK:STDOUT:   %.loc10_44.2: ref i32 = struct_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_44.3: init i32 = initialize_from %.loc10_35 to %.loc10_44.2
@@ -46,7 +46,7 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc10_44.6: init {.a: i32, .b: i32} = struct_init (%.loc10_44.3, %.loc10_44.5) to %x.var
 // CHECK:STDOUT:   %.loc10_44.7: init {.a: i32, .b: i32} = converted %.loc10_44.1, %.loc10_44.6
 // CHECK:STDOUT:   assign %x.var, %.loc10_44.7
-// CHECK:STDOUT:   %.loc11_25: type = struct_type {.a: i32, .b: i32}, const
+// CHECK:STDOUT:   %.loc11_25: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %y.var: ref {.a: i32, .b: i32} = var y
 // CHECK:STDOUT:   %y: ref {.a: i32, .b: i32} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: i32} = name_ref x, %x

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -10,13 +10,13 @@ var y: () = x;
 // CHECK:STDOUT: --- empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7 [template = constants.%.loc7]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
@@ -24,7 +24,7 @@ var y: () = x;
 // CHECK:STDOUT:   %.loc7_14.3: init () = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
 // CHECK:STDOUT:   %.loc8_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7 [template = constants.%.loc7]
 // CHECK:STDOUT:   %y.var: ref () = var y
 // CHECK:STDOUT:   %y: ref () = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, %x

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -12,15 +12,15 @@ var x: (i32,) = ();
 // CHECK:STDOUT: --- fail_assign_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_13.1, constants.%.loc10_13.2, const = constants.%.loc10_13.2
+// CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_13.1, constants.%.loc10_13.2 [template = constants.%.loc10_13.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_18: () = tuple_literal ()

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -12,21 +12,21 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT: --- fail_assign_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type)), const
-// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32)), const
-// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*), const
-// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*), const
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3, const
-// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5, const
-// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6, const
-// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32)), const
+// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type)) [template]
+// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32)) [template]
+// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -34,18 +34,18 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
-// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_18, constants.%.loc10_31.2, const = constants.%.loc10_31.2
-// CHECK:STDOUT:   %.loc10_31.3: type = converted %.loc10_30, constants.%.loc10_31.2, const = constants.%.loc10_31.2
-// CHECK:STDOUT:   %.loc10_31.4: type = converted %.loc10_31.1, constants.%.loc10_31.3, const = constants.%.loc10_31.3
+// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_18, constants.%.loc10_31.2 [template = constants.%.loc10_31.2]
+// CHECK:STDOUT:   %.loc10_31.3: type = converted %.loc10_30, constants.%.loc10_31.2 [template = constants.%.loc10_31.2]
+// CHECK:STDOUT:   %.loc10_31.4: type = converted %.loc10_31.1, constants.%.loc10_31.3 [template = constants.%.loc10_31.3]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), (i32, i32)) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), (i32, i32)) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1, const = constants.%.loc10_37
-// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2, const = constants.%.loc10_40
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3, const = constants.%.loc10_43
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.loc10_37]
+// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2 [template = constants.%.loc10_40]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3 [template = constants.%.loc10_43]
 // CHECK:STDOUT:   %.loc10_44: (i32, i32, i32) = tuple_literal (%.loc10_37, %.loc10_40, %.loc10_43)
-// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4, const = constants.%.loc10_48
-// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5, const = constants.%.loc10_51
-// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6, const = constants.%.loc10_54
+// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4 [template = constants.%.loc10_48]
+// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5 [template = constants.%.loc10_51]
+// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6 [template = constants.%.loc10_54]
 // CHECK:STDOUT:   %.loc10_55: (i32, i32, i32) = tuple_literal (%.loc10_48, %.loc10_51, %.loc10_54)
 // CHECK:STDOUT:   %.loc10_56: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_44, %.loc10_55)
 // CHECK:STDOUT:   assign %x.var, <error>

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -12,17 +12,17 @@ var x: () = (66);
 // CHECK:STDOUT: --- fail_assign_to_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66, const
+// CHECK:STDOUT:   %.loc10_9: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9, const = constants.%.loc10_9
+// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9 [template = constants.%.loc10_9]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66, const = constants.%.loc10_14
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template = constants.%.loc10_14]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -12,22 +12,22 @@ var x: (i32, i32) = (2, 65.89);
 // CHECK:STDOUT: --- fail_element_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2, const
-// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64), const
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2 [template]
+// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2, const = constants.%.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2, const = constants.%.loc10_22
-// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2, const = constants.%.loc10_25
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.loc10_22]
+// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2 [template = constants.%.loc10_25]
 // CHECK:STDOUT:   %.loc10_30.1: (i32, f64) = tuple_literal (%.loc10_22, %.loc10_25)
 // CHECK:STDOUT:   %.loc10_30.2: ref i32 = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_30.3: init i32 = initialize_from %.loc10_22 to %.loc10_30.2

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -22,27 +22,27 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT: --- fail_nested_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete), const
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error>, const
+// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete) [template]
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Incomplete = %Incomplete.decl, .t = %t, .p = %p}
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
-// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete, const
-// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete, const = %Incomplete
+// CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
+// CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
 // CHECK:STDOUT:   %.loc15_24.1: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
-// CHECK:STDOUT:   %.loc15_24.2: type = converted %.loc15_24.1, constants.%.loc15_24.2, const = constants.%.loc15_24.2
+// CHECK:STDOUT:   %.loc15_24.2: type = converted %.loc15_24.1, constants.%.loc15_24.2 [template = constants.%.loc15_24.2]
 // CHECK:STDOUT:   %t.var: ref <error> = var t
 // CHECK:STDOUT:   %t: ref <error> = bind_name t, %t.var
-// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete, const = %Incomplete
-// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete, const
+// CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
+// CHECK:STDOUT:   %.loc20_18: type = ptr_type Incomplete [template]
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var p
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name p, %p.var
 // CHECK:STDOUT:   %t.ref: ref <error> = name_ref t, %t
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1, const = constants.%.loc20_25
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1 [template = constants.%.loc20_25]
 // CHECK:STDOUT:   %.loc20_22: <error>* = addr_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -12,20 +12,20 @@ var x: (i32, i32) = (2, );
 // CHECK:STDOUT: --- fail_too_few_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2, const
-// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32), const
+// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2, const = constants.%.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2, const = constants.%.loc10_22
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.loc10_22]
 // CHECK:STDOUT:   %.loc10_25: (i32,) = tuple_literal (%.loc10_22)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -12,14 +12,14 @@ var x: (i32, ) = (i32, );
 // CHECK:STDOUT: --- fail_type_assign.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32), const
+// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_14.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.2, const = constants.%.loc10_14.2
+// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.2 [template = constants.%.loc10_14.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_24: (type,) = tuple_literal (i32)

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -12,16 +12,16 @@ var x: (1, );
 // CHECK:STDOUT: --- fail_value_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>), const
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1, const = constants.%.loc10_9
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
 // CHECK:STDOUT:   %.loc10_12.1: (i32,) = tuple_literal (%.loc10_9)
-// CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, constants.%.loc10_12.2, const = constants.%.loc10_12.2
+// CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, constants.%.loc10_12.2 [template = constants.%.loc10_12.2]
 // CHECK:STDOUT:   %x.var: ref (<error>,) = var x
 // CHECK:STDOUT:   %x: ref (<error>,) = bind_name x, %x.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -9,30 +9,30 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT: --- nested_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type), const
-// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32), const
-// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32), const
-// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32), const
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12, const
-// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76, const
-// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6, const
+// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type) [template]
+// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32) [template]
+// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76 [template]
+// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18, i32)
-// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_18, constants.%.loc7_24.2, const = constants.%.loc7_24.2
-// CHECK:STDOUT:   %.loc7_24.3: type = converted %.loc7_24.1, constants.%.loc7_24.3, const = constants.%.loc7_24.3
+// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_18, constants.%.loc7_24.2 [template = constants.%.loc7_24.2]
+// CHECK:STDOUT:   %.loc7_24.3: type = converted %.loc7_24.1, constants.%.loc7_24.3 [template = constants.%.loc7_24.3]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), i32) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12, const = constants.%.loc7_30
-// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76, const = constants.%.loc7_34
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76 [template = constants.%.loc7_34]
 // CHECK:STDOUT:   %.loc7_36.1: (i32, i32) = tuple_literal (%.loc7_30, %.loc7_34)
-// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6, const = constants.%.loc7_39
+// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6 [template = constants.%.loc7_39]
 // CHECK:STDOUT:   %.loc7_40.1: ((i32, i32), i32) = tuple_literal (%.loc7_36.1, %.loc7_39)
 // CHECK:STDOUT:   %.loc7_40.2: ref (i32, i32) = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc7_36.2: ref i32 = tuple_access %.loc7_40.2, element0

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -17,26 +17,26 @@ fn H() {
 // CHECK:STDOUT: --- nested_tuple_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type), const
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32), const
-// CHECK:STDOUT:   %.loc10_43.1: type = tuple_type ((type, type, type), (type, type, type)), const
-// CHECK:STDOUT:   %.loc10_43.2: type = tuple_type ((i32, i32, i32), (i32, i32, i32)), const
-// CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*), const
-// CHECK:STDOUT:   %.loc10_43.4: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*), const
-// CHECK:STDOUT:   %.loc14_36.1: type = tuple_type (type, (type, type, type), type), const
-// CHECK:STDOUT:   %.loc14_36.2: type = tuple_type (i32, (i32, i32, i32), i32), const
-// CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32)*, i32), const
-// CHECK:STDOUT:   %.loc14_36.4: type = ptr_type (i32, (i32, i32, i32)*, i32), const
-// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2, const
+// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.loc10_43.1: type = tuple_type ((type, type, type), (type, type, type)) [template]
+// CHECK:STDOUT:   %.loc10_43.2: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
+// CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
+// CHECK:STDOUT:   %.loc10_43.4: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
+// CHECK:STDOUT:   %.loc14_36.1: type = tuple_type (type, (type, type, type), type) [template]
+// CHECK:STDOUT:   %.loc14_36.2: type = tuple_type (i32, (i32, i32, i32), i32) [template]
+// CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.loc14_36.4: type = ptr_type (i32, (i32, i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .G = %G, .H = %H}
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: (i32, i32, i32);
@@ -46,15 +46,15 @@ fn H() {
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_42: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_43.1: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
-// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_25, constants.%.loc7_25.2, const = constants.%.loc7_25.2
-// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_42, constants.%.loc7_25.2, const = constants.%.loc7_25.2
-// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_43.1, constants.%.loc10_43.2, const = constants.%.loc10_43.2
+// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_25, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_42, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_43.1, constants.%.loc10_43.2 [template = constants.%.loc10_43.2]
 // CHECK:STDOUT:   %v.var: ref ((i32, i32, i32), (i32, i32, i32)) = var v
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = bind_name v, %v.var
-// CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_56.1: ref (i32, i32, i32) = tuple_access %v.var, element0
 // CHECK:STDOUT:   %.loc10_49: init (i32, i32, i32) = call %F.ref.loc10_48() to %.loc10_56.1
-// CHECK:STDOUT:   %F.ref.loc10_53: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref.loc10_53: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_56.2: ref (i32, i32, i32) = tuple_access %v.var, element1
 // CHECK:STDOUT:   %.loc10_54: init (i32, i32, i32) = call %F.ref.loc10_53() to %.loc10_56.2
 // CHECK:STDOUT:   %.loc10_56.3: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_49, %.loc10_54)
@@ -68,15 +68,15 @@ fn H() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14_30: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc14_36.1: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
-// CHECK:STDOUT:   %.loc7: type = converted %.loc14_30, constants.%.loc7_25.2, const = constants.%.loc7_25.2
-// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_36.1, constants.%.loc14_36.2, const = constants.%.loc14_36.2
+// CHECK:STDOUT:   %.loc7: type = converted %.loc14_30, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_36.1, constants.%.loc14_36.2 [template = constants.%.loc14_36.2]
 // CHECK:STDOUT:   %v.var: ref (i32, (i32, i32, i32), i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1, const = constants.%.loc14_41
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template = constants.%.loc14_41]
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc14_50.1: ref (i32, i32, i32) = tuple_access %v.var, element1
 // CHECK:STDOUT:   %.loc14_45: init (i32, i32, i32) = call %F.ref() to %.loc14_50.1
-// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2, const = constants.%.loc14_49
+// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2 [template = constants.%.loc14_49]
 // CHECK:STDOUT:   %.loc14_50.2: (i32, (i32, i32, i32), i32) = tuple_literal (%.loc14_41, %.loc14_45, %.loc14_49)
 // CHECK:STDOUT:   %.loc14_50.3: ref i32 = tuple_access %v.var, element0
 // CHECK:STDOUT:   %.loc14_50.4: init i32 = initialize_from %.loc14_41 to %.loc14_50.3

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -10,24 +10,24 @@ var y: (i32,) = x;
 // CHECK:STDOUT: --- one_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type), const
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32), const
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4, const
+// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4, const = constants.%.loc7_18
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.loc7_18]
 // CHECK:STDOUT:   %.loc7_20.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to %x.var
 // CHECK:STDOUT:   %.loc7_20.3: init (i32,) = converted %.loc7_20.1, %.loc7_20.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_20.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2, const = constants.%.loc7_13.2
+// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
 // CHECK:STDOUT:   %y.var: ref (i32,) = var y
 // CHECK:STDOUT:   %y: ref (i32,) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -13,36 +13,36 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT: --- two_elements.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type), const
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32), const
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102, const
-// CHECK:STDOUT:   %.loc7_28: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25), const
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4, const
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102, const
+// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template]
+// CHECK:STDOUT:   %.loc7_28: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2, const = constants.%.loc7_17.2
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4, const = constants.%.loc7_22
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102, const = constants.%.loc7_25
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template = constants.%.loc7_22]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.loc7_25]
 // CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
-// CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25), const = constants.%.loc7_28
-// CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2, const = constants.%.loc7_28
+// CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.loc7_28]
+// CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.loc7_28]
 // CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3
 // CHECK:STDOUT:   %.loc8: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = converted %.loc8, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.3: type = converted %.loc8, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %w: (i32, i32) = bind_name w, %v.ref
 // CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = converted %.loc10_17, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.4: type = converted %.loc10_17, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4, const = constants.%.loc10_22
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102, const = constants.%.loc10_25
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template = constants.%.loc10_22]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102 [template = constants.%.loc10_25]
 // CHECK:STDOUT:   %.loc10_28.1: (i32, i32) = tuple_literal (%.loc10_22, %.loc10_25)
 // CHECK:STDOUT:   %.loc10_28.2: ref i32 = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_28.3: init i32 = initialize_from %.loc10_22 to %.loc10_28.2
@@ -52,7 +52,7 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc10_28.7: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6
 // CHECK:STDOUT:   assign %x.var, %.loc10_28.7
 // CHECK:STDOUT:   %.loc11_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.5: type = converted %.loc11_17, constants.%.loc7_17.2, const = constants.%.loc7_17.2
+// CHECK:STDOUT:   %.loc7_17.5: type = converted %.loc11_17, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
 // CHECK:STDOUT:   %y.var: ref (i32, i32) = var y
 // CHECK:STDOUT:   %y: ref (i32, i32) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32, i32) = name_ref x, %x

--- a/toolchain/check/testdata/var/decl.carbon
+++ b/toolchain/check/testdata/var/decl.carbon
@@ -12,7 +12,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/decl_with_init.carbon
@@ -11,19 +11,19 @@ fn Main() {
 // CHECK:STDOUT: --- decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %x.var, %.loc8
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/fail_duplicate_decl.carbon
@@ -19,24 +19,24 @@ fn Main() {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var.loc9: ref i32 = var x
 // CHECK:STDOUT:   %x.loc9: ref i32 = bind_name x, %x.var.loc9
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
 // CHECK:STDOUT:   assign %x.var.loc9, %.loc9
 // CHECK:STDOUT:   %x.var.loc16: ref i32 = var x
 // CHECK:STDOUT:   %x.loc16: ref i32 = bind_name x, %x.var.loc16
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0, const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template = constants.%.loc16]
 // CHECK:STDOUT:   assign %x.var.loc16, %.loc16
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_generic.carbon
+++ b/toolchain/check/testdata/var/fail_generic.carbon
@@ -25,7 +25,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
-// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var, sym
 // CHECK:STDOUT:   %.loc11: i32 = int_literal 0, const = constants.%.loc11
 // CHECK:STDOUT:   assign %x.var, %.loc11
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/var/fail_generic.carbon
+++ b/toolchain/check/testdata/var/fail_generic.carbon
@@ -14,19 +14,19 @@ fn Main() {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
-// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var, sym
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0, const = constants.%.loc11
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var [symbolic]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.loc11]
 // CHECK:STDOUT:   assign %x.var, %.loc11
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
@@ -14,19 +14,19 @@ fn Main() {
 // CHECK:STDOUT: --- fail_init_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1, const
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1, const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.loc11]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_init_with_self.carbon
+++ b/toolchain/check/testdata/var/fail_init_with_self.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
+++ b/toolchain/check/testdata/var/fail_lookup_outside_scope.carbon
@@ -17,7 +17,7 @@ var y: i32 = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main, .y = %y}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: <error> = name_ref x, <error>

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -25,18 +25,18 @@ fn F(x: X) {
 // CHECK:STDOUT: --- fail_not_copyable.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_1.1: type = struct_type {}, const
-// CHECK:STDOUT:   %.loc8_1.2: type = tuple_type (), const
-// CHECK:STDOUT:   %.loc7: type = ptr_type {}, const
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc16: String = string_literal "hello", const
+// CHECK:STDOUT:   %.loc8_1.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.loc8_1.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.X = %X.decl, .F = %F}
 // CHECK:STDOUT:   %X.decl = class_decl @X, ()
-// CHECK:STDOUT:   %X: type = class_type @X, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
+// CHECK:STDOUT:   %X: type = class_type @X [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @X {
@@ -48,9 +48,9 @@ fn F(x: X) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.var: ref String = var s
 // CHECK:STDOUT:   %s: ref String = bind_name s, %s.var
-// CHECK:STDOUT:   %.loc16: String = string_literal "hello", const = constants.%.loc16
+// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template = constants.%.loc16]
 // CHECK:STDOUT:   assign %s.var, <error>
-// CHECK:STDOUT:   %X.ref: type = name_ref X, file.%X, const = file.%X
+// CHECK:STDOUT:   %X.ref: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %y.var: ref X = var y
 // CHECK:STDOUT:   %y: ref X = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: X = name_ref x, %x

--- a/toolchain/check/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/check/testdata/var/fail_storage_is_literal.carbon
@@ -14,21 +14,21 @@ fn Main() {
 // CHECK:STDOUT: --- fail_storage_is_literal.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1, const
-// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1, const = constants.%.loc11_10
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1 [template = constants.%.loc11_10]
 // CHECK:STDOUT:   %x.var: ref <error> = var x
 // CHECK:STDOUT:   %x: ref <error> = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1, const = constants.%.loc11_14
+// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1 [template = constants.%.loc11_14]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/check/testdata/var/global_decl_with_init.carbon
@@ -9,14 +9,14 @@ var x: i32 = 0;
 // CHECK:STDOUT: --- global_decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/global_lookup.carbon
+++ b/toolchain/check/testdata/var/global_lookup.carbon
@@ -10,14 +10,14 @@ var y: i32 = x;
 // CHECK:STDOUT: --- global_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -13,16 +13,16 @@ fn Main() {
 // CHECK:STDOUT: --- global_lookup_in_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0, const = constants.%.loc7
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
 // CHECK:STDOUT:   assign %x.var, %.loc7
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {

--- a/toolchain/check/testdata/var/lookup.carbon
+++ b/toolchain/check/testdata/var/lookup.carbon
@@ -12,19 +12,19 @@ fn Main() {
 // CHECK:STDOUT: --- lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %x.var, %.loc8
 // CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/var/shadowing.carbon
+++ b/toolchain/check/testdata/var/shadowing.carbon
@@ -17,33 +17,33 @@ fn Main() {
 // CHECK:STDOUT: --- shadowing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc9: bool = bool_literal true, const
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0, const
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 1, const
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Main = %Main}
-// CHECK:STDOUT:   %Main: <function> = fn_decl @Main, const
+// CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var.loc8: ref i32 = var x
 // CHECK:STDOUT:   %x.loc8: ref i32 = bind_name x, %x.var.loc8
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0, const = constants.%.loc8
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
 // CHECK:STDOUT:   assign %x.var.loc8, %.loc8
-// CHECK:STDOUT:   %.loc9: bool = bool_literal true, const = constants.%.loc9
+// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template = constants.%.loc9]
 // CHECK:STDOUT:   if %.loc9 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %x.var.loc10: ref i32 = var x
 // CHECK:STDOUT:   %x.loc10: ref i32 = bind_name x, %x.var.loc10
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0, const = constants.%.loc10
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template = constants.%.loc10]
 // CHECK:STDOUT:   assign %x.var.loc10, %.loc10
 // CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x.loc10
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 1, const = constants.%.loc13
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template = constants.%.loc13]
 // CHECK:STDOUT:   assign %x.ref, %.loc13
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -30,15 +30,15 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %A, .B = %B, .C = %C, .D = %D, .E = %E, .F = %F, .G = %G, .H = %H, .While = %While}
-// CHECK:STDOUT:   %A: <function> = fn_decl @A, const
-// CHECK:STDOUT:   %B: <function> = fn_decl @B, const
-// CHECK:STDOUT:   %C: <function> = fn_decl @C, const
-// CHECK:STDOUT:   %D: <function> = fn_decl @D, const
-// CHECK:STDOUT:   %E: <function> = fn_decl @E, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %While: <function> = fn_decl @While, const
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template]
+// CHECK:STDOUT:   %B: <function> = fn_decl @B [template]
+// CHECK:STDOUT:   %C: <function> = fn_decl @C [template]
+// CHECK:STDOUT:   %D: <function> = fn_decl @D [template]
+// CHECK:STDOUT:   %E: <function> = fn_decl @E [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %While: <function> = fn_decl @While [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> bool;
@@ -62,14 +62,14 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc17:
-// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A, const = file.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc17_11: init bool = call %A.ref()
 // CHECK:STDOUT:   %.loc17_13.1: bool = value_of_initializer %.loc17_11
 // CHECK:STDOUT:   %.loc17_13.2: bool = converted %.loc17_11, %.loc17_13.1
 // CHECK:STDOUT:   if %.loc17_13.2 br !while.body.loc17 else br !while.done.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc17:
-// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B, const = file.%B
+// CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
 // CHECK:STDOUT:   %.loc18_10: init bool = call %B.ref()
 // CHECK:STDOUT:   %.loc18_12.1: bool = value_of_initializer %.loc18_10
 // CHECK:STDOUT:   %.loc18_12.2: bool = converted %.loc18_10, %.loc18_12.1
@@ -79,7 +79,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc18:
-// CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C, const = file.%C
+// CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc19_10: init bool = call %C.ref()
 // CHECK:STDOUT:   %.loc19_12.1: bool = value_of_initializer %.loc19_10
 // CHECK:STDOUT:   %.loc19_12.2: bool = converted %.loc19_10, %.loc19_12.1
@@ -92,14 +92,14 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc20:
-// CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D, const = file.%D
+// CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
 // CHECK:STDOUT:   %.loc20_13: init bool = call %D.ref()
 // CHECK:STDOUT:   %.loc20_15.1: bool = value_of_initializer %.loc20_13
 // CHECK:STDOUT:   %.loc20_15.2: bool = converted %.loc20_13, %.loc20_15.1
 // CHECK:STDOUT:   if %.loc20_15.2 br !while.body.loc20 else br !while.done.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc20:
-// CHECK:STDOUT:   %E.ref: <function> = name_ref E, file.%E, const = file.%E
+// CHECK:STDOUT:   %E.ref: <function> = name_ref E, file.%E [template = file.%E]
 // CHECK:STDOUT:   %.loc21_12: init bool = call %E.ref()
 // CHECK:STDOUT:   %.loc21_14.1: bool = value_of_initializer %.loc21_12
 // CHECK:STDOUT:   %.loc21_14.2: bool = converted %.loc21_12, %.loc21_14.1
@@ -109,7 +109,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc21:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc22_12: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc22_14.1: bool = value_of_initializer %.loc22_12
 // CHECK:STDOUT:   %.loc22_14.2: bool = converted %.loc22_12, %.loc22_14.1
@@ -122,7 +122,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done.loc20:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc24_10: init bool = call %G.ref()
 // CHECK:STDOUT:   %.loc24_12.1: bool = value_of_initializer %.loc24_10
 // CHECK:STDOUT:   %.loc24_12.2: bool = converted %.loc24_10, %.loc24_12.1
@@ -132,7 +132,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc24:
-// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H, const = file.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
 // CHECK:STDOUT:   %.loc25_10: init bool = call %H.ref()
 // CHECK:STDOUT:   %.loc25_12.1: bool = value_of_initializer %.loc25_10
 // CHECK:STDOUT:   %.loc25_12.2: bool = converted %.loc25_10, %.loc25_12.1

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -14,13 +14,13 @@ fn While() {
 // CHECK:STDOUT: --- fail_bad_condition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.1: type = ptr_type String, const
-// CHECK:STDOUT:   %.loc11: String = string_literal "Hello", const
+// CHECK:STDOUT:   %.1: type = ptr_type String [template]
+// CHECK:STDOUT:   %.loc11: String = string_literal "Hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.While = %While}
-// CHECK:STDOUT:   %While: <function> = fn_decl @While, const
+// CHECK:STDOUT:   %While: <function> = fn_decl @While [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
@@ -28,7 +28,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %.loc11: String = string_literal "Hello", const = constants.%.loc11
+// CHECK:STDOUT:   %.loc11: String = string_literal "Hello" [template = constants.%.loc11]
 // CHECK:STDOUT:   if <error> br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:

--- a/toolchain/check/testdata/while/fail_break_continue.carbon
+++ b/toolchain/check/testdata/while/fail_break_continue.carbon
@@ -30,12 +30,12 @@ fn While() {
 // CHECK:STDOUT: --- fail_break_continue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: bool = bool_literal false, const
+// CHECK:STDOUT:   %.loc16: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.While = %While}
-// CHECK:STDOUT:   %While: <function> = fn_decl @While, const
+// CHECK:STDOUT:   %While: <function> = fn_decl @While [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -22,16 +22,16 @@ fn While() {
 // CHECK:STDOUT: --- unreachable_end.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Cond = %Cond, .F = %F, .G = %G, .H = %H, .While = %While}
-// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %While: <function> = fn_decl @While, const
+// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %While: <function> = fn_decl @While [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
@@ -44,24 +44,24 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc14: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond, const = file.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
 // CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
 // CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
 // CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
 // CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc16: init () = call %G.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H, const = file.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
 // CHECK:STDOUT:   %.loc19: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -21,16 +21,16 @@ fn While() {
 // CHECK:STDOUT: --- while.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type (), const
+// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Cond = %Cond, .F = %F, .G = %G, .H = %H, .While = %While}
-// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond, const
-// CHECK:STDOUT:   %F: <function> = fn_decl @F, const
-// CHECK:STDOUT:   %G: <function> = fn_decl @G, const
-// CHECK:STDOUT:   %H: <function> = fn_decl @H, const
-// CHECK:STDOUT:   %While: <function> = fn_decl @While, const
+// CHECK:STDOUT:   %Cond: <function> = fn_decl @Cond [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
+// CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
+// CHECK:STDOUT:   %H: <function> = fn_decl @H [template]
+// CHECK:STDOUT:   %While: <function> = fn_decl @While [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Cond() -> bool;
@@ -43,24 +43,24 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @While() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F, const = file.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc14: init () = call %F.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond, const = file.%Cond
+// CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
 // CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
 // CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
 // CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
 // CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
-// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G, const = file.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc16: init () = call %G.ref()
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done:
-// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H, const = file.%H
+// CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
 // CHECK:STDOUT:   %.loc18: init () = call %H.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -769,11 +769,11 @@ class Formatter {
     out_ << InstT::Kind.ir_name();
     FormatInstructionRHS(inst);
     if (auto const_id = sem_ir_.constant_values().Get(inst_id);
-        const_id.is_valid()) {
-      out_ << ", const";
-      if (const_id != inst_id) {
+        const_id.is_constant()) {
+      out_ << (const_id.is_symbolic() ? ", sym" : ", const");
+      if (const_id.inst_id() != inst_id) {
         out_ << " = ";
-        FormatInstName(const_id);
+        FormatInstName(const_id.inst_id());
       }
     }
     out_ << "\n";

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -770,11 +770,12 @@ class Formatter {
     FormatInstructionRHS(inst);
     if (auto const_id = sem_ir_.constant_values().Get(inst_id);
         const_id.is_constant()) {
-      out_ << (const_id.is_symbolic() ? ", sym" : ", const");
+      out_ << (const_id.is_symbolic() ? " [symbolic" : " [template");
       if (const_id.inst_id() != inst_id) {
         out_ << " = ";
         FormatInstName(const_id.inst_id());
       }
+      out_ << "]";
     }
     out_ << "\n";
   }

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -112,9 +112,9 @@ struct ConstantId : public IdBase, public Printable<ConstantId> {
 
   auto Print(llvm::raw_ostream& out) const -> void {
     if (is_template()) {
-      out << "!" << inst_id();
+      out << "const " << inst_id();
     } else if (is_symbolic()) {
-      out << "!!" << inst_id();
+      out << "sym " << inst_id();
     } else {
       out << "nonconst";
     }

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -112,11 +112,11 @@ struct ConstantId : public IdBase, public Printable<ConstantId> {
 
   auto Print(llvm::raw_ostream& out) const -> void {
     if (is_template()) {
-      out << "const " << inst_id();
+      out << "template " << inst_id();
     } else if (is_symbolic()) {
-      out << "sym " << inst_id();
+      out << "symbolic " << inst_id();
     } else {
-      out << "nonconst";
+      out << "runtime";
     }
   }
 

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -57,21 +57,21 @@ class InstStore {
 // instructions.
 class ConstantValueStore : public Yaml::Printable<ConstantValueStore> {
  public:
-  // Returns the constant value of the requested instruction, or InstId::Invalid
-  // if it is not constant.
-  auto Get(InstId inst_id) const -> InstId {
+  // Returns the constant value of the requested instruction, or
+  // `ConstantId::NotConstant` if it is not constant.
+  auto Get(InstId inst_id) const -> ConstantId {
     CARBON_CHECK(inst_id.index >= 0);
     return static_cast<size_t>(inst_id.index) >= values_.size()
-               ? InstId::Invalid
+               ? ConstantId::NotConstant
                : values_[inst_id.index];
   }
 
   // Sets the constant value of the given instruction.
-  auto Set(InstId inst_id, InstId const_id) -> void {
+  auto Set(InstId inst_id, ConstantId const_id) -> void {
     CARBON_CHECK(inst_id.index >= 0);
-    CARBON_CHECK(const_id.is_valid());
+    CARBON_CHECK(const_id.is_constant());
     if (static_cast<size_t>(inst_id.index) >= values_.size()) {
-      values_.resize(inst_id.index + 1, InstId::Invalid);
+      values_.resize(inst_id.index + 1, ConstantId::NotConstant);
     }
     values_[inst_id.index] = const_id;
   }
@@ -81,7 +81,7 @@ class ConstantValueStore : public Yaml::Printable<ConstantValueStore> {
   auto OutputYaml() const -> Yaml::OutputMapping {
     return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
       for (auto [id, value] : llvm::enumerate(values_)) {
-        if (value.is_valid()) {
+        if (value.is_constant()) {
           map.Add(PrintToString(InstId(id)), Yaml::OutputScalar(value));
         }
       }
@@ -95,7 +95,7 @@ class ConstantValueStore : public Yaml::Printable<ConstantValueStore> {
   //
   // Set inline size to 0 because these will typically be too large for the
   // stack, while this does make File smaller.
-  llvm::SmallVector<InstId, 0> values_;
+  llvm::SmallVector<ConstantId, 0> values_;
 };
 
 // Provides storage for instructions representing global constants.

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -42,7 +42,8 @@ TEST(SemIRTest, YAML) {
   // cross-references, so this code is only doing loose structural checks.
   auto int_id = Yaml::Scalar(MatchesRegex(R"(int\d+)"));
   auto inst_id = Yaml::Scalar(MatchesRegex(R"(inst\+\d+)"));
-  auto constant_id = Yaml::Scalar(MatchesRegex(R"((const|sym) inst\+\d+)"));
+  auto constant_id =
+      Yaml::Scalar(MatchesRegex(R"((template|symbolic) inst\+\d+)"));
   auto inst_builtin = Yaml::Scalar(MatchesRegex(R"(inst\w+)"));
   auto type_id = Yaml::Scalar(MatchesRegex(R"(type\d+)"));
   auto type_builtin = Pair(

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -42,6 +42,7 @@ TEST(SemIRTest, YAML) {
   // cross-references, so this code is only doing loose structural checks.
   auto int_id = Yaml::Scalar(MatchesRegex(R"(int\d+)"));
   auto inst_id = Yaml::Scalar(MatchesRegex(R"(inst\+\d+)"));
+  auto constant_id = Yaml::Scalar(MatchesRegex(R"((const|sym) inst\+\d+)"));
   auto inst_builtin = Yaml::Scalar(MatchesRegex(R"(inst\w+)"));
   auto type_id = Yaml::Scalar(MatchesRegex(R"(type\d+)"));
   auto type_builtin = Pair(
@@ -75,7 +76,7 @@ TEST(SemIRTest, YAML) {
                                                 Pair("arg0", inst_id),
                                                 Pair("arg1", inst_id)))))))),
       Pair("constant_values",
-           Yaml::Mapping(AllOf(Each(Pair(inst_id, inst_id))))),
+           Yaml::Mapping(AllOf(Each(Pair(inst_id, constant_id))))),
       // This production has only two instruction blocks.
       Pair("inst_blocks",
            Yaml::Mapping(ElementsAre(


### PR DESCRIPTION
This is accomplished by tracking an extra bit on the ID we store in the constant values table, and propagating that from subexpressions to the enclosing expression. This extra bit is not yet computed correctly for types; that will be addressed in later PRs.