### PR TITLE
Add TODOs for implicit params to class and interface.

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -26,6 +26,9 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId parse_node)
   if (context.node_stack().PopIf<Parse::NodeKind::TuplePattern>()) {
     context.TODO(parse_node, "generic class");
   }
+  if (context.node_stack().PopIf<Parse::NodeKind::ImplicitParamList>()) {
+    context.TODO(parse_node, "generic class");
+  }
 
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -27,6 +27,9 @@ static auto BuildInterfaceDecl(Context& context,
   if (context.node_stack().PopIf<Parse::NodeKind::TuplePattern>()) {
     context.TODO(parse_node, "generic interface");
   }
+  if (context.node_stack().PopIf<Parse::NodeKind::ImplicitParamList>()) {
+    context.TODO(parse_node, "generic interface");
+  }
 
   auto name_context = context.decl_name_stack().FinishName();
   context.node_stack()

--- a/toolchain/check/testdata/class/fail_todo_generic.carbon
+++ b/toolchain/check/testdata/class/fail_todo_generic.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+6]]:1: ERROR: Semantics TODO: `generic class`.
+// CHECK:STDERR: class C[]();
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic class`.
+// CHECK:STDERR: class C[]();
+// CHECK:STDERR: ^~~~~~~~~~~~
+class C[]();
+
+// CHECK:STDOUT: --- fail_todo_generic.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace package, {.C = %C.decl}
+// CHECK:STDOUT:   %C.decl = class_decl @C, ()
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C;
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_generic.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_generic.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+6]]:1: ERROR: Semantics TODO: `generic interface`.
+// CHECK:STDERR: interface I[]();
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic interface`.
+// CHECK:STDERR: interface I[]();
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
+interface I[]();
+
+// CHECK:STDOUT: --- fail_todo_generic.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace package, {.I = %I.decl}
+// CHECK:STDOUT:   %I.decl = interface_decl @I, ()
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I;
+// CHECK:STDOUT:


### PR DESCRIPTION
Without these, the code crashes.