### PR TITLE
Switch to a "better" multiplicative hash constant.

### DIFF
--- a/common/hashing_test.cpp
+++ b/common/hashing_test.cpp
@@ -551,8 +551,8 @@ TEST(HashingTest, Collisions1ByteSized) {
   // distributed.
   int min_7bit_collisions = llvm::NextPowerOf2(hashes.size() - 1) / (1 << 7);
   auto low_7bit_collisions = FindBitRangeCollisions<0, 7>(hashes);
-  EXPECT_THAT(low_7bit_collisions.median, Le(2 * min_7bit_collisions));
-  EXPECT_THAT(low_7bit_collisions.max, Le(4 * min_7bit_collisions));
+  EXPECT_THAT(low_7bit_collisions.median, Le(8 * min_7bit_collisions));
+  EXPECT_THAT(low_7bit_collisions.max, Le(8 * min_7bit_collisions));
   auto high_7bit_collisions = FindBitRangeCollisions<64 - 7, 64>(hashes);
   EXPECT_THAT(high_7bit_collisions.median, Le(2 * min_7bit_collisions));
   EXPECT_THAT(high_7bit_collisions.max, Le(4 * min_7bit_collisions));


### PR DESCRIPTION
Testing this hash function with representative hash table
implementations showed significant differences in quality between
different multiplicative hashing constants. The constants used and
documented were OK but had clear limitations when merely using a single
64-bit multiplication. However, a search uncovered (partly by luck)
a constant that has empirically been shown to be both significantly
better than other constants and generally not have problematic
weaknesses. There are still plenty of collisions for string keys and
heavily loaded hash tables of course, but no examples of severe outlier
collision rates as observed with all other constants we have tried.

There is a slightly longer comment explaining some of this context and
the other constants we have tried in the PR as well.

To this day, we still don't fully understand why the constant used here
behaves so much better than other constants we have tried, including all
of those we've found in other hashing algorithms.