### PR TITLE
Remove is_convertible comparisons for IndexBase

### DIFF
--- a/toolchain/base/index_base.h
+++ b/toolchain/base/index_base.h
@@ -53,19 +53,12 @@ struct IndexBase : public IdBase {
   using IdBase::IdBase;
 };
 
-// Support equality comparison when one operand is a child of `IdBase`
-// (including `IndexBase`) and the other operand is either the same type or
-// convertible to that type.
+// Support equality comparison for types derived from `IdBase` (including
+// `IndexBase`).
 template <typename IndexType>
   requires std::derived_from<IndexType, IdBase>
 auto operator==(IndexType lhs, IndexType rhs) -> bool {
   return lhs.index == rhs.index;
-}
-template <typename IndexType, typename RHSType>
-  requires std::derived_from<IndexType, IdBase> &&
-           std::convertible_to<RHSType, IndexType>
-auto operator==(IndexType lhs, RHSType rhs) -> bool {
-  return lhs.index == IndexType(rhs).index;
 }
 
 // Relational comparisons are only supported for types derived from `IndexBase`.

--- a/toolchain/parse/tree_test.cpp
+++ b/toolchain/parse/tree_test.cpp
@@ -80,7 +80,7 @@ TEST_F(TreeTest, AsAndTryAs) {
   // A FunctionDecl node, so will match.
   fn_decl_id = tree.TryAs<FunctionDeclId>(n);
   ASSERT_TRUE(fn_decl_id.has_value());
-  EXPECT_TRUE(*fn_decl_id == n);
+  EXPECT_TRUE(*fn_decl_id == FunctionDeclId(n));
   // Under normal usage, this function should be used with `auto`, but for
   // a test it is nice to verify that it is returning the expected type.
   // NOLINTNEXTLINE(modernize-use-auto).
@@ -89,14 +89,14 @@ TEST_F(TreeTest, AsAndTryAs) {
 
   any_fn_decl_id = tree.TryAs<AnyFunctionDeclId>(n);
   ASSERT_TRUE(any_fn_decl_id.has_value());
-  EXPECT_TRUE(*any_fn_decl_id == n);
+  EXPECT_TRUE(*any_fn_decl_id == AnyFunctionDeclId(n));
   // NOLINTNEXTLINE(modernize-use-auto).
   AnyFunctionDeclId any_fn_decl_id2 = tree.As<AnyFunctionDeclId>(n);
   EXPECT_TRUE(*any_fn_decl_id == any_fn_decl_id2);
 
   any_decl_id = tree.TryAs<AnyDeclId>(n);
   ASSERT_TRUE(any_decl_id.has_value());
-  EXPECT_TRUE(*any_decl_id == n);
+  EXPECT_TRUE(*any_decl_id == AnyDeclId(n));
   // NOLINTNEXTLINE(modernize-use-auto).
   AnyDeclId any_decl_id2 = tree.As<AnyDeclId>(n);
   EXPECT_TRUE(*any_decl_id == any_decl_id2);


### PR DESCRIPTION
These convertible checks are only used in one test, so that index types can be compared with NodeId. We aren't doing this otherwise: can we remove them?