### PR TITLE
Refactor File constructors to share logic.

### DIFF
--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -315,6 +315,10 @@ class File : public Printable<File> {
   auto filename() const -> llvm::StringRef { return filename_; }
 
  private:
+  // Common File initialization.
+  explicit File(SharedValueStores& value_stores, std::string filename,
+                const File* builtins, llvm::function_ref<void()> init_builtins);
+
   bool has_errors_ = false;
 
   // Shared, compile-scoped values.


### PR DESCRIPTION
I was considering this again while working on #3674, it would be helpful to share initialization for both regular and builtin File constructors.