### PR TITLE
Fix up the C++ snippet to reflect the carbon snippet

### DIFF
--- a/docs/images/snippets.md
+++ b/docs/images/snippets.md
@@ -55,7 +55,7 @@ struct Circle {
 
 void PrintTotalArea(std::span<Circle> circles) {
   std::float32_t area = 0;
-  for (Circle c : circles) {
+  for (const Circle& c : circles) {
     area += std::numbers::pi * c.r * c.r;
   }
   std::print("Total area: {}\n", area);
@@ -101,8 +101,9 @@ fn Main() -> i32 {
 
 ```cpp
 // C++ code used in both Carbon and C++:
+import std;
 struct Circle {
-  float r;
+  std::float32_t r;
 };
 
 // Carbon exposing a function for C++:
@@ -119,9 +120,9 @@ fn PrintTotalArea(circles: Slice(Cpp.Circle)) {
 }
 
 // C++ calling Carbon:
-#include <vector>
-#include "circle.h"
-#include "geometry.carbon.h"
+import std;
+import "circle.h";
+import "geometry.carbon.h";
 
 auto main() -> int {
   std::vector<Circle> circles = {{1.0}, {2.0}};

--- a/docs/images/snippets.md
+++ b/docs/images/snippets.md
@@ -47,7 +47,12 @@ fn QuickSort[T:! Comparable & Movable](s: Slice(T)) {
 
 ```cpp
 // C++:
-import std;
+#include <numbers>
+#include <print>
+#include <span>
+#include <stdfloat>
+#include <vector>
+// or: import std;
 
 struct Circle {
   std::float32_t r;
@@ -101,7 +106,7 @@ fn Main() -> i32 {
 
 ```cpp
 // C++ code used in both Carbon and C++:
-import std;
+#include <stdfloat>
 struct Circle {
   std::float32_t r;
 };
@@ -120,9 +125,9 @@ fn PrintTotalArea(circles: Slice(Cpp.Circle)) {
 }
 
 // C++ calling Carbon:
-import std;
-import "circle.h";
-import "geometry.carbon.h";
+#include <vector>
+#include "circle.h"
+#include "geometry.carbon.h"
 
 auto main() -> int {
   std::vector<Circle> circles = {{1.0}, {2.0}};

--- a/docs/images/snippets.md
+++ b/docs/images/snippets.md
@@ -47,26 +47,23 @@ fn QuickSort[T:! Comparable & Movable](s: Slice(T)) {
 
 ```cpp
 // C++:
-#include <math.h>
-#include <iostream>
-#include <span>
-#include <vector>
+import std;
 
 struct Circle {
-  float r;
+  std::float32_t r;
 };
 
 void PrintTotalArea(std::span<Circle> circles) {
-  float area = 0;
-  for (const Circle& c : circles) {
-    area += M_PI * c.r * c.r;
+  std::float32_t area = 0;
+  for (Circle c : circles) {
+    area += std::numbers::pi * c.r * c.r;
   }
-  std::cout << "Total area: " << area << "\n";
+  std::print("Total area: {}\n", area);
 }
 
-auto main(int argc, char** argv) -> int {
-  std::vector<Circle> circles = {{1.0}, {2.0}};
-  // Implicitly constructors `span` from `vector`.
+auto main() -> int {
+  std::vector<Circle> circles{{.r = 1.0}, {.r = 2.0}};
+  // Implicitly converts `vector` to `span`.
   PrintTotalArea(circles);
   return 0;
 }
@@ -126,7 +123,7 @@ fn PrintTotalArea(circles: Slice(Cpp.Circle)) {
 #include "circle.h"
 #include "geometry.carbon.h"
 
-auto main(int argc, char** argv) -> int {
+auto main() -> int {
   std::vector<Circle> circles = {{1.0}, {2.0}};
   // Carbon's `Slice` supports implicit construction from `std::vector`,
   // similar to `std::span`.


### PR DESCRIPTION
Offers a more precise apples-to-apples language comparison. Replaces the non-portable `M_PI` and removes the extraneous arg parameters. It does use C++23, so I can understand if that's unacceptable for the time being.
