### PR TITLE
Remove the link to a GSoC organization (for now).

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,6 @@ contribute.
 
 -   Most of Carbon's design discussions occur on
     [Discord](https://discord.gg/ZjVdShJDAs).
--   Carbon is a
-    [Google Summer of Code 2023 organization](https://summerofcode.withgoogle.com/programs/2023/organizations/carbon-language).
 -   To watch for major release announcements, subscribe to our
     [Carbon release post on GitHub](https://github.com/carbon-language/carbon-lang/discussions/1020)
     and [star carbon-lang](https://github.com/carbon-language/carbon-lang).


### PR DESCRIPTION
We had some amazing GSoC participants last year, but because Carbon is still pretty small, we ended up stetched a bit too much to be sustainable. And this year, we're trying to have an even narrower focus on the toolchain.

Between these aspects, we sadly don't have the bandwidth to run an effective GSoC project this year. We think it's really important that we can give mentees an excellent experience on the project, and don't want to overcommit ourselves, or worse, let them down.

We're really hopeful to be back when the project is a bit larger though, and we have good bandwidth to host folks.