### PR TITLE
Use concepts and better comparisons from C++20 in `IndexBase`.

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,8 +53,9 @@ struct IndexBase : public IdBase {
   using IdBase::IdBase;
 };
 
-// Support equality comparison when one operand is a child of IdBase (including IndexBase) and the other operand is either the same type or convertible. Inequality
-// automatically uses these in C++20.
+// Support equality comparison when one operand is a child of `IdBase`
+// (including `IndexBase`) and the other operand is either the same type or
+// convertible to that type.
 template <typename IndexType>
   requires std::derived_from<IndexType, IdBase>
 auto operator==(IndexType lhs, IndexType rhs) -> bool {
@@ -66,14 +67,8 @@ template <typename IndexType, typename RHSType>
 auto operator==(IndexType lhs, RHSType rhs) -> bool {
   return lhs.index == IndexType(rhs).index;
 }
-template <typename LHSType, typename IndexType>
-  requires std::derived_from<IndexType, IdBase> &&
-           std::convertible_to<LHSType, IndexType>
-auto operator==(LHSType lhs, IndexType rhs) -> bool {
-  return IndexType(lhs).index == rhs.index;
-}
 
-// Relational comparisons for only IndexBase.
+// Relational comparisons are only supported for types derived from `IndexBase`.
 template <typename IndexType>
   requires std::derived_from<IndexType, IndexBase>
 auto operator<=>(IndexType lhs, IndexType rhs) -> std::strong_ordering {

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,8 +53,7 @@ struct IndexBase : public IdBase {
   using IdBase::IdBase;
 };
 
-// Equality comparison for both IdBase and IndexBase, including the index type
-// on either the LHS or RHS with something convertible to it. Inequality
+// Support equality comparison when one operand is a child of IdBase (including IndexBase) and the other operand is either the same type or convertible. Inequality
 // automatically uses these in C++20.
 template <typename IndexType>
   requires std::derived_from<IndexType, IdBase>


### PR DESCRIPTION
This is one of the nicer improvements to boiler-plate as we benefit from concepts simplifying the constraints on the templates, defaulted `!=` finding `==`, and the `<=>` operator for a single definition of all relational operators.

I've checked and the `!=` usages do seem to be effective at finding the `==` definitions, but we still need both the RHS- and LHS-based overloads of `==` as far as I can tell.