### PR TITLE
Form the contents of the witness table.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -154,6 +154,7 @@ cc_library(
         ":context",
         ":function",
         "//common:check",
+        "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:ids",
         "//toolchain/sem_ir:inst",

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -152,6 +152,7 @@ cc_library(
     hdrs = ["impl.h"],
     deps = [
         ":context",
+        ":function",
         "//common:check",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:ids",

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -173,6 +173,12 @@ static auto CheckRedecl(Context& context, const SemIR::Function& new_function,
   return true;
 }
 
+auto CheckFunctionRedecl(Context& context, SemIR::FunctionId new_function_id,
+                         SemIR::FunctionId prev_function_id) -> bool {
+  return CheckRedecl(context, context.functions().Get(new_function_id),
+                     context.functions().Get(prev_function_id));
+}
+
 auto MergeFunctionRedecl(Context& context, Parse::NodeId parse_node,
                          SemIR::Function& new_function,
                          SemIR::FunctionId prev_function_id, bool is_definition)

--- a/toolchain/check/function.h
+++ b/toolchain/check/function.h
@@ -10,6 +10,11 @@
 
 namespace Carbon::Check {
 
+// Checks that `new_function_id` does not differ from `prev_function_id`.
+// Prints a suitable diagnostic and returns false if not.
+auto CheckFunctionRedecl(Context& context, SemIR::FunctionId new_function_id,
+                         SemIR::FunctionId prev_function_id) -> bool;
+
 // Tries to merge new_function into prev_function_id. Since new_function won't
 // have a definition even if one is upcoming, set is_definition to indicate the
 // planned result.

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -5,13 +5,88 @@
 #include "toolchain/check/impl.h"
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/function.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/impl.h"
+#include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
 
+// Checks that `impl_function_id` is a valid implementation of the function
+// described in the interface as `interface_function_id`. Returns the value to
+// put into the corresponding slot in the witness table, which can be
+// `BuiltinError` if the function is not usable.
+static auto CheckAssociatedFunctionImplementation(
+    Context& context, SemIR::FunctionId interface_function_id,
+    SemIR::InstId impl_decl_id) -> SemIR::InstId {
+  auto decl_node = context.insts().GetParseNode(impl_decl_id);
+  auto impl_function_decl =
+      context.insts().TryGetAs<SemIR::FunctionDecl>(impl_decl_id);
+  if (!impl_function_decl) {
+    context.TODO(decl_node, "diagnose non-function implementing function");
+    return SemIR::InstId::BuiltinError;
+  }
+
+  // TODO: Substitute the `Self` from the `impl` into the type in the interface
+  // before checking. Also, this should be a semantic check rather than a
+  // syntactic one. The functions should be allowed to have different signatures
+  // as long as we can synthesize a suitable thunk.
+  if (!CheckFunctionRedecl(context, impl_function_decl->function_id,
+                           interface_function_id)) {
+    return SemIR::InstId::BuiltinError;
+  }
+  return impl_decl_id;
+}
+
+// Builds a witness that the specified impl implements the given interface.
+static auto BuildInterfaceWitness(
+    Context& context, const SemIR::Impl& impl, SemIR::InterfaceId interface_id,
+    llvm::SmallVectorImpl<SemIR::InstId>& used_decl_ids) -> SemIR::InstId {
+  const auto& interface = context.interfaces().Get(interface_id);
+  if (!interface.is_defined()) {
+    context.TODO(context.insts().GetParseNode(impl.definition_id),
+                 "impl of non-defined interface");
+    return SemIR::InstId::BuiltinError;
+  }
+
+  auto& impl_scope = context.name_scopes().Get(impl.scope_id);
+
+  llvm::SmallVector<SemIR::InstId, 32> table;
+  auto assoc_entities = context.inst_blocks().Get(interface.associated_entities_id);
+  table.reserve(assoc_entities.size());
+
+  for (auto decl_id : assoc_entities) {
+    auto decl = context.insts().Get(decl_id);
+    if (auto fn_decl = decl.TryAs<SemIR::FunctionDecl>()) {
+      auto& fn = context.functions().Get(fn_decl->function_id);
+      auto impl_decl_id = context.LookupNameInExactScope(fn.name_id, impl_scope);
+      if (impl_decl_id.is_valid()) {
+        used_decl_ids.push_back(impl_decl_id);
+        table.push_back(CheckAssociatedFunctionImplementation(
+            context, fn_decl->function_id, impl_decl_id));
+      } else {
+        context.TODO(context.insts().GetParseNode(impl.definition_id),
+                     "diagnose missing decl in impl");
+        table.push_back(SemIR::InstId::BuiltinError);
+      }
+    } else if (auto const_decl = decl.TryAs<SemIR::AssociatedConstantDecl>()) {
+      // TODO: Check we have a value for this constant in the constraint.
+      context.TODO(context.insts().GetParseNode(impl.definition_id),
+                   "impl of interface with associated constant");
+      return SemIR::InstId::BuiltinError;
+    } else {
+      CARBON_FATAL() << "Unexpected kind of associated entity " << decl;
+    }
+  }
+
+  auto table_id = context.inst_blocks().Add(table);
+  return context.AddInst(SemIR::InterfaceWitness{
+      context.GetBuiltinType(SemIR::BuiltinKind::WitnessType), interface_id,
+      table_id});
+}
+
 auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)
-    -> SemIR::InstId {
+	-> SemIR::InstId {
   auto& impl = context.impls().Get(impl_id);
   CARBON_CHECK(impl.is_being_defined());
 
@@ -24,14 +99,14 @@ auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)
     return SemIR::InstId::BuiltinError;
   }
 
-  auto interface_id = interface_type->interface_id;
+  llvm::SmallVector<SemIR::InstId, 32> used_decl_ids;
 
-  // TODO: Form the witness table.
+  auto witness_id =
+      BuildInterfaceWitness(context, impl, interface_type->interface_id, used_decl_ids);
 
-  auto table_id = context.inst_blocks().Add({});
-  return context.AddInst(SemIR::InterfaceWitness{
-      context.GetBuiltinType(SemIR::BuiltinKind::WitnessType), interface_id,
-      table_id});
+  // TODO: Diagnose if any declarations in the impl are not in used_decl_ids.
+
+  return witness_id;
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -20,8 +20,7 @@ static auto NoteAssociatedFunction(Context& context,
   CARBON_DIAGNOSTIC(ImplAssociatedFunctionHere, Note,
                     "Associated function {0} declared here.", SemIR::NameId);
   const auto& function = context.functions().Get(function_id);
-  builder.Note(function.decl_id,
-               ImplAssociatedFunctionHere, function.name_id);
+  builder.Note(function.decl_id, ImplAssociatedFunctionHere, function.name_id);
 }
 
 // Checks that `impl_function_id` is a valid implementation of the function
@@ -67,8 +66,7 @@ static auto BuildInterfaceWitness(
                       "Implementation of undefined interface {0}.",
                       SemIR::NameId);
     auto builder = context.emitter().Build(
-        impl.definition_id,
-        ImplOfUndefinedInterface, interface.name_id);
+        impl.definition_id, ImplOfUndefinedInterface, interface.name_id);
     context.NoteUndefinedInterface(interface_id, builder);
     builder.Emit();
     return SemIR::InstId::BuiltinError;
@@ -96,9 +94,9 @@ static auto BuildInterfaceWitness(
             ImplMissingFunction, Error,
             "Missing implementation of {0} in impl of interface {1}.",
             SemIR::NameId, SemIR::NameId);
-        auto builder = context.emitter().Build(
-            impl.definition_id,
-            ImplMissingFunction, fn.name_id, interface.name_id);
+        auto builder =
+            context.emitter().Build(impl.definition_id, ImplMissingFunction,
+                                    fn.name_id, interface.name_id);
         NoteAssociatedFunction(context, builder, fn_decl->function_id);
         builder.Emit();
 

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -74,7 +74,7 @@ static auto BuildInterfaceWitness(
 
   auto& impl_scope = context.name_scopes().Get(impl.scope_id);
 
-  llvm::SmallVector<SemIR::InstId, 32> table;
+  llvm::SmallVector<SemIR::InstId> table;
   auto assoc_entities =
       context.inst_blocks().Get(interface.associated_entities_id);
   table.reserve(assoc_entities.size());
@@ -132,7 +132,7 @@ auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)
     return SemIR::InstId::BuiltinError;
   }
 
-  llvm::SmallVector<SemIR::InstId, 32> used_decl_ids;
+  llvm::SmallVector<SemIR::InstId> used_decl_ids;
 
   auto witness_id = BuildInterfaceWitness(
       context, impl, interface_type->interface_id, used_decl_ids);

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -13,13 +13,14 @@
 
 namespace Carbon::Check {
 
+// Adds the location of the associated function to a diagnostic.
 static auto NoteAssociatedFunction(Context& context,
                                    Context::DiagnosticBuilder& builder,
                                    SemIR::FunctionId function_id) -> void {
   CARBON_DIAGNOSTIC(ImplAssociatedFunctionHere, Note,
                     "Associated function {0} declared here.", SemIR::NameId);
   const auto& function = context.functions().Get(function_id);
-  builder.Note(context.insts().GetParseNode(function.decl_id),
+  builder.Note(function.decl_id,
                ImplAssociatedFunctionHere, function.name_id);
 }
 
@@ -37,7 +38,7 @@ static auto CheckAssociatedFunctionImplementation(
                       "Associated function {0} implemented by non-function.",
                       SemIR::NameId);
     auto builder = context.emitter().Build(
-        context.insts().GetParseNode(impl_decl_id), ImplFunctionWithNonFunction,
+        impl_decl_id, ImplFunctionWithNonFunction,
         context.functions().Get(interface_function_id).name_id);
     NoteAssociatedFunction(context, builder, interface_function_id);
     builder.Emit();
@@ -66,7 +67,7 @@ static auto BuildInterfaceWitness(
                       "Implementation of undefined interface {0}.",
                       SemIR::NameId);
     auto builder = context.emitter().Build(
-        context.insts().GetParseNode(impl.definition_id),
+        impl.definition_id,
         ImplOfUndefinedInterface, interface.name_id);
     context.NoteUndefinedInterface(interface_id, builder);
     builder.Emit();
@@ -96,7 +97,7 @@ static auto BuildInterfaceWitness(
             "Missing implementation of {0} in impl of interface {1}.",
             SemIR::NameId, SemIR::NameId);
         auto builder = context.emitter().Build(
-            context.insts().GetParseNode(impl.definition_id),
+            impl.definition_id,
             ImplMissingFunction, fn.name_id, interface.name_id);
         NoteAssociatedFunction(context, builder, fn_decl->function_id);
         builder.Emit();

--- a/toolchain/check/testdata/impl/basic.carbon
+++ b/toolchain/check/testdata/impl/basic.carbon
@@ -18,7 +18,7 @@ impl i32 as Simple {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
-// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, () [template]
+// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -44,7 +44,7 @@ impl i32 as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: i32 as Simple {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
-// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, () [template = constants.%.4]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, (%F) [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
@@ -21,7 +21,7 @@ impl as Simple {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
-// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, () [template]
+// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,7 +47,7 @@ impl as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: <error> as Simple {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
-// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, () [template = constants.%.4]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, (%F) [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
@@ -1,0 +1,47 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+interface I { let T:! type; }
+
+// CHECK:STDERR: fail_impl_bad_assoc_const.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `impl of interface with associated constant`.
+// CHECK:STDERR: impl bool as I {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~
+impl bool as I {}
+
+// CHECK:STDOUT: --- fail_impl_bad_assoc_const.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
+// CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%.1] {}
+// CHECK:STDOUT:   impl_decl @impl {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, %I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
+// CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .T = %.loc7
+// CHECK:STDOUT:   witness = (%T)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: bool as I {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -1,0 +1,570 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+interface I { fn F(); }
+
+class NoF {
+  // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:3: ERROR: Missing implementation of F in impl of interface I.
+  // CHECK:STDERR:   impl as I {}
+  // CHECK:STDERR:   ^~~~~~~~~~~
+  // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-6]]:15: Associated function F declared here.
+  // CHECK:STDERR: interface I { fn F(); }
+  // CHECK:STDERR:               ^~~~~~~
+  impl as I {}
+}
+
+class FNotFunction {
+  impl as I {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Associated function F implemented by non-function.
+    // CHECK:STDERR:     class F;
+    // CHECK:STDERR:     ^~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-17]]:15: Associated function F declared here.
+    // CHECK:STDERR: interface I { fn F(); }
+    // CHECK:STDERR:               ^~~~~~~
+    class F;
+  }
+}
+
+fn PossiblyF();
+
+// TODO: Should this be permitted?
+class FAlias {
+  impl as I {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:11: ERROR: Associated function F implemented by non-function.
+    // CHECK:STDERR:     alias F = PossiblyF;
+    // CHECK:STDERR:           ^
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-32]]:15: Associated function F declared here.
+    // CHECK:STDERR: interface I { fn F(); }
+    // CHECK:STDERR:               ^~~~~~~
+    alias F = PossiblyF;
+  }
+}
+
+class FExtraParam {
+  impl as I {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of parameter count of 1.
+    // CHECK:STDERR:     fn F(b: bool);
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-44]]:15: Previously declared with parameter count of 0.
+    // CHECK:STDERR: interface I { fn F(); }
+    // CHECK:STDERR:               ^~~~~~~
+    fn F(b: bool);
+  }
+}
+
+class FExtraImplicitParam {
+  impl as I {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 1.
+    // CHECK:STDERR:     fn F[self: Self]();
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-56]]:15: Previously declared with implicit parameter count of 0.
+    // CHECK:STDERR: interface I { fn F(); }
+    // CHECK:STDERR:               ^~~~~~~
+    fn F[self: Self]();
+  }
+}
+
+// TODO: Should this be permitted?
+class FExtraReturnType {
+  impl as I {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `bool`.
+    // CHECK:STDERR:     fn F() -> bool;
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-69]]:15: Previously declared with no return type.
+    // CHECK:STDERR: interface I { fn F(); }
+    // CHECK:STDERR:               ^~~~~~~
+    fn F() -> bool;
+  }
+}
+
+interface J { fn F[self: bool](b: bool) -> bool; }
+
+class FMissingParam {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of parameter count of 0.
+    // CHECK:STDERR:     fn F[self: bool]() -> bool;
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-7]]:15: Previously declared with parameter count of 1.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F[self: bool]() -> bool;
+  }
+}
+
+class FMissingImplicitParam {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 0.
+    // CHECK:STDERR:     fn F(b: bool) -> bool;
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-19]]:15: Previously declared with implicit parameter count of 1.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F(b: bool) -> bool;
+  }
+}
+
+class FMissingReturnType {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because no return type is provided.
+    // CHECK:STDERR:     fn F[self: bool](b: bool);
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-31]]:15: Previously declared with return type `bool`.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F[self: bool](b: bool);
+  }
+}
+
+class FDifferentParamType {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:22: ERROR: Function redeclaration differs at parameter 1.
+    // CHECK:STDERR:     fn F[self: bool](b: Self) -> bool;
+    // CHECK:STDERR:                      ^
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-43]]:32: Previous declaration's corresponding parameter here.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:                                ^
+    fn F[self: bool](b: Self) -> bool;
+  }
+}
+
+class FDifferentImplicitParamType {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:10: ERROR: Function redeclaration differs at implicit parameter 1.
+    // CHECK:STDERR:     fn F[self: Self](b: bool) -> bool;
+    // CHECK:STDERR:          ^~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-55]]:20: Previous declaration's corresponding implicit parameter here.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:                    ^~~~
+    fn F[self: Self](b: bool) -> bool;
+  }
+}
+
+class FDifferentReturnType {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:31: ERROR: Function returns incomplete type `FDifferentReturnType`.
+    // CHECK:STDERR:     fn F[self: bool](b: bool) -> Self;
+    // CHECK:STDERR:                               ^~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
+    // CHECK:STDERR: class FDifferentReturnType {
+    // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F[self: bool](b: bool) -> Self;
+  }
+}
+
+// TODO: This should probably be permitted.
+class FDifferentParamName {
+  impl as J {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:22: ERROR: Function redeclaration differs at parameter 1.
+    // CHECK:STDERR:     fn F[self: bool](not_b: bool) -> bool;
+    // CHECK:STDERR:                      ^~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-80]]:32: Previous declaration's corresponding parameter here.
+    // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
+    // CHECK:STDERR:                                ^
+    fn F[self: bool](not_b: bool) -> bool;
+  }
+}
+
+// CHECK:STDOUT: --- fail_impl_bad_assoc_fn.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
+// CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
+// CHECK:STDOUT:   %NoF: type = class_type @NoF [template]
+// CHECK:STDOUT:   %.4: type = struct_type {} [template]
+// CHECK:STDOUT:   %FNotFunction: type = class_type @FNotFunction [template]
+// CHECK:STDOUT:   %F: type = class_type @F.13 [template]
+// CHECK:STDOUT:   %FAlias: type = class_type @FAlias [template]
+// CHECK:STDOUT:   %FExtraParam: type = class_type @FExtraParam [template]
+// CHECK:STDOUT:   %FExtraImplicitParam: type = class_type @FExtraImplicitParam [template]
+// CHECK:STDOUT:   %FExtraReturnType: type = class_type @FExtraReturnType [template]
+// CHECK:STDOUT:   %.5: type = interface_type @J [template]
+// CHECK:STDOUT:   %.6: type = assoc_entity_type @J, <function> [template]
+// CHECK:STDOUT:   %.7: <associated <function> in J> = assoc_entity element0, @J.%F [template]
+// CHECK:STDOUT:   %FMissingParam: type = class_type @FMissingParam [template]
+// CHECK:STDOUT:   %FMissingImplicitParam: type = class_type @FMissingImplicitParam [template]
+// CHECK:STDOUT:   %FMissingReturnType: type = class_type @FMissingReturnType [template]
+// CHECK:STDOUT:   %FDifferentParamType: type = class_type @FDifferentParamType [template]
+// CHECK:STDOUT:   %FDifferentImplicitParamType: type = class_type @FDifferentImplicitParamType [template]
+// CHECK:STDOUT:   %FDifferentReturnType: type = class_type @FDifferentReturnType [template]
+// CHECK:STDOUT:   %FDifferentParamName: type = class_type @FDifferentParamName [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:     .NoF = %NoF.decl
+// CHECK:STDOUT:     .FNotFunction = %FNotFunction.decl
+// CHECK:STDOUT:     .PossiblyF = %PossiblyF
+// CHECK:STDOUT:     .FAlias = %FAlias.decl
+// CHECK:STDOUT:     .FExtraParam = %FExtraParam.decl
+// CHECK:STDOUT:     .FExtraImplicitParam = %FExtraImplicitParam.decl
+// CHECK:STDOUT:     .FExtraReturnType = %FExtraReturnType.decl
+// CHECK:STDOUT:     .J = %J.decl
+// CHECK:STDOUT:     .FMissingParam = %FMissingParam.decl
+// CHECK:STDOUT:     .FMissingImplicitParam = %FMissingImplicitParam.decl
+// CHECK:STDOUT:     .FMissingReturnType = %FMissingReturnType.decl
+// CHECK:STDOUT:     .FDifferentParamType = %FDifferentParamType.decl
+// CHECK:STDOUT:     .FDifferentImplicitParamType = %FDifferentImplicitParamType.decl
+// CHECK:STDOUT:     .FDifferentReturnType = %FDifferentReturnType.decl
+// CHECK:STDOUT:     .FDifferentParamName = %FDifferentParamName.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%.1] {}
+// CHECK:STDOUT:   %NoF.decl: type = class_decl @NoF [template = constants.%NoF] {}
+// CHECK:STDOUT:   %FNotFunction.decl: type = class_decl @FNotFunction [template = constants.%FNotFunction] {}
+// CHECK:STDOUT:   %PossiblyF: <function> = fn_decl @PossiblyF [template] {}
+// CHECK:STDOUT:   %FAlias.decl: type = class_decl @FAlias [template = constants.%FAlias] {}
+// CHECK:STDOUT:   %FExtraParam.decl: type = class_decl @FExtraParam [template = constants.%FExtraParam] {}
+// CHECK:STDOUT:   %FExtraImplicitParam.decl: type = class_decl @FExtraImplicitParam [template = constants.%FExtraImplicitParam] {}
+// CHECK:STDOUT:   %FExtraReturnType.decl: type = class_decl @FExtraReturnType [template = constants.%FExtraReturnType] {}
+// CHECK:STDOUT:   %J.decl: type = interface_decl @J [template = constants.%.5] {}
+// CHECK:STDOUT:   %FMissingParam.decl: type = class_decl @FMissingParam [template = constants.%FMissingParam] {}
+// CHECK:STDOUT:   %FMissingImplicitParam.decl: type = class_decl @FMissingImplicitParam [template = constants.%FMissingImplicitParam] {}
+// CHECK:STDOUT:   %FMissingReturnType.decl: type = class_decl @FMissingReturnType [template = constants.%FMissingReturnType] {}
+// CHECK:STDOUT:   %FDifferentParamType.decl: type = class_decl @FDifferentParamType [template = constants.%FDifferentParamType] {}
+// CHECK:STDOUT:   %FDifferentImplicitParamType.decl: type = class_decl @FDifferentImplicitParamType [template = constants.%FDifferentImplicitParamType] {}
+// CHECK:STDOUT:   %FDifferentReturnType.decl: type = class_decl @FDifferentReturnType [template = constants.%FDifferentReturnType] {}
+// CHECK:STDOUT:   %FDifferentParamName.decl: type = class_decl @FDifferentParamName [template = constants.%FDifferentParamName] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
+// CHECK:STDOUT:   %.loc7: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .F = %.loc7
+// CHECK:STDOUT:   witness = (%F)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @J {
+// CHECK:STDOUT:   %Self: J = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.5 [template] {
+// CHECK:STDOUT:     %self.loc83_20.1: bool = param self
+// CHECK:STDOUT:     %self.loc83_20.2: bool = bind_name self, %self.loc83_20.1
+// CHECK:STDOUT:     %b.loc83_32.1: bool = param b
+// CHECK:STDOUT:     %b.loc83_32.2: bool = bind_name b, %b.loc83_32.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc83: <associated <function> in J> = assoc_entity element0, %F [template = constants.%.7]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .F = %.loc83
+// CHECK:STDOUT:   witness = (%F)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.1: NoF as I {
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.2: FNotFunction as I {
+// CHECK:STDOUT:   %F.decl: type = class_decl @F.13 [template = constants.%F] {}
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F.decl
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.3: FAlias as I {
+// CHECK:STDOUT:   %PossiblyF.ref: <function> = name_ref PossiblyF, file.%PossiblyF [template = file.%PossiblyF]
+// CHECK:STDOUT:   %F: <function> = bind_alias F, file.%PossiblyF [template = file.%PossiblyF]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.4: FExtraParam as I {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
+// CHECK:STDOUT:     %b.loc54_10.1: bool = param b
+// CHECK:STDOUT:     %b.loc54_10.2: bool = bind_name b, %b.loc54_10.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.5: FExtraImplicitParam as I {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FExtraImplicitParam [template = constants.%FExtraImplicitParam]
+// CHECK:STDOUT:     %self.loc66_10.1: FExtraImplicitParam = param self
+// CHECK:STDOUT:     %self.loc66_10.2: FExtraImplicitParam = bind_name self, %self.loc66_10.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.6: FExtraReturnType as I {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.4 [template] {
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @I, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.7: FMissingParam as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.6 [template] {
+// CHECK:STDOUT:     %self.loc93_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc93_10.2: bool = bind_name self, %self.loc93_10.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.8: FMissingImplicitParam as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.7 [template] {
+// CHECK:STDOUT:     %b.loc105_10.1: bool = param b
+// CHECK:STDOUT:     %b.loc105_10.2: bool = bind_name b, %b.loc105_10.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.9: FMissingReturnType as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.8 [template] {
+// CHECK:STDOUT:     %self.loc117_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc117_10.2: bool = bind_name self, %self.loc117_10.1
+// CHECK:STDOUT:     %b.loc117_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc117_22.2: bool = bind_name b, %b.loc117_22.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.10: FDifferentParamType as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.9 [template] {
+// CHECK:STDOUT:     %self.loc129_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc129_10.2: bool = bind_name self, %self.loc129_10.1
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentParamType [template = constants.%FDifferentParamType]
+// CHECK:STDOUT:     %b.loc129_22.1: FDifferentParamType = param b
+// CHECK:STDOUT:     %b.loc129_22.2: FDifferentParamType = bind_name b, %b.loc129_22.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.11: FDifferentImplicitParamType as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.10 [template] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentImplicitParamType [template = constants.%FDifferentImplicitParamType]
+// CHECK:STDOUT:     %self.loc141_10.1: FDifferentImplicitParamType = param self
+// CHECK:STDOUT:     %self.loc141_10.2: FDifferentImplicitParamType = bind_name self, %self.loc141_10.1
+// CHECK:STDOUT:     %b.loc141_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc141_22.2: bool = bind_name b, %b.loc141_22.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.12: FDifferentReturnType as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.11 [template] {
+// CHECK:STDOUT:     %self.loc153_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc153_10.2: bool = bind_name self, %self.loc153_10.1
+// CHECK:STDOUT:     %b.loc153_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc153_22.2: bool = bind_name b, %b.loc153_22.1
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentReturnType [template = constants.%FDifferentReturnType]
+// CHECK:STDOUT:     %return.var: ref FDifferentReturnType = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.13: FDifferentParamName as J {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.12 [template] {
+// CHECK:STDOUT:     %self.loc166_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc166_10.2: bool = bind_name self, %self.loc166_10.1
+// CHECK:STDOUT:     %not_b.loc166_22.1: bool = param not_b
+// CHECK:STDOUT:     %not_b.loc166_22.2: bool = bind_name not_b, %not_b.loc166_22.1
+// CHECK:STDOUT:     %return.var: ref bool = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @J, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @NoF {
+// CHECK:STDOUT:   impl_decl @impl.1 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%NoF
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FNotFunction {
+// CHECK:STDOUT:   impl_decl @impl.2 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FNotFunction
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @F.13;
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FAlias {
+// CHECK:STDOUT:   impl_decl @impl.3 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FAlias
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FExtraParam {
+// CHECK:STDOUT:   impl_decl @impl.4 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FExtraParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FExtraImplicitParam {
+// CHECK:STDOUT:   impl_decl @impl.5 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FExtraImplicitParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FExtraReturnType {
+// CHECK:STDOUT:   impl_decl @impl.6 {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FExtraReturnType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FMissingParam {
+// CHECK:STDOUT:   impl_decl @impl.7 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FMissingParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FMissingImplicitParam {
+// CHECK:STDOUT:   impl_decl @impl.8 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FMissingImplicitParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FMissingReturnType {
+// CHECK:STDOUT:   impl_decl @impl.9 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FMissingReturnType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FDifferentParamType {
+// CHECK:STDOUT:   impl_decl @impl.10 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FDifferentParamType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FDifferentImplicitParamType {
+// CHECK:STDOUT:   impl_decl @impl.11 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FDifferentImplicitParamType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FDifferentReturnType {
+// CHECK:STDOUT:   impl_decl @impl.12 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FDifferentReturnType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @FDifferentParamName {
+// CHECK:STDOUT:   impl_decl @impl.13 {
+// CHECK:STDOUT:     %J.ref: type = name_ref J, file.%J.decl [template = constants.%.5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%FDifferentParamName
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.1();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @PossiblyF();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2(@impl.4.%b.loc54_10.2: bool);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.3[@impl.5.%self.loc66_10.2: FExtraImplicitParam]();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.4() -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.5[@J.%self.loc83_20.2: bool](@J.%b.loc83_32.2: bool) -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.6[@impl.7.%self.loc93_10.2: bool]() -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.7(@impl.8.%b.loc105_10.2: bool) -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.8[@impl.9.%self.loc117_10.2: bool](@impl.9.%b.loc117_22.2: bool);
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.9[@impl.10.%self.loc129_10.2: bool](@impl.10.%b.loc129_22.2: FDifferentParamType) -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.10[@impl.11.%self.loc141_10.2: FDifferentImplicitParamType](@impl.11.%b.loc141_22.2: bool) -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.11[@impl.12.%self.loc153_10.2: bool](@impl.12.%b.loc153_22.2: bool) -> <error>;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.12[@impl.13.%self.loc166_10.2: bool](@impl.13.%not_b.loc166_22.2: bool) -> bool;
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_todo_extend_impl.carbon
+++ b/toolchain/check/testdata/impl/fail_todo_extend_impl.carbon
@@ -34,7 +34,7 @@ fn G(c: C) {
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
-// CHECK:STDOUT:   %.4: <witness> = interface_witness @HasF, () [template]
+// CHECK:STDOUT:   %.4: <witness> = interface_witness @HasF, (@impl.%F) [template]
 // CHECK:STDOUT:   %.5: type = struct_type {} [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
@@ -68,7 +68,7 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as HasF {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
-// CHECK:STDOUT:   %.1: <witness> = interface_witness @HasF, () [template = constants.%.4]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @HasF, (%F) [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
@@ -1,0 +1,44 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+interface I { let T:! type; }
+
+// CHECK:STDERR: fail_todo_impl_assoc_const.carbon:[[@LINE+3]]:16: ERROR: `impl` declarations must either end with a `;` or have a `{ ... }` block for a definition.
+// CHECK:STDERR: impl bool as I where .T = bool {}
+// CHECK:STDERR:                ^~~~~
+impl bool as I where .T = bool {}
+
+// CHECK:STDOUT: --- fail_todo_impl_assoc_const.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
+// CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .I = %I.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%.1] {}
+// CHECK:STDOUT:   impl_decl @impl {
+// CHECK:STDOUT:     %I.ref: type = name_ref I, %I.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @I {
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
+// CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .T = %.loc7
+// CHECK:STDOUT:   witness = (%T)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: bool as I;
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_todo_self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/fail_todo_self_in_signature.carbon
@@ -12,16 +12,16 @@ class C {}
 
 impl C as UseSelf {
   // TODO: Use `Self` below once it's supported.
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Function redeclaration differs at implicit parameter 1.
+  // CHECK:STDERR: fail_todo_self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Function redeclaration differs at implicit parameter 1.
   // CHECK:STDERR:   fn F[self: C](x: C) -> C { return {}; }
   // CHECK:STDERR:        ^~~~
-  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-10]]:8: Previous declaration's corresponding implicit parameter here.
+  // CHECK:STDERR: fail_todo_self_in_signature.carbon:[[@LINE-10]]:8: Previous declaration's corresponding implicit parameter here.
   // CHECK:STDERR:   fn F[self: Self](x: Self) -> Self;
   // CHECK:STDERR:        ^~~~
   fn F[self: C](x: C) -> C { return {}; }
 }
 
-// CHECK:STDOUT: --- self_in_signature.carbon
+// CHECK:STDOUT: --- fail_todo_self_in_signature.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -21,7 +21,7 @@ class C {
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
-// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, () [template]
+// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, (@impl.%F) [template]
 // CHECK:STDOUT:   %.5: type = struct_type {} [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -47,7 +47,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as Simple {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
-// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, () [template = constants.%.4]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, (%F) [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -18,7 +18,7 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
-// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, () [template]
+// CHECK:STDOUT:   %.4: <witness> = interface_witness @Simple, (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,7 +47,7 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: T as Simple {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
-// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, () [template = constants.%.4]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @Simple, (%F) [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -75,13 +75,13 @@ impl C as UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as UseSelf {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %C.ref.loc24_14: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %self.loc24_8.1: C = param self
-// CHECK:STDOUT:     %self.loc24_8.2: C = bind_name self, %self.loc24_8.1
-// CHECK:STDOUT:     %C.ref.loc24_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x.loc24_17.1: C = param x
-// CHECK:STDOUT:     %x.loc24_17.2: C = bind_name x, %x.loc24_17.1
-// CHECK:STDOUT:     %C.ref.loc24_26: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc21_14: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %self.loc21_8.1: C = param self
+// CHECK:STDOUT:     %self.loc21_8.2: C = bind_name self, %self.loc21_8.1
+// CHECK:STDOUT:     %C.ref.loc21_20: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %x.loc21_17.1: C = param x
+// CHECK:STDOUT:     %x.loc21_17.2: C = bind_name x, %x.loc21_17.1
+// CHECK:STDOUT:     %C.ref.loc21_26: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %return.var: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness @UseSelf, (<error>) [template = <error>]
@@ -98,11 +98,11 @@ impl C as UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1[@UseSelf.%self.loc8_8.2: Self](@UseSelf.%x.loc8_20.2: Self) -> Self;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2[@impl.%self.loc24_8.2: C](@impl.%x.loc24_17.2: C) -> @impl.%return.var: C {
+// CHECK:STDOUT: fn @F.2[@impl.%self.loc21_8.2: C](@impl.%x.loc21_17.2: C) -> @impl.%return.var: C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc24_38.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc24_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc24_38.3: init C = converted %.loc24_38.1, %.loc24_38.2 [template = constants.%.7]
-// CHECK:STDOUT:   return %.loc24_38.3
+// CHECK:STDOUT:   %.loc21_38.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc21_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_38.3: init C = converted %.loc21_38.1, %.loc21_38.2 [template = constants.%.7]
+// CHECK:STDOUT:   return %.loc21_38.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -1,0 +1,108 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+interface UseSelf {
+  fn F[self: Self](x: Self) -> Self;
+}
+
+class C {}
+
+impl C as UseSelf {
+  // TODO: Use `Self` below once it's supported.
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Function redeclaration differs at implicit parameter 1.
+  // CHECK:STDERR:   fn F[self: C](x: C) -> C { return {}; }
+  // CHECK:STDERR:        ^~~~
+  // CHECK:STDERR: self_in_signature.carbon:[[@LINE-10]]:8: Previous declaration's corresponding implicit parameter here.
+  // CHECK:STDERR:   fn F[self: Self](x: Self) -> Self;
+  // CHECK:STDERR:        ^~~~
+  fn F[self: C](x: C) -> C { return {}; }
+}
+
+// CHECK:STDOUT: --- self_in_signature.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
+// CHECK:STDOUT:   %.2: type = assoc_entity_type @UseSelf, <function> [template]
+// CHECK:STDOUT:   %.3: <associated <function> in UseSelf> = assoc_entity element0, @UseSelf.%F [template]
+// CHECK:STDOUT:   %C: type = class_type @C [template]
+// CHECK:STDOUT:   %.4: type = struct_type {} [template]
+// CHECK:STDOUT:   %.5: type = tuple_type () [template]
+// CHECK:STDOUT:   %.6: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.7: C = struct_value () [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .UseSelf = %UseSelf.decl
+// CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %UseSelf.decl: type = interface_decl @UseSelf [template = constants.%.1] {}
+// CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT:   impl_decl @impl {
+// CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %UseSelf.ref: type = name_ref UseSelf, %UseSelf.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: interface @UseSelf {
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
+// CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %self.loc8_8.1: Self = param self
+// CHECK:STDOUT:     %self.loc8_8.2: Self = bind_name self, %self.loc8_8.1
+// CHECK:STDOUT:     %Self.ref.loc8_23: UseSelf = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_23.1: type = facet_type_access %Self.ref.loc8_23 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_23.2: type = converted %Self.ref.loc8_23, %.loc8_23.1 [symbolic = %Self]
+// CHECK:STDOUT:     %x.loc8_20.1: Self = param x
+// CHECK:STDOUT:     %x.loc8_20.2: Self = bind_name x, %x.loc8_20.1
+// CHECK:STDOUT:     %Self.ref.loc8_32: UseSelf = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_32.1: type = facet_type_access %Self.ref.loc8_32 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_32.2: type = converted %Self.ref.loc8_32, %.loc8_32.1 [symbolic = %Self]
+// CHECK:STDOUT:     %return.var: ref Self = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc8_36: <associated <function> in UseSelf> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .F = %.loc8_36
+// CHECK:STDOUT:   witness = (%F)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl: C as UseSelf {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
+// CHECK:STDOUT:     %C.ref.loc24_14: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %self.loc24_8.1: C = param self
+// CHECK:STDOUT:     %self.loc24_8.2: C = bind_name self, %self.loc24_8.1
+// CHECK:STDOUT:     %C.ref.loc24_20: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %x.loc24_17.1: C = param x
+// CHECK:STDOUT:     %x.loc24_17.2: C = bind_name x, %x.loc24_17.1
+// CHECK:STDOUT:     %C.ref.loc24_26: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %return.var: ref C = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness @UseSelf, (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @C {
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%C
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.1[@UseSelf.%self.loc8_8.2: Self](@UseSelf.%x.loc8_20.2: Self) -> Self;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2[@impl.%self.loc24_8.2: C](@impl.%x.loc24_17.2: C) -> @impl.%return.var: C {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc24_38.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc24_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
+// CHECK:STDOUT:   %.loc24_38.3: init C = converted %.loc24_38.1, %.loc24_38.2 [template = constants.%.7]
+// CHECK:STDOUT:   return %.loc24_38.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -198,6 +198,9 @@ CARBON_DIAGNOSTIC_KIND(ExtendUndefinedInterface)
 CARBON_DIAGNOSTIC_KIND(ImplAsOutsideClass)
 CARBON_DIAGNOSTIC_KIND(ImplPreviousDefinition)
 CARBON_DIAGNOSTIC_KIND(ImplRedefinition)
+CARBON_DIAGNOSTIC_KIND(ImplMissingFunction)
+CARBON_DIAGNOSTIC_KIND(ImplFunctionWithNonFunction)
+CARBON_DIAGNOSTIC_KIND(ImplAssociatedFunctionHere)
 
 // Let declaration checking.
 CARBON_DIAGNOSTIC_KIND(ExpectedInitializerAfterLet)

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -201,6 +201,7 @@ CARBON_DIAGNOSTIC_KIND(ImplRedefinition)
 CARBON_DIAGNOSTIC_KIND(ImplMissingFunction)
 CARBON_DIAGNOSTIC_KIND(ImplFunctionWithNonFunction)
 CARBON_DIAGNOSTIC_KIND(ImplAssociatedFunctionHere)
+CARBON_DIAGNOSTIC_KIND(ImplOfUndefinedInterface)
 
 // Let declaration checking.
 CARBON_DIAGNOSTIC_KIND(ExpectedInitializerAfterLet)


### PR DESCRIPTION
Check that functions in an `impl` are declared properly. For now, simply reuse the redeclaration checking logic. Longer-term, we need to check that the signatures match in a more approximate way, after substituting the `Self` type into the signature in the `interface`.