### PR TITLE
Add 'let' handling for ImportRefUsed.

### DIFF
--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -71,6 +71,9 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId parse_node) -> bool {
   // Add the name of the binding to the current scope.
   auto name_id = context.bind_names().Get(bind_name.bind_name_id).name_id;
   context.AddNameToLookup(name_id, pattern_id);
+  if (context.scope_stack().PeekNameScopeId() == SemIR::NameScopeId::Package) {
+    context.AddExport(pattern_id);
+  }
   return true;
 }
 

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -21,9 +21,10 @@ static auto GetImportName(const SemIR::File& import_sem_ir,
                           SemIR::Inst import_inst)
     -> std::pair<SemIR::NameId, SemIR::NameScopeId> {
   switch (import_inst.kind()) {
-    case SemIR::InstKind::BindName: {
+    case SemIR::InstKind::BindName:
+    case SemIR::InstKind::BindSymbolicName: {
       const auto& bind_name = import_sem_ir.bind_names().Get(
-          import_inst.As<SemIR::BindName>().bind_name_id);
+          import_inst.As<SemIR::AnyBindName>().bind_name_id);
       return {bind_name.name_id, bind_name.enclosing_scope_id};
     }
 

--- a/toolchain/check/testdata/class/fail_todo_import.carbon
+++ b/toolchain/check/testdata/class/fail_todo_import.carbon
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: b.carbon: ERROR: Semantics TODO: `TryResolveImportRefUnused on ClassDecl`.
-// CHECK:STDERR: b.carbon: ERROR: Semantics TODO: `TryResolveImportRefUnused on ClassDecl`.
 // CHECK:STDERR: b.carbon: ERROR: Semantics TODO: `TryResolveInst on ClassType`.
 // CHECK:STDERR: b.carbon: ERROR: Semantics TODO: `TryResolveInst on ClassType`.
 
@@ -114,23 +112,23 @@ var d: (ForwardDeclared,) = d_ref;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace {.Empty = %import_ref.1, .ForwardDeclared = %import_ref.2, .a_ref = %import_ref.3, .b_ref = %import_ref.4, .c_ref = %import_ref.5, .Run = %Run, .a = %a, .b = %b, .c = %c, .d = %d} [template]
-// CHECK:STDOUT:   %import_ref.1: <error> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %import_ref.2: <error> = import_ref ir1, inst+4, used
+// CHECK:STDOUT:   %import_ref.1: <error> = import_ref ir1, inst+1, used [template = <error>]
+// CHECK:STDOUT:   %import_ref.2: <error> = import_ref ir1, inst+4, used [template = <error>]
 // CHECK:STDOUT:   %import_ref.3: ref <error> = import_ref ir1, inst+12, used
 // CHECK:STDOUT:   %import_ref.4: ref <error> = import_ref ir1, inst+20, used
 // CHECK:STDOUT:   %import_ref.5: ref <error> = import_ref ir1, inst+30, used
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template]
-// CHECK:STDOUT:   %Empty.ref: <error> = name_ref Empty, %import_ref.1
+// CHECK:STDOUT:   %Empty.ref: <error> = name_ref Empty, %import_ref.1 [template = <error>]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc13: <error> = name_ref ForwardDeclared, %import_ref.2
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc13: <error> = name_ref ForwardDeclared, %import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %b.var: ref <error> = var b
 // CHECK:STDOUT:   %b: ref <error> = bind_name b, %b.var
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc14: <error> = name_ref ForwardDeclared, %import_ref.2
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc14: <error> = name_ref ForwardDeclared, %import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %.loc14: type = ptr_type <error> [template = <error>]
 // CHECK:STDOUT:   %c.var: ref <error> = var c
 // CHECK:STDOUT:   %c: ref <error> = bind_name c, %c.var
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc18: <error> = name_ref ForwardDeclared, %import_ref.2
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc18: <error> = name_ref ForwardDeclared, %import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %.loc18: <error> = tuple_literal (%ForwardDeclared.ref.loc18)
 // CHECK:STDOUT:   %d.var: ref <error> = var d
 // CHECK:STDOUT:   %d: ref <error> = bind_name d, %d.var
@@ -138,12 +136,12 @@ var d: (ForwardDeclared,) = d_ref;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Empty.ref: <error> = name_ref Empty, file.%import_ref.1
+// CHECK:STDOUT:   %Empty.ref: <error> = name_ref Empty, file.%import_ref.1 [template = <error>]
 // CHECK:STDOUT:   %x.var: ref <error> = var x
 // CHECK:STDOUT:   %x: ref <error> = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc7: {} = struct_literal ()
 // CHECK:STDOUT:   assign %x.var, <error>
-// CHECK:STDOUT:   %ForwardDeclared.ref: <error> = name_ref ForwardDeclared, file.%import_ref.2
+// CHECK:STDOUT:   %ForwardDeclared.ref: <error> = name_ref ForwardDeclared, file.%import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %y.var: ref <error> = var y
 // CHECK:STDOUT:   %y: ref <error> = bind_name y, %y.var
 // CHECK:STDOUT:   %.loc8: {} = struct_literal ()

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -1,0 +1,43 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- implicit.carbon
+
+package Implicit api;
+
+let T:! type = i32;
+
+// --- implicit.impl.carbon
+
+package Implicit impl;
+
+// TODO: Should this be valid?
+// CHECK:STDERR: implicit.impl.carbon:[[@LINE+3]]:1: ERROR: Cannot implicitly convert from `i32` to `T`.
+// CHECK:STDERR: let a: T = 0;
+// CHECK:STDERR: ^~~~~~~~~~~~~
+let a: T = 0;
+
+// CHECK:STDOUT: --- implicit.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {} [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- implicit.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.T = %import_ref} [template]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+1, used [symbolic]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %import_ref [symbolic = %import_ref]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %a: T = bind_name a, <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -1,0 +1,54 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- implicit.carbon
+
+package Implicit api;
+
+let T:! type = i32;
+
+// --- implicit.impl.carbon
+
+package Implicit impl;
+
+var a: T*;
+var b: T = *a;
+
+// CHECK:STDOUT: --- implicit.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {} [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- implicit.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.T = %import_ref, .a = %a, .b = %b} [template]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+1, used [symbolic]
+// CHECK:STDOUT:   %T.ref.loc4: type = name_ref T, %import_ref [symbolic = %import_ref]
+// CHECK:STDOUT:   %.loc4: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:   %a.var: ref T* = var a
+// CHECK:STDOUT:   %a: ref T* = bind_name a, %a.var
+// CHECK:STDOUT:   %T.ref.loc5: type = name_ref T, %import_ref [symbolic = %import_ref]
+// CHECK:STDOUT:   %b.var: ref T = var b
+// CHECK:STDOUT:   %b: ref T = bind_name b, %b.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %a.ref: ref T* = name_ref a, file.%a
+// CHECK:STDOUT:   %.loc5_13: T* = bind_value %a.ref
+// CHECK:STDOUT:   %.loc5_12.1: ref T = deref %.loc5_13
+// CHECK:STDOUT:   %.loc5_12.2: T = bind_value %.loc5_12.1
+// CHECK:STDOUT:   assign file.%b.var, %.loc5_12.2
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/let/import.carbon
+++ b/toolchain/check/testdata/let/import.carbon
@@ -1,0 +1,39 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- implicit.carbon
+
+package Implicit api;
+
+let a:! bool = true;
+
+// --- implicit.impl.carbon
+
+package Implicit impl;
+
+let b:! bool = a;
+
+// CHECK:STDOUT: --- implicit.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {} [template]
+// CHECK:STDOUT:   %.loc4: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a, %.loc4 [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- implicit.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.a = %import_ref} [template]
+// CHECK:STDOUT:   %import_ref: bool = import_ref ir1, inst+1, used [symbolic]
+// CHECK:STDOUT:   %a.ref: bool = name_ref a, %import_ref [symbolic = %import_ref]
+// CHECK:STDOUT:   %b: bool = bind_symbolic_name b, %a.ref [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:


### PR DESCRIPTION
- File::StringifyTypeExpr now has a case that hits the ImportRefUsed TODO, so implementing that. I think the `static` approach will be helpful in ensuring there aren't access bugs, particularly when future support is added.

- `let` wasn't adding to exports because it doesn't use `decl_name_stack` the way `var` does. This now adds to exports, but we might want to unify logic for issues such as this.

- BuildImportRefUsedValueRepr is now called for another inst kind, and it seemed like calling back to BuildValueRepr was the best way to resolve this. I don't *think* that's going to cause recursion.