### PR TITLE
CrossRefIRId -> ImportIRId

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -53,7 +53,7 @@ class SemIRLocationTranslator
       // possible.
       if (auto import_ref = cursor_ir->insts().TryGetAs<SemIR::AnyImportRef>(
               cursor_inst_id)) {
-        cursor_ir = cursor_ir->cross_ref_irs().Get(import_ref->ir_id);
+        cursor_ir = cursor_ir->import_irs().Get(import_ref->ir_id);
         cursor_inst_id = import_ref->inst_id;
         continue;
       }

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -174,20 +174,20 @@ auto Context::AddPackageImports(Parse::NodeId import_node,
 
   auto name_id = SemIR::NameId::ForIdentifier(package_id);
 
-  SemIR::CrossRefIRId first_id(cross_ref_irs().size());
+  SemIR::ImportIRId first_id(import_irs().size());
   for (const auto* sem_ir : sem_irs) {
-    cross_ref_irs().Add(sem_ir);
+    import_irs().Add(sem_ir);
   }
   if (has_load_error) {
-    cross_ref_irs().Add(nullptr);
+    import_irs().Add(nullptr);
   }
-  SemIR::CrossRefIRId last_id(cross_ref_irs().size() - 1);
+  SemIR::ImportIRId last_id(import_irs().size() - 1);
 
   auto type_id = GetBuiltinType(SemIR::BuiltinKind::NamespaceType);
   auto inst_id =
       AddInst({import_node, SemIR::Import{.type_id = type_id,
-                                          .first_cross_ref_ir_id = first_id,
-                                          .last_cross_ref_ir_id = last_id}});
+                                          .first_import_ir_id = first_id,
+                                          .last_import_ir_id = last_id}});
 
   // Add the import to lookup. Should always succeed because imports will be
   // uniquely named.
