### PR TITLE
Address a likely issue with language_server

### DIFF
--- a/language_server/language_server.cpp
+++ b/language_server/language_server.cpp
@@ -84,7 +84,7 @@ static auto GetIdentifierName(const SharedValueStores& value_stores,
   for (auto ch : p.children(node)) {
     if (p.node_kind(ch) == Parse::NodeKind::IdentifierName) {
       return value_stores.identifiers().Get(
-          tokens.GetIdentifier(p.node_token(node)));
+          tokens.GetIdentifier(p.node_token(ch)));
     }
   }
   return std::nullopt;


### PR DESCRIPTION
The `node_kind` check is on `ch`, so the `node_token` probably should be too. Trying to address the issue reported by [skoriop on Discord](https://discord.com/channels/655572317891461132/993958660277555301/1197201736226574420)

Note, I haven't tested this beyond building.