### PR TITLE
Make Function member comments align with Class/Interface

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -513,6 +513,7 @@ auto Context::FinalizeGlobalInit() -> void {
     sem_ir().functions().Add(
         {.name_id = SemIR::NameId::ForIdentifier(name_id),
          .enclosing_scope_id = SemIR::NameScopeId::Package,
+         .decl_id = SemIR::InstId::Invalid,
          .implicit_param_refs_id = SemIR::InstBlockId::Empty,
          .param_refs_id = SemIR::InstBlockId::Empty,
          .return_type_id = SemIR::TypeId::Invalid,

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -35,15 +35,15 @@ struct Function : public Printable<Function> {
   static auto GetParamFromParamRefId(const File& sem_ir, InstId param_ref_id)
       -> std::pair<InstId, Param>;
 
+  // The following members always have values, and do not change throughout the
+  // lifetime of the function.
+
   // The function name.
   NameId name_id;
   // The enclosing scope.
   NameScopeId enclosing_scope_id;
   // The first declaration of the function. This is a FunctionDecl.
-  InstId decl_id = InstId::Invalid;
-  // The definition, if the function has been defined or is currently being
-  // defined. This is a FunctionDecl.
-  InstId definition_id = InstId::Invalid;
+  InstId decl_id;
   // A block containing a single reference instruction per implicit parameter.
   InstBlockId implicit_param_refs_id;
   // A block containing a single reference instruction per parameter.
@@ -56,6 +56,15 @@ struct Function : public Printable<Function> {
   // expected to have an additional final argument corresponding to the return
   // slot.
   InstId return_slot_id;
+
+  // The following members are set at the `{` of the function definition.
+
+  // The definition, if the function has been defined or is currently being
+  // defined. This is a FunctionDecl.
+  InstId definition_id = InstId::Invalid;
+
+  // The following members are accumulated throughout the function definition.
+
   // A list of the statically reachable code blocks in the body of the
   // function, in lexical order. The first block is the entry block. This will
   // be empty for declarations that don't have a visible definition.


### PR DESCRIPTION
In `Class` we have:

```
  // The following members always have values, and do not change throughout the
  // lifetime of the class.

  // The following members are set at the `{` of the class definition.

  // The following members are accumulated throughout the class definition.

  // The following members are set at the `}` of the class definition.
```

`Interface` has similar, minus the "accumulated" members. I'm echoing this, except `Function` has no `}` members; at present, nothing differentiates between "started definition" and "completed definition", unlike the other two.

Also removing a slightly inconsistent default value for decl_id.