### PR TITLE
Fix for MakeUnqualifiedName conflicting with a namespace

### DIFF
--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -201,7 +201,7 @@ class DeclNameStack {
 
   // Applies a Name from the name stack to given name context.
   auto ApplyNameQualifierTo(NameContext& name_context, Parse::NodeId parse_node,
-                            SemIR::NameId name_id) -> void;
+                            SemIR::NameId name_id, bool is_unqualified) -> void;
 
   // Returns true if the context is in a state where it can resolve qualifiers.
   // Updates name_context as needed.
@@ -209,8 +209,11 @@ class DeclNameStack {
       -> bool;
 
   // Updates the scope on name_context as needed. This is called after
-  // resolution is complete, whether for Name or expression.
-  auto UpdateScopeIfNeeded(NameContext& name_context) -> void;
+  // resolution is complete, whether for Name or expression. When updating for
+  // an unqualified name, the resolution is noted without pushing scopes; it's
+  // instead expected this will become a name conflict.
+  auto UpdateScopeIfNeeded(NameContext& name_context, bool is_unqualified)
+      -> void;
 
   // The linked context.
   Context* context_;

--- a/toolchain/check/testdata/var/fail_namespace_conflict.carbon
+++ b/toolchain/check/testdata/var/fail_namespace_conflict.carbon
@@ -6,27 +6,21 @@
 
 namespace A;
 
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+9]]:5: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: var A: b;
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: var A: i32;
 // CHECK:STDERR:     ^
 // CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace A;
 // CHECK:STDERR: ^~~~~~~~~~~~
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+3]]:8: ERROR: Name `b` not found.
-// CHECK:STDERR: var A: b;
-// CHECK:STDERR:        ^
-var A: b;
+var A: i32;
 
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+9]]:5: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: var A: b = 1;
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: var A: i32 = 1;
 // CHECK:STDERR:     ^
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-16]]:1: Name is previously declared here.
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-13]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace A;
 // CHECK:STDERR: ^~~~~~~~~~~~
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+3]]:8: ERROR: Name `b` not found.
-// CHECK:STDERR: var A: b = 1;
-// CHECK:STDERR:        ^
-var A: b = 1;
+var A: i32 = 1;
 
 // CHECK:STDOUT: --- fail_namespace_conflict.carbon
 // CHECK:STDOUT:
@@ -37,18 +31,16 @@ var A: b = 1;
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace {.A = %.loc7} [template]
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace {} [template]
-// CHECK:STDOUT:   %b.ref.loc18: <error> = name_ref b, <error> [template = <error>]
-// CHECK:STDOUT:   %A.var.loc18: ref <error> = var A
-// CHECK:STDOUT:   %A.loc18: ref <error> = bind_name A, %A.var.loc18
-// CHECK:STDOUT:   %b.ref.loc29: <error> = name_ref b, <error> [template = <error>]
-// CHECK:STDOUT:   %A.var.loc29: ref <error> = var A
-// CHECK:STDOUT:   %A.loc29: ref <error> = bind_name A, %A.var.loc29
+// CHECK:STDOUT:   %A.var.loc15: ref i32 = var A
+// CHECK:STDOUT:   %A.loc15: ref i32 = bind_name A, %A.var.loc15
+// CHECK:STDOUT:   %A.var.loc23: ref i32 = var A
+// CHECK:STDOUT:   %A.loc23: ref i32 = bind_name A, %A.var.loc23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   assign file.%A.var.loc29, <error>
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   assign file.%A.var.loc23, %.loc23
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_namespace_conflict.carbon
+++ b/toolchain/check/testdata/var/fail_namespace_conflict.carbon
@@ -1,0 +1,54 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+namespace A;
+
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+9]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: var A: b;
+// CHECK:STDERR:     ^
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-5]]:1: Name is previously declared here.
+// CHECK:STDERR: namespace A;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+3]]:8: ERROR: Name `b` not found.
+// CHECK:STDERR: var A: b;
+// CHECK:STDERR:        ^
+var A: b;
+
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+9]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: var A: b = 1;
+// CHECK:STDERR:     ^
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-16]]:1: Name is previously declared here.
+// CHECK:STDERR: namespace A;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+3]]:8: ERROR: Name `b` not found.
+// CHECK:STDERR: var A: b = 1;
+// CHECK:STDERR:        ^
+var A: b = 1;
+
+// CHECK:STDOUT: --- fail_namespace_conflict.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace {.A = %.loc7} [template]
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {} [template]
+// CHECK:STDOUT:   %b.ref.loc18: <error> = name_ref b, <error> [template = <error>]
+// CHECK:STDOUT:   %A.var.loc18: ref <error> = var A
+// CHECK:STDOUT:   %A.loc18: ref <error> = bind_name A, %A.var.loc18
+// CHECK:STDOUT:   %b.ref.loc29: <error> = name_ref b, <error> [template = <error>]
+// CHECK:STDOUT:   %A.var.loc29: ref <error> = var A
+// CHECK:STDOUT:   %A.loc29: ref <error> = bind_name A, %A.var.loc29
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   assign file.%A.var.loc29, <error>
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/var/shadowing.carbon
+++ b/toolchain/check/testdata/var/shadowing.carbon
@@ -4,7 +4,12 @@
 //
 // AUTOUPDATE
 
