### PR TITLE
Remove `operator!=` now that C++20 lets us use `operator==`.

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -13,4 +13,5 @@ forin
 inout
 parameteras
 pullrequest
+rightt
 statics

--- a/common/BUILD
+++ b/common/BUILD
@@ -63,6 +63,11 @@ cc_test(
 )
 
 cc_library(
+    name = "crtp_helpers",
+    hdrs = ["crtp_helpers.h"],
+)
+
+cc_library(
     name = "enum_base",
     hdrs = ["enum_base.h"],
     deps = [
@@ -195,6 +200,7 @@ cc_library(
     name = "ostream",
     hdrs = ["ostream.h"],
     deps = [
+        ":crtp_helpers",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/common/crtp_helpers.h
+++ b/common/crtp_helpers.h
@@ -1,0 +1,71 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_CRTP_HELPERS_H_
+#define CARBON_COMMON_CRTP_HELPERS_H_
+
+#include <compare>
+#include <concepts>
+
+namespace Carbon {
+
+// Helper for building correct empty or stateless [CRTP] base classes.
+//
+// [CRTP]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
+//
+// C++ conflates _compositional_ type authoring with inheritance. An effective
+// pattern for doing compositional type design in C++ are CRTP base classes.
+// However, because they are ultimately base classes, they have to be specially
+// crafted in order to not disrupt useful C++ features such as defaulted
+// comparisons.
+//
+// For an empty or stateless CRTP base class, we provide this helper that should
+// itself follow the CRTP pattern when building a CRTP base class:
+//
+// ```cpp
+// template <typename DerivedT>
+// class ComposingWidget : EmptyCRTPBase<ComposingWidget<DerivedT>> {
+//   ...
+// };
+// ```
+//
+// This will provide the necessary comparison functions to allow `DerivedT` to
+// default its comparison functions (or not) as desired. These will be stateless
+// comparison functions, and this helper is only valid when `ComposableWidget`
+// is stateless and should not contribute in any way to the comparison function
+// of `DerivedT`.
+template <typename CRTPBaseT>
+class EmptyCRTPBase {
+  // For both equality and relational operators, we need to deduce the types on
+  // both sides and require both to be exactly the provided `CRTPBaseT`. This
+  // ensures these overloads are only used inside the implementation of a
+  // defaulted operator in the derived type.
+  //
+  // The parameters are also accepted by value rather than by const reference
+  // because this base is required to be empty. We don't want to force an
+  // address to exist for it, and empty types have special low-cost
+  // implementations in the ABI.
+  template <typename LeftT, typename RightT>
+    requires std::same_as<LeftT, CRTPBaseT> && std::same_as<RightT, CRTPBaseT>
+  friend constexpr auto operator==(LeftT /*lhs*/, RightT /*rhs*/) -> bool {
+    static_assert(std::is_empty_v<CRTPBaseT>,
+                  "Can only use `EmptyCRTPBase` with empty and stateless CRTP "
+                  "classes, as the operators it provides consider all "
+                  "instances to be exactly equal to each other.");
+    return true;
+  }
+  template <typename LeftT, typename RightT>
+    requires std::same_as<LeftT, CRTPBaseT> && std::same_as<RightT, CRTPBaseT>
+  friend constexpr auto operator<=>(LeftT /*lhs*/, RightT /*rhs*/) -> auto {
+    static_assert(std::is_empty_v<CRTPBaseT>,
+                  "Can only use `EmptyCRTPBase` with empty and stateless CRTP "
+                  "classes, as the operators it provides consider all "
+                  "instances to be exactly equal to each other.");
+    return std::strong_ordering::equal;
+  }
+};
+
+}  // namespace Carbon
+
+#endif  // CARBON_COMMON_CRTP_HELPERS_H_

--- a/common/hashing.h
+++ b/common/hashing.h
@@ -37,12 +37,8 @@ class HashCode : public Printable<HashCode> {
 
   constexpr explicit HashCode(uint64_t value) : value_(value) {}
 
-  friend constexpr auto operator==(HashCode lhs, HashCode rhs) -> bool {
-    return lhs.value_ == rhs.value_;
-  }
-  friend constexpr auto operator!=(HashCode lhs, HashCode rhs) -> bool {
-    return lhs.value_ != rhs.value_;
-  }
+  friend constexpr auto operator==(HashCode lhs, HashCode rhs)
+      -> bool = default;
 
   // Extracts an index from the hash code as a `ssize_t`. This index covers the
   // full range of that type, and may even be negative. Typical usage will

--- a/common/ostream.h
+++ b/common/ostream.h
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <type_traits>
 
+#include "common/crtp_helpers.h"
 #include "llvm/Support/raw_os_ostream.h"
 // Libraries should include this header instead of raw_ostream.
 #include "llvm/Support/Compiler.h"
@@ -19,7 +20,7 @@ namespace Carbon {
 // CRTP base class for printable types. Children (DerivedT) must implement:
 // - auto Print(llvm::raw_ostream& out) -> void
 template <typename DerivedT>
-class Printable {
+class Printable : EmptyCRTPBase<Printable<DerivedT>> {
   // Provides simple printing for debuggers.
   LLVM_DUMP_METHOD void Dump() const {
     static_cast<const DerivedT*>(this)->Print(llvm::errs());

--- a/toolchain/parse/precedence.h
+++ b/toolchain/parse/precedence.h
@@ -70,12 +70,8 @@ class PrecedenceGroup {
   static auto ForTrailing(Lex::TokenKind kind, bool infix)
       -> std::optional<Trailing>;
 
-  friend auto operator==(PrecedenceGroup lhs, PrecedenceGroup rhs) -> bool {
-    return lhs.level_ == rhs.level_;
-  }
-  friend auto operator!=(PrecedenceGroup lhs, PrecedenceGroup rhs) -> bool {
-    return lhs.level_ != rhs.level_;
-  }
+  friend auto operator==(PrecedenceGroup lhs, PrecedenceGroup rhs)
+      -> bool = default;
 
   // Compare the precedence levels for two adjacent operators.
   static auto GetPriority(PrecedenceGroup left, PrecedenceGroup right)

--- a/toolchain/testing/yaml_test_helpers.h
+++ b/toolchain/testing/yaml_test_helpers.h
@@ -63,10 +63,6 @@ struct EmptyComparable {
       -> bool {
     return true;
   }
-  friend auto operator!=(EmptyComparable /*lhs*/, EmptyComparable /*rhs*/)
-      -> bool {
-    return false;
-  }
 };
 
 struct Value;


### PR DESCRIPTION
Also switches to defaulting `operator==` where we can, and adds a CRTP helper to let us do this even when using CRTP classes. It turns out to be quite surprising what is needed to allow a CRTP base class to not interfere in the defaulting of comparison functions, and so I've extracted it into its own helper and tried to document it. We don't have a lot of users yet, but it should ensure things like `Printable` continue to work without interfering with other patterns.