### PR TITLE
Runtime `:` name bindings are not constants.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -339,12 +339,6 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
       // are treated as the same value.
       return SemIR::ConstantId::ForSymbolicConstant(inst_id);
 
-    case SemIR::BindName::Kind:
-      // TODO: We need to look through `BindName`s for member accesses naming
-      // fields, where the member name is a `BindName`. Should we really be
-      // creating a `BindName` in that case?
-      return context.constant_values().Get(inst.As<SemIR::BindName>().value_id);
-
     // These semnatic wrappers don't change the constant value.
     case SemIR::NameRef::Kind:
       return context.constant_values().Get(inst.As<SemIR::NameRef>().value_id);
@@ -396,6 +390,7 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     // These cases are either not expressions or not constant.
     case SemIR::AddrPattern::Kind:
     case SemIR::Assign::Kind:
+    case SemIR::BindName::Kind:
     case SemIR::BlockArg::Kind:
     case SemIR::Branch::Kind:
     case SemIR::BranchIf::Kind:

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -52,6 +52,12 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId parse_node)
         context.bind_names().Get(bind_name->bind_name_id).name_id);
     context.decl_name_stack().AddNameToLookup(name_context, value_id);
     value_id = bind_name->value_id;
+  } else if (auto field_decl =
+                 context.insts().TryGetAs<SemIR::FieldDecl>(value_id)) {
+    // Introduce the field name into the class.
+    auto name_context = context.decl_name_stack().MakeUnqualifiedName(
+        context.insts().GetParseNode(value_id), field_decl->name_id);
+    context.decl_name_stack().AddNameToLookup(name_context, value_id);
   }
   // TODO: Handle other kinds of pattern.
 

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -17,6 +17,6 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT:   package: <namespace> = namespace package, {} [template]
 // CHECK:STDOUT:   %.loc7_24.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_24.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_24.2 [template = constants.%.2]
+// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_24.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_no_conversion.carbon
+++ b/toolchain/check/testdata/as/fail_no_conversion.carbon
@@ -25,6 +25,6 @@ let n: (i32, i32) = 1 as (i32, i32);
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_35.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_35.2: type = converted %.loc10_35.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %n: (i32, i32) = bind_name n, <error> [template = <error>]
+// CHECK:STDOUT:   %n: (i32, i32) = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/fail_not_type.carbon
+++ b/toolchain/check/testdata/as/fail_not_type.carbon
@@ -20,6 +20,6 @@ let n: i32 = 1 as 2;
 // CHECK:STDOUT:   package: <namespace> = namespace package, {} [template]
 // CHECK:STDOUT:   %.loc10_14: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_19: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %n: i32 = bind_name n, <error> [template = <error>]
+// CHECK:STDOUT:   %n: i32 = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/builtin_types.carbon
+++ b/toolchain/check/testdata/basics/builtin_types.carbon
@@ -29,7 +29,7 @@ var test_type: type = i32;
 // CHECK:STDOUT:   %.loc8: f64 = real_literal 1e-1 [template = constants.%.2]
 // CHECK:STDOUT:   assign %test_f64.var, %.loc8
 // CHECK:STDOUT:   %.loc9: String = string_literal "Test" [template = constants.%.4]
-// CHECK:STDOUT:   %test_str: String = bind_name test_str, %.loc9 [template = constants.%.4]
+// CHECK:STDOUT:   %test_str: String = bind_name test_str, %.loc9
 // CHECK:STDOUT:   %test_type.var: ref type = var test_type
 // CHECK:STDOUT:   %test_type: ref type = bind_name test_type, %test_type.var
 // CHECK:STDOUT:   assign %test_type.var, i32

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -56,21 +56,19 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Base> = field_decl b, element0 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .b = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, constants.%Base [template = constants.%Base]
 // CHECK:STDOUT:   %.loc12: <unbound element of class Derived> = base_decl Base, element0 [template]
 // CHECK:STDOUT:   %.loc14: <unbound element of class Derived> = field_decl d, element1 [template]
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14 [template = %.loc14]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12
-// CHECK:STDOUT:   .d = %d
+// CHECK:STDOUT:   .d = %.loc14
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -48,30 +48,25 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Base> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Base> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Base> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:   %.loc10: <unbound element of class Base> = field_decl c, element2 [template]
-// CHECK:STDOUT:   %c: <unbound element of class Base> = bind_name c, %.loc10 [template = %.loc10]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
-// CHECK:STDOUT:   .c = %c
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
+// CHECK:STDOUT:   .c = %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, constants.%Base [template = constants.%Base]
 // CHECK:STDOUT:   %.loc14: <unbound element of class Derived> = base_decl Base, element0 [template]
 // CHECK:STDOUT:   %.loc16: <unbound element of class Derived> = field_decl d, element1 [template]
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc16 [template = %.loc16]
 // CHECK:STDOUT:   %.loc17: <unbound element of class Derived> = field_decl e, element2 [template]
