### PR TITLE
Switch remaining relational operator overloads to spaceship.

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,8 +53,9 @@ struct IndexBase : public IdBase {
   using IdBase::IdBase;
 };
 
-// Support equality comparison when one operand is a child of IdBase (including IndexBase) and the other operand is either the same type or convertible. Inequality
-// automatically uses these in C++20.
+// Support equality comparison when one operand is a child of `IdBase`
+// (including `IndexBase`) and the other operand is either the same type or
+// convertible to that type.
 template <typename IndexType>
   requires std::derived_from<IndexType, IdBase>
 auto operator==(IndexType lhs, IndexType rhs) -> bool {
@@ -66,14 +67,8 @@ template <typename IndexType, typename RHSType>
 auto operator==(IndexType lhs, RHSType rhs) -> bool {
   return lhs.index == IndexType(rhs).index;
 }
-template <typename LHSType, typename IndexType>
-  requires std::derived_from<IndexType, IdBase> &&
-           std::convertible_to<LHSType, IndexType>
-auto operator==(LHSType lhs, IndexType rhs) -> bool {
-  return IndexType(lhs).index == rhs.index;
-}
 
-// Relational comparisons for only IndexBase.
+// Relational comparisons are only supported for types derived from `IndexBase`.
 template <typename IndexType>
   requires std::derived_from<IndexType, IndexBase>
 auto operator<=>(IndexType lhs, IndexType rhs) -> std::strong_ordering {

--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,8 +53,7 @@ struct IndexBase : public IdBase {
   using IdBase::IdBase;
 };
 
-// Equality comparison for both IdBase and IndexBase, including the index type
-// on either the LHS or RHS with something convertible to it. Inequality
+// Support equality comparison when one operand is a child of IdBase (including IndexBase) and the other operand is either the same type or convertible. Inequality
 // automatically uses these in C++20.
 template <typename IndexType>
   requires std::derived_from<IndexType, IdBase>

--- a/toolchain/lex/tokenized_buffer.h
+++ b/toolchain/lex/tokenized_buffer.h
@@ -5,6 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_LEX_TOKENIZED_BUFFER_H_
 #define CARBON_TOOLCHAIN_LEX_TOKENIZED_BUFFER_H_
 
+#include <compare>
 #include <cstdint>
 #include <iterator>
 
@@ -81,8 +82,8 @@ class TokenIterator
   auto operator==(const TokenIterator& rhs) const -> bool {
     return token_ == rhs.token_;
   }
-  auto operator<(const TokenIterator& rhs) const -> bool {
-    return token_ < rhs.token_;
+  auto operator<=>(const TokenIterator& rhs) const -> std::strong_ordering {
+    return token_ <=> rhs.token_;
   }
 
   auto operator*() const -> const TokenIndex& { return token_; }

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -355,8 +355,12 @@ class Tree::PostorderIterator
   auto operator==(const PostorderIterator& rhs) const -> bool {
     return node_ == rhs.node_;
   }
-  auto operator<(const PostorderIterator& rhs) const -> bool {
-    return node_.index < rhs.node_.index;
+  // While we don't want users to directly leverage the index of `NodeId` for
+  // ordering, when we're explicitly walking in postorder, that becomes
+  // reasonable so add the ordering here and reach down for the index
+  // explicitly.
+  auto operator<=>(const PostorderIterator& rhs) const -> std::strong_ordering {
+    return node_.index <=> rhs.node_.index;
   }
 
   auto operator*() const -> NodeId { return node_; }


### PR DESCRIPTION
This doesn't matter too much as these were expanded by the LLVM iterator
facade, but eventually this should enable that facade to be a little
less fancy and should also simplify the dispatch to directly use the
three-way comparison.

One case is a bit subtle and didn't have a comment so I added one to
explain a bit what is going on there.