### PR TITLE
Avoid private inheritance in DiagnosticAnnotationScope.

### DIFF
--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -282,8 +282,8 @@ class DiagnosticEmitter {
     // For the expected usage see the builder API: `DiagnosticEmitter::Build`.
     template <typename... Args>
     auto Emit() -> void {
-      for (auto* annotator : emitter_->annotators_) {
-        annotator->Annotate(*this);
+      for (auto annotator : emitter_->annotators_) {
+        annotator(*this);
       }
       emitter_->consumer_->HandleDiagnostic(std::move(diagnostic_));
     }
@@ -356,30 +356,7 @@ class DiagnosticEmitter {
   }
 
  private:
-  // Base class for scopes in which we perform diagnostic annotation, such as
-  // adding notes with contextual information.
-  class DiagnosticAnnotationScopeBase {
-   public:
-    virtual auto Annotate(DiagnosticBuilder& builder) -> void = 0;
-
-    DiagnosticAnnotationScopeBase(const DiagnosticAnnotationScopeBase&) =
-        delete;
-    auto operator=(const DiagnosticAnnotationScopeBase&)
-        -> DiagnosticAnnotationScopeBase& = delete;
-
-   protected:
-    explicit DiagnosticAnnotationScopeBase(DiagnosticEmitter* emitter)
-        : emitter_(emitter) {
-      emitter_->annotators_.push_back(this);
-    }
-    ~DiagnosticAnnotationScopeBase() {
-      CARBON_CHECK(emitter_->annotators_.back() == this);
-      emitter_->annotators_.pop_back();
-    }
-
-   private:
-    DiagnosticEmitter* emitter_;
-  };
+  using AnnotateFn = llvm::function_ref<auto(DiagnosticBuilder& builder)->void>;
 
   // Converts an argument to llvm::Any for storage, handling input to storage
   // type translation when needed.
@@ -399,7 +376,7 @@ class DiagnosticEmitter {
 
   DiagnosticLocationTranslator<LocationT>* translator_;
   DiagnosticConsumer* consumer_;
-  llvm::SmallVector<DiagnosticAnnotationScopeBase*> annotators_;
+  llvm::SmallVector<AnnotateFn> annotators_;
 };
 
 class StreamDiagnosticConsumer : public DiagnosticConsumer {
@@ -492,25 +469,15 @@ class DiagnosticAnnotationScope {
 
  public:
   DiagnosticAnnotationScope(Emitter* emitter, AnnotateFn annotate)
-      : impl_(emitter, std::move(annotate)) {}
+      : emitter_(emitter), annotate_(std::move(annotate)) {
+    emitter_->annotators_.push_back(annotate_);
+  }
+  ~DiagnosticAnnotationScope() { emitter_->annotators_.pop_back(); }
 
  private:
-  using Base = typename Emitter::DiagnosticAnnotationScopeBase;
-  class Impl : public Base {
-   public:
-    Impl(Emitter* emitter, AnnotateFn annotate)
-        : Base(emitter), annotate_(std::move(annotate)) {}
-
-    auto Annotate(typename Emitter::DiagnosticBuilder& builder)
-        -> void override {
-      annotate_(builder);
-    }
-
-   private:
-    AnnotateFn annotate_;
-  };
-
-  Impl impl_;
+  Emitter* emitter_;
+  // Make a copy of the annotation function to ensure that it lives long enough.
+  AnnotateFn annotate_;
 };
 
 template <typename LocationT, typename AnnotateFn>


### PR DESCRIPTION
The style guide doesn't permit private inheritance, so switch to a member instead. Keep storing the callable to ensure it lives long enough, but type-erase it using `function_ref` instead of a hand-rolled mechanism.