+namespace NS;
+
 fn Main() {
+  var NS: i32 = 0;
+  NS = 1;
+
   var x: i32 = 0;
   if (true) {
     var x: i32 = 0;
@@ -18,32 +23,40 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace {.Main = %Main} [template]
+// CHECK:STDOUT:   package: <namespace> = namespace {.NS = %.loc7, .Main = %Main} [template]
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace {} [template]
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %x.var.loc8: ref i32 = var x
-// CHECK:STDOUT:   %x.loc8: ref i32 = bind_name x, %x.var.loc8
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   assign %x.var.loc8, %.loc8
-// CHECK:STDOUT:   %.loc9: bool = bool_literal true [template = constants.%.2]
-// CHECK:STDOUT:   if %.loc9 br !if.then else br !if.else
+// CHECK:STDOUT:   %NS.var: ref i32 = var NS
+// CHECK:STDOUT:   %NS: ref i32 = bind_name NS, %NS.var
+// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   assign %NS.var, %.loc10
+// CHECK:STDOUT:   %NS.ref: ref i32 = name_ref NS, %NS
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   assign %NS.ref, %.loc11
+// CHECK:STDOUT:   %x.var.loc13: ref i32 = var x
+// CHECK:STDOUT:   %x.loc13: ref i32 = bind_name x, %x.var.loc13
+// CHECK:STDOUT:   %.loc13: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   assign %x.var.loc13, %.loc13
+// CHECK:STDOUT:   %.loc14: bool = bool_literal true [template = constants.%.3]
+// CHECK:STDOUT:   if %.loc14 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %x.var.loc10: ref i32 = var x
-// CHECK:STDOUT:   %x.loc10: ref i32 = bind_name x, %x.var.loc10
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   assign %x.var.loc10, %.loc10
-// CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x.loc10
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   assign %x.ref, %.loc13
+// CHECK:STDOUT:   %x.var.loc15: ref i32 = var x
+// CHECK:STDOUT:   %x.loc15: ref i32 = bind_name x, %x.var.loc15
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   assign %x.var.loc15, %.loc15
+// CHECK:STDOUT:   %x.ref: ref i32 = name_ref x, %x.loc15
+// CHECK:STDOUT:   %.loc18: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   assign %x.ref, %.loc18
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:


### PR DESCRIPTION
Unqualified names don't handle scopes the way that typical names do, so a name conflict with a namespace needs to be handled specially. I'm still favoring keeping code close as much as possible, particularly since long-term this syntax will probably shift to be more consistent. For now I'm just flagging when we shouldn't push scopes, so that MakeUnqualifiedName doesn't need to clean up.

Note, a different approach would basically be:

```
PushScopeAndStartName
ApplyNameQualifierTo
result = decl_name_stack_.back();
decl_name_stack_.back().state = NameContext::State::Finished;
PopScope
return result;
```

But that approach feels worse to me, due to the additional stack manipulations and the need to duplicate some of the FinishName logic just to be able to pop the scope that didn't really need to be added.