### PR TITLE
Pass the event path to reviewdog, not to `cat`.

### DIFF
--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -47,5 +47,6 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          GITHUB_EVENT_PATH=./event cat ./diff | \
-          reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-review
+          cat ./diff | \
+          GITHUB_EVENT_PATH=./event \
+            reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-review


### PR DESCRIPTION
Should hopefully cause suggestions to be successfully created.