### PR TITLE
Switch reviewdog to a bespoke secret.

### DIFF
--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -47,7 +47,8 @@ jobs:
       # matching the diff that pre-commit created.
       - name: Create suggestions
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN:
+            ${{ secrets.CARBON_INFRA_BOT_FOR_REVIEWDOG }}
         run: |
           cat ./diff | \
           GITHUB_EVENT_PATH=./event \


### PR DESCRIPTION
This uses a token from the low-privilege CarbonInfraBot, which should allow us to separate out permission for Google's CLA bot.