### PR TITLE
Remove self_type_id from Class

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -1007,8 +1007,7 @@ auto Context::GetTupleType(llvm::ArrayRef<SemIR::TypeId> type_ids)
 
 auto Context::GetBuiltinType(SemIR::BuiltinKind kind) -> SemIR::TypeId {
   CARBON_CHECK(kind != SemIR::BuiltinKind::Invalid);
-  auto type_id = GetTypeIdForTypeConstant(
-      constant_values().Get(SemIR::InstId::ForBuiltin(kind)));
+  auto type_id = GetTypeIdForTypeInstId(SemIR::InstId::ForBuiltin(kind));
   // To keep client code simpler, complete builtin types before returning them.
   bool complete = TryToCompleteType(type_id);
   CARBON_CHECK(complete) << "Failed to complete builtin type";

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -154,13 +154,6 @@ class Context {
   auto NoteUndefinedInterface(SemIR::InterfaceId interface_id,
                               DiagnosticBuilder& builder) -> void;
 
-  // Returns the current scope, if it is of the specified kind. Otherwise,
-  // returns nullopt.
-  template <typename InstT>
-  auto GetCurrentScopeAs() -> std::optional<InstT> {
-    return scope_stack().GetCurrentScopeAs<InstT>(sem_ir());
-  }
-
   // Adds a `Branch` instruction branching to a new instruction block, and
   // returns the ID of the new block. All paths to the branch target must go
   // through the current block, though not necessarily through this branch.
@@ -209,6 +202,12 @@ class Context {
 
   // Returns the type ID for a constant of type `type`.
   auto GetTypeIdForTypeConstant(SemIR::ConstantId constant_id) -> SemIR::TypeId;
+
+  // Returns the type ID for an instruction whose constant is of type `type`.
+  // This does not require the instruction itself to be the type.
+  auto GetTypeIdForTypeInstId(SemIR::InstId inst_id) -> SemIR::TypeId {
+    return GetTypeIdForTypeConstant(constant_values().Get(inst_id));
+  }
 
   // Attempts to complete the type `type_id`. Returns `true` if the type is
   // complete, or `false` if it could not be completed. A complete type has

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -242,7 +242,7 @@ auto DeclNameStack::TryResolveQualifier(NameContext& name_context,
                           SemIR::TypeId);
         auto builder = context_->emitter().Build(
             name_context.parse_node, QualifiedDeclInIncompleteClassScope,
-            context_->classes().Get(class_decl->class_id).self_type_id);
+            context_->GetTypeIdForTypeInstId(name_context.resolved_inst_id));
         context_->NoteIncompleteClass(class_decl->class_id, builder);
         builder.Emit();
       } else {

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -75,7 +75,9 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId parse_node)
 
   // If there was an initializer, assign it to the storage.
   if (init_id) {
-    if (context.GetCurrentScopeAs<SemIR::ClassDecl>()) {
+    if (auto scope_inst_id = context.scope_stack().PeekInstId();
+        scope_inst_id.is_valid() &&
+        context.insts().Is<SemIR::ClassDecl>(scope_inst_id)) {
       // TODO: In a class scope, we should instead save the initializer
       // somewhere so that we can use it as a default.
       context.TODO(parse_node, "Field initializer");

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -353,8 +353,6 @@ class ImportRefResolver {
     class_decl.class_id = context_.classes().Add({
         .name_id = GetLocalNameId(import_class.name_id),
         .enclosing_scope_id = NoEnclosingScopeForImports,
-        // `.self_type_id` depends on the ClassType, so is set below.
-        .self_type_id = SemIR::TypeId::Invalid,
         .decl_id = class_decl_id,
         .inheritance_kind = import_class.inheritance_kind,
     });
@@ -362,13 +360,9 @@ class ImportRefResolver {
     // Write the function ID into the ClassDecl.
     context_.ReplaceInstBeforeConstantUse(class_decl_id,
                                           {Parse::NodeId::Invalid, class_decl});
-    auto self_const_id = context_.constant_values().Get(class_decl_id);
-
-    // Build the `Self` type using the resulting type constant.
-    auto& class_info = context_.classes().Get(class_decl.class_id);
-    class_info.self_type_id = context_.GetTypeIdForTypeConstant(self_const_id);
 
     // Set a constant corresponding to the incomplete class.
+    auto self_const_id = context_.constant_values().Get(class_decl_id);
     import_ir_constant_values_.Set(inst_id, self_const_id);
     return self_const_id;
   }

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -79,17 +79,6 @@ class ScopeStack {
   // there is no such instruction, such as for a block scope.
   auto PeekInstId() const -> SemIR::InstId { return Peek().scope_inst_id; }
 
-  // Returns the current scope, if it is of the specified kind. Otherwise,
-  // returns nullopt.
-  template <typename InstT>
-  auto GetCurrentScopeAs(const SemIR::File& sem_ir) -> std::optional<InstT> {
-    auto inst_id = PeekInstId();
-    if (!inst_id.is_valid()) {
-      return std::nullopt;
-    }
-    return sem_ir.insts().TryGetAs<InstT>(inst_id);
-  }
-
   // If there is no `returned var` in scope, sets the given instruction to be
   // the current `returned var` and returns an invalid instruction ID. If there
   // is already a `returned var`, returns it instead.

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -53,7 +53,7 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Outer {
 // CHECK:STDOUT:   %Inner.decl = class_decl @Inner, () [template = constants.%Inner]
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Outer [template = constants.%Outer]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Outer.decl [template = constants.%Outer]
 // CHECK:STDOUT:   %.loc14_15: type = ptr_type Outer [template = constants.%.3]
 // CHECK:STDOUT:   %.loc14_9: <unbound element of class Outer> = field_decl po, element0 [template]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer.decl [template = constants.%Outer]
@@ -71,7 +71,7 @@ fn F(a: Outer*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Inner {
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Inner [template = constants.%Inner]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, @Outer.%Inner.decl [template = constants.%Inner]
 // CHECK:STDOUT:   %.loc9_17: type = ptr_type Inner [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_11: <unbound element of class Inner> = field_decl pi, element0 [template]
 // CHECK:STDOUT:   %Outer.ref: type = name_ref Outer, file.%Outer.decl [template = constants.%Outer]

--- a/toolchain/check/testdata/class/raw_self_type.carbon
+++ b/toolchain/check/testdata/class/raw_self_type.carbon
@@ -33,11 +33,11 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Self.ref.loc9: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:   %Self.ref.loc9: type = name_ref Self, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %.loc9: type = ptr_type Class [template = constants.%.1]
 // CHECK:STDOUT:   %Self.var: ref Class* = var r#Self
 // CHECK:STDOUT:   %Self: ref Class* = bind_name r#Self, %Self.var
-// CHECK:STDOUT:   %Self.ref.loc10_12: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:   %Self.ref.loc10_12: type = name_ref Self, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %.loc10_16: type = ptr_type Class [template = constants.%.1]
 // CHECK:STDOUT:   %p.var: ref Class* = var p
 // CHECK:STDOUT:   %p: ref Class* = bind_name p, %p.var

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -34,7 +34,7 @@ fn Class.F[self: Class]() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template]
-// CHECK:STDOUT:   %Self.ref: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:   %Self.ref: type = name_ref Self, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %.loc9_14: type = ptr_type Class [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_8: <unbound element of class Class> = field_decl p, element0 [template]
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -110,8 +110,6 @@ struct Class : public Printable<Class> {
   NameId name_id;
   // The enclosing scope.
   NameScopeId enclosing_scope_id;
-  // The class type, which is the type of `Self` in the class definition.
-  TypeId self_type_id;
   // The first declaration of the class. This is a ClassDecl.
   InstId decl_id = InstId::Invalid;
   // The kind of inheritance that this class supports.


### PR DESCRIPTION
This relies more on the constant built for ClassDecl's new constant to provide class information, but as a consequence, does more type lookups for the constant.