### PR TITLE
Homebrew recommends installing pre-commit directly

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -107,12 +107,9 @@ brew install \
   bazelisk \
   gh \
   llvm \
-  python@3.10
+  pre-commit
 
 # IMPORTANT: Make sure `llvm` is added to the PATH! It's separate from `brew`.
-
-# Install pre-commit.
-pip3 install pre-commit
 
 # Set up git.
 gh repo fork --clone carbon-language/carbon-lang

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -107,6 +107,7 @@ brew install \
   bazelisk \
   gh \
   llvm \
+  python@3.10 \
   pre-commit
 
 # IMPORTANT: Make sure `llvm` is added to the PATH! It's separate from `brew`.


### PR DESCRIPTION
On macOS, Homebrew recommends `pipx` to install Python binaries, or installing `pre-commit` directly, since it is available.

Here is the message in full. 

```console
❯ pip3 install pre-commit

error: externally-managed-environment
 × This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
```

~~Also, unless there is a compelling reason to install a particular 3.x version of Python, it may be better to let Homebrew use whatever version people may already have installed (or let it automatically install the version they've tested).~~

Here are the details of the pre-commit Homebrew package:

```
❯ brew info pre-commit
==> pre-commit: stable 3.6.2 (bottled), HEAD
Framework for managing multi-language pre-commit hooks
https://pre-commit.com/
/opt/homebrew/Cellar/pre-commit/3.6.2 (679 files, 9.9MB) *
  Poured from bottle using the formulae.brew.sh API on 2024-03-08 at 22:22:11
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/p/pre-commit.rb
License: MIT
==> Dependencies
Required: libyaml ✔, python@3.12 ✔
```

Installing directly with Homebrew is a supported option in the pre-commit documentation. https://pre-commit.com/#install