### PR TITLE
Fix missing abi requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ sudo apt install \
   bazel \
   clang \
   libc++-dev \
+  libc++abi-dev \
   lld
 
 # Download Carbon's code.


### PR DESCRIPTION
#3649 added a requirement for libc++abi-dev but missed updating the README to mention it.