### PR TITLE
Update to checkout v4

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -14,7 +14,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
 

--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           reviewdog_version: latest
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download pre-commit output
         uses: actions/download-artifact@v4

--- a/.github/workflows/sync_repos.yaml
+++ b/.github/workflows/sync_repos.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout our main repository.
       - name: Checkout the main repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Run the sync script.
       - name: Sync to other repositories

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,13 +56,13 @@ jobs:
       # Checkout the pull request head or the branch.
       - name: Checkout pull request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Tests should only run on applicable paths, but we still need to have an
       # action run for the merge queue. We filter steps based on the paths here,


### PR DESCRIPTION
Noticed due to https://github.com/carbon-language/carbon-lang/actions/runs/8207272518

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

I'm expecting we can just update the version number on these.

