### PR TITLE
Remove parse nodes from constants.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -61,8 +61,7 @@ class Context {
   auto AddInst(SemIR::ParseNodeAndInst parse_node_and_inst) -> SemIR::InstId;
 
   // Adds an instruction to the constants block, returning the produced ID.
-  auto AddConstant(SemIR::ParseNodeAndInst parse_node_and_inst,
-                   bool is_symbolic) -> SemIR::ConstantId;
+  auto AddConstant(SemIR::Inst inst, bool is_symbolic) -> SemIR::ConstantId;
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
   // result.
@@ -237,13 +236,11 @@ class Context {
   // Individual struct type fields aren't canonicalized because they may have
   // name conflicts or other diagnostics during creation, which can use the
   // parse node.
-  auto CanonicalizeStructType(Parse::NodeId parse_node,
-                              SemIR::InstBlockId refs_id) -> SemIR::TypeId;
+  auto CanonicalizeStructType(SemIR::InstBlockId refs_id) -> SemIR::TypeId;
 
   // Handles canonicalization of tuple types. This may create a new tuple type
   // if the `type_ids` doesn't match an existing tuple type.
-  auto CanonicalizeTupleType(Parse::NodeId parse_node,
-                             llvm::ArrayRef<SemIR::TypeId> type_ids)
+  auto CanonicalizeTupleType(llvm::ArrayRef<SemIR::TypeId> type_ids)
       -> SemIR::TypeId;
 
   // Attempts to complete the type `type_id`. Returns `true` if the type is
@@ -272,8 +269,7 @@ class Context {
   auto GetBuiltinType(SemIR::BuiltinKind kind) -> SemIR::TypeId;
 
   // Returns a pointer type whose pointee type is `pointee_type_id`.
-  auto GetPointerType(Parse::NodeId parse_node, SemIR::TypeId pointee_type_id)
-      -> SemIR::TypeId;
+  auto GetPointerType(SemIR::TypeId pointee_type_id) -> SemIR::TypeId;
 
   // Removes any top-level `const` qualifiers from a type.
   auto GetUnqualifiedType(SemIR::TypeId type_id) -> SemIR::TypeId;
@@ -459,8 +455,7 @@ class Context {
 
   // Forms a canonical type ID for a type. If the type is new, adds the
   // instruction to the current block.
-  auto CanonicalizeTypeAndAddInstIfNew(Parse::NodeId parse_node,
-                                       SemIR::Inst inst) -> SemIR::TypeId;
+  auto CanonicalizeTypeAndAddInstIfNew(SemIR::Inst inst) -> SemIR::TypeId;
 
   // If the passed in instruction ID is a LazyImportRef, resolves it for use.
   // Called when name lookup intends to return an inst_id.

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -821,7 +821,7 @@ static auto PerformBuiltinConversion(Context& context, Parse::NodeId parse_node,
         // iterative approach.
         type_ids.push_back(ExprAsType(context, parse_node, tuple_inst_id));
       }
-      auto tuple_type_id = context.CanonicalizeTupleType(parse_node, type_ids);
+      auto tuple_type_id = context.CanonicalizeTupleType(type_ids);
       return sem_ir.types().GetInstId(tuple_type_id);
     }
 
@@ -1124,9 +1124,8 @@ static auto ConvertSelf(Context& context, Parse::NodeId call_parse_node,
     }
     auto parse_node = context.insts().GetParseNode(self_or_addr_id);
     self_or_addr_id = context.AddInst(
-        {parse_node,
-         SemIR::AddrOf{context.GetPointerType(parse_node, self.type_id()),
-                       self_or_addr_id}});
+        {parse_node, SemIR::AddrOf{context.GetPointerType(self.type_id()),
+                                   self_or_addr_id}});
   }
 
   return ConvertToValueOfType(context, call_parse_node, self_or_addr_id,

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -945,7 +945,7 @@ auto Convert(Context& context, Parse::NodeId parse_node, SemIR::InstId expr_id,
   // Track that we performed a type conversion, if we did so.
   if (orig_expr_id != expr_id) {
     expr_id = context.AddInst(
-        {context.insts().GetParseNode(expr_id),
+        {context.insts().GetParseNode(orig_expr_id),
          SemIR::Converted{target.type_id, orig_expr_id, expr_id}});
   }
 

--- a/toolchain/check/handle_call_expr.cpp
+++ b/toolchain/check/handle_call_expr.cpp
@@ -73,7 +73,7 @@ auto HandleCallExpr(Context& context, Parse::CallExprId parse_node) -> bool {
   // tuple type.
   SemIR::TypeId type_id = callable.return_type_id;
   if (!type_id.is_valid()) {
-    type_id = context.CanonicalizeTupleType(call_expr_parse_node, {});
+    type_id = context.CanonicalizeTupleType({});
   }
 
   // If there is a return slot, build storage for the result.

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -326,7 +326,7 @@ auto HandleBaseDecl(Context& context, Parse::BaseDeclId parse_node) -> bool {
 }
 
 auto HandleClassDefinition(Context& context,
-                           Parse::ClassDefinitionId parse_node) -> bool {
+                           Parse::ClassDefinitionId /*parse_node*/) -> bool {
   auto fields_id = context.args_type_info_stack().Pop();
   auto class_id =
       context.node_stack().Pop<Parse::NodeKind::ClassDefinitionStart>();
@@ -336,8 +336,7 @@ auto HandleClassDefinition(Context& context,
 
   // The class type is now fully defined.
   auto& class_info = context.classes().Get(class_id);
-  class_info.object_repr_id =
-      context.CanonicalizeStructType(parse_node, fields_id);
+  class_info.object_repr_id = context.CanonicalizeStructType(fields_id);
   return true;
 }
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -189,7 +189,7 @@ static auto BuildFunctionDecl(Context& context,
         (return_slot_id.is_valid() &&
          return_type_id !=
              context.GetBuiltinType(SemIR::BuiltinKind::BoolType) &&
-         return_type_id != context.CanonicalizeTupleType(parse_node, {}))) {
+         return_type_id != context.CanonicalizeTupleType({}))) {
       CARBON_DIAGNOSTIC(InvalidMainRunSignature, Error,
                         "Invalid signature for `Main.Run` function. Expected "
                         "`fn ()` or `fn () -> i32`.");

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -223,10 +223,9 @@ auto HandlePrefixOperatorAmp(Context& context,
       break;
   }
   context.AddInstAndPush(
-      {parse_node,
-       SemIR::AddrOf{context.GetPointerType(
-                         parse_node, context.insts().Get(value_id).type_id()),
-                     value_id}});
+      {parse_node, SemIR::AddrOf{context.GetPointerType(
+                                     context.insts().Get(value_id).type_id()),
+                                 value_id}});
   return true;
 }
 

--- a/toolchain/check/handle_paren.cpp
+++ b/toolchain/check/handle_paren.cpp
@@ -43,7 +43,7 @@ auto HandleTupleLiteral(Context& context, Parse::TupleLiteralId parse_node)
   for (auto inst : inst_block) {
     type_ids.push_back(context.insts().Get(inst).type_id());
   }
-  auto type_id = context.CanonicalizeTupleType(parse_node, type_ids);
+  auto type_id = context.CanonicalizeTupleType(type_ids);
 
   auto value_id =
       context.AddInst({parse_node, SemIR::TupleLiteral{type_id, refs_id}});

--- a/toolchain/check/handle_struct.cpp
+++ b/toolchain/check/handle_struct.cpp
@@ -105,7 +105,7 @@ auto HandleStructLiteral(Context& context, Parse::StructLiteralId parse_node)
     return true;
   }
 
-  auto type_id = context.CanonicalizeStructType(parse_node, type_block_id);
+  auto type_id = context.CanonicalizeStructType(type_block_id);
 
   auto value_id =
       context.AddInst({parse_node, SemIR::StructLiteral{type_id, refs_id}});

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -32,9 +32,9 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_25.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template = constants.%.4]
-// CHECK:STDOUT:   %.1: type = converted %.loc10_25, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_25.2: type = converted %.loc10_25.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32) [template = constants.%.5]
 // CHECK:STDOUT:   %v.var: ref [(i32, i32, i32); 2] = var v
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = bind_name v, %v.var

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -13,13 +13,13 @@ fn G() {
 // CHECK:STDOUT: --- array_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_29.1: type = array_type %.loc10_28, (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_29.2: type = ptr_type [(i32, i32, i32); 2] [template]
-// CHECK:STDOUT:   %.loc10_42: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: type = array_type %.4, (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.6: type = ptr_type [(i32, i32, i32); 2] [template]
+// CHECK:STDOUT:   %.7: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,9 +33,9 @@ fn G() {
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template = constants.%.loc10_28]
-// CHECK:STDOUT:   %.loc7: type = converted %.loc10_25, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
-// CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32) [template = constants.%.loc10_29.1]
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 2 [template = constants.%.4]
+// CHECK:STDOUT:   %.1: type = converted %.loc10_25, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_29: type = array_type %.loc10_28, (i32, i32, i32) [template = constants.%.5]
 // CHECK:STDOUT:   %v.var: ref [(i32, i32, i32); 2] = var v
 // CHECK:STDOUT:   %v: ref [(i32, i32, i32); 2] = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10_34: <function> = name_ref F, file.%F [template = file.%F]

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -13,13 +13,13 @@ fn Run() {
 // CHECK:STDOUT: --- assign_return_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28) [template]
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_17.1: type = array_type %.loc10_16, i32 [template]
-// CHECK:STDOUT:   %.loc10_17.2: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: type = array_type %.5, i32 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,17 +30,17 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.loc7_28]
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.loc7_30]
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
 // CHECK:STDOUT:   return %.loc7_30.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.loc10_16]
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.loc10_17.1]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.6]
 // CHECK:STDOUT:   %t.var: ref [i32; 1] = var t
 // CHECK:STDOUT:   %t: ref [i32; 1] = bind_name t, %t.var
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -10,26 +10,26 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT: --- assign_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_22.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc7_22.2: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22.3: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, i32 [template]
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.8: type = array_type %.7, i32 [template]
+// CHECK:STDOUT:   %.9: type = ptr_type [i32; 3] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_22.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_22.2: type = converted %.loc7_22.1, constants.%.loc7_22.2 [template = constants.%.loc7_22.2]
+// CHECK:STDOUT:   %.loc7_22: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_22, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template = constants.%.loc7_27]
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2 [template = constants.%.loc7_30]
-// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3 [template = constants.%.loc7_33]
+// CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_33: i32 = int_literal 3 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_34.1: (i32, i32, i32) = tuple_literal (%.loc7_27, %.loc7_30, %.loc7_33)
 // CHECK:STDOUT:   %.loc7_34.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_34.3: init i32 = initialize_from %.loc7_27 to %.loc7_34.2
@@ -40,8 +40,8 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7) to %a.var
 // CHECK:STDOUT:   %.loc7_34.9: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8
 // CHECK:STDOUT:   assign %a.var, %.loc7_34.9
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template = constants.%.loc8_14]
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32 [template = constants.%.loc8_15.1]
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32 [template = constants.%.8]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32, i32) = name_ref a, %a

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -23,8 +23,8 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_22: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_22, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_22.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc7_22.2: type = converted %.loc7_22.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_27: i32 = int_literal 1 [template = constants.%.4]

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -11,31 +11,31 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT: --- base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_22: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc8_15.1: type = array_type %.loc8_14, f64 [template]
-// CHECK:STDOUT:   %.loc8_15.2: type = ptr_type [f64; 2] [template]
-// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template]
-// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template]
-// CHECK:STDOUT:   %.loc8_30: type = tuple_type (f64, f64) [template]
-// CHECK:STDOUT:   %.loc9_10: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc9_14.1: type = array_type %.loc9_13, () [template]
-// CHECK:STDOUT:   %.loc9_14.2: type = ptr_type [(); 5] [template]
-// CHECK:STDOUT:   %.loc9_38: type = tuple_type ((), (), (), (), ()) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.7: type = array_type %.6, f64 [template]
+// CHECK:STDOUT:   %.8: type = ptr_type [f64; 2] [template]
+// CHECK:STDOUT:   %.9: f64 = real_literal 111e-1 [template]
+// CHECK:STDOUT:   %.10: f64 = real_literal 22e-1 [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (f64, f64) [template]
+// CHECK:STDOUT:   %.12: type = tuple_type () [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.14: type = array_type %.13, () [template]
+// CHECK:STDOUT:   %.15: type = ptr_type [(); 5] [template]
+// CHECK:STDOUT:   %.16: type = tuple_type ((), (), (), (), ()) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_22.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_22.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_22.3: ref i32 = array_index %a.var, %.loc7_22.2
@@ -43,12 +43,12 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init (%.loc7_22.4) to %a.var
 // CHECK:STDOUT:   %.loc7_22.6: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5
 // CHECK:STDOUT:   assign %a.var, %.loc7_22.6
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template = constants.%.loc8_14]
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64 [template = constants.%.loc8_15.1]
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64 [template = constants.%.7]
 // CHECK:STDOUT:   %b.var: ref [f64; 2] = var b
 // CHECK:STDOUT:   %b: ref [f64; 2] = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template = constants.%.loc8_20]
-// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template = constants.%.loc8_26]
+// CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc8_30.1: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
 // CHECK:STDOUT:   %.loc8_30.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc8_30.3: ref f64 = array_index %b.var, %.loc8_30.2
@@ -59,10 +59,10 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init (%.loc8_30.4, %.loc8_30.7) to %b.var
 // CHECK:STDOUT:   %.loc8_30.9: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8
 // CHECK:STDOUT:   assign %b.var, %.loc8_30.9
-// CHECK:STDOUT:   %.loc9_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.loc9_13]
-// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.loc9_10 [template = constants.%.loc9_10]
-// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.loc9_14.1]
+// CHECK:STDOUT:   %.loc9_10: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.13]
+// CHECK:STDOUT:   %.2: type = converted %.loc9_10, constants.%.12 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.14]
 // CHECK:STDOUT:   %c.var: ref [(); 5] = var c
 // CHECK:STDOUT:   %c: ref [(); 5] = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc9_20.1: () = tuple_literal ()

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -59,9 +59,9 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init (%.loc8_30.4, %.loc8_30.7) to %b.var
 // CHECK:STDOUT:   %.loc8_30.9: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8
 // CHECK:STDOUT:   assign %b.var, %.loc8_30.9
-// CHECK:STDOUT:   %.loc9_10: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc9_10.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.13]
-// CHECK:STDOUT:   %.2: type = converted %.loc9_10, constants.%.12 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.12 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.14]
 // CHECK:STDOUT:   %c.var: ref [(); 5] = var c
 // CHECK:STDOUT:   %c: ref [(); 5] = bind_name c, %c.var

--- a/toolchain/check/testdata/array/fail_bound_overflow.carbon
+++ b/toolchain/check/testdata/array/fail_bound_overflow.carbon
@@ -12,14 +12,14 @@ var a: [1; 39999999999999999993];
 // CHECK:STDOUT: --- fail_bound_overflow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 39999999999999999993 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993 [template = constants.%.loc10_12]
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 39999999999999999993 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_incomplete_element.carbon
+++ b/toolchain/check/testdata/array/fail_incomplete_element.carbon
@@ -22,10 +22,10 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT: --- fail_incomplete_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete [template]
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error> [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, Incomplete [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,8 +33,8 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1 [template = constants.%.loc15_21]
-// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete [template = constants.%.loc15_22]
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc15_22: type = array_type %.loc15_21, Incomplete [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
 // CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
@@ -42,7 +42,7 @@ var p: Incomplete* = &a[0];
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var p
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name p, %p.var
 // CHECK:STDOUT:   %a.ref: ref <error> = name_ref a, %a
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0 [template = constants.%.loc20_25]
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc20_22: <error>* = addr_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_invalid_type.carbon
+++ b/toolchain/check/testdata/array/fail_invalid_type.carbon
@@ -12,17 +12,17 @@ var a: [1; 1];
 // CHECK:STDOUT: --- fail_invalid_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_13.1: type = array_type %.loc10_12, <error> [template]
-// CHECK:STDOUT:   %.loc10_13.2: type = ptr_type [<error>; 1] [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: type = array_type %.2, <error> [template]
+// CHECK:STDOUT:   %.4: type = ptr_type [<error>; 1] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
-// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1 [template = constants.%.loc10_12]
-// CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error> [template = constants.%.loc10_13.1]
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_12: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_13: type = array_type %.loc10_12, <error> [template = constants.%.3]
 // CHECK:STDOUT:   %a.var: ref [<error>; 1] = var a
 // CHECK:STDOUT:   %a: ref [<error>; 1] = bind_name a, %a.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_out_of_bound.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound.carbon
@@ -12,24 +12,24 @@ var a: [i32; 1] = (1, 2, 3);
 // CHECK:STDOUT: --- fail_out_of_bound.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32 [template]
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_27: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
-// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.loc10_15.1]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
-// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2 [template = constants.%.loc10_23]
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3 [template = constants.%.loc10_26]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_23: i32 = int_literal 2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 3 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc10_27: (i32, i32, i32) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_26)
 // CHECK:STDOUT:   assign %a.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -29,50 +29,50 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_15.1: type = array_type %.loc10_14, i32 [template]
-// CHECK:STDOUT:   %.loc10_15.2: type = ptr_type [i32; 3] [template]
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template]
-// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template]
-// CHECK:STDOUT:   %.loc10_39.1: type = tuple_type (i32, String, String) [template]
-// CHECK:STDOUT:   %.loc12: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc10_39.2: type = tuple_type (i32, String*, String*) [template]
-// CHECK:STDOUT:   %.loc10_39.3: type = ptr_type (i32, String*, String*) [template]
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template]
-// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template]
-// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc21_24.1: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc23: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc21_24.2: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: type = ptr_type String [template]
+// CHECK:STDOUT:   %.6: String = string_literal "Hello" [template]
+// CHECK:STDOUT:   %.7: String = string_literal "World" [template]
+// CHECK:STDOUT:   %.8: type = tuple_type (i32, String, String) [template]
+// CHECK:STDOUT:   %.9: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.10: type = tuple_type (i32, String*, String*) [template]
+// CHECK:STDOUT:   %.11: type = ptr_type (i32, String*, String*) [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.13: type = array_type %.12, i32 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.15: type = array_type %.14, i32 [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.18: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.19: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.20: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.21: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.22: type = array_type %.21, i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .t1 = %t1, .b = %b, .c = %c, .t2 = %t2, .d = %d}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template = constants.%.loc10_14]
-// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.loc10_15.1]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
-// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template = constants.%.loc10_23]
-// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template = constants.%.loc10_32]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template = constants.%.7]
 // CHECK:STDOUT:   %.loc10_39.1: (i32, String, String) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_32)
 // CHECK:STDOUT:   %.loc10_39.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_39.3: ref i32 = array_index %a.var, %.loc10_39.2
 // CHECK:STDOUT:   %.loc10_39.4: init i32 = initialize_from %.loc10_20 to %.loc10_39.3
 // CHECK:STDOUT:   assign %a.var, <error>
 // CHECK:STDOUT:   %.loc12: (type, type, type) = tuple_literal (i32, String, String)
-// CHECK:STDOUT:   %.loc10_39.5: type = converted %.loc12, constants.%.loc10_39.1 [template = constants.%.loc10_39.1]
+// CHECK:STDOUT:   %.2: type = converted %.loc12, constants.%.8 [template = constants.%.8]
 // CHECK:STDOUT:   %t1.var: ref (i32, String, String) = var t1
 // CHECK:STDOUT:   %t1: ref (i32, String, String) = bind_name t1, %t1.var
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template = constants.%.loc16_14]
-// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template = constants.%.loc16_15]
+// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template = constants.%.13]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
 // CHECK:STDOUT:   %t1.ref: ref (i32, String, String) = name_ref t1, %t1
@@ -83,20 +83,20 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %.loc16_19.5: init i32 = initialize_from %.loc16_19.2 to %.loc16_19.4
 // CHECK:STDOUT:   %.loc16_19.6: ref String = tuple_access %t1.ref, element1
 // CHECK:STDOUT:   assign %b.var, <error>
-// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template = constants.%.loc21_14]
-// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template = constants.%.loc21_15]
+// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template = constants.%.15]
 // CHECK:STDOUT:   %c.var: ref [i32; 3] = var c
 // CHECK:STDOUT:   %c: ref [i32; 3] = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template = constants.%.loc21_20]
-// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template = constants.%.loc21_23]
-// CHECK:STDOUT:   %.loc21_24.1: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
+// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc21_24: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %.loc23: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc21_24.2: type = converted %.loc23, constants.%.loc21_24.1 [template = constants.%.loc21_24.1]
+// CHECK:STDOUT:   %.3: type = converted %.loc23, constants.%.18 [template = constants.%.18]
 // CHECK:STDOUT:   %t2.var: ref (i32, i32) = var t2
 // CHECK:STDOUT:   %t2: ref (i32, i32) = bind_name t2, %t2.var
-// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template = constants.%.loc27_14]
-// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template = constants.%.loc27_15]
+// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template = constants.%.22]
 // CHECK:STDOUT:   %d.var: ref [i32; 3] = var d
 // CHECK:STDOUT:   %d: ref [i32; 3] = bind_name d, %d.var
 // CHECK:STDOUT:   %t2.ref: ref (i32, i32) = name_ref t2, %t2

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -67,8 +67,8 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %.loc10_39.3: ref i32 = array_index %a.var, %.loc10_39.2
 // CHECK:STDOUT:   %.loc10_39.4: init i32 = initialize_from %.loc10_20 to %.loc10_39.3
 // CHECK:STDOUT:   assign %a.var, <error>
-// CHECK:STDOUT:   %.loc12: (type, type, type) = tuple_literal (i32, String, String)
-// CHECK:STDOUT:   %.2: type = converted %.loc12, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc12_29.1: (type, type, type) = tuple_literal (i32, String, String)
+// CHECK:STDOUT:   %.loc12_29.2: type = converted %.loc12_29.1, constants.%.8 [template = constants.%.8]
 // CHECK:STDOUT:   %t1.var: ref (i32, String, String) = var t1
 // CHECK:STDOUT:   %t1: ref (i32, String, String) = bind_name t1, %t1.var
 // CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template = constants.%.12]
@@ -91,8 +91,8 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc21_24: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
 // CHECK:STDOUT:   assign %c.var, <error>
-// CHECK:STDOUT:   %.loc23: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc23, constants.%.18 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc23_18.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc23_18.2: type = converted %.loc23_18.1, constants.%.18 [template = constants.%.18]
 // CHECK:STDOUT:   %t2.var: ref (i32, i32) = var t2
 // CHECK:STDOUT:   %t2: ref (i32, i32) = bind_name t2, %t2.var
 // CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template = constants.%.21]

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -63,9 +63,9 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc12_20.13: init [i32; 3] = converted %.loc12_20.1, %.loc12_20.12
 // CHECK:STDOUT:   %.loc12_20.14: ref [i32; 3] = temporary %.loc12_20.2, %.loc12_20.13
 // CHECK:STDOUT:   %.loc12_20.15: [i32; 3] = bind_value %.loc12_20.14
-// CHECK:STDOUT:   %.loc12_11: init i32 = call %F.ref(%.loc12_20.15, %.loc12_23)
-// CHECK:STDOUT:   %.loc12_25.1: i32 = value_of_initializer %.loc12_11
-// CHECK:STDOUT:   %.loc12_25.2: i32 = converted %.loc12_11, %.loc12_25.1
-// CHECK:STDOUT:   return %.loc12_25.2
+// CHECK:STDOUT:   %.loc12_11.1: init i32 = call %F.ref(%.loc12_20.15, %.loc12_23)
+// CHECK:STDOUT:   %.loc12_25: i32 = value_of_initializer %.loc12_11.1
+// CHECK:STDOUT:   %.loc12_11.2: i32 = converted %.loc12_11.1, %.loc12_25
+// CHECK:STDOUT:   return %.loc12_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -15,14 +15,14 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- function_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc12_20: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -44,11 +44,11 @@ fn G() -> i32 {
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1 [template = constants.%.loc12_13]
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2 [template = constants.%.loc12_16]
-// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3 [template = constants.%.loc12_19]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_19: i32 = int_literal 3 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, i32) = tuple_literal (%.loc12_13, %.loc12_16, %.loc12_19)
-// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1 [template = constants.%.loc12_23]
+// CHECK:STDOUT:   %.loc12_23: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc12_20.2: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc12_20.3: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc12_20.4: ref i32 = array_index %.loc12_20.2, %.loc12_20.3

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -9,36 +9,36 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT: --- nine_elements.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 9] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7 [template]
-// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8 [template]
-// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9 [template]
-// CHECK:STDOUT:   %.loc7_45: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 9] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.13: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 9 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 9] = var a
 // CHECK:STDOUT:   %a: ref [i32; 9] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.loc7_20]
-// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2 [template = constants.%.loc7_23]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3 [template = constants.%.loc7_26]
-// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4 [template = constants.%.loc7_29]
-// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5 [template = constants.%.loc7_32]
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6 [template = constants.%.loc7_35]
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7 [template = constants.%.loc7_38]
-// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8 [template = constants.%.loc7_41]
-// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9 [template = constants.%.loc7_44]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_23: i32 = int_literal 2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_29: i32 = int_literal 4 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_32: i32 = int_literal 5 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 6 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 7 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc7_41: i32 = int_literal 8 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc7_44: i32 = int_literal 9 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc7_45.1: (i32, i32, i32, i32, i32, i32, i32, i32, i32) = tuple_literal (%.loc7_20, %.loc7_23, %.loc7_26, %.loc7_29, %.loc7_32, %.loc7_35, %.loc7_38, %.loc7_41, %.loc7_44)
 // CHECK:STDOUT:   %.loc7_45.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_45.3: ref i32 = array_index %a.var, %.loc7_45.2

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -15,8 +15,8 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc7: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %t: type = bind_name t, %.2
+// CHECK:STDOUT:   %.loc7_24.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_24.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_24.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -9,14 +9,14 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT: --- as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_24: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc7_24: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_26: type = converted %.loc7_24, constants.%.loc7_26 [template = constants.%.loc7_26]
-// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_26
+// CHECK:STDOUT:   %.loc7: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %t: type = bind_name t, %.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/basic.carbon
+++ b/toolchain/check/testdata/as/basic.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,7 +21,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -20,11 +20,11 @@ let n: (i32, i32) = 1 as (i32, i32);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_35: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc10_35, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_35.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_35.2: type = converted %.loc10_35.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %n: (i32, i32) = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -12,19 +12,19 @@ let n: (i32, i32) = 1 as (i32, i32);
 // CHECK:STDOUT: --- fail_no_conversion.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
-// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template = constants.%.loc10_21]
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_35: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.3: type = converted %.loc10_35, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc10_35, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %n: (i32, i32) = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_not_type.carbon
+++ b/toolchain/check/testdata/as/fail_not_type.carbon
@@ -12,14 +12,14 @@ let n: i32 = 1 as 2;
 // CHECK:STDOUT: --- fail_not_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template = constants.%.loc10_19]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   %n: i32 = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/identity.carbon
