### PR TITLE
Remove headers marked as unused by ClangD.

### DIFF
--- a/common/check_internal.h
+++ b/common/check_internal.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_COMMON_CHECK_INTERNAL_H_
 #define CARBON_COMMON_CHECK_INTERNAL_H_
 
-#include <cstdlib>
-
 #include "common/ostream.h"
 
 namespace Carbon::Internal {

--- a/common/command_line.cpp
+++ b/common/command_line.cpp
@@ -4,9 +4,10 @@
 
 #include "common/command_line.h"
 
-#include <initializer_list>
 #include <memory>
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/PointerIntPair.h"
 #include "llvm/Support/FormatVariadic.h"
 
 namespace Carbon::CommandLine {

--- a/common/command_line.h
+++ b/common/command_line.h
@@ -5,24 +5,17 @@
 #ifndef CARBON_COMMON_COMMAND_LINE_H_
 #define CARBON_COMMON_COMMAND_LINE_H_
 
-#include <initializer_list>
 #include <memory>
-#include <tuple>
-#include <type_traits>
 #include <utility>
 
 #include "common/check.h"
 #include "common/ostream.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/PointerIntPair.h"
-#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Allocator.h"
 
 // # Command-line argument parsing library.
 //

--- a/common/hashing.h
+++ b/common/hashing.h
@@ -16,7 +16,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/MathExtras.h"
 
 #ifdef __ARM_ACLE
 #include <arm_acle.h>

--- a/common/string_helpers_test.cpp
+++ b/common/string_helpers_test.cpp
@@ -9,8 +9,6 @@
 
 #include <string>
 
-#include "llvm/Support/Error.h"
-
 using ::testing::Eq;
 using ::testing::Optional;
 

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -23,7 +23,7 @@ cc_library(
         "//common:vlog",
         "//toolchain/parse:node_kind",
         "//toolchain/parse:tree",
-        "//toolchain/sem_ir:inst",
+        "//toolchain/sem_ir:ids",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -15,7 +15,6 @@
 #include "toolchain/parse/tree_node_location_translator.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
-#include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -7,7 +7,6 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/pending_block.h"
-#include "toolchain/parse/tree.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -7,7 +7,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/scope_index.h"
-#include "toolchain/parse/tree.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/decl_state.h
+++ b/toolchain/check/decl_state.h
@@ -6,7 +6,7 @@
 #define CARBON_TOOLCHAIN_CHECK_DECL_STATE_H_
 
 #include "llvm/ADT/BitmaskEnum.h"
-#include "toolchain/parse/tree.h"
+#include "toolchain/parse/node_ids.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_array.cpp
+++ b/toolchain/check/handle_array.cpp
@@ -5,7 +5,6 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/parse/node_kind.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_if_statement.cpp
+++ b/toolchain/check/handle_if_statement.cpp
@@ -4,7 +4,6 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -5,7 +5,6 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/modifiers.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/lexical_lookup.h
+++ b/toolchain/check/lexical_lookup.h
@@ -7,7 +7,6 @@
 #define CARBON_TOOLCHAIN_CHECK_LEXICAL_LOOKUP_H_
 
 #include "toolchain/check/scope_index.h"
-#include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/node_stack.cpp
+++ b/toolchain/check/node_stack.cpp
@@ -5,7 +5,6 @@
 #include "toolchain/check/node_stack.h"
 
 #include "llvm/ADT/STLExtras.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -12,7 +12,7 @@
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/tree.h"
 #include "toolchain/parse/typed_nodes.h"
-#include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -4,8 +4,6 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
-#include "toolchain/parse/tree.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/check/return.h
+++ b/toolchain/check/return.h
@@ -6,8 +6,7 @@
 #define CARBON_TOOLCHAIN_CHECK_RETURN_H_
 
 #include "toolchain/check/context.h"
-#include "toolchain/parse/tree.h"
-#include "toolchain/sem_ir/inst.h"
+#include "toolchain/parse/node_ids.h"
 
 namespace Carbon::Check {
 

--- a/toolchain/diagnostics/diagnostic_kind.cpp
+++ b/toolchain/diagnostics/diagnostic_kind.cpp
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/diagnostics/diagnostic_kind.h"
+#include "toolchain/diagnostics/diagnostic_kind.h"  // IWYU pragma: keep
 
 namespace Carbon {
 

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -9,7 +9,6 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "toolchain/sem_ir/file.h"
-#include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::Lower {
 

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -110,8 +110,6 @@ cc_library(
         "//common:error",
         "//common:ostream",
         "//common:struct_reflection",
-        "//toolchain/base:pretty_stack_trace_function",
-        "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lex:tokenized_buffer",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -6,7 +6,6 @@
 #include "toolchain/base/pretty_stack_trace_function.h"
 #include "toolchain/parse/context.h"
 #include "toolchain/parse/node_kind.h"
-#include "toolchain/parse/typed_nodes.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/state.cpp
+++ b/toolchain/parse/state.cpp
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "toolchain/parse/state.h"
+#include "toolchain/parse/state.h"  // IWYU pragma: keep
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/tree.cpp
+++ b/toolchain/parse/tree.cpp
@@ -8,7 +8,6 @@
 #include "common/error.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
-#include "toolchain/base/pretty_stack_trace_function.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/typed_nodes.h"

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -13,7 +13,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"

--- a/toolchain/parse/typed_nodes_test.cpp
+++ b/toolchain/parse/typed_nodes_test.cpp
@@ -9,7 +9,6 @@
 
 #include <forward_list>
 
-#include "toolchain/diagnostics/mocks.h"
 #include "toolchain/lex/lex.h"
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/parse.h"

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -37,7 +37,6 @@ cc_library(
     deps = [
         "//common:enum_base",
         "//toolchain/parse:node_kind",
-        "//toolchain/parse:tree",
         "//toolchain/sem_ir:builtin_kind",
         "//toolchain/sem_ir:ids",
         "@llvm-project//llvm:Support",
@@ -55,7 +54,6 @@ cc_library(
         "//common:ostream",
         "//common:struct_reflection",
         "//toolchain/base:index_base",
-        "//toolchain/parse:tree",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -79,6 +77,7 @@ cc_library(
         ":inst_kind",
         ":type_info",
         "//common:check",
+        "//common:error",
         "//toolchain/base:value_store",
         "//toolchain/base:yaml",
         "//toolchain/lex:token_kind",

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -5,6 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 #define CARBON_TOOLCHAIN_SEM_IR_FILE_H_
 
+#include "common/error.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"

--- a/toolchain/sem_ir/formatter.h
+++ b/toolchain/sem_ir/formatter.h
@@ -6,6 +6,8 @@
 #define CARBON_TOOLCHAIN_SEM_IR_FORMATTER_H_
 
 #include "llvm/Support/raw_ostream.h"
+#include "toolchain/lex/tokenized_buffer.h"
+#include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/file.h"
 
 namespace Carbon::SemIR {

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -12,7 +12,6 @@
 #include "common/ostream.h"
 #include "common/struct_reflection.h"
 #include "toolchain/base/index_base.h"
-#include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/inst_kind.h"
 #include "toolchain/sem_ir/typed_insts.h"

--- a/toolchain/sem_ir/inst_profile.cpp
+++ b/toolchain/sem_ir/inst_profile.cpp
@@ -6,7 +6,6 @@
 
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/inst.h"
-#include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::SemIR {
 

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -6,7 +6,6 @@
 #define CARBON_TOOLCHAIN_SEM_IR_TYPED_INSTS_H_
 
 #include "toolchain/parse/node_ids.h"
-#include "toolchain/parse/tree.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_kind.h"


### PR DESCRIPTION
This required adding a few headers that were found transitively before, but not too many. This is sadly a fairly manual process of opening every file in my IDE, but I think I got everything in `//common` and `//toolchain`.

There are a few cases where technically we don't need `foo.h` to be included into `foo.cpp`, but I've forced those to stay with a pragma.

I've tried to catch the places where we can cut deps in Bazel as well, but not sure I got all of those.

I had been noticing these in other PRs and it seemed better to isolate the change.