### PR TITLE
Update LLVM version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -134,8 +134,8 @@ bazel_dep(name = "zstd", version = "1.5.5", repo_name = "llvm_zstd")
 
 # We pin to specific upstream commits and try to track top-of-tree reasonably
 # closely rather than pinning to a specific release.
-# HEAD as of 2024-01-03.
-llvm_project_version = "82e33d6203f62c0be16f8da8d4178e7fa9e790ea"
+# HEAD as of 2024-03-06.
+llvm_project_version = "be15a6b3b68bed7b9d982f25b2e10a273302002a"
 
 # Load a repository for the raw llvm-project, pre-overlay.
 http_archive(
@@ -147,7 +147,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
         "@carbon//bazel/llvm_project:0003_Add_library_for_clangd.patch",
     ],
-    sha256 = "402a6dc72452f24ff27ae8157c6d55ea74124de83c57855bbff89b85787fad1c",
+    sha256 = "1e6cc2eb634438a59fb5e1b87e7bb35883fb680dc2934f431150db22fb3a6c09",
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "a678258017137eb32b5857aca1ae0d8c752d0a4d222709f595f16c91e0454851",
+  "moduleFileHash": "1e5fd738dfb368b107a4de0de60d2855d02194e868c5b86031d157353b45f1f5",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -96,10 +96,10 @@
                   "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
                   "@carbon//bazel/llvm_project:0003_Add_library_for_clangd.patch"
                 ],
-                "sha256": "402a6dc72452f24ff27ae8157c6d55ea74124de83c57855bbff89b85787fad1c",
-                "strip_prefix": "llvm-project-82e33d6203f62c0be16f8da8d4178e7fa9e790ea",
+                "sha256": "1e6cc2eb634438a59fb5e1b87e7bb35883fb680dc2934f431150db22fb3a6c09",
+                "strip_prefix": "llvm-project-be15a6b3b68bed7b9d982f25b2e10a273302002a",
                 "urls": [
-                  "https://github.com/llvm/llvm-project/archive/82e33d6203f62c0be16f8da8d4178e7fa9e790ea.tar.gz"
+                  "https://github.com/llvm/llvm-project/archive/be15a6b3b68bed7b9d982f25b2e10a273302002a.tar.gz"
                 ],
                 "name": "llvm-raw"
               },
@@ -1662,10 +1662,10 @@
                 "@@//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
                 "@@//bazel/llvm_project:0003_Add_library_for_clangd.patch"
               ],
-              "sha256": "402a6dc72452f24ff27ae8157c6d55ea74124de83c57855bbff89b85787fad1c",
-              "strip_prefix": "llvm-project-82e33d6203f62c0be16f8da8d4178e7fa9e790ea",
+              "sha256": "1e6cc2eb634438a59fb5e1b87e7bb35883fb680dc2934f431150db22fb3a6c09",
+              "strip_prefix": "llvm-project-be15a6b3b68bed7b9d982f25b2e10a273302002a",
               "urls": [
-                "https://github.com/llvm/llvm-project/archive/82e33d6203f62c0be16f8da8d4178e7fa9e790ea.tar.gz"
+                "https://github.com/llvm/llvm-project/archive/be15a6b3b68bed7b9d982f25b2e10a273302002a.tar.gz"
               ],
               "name": "_main~_repo_rules~llvm-raw"
             }

--- a/bazel/llvm_project/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
+++ b/bazel/llvm_project/0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch
@@ -8,12 +8,12 @@ Subject: [PATCH] Add libfuzzer target to compiler-rt.
  1 file changed, 17 insertions(+)
 
 diff --git a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
-index 573549781ab7..65c9522e022b 100644
+index 9bdd454e1e36..0f30c21f63dc 100644
 --- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
 +++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
-@@ -49,3 +49,20 @@ cc_library(
+@@ -50,3 +50,20 @@ cc_library(
+         ":config",
      ],
-     linkstatic = True,
  )
 +
 +cc_library(

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -777,7 +777,8 @@ static auto Main(int argc, char** argv) -> int {
   llvm::SmallVector<std::string> tests = GetTests();
   auto test_factory = GetFileTestFactory();
   if (absl::GetFlag(FLAGS_autoupdate)) {
-    llvm::ThreadPool pool({.ThreadsRequested = absl::GetFlag(FLAGS_threads)});
+    llvm::DefaultThreadPool pool(
+        {.ThreadsRequested = absl::GetFlag(FLAGS_threads)});
     std::mutex errs_mutex;
 
     for (const auto& test_name : tests) {


### PR DESCRIPTION
Update the compiler-rt patch (maybe this could be upstreamed, or try out https://github.com/google/fuzztest?) and handle the ThreadPool -> DefaultThreadPool rename.