+++ b/toolchain/check/testdata/as/identity.carbon
@@ -27,9 +27,9 @@ fn Initializing() {
 // CHECK:STDOUT: --- identity.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc9: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -52,8 +52,8 @@ fn Var() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %X.ref.loc15_11: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc15_14: type = name_ref X, file.%X [template = file.%X]
-// CHECK:STDOUT:   %.loc15_15: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
-// CHECK:STDOUT:   %.1: type = converted %.loc15_15, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc15_15.1: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
+// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc15_15.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %Make.ref.loc15_20: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc15_24.1: ref X = temporary_storage
 // CHECK:STDOUT:   %.loc15_24.2: init X = call %Make.ref.loc15_20() to %.loc15_24.1
@@ -63,8 +63,8 @@ fn Var() {
 // CHECK:STDOUT:   %.loc15_34.1: (X, X) = tuple_literal (%.loc15_24.2, %.loc15_32.2)
 // CHECK:STDOUT:   %X.ref.loc15_40: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc15_43: type = name_ref X, file.%X [template = file.%X]
-// CHECK:STDOUT:   %.loc15_44: (type, type) = tuple_literal (%X.ref.loc15_40, %X.ref.loc15_43)
-// CHECK:STDOUT:   %.2: type = converted %.loc15_44, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc15_44.1: (type, type) = tuple_literal (%X.ref.loc15_40, %X.ref.loc15_43)
+// CHECK:STDOUT:   %.loc15_44.2: type = converted %.loc15_44.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc15_24.3: ref X = temporary %.loc15_24.1, %.loc15_24.2
 // CHECK:STDOUT:   %.loc15_24.4: X = bind_value %.loc15_24.3
 // CHECK:STDOUT:   %.loc15_32.3: ref X = temporary %.loc15_32.1, %.loc15_32.2
@@ -79,8 +79,8 @@ fn Var() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %X.ref.loc20_11: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc20_14: type = name_ref X, file.%X [template = file.%X]
-// CHECK:STDOUT:   %.loc20_15: (type, type) = tuple_literal (%X.ref.loc20_11, %X.ref.loc20_14)
-// CHECK:STDOUT:   %.1: type = converted %.loc20_15, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_15.1: (type, type) = tuple_literal (%X.ref.loc20_11, %X.ref.loc20_14)
+// CHECK:STDOUT:   %.loc20_15.2: type = converted %.loc20_15.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %b.var: ref (X, X) = var b
 // CHECK:STDOUT:   %b: ref (X, X) = bind_name b, %b.var
 // CHECK:STDOUT:   %Make.ref.loc20_20: <function> = name_ref Make, file.%Make [template = file.%Make]
@@ -92,8 +92,8 @@ fn Var() {
 // CHECK:STDOUT:   %.loc20_34.3: (X, X) = tuple_literal (%.loc20_24, %.loc20_32)
 // CHECK:STDOUT:   %X.ref.loc20_40: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc20_43: type = name_ref X, file.%X [template = file.%X]
-// CHECK:STDOUT:   %.loc20_44: (type, type) = tuple_literal (%X.ref.loc20_40, %X.ref.loc20_43)
-// CHECK:STDOUT:   %.2: type = converted %.loc20_44, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_44.1: (type, type) = tuple_literal (%X.ref.loc20_40, %X.ref.loc20_43)
+// CHECK:STDOUT:   %.loc20_44.2: type = converted %.loc20_44.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc20_34.4: init (X, X) = tuple_init (%.loc20_24, %.loc20_32) to %b.var
 // CHECK:STDOUT:   %.loc20_34.5: init (X, X) = converted %.loc20_34.3, %.loc20_34.4
 // CHECK:STDOUT:   assign %b.var, %.loc20_34.5

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -23,13 +23,13 @@ fn Var() {
 // CHECK:STDOUT: --- tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc15_15.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc15_15.2: type = tuple_type (X, X) [template]
-// CHECK:STDOUT:   %.loc15_15.3: type = tuple_type ({}*, {}*) [template]
-// CHECK:STDOUT:   %.loc15_15.4: type = ptr_type ({}*, {}*) [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (X, X) [template]
+// CHECK:STDOUT:   %.6: type = tuple_type ({}*, {}*) [template]
+// CHECK:STDOUT:   %.7: type = ptr_type ({}*, {}*) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -52,8 +52,8 @@ fn Var() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %X.ref.loc15_11: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc15_14: type = name_ref X, file.%X [template = file.%X]
-// CHECK:STDOUT:   %.loc15_15.1: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
-// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc15_15.1, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
+// CHECK:STDOUT:   %.loc15_15: (type, type) = tuple_literal (%X.ref.loc15_11, %X.ref.loc15_14)
+// CHECK:STDOUT:   %.1: type = converted %.loc15_15, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %Make.ref.loc15_20: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc15_24.1: ref X = temporary_storage
 // CHECK:STDOUT:   %.loc15_24.2: init X = call %Make.ref.loc15_20() to %.loc15_24.1
@@ -64,7 +64,7 @@ fn Var() {
 // CHECK:STDOUT:   %X.ref.loc15_40: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc15_43: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc15_44: (type, type) = tuple_literal (%X.ref.loc15_40, %X.ref.loc15_43)
-// CHECK:STDOUT:   %.loc15_15.3: type = converted %.loc15_44, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc15_44, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc15_24.3: ref X = temporary %.loc15_24.1, %.loc15_24.2
 // CHECK:STDOUT:   %.loc15_24.4: X = bind_value %.loc15_24.3
 // CHECK:STDOUT:   %.loc15_32.3: ref X = temporary %.loc15_32.1, %.loc15_32.2
@@ -80,7 +80,7 @@ fn Var() {
 // CHECK:STDOUT:   %X.ref.loc20_11: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc20_14: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc20_15: (type, type) = tuple_literal (%X.ref.loc20_11, %X.ref.loc20_14)
-// CHECK:STDOUT:   %.loc15_15.1: type = converted %.loc20_15, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
+// CHECK:STDOUT:   %.1: type = converted %.loc20_15, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %b.var: ref (X, X) = var b
 // CHECK:STDOUT:   %b: ref (X, X) = bind_name b, %b.var
 // CHECK:STDOUT:   %Make.ref.loc20_20: <function> = name_ref Make, file.%Make [template = file.%Make]
@@ -93,7 +93,7 @@ fn Var() {
 // CHECK:STDOUT:   %X.ref.loc20_40: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %X.ref.loc20_43: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %.loc20_44: (type, type) = tuple_literal (%X.ref.loc20_40, %X.ref.loc20_43)
-// CHECK:STDOUT:   %.loc15_15.2: type = converted %.loc20_44, constants.%.loc15_15.2 [template = constants.%.loc15_15.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc20_44, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc20_34.4: init (X, X) = tuple_init (%.loc20_24, %.loc20_32) to %b.var
 // CHECK:STDOUT:   %.loc20_34.5: init (X, X) = converted %.loc20_34.3, %.loc20_34.4
 // CHECK:STDOUT:   assign %b.var, %.loc20_34.5

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -12,23 +12,23 @@ var test_type: type = i32;
 // CHECK:STDOUT: --- builtin_types.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template]
-// CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: f64 = real_literal 1e-1 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type String [template]
+// CHECK:STDOUT:   %.4: String = string_literal "Test" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.test_i32 = %test_i32, .test_f64 = %test_f64, .test_type = %test_type}
 // CHECK:STDOUT:   %test_i32.var: ref i32 = var test_i32
 // CHECK:STDOUT:   %test_i32: ref i32 = bind_name test_i32, %test_i32.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %test_i32.var, %.loc7
 // CHECK:STDOUT:   %test_f64.var: ref f64 = var test_f64
 // CHECK:STDOUT:   %test_f64: ref f64 = bind_name test_f64, %test_f64.var
-// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %test_f64.var, %.loc8
-// CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template = constants.%.4]
 // CHECK:STDOUT:   %test_str: String = bind_name test_str, %.loc9
 // CHECK:STDOUT:   %test_type.var: ref type = var test_type
 // CHECK:STDOUT:   %test_type: ref type = bind_name test_type, %test_type.var

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -16,7 +16,7 @@ fn Run() -> String {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc13: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
+++ b/toolchain/check/testdata/basics/fail_non_type_as_type.carbon
@@ -12,14 +12,14 @@ var x: type = 42;
 // CHECK:STDOUT: --- fail_non_type_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 42 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 42 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %x.var: ref type = var x
 // CHECK:STDOUT:   %x: ref type = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 42 [template = constants.%.loc10]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 42 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -28,26 +28,26 @@ fn F() {
 // CHECK:STDOUT: --- numeric_literals.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc10_20.1: type = array_type %.loc10_19, i32 [template]
-// CHECK:STDOUT:   %.loc10_20.2: type = ptr_type [i32; 5] [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 8 [template]
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 9 [template]
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 8 [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 8 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993 [template]
-// CHECK:STDOUT:   %.loc16: type = tuple_type (i32, i32, i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7 [template]
-// CHECK:STDOUT:   %.loc17_22.1: type = array_type %.loc17_21, f64 [template]
-// CHECK:STDOUT:   %.loc17_22.2: type = ptr_type [f64; 7] [template]
-// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1 [template]
-// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1 [template]
-// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1 [template]
-// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6 [template]
-// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7 [template]
-// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9 [template]
-// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992 [template]
-// CHECK:STDOUT:   %.loc25: type = tuple_type (f64, f64, f64, f64, f64, f64, f64) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 5] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 8 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 39999999999999999993 [template]
+// CHECK:STDOUT:   %.9: type = tuple_type (i32, i32, i32, i32, i32) [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.11: type = array_type %.10, f64 [template]
+// CHECK:STDOUT:   %.12: type = ptr_type [f64; 7] [template]
+// CHECK:STDOUT:   %.13: f64 = real_literal 9e-1 [template]
+// CHECK:STDOUT:   %.14: f64 = real_literal 80e-1 [template]
+// CHECK:STDOUT:   %.15: f64 = real_literal 800e-1 [template]
+// CHECK:STDOUT:   %.16: f64 = real_literal 10e6 [template]
+// CHECK:STDOUT:   %.17: f64 = real_literal 10e7 [template]
+// CHECK:STDOUT:   %.18: f64 = real_literal 10e-9 [template]
+// CHECK:STDOUT:   %.19: f64 = real_literal 399999999999999999930e39999999999999999992 [template]
+// CHECK:STDOUT:   %.20: type = tuple_type (f64, f64, f64, f64, f64, f64, f64) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -57,15 +57,15 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5 [template = constants.%.loc10_19]
-// CHECK:STDOUT:   %.loc10_20: type = array_type %.loc10_19, i32 [template = constants.%.loc10_20.1]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 5 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_20: type = array_type %.loc10_19, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %ints.var: ref [i32; 5] = var ints
 // CHECK:STDOUT:   %ints: ref [i32; 5] = bind_name ints, %ints.var
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 8 [template = constants.%.loc11]
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 9 [template = constants.%.loc12]
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 8 [template = constants.%.loc13]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 8 [template = constants.%.loc14]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 8 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 9 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 8 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 8 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 39999999999999999993 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc16_3.1: (i32, i32, i32, i32, i32) = tuple_literal (%.loc11, %.loc12, %.loc13, %.loc14, %.loc15)
 // CHECK:STDOUT:   %.loc16_3.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc16_3.3: ref i32 = array_index %ints.var, %.loc16_3.2
@@ -85,17 +85,17 @@ fn F() {
 // CHECK:STDOUT:   %.loc16_3.17: init [i32; 5] = array_init (%.loc16_3.4, %.loc16_3.7, %.loc16_3.10, %.loc16_3.13, %.loc16_3.16) to %ints.var
 // CHECK:STDOUT:   %.loc16_3.18: init [i32; 5] = converted %.loc16_3.1, %.loc16_3.17
 // CHECK:STDOUT:   assign %ints.var, %.loc16_3.18
-// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7 [template = constants.%.loc17_21]
-// CHECK:STDOUT:   %.loc17_22: type = array_type %.loc17_21, f64 [template = constants.%.loc17_22.1]
+// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 7 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc17_22: type = array_type %.loc17_21, f64 [template = constants.%.11]
 // CHECK:STDOUT:   %floats.var: ref [f64; 7] = var floats
 // CHECK:STDOUT:   %floats: ref [f64; 7] = bind_name floats, %floats.var
-// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1 [template = constants.%.loc18]
-// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1 [template = constants.%.loc19]
-// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1 [template = constants.%.loc20]
-// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6 [template = constants.%.loc21]
-// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7 [template = constants.%.loc22]
-// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9 [template = constants.%.loc23]
-// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992 [template = constants.%.loc24]
+// CHECK:STDOUT:   %.loc18: f64 = real_literal 9e-1 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc19: f64 = real_literal 80e-1 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc20: f64 = real_literal 800e-1 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc21: f64 = real_literal 10e6 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc22: f64 = real_literal 10e7 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc23: f64 = real_literal 10e-9 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc24: f64 = real_literal 399999999999999999930e39999999999999999992 [template = constants.%.19]
 // CHECK:STDOUT:   %.loc25_3.1: (f64, f64, f64, f64, f64, f64, f64) = tuple_literal (%.loc18, %.loc19, %.loc20, %.loc21, %.loc22, %.loc23, %.loc24)
 // CHECK:STDOUT:   %.loc25_3.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc25_3.3: ref f64 = array_index %floats.var, %.loc25_3.2

--- a/toolchain/check/testdata/basics/parens.carbon
+++ b/toolchain/check/testdata/basics/parens.carbon
@@ -10,19 +10,19 @@ var b: i32 = ((2));
 // CHECK:STDOUT: --- parens.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   assign %a.var, %.loc7
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -122,11 +122,11 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: --- raw_and_textual_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64) [template]
-// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64) [template]
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -137,8 +137,8 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, i32, f64) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.loc12_14]
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.loc12_17]
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, f64) = tuple_literal (%n.ref, %.loc12_14, %.loc12_17)
 // CHECK:STDOUT:   %.loc12_20.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc12_20.3: init i32 = initialize_from %n.ref to %.loc12_20.2

--- a/toolchain/check/testdata/basics/run_i32.carbon
+++ b/toolchain/check/testdata/basics/run_i32.carbon
@@ -9,7 +9,7 @@ fn Run() -> i32 { return 0; }
 // CHECK:STDOUT: --- run_i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -19,7 +19,7 @@ fn Run() -> i32 { return 0; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -15,11 +15,11 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: --- textual_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_33.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc11_33.2: type = tuple_type (i32, i32, f64) [template]
-// CHECK:STDOUT:   %.loc11_33.3: type = ptr_type (i32, i32, f64) [template]
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, f64) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,8 +30,8 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: fn @Foo(%n: i32) -> %return: (i32, i32, f64) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.loc12_14]
-// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.loc12_17]
+// CHECK:STDOUT:   %.loc12_14: i32 = int_literal 2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_17: f64 = real_literal 34e-1 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_20.1: (i32, i32, f64) = tuple_literal (%n.ref, %.loc12_14, %.loc12_17)
 // CHECK:STDOUT:   %.loc12_20.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc12_20.3: init i32 = initialize_from %n.ref to %.loc12_20.2

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -25,18 +25,18 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: --- base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.b: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.b: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Base, .d: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.b: i32}*, .d: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.b: i32}*, .d: i32} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base, .d: i32} [template]
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7 [template]
-// CHECK:STDOUT:   %.loc18_35: type = struct_type {.base: {.b: i32}, .d: i32} [template]
-// CHECK:STDOUT:   %.loc21_35.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc21_35.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc21_35.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.b: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.b: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: Base, .d: i32} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: {.b: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.base: {.b: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: Base, .d: i32} [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.9: type = struct_type {.base: {.b: i32}, .d: i32} [template]
+// CHECK:STDOUT:   %.10: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.12: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -74,9 +74,9 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return: Derived {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4 [template = constants.%.loc18_25]
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 4 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc18_26.1: {.b: i32} = struct_literal (%.loc18_25)
-// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7 [template = constants.%.loc18_34]
+// CHECK:STDOUT:   %.loc18_34: i32 = int_literal 7 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc18_35.1: {.base: {.b: i32}, .d: i32} = struct_literal (%.loc18_26.1, %.loc18_34)
 // CHECK:STDOUT:   %.loc18_35.2: ref Base = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc18_26.2: ref i32 = class_element_access %.loc18_35.2, element0

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -79,11 +79,11 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: fn @Access(%p: Derived*) -> i32* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
-// CHECK:STDOUT:   %.loc21_12: ref Derived = deref %p.ref
-// CHECK:STDOUT:   %.loc21_15.1: ref Base = class_element_access %.loc21_12, element0
-// CHECK:STDOUT:   %.loc21_15.2: ref Base = converted %.loc21_12, %.loc21_15.1
-// CHECK:STDOUT:   %.loc21_15.3: ref i32 = class_element_access %.loc21_15.2, element2
-// CHECK:STDOUT:   %.loc21_10: i32* = addr_of %.loc21_15.3
+// CHECK:STDOUT:   %.loc21_12.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc21_15.1: ref Base = class_element_access %.loc21_12.1, element0
+// CHECK:STDOUT:   %.loc21_12.2: ref Base = converted %.loc21_12.1, %.loc21_15.1
+// CHECK:STDOUT:   %.loc21_15.2: ref i32 = class_element_access %.loc21_12.2, element2
+// CHECK:STDOUT:   %.loc21_10: i32* = addr_of %.loc21_15.2
 // CHECK:STDOUT:   return %.loc21_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -24,12 +24,12 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: --- base_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.loc11_1.2: type = ptr_type {.a: i32, .b: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: Base, .d: i32, .e: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
-// CHECK:STDOUT:   %.loc13: type = ptr_type {.base: Base, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: Base, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: Base, .d: i32, .e: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/base_function_unqualified.carbon
+++ b/toolchain/check/testdata/class/base_function_unqualified.carbon
@@ -22,10 +22,10 @@ fn Derived.H() {
 // CHECK:STDOUT: --- base_function_unqualified.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc16: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: Base} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -84,8 +84,8 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   %.loc22_9.1: ref Derived = deref %.loc22_4.2
 // CHECK:STDOUT:   %.loc22_9.2: ref Base = class_element_access %.loc22_9.1, element0
 // CHECK:STDOUT:   %.loc22_9.3: Base* = addr_of %.loc22_9.2
-// CHECK:STDOUT:   %.loc22_9.4: Base* = converted %.loc22_4.2, %.loc22_9.3
-// CHECK:STDOUT:   %.loc22_9.5: init () = call %.loc22_7(%.loc22_9.4)
+// CHECK:STDOUT:   %.loc22_4.3: Base* = converted %.loc22_4.2, %.loc22_9.3
+// CHECK:STDOUT:   %.loc22_9.4: init () = call %.loc22_7(%.loc22_4.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -25,13 +25,13 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: --- base_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: Base} [template]
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.a: i32}*} [template]
-// CHECK:STDOUT:   %.loc17: type = ptr_type {.base: Base} [template]
-// CHECK:STDOUT:   %.loc22: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: Base} [template]
+// CHECK:STDOUT:   %.7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -70,7 +70,7 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc14_4: ref Base = deref %self.ref
 // CHECK:STDOUT:   %.loc14_10: ref i32 = class_element_access %.loc14_4, element0
-// CHECK:STDOUT:   %.loc14_15: i32 = int_literal 1 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14_15: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   assign %.loc14_10, %.loc14_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -127,8 +127,8 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT:   %.loc29_9.1: ref D = deref %.loc29_4.2
 // CHECK:STDOUT:   %.loc29_9.2: ref B = class_element_access %.loc29_9.1, element0
 // CHECK:STDOUT:   %.loc29_9.3: B* = addr_of %.loc29_9.2
-// CHECK:STDOUT:   %.loc29_9.4: B* = converted %.loc29_4.2, %.loc29_9.3
-// CHECK:STDOUT:   %.loc29_9.5: init () = call %.loc29_7(%.loc29_9.4)
+// CHECK:STDOUT:   %.loc29_4.3: B* = converted %.loc29_4.2, %.loc29_9.3
+// CHECK:STDOUT:   %.loc29_9.4: init () = call %.loc29_7(%.loc29_4.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -32,15 +32,15 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: --- base_method_shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A} [template]
-// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {}*} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A} [template]
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B} [template]
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A}*} [template]
-// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: A} [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: {}*} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: A} [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.base: {.base: A}*} [template]
+// CHECK:STDOUT:   %.9: type = ptr_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -25,8 +25,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = struct_type {.k: i32} [template]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.k: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -66,7 +66,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc22_17: init i32 = call %F.ref(%.loc22_18)
 // CHECK:STDOUT:   %.loc22_20.1: i32 = value_of_initializer %.loc22_17
 // CHECK:STDOUT:   %.loc22_20.2: i32 = converted %.loc22_17, %.loc22_20.1

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -67,9 +67,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc22_17: init i32 = call %F.ref(%.loc22_18)
-// CHECK:STDOUT:   %.loc22_20.1: i32 = value_of_initializer %.loc22_17
-// CHECK:STDOUT:   %.loc22_20.2: i32 = converted %.loc22_17, %.loc22_20.1
-// CHECK:STDOUT:   return %.loc22_20.2
+// CHECK:STDOUT:   %.loc22_17.1: init i32 = call %F.ref(%.loc22_18)
+// CHECK:STDOUT:   %.loc22_20: i32 = value_of_initializer %.loc22_17.1
+// CHECK:STDOUT:   %.loc22_17.2: i32 = converted %.loc22_17.1, %.loc22_20
+// CHECK:STDOUT:   return %.loc22_17.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -113,8 +113,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc21_39.1: ref C = deref %p.ref
 // CHECK:STDOUT:   %.loc21_39.2: ref B = class_element_access %.loc21_39.1, element0
 // CHECK:STDOUT:   %.loc21_39.3: B* = addr_of %.loc21_39.2
-// CHECK:STDOUT:   %.loc21_39.4: B* = converted %p.ref, %.loc21_39.3
-// CHECK:STDOUT:   return %.loc21_39.4
+// CHECK:STDOUT:   %.loc21_38: B* = converted %p.ref, %.loc21_39.3
+// CHECK:STDOUT:   return %.loc21_38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertBToA(%p: B*) -> A* {
@@ -123,8 +123,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc22_39.1: ref B = deref %p.ref
 // CHECK:STDOUT:   %.loc22_39.2: ref A = class_element_access %.loc22_39.1, element0
 // CHECK:STDOUT:   %.loc22_39.3: A* = addr_of %.loc22_39.2
-// CHECK:STDOUT:   %.loc22_39.4: A* = converted %p.ref, %.loc22_39.3
-// CHECK:STDOUT:   return %.loc22_39.4
+// CHECK:STDOUT:   %.loc22_38: A* = converted %p.ref, %.loc22_39.3
+// CHECK:STDOUT:   return %.loc22_38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertCToA(%p: C*) -> A* {
@@ -134,8 +134,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc23_39.2: ref B = class_element_access %.loc23_39.1, element0
 // CHECK:STDOUT:   %.loc23_39.3: ref A = class_element_access %.loc23_39.2, element0
 // CHECK:STDOUT:   %.loc23_39.4: A* = addr_of %.loc23_39.3
-// CHECK:STDOUT:   %.loc23_39.5: A* = converted %p.ref, %.loc23_39.4
-// CHECK:STDOUT:   return %.loc23_39.5
+// CHECK:STDOUT:   %.loc23_38: A* = converted %p.ref, %.loc23_39.4
+// CHECK:STDOUT:   return %.loc23_38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertValue(%c: C) {
@@ -144,21 +144,21 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %c.ref: C = name_ref c, %c
 // CHECK:STDOUT:   %.loc26_15.1: ref B = class_element_access %c.ref, element0
 // CHECK:STDOUT:   %.loc26_15.2: ref A = class_element_access %.loc26_15.1, element0
-// CHECK:STDOUT:   %.loc26_15.3: ref A = converted %c.ref, %.loc26_15.2
-// CHECK:STDOUT:   %.loc26_15.4: A = bind_value %.loc26_15.3
-// CHECK:STDOUT:   %a: A = bind_name a, %.loc26_15.4
+// CHECK:STDOUT:   %.loc26_14.1: ref A = converted %c.ref, %.loc26_15.2
+// CHECK:STDOUT:   %.loc26_14.2: A = bind_value %.loc26_14.1
+// CHECK:STDOUT:   %a: A = bind_name a, %.loc26_14.2
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertRef(%c: C*) -> A* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: C* = name_ref c, %c
-// CHECK:STDOUT:   %.loc30_12: ref C = deref %c.ref
+// CHECK:STDOUT:   %.loc30_12.1: ref C = deref %c.ref
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc30_15.1: ref B = class_element_access %.loc30_12, element0
+// CHECK:STDOUT:   %.loc30_15.1: ref B = class_element_access %.loc30_12.1, element0
 // CHECK:STDOUT:   %.loc30_15.2: ref A = class_element_access %.loc30_15.1, element0
-// CHECK:STDOUT:   %.loc30_15.3: ref A = converted %.loc30_12, %.loc30_15.2
-// CHECK:STDOUT:   %.loc30_10: A* = addr_of %.loc30_15.3
+// CHECK:STDOUT:   %.loc30_12.2: ref A = converted %.loc30_12.1, %.loc30_15.2
+// CHECK:STDOUT:   %.loc30_10: A* = addr_of %.loc30_12.2
 // CHECK:STDOUT:   return %.loc30_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -190,9 +190,9 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc34_57.8: ref C = converted %.loc34_57.1, %.loc34_57.7
 // CHECK:STDOUT:   %.loc34_63.1: ref B = class_element_access %.loc34_57.8, element0
 // CHECK:STDOUT:   %.loc34_63.2: ref A = class_element_access %.loc34_63.1, element0