-// CHECK:STDOUT:   %e: <unbound element of class Derived> = bind_name e, %.loc17 [template = %.loc17]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc14
-// CHECK:STDOUT:   .d = %d
-// CHECK:STDOUT:   .e = %e
+// CHECK:STDOUT:   .d = %.loc16
+// CHECK:STDOUT:   .e = %.loc17
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -50,11 +50,10 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Base> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc8
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -42,12 +42,11 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %.loc14: <unbound element of class Class> = field_decl k, element0 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc14 [template = %.loc14]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .k = %k
+// CHECK:STDOUT:   .k = %.loc14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%n: i32) -> i32 {

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -83,21 +83,19 @@ fn ConvertInit() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {
 // CHECK:STDOUT:   %.loc8: <unbound element of class A> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class A> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_ref A, constants.%A [template = constants.%A]
 // CHECK:STDOUT:   %.loc12: <unbound element of class B> = base_decl A, element0 [template]
 // CHECK:STDOUT:   %.loc13: <unbound element of class B> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class B> = bind_name b, %.loc13 [template = %.loc13]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .b = %.loc13
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -105,11 +103,10 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, constants.%B [template = constants.%B]
 // CHECK:STDOUT:   %.loc17: <unbound element of class C> = base_decl B, element0 [template]
 // CHECK:STDOUT:   %.loc18: <unbound element of class C> = field_decl c, element1 [template]
-// CHECK:STDOUT:   %c: <unbound element of class C> = bind_name c, %.loc18 [template = %.loc18]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc17
-// CHECK:STDOUT:   .c = %c
+// CHECK:STDOUT:   .c = %.loc18
 // CHECK:STDOUT:   extend name_scope2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -58,21 +58,19 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Abstract {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Abstract> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Abstract> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {
 // CHECK:STDOUT:   %Abstract.ref: type = name_ref Abstract, constants.%Abstract [template = constants.%Abstract]
 // CHECK:STDOUT:   %.loc12: <unbound element of class Derived> = base_decl Abstract, element0 [template]
 // CHECK:STDOUT:   %.loc14: <unbound element of class Derived> = field_decl d, element1 [template]
-// CHECK:STDOUT:   %d: <unbound element of class Derived> = bind_name d, %.loc14 [template = %.loc14]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc12
-// CHECK:STDOUT:   .d = %d
+// CHECK:STDOUT:   .d = %.loc14
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -201,10 +201,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Final {
 // CHECK:STDOUT:   %.loc9: <unbound element of class Final> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Final> = bind_name a, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromError {

--- a/toolchain/check/testdata/class/fail_base_unbound.carbon
+++ b/toolchain/check/testdata/class/fail_base_unbound.carbon
@@ -34,7 +34,7 @@ let b: B = C.base;
 // CHECK:STDOUT:   %B.ref: type = name_ref B, constants.%B [template = constants.%B]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, constants.%C [template = constants.%C]
 // CHECK:STDOUT:   %base.ref: <unbound element of class C> = name_ref base, @C.%.loc10 [template = @C.%.loc10]
-// CHECK:STDOUT:   %b: B = bind_name b, <error> [template = <error>]
+// CHECK:STDOUT:   %b: B = bind_name b, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -64,29 +64,26 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A1 {
 // CHECK:STDOUT:   %.loc8: <unbound element of class A1> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class A1> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A2 {
 // CHECK:STDOUT:   %.loc12: <unbound element of class A2> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class A2> = bind_name a, %.loc12 [template = %.loc12]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B2 {
 // CHECK:STDOUT:   %A2.ref: type = name_ref A2, constants.%A2 [template = constants.%A2]
 // CHECK:STDOUT:   %.loc16: <unbound element of class B2> = base_decl A2, element0 [template]
 // CHECK:STDOUT:   %.loc17: <unbound element of class B2> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class B2> = bind_name b, %.loc17 [template = %.loc17]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .base = %.loc16
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .b = %.loc17
 // CHECK:STDOUT:   extend name_scope2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -44,16 +44,14 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc12: <unbound element of class Class> = field_decl j, element0 [template]
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc12 [template = %.loc12]
 // CHECK:STDOUT:   %.loc17: <unbound element of class Class> = field_decl k, element1 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc17 [template = %.loc17]
 // CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %l: i32 = bind_name l, %.loc22 [template = constants.%.2]
+// CHECK:STDOUT:   %l: i32 = bind_name l, %.loc22
 // CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %m: i32 = bind_name m, %.loc27 [template = constants.%.3]
+// CHECK:STDOUT:   %m: i32 = bind_name m, %.loc27
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .j = %j
-// CHECK:STDOUT:   .k = %k
+// CHECK:STDOUT:   .j = %.loc12
+// CHECK:STDOUT:   .k = %.loc17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -181,7 +181,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc75: ref Class = deref %p.ref
-// CHECK:STDOUT:   %c: <error> = bind_name c, <error> [template = <error>]
+// CHECK:STDOUT:   %c: <error> = bind_name c, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -47,13 +47,11 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Class> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -45,13 +45,11 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Class> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%p: Class*);

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -65,10 +65,9 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: class @B {
 // CHECK:STDOUT:   %A.ref: type = name_ref A, constants.%A [template = constants.%A]
 // CHECK:STDOUT:   %.loc12: <unbound element of class B> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class B> = bind_name a, %.loc12 [template = %.loc12]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1[addr %self: A*]();

--- a/toolchain/check/testdata/class/fail_member_of_let.carbon
+++ b/toolchain/check/testdata/class/fail_member_of_let.carbon
@@ -29,7 +29,7 @@ fn T.F() {}
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.Class = %Class.decl} [template]
 // CHECK:STDOUT:   %Class.decl = class_decl @Class, ()
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, constants.%Class [template = constants.%Class]
-// CHECK:STDOUT:   %T: type = bind_name T, %Class.ref [template = constants.%Class]
+// CHECK:STDOUT:   %T: type = bind_name T, %Class.ref
 // CHECK:STDOUT:   %.loc19: <function> = fn_decl @.1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_todo_modifiers.carbon
@@ -80,15 +80,13 @@ abstract class Abstract {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %.loc22: <unbound element of class Access> = field_decl k, element0 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Access> = bind_name k, %.loc22 [template = %.loc22]
 // CHECK:STDOUT:   %.loc27: <unbound element of class Access> = field_decl l, element1 [template]
-// CHECK:STDOUT:   %l: <unbound element of class Access> = bind_name l, %.loc27 [template = %.loc27]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .k = %k
-// CHECK:STDOUT:   .l = %l
+// CHECK:STDOUT:   .k = %.loc22
+// CHECK:STDOUT:   .l = %.loc27
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -37,24 +37,23 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl field, element0 [template]
-// CHECK:STDOUT:   %field: <unbound element of class Class> = bind_name field, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .field = %field
+// CHECK:STDOUT:   .field = %.loc8
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field [template = @Class.%.loc8]
+// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, constants.%Class [template = constants.%Class]
-// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%field [template = @Class.%.loc8]
+// CHECK:STDOUT:   %field.ref: <unbound element of class Class> = name_ref field, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_unknown_member.carbon
+++ b/toolchain/check/testdata/class/fail_unknown_member.carbon
@@ -33,10 +33,9 @@ fn G(c: Class) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl n, element0 [template]
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .n = %n
+// CHECK:STDOUT:   .n = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%c: Class) -> i32 {

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -36,13 +36,11 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl j, element0 [template]
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Class> = field_decl k, element1 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .j = %j
-// CHECK:STDOUT:   .k = %k
+// CHECK:STDOUT:   .j = %.loc8
+// CHECK:STDOUT:   .k = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -37,13 +37,11 @@ fn Test() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl j, element0 [template]
-// CHECK:STDOUT:   %j: <unbound element of class Class> = bind_name j, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Class> = field_decl k, element1 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .j = %j
-// CHECK:STDOUT:   .k = %k
+// CHECK:STDOUT:   .j = %.loc8
+// CHECK:STDOUT:   .k = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -38,15 +38,13 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl n, element0 [template]
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:   %.loc9_18: type = ptr_type Class [template = constants.%.2]
 // CHECK:STDOUT:   %.loc9_11: <unbound element of class Class> = field_decl next, element1 [template]
-// CHECK:STDOUT:   %next: <unbound element of class Class> = bind_name next, %.loc9_11 [template = %.loc9_11]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .n = %n
-// CHECK:STDOUT:   .next = %next
+// CHECK:STDOUT:   .n = %.loc8
+// CHECK:STDOUT:   .next = %.loc9_11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make(%n: i32, %next: Class*) -> %return: Class {

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -33,13 +33,11 @@ fn F() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Class> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Class> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Class> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Class> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -45,26 +45,22 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Inner> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Inner> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class Inner> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class Inner> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
 // CHECK:STDOUT:   %Inner.ref.loc15: type = name_ref Inner, constants.%Inner [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc15: <unbound element of class Outer> = field_decl c, element0 [template]
-// CHECK:STDOUT:   %c: <unbound element of class Outer> = bind_name c, %.loc15 [template = %.loc15]
 // CHECK:STDOUT:   %Inner.ref.loc16: type = name_ref Inner, constants.%Inner [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc16: <unbound element of class Outer> = field_decl d, element1 [template]
-// CHECK:STDOUT:   %d: <unbound element of class Outer> = bind_name d, %.loc16 [template = %.loc16]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .c = %c
-// CHECK:STDOUT:   .d = %d
+// CHECK:STDOUT:   .c = %.loc15
+// CHECK:STDOUT:   .d = %.loc16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeInner() -> %return: Inner;

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -78,12 +78,11 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %.loc11: <unbound element of class Class> = field_decl k, element0 [template]
-// CHECK:STDOUT:   %k: <unbound element of class Class> = bind_name k, %.loc11 [template = %.loc11]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .k = %k
+// CHECK:STDOUT:   .k = %.loc11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -56,41 +56,35 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Outer [template = constants.%Outer]
 // CHECK:STDOUT:   %.loc14_15: type = ptr_type Outer [template = constants.%.3]
 // CHECK:STDOUT:   %.loc14_9: <unbound element of class Outer> = field_decl po, element0 [template]
-// CHECK:STDOUT:   %po: <unbound element of class Outer> = bind_name po, %.loc14_9 [template = %.loc14_9]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, constants.%Outer [template = constants.%Outer]
 // CHECK:STDOUT:   %.loc15_16: type = ptr_type Outer [template = constants.%.3]
 // CHECK:STDOUT:   %.loc15_9: <unbound element of class Outer> = field_decl qo, element1 [template]
-// CHECK:STDOUT:   %qo: <unbound element of class Outer> = bind_name qo, %.loc15_9 [template = %.loc15_9]
 // CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, constants.%Inner [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc16_16: type = ptr_type Inner [template = constants.%.1]
 // CHECK:STDOUT:   %.loc16_9: <unbound element of class Outer> = field_decl pi, element2 [template]
-// CHECK:STDOUT:   %pi: <unbound element of class Outer> = bind_name pi, %.loc16_9 [template = %.loc16_9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Inner = %Inner.decl
-// CHECK:STDOUT:   .po = %po
-// CHECK:STDOUT:   .qo = %qo
-// CHECK:STDOUT:   .pi = %pi
+// CHECK:STDOUT:   .po = %.loc14_9
+// CHECK:STDOUT:   .qo = %.loc15_9
+// CHECK:STDOUT:   .pi = %.loc16_9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Inner [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc9_17: type = ptr_type Inner [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_11: <unbound element of class Inner> = field_decl pi, element0 [template]
-// CHECK:STDOUT:   %pi: <unbound element of class Inner> = bind_name pi, %.loc9_11 [template = %.loc9_11]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, constants.%Outer [template = constants.%Outer]
 // CHECK:STDOUT:   %.loc10_18: type = ptr_type Outer [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_11: <unbound element of class Inner> = field_decl po, element1 [template]
-// CHECK:STDOUT:   %po: <unbound element of class Inner> = bind_name po, %.loc10_11 [template = %.loc10_11]
 // CHECK:STDOUT:   %Inner.ref: type = name_ref Inner, constants.%Inner [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc11_18: type = ptr_type Inner [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_11: <unbound element of class Inner> = field_decl qi, element2 [template]
-// CHECK:STDOUT:   %qi: <unbound element of class Inner> = bind_name qi, %.loc11_11 [template = %.loc11_11]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .pi = %pi
-// CHECK:STDOUT:   .po = %po
-// CHECK:STDOUT:   .qi = %qi
+// CHECK:STDOUT:   .pi = %.loc9_11
+// CHECK:STDOUT:   .po = %.loc10_11
+// CHECK:STDOUT:   .qi = %.loc11_11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: Outer*) {

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -47,10 +47,9 @@ fn G(o: Outer) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
 // CHECK:STDOUT:   %.loc9: <unbound element of class Inner> = field_decl n, element0 [template]
-// CHECK:STDOUT:   %n: <unbound element of class Inner> = bind_name n, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .n = %n
+// CHECK:STDOUT:   .n = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%oi: Inner) -> i32 {

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -42,12 +42,11 @@ fn Class.G[self: Class](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %.loc10: <unbound element of class Class> = field_decl n, element0 [template]
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc10 [template = %.loc10]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .n = %n
+// CHECK:STDOUT:   .n = %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[addr %self.loc13_17: Class*](%self.loc13_31: i32) {

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -40,12 +40,11 @@ fn Class.G[addr self: Class*]() -> i32 {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template]
 // CHECK:STDOUT:   %.loc11: <unbound element of class Class> = field_decl n, element0 [template]
-// CHECK:STDOUT:   %n: <unbound element of class Class> = bind_name n, %.loc11 [template = %.loc11]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .n = %n
+// CHECK:STDOUT:   .n = %.loc11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -57,10 +57,9 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {
 // CHECK:STDOUT:   %.loc8: <unbound element of class Base> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class Base> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
+// CHECK:STDOUT:   .a = %.loc8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Derived {

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -37,11 +37,10 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:   %.loc9_14: type = ptr_type Class [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_8: <unbound element of class Class> = field_decl p, element0 [template]
-// CHECK:STDOUT:   %p: <unbound element of class Class> = bind_name p, %.loc9_8 [template = %.loc9_8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
-// CHECK:STDOUT:   .p = %p
+// CHECK:STDOUT:   .p = %.loc9_8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {

--- a/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
@@ -33,7 +33,7 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc12_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc12_14: ref T = deref %.loc12_15
-// CHECK:STDOUT:   %n: U = bind_name n, <error> [template = <error>]
+// CHECK:STDOUT:   %n: U = bind_name n, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -55,6 +55,6 @@ class C {
 // CHECK:STDOUT:   if %.loc33 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .n = <unexpected instref inst+25>
+// CHECK:STDOUT:   .n = <unexpected instref inst+22>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/let/fail_duplicate_decl.carbon
@@ -28,7 +28,7 @@ fn F(a: i32) {
 // CHECK:STDOUT: fn @F(%a.loc7: i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %a.loc14: i32 = bind_name a, %.loc14 [template = constants.%.1]
+// CHECK:STDOUT:   %a.loc14: i32 = bind_name a, %.loc14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -33,8 +33,8 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
 // CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template = constants.%.1]
-// CHECK:STDOUT:   %x: T = bind_name x, <error> [template = <error>]
-// CHECK:STDOUT:   %x.ref: T = name_ref x, %x [template = <error>]
+// CHECK:STDOUT:   %x: T = bind_name x, <error>
+// CHECK:STDOUT:   %x.ref: T = name_ref x, %x
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_modifiers.carbon
@@ -77,20 +77,20 @@ protected protected let i: i32 = 1;
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {} [template]
 // CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %b: i32 = bind_name b, %.loc10 [template = constants.%.1]
+// CHECK:STDOUT:   %b: i32 = bind_name b, %.loc10
 // CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc15 [template = constants.%.1]
+// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc15
 // CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %d: i32 = bind_name d, %.loc20 [template = constants.%.1]
+// CHECK:STDOUT:   %d: i32 = bind_name d, %.loc20
 // CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %e: i32 = bind_name e, %.loc25 [template = constants.%.1]
+// CHECK:STDOUT:   %e: i32 = bind_name e, %.loc25
 // CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %f: i32 = bind_name f, %.loc36 [template = constants.%.1]
+// CHECK:STDOUT:   %f: i32 = bind_name f, %.loc36
 // CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %g: i32 = bind_name g, %.loc47 [template = constants.%.1]
+// CHECK:STDOUT:   %g: i32 = bind_name g, %.loc47
 // CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %h: i32 = bind_name h, %.loc58 [template = constants.%.1]
+// CHECK:STDOUT:   %h: i32 = bind_name h, %.loc58
 // CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %i: i32 = bind_name i, %.loc69 [template = constants.%.1]
+// CHECK:STDOUT:   %i: i32 = bind_name i, %.loc69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_todo_modifiers.carbon
@@ -18,6 +18,6 @@ private let a: i32 = 1;
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {} [template]
 // CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %a: i32 = bind_name a, %.loc10 [template = constants.%.1]
+// CHECK:STDOUT:   %a: i32 = bind_name a, %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_use_in_init.carbon
+++ b/toolchain/check/testdata/let/fail_use_in_init.carbon
@@ -21,7 +21,7 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [template = <error>]
-// CHECK:STDOUT:   %a: i32 = bind_name a, <error> [template = <error>]
+// CHECK:STDOUT:   %a: i32 = bind_name a, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/global.carbon
+++ b/toolchain/check/testdata/let/global.carbon
@@ -17,13 +17,13 @@ fn F() -> i32 { return n; }
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace package, {.F = %F} [template]
 // CHECK:STDOUT:   %.loc7: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7 [template = constants.%.1]
+// CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref: i32 = name_ref n, file.%n [template = constants.%.1]
+// CHECK:STDOUT:   %n.ref: i32 = name_ref n, file.%n
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/unary_op.carbon
+++ b/toolchain/check/testdata/operators/unary_op.carbon
@@ -23,10 +23,10 @@ let not_false: bool = not false;
 // CHECK:STDOUT:   %Not: <function> = fn_decl @Not [template]
 // CHECK:STDOUT:   %.loc11_26: bool = bool_literal true [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_22: bool = not %.loc11_26 [template = constants.%.2]
-// CHECK:STDOUT:   %not_true: bool = bind_name not_true, %.loc11_22 [template = constants.%.2]
+// CHECK:STDOUT:   %not_true: bool = bind_name not_true, %.loc11_22
 // CHECK:STDOUT:   %.loc12_27: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc12_23: bool = not %.loc12_27 [template = constants.%.1]
-// CHECK:STDOUT:   %not_false: bool = bind_name not_false, %.loc12_23 [template = constants.%.1]
+// CHECK:STDOUT:   %not_false: bool = bind_name not_false, %.loc12_23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Not(%b: bool) -> bool {

--- a/toolchain/check/testdata/pointer/fail_deref_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_error.carbon
@@ -15,6 +15,6 @@ let n: i32 = *undeclared;
 // CHECK:STDOUT:   package: <namespace> = namespace package, {} [template]
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error> [template = <error>]
 // CHECK:STDOUT:   %.loc10: ref <error> = deref <error>
-// CHECK:STDOUT:   %n: i32 = bind_name n, <error> [template = <error>]
+// CHECK:STDOUT:   %n: i32 = bind_name n, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -35,13 +35,13 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @HalfDozen() -> y {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc19: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -4,8 +4,10 @@
 //
 // AUTOUPDATE
 
-// TODO: This should require `:!` rather than just `:`.
 let x: type = i32;
+// CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+3]]:13: ERROR: Cannot evaluate type expression.
+// CHECK:STDERR: fn Six() -> x { return 6; }
+// CHECK:STDERR:             ^
 fn Six() -> x { return 6; }
 
 // TODO: This should probably work.
@@ -31,15 +33,15 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT: file {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Six() -> i32 {
+// CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc9: i32 = int_literal 6 [template = constants.%.1]
-// CHECK:STDOUT:   return %.loc9
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @HalfDozen() -> y {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc19: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -49,13 +49,11 @@ fn G() -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %.loc18_16: <unbound element of class C> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc18_16 [template = %.loc18_16]
 // CHECK:STDOUT:   %.loc18_28: <unbound element of class C> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc18_28 [template = %.loc18_28]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc18_16
+// CHECK:STDOUT:   .b = %.loc18_28
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_no_return_type.carbon
@@ -30,7 +30,7 @@ fn Procedure() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc14_20.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc14_20.2: type = converted %.loc14_20.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:   %v: () = bind_name v, <error> [template = <error>]
+// CHECK:STDOUT:   %v: () = bind_name v, <error>
 // CHECK:STDOUT:   %.loc14_25: () = tuple_literal ()
 // CHECK:STDOUT:   assign <error>, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/return/fail_returned_var_type.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_type.carbon
@@ -28,7 +28,7 @@ fn Mismatch() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Mismatch() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %v: f64 = bind_name v, <error> [template = <error>]
+// CHECK:STDOUT:   %v: f64 = bind_name v, <error>
 // CHECK:STDOUT:   %.loc14: f64 = real_literal 0e-1 [template = constants.%.1]
 // CHECK:STDOUT:   assign <error>, <error>
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -41,13 +41,11 @@ fn G() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   %.loc8: <unbound element of class C> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %a: <unbound element of class C> = bind_name a, %.loc8 [template = %.loc8]
 // CHECK:STDOUT:   %.loc9: <unbound element of class C> = field_decl b, element1 [template]
-// CHECK:STDOUT:   %b: <unbound element of class C> = bind_name b, %.loc9 [template = %.loc9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .a = %a
-// CHECK:STDOUT:   .b = %b
+// CHECK:STDOUT:   .a = %.loc8
+// CHECK:STDOUT:   .b = %.loc9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> %return: C {

--- a/toolchain/check/testdata/struct/fail_duplicate_name.carbon
+++ b/toolchain/check/testdata/struct/fail_duplicate_name.carbon
@@ -61,10 +61,10 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
 // CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc21_36: {.a: i32} = struct_literal (%.loc21_35)
-// CHECK:STDOUT:   %v: <error> = bind_name v, <error> [template = <error>]
+// CHECK:STDOUT:   %v: <error> = bind_name v, <error>
 // CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template = constants.%.3]
-// CHECK:STDOUT:   %w: i32 = bind_name w, <error> [template = <error>]
+// CHECK:STDOUT:   %w: i32 = bind_name w, <error>
 // CHECK:STDOUT:   %.loc37_16: type = struct_type {.a: i32} [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -28,10 +28,10 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc7_44.1: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
 // CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.5]
-// CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_44.3 [template = constants.%.5]
+// CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_44.3
 // CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
-// CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v [template = constants.%.5]
-// CHECK:STDOUT:   %w: {.a: i32, .b: i32} = bind_name w, %v.ref [template = constants.%.5]
+// CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v
+// CHECK:STDOUT:   %w: {.a: i32, .b: i32} = bind_name w, %v.ref
 // CHECK:STDOUT:   %.loc10_25: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {.a: i32, .b: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32, .b: i32} = bind_name x, %x.var

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -30,11 +30,11 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
 // CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
-// CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3 [template = constants.%.6]
+// CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3
 // CHECK:STDOUT:   %.loc8_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v [template = constants.%.6]
-// CHECK:STDOUT:   %w: (i32, i32) = bind_name w, %v.ref [template = constants.%.6]
+// CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v
+// CHECK:STDOUT:   %w: (i32, i32) = bind_name w, %v.ref
 // CHECK:STDOUT:   %.loc10_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc10_17.2: type = converted %.loc10_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref (i32, i32) = var x


### PR DESCRIPTION
Do not create runtime name bindings for `FieldDecl`s even though they're declared with `:`, so that we can still constant-evaluate references to fields.