### PR TITLE
Provide diagnostic locations for imports.

### DIFF
--- a/toolchain/check/testdata/packages/fail_conflict_namespace_first.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_namespace_first.carbon
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: namespace_then_fn.carbon: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: namespace_then_fn.carbon: Name is previously declared here.
 
 // --- namespace.carbon
 
@@ -17,6 +15,10 @@ fn NS.Foo() {}
 
 package Example library "fn" api;
 
+// CHECK:STDERR: fn.carbon:[[@LINE+4]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fn NS() {}
+// CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR: namespace_then_fn.carbon: Name is previously declared here.
 fn NS() {}
 
 // --- namespace_then_fn.carbon

--- a/toolchain/check/testdata/packages/fail_conflict_namespace_second.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_namespace_second.carbon
@@ -4,7 +4,6 @@
 //
 // AUTOUPDATE
 // CHECK:STDERR: fn_then_namespace.carbon: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: fn_then_namespace.carbon: Name is previously declared here.
 
 // --- namespace.carbon
 
@@ -17,6 +16,9 @@ fn NS.Foo() {}
 
 package Example library "fn" api;
 
+// CHECK:STDERR: fn.carbon:[[@LINE+3]]:1: Name is previously declared here.
+// CHECK:STDERR: fn NS() {}
+// CHECK:STDERR: ^~~~~~~~~
 fn NS() {}
 
 // --- fn_then_namespace.carbon

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: conflict.carbon: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: conflict.carbon: Name is previously declared here.
 
 // --- fn.carbon
 
@@ -16,6 +14,12 @@ fn Foo();
 
 package Example library "var" api;
 
+// CHECK:STDERR: var.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: var Foo: i32;
+// CHECK:STDERR:     ^~~
+// CHECK:STDERR: fn.carbon:4:1: Name is previously declared here.
+// CHECK:STDERR: fn Foo();
+// CHECK:STDERR: ^~~~~~~~~
 var Foo: i32;
 
 // --- conflict.carbon


### PR DESCRIPTION
Note namespaces aren't handled well, because they can be generated from merging imports. That's on my internal TODO list.