### PR TITLE
Use llvm:: for specializations instead of 'namespace llvm'

### DIFF
--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -12,12 +12,10 @@
 #include "toolchain/lex/character_set.h"
 #include "toolchain/lex/helpers.h"
 
-namespace llvm {
-
 // We use formatv primarily for diagnostics. In these cases, it's expected that
 // the spelling in source code should be used.
 template <>
-struct format_provider<Carbon::Lex::NumericLiteral::Radix> {
+struct llvm::format_provider<Carbon::Lex::NumericLiteral::Radix> {
   using Radix = Carbon::Lex::NumericLiteral::Radix;
   static void format(const Radix& radix, raw_ostream& out,
                      StringRef /*style*/) {
@@ -34,8 +32,6 @@ struct format_provider<Carbon::Lex::NumericLiteral::Radix> {
     }
   }
 };
-
-}  // namespace llvm
 
 namespace Carbon::Lex {
 

--- a/toolchain/lex/token_kind.h
+++ b/toolchain/lex/token_kind.h
@@ -133,12 +133,10 @@ constexpr llvm::ArrayRef<TokenKind> TokenKind::KeywordTokens =
 
 }  // namespace Carbon::Lex
 
-namespace llvm {
-
 // We use formatv primarily for diagnostics. In these cases, it's expected that
 // the spelling in source code should be used.
 template <>
-struct format_provider<Carbon::Lex::TokenKind> {
+struct llvm::format_provider<Carbon::Lex::TokenKind> {
   static void format(const Carbon::Lex::TokenKind& kind, raw_ostream& out,
                      StringRef /*style*/) {
     auto spelling = kind.fixed_spelling();
@@ -150,7 +148,5 @@ struct format_provider<Carbon::Lex::TokenKind> {
     }
   }
 };
-
-}  // namespace llvm
 
 #endif  // CARBON_TOOLCHAIN_LEX_TOKEN_KIND_H_

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -25,11 +25,9 @@ enum class RelativeLocation : int8_t {
 
 }  // namespace Carbon::Parse
 
-namespace llvm {
-
 // Adapts RelativeLocation for use with formatv.
 template <>
-struct format_provider<Carbon::Parse::RelativeLocation> {
+struct llvm::format_provider<Carbon::Parse::RelativeLocation> {
   using RelativeLocation = Carbon::Parse::RelativeLocation;
   static void format(const RelativeLocation& loc, raw_ostream& out,
                      StringRef /*style*/) {
@@ -46,8 +44,6 @@ struct format_provider<Carbon::Parse::RelativeLocation> {
     }
   }
 };
-
-}  // namespace llvm
 
 namespace Carbon::Parse {
 


### PR DESCRIPTION
We already do this with things like llvm::DenseMapInfo, I don't know why I was doing this with format_provider. But this should be more consistent, and slightly better for not entering another library's namespace.