@@ -225,7 +225,7 @@ auto Context::ResolveIfImportRefUnused(SemIR::InstId inst_id) -> void {
   if (!unused_inst) {
     return;
   }
-  const SemIR::File& import_ir = *cross_ref_irs().Get(unused_inst->ir_id);
+  const SemIR::File& import_ir = *import_irs().Get(unused_inst->ir_id);
   auto import_inst = import_ir.insts().Get(unused_inst->inst_id);
   switch (import_inst.kind()) {
     default:
@@ -798,7 +798,7 @@ class TypeCompleter {
         << "TODO: Handle non-builtin ImportRefUsed cases, such as functions, "
            "classes, and interfaces";
 
-    const auto& import_ir = context_.cross_ref_irs().Get(import_ref.ir_id);
+    const auto& import_ir = context_.import_irs().Get(import_ref.ir_id);
     auto import_inst = import_ir->insts().Get(import_ref.inst_id);
 
     switch (import_inst.As<SemIR::Builtin>().builtin_kind) {

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -425,8 +425,8 @@ class Context {
   auto interfaces() -> ValueStore<SemIR::InterfaceId>& {
     return sem_ir().interfaces();
   }
-  auto cross_ref_irs() -> ValueStore<SemIR::CrossRefIRId>& {
-    return sem_ir().cross_ref_irs();
+  auto import_irs() -> ValueStore<SemIR::ImportIRId>& {
+    return sem_ir().import_irs();
   }
   auto names() -> SemIR::NameStoreWrapper { return sem_ir().names(); }
   auto name_scopes() -> SemIR::NameScopeStore& {

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -85,7 +85,7 @@ static auto CacheCopiedNamespace(
 static auto CopySingleNameScopeFromImportIR(
     Context& context,
     llvm::DenseMap<SemIR::NameScopeId, SemIR::NameScopeId>& copied_namespaces,
-    SemIR::CrossRefIRId ir_id, SemIR::InstId import_inst_id,
+    SemIR::ImportIRId ir_id, SemIR::InstId import_inst_id,
     SemIR::NameScopeId import_scope_id, SemIR::NameScopeId enclosing_scope_id,
     SemIR::NameId name_id, SemIR::TypeId namespace_type_id)
     -> SemIR::NameScopeId {
@@ -132,7 +132,7 @@ static auto CopySingleNameScopeFromImportIR(
 // import_enclosing_scope_id.
 static auto CopyEnclosingNameScopesFromImportIR(
     Context& context, SemIR::TypeId namespace_type_id,
-    const SemIR::File& import_sem_ir, SemIR::CrossRefIRId ir_id,
+    const SemIR::File& import_sem_ir, SemIR::ImportIRId ir_id,
     SemIR::NameScopeId import_enclosing_scope_id,
     llvm::DenseMap<SemIR::NameScopeId, SemIR::NameScopeId>& copied_namespaces)
     -> SemIR::NameScopeId {
@@ -181,7 +181,7 @@ static auto CopyEnclosingNameScopesFromImportIR(
 
 auto Import(Context& context, SemIR::TypeId namespace_type_id,
             const SemIR::File& import_sem_ir) -> void {
-  auto ir_id = context.cross_ref_irs().Add(&import_sem_ir);
+  auto ir_id = context.import_irs().Add(&import_sem_ir);
 
   for (const auto import_inst_id :
        import_sem_ir.inst_blocks().Get(SemIR::InstBlockId::Exports)) {

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        builtin_insts.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -65,7 +65,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -52,7 +52,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_and_textual_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+9}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   cross_ref_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+9}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -270,9 +270,9 @@ class File : public Printable<File> {
   auto interfaces() const -> const ValueStore<InterfaceId>& {
     return interfaces_;
   }
-  auto cross_ref_irs() -> ValueStore<CrossRefIRId>& { return cross_ref_irs_; }
-  auto cross_ref_irs() const -> const ValueStore<CrossRefIRId>& {
-    return cross_ref_irs_;
+  auto import_irs() -> ValueStore<ImportIRId>& { return import_irs_; }
+  auto import_irs() const -> const ValueStore<ImportIRId>& {
+    return import_irs_;
   }
   auto names() const -> NameStoreWrapper {
     return NameStoreWrapper(&identifiers());
@@ -339,10 +339,9 @@ class File : public Printable<File> {
   // Storage for interfaces.
   ValueStore<InterfaceId> interfaces_;
 
-  // Related IRs. There will always be at least 2 entries, the builtin IR (used
-  // for references of builtins) followed by the current IR (used for references
-  // crossing instruction blocks).
-  ValueStore<CrossRefIRId> cross_ref_irs_;
+  // Related IRs. There will always be at least one entry, the builtin IR (used
+  // for references of builtins).
+  ValueStore<ImportIRId> import_irs_;
 
   // Storage for name scopes.
   NameScopeStore name_scopes_;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1005,7 +1005,7 @@ class Formatter {
 
   auto FormatArg(InterfaceId id) -> void { FormatInterfaceName(id); }
 
-  auto FormatArg(CrossRefIRId id) -> void { out_ << id; }
+  auto FormatArg(ImportIRId id) -> void { out_ << id; }
 
   auto FormatArg(IntId id) -> void {
     sem_ir_.ints().Get(id).print(out_, /*isSigned=*/false);

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -204,11 +204,11 @@ struct InterfaceId : public IdBase, public Printable<InterfaceId> {
 constexpr InterfaceId InterfaceId::Invalid =
     InterfaceId(InterfaceId::InvalidIndex);
 
-// The ID of a cross-referenced IR.
-struct CrossRefIRId : public IdBase, public Printable<CrossRefIRId> {
+// The ID of an imported IR.
+struct ImportIRId : public IdBase, public Printable<ImportIRId> {
   using ValueType = const File*;
 
-  static const CrossRefIRId Builtins;
+  static const ImportIRId Builtins;
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "ir";
@@ -216,7 +216,7 @@ struct CrossRefIRId : public IdBase, public Printable<CrossRefIRId> {
   }
 };
 
-constexpr CrossRefIRId CrossRefIRId::Builtins = CrossRefIRId(0);
+constexpr ImportIRId ImportIRId::Builtins = ImportIRId(0);
 
 // A boolean value.
 struct BoolValue : public IdBase, public Printable<BoolValue> {

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -391,16 +391,16 @@ struct FunctionDecl {
 };
 
 // An import corresponds to some number of IRs. The range of imported IRs is
-// inclusive of last_cross_ref_ir_id, and will always be non-empty. If
-// there was an import error, first_cross_ref_ir_id will reference a
+// inclusive of last_import_ir_id, and will always be non-empty. If
+// there was an import error, first_import_ir_id will reference a
 // nullptr IR; there should only ever be one nullptr in the range.
 struct Import {
   // TODO: Should always be an ImportDirectiveId?
   static constexpr auto Kind = InstKind::Import.Define<Parse::NodeId>("import");
 
   TypeId type_id;
-  CrossRefIRId first_cross_ref_ir_id;
-  CrossRefIRId last_cross_ref_ir_id;
+  ImportIRId first_import_ir_id;
+  ImportIRId last_import_ir_id;
 };
 
 // Common representation for all kinds of `ImportRef*` node.
@@ -409,7 +409,7 @@ struct AnyImportRef {
                                        InstKind::ImportRefUsed};
 
   InstKind kind;
-  CrossRefIRId ir_id;
+  ImportIRId ir_id;
   InstId inst_id;
 };
 
@@ -421,7 +421,7 @@ struct ImportRefUnused {
   static constexpr auto Kind =
       InstKind::ImportRefUnused.Define<Parse::InvalidNodeId>("import_ref");
 
-  CrossRefIRId ir_id;
+  ImportIRId ir_id;
   InstId inst_id;
 };
 
@@ -432,7 +432,7 @@ struct ImportRefUsed {
       InstKind::ImportRefUsed.Define<Parse::InvalidNodeId>("import_ref");
 
   TypeId type_id;
-  CrossRefIRId ir_id;
+  ImportIRId ir_id;
   InstId inst_id;
 };
 

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -51,7 +51,7 @@ TEST(SemIRTest, YAML) {
                                          Pair("value_rep", Yaml::Mapping(_)))));
 
   auto file = Yaml::Mapping(ElementsAre(
-      Pair("cross_ref_irs_size", "1"),
+      Pair("import_irs_size", "1"),
       Pair("name_scopes", Yaml::Mapping(SizeIs(1))),
       Pair("bind_names", Yaml::Mapping(SizeIs(1))),
       Pair("functions", Yaml::Mapping(SizeIs(1))),


### PR DESCRIPTION
One more (hopefully last) rename on the Import instruction renaming.

I was kind of tempted to rename to just "IRId", since the IRs aren't all imports. However, this felt easier to read, and a better choice than CrossRef because it's more consistent with the other ways imports exist in code. (even if IRs aren't all imports, most use-cases are derived from imports)

Note though that import_irs may include IRs not just from direct imports. Beyond the builtin IR, I'm thinking that for indirect imports, or the prelude, we may end up adding them. e.g., so that constants can be generated for indirect imports and still correspond to a directly known IR, and for a given IR that's indirectly imported multiple times to be deduplicated locally. I'm not there yet, I'm just mentioning this to help give background for naming thoughts.