### PR TITLE
Provide a git checkout for reviewdog.

### DIFF
--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -34,6 +34,8 @@ jobs:
         with:
           reviewdog_version: latest
 
+      - uses: actions/checkout@v3
+
       - name: Download pre-commit output
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
It shouldn't actually need or use this, but it fails if there's no `.git` directory at all.