-// CHECK:STDOUT:   %.loc34_63.3: ref A = converted %.loc34_57.8, %.loc34_63.2
-// CHECK:STDOUT:   %.loc34_63.4: A = bind_value %.loc34_63.3
-// CHECK:STDOUT:   %a: A = bind_name a, %.loc34_63.4
+// CHECK:STDOUT:   %.loc34_57.9: ref A = converted %.loc34_57.8, %.loc34_63.2
+// CHECK:STDOUT:   %.loc34_57.10: A = bind_value %.loc34_57.9
+// CHECK:STDOUT:   %a: A = bind_name a, %.loc34_57.10
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -37,21 +37,21 @@ fn ConvertInit() {
 // CHECK:STDOUT: --- derived_to_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc14_1.1: type = struct_type {.base: A, .b: i32} [template]
-// CHECK:STDOUT:   %.loc14_1.2: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
-// CHECK:STDOUT:   %.loc14_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: A, .b: i32} [template]
-// CHECK:STDOUT:   %.loc19_1.1: type = struct_type {.base: B, .c: i32} [template]
-// CHECK:STDOUT:   %.loc19_1.2: type = struct_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
-// CHECK:STDOUT:   %.loc19_1.3: type = ptr_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
-// CHECK:STDOUT:   %.loc16: type = ptr_type {.base: B, .c: i32} [template]
-// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc34_48: type = struct_type {.base: {.a: i32}, .b: i32} [template]
-// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc34_57: type = struct_type {.base: {.base: {.a: i32}, .b: i32}, .c: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: A, .b: i32} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: A, .b: i32} [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.base: B, .c: i32} [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.9: type = ptr_type {.base: {.base: A, .b: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.10: type = ptr_type {.base: B, .c: i32} [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.13: type = struct_type {.base: {.a: i32}, .b: i32} [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.15: type = struct_type {.base: {.base: {.a: i32}, .b: i32}, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -165,11 +165,11 @@ fn ConvertInit() {
 // CHECK:STDOUT: fn @ConvertInit() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1 [template = constants.%.loc34_38]
+// CHECK:STDOUT:   %.loc34_38: i32 = int_literal 1 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc34_39.1: {.a: i32} = struct_literal (%.loc34_38)
-// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2 [template = constants.%.loc34_47]
+// CHECK:STDOUT:   %.loc34_47: i32 = int_literal 2 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc34_48.1: {.base: {.a: i32}, .b: i32} = struct_literal (%.loc34_39.1, %.loc34_47)
-// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3 [template = constants.%.loc34_56]
+// CHECK:STDOUT:   %.loc34_56: i32 = int_literal 3 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc34_57.1: {.base: {.base: {.a: i32}, .b: i32}, .c: i32} = struct_literal (%.loc34_48.1, %.loc34_56)
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc34_57.2: ref C = temporary_storage

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -29,18 +29,18 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: --- fail_abstract.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.1: type = struct_type {.base: Abstract, .d: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.2: type = struct_type {.base: {.a: i32}*, .d: i32} [template]
-// CHECK:STDOUT:   %.loc15_1.3: type = ptr_type {.base: {.a: i32}*, .d: i32} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Abstract, .d: i32} [template]
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7 [template]
-// CHECK:STDOUT:   %.loc22_35: type = struct_type {.base: {.a: i32}, .d: i32} [template]
-// CHECK:STDOUT:   %.loc25_35.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc25_35.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc25_35.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: Abstract, .d: i32} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: {.a: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.base: {.a: i32}*, .d: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: Abstract, .d: i32} [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.9: type = struct_type {.base: {.a: i32}, .d: i32} [template]
+// CHECK:STDOUT:   %.10: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.12: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -78,9 +78,9 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return: Derived {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.loc22_25]
+// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc22_26: {.a: i32} = struct_literal (%.loc22_25)
-// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7 [template = constants.%.loc22_34]
+// CHECK:STDOUT:   %.loc22_34: i32 = int_literal 7 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc22_35: {.base: {.a: i32}, .d: i32} = struct_literal (%.loc22_26, %.loc22_34)
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -19,7 +19,7 @@ class Class {
 // CHECK:STDOUT: --- fail_addr_not_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -41,9 +41,9 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT: --- fail_addr_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -219,8 +219,8 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromTuple {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
-// CHECK:STDOUT:   %.loc51_22: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:   %.1: type = converted %.loc51_22, constants.%.7 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc51_22.1: (type,) = tuple_literal (%Base.ref)
+// CHECK:STDOUT:   %.loc51_22.2: type = converted %.loc51_22.1, constants.%.7 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc51_23.1: type = unbound_element_type DeriveFromTuple, <error> [template]
 // CHECK:STDOUT:   %.loc51_23.2: <unbound element of class DeriveFromTuple> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
@@ -339,19 +339,19 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:   %.loc106_11.1: ref DeriveFromFinal = deref %p.ref
 // CHECK:STDOUT:   %.loc106_11.2: ref Final = class_element_access %.loc106_11.1, element0
 // CHECK:STDOUT:   %.loc106_11.3: Final* = addr_of %.loc106_11.2
-// CHECK:STDOUT:   %.loc106_11.4: Final* = converted %p.ref, %.loc106_11.3
-// CHECK:STDOUT:   return %.loc106_11.4
+// CHECK:STDOUT:   %.loc106_10: Final* = converted %p.ref, %.loc106_11.3
+// CHECK:STDOUT:   return %.loc106_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_WithMember(%p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
-// CHECK:STDOUT:   %.loc110_11: ref DeriveFromFinal = deref %p.ref
-// CHECK:STDOUT:   %.loc110_14.1: ref Final = class_element_access %.loc110_11, element0
-// CHECK:STDOUT:   %.loc110_14.2: ref Final = converted %.loc110_11, %.loc110_14.1
-// CHECK:STDOUT:   %.loc110_14.3: ref i32 = class_element_access %.loc110_14.2, element0
-// CHECK:STDOUT:   %.loc110_14.4: i32 = bind_value %.loc110_14.3
-// CHECK:STDOUT:   return %.loc110_14.4
+// CHECK:STDOUT:   %.loc110_11.1: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %.loc110_14.1: ref Final = class_element_access %.loc110_11.1, element0
+// CHECK:STDOUT:   %.loc110_11.2: ref Final = converted %.loc110_11.1, %.loc110_14.1
+// CHECK:STDOUT:   %.loc110_14.2: ref i32 = class_element_access %.loc110_11.2, element0
+// CHECK:STDOUT:   %.loc110_14.3: i32 = bind_value %.loc110_14.2
+// CHECK:STDOUT:   return %.loc110_14.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_NoMember(%p: DeriveFromFinal*) -> i32 {

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -120,21 +120,21 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: --- fail_base_bad_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_18.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc17: type = struct_type {.base: <error>} [template]
-// CHECK:STDOUT:   %.loc12: type = ptr_type {.base: <error>} [template]
-// CHECK:STDOUT:   %.loc26: i32 = int_literal 32 [template]
-// CHECK:STDOUT:   %.loc51_22: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc51_23.1: type = tuple_type (Base) [template]
-// CHECK:STDOUT:   %.loc7_18.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7_17: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc51_23.2: type = tuple_type ({}*) [template]
-// CHECK:STDOUT:   %.loc67: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc8: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc102_1.1: type = struct_type {.base: Final} [template]
-// CHECK:STDOUT:   %.loc102_1.2: type = struct_type {.base: {.a: i32}*} [template]
-// CHECK:STDOUT:   %.loc97: type = ptr_type {.base: Final} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: <error>} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type {.base: <error>} [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 32 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.7: type = tuple_type (Base) [template]
+// CHECK:STDOUT:   %.8: type = tuple_type () [template]
+// CHECK:STDOUT:   %.9: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.10: type = tuple_type ({}*) [template]
+// CHECK:STDOUT:   %.11: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.12: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.13: type = struct_type {.base: Final} [template]
+// CHECK:STDOUT:   %.14: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.15: type = ptr_type {.base: Final} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -199,7 +199,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromNonType {
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 32 [template = constants.%.loc26]
+// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 32 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc26_18.1: type = unbound_element_type DeriveFromNonType, <error> [template]
 // CHECK:STDOUT:   %.loc26_18.2: <unbound element of class DeriveFromNonType> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
@@ -220,12 +220,12 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: class @DeriveFromTuple {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base [template = file.%Base]
 // CHECK:STDOUT:   %.loc51_22: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:   %.loc51_23.1: type = converted %.loc51_22, constants.%.loc51_23.1 [template = constants.%.loc51_23.1]
-// CHECK:STDOUT:   %.loc51_23.2: type = unbound_element_type DeriveFromTuple, <error> [template]
-// CHECK:STDOUT:   %.loc51_23.3: <unbound element of class DeriveFromTuple> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.1: type = converted %.loc51_22, constants.%.7 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc51_23.1: type = unbound_element_type DeriveFromTuple, <error> [template]
+// CHECK:STDOUT:   %.loc51_23.2: <unbound element of class DeriveFromTuple> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .base = %.loc51_23.3
+// CHECK:STDOUT:   .base = %.loc51_23.2
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_method_define.carbon
+++ b/toolchain/check/testdata/class/fail_base_method_define.carbon
@@ -29,10 +29,10 @@ fn D.C.F() {}
 // CHECK:STDOUT: --- fail_base_method_define.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc12_3.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc17: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_misplaced.carbon
+++ b/toolchain/check/testdata/class/fail_base_misplaced.carbon
@@ -24,7 +24,7 @@ fn F() {
 // CHECK:STDOUT: --- fail_base_misplaced.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -46,10 +46,10 @@ class C4 {
 // CHECK:STDOUT: --- fail_base_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_no_extend.carbon
+++ b/toolchain/check/testdata/class/fail_base_no_extend.carbon
@@ -16,10 +16,10 @@ class C {
 // CHECK:STDOUT: --- fail_base_no_extend.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc14: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_repeated.carbon
+++ b/toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -33,10 +33,10 @@ class D {
 // CHECK:STDOUT: --- fail_base_repeated.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7_15: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc19: type = struct_type {.base: B1} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: B1} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_base_unbound.carbon
+++ b/toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -18,10 +18,10 @@ let b: B = C.base;
 // CHECK:STDOUT: --- fail_base_unbound.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_15.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7_14: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc11: type = struct_type {.base: B} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: B} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -32,12 +32,12 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT: --- fail_derived_to_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.1: type = struct_type {.base: A2, .b: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.2: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
-// CHECK:STDOUT:   %.loc18_1.3: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
-// CHECK:STDOUT:   %.loc15: type = ptr_type {.base: A2, .b: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: A2, .b: i32} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.base: {.a: i32}*, .b: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: A2, .b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -30,9 +30,9 @@ class Class {
 // CHECK:STDOUT: --- fail_field_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc28: type = struct_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.j: i32, .k: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,9 +48,9 @@ class Class {
 // CHECK:STDOUT:   %.loc17_14.1: type = unbound_element_type Class, i32 [template]
 // CHECK:STDOUT:   %.loc17_14.2: <unbound element of class Class> = field_decl k, element1 [template]
 // CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc17_14.2 [template = %.loc17_14.2]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   %l: i32 = bind_name l, %.loc22
-// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template = constants.%.loc27]
+// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %m: i32 = bind_name m, %.loc27
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -118,8 +118,8 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT: --- fail_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc41: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc100: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -27,17 +27,17 @@ fn F() {
 // CHECK:STDOUT: --- fail_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc16_10: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc20_18: type = struct_type {.a: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc24_26: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.a: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.11: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -62,14 +62,14 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template = constants.%.loc16_9]
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc16_10.1: {.a: i32} = struct_literal (%.loc16_9)
 // CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc16_10.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc16_10.3: ref Class = temporary %.loc16_10.2, <error>
 // CHECK:STDOUT:   %.loc16_10.4: ref Class = converted %.loc16_10.1, %.loc16_10.3
-// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template = constants.%.loc20_9]
-// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template = constants.%.loc20_17]
+// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc20_18.1: {.a: i32, .c: i32} = struct_literal (%.loc20_9, %.loc20_17)
 // CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc20_18.2: ref Class = temporary_storage
@@ -77,9 +77,9 @@ fn F() {
 // CHECK:STDOUT:   %.loc20_18.4: init i32 = initialize_from %.loc20_9 to %.loc20_18.3
 // CHECK:STDOUT:   %.loc20_18.5: ref Class = temporary %.loc20_18.2, <error>
 // CHECK:STDOUT:   %.loc20_18.6: ref Class = converted %.loc20_18.1, %.loc20_18.5
-// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template = constants.%.loc24_9]
-// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template = constants.%.loc24_17]
-// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template = constants.%.loc24_25]
+// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc24_26.1: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc24_9, %.loc24_17, %.loc24_25)
 // CHECK:STDOUT:   %Class.ref.loc24: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc24_26.2: ref Class = temporary_storage

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -25,11 +25,11 @@ fn F() {
 // CHECK:STDOUT: --- fail_init_as_inplace.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc22: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -60,8 +60,8 @@ fn F() {
 // CHECK:STDOUT:   %Class.ref.loc21_10: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1 [template = constants.%.loc21_24]
-// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2 [template = constants.%.loc21_32]
+// CHECK:STDOUT:   %.loc21_24: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc21_32: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc21_33.1: {.a: i32, .b: i32} = struct_literal (%.loc21_24, %.loc21_32)
 // CHECK:STDOUT:   %Class.ref.loc21_38: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc21_33.2: ref Class = temporary_storage

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -36,12 +36,12 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: --- fail_memaccess_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.loc13_1.1: type = struct_type {.a: A} [template]
-// CHECK:STDOUT:   %.loc13_1.2: type = struct_type {.a: {}*} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.a: A} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.a: A} [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.a: {}*} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.a: A} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -21,7 +21,7 @@ fn T.F() {}
 // CHECK:STDOUT: --- fail_member_of_let.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -33,9 +33,9 @@ fn F(c: Class) {
 // CHECK:STDOUT: --- fail_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_method_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_method_modifiers.carbon
@@ -50,7 +50,7 @@ base class BaseClass {
 // CHECK:STDOUT: --- fail_method_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc24: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_modifiers.carbon
@@ -67,7 +67,7 @@ abstract base class AbstractAndBase {}
 // CHECK:STDOUT: --- fail_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc27: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
+++ b/toolchain/check/testdata/class/fail_out_of_line_decl.carbon
@@ -14,7 +14,7 @@ fn C.F() {}
 // CHECK:STDOUT: --- fail_out_of_line_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
@@ -77,7 +77,7 @@ base class G;
 // CHECK:STDOUT: --- fail_redeclaration_introducer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_scope.carbon
@@ -24,7 +24,7 @@ class Y {
 // CHECK:STDOUT: --- fail_redeclaration_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -27,7 +27,7 @@ fn Class.H() {}
 // CHECK:STDOUT: --- fail_redefinition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -28,8 +28,8 @@ class Class {
 // CHECK:STDOUT: --- fail_reorder.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc26: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -56,7 +56,7 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template = constants.%.loc24]
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_scope.carbon
+++ b/toolchain/check/testdata/class/fail_scope.carbon
@@ -20,8 +20,8 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- fail_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -40,7 +40,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -53,9 +53,9 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: --- fail_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc20_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_todo_modifiers.carbon
@@ -61,8 +61,8 @@ abstract class Abstract {
 // CHECK:STDOUT: --- fail_todo_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc28: type = struct_type {.k: i32, .l: i32} [template]
-// CHECK:STDOUT:   %.loc41: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.k: i32, .l: i32} [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -24,7 +24,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- fail_unbound_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = struct_type {.field: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.field: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -19,8 +19,8 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT: --- fail_unknown_member.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.n: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -20,10 +20,10 @@ fn Run() {
 // CHECK:STDOUT: --- field_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32} [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -53,11 +53,11 @@ fn Run() {
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref.loc14: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc14_4: ref i32 = class_element_access %c.ref.loc14, element0
-// CHECK:STDOUT:   %.loc14_9: i32 = int_literal 1 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14_9: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   assign %.loc14_4, %.loc14_9
 // CHECK:STDOUT:   %c.ref.loc15: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc15_4: ref i32 = class_element_access %c.ref.loc15, element1
-// CHECK:STDOUT:   %.loc15_9: i32 = int_literal 2 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15_9: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc15_4, %.loc15_9
 // CHECK:STDOUT:   %cj.var: ref i32 = var cj
 // CHECK:STDOUT:   %cj: ref i32 = bind_name cj, %cj.var

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -21,10 +21,10 @@ fn Test() {
 // CHECK:STDOUT: --- field_access_in_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.j: i32, .k: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.j: i32, .k: i32} [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.j: i32, .k: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,11 +54,11 @@ fn Test() {
 // CHECK:STDOUT:   %cv: ref Class = bind_name cv, %cv.var
 // CHECK:STDOUT:   %cv.ref.loc14: ref Class = name_ref cv, %cv
 // CHECK:STDOUT:   %.loc14_5: ref i32 = class_element_access %cv.ref.loc14, element0
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 1 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   assign %.loc14_5, %.loc14_10
 // CHECK:STDOUT:   %cv.ref.loc15: ref Class = name_ref cv, %cv
 // CHECK:STDOUT:   %.loc15_5: ref i32 = class_element_access %cv.ref.loc15, element1
-// CHECK:STDOUT:   %.loc15_10: i32 = int_literal 2 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15_10: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc15_5, %.loc15_10
 // CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %cv.ref.loc16: ref Class = name_ref cv, %cv

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -20,9 +20,9 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT: --- init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.n: i32, .next: Class*} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.n: i32, .next: Class*} [template]
-// CHECK:STDOUT:   %.loc17: type = struct_type {.next: Class*, .n: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.n: i32, .next: Class*} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.n: i32, .next: Class*} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.next: Class*, .n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -16,10 +16,10 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- init_as.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -44,8 +44,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1 [template = constants.%.loc13_17]
-// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2 [template = constants.%.loc13_25]
+// CHECK:STDOUT:   %.loc13_17: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc13_25: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc13_26.1: {.a: i32, .b: i32} = struct_literal (%.loc13_17, %.loc13_25)
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc13_26.2: ref Class = temporary_storage

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -23,12 +23,12 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT: --- init_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.c: Inner, .d: Inner} [template]
-// CHECK:STDOUT:   %.loc17_1.2: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
-// CHECK:STDOUT:   %.loc17_1.3: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
-// CHECK:STDOUT:   %.loc14: type = ptr_type {.c: Inner, .d: Inner} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.c: Inner, .d: Inner} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.c: {.a: i32, .b: i32}*, .d: {.a: i32, .b: i32}*} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.c: Inner, .d: Inner} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -51,9 +51,9 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: --- method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.k: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.k: i32} [template]
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.k: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.k: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -106,7 +106,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallOnConstBoundMethod() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc25_17: i32 = int_literal 1 [template = constants.%.loc25]
+// CHECK:STDOUT:   %.loc25_17: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc25_18.1: {.k: i32} = struct_literal (%.loc25_17)
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class [template = file.%Class]
 // CHECK:STDOUT:   %.loc25_18.2: ref Class = temporary_storage

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -98,10 +98,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc21_11: <bound method> = bound_method %c.ref, @Class.%F
-// CHECK:STDOUT:   %.loc21_13: init i32 = call %.loc21_11(%c.ref)
-// CHECK:STDOUT:   %.loc21_15.1: i32 = value_of_initializer %.loc21_13
-// CHECK:STDOUT:   %.loc21_15.2: i32 = converted %.loc21_13, %.loc21_15.1
-// CHECK:STDOUT:   return %.loc21_15.2
+// CHECK:STDOUT:   %.loc21_13.1: init i32 = call %.loc21_11(%c.ref)
+// CHECK:STDOUT:   %.loc21_15: i32 = value_of_initializer %.loc21_13.1
+// CHECK:STDOUT:   %.loc21_13.2: i32 = converted %.loc21_13.1, %.loc21_15
+// CHECK:STDOUT:   return %.loc21_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallOnConstBoundMethod() -> i32 {
@@ -117,10 +117,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc25_18.7: ref Class = converted %.loc25_18.1, %.loc25_18.6
 // CHECK:STDOUT:   %.loc25_29: <bound method> = bound_method %.loc25_18.7, @Class.%F
 // CHECK:STDOUT:   %.loc25_18.8: Class = bind_value %.loc25_18.7
-// CHECK:STDOUT:   %.loc25_31: init i32 = call %.loc25_29(%.loc25_18.8)
-// CHECK:STDOUT:   %.loc25_33.1: i32 = value_of_initializer %.loc25_31
-// CHECK:STDOUT:   %.loc25_33.2: i32 = converted %.loc25_31, %.loc25_33.1
-// CHECK:STDOUT:   return %.loc25_33.2
+// CHECK:STDOUT:   %.loc25_31.1: init i32 = call %.loc25_29(%.loc25_18.8)
+// CHECK:STDOUT:   %.loc25_33: i32 = value_of_initializer %.loc25_31.1
+// CHECK:STDOUT:   %.loc25_31.2: i32 = converted %.loc25_31.1, %.loc25_33
+// CHECK:STDOUT:   return %.loc25_31.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallWithAddr() -> i32 {
@@ -131,10 +131,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %.loc30_11: <bound method> = bound_method %c.ref, @Class.%G
 // CHECK:STDOUT:   %.loc30_10: Class* = addr_of %c.ref
-// CHECK:STDOUT:   %.loc30_13: init i32 = call %.loc30_11(%.loc30_10)
-// CHECK:STDOUT:   %.loc30_15.1: i32 = value_of_initializer %.loc30_13
-// CHECK:STDOUT:   %.loc30_15.2: i32 = converted %.loc30_13, %.loc30_15.1
-// CHECK:STDOUT:   return %.loc30_15.2
+// CHECK:STDOUT:   %.loc30_13.1: init i32 = call %.loc30_11(%.loc30_10)
+// CHECK:STDOUT:   %.loc30_15: i32 = value_of_initializer %.loc30_13.1
+// CHECK:STDOUT:   %.loc30_13.2: i32 = converted %.loc30_13.1, %.loc30_15
+// CHECK:STDOUT:   return %.loc30_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallFThroughPointer(%p: Class*) -> i32 {
@@ -143,10 +143,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc34_11.1: ref Class = deref %p.ref
 // CHECK:STDOUT:   %.loc34_14: <bound method> = bound_method %.loc34_11.1, @Class.%F
 // CHECK:STDOUT:   %.loc34_11.2: Class = bind_value %.loc34_11.1
-// CHECK:STDOUT:   %.loc34_16: init i32 = call %.loc34_14(%.loc34_11.2)
-// CHECK:STDOUT:   %.loc34_18.1: i32 = value_of_initializer %.loc34_16
-// CHECK:STDOUT:   %.loc34_18.2: i32 = converted %.loc34_16, %.loc34_18.1
-// CHECK:STDOUT:   return %.loc34_18.2
+// CHECK:STDOUT:   %.loc34_16.1: init i32 = call %.loc34_14(%.loc34_11.2)
+// CHECK:STDOUT:   %.loc34_18: i32 = value_of_initializer %.loc34_16.1
+// CHECK:STDOUT:   %.loc34_16.2: i32 = converted %.loc34_16.1, %.loc34_18
+// CHECK:STDOUT:   return %.loc34_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGThroughPointer(%p: Class*) -> i32 {
@@ -155,10 +155,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc38_11.1: ref Class = deref %p.ref
 // CHECK:STDOUT:   %.loc38_14: <bound method> = bound_method %.loc38_11.1, @Class.%G
 // CHECK:STDOUT:   %.loc38_11.2: Class* = addr_of %.loc38_11.1
-// CHECK:STDOUT:   %.loc38_16: init i32 = call %.loc38_14(%.loc38_11.2)
-// CHECK:STDOUT:   %.loc38_18.1: i32 = value_of_initializer %.loc38_16
-// CHECK:STDOUT:   %.loc38_18.2: i32 = converted %.loc38_16, %.loc38_18.1
-// CHECK:STDOUT:   return %.loc38_18.2
+// CHECK:STDOUT:   %.loc38_16.1: init i32 = call %.loc38_14(%.loc38_11.2)
+// CHECK:STDOUT:   %.loc38_18: i32 = value_of_initializer %.loc38_16.1
+// CHECK:STDOUT:   %.loc38_16.2: i32 = converted %.loc38_16.1, %.loc38_18
+// CHECK:STDOUT:   return %.loc38_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> %return: Class;
@@ -171,10 +171,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc44_14.3: ref Class = temporary %.loc44_14.1, %.loc44_14.2
 // CHECK:STDOUT:   %.loc44_16: <bound method> = bound_method %.loc44_14.3, @Class.%F
 // CHECK:STDOUT:   %.loc44_14.4: Class = bind_value %.loc44_14.3
-// CHECK:STDOUT:   %.loc44_18: init i32 = call %.loc44_16(%.loc44_14.4)
-// CHECK:STDOUT:   %.loc44_20.1: i32 = value_of_initializer %.loc44_18
-// CHECK:STDOUT:   %.loc44_20.2: i32 = converted %.loc44_18, %.loc44_20.1
-// CHECK:STDOUT:   return %.loc44_20.2
+// CHECK:STDOUT:   %.loc44_18.1: init i32 = call %.loc44_16(%.loc44_14.4)
+// CHECK:STDOUT:   %.loc44_20: i32 = value_of_initializer %.loc44_18.1
+// CHECK:STDOUT:   %.loc44_18.2: i32 = converted %.loc44_18.1, %.loc44_20
+// CHECK:STDOUT:   return %.loc44_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGOnInitializingExpr() -> i32 {
@@ -185,9 +185,9 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc48_14.3: ref Class = temporary %.loc48_14.1, %.loc48_14.2
 // CHECK:STDOUT:   %.loc48_16: <bound method> = bound_method %.loc48_14.3, @Class.%G
 // CHECK:STDOUT:   %.loc48_14.4: Class* = addr_of %.loc48_14.3
-// CHECK:STDOUT:   %.loc48_18: init i32 = call %.loc48_16(%.loc48_14.4)
-// CHECK:STDOUT:   %.loc48_20.1: i32 = value_of_initializer %.loc48_18
-// CHECK:STDOUT:   %.loc48_20.2: i32 = converted %.loc48_18, %.loc48_20.1
-// CHECK:STDOUT:   return %.loc48_20.2
+// CHECK:STDOUT:   %.loc48_18.1: init i32 = call %.loc48_16(%.loc48_14.4)
+// CHECK:STDOUT:   %.loc48_20: i32 = value_of_initializer %.loc48_18.1
+// CHECK:STDOUT:   %.loc48_18.2: i32 = converted %.loc48_18.1, %.loc48_20
+// CHECK:STDOUT:   return %.loc48_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -31,10 +31,10 @@ fn F(a: Outer*) {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12_3.1: type = struct_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
-// CHECK:STDOUT:   %.loc17_1.1: type = struct_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
-// CHECK:STDOUT:   %.loc17_1.2: type = ptr_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
-// CHECK:STDOUT:   %.loc12_3.2: type = ptr_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {.po: Outer*, .qo: Outer*, .pi: Inner*} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type {.pi: Inner*, .po: Outer*, .qi: Inner*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -21,11 +21,11 @@ fn G(o: Outer) {
 // CHECK:STDOUT: --- nested_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.n: i32} [template]
-// CHECK:STDOUT:   %.loc11_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc8: type = ptr_type {.n: i32} [template]
-// CHECK:STDOUT:   %.loc11_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {.n: i32} [template]
+// CHECK:STDOUT:   %.4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -21,11 +21,11 @@ fn Class.G[self: Class](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT: --- raw_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_46.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc9_46.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc9_46.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc11: type = struct_type {.n: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/raw_self_type.carbon
+++ b/toolchain/check/testdata/class/raw_self_type.carbon
@@ -14,7 +14,7 @@ class Class {
 // CHECK:STDOUT: --- raw_self_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/redeclaration.carbon
+++ b/toolchain/check/testdata/class/redeclaration.carbon
@@ -15,7 +15,7 @@ fn Class.F() {}
 // CHECK:STDOUT: --- redeclaration.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/redeclaration_introducer.carbon
@@ -15,7 +15,7 @@ abstract class C {}
 // CHECK:STDOUT: --- redeclaration_introducer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -38,10 +38,10 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
-// CHECK:STDOUT:   %.loc13_11: init i32 = call %G.ref()
-// CHECK:STDOUT:   %.loc13_13.1: i32 = value_of_initializer %.loc13_11
-// CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_11, %.loc13_13.1
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %.loc13_11.1: init i32 = call %G.ref()
+// CHECK:STDOUT:   %.loc13_13: i32 = value_of_initializer %.loc13_11.1
+// CHECK:STDOUT:   %.loc13_11.2: i32 = converted %.loc13_11.1, %.loc13_13
+// CHECK:STDOUT:   return %.loc13_11.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -16,7 +16,7 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT: --- reenter_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -26,9 +26,9 @@ fn Run() {
 // CHECK:STDOUT: --- scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,7 +50,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -65,7 +65,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 2 [template = constants.%.loc18]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   return %.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -57,10 +57,10 @@ fn Run() {
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
-// CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1
-// CHECK:STDOUT:   return %.loc13_15.2
+// CHECK:STDOUT:   %.loc13_13.1: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc13_15: i32 = value_of_initializer %.loc13_13.1
+// CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_13.1, %.loc13_15
+// CHECK:STDOUT:   return %.loc13_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32 {

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -22,8 +22,8 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT: --- self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = struct_type {.n: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.n: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.n: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.n: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -101,17 +101,17 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %.loc27_20.1: ref Derived = deref %.loc27_4.2
 // CHECK:STDOUT:   %.loc27_20.2: ref Base = class_element_access %.loc27_20.1, element0
 // CHECK:STDOUT:   %.loc27_20.3: Base* = addr_of %.loc27_20.2
-// CHECK:STDOUT:   %.loc27_20.4: Base* = converted %.loc27_4.2, %.loc27_20.3
-// CHECK:STDOUT:   %.loc27_20.5: init () = call %.loc27_7(%.loc27_20.4)
+// CHECK:STDOUT:   %.loc27_4.3: Base* = converted %.loc27_4.2, %.loc27_20.3
+// CHECK:STDOUT:   %.loc27_20.4: init () = call %.loc27_7(%.loc27_4.3)
 // CHECK:STDOUT:   %p.ref.loc28: Derived* = name_ref p, %p
-// CHECK:STDOUT:   %.loc28_11: ref Derived = deref %p.ref.loc28
-// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11, @Derived.%SelfBase
-// CHECK:STDOUT:   %.loc28_23.1: ref Base = class_element_access %.loc28_11, element0
-// CHECK:STDOUT:   %.loc28_23.2: ref Base = converted %.loc28_11, %.loc28_23.1
-// CHECK:STDOUT:   %.loc28_23.3: Base = bind_value %.loc28_23.2
-// CHECK:STDOUT:   %.loc28_23.4: init i32 = call %.loc28_14(%.loc28_23.3)
-// CHECK:STDOUT:   %.loc28_25.1: i32 = value_of_initializer %.loc28_23.4
-// CHECK:STDOUT:   %.loc28_25.2: i32 = converted %.loc28_23.4, %.loc28_25.1
-// CHECK:STDOUT:   return %.loc28_25.2
+// CHECK:STDOUT:   %.loc28_11.1: ref Derived = deref %p.ref.loc28
+// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11.1, @Derived.%SelfBase
+// CHECK:STDOUT:   %.loc28_23.1: ref Base = class_element_access %.loc28_11.1, element0
+// CHECK:STDOUT:   %.loc28_11.2: ref Base = converted %.loc28_11.1, %.loc28_23.1
+// CHECK:STDOUT:   %.loc28_11.3: Base = bind_value %.loc28_11.2
+// CHECK:STDOUT:   %.loc28_23.2: init i32 = call %.loc28_14(%.loc28_11.3)
+// CHECK:STDOUT:   %.loc28_25: i32 = value_of_initializer %.loc28_23.2
+// CHECK:STDOUT:   %.loc28_23.3: i32 = converted %.loc28_23.2, %.loc28_25
+// CHECK:STDOUT:   return %.loc28_23.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -31,13 +31,13 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: --- self_conversion.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc16_1.1: type = struct_type {.base: Base} [template]
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc16_1.2: type = struct_type {.base: {.a: i32}*} [template]
-// CHECK:STDOUT:   %.loc11: type = ptr_type {.base: Base} [template]
-// CHECK:STDOUT:   %.loc27: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: {.a: i32}*} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.base: Base} [template]
+// CHECK:STDOUT:   %.7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -87,7 +87,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc23_4: ref Base = deref %self.ref
 // CHECK:STDOUT:   %.loc23_10: ref i32 = class_element_access %.loc23_4, element0
-// CHECK:STDOUT:   %.loc23_15: i32 = int_literal 1 [template = constants.%.loc23]
+// CHECK:STDOUT:   %.loc23_15: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc23_10, %.loc23_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -51,9 +51,9 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT:   %.loc16_11.1: ref Class = deref %.loc16_16.2
 // CHECK:STDOUT:   %.loc16_19: <bound method> = bound_method %.loc16_11.1, @Class.%F
 // CHECK:STDOUT:   %.loc16_11.2: Class = bind_value %.loc16_11.1
-// CHECK:STDOUT:   %.loc16_21: init i32 = call %.loc16_19(%.loc16_11.2)
-// CHECK:STDOUT:   %.loc16_23.1: i32 = value_of_initializer %.loc16_21
-// CHECK:STDOUT:   %.loc16_23.2: i32 = converted %.loc16_21, %.loc16_23.1
-// CHECK:STDOUT:   return %.loc16_23.2
+// CHECK:STDOUT:   %.loc16_21.1: init i32 = call %.loc16_19(%.loc16_11.2)
+// CHECK:STDOUT:   %.loc16_23: i32 = value_of_initializer %.loc16_21.1
+// CHECK:STDOUT:   %.loc16_21.2: i32 = converted %.loc16_21.1, %.loc16_23
+// CHECK:STDOUT:   return %.loc16_21.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -19,8 +19,8 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT: --- self_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {.p: Class*} [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.p: Class*} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.p: Class*} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.p: Class*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -16,9 +16,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- static_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc9_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -44,9 +44,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
-// CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1
-// CHECK:STDOUT:   return %.loc13_15.2
+// CHECK:STDOUT:   %.loc13_13.1: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc13_15: i32 = value_of_initializer %.loc13_13.1
+// CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_13.1, %.loc13_15
+// CHECK:STDOUT:   return %.loc13_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
+++ b/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
@@ -36,8 +36,8 @@ fn H() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_19: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc10_19, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_19.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_19.2: type = converted %.loc10_19.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32) = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10: <function> = name_ref F, file.%F [template = file.%F]

--- a/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
+++ b/toolchain/check/testdata/expr_category/in_place_tuple_init.carbon
@@ -19,10 +19,10 @@ fn H() -> i32 {
 // CHECK:STDOUT: --- in_place_tuple_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_20.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_20.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_20.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,7 +37,7 @@ fn H() -> i32 {
 // CHECK:STDOUT: fn @G() -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_19: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7: type = converted %.loc10_19, constants.%.loc7_20.2 [template = constants.%.loc7_20.2]
+// CHECK:STDOUT:   %.1: type = converted %.loc10_19, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32) = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10: <function> = name_ref F, file.%F [template = file.%F]
@@ -60,7 +60,7 @@ fn H() -> i32 {
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc16_11.1: ref (i32, i32) = temporary_storage
 // CHECK:STDOUT:   %.loc16_11.2: init (i32, i32) = call %G.ref() to %.loc16_11.1
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0 [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc16_11.3: ref (i32, i32) = temporary %.loc16_11.1, %.loc16_11.2
 // CHECK:STDOUT:   %.loc16_15.1: ref i32 = tuple_index %.loc16_11.3, %.loc16_14
 // CHECK:STDOUT:   %.loc16_15.2: i32 = bind_value %.loc16_15.1

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -15,9 +15,9 @@ fn Main() {
 // CHECK:STDOUT: --- empty_struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc12: {} = struct_value () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -36,8 +36,8 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: {} = struct_value () [template = constants.%.loc12]
-// CHECK:STDOUT:   %.loc12_9.3: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_9.2: {} = struct_value () [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_9.3: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc12_7: init {} = call %Echo.ref(%.loc12_9.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -15,8 +15,8 @@ fn Main() {
 // CHECK:STDOUT: --- empty_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc12: () = tuple_value () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,8 +35,8 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: () = tuple_value () [template = constants.%.loc12]
-// CHECK:STDOUT:   %.loc12_9.3: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_9.2: () = tuple_value () [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_9.3: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc12_7: init () = call %Echo.ref(%.loc12_9.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_not_callable.carbon
+++ b/toolchain/check/testdata/function/call/fail_not_callable.carbon
@@ -15,7 +15,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc11: String = string_literal "hello" [template]
+// CHECK:STDOUT:   %.2: String = string_literal "hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11: String = string_literal "hello" [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: String = string_literal "hello" [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -58,13 +58,13 @@ fn Main() {
 // CHECK:STDOUT: --- fail_param_count.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc18_7: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc55: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -93,22 +93,22 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
-// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template = constants.%.loc18_8]
+// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc18_7: init () = call %Run0.ref.loc18(<invalid>)
 // CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
-// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template = constants.%.loc25_8]
-// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template = constants.%.loc25_11]
+// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc25_7: init () = call %Run0.ref.loc25(<invalid>)
 // CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
 // CHECK:STDOUT:   %.loc33: init () = call %Run1.ref.loc33(<invalid>)
 // CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
-// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template = constants.%.loc40_8]
-// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template = constants.%.loc40_11]
+// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc40_7: init () = call %Run1.ref.loc40(<invalid>)
 // CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
 // CHECK:STDOUT:   %.loc48: init () = call %Run2.ref.loc48(<invalid>)
 // CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
-// CHECK:STDOUT:   %.loc55_8: i32 = int_literal 0 [template = constants.%.loc55]
+// CHECK:STDOUT:   %.loc55_8: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc55_7: init () = call %Run2.ref.loc55(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_param_type.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_type.carbon
@@ -19,8 +19,8 @@ fn F() {
 // CHECK:STDOUT: --- fail_param_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1 [template]
-// CHECK:STDOUT:   %.loc16_4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,7 +37,7 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1 [template = constants.%.loc16_5]
+// CHECK:STDOUT:   %.loc16_5: f64 = real_literal 10e-1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc16_4: init () = call %G.ref(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
+++ b/toolchain/check/testdata/function/call/fail_return_type_mismatch.carbon
@@ -16,7 +16,7 @@ fn Run() {
 // CHECK:STDOUT: --- fail_return_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +27,7 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo() -> f64 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: f64 = real_literal 10e-1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/i32.carbon
+++ b/toolchain/check/testdata/function/call/i32.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT: --- i32.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,7 +35,7 @@ fn Main() {
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
-// CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_21: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc12_20: init i32 = call %Echo.ref(%.loc12_21)
 // CHECK:STDOUT:   assign %b.var, %.loc12_20
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -36,8 +36,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_15: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc10_15, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_15.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc10_15.2: type = converted %.loc10_15.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.3]

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -15,12 +15,12 @@ fn Main() {
 // CHECK:STDOUT: --- more_param_ir.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_15.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc10_15.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc12_6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -36,20 +36,20 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_15.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_15.2: type = converted %.loc10_15.1, constants.%.loc10_15.2 [template = constants.%.loc10_15.2]
+// CHECK:STDOUT:   %.loc10_15: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.1: type = converted %.loc10_15, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.loc10_20]
+// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_22.1: (i32,) = tuple_literal (%.loc10_20)
 // CHECK:STDOUT:   %.loc10_22.2: init (i32,) = tuple_init (%.loc10_20) to %x.var
 // CHECK:STDOUT:   %.loc10_22.3: init (i32,) = converted %.loc10_22.1, %.loc10_22.2
 // CHECK:STDOUT:   assign %x.var, %.loc10_22.3
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x
-// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.loc12_9]
+// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc12_10.1: ref i32 = tuple_index %x.ref, %.loc12_9
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template = constants.%.loc12_13]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_10.2: i32 = bind_value %.loc12_10.1
 // CHECK:STDOUT:   %.loc12_6: init () = call %Foo.ref(%.loc12_10.2, %.loc12_13)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/params_one.carbon
+++ b/toolchain/check/testdata/function/call/params_one.carbon
@@ -13,8 +13,8 @@ fn Main() {
 // CHECK:STDOUT: --- params_one.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,7 +31,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_one_comma.carbon
@@ -14,9 +14,9 @@ fn Main() {
 // CHECK:STDOUT: --- params_one_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,10 +33,10 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7)
 // CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two.carbon
+++ b/toolchain/check/testdata/function/call/params_two.carbon
@@ -13,9 +13,9 @@ fn Main() {
 // CHECK:STDOUT: --- params_two.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,8 +32,8 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.loc10_10]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref(%.loc10_7, %.loc10_10)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/check/testdata/function/call/params_two_comma.carbon
@@ -14,11 +14,11 @@ fn Main() {
 // CHECK:STDOUT: --- params_two_comma.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_6: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: type = tuple_type () [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,12 +35,12 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Foo.ref.loc10: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.loc10_7]
-// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.loc10_10]
+// CHECK:STDOUT:   %.loc10_7: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_10: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_6: init () = call %Foo.ref.loc10(%.loc10_7, %.loc10_10)
 // CHECK:STDOUT:   %Foo.ref.loc11: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
-// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.loc11_7]
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2 [template = constants.%.loc11_10]
+// CHECK:STDOUT:   %.loc11_7: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc11_6: init () = call %Foo.ref.loc11(%.loc11_7, %.loc11_10)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/params_zero.carbon
+++ b/toolchain/check/testdata/function/call/params_zero.carbon
@@ -13,7 +13,7 @@ fn Main() {
 // CHECK:STDOUT: --- params_zero.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- return_implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_11.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc11_11.2: type = converted %.loc11_11.1, constants.%.loc11 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_11: () = tuple_literal ()
+// CHECK:STDOUT:   %.1: type = converted %.loc11_11, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_ref MakeImplicitEmptyTuple, file.%MakeImplicitEmptyTuple [template = file.%MakeImplicitEmptyTuple]

--- a/toolchain/check/testdata/function/call/return_implicit.carbon
+++ b/toolchain/check/testdata/function/call/return_implicit.carbon
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_11: () = tuple_literal ()
-// CHECK:STDOUT:   %.1: type = converted %.loc11_11, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11_11.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc11_11.2: type = converted %.loc11_11.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %MakeImplicitEmptyTuple.ref: <function> = name_ref MakeImplicitEmptyTuple, file.%MakeImplicitEmptyTuple [template = file.%MakeImplicitEmptyTuple]

--- a/toolchain/check/testdata/function/declaration/simple.carbon
+++ b/toolchain/check/testdata/function/declaration/simple.carbon
@@ -11,7 +11,7 @@ fn G() { F(); }
 // CHECK:STDOUT: --- simple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/if/else.carbon
+++ b/toolchain/check/testdata/if/else.carbon
@@ -20,7 +20,7 @@ fn If(b: bool) {
 // CHECK:STDOUT: --- else.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -36,9 +36,9 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_reachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,7 +54,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
@@ -72,7 +72,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template = constants.%.loc20]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
@@ -84,7 +84,7 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.loc29]
+// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   return %.loc29
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:

--- a/toolchain/check/testdata/if/fail_scope.carbon
+++ b/toolchain/check/testdata/if/fail_scope.carbon
@@ -18,7 +18,7 @@ fn VarScope(b: bool) -> i32 {
 // CHECK:STDOUT: --- fail_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -34,7 +34,7 @@ fn VarScope(b: bool) -> i32 {
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 2 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 2 [template = constants.%.1]
 // CHECK:STDOUT:   assign %n.var, %.loc9
 // CHECK:STDOUT:   %n.ref.loc10: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc10: i32 = bind_value %n.ref.loc10

--- a/toolchain/check/testdata/if/no_else.carbon
+++ b/toolchain/check/testdata/if/no_else.carbon
@@ -17,7 +17,7 @@ fn If(b: bool) {
 // CHECK:STDOUT: --- no_else.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/if/unreachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/unreachable_fallthrough.carbon
@@ -16,8 +16,8 @@ fn If(b: bool) -> i32 {
 // CHECK:STDOUT: --- unreachable_fallthrough.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,11 +31,11 @@ fn If(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -12,11 +12,11 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8_17.1: type = array_type %.loc8_16, i32 [template]
-// CHECK:STDOUT:   %.loc8_17.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc8_24: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,11 +26,11 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool, %n: i32, %m: i32) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1 [template = constants.%.loc8_16]
-// CHECK:STDOUT:   %.loc8_17: type = array_type %.loc8_16, i32 [template = constants.%.loc8_17.1]
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_17: type = array_type %.loc8_16, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref [i32; 1] = var x
 // CHECK:STDOUT:   %x: ref [i32; 1] = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0 [template = constants.%.loc8_22]
+// CHECK:STDOUT:   %.loc8_22: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_24.1: (i32,) = tuple_literal (%.loc8_22)
 // CHECK:STDOUT:   %.loc8_24.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc8_24.3: ref i32 = array_index %x.var, %.loc8_24.2

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -58,10 +58,10 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc11_33: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc11_27.1: i32 = value_of_initializer %.loc11_33
-// CHECK:STDOUT:   %.loc11_27.2: i32 = converted %.loc11_33, %.loc11_27.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_27.2)
+// CHECK:STDOUT:   %.loc11_33.1: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc11_27: i32 = value_of_initializer %.loc11_33.1
+// CHECK:STDOUT:   %.loc11_33.2: i32 = converted %.loc11_33.1, %.loc11_27
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_33.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_10: i32 = block_arg !if.expr.result
@@ -82,10 +82,10 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc15_34: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc15_28.1: i32 = value_of_initializer %.loc15_34
-// CHECK:STDOUT:   %.loc15_28.2: i32 = converted %.loc15_34, %.loc15_28.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_28.2)
+// CHECK:STDOUT:   %.loc15_34.1: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc15_28: i32 = value_of_initializer %.loc15_34.1
+// CHECK:STDOUT:   %.loc15_34.2: i32 = converted %.loc15_34.1, %.loc15_28
+// CHECK:STDOUT:   br !if.expr.result(%.loc15_34.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc15_10: i32 = block_arg !if.expr.result

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -18,10 +18,10 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- constant_condition.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc15: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.4: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -34,19 +34,19 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_13: bool = bool_literal true [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_13: bool = bool_literal true [template = constants.%.3]
 // CHECK:STDOUT:   if %.loc11_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
@@ -70,7 +70,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc15_13: bool = bool_literal false [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15_13: bool = bool_literal false [template = constants.%.4]
 // CHECK:STDOUT:   if %.loc15_13 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -14,8 +14,8 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- control_flow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,13 +27,13 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -51,10 +51,10 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc11_30: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc11_24.1: i32 = value_of_initializer %.loc11_30
-// CHECK:STDOUT:   %.loc11_24.2: i32 = converted %.loc11_30, %.loc11_24.1
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_24.2)
+// CHECK:STDOUT:   %.loc11_30.1: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc11_24: i32 = value_of_initializer %.loc11_30.1
+// CHECK:STDOUT:   %.loc11_30.2: i32 = converted %.loc11_30.1, %.loc11_24
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_30.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_10: i32 = block_arg !if.expr.result

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -36,11 +36,11 @@ class C {
 // CHECK:STDOUT: --- fail_not_in_function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17_17: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc17_27: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc17_34: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc34: type = struct_type {.n: <error>} [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.n: <error>} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -51,7 +51,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template = constants.%.loc33]
+// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template = constants.%.4]
 // CHECK:STDOUT:   if %.loc33 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/if_expr/nested.carbon
+++ b/toolchain/check/testdata/if_expr/nested.carbon
@@ -11,10 +11,10 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,11 +32,11 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.expr.then.loc8_20 else br !if.expr.else.loc8_20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8_20:
-// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template = constants.%.loc8_30]
+// CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   br !if.expr.result.loc8_20(%.loc8_30)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc8_20:
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2 [template = constants.%.loc8_37]
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   br !if.expr.result.loc8_20(%.loc8_37)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8_20:
@@ -48,11 +48,11 @@ fn F(a: bool, b: bool, c: bool) -> i32 {
 // CHECK:STDOUT:   if %c.ref br !if.expr.then.loc8_44 else br !if.expr.else.loc8_44
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8_44:
-// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3 [template = constants.%.loc8_54]
+// CHECK:STDOUT:   %.loc8_54: i32 = int_literal 3 [template = constants.%.3]
 // CHECK:STDOUT:   br !if.expr.result.loc8_44(%.loc8_54)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc8_44:
-// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4 [template = constants.%.loc8_61]
+// CHECK:STDOUT:   %.loc8_61: i32 = int_literal 4 [template = constants.%.4]
 // CHECK:STDOUT:   br !if.expr.result.loc8_44(%.loc8_61)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8_44:

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -14,10 +14,10 @@ fn F(cond: bool) {
 // CHECK:STDOUT: --- struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,8 +33,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %a.var: ref {.a: i32, .b: i32} = var a
 // CHECK:STDOUT:   %a: ref {.a: i32, .b: i32} = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.loc10_37]
-// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2 [template = constants.%.loc10_45]
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_45: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_46.1: {.a: i32, .b: i32} = struct_literal (%.loc10_37, %.loc10_45)
 // CHECK:STDOUT:   %.loc10_46.2: ref i32 = struct_access %a.var, element0
 // CHECK:STDOUT:   %.loc10_46.3: init i32 = initialize_from %.loc10_37 to %.loc10_46.2

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -12,24 +12,24 @@ var d: i32 = a[b];
 // CHECK:STDOUT: --- array_element_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 2] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24 [template]
-// CHECK:STDOUT:   %.loc7_26: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 2] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 24 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c, .d = %d}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 2 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 2] = var a
 // CHECK:STDOUT:   %a: ref [i32; 2] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
-// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24 [template = constants.%.loc7_24]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_24: i32 = int_literal 24 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_26.1: (i32, i32) = tuple_literal (%.loc7_20, %.loc7_24)
 // CHECK:STDOUT:   %.loc7_26.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_26.3: ref i32 = array_index %a.var, %.loc7_26.2
@@ -42,12 +42,12 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   assign %a.var, %.loc7_26.9
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %a.ref.loc9: ref [i32; 2] = name_ref a, %a
-// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = array_index %a.ref.loc9, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2

--- a/toolchain/check/testdata/index/expr_category.carbon
+++ b/toolchain/check/testdata/index/expr_category.carbon
@@ -27,30 +27,30 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT: --- expr_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32 [template]
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template]
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_29: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc17_26: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc17_27: type = array_type %.loc17_26, i32 [template]
-// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32 [template]
-// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.5: type = array_type %.4, i32 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: type = array_type %.6, i32 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.15: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.16: type = array_type %.15, i32 [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.18: type = array_type %.17, i32 [template]
+// CHECK:STDOUT:   %.19: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.20: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.21: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.22: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.23: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.24: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -64,13 +64,13 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3 [template = constants.%.loc10_16]
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.loc10_17]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.7]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template = constants.%.loc10_22]
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2 [template = constants.%.loc10_25]
-// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3 [template = constants.%.loc10_28]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 2 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc10_28: i32 = int_literal 3 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc10_29.1: (i32, i32, i32) = tuple_literal (%.loc10_22, %.loc10_25, %.loc10_28)
 // CHECK:STDOUT:   %.loc10_29.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc10_29.3: ref i32 = array_index %a.var, %.loc10_29.2
@@ -88,27 +88,27 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %pa.var: ref i32* = var pa
 // CHECK:STDOUT:   %pa: ref i32* = bind_name pa, %pa.var
 // CHECK:STDOUT:   %a.ref.loc13: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc13_21: i32 = int_literal 0 [template = constants.%.loc13]
+// CHECK:STDOUT:   %.loc13_21: i32 = int_literal 0 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc13_22: ref i32 = array_index %a.ref.loc13, %.loc13_21
 // CHECK:STDOUT:   %.loc13_18: i32* = addr_of %.loc13_22
 // CHECK:STDOUT:   assign %pa.var, %.loc13_18
 // CHECK:STDOUT:   %a.ref.loc14: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template = constants.%.loc14_5]
+// CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc14_6: ref i32 = array_index %a.ref.loc14, %.loc14_5
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template = constants.%.loc14_10]
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template = constants.%.14]
 // CHECK:STDOUT:   assign %.loc14_6, %.loc14_10
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ValueBinding(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3 [template = constants.%.loc18_16]
-// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32 [template = constants.%.loc18_17]
+// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 3 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc18_17: type = array_type %.loc18_16, i32 [template = constants.%.18]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1 [template = constants.%.loc18_22]
-// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2 [template = constants.%.loc18_25]
-// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3 [template = constants.%.loc18_28]
+// CHECK:STDOUT:   %.loc18_22: i32 = int_literal 1 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc18_25: i32 = int_literal 2 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc18_28: i32 = int_literal 3 [template = constants.%.21]
 // CHECK:STDOUT:   %.loc18_29.1: (i32, i32, i32) = tuple_literal (%.loc18_22, %.loc18_25, %.loc18_28)
 // CHECK:STDOUT:   %.loc18_29.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc18_29.3: ref i32 = array_index %a.var, %.loc18_29.2
@@ -123,17 +123,17 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc18_29.12: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11
 // CHECK:STDOUT:   assign %a.var, %.loc18_29.12
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, %a
-// CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0 [template = constants.%.22]
 // CHECK:STDOUT:   %.loc22_6: ref i32 = array_index %a.ref, %.loc22_5
 // CHECK:STDOUT:   %b.ref: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc23_5: i32 = int_literal 0 [template = constants.%.loc23]
+// CHECK:STDOUT:   %.loc23_5: i32 = int_literal 0 [template = constants.%.23]
 // CHECK:STDOUT:   %.loc23_6.1: ref [i32; 3] = value_as_ref %b.ref
 // CHECK:STDOUT:   %.loc23_6.2: ref i32 = array_index %.loc23_6.1, %.loc23_5
 // CHECK:STDOUT:   %.loc23_6.3: i32 = bind_value %.loc23_6.2
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc24_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc24_4.2: init [i32; 3] = call %F.ref() to %.loc24_4.1
-// CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0 [template = constants.%.loc24]
+// CHECK:STDOUT:   %.loc24_7: i32 = int_literal 0 [template = constants.%.24]
 // CHECK:STDOUT:   %.loc24_4.3: ref [i32; 3] = temporary %.loc24_4.1, %.loc24_4.2
 // CHECK:STDOUT:   %.loc24_8.1: ref i32 = array_index %.loc24_4.3, %.loc24_7
 // CHECK:STDOUT:   %.loc24_8.2: i32 = bind_value %.loc24_8.1

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: --- fail_array_large_index.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 295147905179352825855 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 295147905179352825855 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 295147905179352825855 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 295147905179352825855 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_35.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_35.2: i32 = bind_value %.loc11_35.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_35.2

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: --- fail_array_non_int_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.6: f64 = real_literal 26e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_19.2: i32 = bind_value %.loc11_19.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_19.2

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[2];
 // CHECK:STDOUT: --- fail_array_out_of_bound_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_15.1: type = array_type %.loc7_14, i32 [template]
-// CHECK:STDOUT:   %.loc7_15.2: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_23: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.loc7_14]
-// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.loc7_15.1]
+// CHECK:STDOUT:   %.loc7_14: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.loc7_20]
+// CHECK:STDOUT:   %.loc7_20: i32 = int_literal 12 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.1: (i32,) = tuple_literal (%.loc7_20)
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index %a.var, %.loc7_23.2
@@ -38,7 +38,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_17.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_17.2: i32 = bind_value %.loc11_17.1
 // CHECK:STDOUT:   assign %b.var, %.loc11_17.2

--- a/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_empty_tuple_access.carbon
@@ -16,8 +16,8 @@ fn Run() {
 // CHECK:STDOUT: --- fail_empty_tuple_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_4: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,7 +35,7 @@ fn Run() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc13_4.1: init () = call %F.ref()
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0 [template = constants.%.loc13_7]
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc13_4.2: ref () = temporary_storage
 // CHECK:STDOUT:   %.loc13_4.3: ref () = temporary %.loc13_4.2, %.loc13_4.1
 // CHECK:STDOUT:   %.loc13_8: ref <error> = tuple_index %.loc13_4.3, <error>

--- a/toolchain/check/testdata/index/fail_expr_category.carbon
+++ b/toolchain/check/testdata/index/fail_expr_category.carbon
@@ -32,17 +32,17 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT: --- fail_expr_category.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc7_18.1: type = array_type %.loc7_17, i32 [template]
-// CHECK:STDOUT:   %.loc7_18.2: type = ptr_type [i32; 3] [template]
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc9_16: type = array_type %.loc9_15, i32 [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: type = array_type %.1, i32 [template]
+// CHECK:STDOUT:   %.3: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.5: type = array_type %.4, i32 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -59,18 +59,18 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   %pb.var: ref i32* = var pb
 // CHECK:STDOUT:   %pb: ref i32* = bind_name pb, %pb.var
 // CHECK:STDOUT:   %b.ref.loc14: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc14_21: i32 = int_literal 0 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14_21: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc14_22.1: ref [i32; 3] = value_as_ref %b.ref.loc14
 // CHECK:STDOUT:   %.loc14_22.2: ref i32 = array_index %.loc14_22.1, %.loc14_21
 // CHECK:STDOUT:   %.loc14_22.3: i32 = bind_value %.loc14_22.2
 // CHECK:STDOUT:   %.loc14_18: i32* = addr_of %.loc14_22.3
 // CHECK:STDOUT:   assign %pb.var, %.loc14_18
 // CHECK:STDOUT:   %b.ref.loc18: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template = constants.%.loc18_5]
+// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc18_6.1: ref [i32; 3] = value_as_ref %b.ref.loc18
 // CHECK:STDOUT:   %.loc18_6.2: ref i32 = array_index %.loc18_6.1, %.loc18_5
 // CHECK:STDOUT:   %.loc18_6.3: i32 = bind_value %.loc18_6.2
-// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template = constants.%.loc18_10]
+// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template = constants.%.8]
 // CHECK:STDOUT:   assign %.loc18_6.3, %.loc18_10
 // CHECK:STDOUT:   %.loc25_14: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %pf.var: ref i32* = var pf
@@ -78,7 +78,7 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   %F.ref.loc25: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc25_20.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc25_20.2: init [i32; 3] = call %F.ref.loc25() to %.loc25_20.1
-// CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0 [template = constants.%.loc25]
+// CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc25_20.3: ref [i32; 3] = temporary %.loc25_20.1, %.loc25_20.2
 // CHECK:STDOUT:   %.loc25_24.1: ref i32 = array_index %.loc25_20.3, %.loc25_23
 // CHECK:STDOUT:   %.loc25_24.2: i32 = bind_value %.loc25_24.1
@@ -87,11 +87,11 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:   %F.ref.loc29: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc29_4.1: ref [i32; 3] = temporary_storage
 // CHECK:STDOUT:   %.loc29_4.2: init [i32; 3] = call %F.ref.loc29() to %.loc29_4.1
-// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template = constants.%.loc29_7]
+// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc29_4.3: ref [i32; 3] = temporary %.loc29_4.1, %.loc29_4.2
 // CHECK:STDOUT:   %.loc29_8.1: ref i32 = array_index %.loc29_4.3, %.loc29_7
 // CHECK:STDOUT:   %.loc29_8.2: i32 = bind_value %.loc29_8.1
-// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template = constants.%.loc29_12]
+// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template = constants.%.11]
 // CHECK:STDOUT:   assign %.loc29_8.2, %.loc29_12
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -33,15 +33,15 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT: --- fail_invalid_base.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc26_29.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc26_29.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template]
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.8: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,27 +50,27 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, %.loc11
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %a.var, <error>
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, %F [template = %F]
-// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template = constants.%.loc21]
+// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template = constants.%.loc26_20]
-// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template = constants.%.loc26_28]
+// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc26_29.1: {.a: i32, .b: i32} = struct_literal (%.loc26_20, %.loc26_28)
-// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template = constants.%.loc26_31]
-// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template = constants.%.loc26_29.3]
-// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = converted %.loc26_29.1, %.loc26_29.2 [template = constants.%.loc26_29.3]
+// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = converted %.loc26_29.1, %.loc26_29.2 [template = constants.%.8]
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %d.var: ref i32 = var d
 // CHECK:STDOUT:   %d: ref i32 = bind_name d, %d.var
 // CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0 [template = constants.%.loc31]
+// CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   assign %d.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_name_not_found.carbon
+++ b/toolchain/check/testdata/index/fail_name_not_found.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_name_not_found.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +27,7 @@ fn Main() {
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error>
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -13,12 +13,12 @@ var b: i32 = a[-10];
 // CHECK:STDOUT: --- fail_negative_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -14,22 +14,22 @@ var c: i32 = a[b];
 // CHECK:STDOUT: --- fail_non_deterministic_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template = constants.%.loc7_22]
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3 [template = constants.%.loc7_25]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 3 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_26.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
 // CHECK:STDOUT:   %.loc7_26.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_26.3: init i32 = initialize_from %.loc7_22 to %.loc7_26.2
@@ -40,7 +40,7 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   assign %a.var, %.loc7_26.7
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   assign %b.var, %.loc8
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -24,8 +24,8 @@ var c: i32 = a[b];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 2 [template = constants.%.4]

--- a/toolchain/check/testdata/index/fail_non_tuple_access.carbon
+++ b/toolchain/check/testdata/index/fail_non_tuple_access.carbon
@@ -14,8 +14,8 @@ fn Main() {
 // CHECK:STDOUT: --- fail_non_tuple_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -25,8 +25,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0 [template = constants.%.loc11_3]
-// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1 [template = constants.%.loc11_5]
+// CHECK:STDOUT:   %.loc11_3: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11_5: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -22,8 +22,8 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -13,21 +13,21 @@ var b: i32 = a[oops];
 // CHECK:STDOUT: --- fail_tuple_index_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -14,25 +14,25 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT: --- fail_tuple_large_index.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 295147905179352825855 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 295147905179352825855 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.loc7_18]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a
@@ -44,7 +44,7 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, %b
-// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12_16: i32 = int_literal 295147905179352825855 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc12_35: ref <error> = tuple_index %b.ref, <error>
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -22,8 +22,8 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
@@ -31,8 +31,8 @@ var c: i32 = b[0xFFFFFFFFFFFFFFFFF];
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
-// CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc8_13.2: type = converted %.loc8_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -23,8 +23,8 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -13,22 +13,22 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT: --- fail_tuple_non_int_indexing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 26e-1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.6: f64 = real_literal 26e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2
@@ -40,7 +40,7 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -13,22 +13,22 @@ var b: i32 = a[2];
 // CHECK:STDOUT: --- fail_tuple_out_of_bound_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.loc7_22]
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.loc7_26]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: ref i32 = tuple_access %a.var, element0
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2
@@ -40,7 +40,7 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, %a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign %b.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -23,8 +23,8 @@ var b: i32 = a[2];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b}
-// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 12 [template = constants.%.4]

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -11,25 +11,25 @@ var c: i32 = b[0];
 // CHECK:STDOUT: --- tuple_element_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.loc7_18]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a
@@ -41,7 +41,7 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, %b
-// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign %c.var, %.loc9_17.2

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -19,8 +19,8 @@ var c: i32 = b[0];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, .b = %b, .c = %c}
-// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
@@ -28,8 +28,8 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to %a.var
 // CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2
 // CHECK:STDOUT:   assign %a.var, %.loc7_21.3
-// CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc8_13.2: type = converted %.loc8_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref (i32,) = var b
 // CHECK:STDOUT:   %b: ref (i32,) = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, %a

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -13,11 +13,11 @@ fn Run() -> i32 {
 // CHECK:STDOUT: --- tuple_return_value_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_16.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_16.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_value (%.loc7_28) [template]
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,10 +28,10 @@ fn Run() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.loc7_28]
+// CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.loc7_30]
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.loc7_30]
+// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
 // CHECK:STDOUT:   return %.loc7_30.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -39,7 +39,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc10_11.1: init (i32,) = call %F.ref()
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0 [template = constants.%.loc10]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc10_11.2: ref (i32,) = temporary_storage
 // CHECK:STDOUT:   %.loc10_11.3: ref (i32,) = temporary %.loc10_11.2, %.loc10_11.1
 // CHECK:STDOUT:   %.loc10_15.1: ref i32 = tuple_index %.loc10_11.3, %.loc10_14

--- a/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
+++ b/toolchain/check/testdata/ir/duplicate_name_same_line.carbon
@@ -9,10 +9,10 @@ fn A() { if (true) { var n: i32 = 1; } if (true) { var n: i32 = 2; } }
 // CHECK:STDOUT: --- duplicate_name_same_line.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -22,24 +22,24 @@ fn A() { if (true) { var n: i32 = 1; } if (true) { var n: i32 = 2; } }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true [template = constants.%.loc7_14]
+// CHECK:STDOUT:   %.loc7_14: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   if %.loc7_14 br !if.then.loc7_18 else br !if.else.loc7_18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc7_18:
 // CHECK:STDOUT:   %n.var.loc7_26: ref i32 = var n
 // CHECK:STDOUT:   %n.loc7_26: ref i32 = bind_name n, %n.var.loc7_26
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.loc7_35]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %n.var.loc7_26, %.loc7_35
 // CHECK:STDOUT:   br !if.else.loc7_18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc7_18:
-// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true [template = constants.%.loc7_44]
+// CHECK:STDOUT:   %.loc7_44: bool = bool_literal true [template = constants.%.3]
 // CHECK:STDOUT:   if %.loc7_44 br !if.then.loc7_48 else br !if.else.loc7_48
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc7_48:
 // CHECK:STDOUT:   %n.var.loc7_56: ref i32 = var n
 // CHECK:STDOUT:   %n.loc7_56: ref i32 = bind_name n, %n.var.loc7_56
-// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2 [template = constants.%.loc7_65]
+// CHECK:STDOUT:   %.loc7_65: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   assign %n.var.loc7_56, %.loc7_65
 // CHECK:STDOUT:   br !if.else.loc7_48
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -30,8 +30,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_24: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc8_24, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc8_24.2: type = converted %.loc8_24.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32, i32) = bind_name v, %v.var
 // CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template = constants.%.4]
@@ -47,8 +47,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.8: init (i32, i32, i32) = tuple_init (%.loc8_36.3, %.loc8_36.5, %.loc8_36.7) to %v.var
 // CHECK:STDOUT:   %.loc8_36.9: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8
 // CHECK:STDOUT:   assign %v.var, %.loc8_36.9
-// CHECK:STDOUT:   %.loc10_24: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_24, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_24.2: type = converted %.loc10_24.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: ref (i32, i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %.loc10_28.1: ref i32 = tuple_access %v.ref, element0
 // CHECK:STDOUT:   %.loc10_28.2: i32 = bind_value %.loc10_28.1

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -14,13 +14,13 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- convert.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_24.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc8_24.2: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc8_24.3: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,13 +30,13 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.2: type = converted %.loc8_24.1, constants.%.loc8_24.2 [template = constants.%.loc8_24.2]
+// CHECK:STDOUT:   %.loc8_24: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.1: type = converted %.loc8_24, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.var: ref (i32, i32, i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, i32, i32) = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template = constants.%.loc8_29]
-// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2 [template = constants.%.loc8_32]
-// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3 [template = constants.%.loc8_35]
+// CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc8_32: i32 = int_literal 2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_35: i32 = int_literal 3 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc8_36.1: (i32, i32, i32) = tuple_literal (%.loc8_29, %.loc8_32, %.loc8_35)
 // CHECK:STDOUT:   %.loc8_36.2: ref i32 = tuple_access %v.var, element0
 // CHECK:STDOUT:   %.loc8_36.3: init i32 = initialize_from %.loc8_29 to %.loc8_36.2
@@ -48,7 +48,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.9: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8
 // CHECK:STDOUT:   assign %v.var, %.loc8_36.9
 // CHECK:STDOUT:   %.loc10_24: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc8_24.3: type = converted %.loc10_24, constants.%.loc8_24.2 [template = constants.%.loc8_24.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc10_24, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: ref (i32, i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %.loc10_28.1: ref i32 = tuple_access %v.ref, element0
 // CHECK:STDOUT:   %.loc10_28.2: i32 = bind_value %.loc10_28.1
@@ -60,7 +60,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_28.8: (i32, i32, i32) = converted %v.ref, %.loc10_28.7
 // CHECK:STDOUT:   %w: (i32, i32, i32) = bind_name w, %.loc10_28.8
 // CHECK:STDOUT:   %w.ref: (i32, i32, i32) = name_ref w, %w
-// CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_13: i32 = tuple_index %w.ref, %.loc11_12
 // CHECK:STDOUT:   return %.loc11_13
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -17,7 +17,7 @@ fn F(a: i32) {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +27,7 @@ fn F(a: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a.loc7: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.loc14: i32 = bind_name a, %.loc14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -20,7 +20,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 5 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,7 +32,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template = constants.%.loc13]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template = constants.%.1]
 // CHECK:STDOUT:   %x: T = bind_name x, <error>
 // CHECK:STDOUT:   %x.ref: T = name_ref x, %x
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/let/fail_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_modifiers.carbon
@@ -71,33 +71,33 @@ protected protected let i: i32 = 1;
 // CHECK:STDOUT: --- fail_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.loc10]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %b: i32 = bind_name b, %.loc10
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %c: i32 = bind_name c, %.loc15
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template = constants.%.loc20]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %d: i32 = bind_name d, %.loc20
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.loc25]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %e: i32 = bind_name e, %.loc25
-// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template = constants.%.loc36]
+// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template = constants.%.5]
 // CHECK:STDOUT:   %f: i32 = bind_name f, %.loc36
-// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template = constants.%.loc47]
+// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template = constants.%.6]
 // CHECK:STDOUT:   %g: i32 = bind_name g, %.loc47
-// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template = constants.%.loc58]
+// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   %h: i32 = bind_name h, %.loc58
-// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template = constants.%.loc69]
+// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   %i: i32 = bind_name i, %.loc69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_todo_modifiers.carbon
@@ -12,12 +12,12 @@ private let a: i32 = 1;
 // CHECK:STDOUT: --- fail_todo_modifiers.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {}
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.loc10]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %a: i32 = bind_name a, %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -11,12 +11,12 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT: --- global.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F}
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -28,7 +28,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,7 +45,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -20,7 +20,7 @@ fn Bar() {
 // CHECK:STDOUT: --- function.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc17: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -50,16 +50,16 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %.3: <namespace> = namespace ChildNS, {.B = %.5}
 // CHECK:STDOUT:   %.4: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT:   %.5: <function> = fn_decl @.2 [template]
-// CHECK:STDOUT:   %.loc4_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.6: type = converted %.loc4_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %NS.ref.loc4: <namespace> = name_ref NS, %.2
 // CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.4 [template = %.4]
 // CHECK:STDOUT:   %.loc4_17: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_17
-// CHECK:STDOUT:   %.loc5_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.7: type = converted %.loc5_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %NS.ref.loc5: <namespace> = name_ref NS, %.2
@@ -67,8 +67,8 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %B.ref.loc5: <function> = name_ref B, %.5 [template = %.5]
 // CHECK:STDOUT:   %.loc5_25: init () = call %B.ref.loc5()
 // CHECK:STDOUT:   assign %b.var, %.loc5_25
-// CHECK:STDOUT:   %.loc7_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.8: type = converted %.loc7_17, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_17.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref.loc7: <namespace> = name_ref package, package
@@ -76,8 +76,8 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %A.ref.loc7: <function> = name_ref A, %.4 [template = %.4]
 // CHECK:STDOUT:   %.loc7_33: init () = call %A.ref.loc7()
 // CHECK:STDOUT:   assign %package_a.var, %.loc7_33
-// CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.9: type = converted %.loc8_17, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_17.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref.loc8: <namespace> = name_ref package, package

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -41,7 +41,7 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,8 +50,8 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %.3: <namespace> = namespace ChildNS, {.B = %.5}
 // CHECK:STDOUT:   %.4: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT:   %.5: <function> = fn_decl @.2 [template]
-// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.6: type = converted %.loc4_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %NS.ref.loc4: <namespace> = name_ref NS, %.2
@@ -59,7 +59,7 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %.loc4_17: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_17
 // CHECK:STDOUT:   %.loc5_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc5_9, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.7: type = converted %.loc5_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %NS.ref.loc5: <namespace> = name_ref NS, %.2
@@ -68,7 +68,7 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %.loc5_25: init () = call %B.ref.loc5()
 // CHECK:STDOUT:   assign %b.var, %.loc5_25
 // CHECK:STDOUT:   %.loc7_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.4: type = converted %.loc7_17, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.8: type = converted %.loc7_17, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref.loc7: <namespace> = name_ref package, package
@@ -77,7 +77,7 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:   %.loc7_33: init () = call %A.ref.loc7()
 // CHECK:STDOUT:   assign %package_a.var, %.loc7_33
 // CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.5: type = converted %.loc8_17, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.9: type = converted %.loc8_17, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref.loc8: <namespace> = name_ref package, package

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -89,8 +89,8 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   %.3: <namespace> = namespace B, {.C = %.4}
 // CHECK:STDOUT:   %.4: <namespace> = namespace C, {.D = %.5}
 // CHECK:STDOUT:   %.5: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc5_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.6: type = converted %.loc5_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %e.var: ref () = var e
 // CHECK:STDOUT:   %e: ref () = bind_name e, %e.var
 // CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, %.2

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -80,7 +80,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT: --- e.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc5: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -89,8 +89,8 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   %.3: <namespace> = namespace B, {.C = %.4}
 // CHECK:STDOUT:   %.4: <namespace> = namespace C, {.D = %.5}
 // CHECK:STDOUT:   %.5: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.loc5 [template = constants.%.loc5]
+// CHECK:STDOUT:   %.loc5_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.6: type = converted %.loc5_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %e.var: ref () = var e
 // CHECK:STDOUT:   %e: ref () = bind_name e, %e.var
 // CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, %.2

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -17,7 +17,7 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: --- nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/namespace/shadow.carbon
+++ b/toolchain/check/testdata/namespace/shadow.carbon
@@ -26,10 +26,10 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT: --- shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc17: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -49,20 +49,20 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %A.ref.loc16: <function> = name_ref A, file.%A.loc10 [template = file.%A.loc10]
 // CHECK:STDOUT:   %.loc16: init () = call %A.ref.loc16()
-// CHECK:STDOUT:   %.loc17: bool = bool_literal true [template = constants.%.loc17]
+// CHECK:STDOUT:   %.loc17: bool = bool_literal true [template = constants.%.2]
 // CHECK:STDOUT:   if %.loc17 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %A.var: ref i32 = var A
 // CHECK:STDOUT:   %A: ref i32 = bind_name A, %A.var
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.loc18]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   assign %A.var, %.loc18
 // CHECK:STDOUT:   %A.ref.loc21: ref i32 = name_ref A, %A
 // CHECK:STDOUT:   %.loc21: i32 = bind_value %A.ref.loc21
 // CHECK:STDOUT:   return %.loc21
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.loc23]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   return %.loc23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/unqualified_lookup.carbon
+++ b/toolchain/check/testdata/namespace/unqualified_lookup.carbon
@@ -29,7 +29,7 @@ fn OuterN.InnerN.CallABC() {
 // CHECK:STDOUT: --- unqualified_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -41,21 +41,21 @@ fn And() -> bool {
 // CHECK:STDOUT: fn @And() -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
-// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false [template = constants.%.3]
-// CHECK:STDOUT:   if %.loc11_14.2 br !and.rhs else br !and.result(%.loc11_14.3)
+// CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11.1
+// CHECK:STDOUT:   %.loc11_11.2: bool = converted %.loc11_11.1, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.2: bool = bool_literal false [template = constants.%.3]
+// CHECK:STDOUT:   if %.loc11_11.2 br !and.rhs else br !and.result(%.loc11_14.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc11_19: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc11_14.4: bool = value_of_initializer %.loc11_19
-// CHECK:STDOUT:   %.loc11_14.5: bool = converted %.loc11_19, %.loc11_14.4
-// CHECK:STDOUT:   br !and.result(%.loc11_14.5)
+// CHECK:STDOUT:   %.loc11_19.1: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc11_14.3: bool = value_of_initializer %.loc11_19.1
+// CHECK:STDOUT:   %.loc11_19.2: bool = converted %.loc11_19.1, %.loc11_14.3
+// CHECK:STDOUT:   br !and.result(%.loc11_19.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc11_14.6: bool = block_arg !and.result
-// CHECK:STDOUT:   return %.loc11_14.6
+// CHECK:STDOUT:   %.loc11_14.4: bool = block_arg !and.result
+// CHECK:STDOUT:   return %.loc11_14.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/and.carbon
+++ b/toolchain/check/testdata/operators/and.carbon
@@ -14,9 +14,9 @@ fn And() -> bool {
 // CHECK:STDOUT: --- and.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc11: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,13 +28,13 @@ fn And() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -44,7 +44,7 @@ fn And() -> bool {
 // CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
 // CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
 // CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false [template = constants.%.3]
 // CHECK:STDOUT:   if %.loc11_14.2 br !and.rhs else br !and.result(%.loc11_14.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -60,8 +60,8 @@ fn Main() {
 // CHECK:STDOUT:   %a.ref.loc9: ref i32 = name_ref a, %a
 // CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template = constants.%.2]
 // CHECK:STDOUT:   assign %a.ref.loc9, %.loc9
-// CHECK:STDOUT:   %.loc11_19: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc11_19, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_19.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc11_19.2: type = converted %.loc11_19.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %b.var: ref (i32, i32) = var b
 // CHECK:STDOUT:   %b: ref (i32, i32) = bind_name b, %b.var
 // CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.6]

--- a/toolchain/check/testdata/operators/assignment.carbon
+++ b/toolchain/check/testdata/operators/assignment.carbon
@@ -25,25 +25,25 @@ fn Main() {
 // CHECK:STDOUT: --- assignment.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template]
-// CHECK:STDOUT:   %.loc11_19.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc11_19.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc11_19.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc15_27: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc17: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.3: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.5: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.12: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.15: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.18: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.19: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -55,17 +55,17 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 12 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 12 [template = constants.%.1]
 // CHECK:STDOUT:   assign %a.var, %.loc8
 // CHECK:STDOUT:   %a.ref.loc9: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 9 [template = constants.%.2]
 // CHECK:STDOUT:   assign %a.ref.loc9, %.loc9
-// CHECK:STDOUT:   %.loc11_19.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc11_19.2: type = converted %.loc11_19.1, constants.%.loc11_19.2 [template = constants.%.loc11_19.2]
+// CHECK:STDOUT:   %.loc11_19: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.1: type = converted %.loc11_19, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %b.var: ref (i32, i32) = var b
 // CHECK:STDOUT:   %b: ref (i32, i32) = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.loc11_24]
-// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2 [template = constants.%.loc11_27]
+// CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc11_27: i32 = int_literal 2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_28.1: (i32, i32) = tuple_literal (%.loc11_24, %.loc11_27)
 // CHECK:STDOUT:   %.loc11_28.2: ref i32 = tuple_access %b.var, element0
 // CHECK:STDOUT:   %.loc11_28.3: init i32 = initialize_from %.loc11_24 to %.loc11_28.2
@@ -75,20 +75,20 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_28.7: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6
 // CHECK:STDOUT:   assign %b.var, %.loc11_28.7
 // CHECK:STDOUT:   %b.ref.loc12: ref (i32, i32) = name_ref b, %b
-// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.loc12_5]
+// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc12_6: ref i32 = tuple_index %b.ref.loc12, %.loc12_5
-// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template = constants.%.loc12_10]
+// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template = constants.%.9]
 // CHECK:STDOUT:   assign %.loc12_6, %.loc12_10
 // CHECK:STDOUT:   %b.ref.loc13: ref (i32, i32) = name_ref b, %b
-// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template = constants.%.loc13_5]
+// CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc13_6: ref i32 = tuple_index %b.ref.loc13, %.loc13_5
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template = constants.%.loc13_10]
+// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template = constants.%.11]
 // CHECK:STDOUT:   assign %.loc13_6, %.loc13_10
 // CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %c.var: ref {.a: i32, .b: i32} = var c
 // CHECK:STDOUT:   %c: ref {.a: i32, .b: i32} = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template = constants.%.loc15_37]
-// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2 [template = constants.%.loc15_45]
+// CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc15_45: i32 = int_literal 2 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc15_46.1: {.a: i32, .b: i32} = struct_literal (%.loc15_37, %.loc15_45)
 // CHECK:STDOUT:   %.loc15_46.2: ref i32 = struct_access %c.var, element0
 // CHECK:STDOUT:   %.loc15_46.3: init i32 = initialize_from %.loc15_37 to %.loc15_46.2
@@ -99,11 +99,11 @@ fn Main() {
 // CHECK:STDOUT:   assign %c.var, %.loc15_46.7
 // CHECK:STDOUT:   %c.ref.loc16: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc16_4: ref i32 = struct_access %c.ref.loc16, element0
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.15]
 // CHECK:STDOUT:   assign %.loc16_4, %.loc16_9
 // CHECK:STDOUT:   %c.ref.loc17: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc17_4: ref i32 = struct_access %c.ref.loc17, element1
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4 [template = constants.%.loc17]
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4 [template = constants.%.16]
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
 // CHECK:STDOUT:   %.loc19_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %p.var: ref i32* = var p
@@ -114,9 +114,9 @@ fn Main() {
 // CHECK:STDOUT:   %p.ref.loc20: ref i32* = name_ref p, %p
 // CHECK:STDOUT:   %.loc20_4: i32* = bind_value %p.ref.loc20
 // CHECK:STDOUT:   %.loc20_3: ref i32 = deref %.loc20_4
-// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5 [template = constants.%.loc20]
+// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5 [template = constants.%.17]
 // CHECK:STDOUT:   assign %.loc20_3, %.loc20_8
-// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template = constants.%.loc22_8]
+// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template = constants.%.18]
 // CHECK:STDOUT:   if %.loc22_8 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
@@ -132,7 +132,7 @@ fn Main() {
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc22_5: i32* = block_arg !if.expr.result
 // CHECK:STDOUT:   %.loc22_3: ref i32 = deref %.loc22_5
-// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template = constants.%.loc22_31]
+// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template = constants.%.19]
 // CHECK:STDOUT:   assign %.loc22_3, %.loc22_31
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_error.carbon
@@ -18,8 +18,8 @@ fn Main() {
 // CHECK:STDOUT: --- fail_assignment_to_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 42 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 42 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 42 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,11 +30,11 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error>
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template = constants.%.1]
 // CHECK:STDOUT:   assign %undeclared.ref, <error>
 // CHECK:STDOUT:   %also_undeclared.ref: <error> = name_ref also_undeclared, <error>
 // CHECK:STDOUT:   %.loc15_3: ref <error> = deref <error>
-// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42 [template = constants.%.2]
 // CHECK:STDOUT:   assign %.loc15_3, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/fail_assignment_to_non_assignable.carbon
@@ -48,32 +48,32 @@ fn Main() {
 // CHECK:STDOUT: --- fail_assignment_to_non_assignable.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc17: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc21_8.1: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc21_8.2: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc34_18.1: type = struct_type {.x: i32, .y: i32} [template]
-// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc34_18.2: type = ptr_type {.x: i32, .y: i32} [template]
-// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template]
-// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.9: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.10: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.15: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.16: type = struct_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.18: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.19: type = ptr_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.20: {.x: i32, .y: i32} = struct_value (%.14, %.15) [template]
+// CHECK:STDOUT:   %.21: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.22: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.23: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.24: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.25: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.26: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -86,18 +86,18 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template = constants.%.loc13_3]
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template = constants.%.loc13_7]
+// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   assign %.loc13_3, %.loc13_7
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc17_4: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1 [template = constants.%.loc17]
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
-// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template = constants.%.loc21_4]
-// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template = constants.%.loc21_7]
+// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc21_8.1: (i32, i32) = tuple_literal (%.loc21_4, %.loc21_7)
-// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template = constants.%.loc21_13]
-// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template = constants.%.loc21_16]
+// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc21_17.1: (i32, i32) = tuple_literal (%.loc21_13, %.loc21_16)
 // CHECK:STDOUT:   %.loc21_17.2: i32 = tuple_access %.loc21_8.1, element0
 // CHECK:STDOUT:   %.loc21_17.3: init i32 = initialize_from %.loc21_13 to %.loc21_17.2
@@ -106,17 +106,17 @@ fn Main() {
 // CHECK:STDOUT:   %.loc21_17.6: init (i32, i32) = tuple_init (%.loc21_17.3, %.loc21_17.5) to %.loc21_8.1
 // CHECK:STDOUT:   %.loc21_17.7: init (i32, i32) = converted %.loc21_17.1, %.loc21_17.6
 // CHECK:STDOUT:   assign %.loc21_8.1, %.loc21_17.7
-// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template = constants.%.loc21_8.3]
-// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = converted %.loc21_8.1, %.loc21_8.2 [template = constants.%.loc21_8.3]
+// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template = constants.%.10]
+// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = converted %.loc21_8.1, %.loc21_8.2 [template = constants.%.10]
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.11]
 // CHECK:STDOUT:   assign %n.var, %.loc22
 // CHECK:STDOUT:   %n.ref.loc26_4: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %n.ref.loc26_7: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc26_8.1: (i32, i32) = tuple_literal (%n.ref.loc26_4, %n.ref.loc26_7)
-// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template = constants.%.loc26_13]
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template = constants.%.loc26_16]
+// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc26_17.1: (i32, i32) = tuple_literal (%.loc26_13, %.loc26_16)
 // CHECK:STDOUT:   %.loc26_17.2: i32 = tuple_access %.loc26_8.1, element0
 // CHECK:STDOUT:   %.loc26_17.3: init i32 = initialize_from %.loc26_13 to %.loc26_17.2
@@ -131,11 +131,11 @@ fn Main() {
 // CHECK:STDOUT:   %.loc26_8.3: (i32, i32) = converted %.loc26_8.1, %.loc26_8.2
 // CHECK:STDOUT:   %.loc30: type = ptr_type i32 [template]
 // CHECK:STDOUT:   assign i32, %.loc30
-// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template = constants.%.loc34_9]
-// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template = constants.%.loc34_17]
+// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template = constants.%.15]
 // CHECK:STDOUT:   %.loc34_18.1: {.x: i32, .y: i32} = struct_literal (%.loc34_9, %.loc34_17)
-// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template = constants.%.loc34_28]
-// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template = constants.%.loc34_36]
+// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template = constants.%.18]
 // CHECK:STDOUT:   %.loc34_37.1: {.x: i32, .y: i32} = struct_literal (%.loc34_28, %.loc34_36)
 // CHECK:STDOUT:   %.loc34_37.2: i32 = struct_access %.loc34_18.1, element0
 // CHECK:STDOUT:   %.loc34_37.3: init i32 = initialize_from %.loc34_28 to %.loc34_37.2
@@ -144,26 +144,26 @@ fn Main() {
 // CHECK:STDOUT:   %.loc34_37.6: init {.x: i32, .y: i32} = struct_init (%.loc34_37.3, %.loc34_37.5) to %.loc34_18.1
 // CHECK:STDOUT:   %.loc34_37.7: init {.x: i32, .y: i32} = converted %.loc34_37.1, %.loc34_37.6
 // CHECK:STDOUT:   assign %.loc34_18.1, %.loc34_37.7
-// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template = constants.%.loc34_18.3]
-// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = converted %.loc34_18.1, %.loc34_18.2 [template = constants.%.loc34_18.3]
-// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template = constants.%.loc38_7]
+// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template = constants.%.20]
+// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = converted %.loc34_18.1, %.loc34_18.2 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template = constants.%.21]
 // CHECK:STDOUT:   if %.loc38_7 br !if.expr.then.loc38 else br !if.expr.else.loc38
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc38:
-// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template = constants.%.loc38_17]
+// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template = constants.%.22]
 // CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_17)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc38:
-// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template = constants.%.loc38_24]
+// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template = constants.%.23]
 // CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_24)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc38:
 // CHECK:STDOUT:   %.loc38_4: i32 = block_arg !if.expr.result.loc38
-// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template = constants.%.loc38_29]
+// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template = constants.%.24]
 // CHECK:STDOUT:   assign %.loc38_4, %.loc38_29
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.loc45_7]
+// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.25]
 // CHECK:STDOUT:   if %.loc45_7 br !if.expr.then.loc45 else br !if.expr.else.loc45
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc45:
@@ -178,7 +178,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc45:
 // CHECK:STDOUT:   %.loc45_4: i32 = block_arg !if.expr.result.loc45
-// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template = constants.%.loc45_29]
+// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template = constants.%.26]
 // CHECK:STDOUT:   assign %.loc45_4, %.loc45_29
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref bool = var x
 // CHECK:STDOUT:   %x: ref bool = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11_21: i32 = int_literal 12 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_21: i32 = int_literal 12 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_17: <error> = not <error>
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_assignment.carbon
@@ -15,8 +15,8 @@ fn Main() {
 // CHECK:STDOUT: --- fail_type_mismatch_assignment.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: f64 = real_literal 56e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,10 +28,10 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 3 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 3 [template = constants.%.1]
 // CHECK:STDOUT:   assign %a.var, %.loc8
 // CHECK:STDOUT:   %a.ref: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12: f64 = real_literal 56e-1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %a.ref, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/fail_type_mismatch_once.carbon
@@ -16,8 +16,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch_once.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc13_15: f64 = real_literal 34e-1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.2: f64 = real_literal 34e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/fail_unimplemented_op.carbon
+++ b/toolchain/check/testdata/operators/fail_unimplemented_op.carbon
@@ -14,8 +14,8 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_unimplemented_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc11_15: i32 = int_literal 34 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 34 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -41,22 +41,22 @@ fn Or() -> bool {
 // CHECK:STDOUT: fn @Or() -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
-// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.3: bool = not %.loc11_14.2
-// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true [template = constants.%.3]
-// CHECK:STDOUT:   if %.loc11_14.3 br !or.rhs else br !or.result(%.loc11_14.4)
+// CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11.1
+// CHECK:STDOUT:   %.loc11_11.2: bool = converted %.loc11_11.1, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.2: bool = not %.loc11_11.2
+// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal true [template = constants.%.3]
+// CHECK:STDOUT:   if %.loc11_14.2 br !or.rhs else br !or.result(%.loc11_14.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc11_18: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc11_14.5: bool = value_of_initializer %.loc11_18
-// CHECK:STDOUT:   %.loc11_14.6: bool = converted %.loc11_18, %.loc11_14.5
-// CHECK:STDOUT:   br !or.result(%.loc11_14.6)
+// CHECK:STDOUT:   %.loc11_18.1: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc11_14.4: bool = value_of_initializer %.loc11_18.1
+// CHECK:STDOUT:   %.loc11_18.2: bool = converted %.loc11_18.1, %.loc11_14.4
+// CHECK:STDOUT:   br !or.result(%.loc11_18.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.result:
-// CHECK:STDOUT:   %.loc11_14.7: bool = block_arg !or.result
-// CHECK:STDOUT:   return %.loc11_14.7
+// CHECK:STDOUT:   %.loc11_14.5: bool = block_arg !or.result
+// CHECK:STDOUT:   return %.loc11_14.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/or.carbon
+++ b/toolchain/check/testdata/operators/or.carbon
@@ -14,9 +14,9 @@ fn Or() -> bool {
 // CHECK:STDOUT: --- or.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,13 +28,13 @@ fn Or() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -45,7 +45,7 @@ fn Or() -> bool {
 // CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
 // CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
 // CHECK:STDOUT:   %.loc11_14.3: bool = not %.loc11_14.2
-// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true [template = constants.%.3]
 // CHECK:STDOUT:   if %.loc11_14.3 br !or.rhs else br !or.result(%.loc11_14.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -14,20 +14,20 @@ let not_false: bool = not false;
 // CHECK:STDOUT: --- unary_op.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_26.1: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc11_26.2: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc12_27.1: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc12_27.2: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.4: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Not = %Not}
 // CHECK:STDOUT:   %Not: <function> = fn_decl @Not [template]
-// CHECK:STDOUT:   %.loc11_26: bool = bool_literal true [template = constants.%.loc11_26.1]
-// CHECK:STDOUT:   %.loc11_22: bool = not %.loc11_26 [template = constants.%.loc11_26.2]
+// CHECK:STDOUT:   %.loc11_26: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11_22: bool = not %.loc11_26 [template = constants.%.2]
 // CHECK:STDOUT:   %not_true: bool = bind_name not_true, %.loc11_22
-// CHECK:STDOUT:   %.loc12_27: bool = bool_literal false [template = constants.%.loc12_27.1]
-// CHECK:STDOUT:   %.loc12_23: bool = not %.loc12_27 [template = constants.%.loc12_27.2]
+// CHECK:STDOUT:   %.loc12_27: bool = bool_literal false [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_23: bool = not %.loc12_27 [template = constants.%.4]
 // CHECK:STDOUT:   %not_false: bool = bind_name not_false, %.loc12_23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/package_expr/syntax.carbon
+++ b/toolchain/check/testdata/package_expr/syntax.carbon
@@ -45,15 +45,15 @@ fn Main() {
 // CHECK:STDOUT: --- global.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc4
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
@@ -62,7 +62,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
@@ -76,15 +76,15 @@ fn Main() {
 // CHECK:STDOUT: --- inside_fn.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc4
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
@@ -93,7 +93,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var
@@ -107,8 +107,8 @@ fn Main() {
 // CHECK:STDOUT: --- namespace.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc11: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -21,8 +21,8 @@ var a: () = A();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, has_error}
-// CHECK:STDOUT:   %.loc7: () = tuple_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc7, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %A.ref: <error> = name_ref A, <error>

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -16,13 +16,13 @@ var a: () = A();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a = %a, has_error}
-// CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: () = tuple_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc7, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %A.ref: <error> = name_ref A, <error>

--- a/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
+++ b/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
@@ -43,8 +43,8 @@ var a: () = a_ref;
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a_ref = %package.var, .a = %a}
 // CHECK:STDOUT:   %package.var: ref <error> = var package
-// CHECK:STDOUT:   %.loc4: () = tuple_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc4, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %a_ref.ref: ref <error> = name_ref a_ref, %package.var

--- a/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
+++ b/toolchain/check/testdata/packages/fail_todo_lazy_import_ref.carbon
@@ -23,28 +23,28 @@ var a: () = a_ref;
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a_ref = %a_ref}
 // CHECK:STDOUT:   %a_ref.var: ref i32 = var a_ref
 // CHECK:STDOUT:   %a_ref: ref i32 = bind_name a_ref, %a_ref.var
-// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %a_ref.var, %.loc4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.a_ref = %package.var, .a = %a}
 // CHECK:STDOUT:   %package.var: ref <error> = var package
-// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4: () = tuple_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc4, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %a_ref.ref: ref <error> = name_ref a_ref, %package.var

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -52,15 +52,15 @@ var package_b: () = package.B();
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %.2, .a = %a, .package_a = %package_a}
 // CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc4_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.3: type = converted %.loc4_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc4_14: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_14
-// CHECK:STDOUT:   %.loc6_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.4: type = converted %.loc6_17, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc6_17.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc6_17.2: type = converted %.loc6_17.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
@@ -89,15 +89,15 @@ var package_b: () = package.B();
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %.2, .b = %b, .package_b = %package_b}
 // CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc6_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.3: type = converted %.loc6_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %B.ref.loc6: <function> = name_ref B, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc6_14: init () = call %B.ref.loc6()
 // CHECK:STDOUT:   assign %b.var, %.loc6_14
-// CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.4: type = converted %.loc8_17, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_17.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -46,21 +46,21 @@ var package_b: () = package.B();
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.A = %.2, .a = %a, .package_a = %package_a}
 // CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.loc4_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.3: type = converted %.loc4_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc4_14: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign %a.var, %.loc4_14
 // CHECK:STDOUT:   %.loc6_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_9.3: type = converted %.loc6_17, constants.%.loc4 [template = constants.%.loc4]
+// CHECK:STDOUT:   %.4: type = converted %.loc6_17, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_a.var: ref () = var package_a
 // CHECK:STDOUT:   %package_a: ref () = bind_name package_a, %package_a.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package
@@ -83,21 +83,21 @@ var package_b: () = package.B();
 // CHECK:STDOUT: --- same_package_importer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.B = %.2, .b = %b, .package_b = %package_b}
 // CHECK:STDOUT:   %.2: <function> = fn_decl @.1 [template]
-// CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.loc6 [template = constants.%.loc6]
+// CHECK:STDOUT:   %.loc6_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.3: type = converted %.loc6_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %B.ref.loc6: <function> = name_ref B, %.2 [template = %.2]
 // CHECK:STDOUT:   %.loc6_14: init () = call %B.ref.loc6()
 // CHECK:STDOUT:   assign %b.var, %.loc6_14
 // CHECK:STDOUT:   %.loc8_17: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc6_9.3: type = converted %.loc8_17, constants.%.loc6 [template = constants.%.loc6]
+// CHECK:STDOUT:   %.4: type = converted %.loc8_17, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %package_b.var: ref () = var package_b
 // CHECK:STDOUT:   %package_b: ref () = bind_name package_b, %package_b.var
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package

--- a/toolchain/check/testdata/pointer/address_of_deref.carbon
+++ b/toolchain/check/testdata/pointer/address_of_deref.carbon
@@ -12,8 +12,8 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- address_of_deref.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc9: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: type = ptr_type i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -25,7 +25,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %n.var, %.loc8
 // CHECK:STDOUT:   %n.ref: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc9_13: i32* = addr_of %n.ref

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -72,8 +72,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_19: ref i32 = struct_access %s.ref.loc12, element1
 // CHECK:STDOUT:   %.loc12_17: i32* = addr_of %.loc12_19
 // CHECK:STDOUT:   assign %r.var, %.loc12_17
-// CHECK:STDOUT:   %.loc14_19: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc14_19, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc14_19.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %t.var: ref (i32, i32) = var t
 // CHECK:STDOUT:   %t: ref (i32, i32) = bind_name t, %t.var
 // CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template = constants.%.7]

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -19,16 +19,16 @@ fn F() {
 // CHECK:STDOUT: --- address_of_lvalue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_27: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc14_19.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc14_19.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc14_19.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.6: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -41,8 +41,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc8_27: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %s.var: ref {.a: i32, .b: i32} = var s
 // CHECK:STDOUT:   %s: ref {.a: i32, .b: i32} = bind_name s, %s.var
-// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1 [template = constants.%.loc8_37]
-// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2 [template = constants.%.loc8_45]
+// CHECK:STDOUT:   %.loc8_37: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_45: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc8_46.1: {.a: i32, .b: i32} = struct_literal (%.loc8_37, %.loc8_45)
 // CHECK:STDOUT:   %.loc8_46.2: ref i32 = struct_access %s.var, element0
 // CHECK:STDOUT:   %.loc8_46.3: init i32 = initialize_from %.loc8_37 to %.loc8_46.2
@@ -72,12 +72,12 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_19: ref i32 = struct_access %s.ref.loc12, element1
 // CHECK:STDOUT:   %.loc12_17: i32* = addr_of %.loc12_19
 // CHECK:STDOUT:   assign %r.var, %.loc12_17
-// CHECK:STDOUT:   %.loc14_19.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.loc14_19.2 [template = constants.%.loc14_19.2]
+// CHECK:STDOUT:   %.loc14_19: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.1: type = converted %.loc14_19, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %t.var: ref (i32, i32) = var t
 // CHECK:STDOUT:   %t: ref (i32, i32) = bind_name t, %t.var
-// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template = constants.%.loc14_24]
-// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2 [template = constants.%.loc14_27]
+// CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc14_27: i32 = int_literal 2 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc14_28.1: (i32, i32) = tuple_literal (%.loc14_24, %.loc14_27)
 // CHECK:STDOUT:   %.loc14_28.2: ref i32 = tuple_access %t.var, element0
 // CHECK:STDOUT:   %.loc14_28.3: init i32 = initialize_from %.loc14_24 to %.loc14_28.2
@@ -90,7 +90,7 @@ fn F() {
 // CHECK:STDOUT:   %t0.var: ref i32* = var t0
 // CHECK:STDOUT:   %t0: ref i32* = bind_name t0, %t0.var
 // CHECK:STDOUT:   %t.ref.loc15: ref (i32, i32) = name_ref t, %t
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc15_22: ref i32 = tuple_index %t.ref.loc15, %.loc15_21
 // CHECK:STDOUT:   %.loc15_18: i32* = addr_of %.loc15_22
 // CHECK:STDOUT:   assign %t0.var, %.loc15_18
@@ -98,7 +98,7 @@ fn F() {
 // CHECK:STDOUT:   %t1.var: ref i32* = var t1
 // CHECK:STDOUT:   %t1: ref i32* = bind_name t1, %t1.var
 // CHECK:STDOUT:   %t.ref.loc16: ref (i32, i32) = name_ref t, %t
-// CHECK:STDOUT:   %.loc16_21: i32 = int_literal 1 [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16_21: i32 = int_literal 1 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc16_22: ref i32 = tuple_index %t.ref.loc16, %.loc16_21
 // CHECK:STDOUT:   %.loc16_18: i32* = addr_of %.loc16_22
 // CHECK:STDOUT:   assign %t1.var, %.loc16_18

--- a/toolchain/check/testdata/pointer/basic.carbon
+++ b/toolchain/check/testdata/pointer/basic.carbon
@@ -14,7 +14,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- basic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %n.var, %.loc8
 // CHECK:STDOUT:   %.loc9_13: type = ptr_type i32 [template]
 // CHECK:STDOUT:   %p.var: ref i32* = var p

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -21,8 +21,8 @@ fn Test() {
 // CHECK:STDOUT: --- fail_address_of_error.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: type = ptr_type <error> [template]
-// CHECK:STDOUT:   %.loc18: type = ptr_type <error>* [template]
+// CHECK:STDOUT:   %.1: type = ptr_type <error> [template]
+// CHECK:STDOUT:   %.2: type = ptr_type <error>* [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -85,36 +85,36 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT: --- fail_address_of_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc15_3.1: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %.loc15_3.2: i32* = addr_of %.loc15_4 [template]
-// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc19_3.1: type = ptr_type bool [template]
-// CHECK:STDOUT:   %.loc19_3.2: bool* = addr_of %.loc19_4 [template]
-// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template]
-// CHECK:STDOUT:   %.loc23_3.1: type = ptr_type f64 [template]
-// CHECK:STDOUT:   %.loc23_3.2: f64* = addr_of %.loc23_4 [template]
-// CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template]
-// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4 [template]
-// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc31_9: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc31_3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc35_3: type = ptr_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc42_10: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc50_9.1: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc50_9.2: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_9.2 [template]
-// CHECK:STDOUT:   %.loc64: type = ptr_type type [template]
-// CHECK:STDOUT:   %.loc68: type* = addr_of @AddressOfType.%.loc68_14 [template]
-// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc75_10: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.3: i32* = addr_of %.1 [template]
+// CHECK:STDOUT:   %.4: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.5: type = ptr_type bool [template]
+// CHECK:STDOUT:   %.6: bool* = addr_of %.4 [template]
+// CHECK:STDOUT:   %.7: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.8: type = ptr_type f64 [template]
+// CHECK:STDOUT:   %.9: f64* = addr_of %.7 [template]
+// CHECK:STDOUT:   %.10: type = ptr_type String [template]
+// CHECK:STDOUT:   %.11: String = string_literal "Hello" [template]
+// CHECK:STDOUT:   %.12: String* = addr_of %.11 [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.15: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.16: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.18: type = ptr_type {.a: i32} [template]
+// CHECK:STDOUT:   %.19: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.20: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.21: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.22: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.23: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.24: bool* = addr_of %.23 [template]
+// CHECK:STDOUT:   %.25: type = ptr_type type [template]
+// CHECK:STDOUT:   %.26: type* = addr_of @AddressOfType.%.loc68_14 [template]
+// CHECK:STDOUT:   %.27: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.28: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.29: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.30: (i32, i32) = tuple_value (%.27, %.28) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -135,19 +135,19 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfLiteral() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template = constants.%.loc15_4]
-// CHECK:STDOUT:   %.loc15_3: i32* = addr_of %.loc15_4 [template = constants.%.loc15_3.2]
-// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template = constants.%.loc19_4]
-// CHECK:STDOUT:   %.loc19_3: bool* = addr_of %.loc19_4 [template = constants.%.loc19_3.2]
-// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template = constants.%.loc23_4]
-// CHECK:STDOUT:   %.loc23_3: f64* = addr_of %.loc23_4 [template = constants.%.loc23_3.2]
-// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template = constants.%.loc27_4]
-// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4 [template = constants.%.loc27_3]
-// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template = constants.%.loc31_5]
-// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template = constants.%.loc31_8]
+// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc15_3: i32* = addr_of %.loc15_4 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_3: bool* = addr_of %.loc19_4 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc23_3: f64* = addr_of %.loc23_4 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template = constants.%.11]
+// CHECK:STDOUT:   %.loc27_3: String* = addr_of %.loc27_4 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc31_9: (i32, i32) = tuple_literal (%.loc31_5, %.loc31_8)
 // CHECK:STDOUT:   %.loc31_3: (i32, i32)* = addr_of %.loc31_9
-// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template = constants.%.loc35_10]
+// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc35_11: {.a: i32} = struct_literal (%.loc35_10)
 // CHECK:STDOUT:   %.loc35_3: {.a: i32}* = addr_of %.loc35_11
 // CHECK:STDOUT:   return
@@ -155,12 +155,12 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfOperator() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template = constants.%.loc42_5]
-// CHECK:STDOUT:   %.loc42_10.1: bool = bool_literal false [template = constants.%.loc42_10]
+// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template = constants.%.19]
+// CHECK:STDOUT:   %.loc42_10.1: bool = bool_literal false [template = constants.%.20]
 // CHECK:STDOUT:   if %.loc42_5 br !and.rhs else br !and.result(%.loc42_10.1)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template = constants.%.loc42_14]
+// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template = constants.%.21]
 // CHECK:STDOUT:   br !and.result(%.loc42_14)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
@@ -172,9 +172,9 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %.loc46_5.3: ref {.a: i32} = temporary %.loc46_5.2, %.loc46_5.1
 // CHECK:STDOUT:   %.loc46_7: ref i32 = struct_access %.loc46_5.3, element0
 // CHECK:STDOUT:   %.loc46_3: i32* = addr_of %.loc46_7
-// CHECK:STDOUT:   %.loc50_9: bool = bool_literal true [template = constants.%.loc50_9.1]
-// CHECK:STDOUT:   %.loc50_5: bool = not %.loc50_9 [template = constants.%.loc50_9.2]
-// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_5 [template = constants.%.loc50_3]
+// CHECK:STDOUT:   %.loc50_9: bool = bool_literal true [template = constants.%.22]
+// CHECK:STDOUT:   %.loc50_5: bool = not %.loc50_9 [template = constants.%.23]
+// CHECK:STDOUT:   %.loc50_3: bool* = addr_of %.loc50_5 [template = constants.%.24]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -191,18 +191,18 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %.loc64: type* = addr_of i32
 // CHECK:STDOUT:   %.loc68_5: type = const_type i32 [template]
 // CHECK:STDOUT:   %.loc68_14: type = ptr_type const i32 [template]
-// CHECK:STDOUT:   %.loc68_3: type* = addr_of %.loc68_14 [template = constants.%.loc68]
+// CHECK:STDOUT:   %.loc68_3: type* = addr_of %.loc68_14 [template = constants.%.26]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfTupleElementValue() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template = constants.%.loc75_6]
-// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template = constants.%.loc75_9]
+// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template = constants.%.27]
+// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template = constants.%.28]
 // CHECK:STDOUT:   %.loc75_10.1: (i32, i32) = tuple_literal (%.loc75_6, %.loc75_9)
-// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template = constants.%.loc75_12]
-// CHECK:STDOUT:   %.loc75_10.2: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template = constants.%.loc75_10]
-// CHECK:STDOUT:   %.loc75_10.3: (i32, i32) = converted %.loc75_10.1, %.loc75_10.2 [template = constants.%.loc75_10]
+// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template = constants.%.29]
+// CHECK:STDOUT:   %.loc75_10.2: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template = constants.%.30]
+// CHECK:STDOUT:   %.loc75_10.3: (i32, i32) = converted %.loc75_10.1, %.loc75_10.2 [template = constants.%.30]
 // CHECK:STDOUT:   %.loc75_13: i32 = tuple_index %.loc75_10.3, %.loc75_12
 // CHECK:STDOUT:   %.loc75_3: i32* = addr_of %.loc75_13
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -22,10 +22,10 @@ fn Deref(n: i32) {
 // CHECK:STDOUT: --- fail_deref_not_pointer.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_5.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value () [template]
-// CHECK:STDOUT:   %.loc19_5.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %.3: type = struct_type {} [template]
+// CHECK:STDOUT:   %.4: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -38,12 +38,12 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:   %n.ref: i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc11: ref <error> = deref %n.ref
 // CHECK:STDOUT:   %.loc15_5.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value () [template = constants.%.loc15_5.2]
-// CHECK:STDOUT:   %.loc15_5.3: () = converted %.loc15_5.1, %.loc15_5.2 [template = constants.%.loc15_5.2]
+// CHECK:STDOUT:   %.loc15_5.2: () = tuple_value () [template = constants.%.2]
+// CHECK:STDOUT:   %.loc15_5.3: () = converted %.loc15_5.1, %.loc15_5.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc15_3: ref <error> = deref %.loc15_5.3
 // CHECK:STDOUT:   %.loc19_5.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value () [template = constants.%.loc19_5.2]
-// CHECK:STDOUT:   %.loc19_5.3: {} = converted %.loc19_5.1, %.loc19_5.2 [template = constants.%.loc19_5.2]
+// CHECK:STDOUT:   %.loc19_5.2: {} = struct_value () [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_5.3: {} = converted %.loc19_5.1, %.loc19_5.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc19_3: ref <error> = deref %.loc19_5.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -14,7 +14,7 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/return/code_after_return.carbon
+++ b/toolchain/check/testdata/return/code_after_return.carbon
@@ -12,7 +12,7 @@ fn Main() {
 // CHECK:STDOUT: --- code_after_return.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/return/code_after_return_value.carbon
+++ b/toolchain/check/testdata/return/code_after_return_value.carbon
@@ -19,11 +19,11 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT: --- code_after_return_value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc12_26: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc12_33: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc13_9: bool = bool_literal false [template]
-// CHECK:STDOUT:   %.loc13_16: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.5: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,7 +33,7 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%b: bool) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_call_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_call_in_type.carbon
@@ -15,7 +15,7 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT: --- fail_call_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,7 +31,7 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 6 [template = constants.%.loc13]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -14,7 +14,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_let_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -25,7 +25,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
+++ b/toolchain/check/testdata/return/fail_missing_return_empty_tuple.carbon
@@ -13,7 +13,7 @@ fn F() -> () {
 // CHECK:STDOUT: --- fail_missing_return_empty_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -30,12 +30,12 @@ fn G() -> C {
 // CHECK:STDOUT: --- fail_return_with_returned_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc18_35.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc18_35.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -63,9 +63,9 @@ fn G() -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %v.var, %.loc8
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.loc15]
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -73,8 +73,8 @@ fn G() -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %c: ref C = bind_name c, %return
-// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template = constants.%.loc20_29]
-// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template = constants.%.loc20_37]
+// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc20_38.1: {.a: i32, .b: i32} = struct_literal (%.loc20_29, %.loc20_37)
 // CHECK:STDOUT:   %.loc20_38.2: ref i32 = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc20_38.3: init i32 = initialize_from %.loc20_29 to %.loc20_38.2

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -28,8 +28,8 @@ fn Procedure() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Procedure() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_20: () = tuple_literal ()
-// CHECK:STDOUT:   %.1: type = converted %.loc14_20, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc14_20.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc14_20.2: type = converted %.loc14_20.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %v: () = bind_name v, <error>
 // CHECK:STDOUT:   %.loc14_25: () = tuple_literal ()
 // CHECK:STDOUT:   assign <error>, <error>

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -18,7 +18,7 @@ fn Procedure() {
 // CHECK:STDOUT: --- fail_returned_var_no_return_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,8 +28,8 @@ fn Procedure() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Procedure() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_20.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc14_20.2: type = converted %.loc14_20.1, constants.%.loc14 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14_20: () = tuple_literal ()
+// CHECK:STDOUT:   %.1: type = converted %.loc14_20, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %v: () = bind_name v, <error>
 // CHECK:STDOUT:   %.loc14_25: () = tuple_literal ()
 // CHECK:STDOUT:   assign <error>, <error>

--- a/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
@@ -37,15 +37,15 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_shadow.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.5: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.7: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -56,42 +56,42 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @SameScope() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   if %.loc8 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   assign %v.var, %.loc9
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   assign %w.var, %.loc16
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.loc18]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   return %.loc18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @DifferentScopes() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template = constants.%.5]
 // CHECK:STDOUT:   if %.loc22 br !if.then.loc22 else br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc22:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.loc23]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   assign %v.var, %.loc23
-// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template = constants.%.loc24]
+// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template = constants.%.7]
 // CHECK:STDOUT:   if %.loc24 br !if.then.loc24 else br !if.else.loc24
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc24:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template = constants.%.loc31]
+// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   assign %w.var, %.loc31
 // CHECK:STDOUT:   br !if.else.loc24
 // CHECK:STDOUT:
@@ -99,7 +99,7 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT:   br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc22:
-// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template = constants.%.loc34]
+// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   return %.loc34
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_returned_var_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_type.carbon
@@ -18,7 +18,7 @@ fn Mismatch() -> i32 {
 // CHECK:STDOUT: --- fail_returned_var_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 0e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -29,7 +29,7 @@ fn Mismatch() -> i32 {
 // CHECK:STDOUT: fn @Mismatch() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %v: f64 = bind_name v, <error>
-// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template = constants.%.1]
 // CHECK:STDOUT:   assign <error>, <error>
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/return/fail_type_mismatch.carbon
@@ -14,7 +14,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- fail_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -24,7 +24,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_value_disallowed.carbon
+++ b/toolchain/check/testdata/return/fail_value_disallowed.carbon
@@ -17,7 +17,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_value_disallowed.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +27,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_var_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_var_in_type.carbon
@@ -13,7 +13,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT: --- fail_var_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn Six() -> x { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -22,11 +22,11 @@ fn G() -> i32 {
 // CHECK:STDOUT: --- returned_var.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_1.1: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc10_1.2: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,8 +54,8 @@ fn G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %result: ref C = bind_name result, %return
-// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template = constants.%.loc13_34]
-// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2 [template = constants.%.loc13_42]
+// CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc13_42: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_43.1: {.a: i32, .b: i32} = struct_literal (%.loc13_34, %.loc13_42)
 // CHECK:STDOUT:   %.loc13_43.2: ref i32 = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc13_43.3: init i32 = initialize_from %.loc13_34 to %.loc13_43.2
@@ -71,7 +71,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %result.var: ref i32 = var result
 // CHECK:STDOUT:   %result: ref i32 = bind_name result, %result.var
-// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0 [template = constants.%.loc18]
+// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   assign %result.var, %.loc18_30
 // CHECK:STDOUT:   %.loc18_16: i32 = bind_value %result
 // CHECK:STDOUT:   return %.loc18_16

--- a/toolchain/check/testdata/return/returned_var_scope.carbon
+++ b/toolchain/check/testdata/return/returned_var_scope.carbon
@@ -26,13 +26,13 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: --- returned_var_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc19: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -43,29 +43,29 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @UnrelatedScopes() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   if %.loc8 br !if.then.loc8 else br !if.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc8:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   assign %v.var, %.loc9
 // CHECK:STDOUT:   br !if.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc8:
-// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: bool = bool_literal true [template = constants.%.3]
 // CHECK:STDOUT:   if %.loc11 br !if.then.loc11 else br !if.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc11:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template = constants.%.loc12]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   assign %w.var, %.loc12
 // CHECK:STDOUT:   br !if.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc11:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.loc14]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   return %.loc14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -77,7 +77,7 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc19_27: i32 = int_literal 0 [template = constants.%.loc19]
+// CHECK:STDOUT:   %.loc19_27: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   assign %v.var, %.loc19_27
 // CHECK:STDOUT:   %.loc19_18: i32 = bind_value %v
 // CHECK:STDOUT:   return %.loc19_18
@@ -85,7 +85,7 @@ fn EnclosingButAfter(b: bool) -> i32 {
 // CHECK:STDOUT: !if.else:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.loc22]
+// CHECK:STDOUT:   %.loc22_25: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   assign %w.var, %.loc22_25
 // CHECK:STDOUT:   %.loc22_16: i32 = bind_value %w
 // CHECK:STDOUT:   return %.loc22_16

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -11,8 +11,8 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT: --- struct.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc8_17: {.a: i32} = struct_value (%.loc8_16) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.2: {.a: i32} = struct_value (%.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -22,10 +22,10 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> {.a: i32} {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template = constants.%.loc8_16]
+// CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc8_17.1: {.a: i32} = struct_literal (%.loc8_16)
-// CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16) [template = constants.%.loc8_17]
-// CHECK:STDOUT:   %.loc8_17.3: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.loc8_17]
+// CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_17.3: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.2]
 // CHECK:STDOUT:   return %.loc8_17.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -12,11 +12,11 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT: --- tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_23.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc8_23.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc8_23.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15 [template]
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 15 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 35 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,8 +26,8 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15 [template = constants.%.loc9_11]
-// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35 [template = constants.%.loc9_15]
+// CHECK:STDOUT:   %.loc9_11: i32 = int_literal 15 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_15: i32 = int_literal 35 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_17.1: (i32, i32) = tuple_literal (%.loc9_11, %.loc9_15)
 // CHECK:STDOUT:   %.loc9_17.2: ref i32 = tuple_access %return, element0
 // CHECK:STDOUT:   %.loc9_17.3: init i32 = initialize_from %.loc9_11 to %.loc9_17.2

--- a/toolchain/check/testdata/return/value.carbon
+++ b/toolchain/check/testdata/return/value.carbon
@@ -11,7 +11,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: --- value.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,7 +21,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   return %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -16,16 +16,16 @@ var y: {} = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_9: {} = struct_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc7_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_9.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc7_14.2: init {} = struct_init () to %x.var
 // CHECK:STDOUT:   %.loc7_14.3: init {} = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
-// CHECK:STDOUT:   %.loc8_9: {} = struct_literal ()
-// CHECK:STDOUT:   %.3: type = converted %.loc8_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_9.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc8_9.2: type = converted %.loc8_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %y.var: ref {} = var y
 // CHECK:STDOUT:   %y: ref {} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {} = name_ref x, %x

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -10,14 +10,14 @@ var y: {} = x;
 // CHECK:STDOUT: --- empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_9.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc7_9.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7_9.1 [template = constants.%.loc7_9.1]
+// CHECK:STDOUT:   %.loc7_9: {} = struct_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc7_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
@@ -25,7 +25,7 @@ var y: {} = x;
 // CHECK:STDOUT:   %.loc7_14.3: init {} = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
 // CHECK:STDOUT:   %.loc8_9: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7_9.1 [template = constants.%.loc7_9.1]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %y.var: ref {} = var y
 // CHECK:STDOUT:   %y: ref {} = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref {} = name_ref x, %x

--- a/toolchain/check/testdata/struct/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_empty.carbon
@@ -12,7 +12,7 @@ var x: {.a: i32} = {};
 // CHECK:STDOUT: --- fail_assign_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = struct_type {} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -20,8 +20,8 @@ var x: {.a: {}} = {.b = {}};
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14: {} = struct_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc10_14, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_14.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: {}} = var x
 // CHECK:STDOUT:   %x: ref {.a: {}} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_nested.carbon
@@ -12,16 +12,16 @@ var x: {.a: {}} = {.b = {}};
 // CHECK:STDOUT: --- fail_assign_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: ()} [template]
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: {}} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.a: ()} [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.b: {}} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.1 [template = constants.%.loc10_14.1]
+// CHECK:STDOUT:   %.loc10_14: {} = struct_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc10_14, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: {}} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: {}} = var x
 // CHECK:STDOUT:   %x: ref {.a: {}} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -20,8 +20,8 @@ var x: {} = {.a = 1};
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9: {} = struct_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc10_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_9.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template = constants.%.3]

--- a/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/struct/fail_assign_to_empty.carbon
@@ -12,19 +12,19 @@ var x: {} = {.a = 1};
 // CHECK:STDOUT: --- fail_assign_to_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc10_9.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_20: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9.1 [template = constants.%.loc10_9.1]
+// CHECK:STDOUT:   %.loc10_9: {} = struct_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc10_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {} = var x
 // CHECK:STDOUT:   %x: ref {} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template = constants.%.loc10_19]
+// CHECK:STDOUT:   %.loc10_19: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_20: {.a: i32} = struct_literal (%.loc10_19)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_duplicate_name.carbon
+++ b/toolchain/check/testdata/struct/fail_duplicate_name.carbon
@@ -47,37 +47,37 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT: --- fail_duplicate_name.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc21_36: type = struct_type {.a: i32} [template]
-// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc45_25: type = ptr_type {.b: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type {.b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F, .x = %x, .y = %y}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
-// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template = constants.%.loc21_35]
+// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc21_36: {.a: i32} = struct_literal (%.loc21_35)
 // CHECK:STDOUT:   %v: <error> = bind_name v, <error>
-// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template = constants.%.loc29_22]
-// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template = constants.%.loc29_32]
+// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %w: i32 = bind_name w, <error>
 // CHECK:STDOUT:   %.loc37_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template = constants.%.loc37_26]
-// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template = constants.%.loc37_34]
+// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   %.loc45_25: type = struct_type {.b: i32, .c: i32} [template]
 // CHECK:STDOUT:   %y.var: ref {.b: i32, .c: i32} = var y
 // CHECK:STDOUT:   %y: ref {.b: i32, .c: i32} = bind_name y, %y.var
-// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template = constants.%.loc45_35]
-// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template = constants.%.loc45_43]
+// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template = constants.%.9]
 // CHECK:STDOUT:   assign %y.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -17,8 +17,8 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT: --- fail_field_name_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_27: type = struct_type {.b: i32} [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.b: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.loc10_26]
+// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_27: {.b: i32} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   %.loc15: type = struct_type {.b: i32} [template]

--- a/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_type_mismatch.carbon
@@ -12,8 +12,8 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT: --- fail_field_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1 [template]
-// CHECK:STDOUT:   %.loc10_29: type = struct_type {.b: f64} [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.b: f64} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,7 +21,7 @@ var x: {.a: i32} = {.b = 1.0};
 // CHECK:STDOUT:   %.loc10_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1 [template = constants.%.loc10_26]
+// CHECK:STDOUT:   %.loc10_26: f64 = real_literal 10e-1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_29: {.b: f64} = struct_literal (%.loc10_26)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -13,7 +13,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_member_access_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: f64 = real_literal 40e-1 [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 40e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,7 +21,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: f64} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: f64} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_29.1: {.a: f64} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_29.2: init {.a: f64} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_29.3: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -22,7 +22,7 @@ var p: Incomplete* = &s.a;
 // CHECK:STDOUT: --- fail_nested_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc20: type = ptr_type <error> [template]
+// CHECK:STDOUT:   %.1: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -13,7 +13,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: --- fail_non_member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,7 +21,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2

--- a/toolchain/check/testdata/struct/fail_too_few_values.carbon
+++ b/toolchain/check/testdata/struct/fail_too_few_values.carbon
@@ -12,9 +12,9 @@ var x: {.a: i32, .b: i32} = {.a = 1};
 // CHECK:STDOUT: --- fail_too_few_values.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_25: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_36: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -22,7 +22,7 @@ var x: {.a: i32, .b: i32} = {.a = 1};
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.loc10_35]
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_36: {.a: i32} = struct_literal (%.loc10_35)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/struct/fail_value_as_type.carbon
@@ -12,13 +12,13 @@ var x: {.a = 1};
 // CHECK:STDOUT: --- fail_value_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_15: type = struct_type {.a: i32} [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.loc10_14]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_15: {.a: i32} = struct_literal (%.loc10_14)
 // CHECK:STDOUT:   %x.var: ref <error> = var x
 // CHECK:STDOUT:   %x: ref <error> = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -13,12 +13,12 @@ fn F() -> i32 {
 // CHECK:STDOUT: --- literal_member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = ptr_type {.x: i32, .y: i32, .z: i32} [template]
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_35.1: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} [template]
-// CHECK:STDOUT:   %.loc10_35.2: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
-// CHECK:STDOUT:   %.loc10_35.3: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.x: i32, .y: i32, .z: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {.a: i32, .b: {.x: i32, .y: i32, .z: i32}*, .c: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,11 +31,11 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.loc10_16]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %.loc10_25.1: ref {.x: i32, .y: i32, .z: i32} = temporary_storage
 // CHECK:STDOUT:   %.loc10_25.2: init {.x: i32, .y: i32, .z: i32} = call %G.ref() to %.loc10_25.1
-// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3 [template = constants.%.loc10_34]
+// CHECK:STDOUT:   %.loc10_34: i32 = int_literal 3 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_35.1: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_literal (%.loc10_16, %.loc10_25.2, %.loc10_34)
 // CHECK:STDOUT:   %.loc10_25.3: ref {.x: i32, .y: i32, .z: i32} = temporary %.loc10_25.1, %.loc10_25.2
 // CHECK:STDOUT:   %.loc10_25.4: ref i32 = struct_access %.loc10_25.3, element0

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -11,9 +11,9 @@ var z: i32 = y;
 // CHECK:STDOUT: --- member_access.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: f64, .b: i32} [template]
-// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1 [template]
-// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: f64, .b: i32} [template]
+// CHECK:STDOUT:   %.2: f64 = real_literal 0e-1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -21,8 +21,8 @@ var z: i32 = y;
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: f64, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: f64, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: f64, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1 [template = constants.%.loc7_35]
-// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1 [template = constants.%.loc7_45]
+// CHECK:STDOUT:   %.loc7_35: f64 = real_literal 0e-1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_45: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_46.1: {.a: f64, .b: i32} = struct_literal (%.loc7_35, %.loc7_45)
 // CHECK:STDOUT:   %.loc7_46.2: ref f64 = struct_access %x.var, element0
 // CHECK:STDOUT:   %.loc7_46.3: init f64 = initialize_from %.loc7_35 to %.loc7_46.2

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -13,11 +13,11 @@ fn G() {
 // CHECK:STDOUT: --- nested_struct_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_51.1: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
-// CHECK:STDOUT:   %.loc10_51.2: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.a: (i32, i32, i32)*, .b: (i32, i32, i32)*} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,9 +31,9 @@ fn G() {
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_29: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_29, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.1: type = converted %.loc10_29, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_50: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_50, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc10_50, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)} [template]
 // CHECK:STDOUT:   %v.var: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var v
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = bind_name v, %v.var

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -30,10 +30,10 @@ fn G() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_29: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc10_29, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_50: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_50, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_29.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_29.2: type = converted %.loc10_29.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_50.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_50.2: type = converted %.loc10_50.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_51: type = struct_type {.a: (i32, i32, i32), .b: (i32, i32, i32)} [template]
 // CHECK:STDOUT:   %v.var: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = var v
 // CHECK:STDOUT:   %v: ref {.a: (i32, i32, i32), .b: (i32, i32, i32)} = bind_name v, %v.var

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -10,7 +10,7 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT: --- one_entry.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -18,7 +18,7 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT:   %.loc7_16: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to %x.var
 // CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -16,9 +16,9 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: --- reorder_fields.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10: type = ptr_type {.a: i32, .b: f64} [template]
-// CHECK:STDOUT:   %.loc11_62.1: type = struct_type {.b: f64, .a: i32} [template]
-// CHECK:STDOUT:   %.loc11_62.2: type = ptr_type {.b: f64, .a: i32} [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: i32, .b: f64} [template]
+// CHECK:STDOUT:   %.2: type = struct_type {.b: f64, .a: i32} [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {.b: f64, .a: i32} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -36,17 +36,17 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc11_27: type = struct_type {.a: i32, .b: f64} [template]
 // CHECK:STDOUT:   %MakeF64.ref: <function> = name_ref MakeF64, file.%MakeF64 [template = file.%MakeF64]
-// CHECK:STDOUT:   %.loc11_44: init f64 = call %MakeF64.ref()
+// CHECK:STDOUT:   %.loc11_44.1: init f64 = call %MakeF64.ref()
 // CHECK:STDOUT:   %MakeI32.ref: <function> = name_ref MakeI32, file.%MakeI32 [template = file.%MakeI32]
-// CHECK:STDOUT:   %.loc11_60: init i32 = call %MakeI32.ref()
-// CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44, %.loc11_60)
-// CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60
-// CHECK:STDOUT:   %.loc11_62.3: i32 = converted %.loc11_60, %.loc11_62.2
-// CHECK:STDOUT:   %.loc11_62.4: f64 = value_of_initializer %.loc11_44
-// CHECK:STDOUT:   %.loc11_62.5: f64 = converted %.loc11_44, %.loc11_62.4
-// CHECK:STDOUT:   %.loc11_62.6: {.a: i32, .b: f64} = struct_value (%.loc11_62.3, %.loc11_62.5)
-// CHECK:STDOUT:   %.loc11_62.7: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.6
-// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_62.7
+// CHECK:STDOUT:   %.loc11_60.1: init i32 = call %MakeI32.ref()
+// CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44.1, %.loc11_60.1)
+// CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60.1
+// CHECK:STDOUT:   %.loc11_60.2: i32 = converted %.loc11_60.1, %.loc11_62.2
+// CHECK:STDOUT:   %.loc11_62.3: f64 = value_of_initializer %.loc11_44.1
+// CHECK:STDOUT:   %.loc11_44.2: f64 = converted %.loc11_44.1, %.loc11_62.3
+// CHECK:STDOUT:   %.loc11_62.4: {.a: i32, .b: f64} = struct_value (%.loc11_60.2, %.loc11_44.2)
+// CHECK:STDOUT:   %.loc11_62.5: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.4
+// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_62.5
 // CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32} [template]
 // CHECK:STDOUT:   %x.ref: {.a: i32, .b: f64} = name_ref x, %x
 // CHECK:STDOUT:   %.loc12_31.1: f64 = struct_access %x.ref, element1

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -10,22 +10,22 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT: --- tuple_as_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_27.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_27.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_28: type = ptr_type {.a: i32, .b: (i32,)} [template]
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {.a: i32, .b: (i32,)} [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_27.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%.loc7_27.2 [template = constants.%.loc7_27.2]
+// CHECK:STDOUT:   %.loc7_27: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_27, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: (i32,)} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: (i32,)} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template = constants.%.loc7_38]
-// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2 [template = constants.%.loc7_47]
+// CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_47: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_49.1: (i32,) = tuple_literal (%.loc7_47)
 // CHECK:STDOUT:   %.loc7_50.1: {.a: i32, .b: (i32,)} = struct_literal (%.loc7_38, %.loc7_49.1)
 // CHECK:STDOUT:   %.loc7_50.2: ref i32 = struct_access %x.var, element0
@@ -38,7 +38,7 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.6
 // CHECK:STDOUT:   assign %x.var, %.loc7_50.7
 // CHECK:STDOUT:   %.loc8_27: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_27.3: type = converted %.loc8_27, constants.%.loc7_27.2 [template = constants.%.loc7_27.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_27, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc8_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %y.var: ref {.a: i32, .b: (i32,)} = var y
 // CHECK:STDOUT:   %y: ref {.a: i32, .b: (i32,)} = bind_name y, %y.var

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -19,8 +19,8 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_27: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_27, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_27.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: (i32,)} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: (i32,)} = bind_name x, %x.var
@@ -37,8 +37,8 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc7_50.6: init {.a: i32, .b: (i32,)} = struct_init (%.loc7_50.3, %.loc7_50.5) to %x.var
 // CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.6
 // CHECK:STDOUT:   assign %x.var, %.loc7_50.7
-// CHECK:STDOUT:   %.loc8_27: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc8_27, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_27.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc8_27.2: type = converted %.loc8_27.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc8_28: type = struct_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %y.var: ref {.a: i32, .b: (i32,)} = var y
 // CHECK:STDOUT:   %y: ref {.a: i32, .b: (i32,)} = bind_name y, %y.var

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -13,22 +13,22 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT: --- two_entries.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc7_44: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template]
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: {.a: i32, .b: i32} = struct_value (%.2, %.3) [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.loc7_35]
-// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template = constants.%.loc7_43]
+// CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_44.1: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
-// CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.loc7_44]
-// CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.loc7_44]
+// CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.4]
 // CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_44.3
 // CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v
@@ -36,8 +36,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.loc10_35]
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2 [template = constants.%.loc10_43]
+// CHECK:STDOUT:   %.loc10_35: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc10_44.1: {.a: i32, .b: i32} = struct_literal (%.loc10_35, %.loc10_43)
 // CHECK:STDOUT:   %.loc10_44.2: ref i32 = struct_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_44.3: init i32 = initialize_from %.loc10_35 to %.loc10_44.2

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -15,16 +15,16 @@ var y: () = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc7_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_14.2: init () = tuple_init () to %x.var
 // CHECK:STDOUT:   %.loc7_14.3: init () = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
-// CHECK:STDOUT:   %.loc8_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.3: type = converted %.loc8_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc8_9.2: type = converted %.loc8_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %y.var: ref () = var y
 // CHECK:STDOUT:   %y: ref () = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, %x

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -10,13 +10,13 @@ var y: () = x;
 // CHECK:STDOUT: --- empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.loc7 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc7_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
@@ -24,7 +24,7 @@ var y: () = x;
 // CHECK:STDOUT:   %.loc7_14.3: init () = converted %.loc7_14.1, %.loc7_14.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_14.3
 // CHECK:STDOUT:   %.loc8_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_9.3: type = converted %.loc8_9, constants.%.loc7 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %y.var: ref () = var y
 // CHECK:STDOUT:   %y: ref () = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, %x

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -19,8 +19,8 @@ var x: (i32,) = ();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_18: () = tuple_literal ()

--- a/toolchain/check/testdata/tuples/fail_assign_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_empty.carbon
@@ -12,15 +12,15 @@ var x: (i32,) = ();
 // CHECK:STDOUT: --- fail_assign_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_13.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc10_13.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_13.1, constants.%.loc10_13.2 [template = constants.%.loc10_13.2]
+// CHECK:STDOUT:   %.loc10_13: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_18: () = tuple_literal ()

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -31,12 +31,12 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_31: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_18, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.3: type = converted %.loc10_30, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.4: type = converted %.loc10_31, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_18.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_30.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18.1, %.loc10_30.1)
+// CHECK:STDOUT:   %.loc10_18.2: type = converted %.loc10_18.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_30.2: type = converted %.loc10_30.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_31.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), (i32, i32)) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), (i32, i32)) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.8]

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -12,40 +12,40 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT: --- fail_assign_nested.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_18: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc10_31.1: type = tuple_type ((type, type), (type, type)) [template]
-// CHECK:STDOUT:   %.loc10_31.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_31.3: type = tuple_type ((i32, i32), (i32, i32)) [template]
-// CHECK:STDOUT:   %.loc10_31.4: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_31.5: type = tuple_type ((i32, i32)*, (i32, i32)*) [template]
-// CHECK:STDOUT:   %.loc10_31.6: type = ptr_type ((i32, i32)*, (i32, i32)*) [template]
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.loc10_44: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.loc10_56: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type ((type, type), (type, type)) [template]
+// CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type ((i32, i32), (i32, i32)) [template]
+// CHECK:STDOUT:   %.5: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.6: type = tuple_type ((i32, i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.7: type = ptr_type ((i32, i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.15: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
-// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_18, constants.%.loc10_31.2 [template = constants.%.loc10_31.2]
-// CHECK:STDOUT:   %.loc10_31.3: type = converted %.loc10_30, constants.%.loc10_31.2 [template = constants.%.loc10_31.2]
-// CHECK:STDOUT:   %.loc10_31.4: type = converted %.loc10_31.1, constants.%.loc10_31.3 [template = constants.%.loc10_31.3]
+// CHECK:STDOUT:   %.loc10_31: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_18, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.3: type = converted %.loc10_30, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.4: type = converted %.loc10_31, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), (i32, i32)) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), (i32, i32)) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.loc10_37]
-// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2 [template = constants.%.loc10_40]
-// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3 [template = constants.%.loc10_43]
+// CHECK:STDOUT:   %.loc10_37: i32 = int_literal 1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc10_40: i32 = int_literal 2 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc10_43: i32 = int_literal 3 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc10_44: (i32, i32, i32) = tuple_literal (%.loc10_37, %.loc10_40, %.loc10_43)
-// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4 [template = constants.%.loc10_48]
-// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5 [template = constants.%.loc10_51]
-// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6 [template = constants.%.loc10_54]
+// CHECK:STDOUT:   %.loc10_48: i32 = int_literal 4 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc10_51: i32 = int_literal 5 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc10_54: i32 = int_literal 6 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc10_55: (i32, i32, i32) = tuple_literal (%.loc10_48, %.loc10_51, %.loc10_54)
 // CHECK:STDOUT:   %.loc10_56: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_44, %.loc10_55)
 // CHECK:STDOUT:   assign %x.var, <error>

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -12,17 +12,17 @@ var x: () = (66);
 // CHECK:STDOUT: --- fail_assign_to_empty.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 66 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.loc10_9 [template = constants.%.loc10_9]
+// CHECK:STDOUT:   %.loc10_9: () = tuple_literal ()
+// CHECK:STDOUT:   %.2: type = converted %.loc10_9, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template = constants.%.loc10_14]
+// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_to_empty.carbon
@@ -18,8 +18,8 @@ var x: () = (66);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9: () = tuple_literal ()
-// CHECK:STDOUT:   %.2: type = converted %.loc10_9, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_9.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc10_9.2: type = converted %.loc10_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 66 [template = constants.%.2]

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -22,8 +22,8 @@ var x: (i32, i32) = (2, 65.89);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.4]

--- a/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
+++ b/toolchain/check/testdata/tuples/fail_element_type_mismatch.carbon
@@ -12,22 +12,22 @@ var x: (i32, i32) = (2, 65.89);
 // CHECK:STDOUT: --- fail_element_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2 [template]
-// CHECK:STDOUT:   %.loc10_30: type = tuple_type (i32, f64) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: f64 = real_literal 6589e-2 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (i32, f64) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.loc10_22]
-// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2 [template = constants.%.loc10_25]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_25: f64 = real_literal 6589e-2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc10_30.1: (i32, f64) = tuple_literal (%.loc10_22, %.loc10_25)
 // CHECK:STDOUT:   %.loc10_30.2: ref i32 = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_30.3: init i32 = initialize_from %.loc10_22 to %.loc10_30.2

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -22,10 +22,10 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT: --- fail_nested_incomplete.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc15_24.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc15_24.2: type = tuple_type (i32, Incomplete) [template]
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc20_22: type = ptr_type <error> [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, Incomplete) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.4: type = ptr_type <error> [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,8 +33,8 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
-// CHECK:STDOUT:   %.loc15_24.1: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
-// CHECK:STDOUT:   %.loc15_24.2: type = converted %.loc15_24.1, constants.%.loc15_24.2 [template = constants.%.loc15_24.2]
+// CHECK:STDOUT:   %.loc15: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
+// CHECK:STDOUT:   %.2: type = converted %.loc15, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %t.var: ref <error> = var t
 // CHECK:STDOUT:   %t: ref <error> = bind_name t, %t.var
 // CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
@@ -42,7 +42,7 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   %p.var: ref Incomplete* = var p
 // CHECK:STDOUT:   %p: ref Incomplete* = bind_name p, %p.var
 // CHECK:STDOUT:   %t.ref: ref <error> = name_ref t, %t
-// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1 [template = constants.%.loc20_25]
+// CHECK:STDOUT:   %.loc20_25: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc20_22: <error>* = addr_of <error>
 // CHECK:STDOUT:   assign %p.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/tuples/fail_nested_incomplete.carbon
@@ -33,8 +33,8 @@ var p: Incomplete* = &t[1];
 // CHECK:STDOUT:   %Incomplete.decl = class_decl @Incomplete, ()
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
 // CHECK:STDOUT:   %Incomplete.ref.loc15: type = name_ref Incomplete, %Incomplete [template = %Incomplete]
-// CHECK:STDOUT:   %.loc15: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
-// CHECK:STDOUT:   %.2: type = converted %.loc15, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc15_24.1: (type, type) = tuple_literal (i32, %Incomplete.ref.loc15)
+// CHECK:STDOUT:   %.loc15_24.2: type = converted %.loc15_24.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %t.var: ref <error> = var t
 // CHECK:STDOUT:   %t: ref <error> = bind_name t, %t.var
 // CHECK:STDOUT:   %Incomplete.ref.loc20: type = name_ref Incomplete, %Incomplete [template = %Incomplete]

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -12,20 +12,20 @@ var x: (i32, i32) = (2, );
 // CHECK:STDOUT: --- fail_too_few_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc10_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.loc10_25: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.loc10_17.2 [template = constants.%.loc10_17.2]
+// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.loc10_22]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_25: (i32,) = tuple_literal (%.loc10_22)
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_too_few_element.carbon
+++ b/toolchain/check/testdata/tuples/fail_too_few_element.carbon
@@ -21,8 +21,8 @@ var x: (i32, i32) = (2, );
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 2 [template = constants.%.4]

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -12,14 +12,14 @@ var x: (i32, ) = (i32, );
 // CHECK:STDOUT: --- fail_type_assign.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_14.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc10_14.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.loc10_14.2 [template = constants.%.loc10_14.2]
+// CHECK:STDOUT:   %.loc10_14: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_14, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_24: (type,) = tuple_literal (i32)

--- a/toolchain/check/testdata/tuples/fail_type_assign.carbon
+++ b/toolchain/check/testdata/tuples/fail_type_assign.carbon
@@ -18,8 +18,8 @@ var x: (i32, ) = (i32, );
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_14: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_14, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_14.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_14.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_24: (type,) = tuple_literal (i32)

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -12,16 +12,16 @@ var x: (1, );
 // CHECK:STDOUT: --- fail_value_as_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc10_12.1: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc10_12.2: type = tuple_type (<error>) [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: type = tuple_type (<error>) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.loc10_9]
-// CHECK:STDOUT:   %.loc10_12.1: (i32,) = tuple_literal (%.loc10_9)
-// CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, constants.%.loc10_12.2 [template = constants.%.loc10_12.2]
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_12: (i32,) = tuple_literal (%.loc10_9)
+// CHECK:STDOUT:   %.2: type = converted %.loc10_12, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %x.var: ref (<error>,) = var x
 // CHECK:STDOUT:   %x: ref (<error>,) = bind_name x, %x.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/fail_value_as_type.carbon
+++ b/toolchain/check/testdata/tuples/fail_value_as_type.carbon
@@ -20,8 +20,8 @@ var x: (1, );
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_12: (i32,) = tuple_literal (%.loc10_9)
-// CHECK:STDOUT:   %.2: type = converted %.loc10_12, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_12.1: (i32,) = tuple_literal (%.loc10_9)
+// CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %x.var: ref (<error>,) = var x
 // CHECK:STDOUT:   %x: ref (<error>,) = bind_name x, %x.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -9,30 +9,30 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT: --- nested_tuple.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_18: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_24.1: type = tuple_type ((type, type), type) [template]
-// CHECK:STDOUT:   %.loc7_24.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_24.3: type = tuple_type ((i32, i32), i32) [template]
-// CHECK:STDOUT:   %.loc7_24.4: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_24.5: type = tuple_type ((i32, i32)*, i32) [template]
-// CHECK:STDOUT:   %.loc7_24.6: type = ptr_type ((i32, i32)*, i32) [template]
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76 [template]
-// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type ((type, type), type) [template]
+// CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type ((i32, i32), i32) [template]
+// CHECK:STDOUT:   %.5: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.6: type = tuple_type ((i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.7: type = ptr_type ((i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 12 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 76 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18, i32)
-// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_18, constants.%.loc7_24.2 [template = constants.%.loc7_24.2]
-// CHECK:STDOUT:   %.loc7_24.3: type = converted %.loc7_24.1, constants.%.loc7_24.3 [template = constants.%.loc7_24.3]
+// CHECK:STDOUT:   %.loc7_24: ((type, type), type) = tuple_literal (%.loc7_18, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_18, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.3: type = converted %.loc7_24, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), i32) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template = constants.%.loc7_30]
-// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76 [template = constants.%.loc7_34]
+// CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_34: i32 = int_literal 76 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc7_36.1: (i32, i32) = tuple_literal (%.loc7_30, %.loc7_34)
-// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6 [template = constants.%.loc7_39]
+// CHECK:STDOUT:   %.loc7_39: i32 = int_literal 6 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc7_40.1: ((i32, i32), i32) = tuple_literal (%.loc7_36.1, %.loc7_39)
 // CHECK:STDOUT:   %.loc7_40.2: ref (i32, i32) = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc7_36.2: ref i32 = tuple_access %.loc7_40.2, element0

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -23,10 +23,10 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
-// CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_24: ((type, type), type) = tuple_literal (%.loc7_18, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_18, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.3: type = converted %.loc7_24, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_18.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18.1, i32)
+// CHECK:STDOUT:   %.loc7_18.2: type = converted %.loc7_18.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_24.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), i32) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), i32) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_30: i32 = int_literal 12 [template = constants.%.8]

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -43,12 +43,12 @@ fn H() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_42: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_43: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
-// CHECK:STDOUT:   %.1: type = converted %.loc10_25, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.2: type = converted %.loc10_42, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.3: type = converted %.loc10_43, constants.%.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_25.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_42.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_43.1: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25.1, %.loc10_42.1)
+// CHECK:STDOUT:   %.loc10_25.2: type = converted %.loc10_25.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_42.2: type = converted %.loc10_42.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_43.1, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %v.var: ref ((i32, i32, i32), (i32, i32, i32)) = var v
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_ref F, file.%F [template = file.%F]
@@ -66,10 +66,10 @@ fn H() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_30: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc14_36: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
-// CHECK:STDOUT:   %.1: type = converted %.loc14_30, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.2: type = converted %.loc14_36, constants.%.9 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc14_30.1: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc14_36.1: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30.1, i32)
+// CHECK:STDOUT:   %.loc14_30.2: type = converted %.loc14_30.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_36.1, constants.%.9 [template = constants.%.9]
 // CHECK:STDOUT:   %v.var: ref (i32, (i32, i32, i32), i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = bind_name v, %v.var
 // CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template = constants.%.12]

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -17,19 +17,19 @@ fn H() {
 // CHECK:STDOUT: --- nested_tuple_in_place.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_25.1: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.loc7_25.2: type = tuple_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_25.3: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.loc10_43.1: type = tuple_type ((type, type, type), (type, type, type)) [template]
-// CHECK:STDOUT:   %.loc10_43.2: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
-// CHECK:STDOUT:   %.loc10_43.3: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
-// CHECK:STDOUT:   %.loc10_43.4: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
-// CHECK:STDOUT:   %.loc14_36.1: type = tuple_type (type, (type, type, type), type) [template]
-// CHECK:STDOUT:   %.loc14_36.2: type = tuple_type (i32, (i32, i32, i32), i32) [template]
-// CHECK:STDOUT:   %.loc14_36.3: type = tuple_type (i32, (i32, i32, i32)*, i32) [template]
-// CHECK:STDOUT:   %.loc14_36.4: type = ptr_type (i32, (i32, i32, i32)*, i32) [template]
-// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type ((type, type, type), (type, type, type)) [template]
+// CHECK:STDOUT:   %.5: type = tuple_type ((i32, i32, i32), (i32, i32, i32)) [template]
+// CHECK:STDOUT:   %.6: type = tuple_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
+// CHECK:STDOUT:   %.7: type = ptr_type ((i32, i32, i32)*, (i32, i32, i32)*) [template]
+// CHECK:STDOUT:   %.8: type = tuple_type (type, (type, type, type), type) [template]
+// CHECK:STDOUT:   %.9: type = tuple_type (i32, (i32, i32, i32), i32) [template]
+// CHECK:STDOUT:   %.10: type = tuple_type (i32, (i32, i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.11: type = ptr_type (i32, (i32, i32, i32)*, i32) [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,10 +45,10 @@ fn H() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_42: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_43.1: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
-// CHECK:STDOUT:   %.loc7_25.1: type = converted %.loc10_25, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
-// CHECK:STDOUT:   %.loc7_25.2: type = converted %.loc10_42, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
-// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_43.1, constants.%.loc10_43.2 [template = constants.%.loc10_43.2]
+// CHECK:STDOUT:   %.loc10_43: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
+// CHECK:STDOUT:   %.1: type = converted %.loc10_25, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc10_42, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc10_43, constants.%.5 [template = constants.%.5]
 // CHECK:STDOUT:   %v.var: ref ((i32, i32, i32), (i32, i32, i32)) = var v
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_ref F, file.%F [template = file.%F]
@@ -67,16 +67,16 @@ fn H() {
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14_30: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc14_36.1: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
-// CHECK:STDOUT:   %.loc7: type = converted %.loc14_30, constants.%.loc7_25.2 [template = constants.%.loc7_25.2]
-// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_36.1, constants.%.loc14_36.2 [template = constants.%.loc14_36.2]
+// CHECK:STDOUT:   %.loc14_36: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
+// CHECK:STDOUT:   %.1: type = converted %.loc14_30, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.2: type = converted %.loc14_36, constants.%.9 [template = constants.%.9]
 // CHECK:STDOUT:   %v.var: ref (i32, (i32, i32, i32), i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template = constants.%.loc14_41]
+// CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template = constants.%.12]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
 // CHECK:STDOUT:   %.loc14_50.1: ref (i32, i32, i32) = tuple_access %v.var, element1
 // CHECK:STDOUT:   %.loc14_45: init (i32, i32, i32) = call %F.ref() to %.loc14_50.1
-// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2 [template = constants.%.loc14_49]
+// CHECK:STDOUT:   %.loc14_49: i32 = int_literal 2 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc14_50.2: (i32, (i32, i32, i32), i32) = tuple_literal (%.loc14_41, %.loc14_45, %.loc14_49)
 // CHECK:STDOUT:   %.loc14_50.3: ref i32 = tuple_access %v.var, element0
 // CHECK:STDOUT:   %.loc14_50.4: init i32 = initialize_from %.loc14_41 to %.loc14_50.3

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -17,8 +17,8 @@ var y: (i32,) = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.3]
@@ -26,8 +26,8 @@ var y: (i32,) = x;
 // CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to %x.var
 // CHECK:STDOUT:   %.loc7_20.3: init (i32,) = converted %.loc7_20.1, %.loc7_20.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_20.3
-// CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_13.1: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc8_13.2: type = converted %.loc8_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %y.var: ref (i32,) = var y
 // CHECK:STDOUT:   %y: ref (i32,) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -10,24 +10,24 @@ var y: (i32,) = x;
 // CHECK:STDOUT: --- one_element.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_13.1: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.loc7_13.2: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_13.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.2: type = converted %.loc7_13.1, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.loc7_13: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32,) = var x
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.loc7_18]
+// CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_20.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to %x.var
 // CHECK:STDOUT:   %.loc7_20.3: init (i32,) = converted %.loc7_20.1, %.loc7_20.2
 // CHECK:STDOUT:   assign %x.var, %.loc7_20.3
 // CHECK:STDOUT:   %.loc8_13: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc7_13.3: type = converted %.loc8_13, constants.%.loc7_13.2 [template = constants.%.loc7_13.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc8_13, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %y.var: ref (i32,) = var y
 // CHECK:STDOUT:   %y: ref (i32,) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -25,20 +25,20 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
 // CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
 // CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3
-// CHECK:STDOUT:   %.loc8: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.3: type = converted %.loc8, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %w: (i32, i32) = bind_name w, %v.ref
-// CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.4: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template = constants.%.7]
@@ -51,8 +51,8 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc10_28.6: init (i32, i32) = tuple_init (%.loc10_28.3, %.loc10_28.5) to %x.var
 // CHECK:STDOUT:   %.loc10_28.7: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6
 // CHECK:STDOUT:   assign %x.var, %.loc10_28.7
-// CHECK:STDOUT:   %.loc11_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.5: type = converted %.loc11_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_17.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc11_17.2: type = converted %.loc11_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %y.var: ref (i32, i32) = var y
 // CHECK:STDOUT:   %y: ref (i32, i32) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32, i32) = name_ref x, %x

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -13,36 +13,36 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT: --- two_elements.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7_17.1: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.loc7_17.2: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_17.3: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template]
-// CHECK:STDOUT:   %.loc7_28: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template]
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102 [template]
+// CHECK:STDOUT:   %.1: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.2: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 102 [template]
+// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 102 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
-// CHECK:STDOUT:   %.loc7_17.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
-// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template = constants.%.loc7_22]
-// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.loc7_25]
+// CHECK:STDOUT:   %.loc7_17: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.2: type = converted %.loc7_17, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
-// CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.loc7_28]
-// CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.loc7_28]
+// CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
 // CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3
 // CHECK:STDOUT:   %.loc8: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.3: type = converted %.loc8, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.3: type = converted %.loc8, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v
 // CHECK:STDOUT:   %w: (i32, i32) = bind_name w, %v.ref
 // CHECK:STDOUT:   %.loc10_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.4: type = converted %.loc10_17, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.4: type = converted %.loc10_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x
 // CHECK:STDOUT:   %x: ref (i32, i32) = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template = constants.%.loc10_22]
-// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102 [template = constants.%.loc10_25]
+// CHECK:STDOUT:   %.loc10_22: i32 = int_literal 4 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc10_25: i32 = int_literal 102 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc10_28.1: (i32, i32) = tuple_literal (%.loc10_22, %.loc10_25)
 // CHECK:STDOUT:   %.loc10_28.2: ref i32 = tuple_access %x.var, element0
 // CHECK:STDOUT:   %.loc10_28.3: init i32 = initialize_from %.loc10_22 to %.loc10_28.2
@@ -52,7 +52,7 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc10_28.7: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6
 // CHECK:STDOUT:   assign %x.var, %.loc10_28.7
 // CHECK:STDOUT:   %.loc11_17: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_17.5: type = converted %.loc11_17, constants.%.loc7_17.2 [template = constants.%.loc7_17.2]
+// CHECK:STDOUT:   %.5: type = converted %.loc11_17, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %y.var: ref (i32, i32) = var y
 // CHECK:STDOUT:   %y: ref (i32, i32) = bind_name y, %y.var
 // CHECK:STDOUT:   %x.ref: ref (i32, i32) = name_ref x, %x

--- a/toolchain/check/testdata/var/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/decl_with_init.carbon
@@ -11,7 +11,7 @@ fn Main() {
 // CHECK:STDOUT: --- decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -23,7 +23,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc8
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/fail_duplicate_decl.carbon
@@ -19,8 +19,8 @@ fn Main() {
 // CHECK:STDOUT: --- fail_duplicate_decl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,11 +32,11 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var.loc9: ref i32 = var x
 // CHECK:STDOUT:   %x.loc9: ref i32 = bind_name x, %x.var.loc9
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var.loc9, %.loc9
 // CHECK:STDOUT:   %x.var.loc16: ref i32 = var x
 // CHECK:STDOUT:   %x.loc16: ref i32 = bind_name x, %x.var.loc16
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var.loc16, %.loc16
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_generic.carbon
+++ b/toolchain/check/testdata/var/fail_generic.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var [symbolic]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc11
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
+++ b/toolchain/check/testdata/var/fail_init_type_mismatch.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_init_type_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template]
+// CHECK:STDOUT:   %.1: f64 = real_literal 10e-1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: f64 = real_literal 10e-1 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -25,11 +25,11 @@ fn F(x: X) {
 // CHECK:STDOUT: --- fail_not_copyable.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8_1.1: type = struct_type {} [template]
-// CHECK:STDOUT:   %.loc8_1.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.loc7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = ptr_type String [template]
+// CHECK:STDOUT:   %.5: String = string_literal "hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,7 +48,7 @@ fn F(x: X) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.var: ref String = var s
 // CHECK:STDOUT:   %s: ref String = bind_name s, %s.var
-// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template = constants.%.loc16]
+// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template = constants.%.5]
 // CHECK:STDOUT:   assign %s.var, <error>
 // CHECK:STDOUT:   %X.ref: type = name_ref X, file.%X [template = file.%X]
 // CHECK:STDOUT:   %y.var: ref X = var y

--- a/toolchain/check/testdata/var/fail_storage_is_literal.carbon
+++ b/toolchain/check/testdata/var/fail_storage_is_literal.carbon
@@ -14,8 +14,8 @@ fn Main() {
 // CHECK:STDOUT: --- fail_storage_is_literal.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -25,10 +25,10 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1 [template = constants.%.loc11_10]
+// CHECK:STDOUT:   %.loc11_10: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref <error> = var x
 // CHECK:STDOUT:   %x: ref <error> = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1 [template = constants.%.loc11_14]
+// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %x.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/global_decl_with_init.carbon
+++ b/toolchain/check/testdata/var/global_decl_with_init.carbon
@@ -9,14 +9,14 @@ var x: i32 = 0;
 // CHECK:STDOUT: --- global_decl_with_init.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/global_lookup.carbon
+++ b/toolchain/check/testdata/var/global_lookup.carbon
@@ -10,14 +10,14 @@ var y: i32 = x;
 // CHECK:STDOUT: --- global_lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .y = %y}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %y.var: ref i32 = var y
 // CHECK:STDOUT:   %y: ref i32 = bind_name y, %y.var

--- a/toolchain/check/testdata/var/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/global_lookup_in_scope.carbon
@@ -13,14 +13,14 @@ fn Main() {
 // CHECK:STDOUT: --- global_lookup_in_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.x = %x, .Main = %Main}
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.loc7]
+// CHECK:STDOUT:   %.loc7: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc7
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/lookup.carbon
+++ b/toolchain/check/testdata/var/lookup.carbon
@@ -12,7 +12,7 @@ fn Main() {
 // CHECK:STDOUT: --- lookup.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -24,7 +24,7 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
 // CHECK:STDOUT:   %x: ref i32 = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc8
 // CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/var/shadowing.carbon
+++ b/toolchain/check/testdata/var/shadowing.carbon
@@ -17,10 +17,10 @@ fn Main() {
 // CHECK:STDOUT: --- shadowing.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,18 +32,18 @@ fn Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var.loc8: ref i32 = var x
 // CHECK:STDOUT:   %x.loc8: ref i32 = bind_name x, %x.var.loc8
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.loc8]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var.loc8, %.loc8
-// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template = constants.%.loc9]
+// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template = constants.%.2]
 // CHECK:STDOUT:   if %.loc9 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
 // CHECK:STDOUT:   %x.var.loc10: ref i32 = var x
 // CHECK:STDOUT:   %x.loc10: ref i32 = bind_name x, %x.var.loc10
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template = constants.%.loc10]
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   assign %x.var.loc10, %.loc10
 // CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x.loc10
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template = constants.%.loc13]
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   assign %x.ref, %.loc13
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -63,27 +63,27 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc17:
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc17_11: init bool = call %A.ref()
-// CHECK:STDOUT:   %.loc17_13.1: bool = value_of_initializer %.loc17_11
-// CHECK:STDOUT:   %.loc17_13.2: bool = converted %.loc17_11, %.loc17_13.1
-// CHECK:STDOUT:   if %.loc17_13.2 br !while.body.loc17 else br !while.done.loc17
+// CHECK:STDOUT:   %.loc17_11.1: init bool = call %A.ref()
+// CHECK:STDOUT:   %.loc17_13: bool = value_of_initializer %.loc17_11.1
+// CHECK:STDOUT:   %.loc17_11.2: bool = converted %.loc17_11.1, %.loc17_13
+// CHECK:STDOUT:   if %.loc17_11.2 br !while.body.loc17 else br !while.done.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc17:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc18_10: init bool = call %B.ref()
-// CHECK:STDOUT:   %.loc18_12.1: bool = value_of_initializer %.loc18_10
-// CHECK:STDOUT:   %.loc18_12.2: bool = converted %.loc18_10, %.loc18_12.1
-// CHECK:STDOUT:   if %.loc18_12.2 br !if.then.loc18 else br !if.else.loc18
+// CHECK:STDOUT:   %.loc18_10.1: init bool = call %B.ref()
+// CHECK:STDOUT:   %.loc18_12: bool = value_of_initializer %.loc18_10.1
+// CHECK:STDOUT:   %.loc18_10.2: bool = converted %.loc18_10.1, %.loc18_12
+// CHECK:STDOUT:   if %.loc18_10.2 br !if.then.loc18 else br !if.else.loc18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc18:
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc18:
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
-// CHECK:STDOUT:   %.loc19_10: init bool = call %C.ref()
-// CHECK:STDOUT:   %.loc19_12.1: bool = value_of_initializer %.loc19_10
-// CHECK:STDOUT:   %.loc19_12.2: bool = converted %.loc19_10, %.loc19_12.1
-// CHECK:STDOUT:   if %.loc19_12.2 br !if.then.loc19 else br !if.else.loc19
+// CHECK:STDOUT:   %.loc19_10.1: init bool = call %C.ref()
+// CHECK:STDOUT:   %.loc19_12: bool = value_of_initializer %.loc19_10.1
+// CHECK:STDOUT:   %.loc19_10.2: bool = converted %.loc19_10.1, %.loc19_12
+// CHECK:STDOUT:   if %.loc19_10.2 br !if.then.loc19 else br !if.else.loc19
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc19:
 // CHECK:STDOUT:   br !while.done.loc17
@@ -93,27 +93,27 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc20:
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
-// CHECK:STDOUT:   %.loc20_13: init bool = call %D.ref()
-// CHECK:STDOUT:   %.loc20_15.1: bool = value_of_initializer %.loc20_13
-// CHECK:STDOUT:   %.loc20_15.2: bool = converted %.loc20_13, %.loc20_15.1
-// CHECK:STDOUT:   if %.loc20_15.2 br !while.body.loc20 else br !while.done.loc20
+// CHECK:STDOUT:   %.loc20_13.1: init bool = call %D.ref()
+// CHECK:STDOUT:   %.loc20_15: bool = value_of_initializer %.loc20_13.1
+// CHECK:STDOUT:   %.loc20_13.2: bool = converted %.loc20_13.1, %.loc20_15
+// CHECK:STDOUT:   if %.loc20_13.2 br !while.body.loc20 else br !while.done.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc20:
 // CHECK:STDOUT:   %E.ref: <function> = name_ref E, file.%E [template = file.%E]
-// CHECK:STDOUT:   %.loc21_12: init bool = call %E.ref()
-// CHECK:STDOUT:   %.loc21_14.1: bool = value_of_initializer %.loc21_12
-// CHECK:STDOUT:   %.loc21_14.2: bool = converted %.loc21_12, %.loc21_14.1
-// CHECK:STDOUT:   if %.loc21_14.2 br !if.then.loc21 else br !if.else.loc21
+// CHECK:STDOUT:   %.loc21_12.1: init bool = call %E.ref()
+// CHECK:STDOUT:   %.loc21_14: bool = value_of_initializer %.loc21_12.1
+// CHECK:STDOUT:   %.loc21_12.2: bool = converted %.loc21_12.1, %.loc21_14
+// CHECK:STDOUT:   if %.loc21_12.2 br !if.then.loc21 else br !if.else.loc21
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc21:
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc21:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc22_12: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc22_14.1: bool = value_of_initializer %.loc22_12
-// CHECK:STDOUT:   %.loc22_14.2: bool = converted %.loc22_12, %.loc22_14.1
-// CHECK:STDOUT:   if %.loc22_14.2 br !if.then.loc22 else br !if.else.loc22
+// CHECK:STDOUT:   %.loc22_12.1: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc22_14: bool = value_of_initializer %.loc22_12.1
+// CHECK:STDOUT:   %.loc22_12.2: bool = converted %.loc22_12.1, %.loc22_14
+// CHECK:STDOUT:   if %.loc22_12.2 br !if.then.loc22 else br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc22:
 // CHECK:STDOUT:   br !while.done.loc20
@@ -123,20 +123,20 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done.loc20:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc24_10: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc24_12.1: bool = value_of_initializer %.loc24_10
-// CHECK:STDOUT:   %.loc24_12.2: bool = converted %.loc24_10, %.loc24_12.1
-// CHECK:STDOUT:   if %.loc24_12.2 br !if.then.loc24 else br !if.else.loc24
+// CHECK:STDOUT:   %.loc24_10.1: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc24_12: bool = value_of_initializer %.loc24_10.1
+// CHECK:STDOUT:   %.loc24_10.2: bool = converted %.loc24_10.1, %.loc24_12
+// CHECK:STDOUT:   if %.loc24_10.2 br !if.then.loc24 else br !if.else.loc24
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc24:
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc24:
 // CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
-// CHECK:STDOUT:   %.loc25_10: init bool = call %H.ref()
-// CHECK:STDOUT:   %.loc25_12.1: bool = value_of_initializer %.loc25_10
-// CHECK:STDOUT:   %.loc25_12.2: bool = converted %.loc25_10, %.loc25_12.1
-// CHECK:STDOUT:   if %.loc25_12.2 br !if.then.loc25 else br !if.else.loc25
+// CHECK:STDOUT:   %.loc25_10.1: init bool = call %H.ref()
+// CHECK:STDOUT:   %.loc25_12: bool = value_of_initializer %.loc25_10.1
+// CHECK:STDOUT:   %.loc25_10.2: bool = converted %.loc25_10.1, %.loc25_12
+// CHECK:STDOUT:   if %.loc25_10.2 br !if.then.loc25 else br !if.else.loc25
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc25:
 // CHECK:STDOUT:   br !while.done.loc17

--- a/toolchain/check/testdata/while/fail_bad_condition.carbon
+++ b/toolchain/check/testdata/while/fail_bad_condition.carbon
@@ -15,7 +15,7 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = ptr_type String [template]
-// CHECK:STDOUT:   %.loc11: String = string_literal "Hello" [template]
+// CHECK:STDOUT:   %.2: String = string_literal "Hello" [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,7 +28,7 @@ fn While() {
 // CHECK:STDOUT:   br !while.cond
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
-// CHECK:STDOUT:   %.loc11: String = string_literal "Hello" [template = constants.%.loc11]
+// CHECK:STDOUT:   %.loc11: String = string_literal "Hello" [template = constants.%.2]
 // CHECK:STDOUT:   if <error> br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:

--- a/toolchain/check/testdata/while/fail_break_continue.carbon
+++ b/toolchain/check/testdata/while/fail_break_continue.carbon
@@ -30,7 +30,7 @@ fn While() {
 // CHECK:STDOUT: --- fail_break_continue.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc16: bool = bool_literal false [template]
+// CHECK:STDOUT:   %.1: bool = bool_literal false [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -22,7 +22,7 @@ fn While() {
 // CHECK:STDOUT: --- unreachable_end.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -50,10 +50,10 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
 // CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
-// CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
-// CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
-// CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
-// CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
+// CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
+// CHECK:STDOUT:   %.loc15_16: bool = value_of_initializer %.loc15_14.1
+// CHECK:STDOUT:   %.loc15_14.2: bool = converted %.loc15_14.1, %.loc15_16
+// CHECK:STDOUT:   if %.loc15_14.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -21,7 +21,7 @@ fn While() {
 // CHECK:STDOUT: --- while.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %.loc14: type = tuple_type () [template]
+// CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -49,10 +49,10 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
 // CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
-// CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
-// CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
-// CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
-// CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
+// CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
+// CHECK:STDOUT:   %.loc15_16: bool = value_of_initializer %.loc15_14.1
+// CHECK:STDOUT:   %.loc15_14.2: bool = converted %.loc15_14.1, %.loc15_16
+// CHECK:STDOUT:   if %.loc15_14.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]


### PR DESCRIPTION
These instructions are intended to be shared across all uses and so don't have a meaningful location. So far, only type constants are shared.