### PR TITLE
Fix syntax highlighting in VSCode (#3630).

### DIFF
--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -143,7 +143,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.character.escape.carbon</string>
                 <key>match</key>
-                <string>\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
+                <string>\\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>


### PR DESCRIPTION
Add missing escape backslash to `string_escapes` matching string.

Closes #3630

VSCode highlighting working after change:
![image](https://github.com/carbon-language/carbon-lang/assets/24532774/92be2aa3-5f12-4430-9b9e-169edfa1da4a)
