### PR TITLE
Add filetype highlighting to block string literals

### DIFF
--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -82,7 +82,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>string.quoted.triple.carbon</string>
                 <key>begin</key>
-                <string>'''([^']*\n)?</string>
+                <string>'''([^\s'#]*\n)?</string>
                 <key>end</key>
                 <string>'''</string>
                 <key>beginCaptures</key>

--- a/utils/textmate/Syntaxes/Carbon.plist
+++ b/utils/textmate/Syntaxes/Carbon.plist
@@ -82,10 +82,17 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                 <key>name</key>
                 <string>string.quoted.triple.carbon</string>
                 <key>begin</key>
-                <string>'''</string>
+                <string>'''([^']*\n)?</string>
                 <key>end</key>
                 <string>'''</string>
-
+                <key>beginCaptures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>constant.character.escape.carbon</string>
+                    </dict>
+                </dict>
                 <key>patterns</key>
                 <array>
                     <dict>


### PR DESCRIPTION
This PR adds filetype highlighting support to block string literals in the TextMate grammar.

After adding the regex in the `begin` of the block string literal, `beginCaptures` is used to access the first capturing group of the regex (which captures the filetype) and apply the `constant.character.escape` rule.

![image](https://github.com/carbon-language/carbon-lang/assets/116057817/edabc820-ed0f-4f5f-a180-f3ac90045b0a)

Closes #3641 
