### PR TITLE
Don't take a NodeId argument for insts that have no parse node.

### DIFF
--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -195,8 +195,7 @@ auto Import(Context& context, SemIR::TypeId namespace_type_id,
     } else {
       // Leave a placeholder that the inst comes from the other IR.
       auto target_id = context.AddPlaceholderInst(
-          {Parse::NodeId::Invalid,
-           SemIR::LazyImportRef{.ir_id = ir_id, .inst_id = import_inst_id}});
+          {SemIR::LazyImportRef{.ir_id = ir_id, .inst_id = import_inst_id}});
       // TODO: When importing from other packages, the scope's names should
       // be changed to allow for ambiguous names. When importing from the
       // current package, as is currently being done, we should issue a

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -77,8 +77,7 @@ File::File(SharedValueStores& value_stores)
   // self-referential TypeType.
 #define CARBON_SEM_IR_BUILTIN_KIND(Name, ...)                              \
   insts_.AddInNoBlock(                                                     \
-      {Parse::NodeId::Invalid,                                             \
-       Builtin{BuiltinKind::Name == BuiltinKind::Error ? TypeId::Error     \
+      {Builtin{BuiltinKind::Name == BuiltinKind::Error ? TypeId::Error     \
                                                        : TypeId::TypeType, \
                BuiltinKind::Name}});
 #include "toolchain/sem_ir/builtin_kind.def"

--- a/toolchain/sem_ir/value_stores.h
+++ b/toolchain/sem_ir/value_stores.h
@@ -5,6 +5,8 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_VALUE_STORES_H_
 #define CARBON_TOOLCHAIN_SEM_IR_VALUE_STORES_H_
 
+#include <type_traits>
+
 #include "llvm/ADT/DenseMap.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/base/yaml.h"
@@ -27,11 +29,22 @@ struct ParseNodeAndInst {
 
   // For the common case, support construction as:
   //   context.AddInst({parse_node, SemIR::MyInst{...}});
-  template <typename InstT>
+  template <typename InstT, typename std::enable_if_t<!std::is_same_v<
+                                typename decltype(InstT::Kind)::TypedNodeId,
+                                Parse::InvalidNodeId>>* = nullptr>
   // NOLINTNEXTLINE(google-explicit-constructor)
   ParseNodeAndInst(typename decltype(InstT::Kind)::TypedNodeId parse_node,
                    InstT inst)
       : parse_node(parse_node), inst(inst) {}
+
+  // For cases with no parse node, support construction as:
+  //   context.AddInst({SemIR::MyInst{...}});
+  template <typename InstT, typename std::enable_if_t<std::is_same_v<
+                                typename decltype(InstT::Kind)::TypedNodeId,
+                                Parse::InvalidNodeId>>* = nullptr>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  ParseNodeAndInst(InstT inst)
+      : parse_node(Parse::NodeId::Invalid), inst(inst) {}
 
   Parse::NodeId parse_node;
   Inst inst;


### PR DESCRIPTION
This is low impact because we typically support a parse node, but I was hoping to reduce ambiguity in the cases that don't.