### PR TITLE
Add support for importing interfaces.

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -132,7 +132,7 @@ auto HandleClassDefinitionStart(Context& context,
   auto& class_info = context.classes().Get(class_id);
 
   // Track that this declaration is the definition.
-  if (class_info.definition_id.is_valid()) {
+  if (class_info.is_defined()) {
     CARBON_DIAGNOSTIC(ClassRedefinition, Error, "Redefinition of class {0}.",
                       SemIR::NameId);
     CARBON_DIAGNOSTIC(ClassPreviousDefinition, Note,

--- a/toolchain/check/handle_impl.cpp
+++ b/toolchain/check/handle_impl.cpp
@@ -230,7 +230,7 @@ auto HandleImplDefinitionStart(Context& context,
   auto [impl_id, impl_decl_id] = BuildImplDecl(context, parse_node);
   auto& impl_info = context.impls().Get(impl_id);
 
-  if (impl_info.definition_id.is_valid()) {
+  if (impl_info.is_defined()) {
     CARBON_DIAGNOSTIC(ImplRedefinition, Error,
                       "Redefinition of `impl {0} as {1}`.", SemIR::TypeId,
                       SemIR::TypeId);

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -107,7 +107,7 @@ auto HandleInterfaceDefinitionStart(
   auto& interface_info = context.interfaces().Get(interface_id);
 
   // Track that this declaration is the definition.
-  if (interface_info.definition_id.is_valid()) {
+  if (interface_info.is_defined()) {
     CARBON_DIAGNOSTIC(InterfaceRedefinition, Error,
                       "Redefinition of interface {0}.", SemIR::NameId);
     CARBON_DIAGNOSTIC(InterfacePreviousDefinition, Note,

--- a/toolchain/check/testdata/interface/import.carbon
+++ b/toolchain/check/testdata/interface/import.carbon
@@ -17,26 +17,38 @@ interface ForwardDeclared {
   fn F();
 }
 
+var f_ref: {.f: ForwardDeclared};
+
 // --- b.carbon
 
 library "b" api;
 
 import library "a";
 
-// TODO: When ready, consider tests of basic import functionality.
+fn UseEmpty(e: Empty) {}
+fn UseForwardDeclared(f: ForwardDeclared) {}
+
+var f: ForwardDeclared* = &f_ref.f;
 
 // CHECK:STDOUT: --- a.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
 // CHECK:STDOUT:   %.2: type = interface_type @ForwardDeclared [template]
+// CHECK:STDOUT:   %.3: type = struct_type {.f: ForwardDeclared} [template]
+// CHECK:STDOUT:   %.4: type = tuple_type () [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.f: ()} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace {.Empty = %Empty.decl, .ForwardDeclared = %ForwardDeclared.decl.loc7} [template]
+// CHECK:STDOUT:   package: <namespace> = namespace {.Empty = %Empty.decl, .ForwardDeclared = %ForwardDeclared.decl.loc7, .f_ref = %f_ref} [template]
 // CHECK:STDOUT:   %Empty.decl = interface_decl @Empty, () [template = constants.%.1]
 // CHECK:STDOUT:   %ForwardDeclared.decl.loc7 = interface_decl @ForwardDeclared, () [template = constants.%.2]
 // CHECK:STDOUT:   %ForwardDeclared.decl.loc9 = interface_decl @ForwardDeclared, () [template = constants.%.2]
+// CHECK:STDOUT:   %ForwardDeclared.ref: type = name_ref ForwardDeclared, %ForwardDeclared.decl.loc7 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc13: type = struct_type {.f: ForwardDeclared} [template = constants.%.3]
+// CHECK:STDOUT:   %f_ref.var: ref {.f: ForwardDeclared} = var f_ref
+// CHECK:STDOUT:   %f_ref: ref {.f: ForwardDeclared} = bind_name f_ref, %f_ref.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
@@ -55,9 +67,56 @@ import library "a";
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = interface_type @ForwardDeclared [template]
+// CHECK:STDOUT:   %.4: type = ptr_type ForwardDeclared [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.f: ForwardDeclared} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.f: ()} [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   package: <namespace> = namespace {.Empty = %import_ref.1, .ForwardDeclared = %import_ref.2} [template]
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unused
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unused
+// CHECK:STDOUT:   package: <namespace> = namespace {.Empty = %import_ref.1, .ForwardDeclared = %import_ref.2, .f_ref = %import_ref.3, .UseEmpty = %UseEmpty, .UseForwardDeclared = %UseForwardDeclared, .f = %f} [template]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, used [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+3, used [template = constants.%.3]
+// CHECK:STDOUT:   %import_ref.3: ref {.f: ForwardDeclared} = import_ref ir1, inst+16, used
+// CHECK:STDOUT:   %UseEmpty: <function> = fn_decl @UseEmpty [template]
+// CHECK:STDOUT:   %UseForwardDeclared: <function> = fn_decl @UseForwardDeclared [template]
+// CHECK:STDOUT:   %ForwardDeclared.ref: type = name_ref ForwardDeclared, %import_ref.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc9: type = ptr_type ForwardDeclared [template = constants.%.4]
+// CHECK:STDOUT:   %f.var: ref ForwardDeclared* = var f
+// CHECK:STDOUT:   %f: ref ForwardDeclared* = bind_name f, %f.var
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @Empty {
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @ForwardDeclared {
+// CHECK:STDOUT:   %import_ref = import_ref ir1, inst+6, unused
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %import_ref
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @UseEmpty(%e: Empty) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @UseForwardDeclared(%f: ForwardDeclared) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %f_ref.ref: ref {.f: ForwardDeclared} = name_ref f_ref, file.%import_ref.3
+// CHECK:STDOUT:   %.loc9_33: ref ForwardDeclared = struct_access %f_ref.ref, element0
+// CHECK:STDOUT:   %.loc9_27: ForwardDeclared* = addr_of %.loc9_33
+// CHECK:STDOUT:   assign file.%f.var, %.loc9_27
+// CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Interface support is pretty skeletal so this may need additions later, but I think it's still worthwhile to fill in the necessary bits now. With this change, the expectation is then that everything we have right now which _can_ be imported, is supported for import (at least for the "current package, no overlap" case).