### PR TITLE
Fix block string literals highlighting

### DIFF
--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -82,9 +82,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>string.quoted.triple.carbon</string>
                 <key>begin</key>
-                <string>"""</string>
+                <string>'''</string>
                 <key>end</key>
-                <string>"""</string>
+                <string>'''</string>
 
                 <key>patterns</key>
                 <array>
@@ -143,7 +143,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.character.escape.carbon</string>
                 <key>match</key>
-                <string>\\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
+                <string>\\('''|[tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -143,7 +143,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>constant.character.escape.carbon</string>
                 <key>match</key>
-                <string>\\('''|[tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
+                <string>\\([tnr'"0\0]|x[0-9A-F]{2}|u\{[0-9A-F]{4,}\})</string>
             </dict>
         </dict>
     </dict>


### PR DESCRIPTION
Replace block string literals quotes.

Highlighting after change:
![image](https://github.com/carbon-language/carbon-lang/assets/24532774/4c55c021-b8ce-4933-9742-81a8eee6ffe1)


Closes #3634
