### PR TITLE
Offer GetTypeIdForTypeInst

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -989,8 +989,7 @@ auto Context::GetAssociatedEntityType(SemIR::InterfaceId interface_id,
 
 auto Context::GetBuiltinType(SemIR::BuiltinKind kind) -> SemIR::TypeId {
   CARBON_CHECK(kind != SemIR::BuiltinKind::Invalid);
-  auto type_id = GetTypeIdForTypeConstant(
-      constant_values().Get(SemIR::InstId::ForBuiltin(kind)));
+  auto type_id = GetTypeIdForTypeInst(SemIR::InstId::ForBuiltin(kind));
   // To keep client code simpler, complete builtin types before returning them.
   bool complete = TryToCompleteType(type_id);
   CARBON_CHECK(complete) << "Failed to complete builtin type";

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -210,6 +210,12 @@ class Context {
   // Returns the type ID for a constant of type `type`.
   auto GetTypeIdForTypeConstant(SemIR::ConstantId constant_id) -> SemIR::TypeId;
 
+  // Returns the type ID for an instruction whose constant value is of type
+  // `type`.
+  auto GetTypeIdForTypeInst(SemIR::InstId inst_id) -> SemIR::TypeId {
+    return GetTypeIdForTypeConstant(constant_values().Get(inst_id));
+  }
+
   // Attempts to complete the type `type_id`. Returns `true` if the type is
   // complete, or `false` if it could not be completed. A complete type has
   // known object and value representations.

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -112,8 +112,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId parse_node)
   if (is_new_class) {
     // Build the `Self` type using the resulting type constant.
     auto& class_info = context.classes().Get(class_decl.class_id);
-    class_info.self_type_id = context.GetTypeIdForTypeConstant(
-        context.constant_values().Get(class_decl_id));
+    class_info.self_type_id = context.GetTypeIdForTypeInst(class_decl_id);
   }
 
   return {class_decl.class_id, class_decl_id};

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -139,8 +139,7 @@ auto HandleInterfaceDefinitionStart(
     // TODO: Once we support parameterized interfaces, this won't be the right
     // type. For `interface X(T:! type)`, the type of `Self` is `X(T)`, whereas
     // this will be simply `X`.
-    auto self_type_id = context.GetTypeIdForTypeConstant(
-        context.constant_values().Get(interface_decl_id));
+    auto self_type_id = context.GetTypeIdForTypeInst(interface_decl_id);
 
     // We model `Self` as a symbolic binding whose type is the interface.
     // Because there is no equivalent non-symbolic value, we use `Invalid` as


### PR DESCRIPTION
#3740 added another similar call. This may be temporary, maybe we'll stop using and remove later, but it's a small simplification right now and we might also retain a similar inst -> constant -> type flow.