### PR TITLE
Remove legacy repo_name settings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,17 +25,14 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(
     name = "abseil-cpp",
     version = "20240116.1",
-    repo_name = "com_google_absl",
 )
 bazel_dep(
     name = "re2",
     version = "2024-03-01",
-    repo_name = "com_googlesource_code_re2",
 )
 bazel_dep(
     name = "googletest",
     version = "1.14.0.bcr.1",
-    repo_name = "com_google_googletest",
 )
 
 google_benchmark_version = "1.8.3"
@@ -43,7 +40,6 @@ google_benchmark_version = "1.8.3"
 bazel_dep(
     name = "google_benchmark",
     version = google_benchmark_version,
-    repo_name = "com_github_google_benchmark",
 )
 archive_override(
     module_name = "google_benchmark",
@@ -80,7 +76,6 @@ bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
 bazel_dep(
     name = "protobuf",
     version = "21.7",
-    repo_name = "com_google_protobuf",
 )
 
 libprotobuf_mutator_version = "1.1"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,25 +22,13 @@ http_archive = use_repo_rule(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(
-    name = "abseil-cpp",
-    version = "20240116.1",
-)
-bazel_dep(
-    name = "re2",
-    version = "2024-03-01",
-)
-bazel_dep(
-    name = "googletest",
-    version = "1.14.0.bcr.1",
-)
+bazel_dep(name = "abseil-cpp", version = "20240116.1")
+bazel_dep(name = "re2", version = "2024-03-01")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
 
 google_benchmark_version = "1.8.3"
 
-bazel_dep(
-    name = "google_benchmark",
-    version = google_benchmark_version,
-)
+bazel_dep(name = "google_benchmark", version = google_benchmark_version)
 archive_override(
     module_name = "google_benchmark",
     integrity = "sha256-a8GApX0j1NlRVRn5KwyD1hsFtbqxiJYfNqx7BrDZ6c4=",
@@ -50,12 +38,9 @@ archive_override(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v{0}.tar.gz".format(google_benchmark_version)],
 )
 
-bazel_dep(
-    name = "libpfm",
-    # The registry only has an old version. We use that here to avoid a miss but
-    # override it with a newer version.
-    version = "4.11.0",
-)
+# The registry only has an old version. We use that here to avoid a miss but
+# override it with a newer version.
+bazel_dep(name = "libpfm", version = "4.11.0")
 
 libpfm_version = "4.13.0"
 
@@ -73,10 +58,7 @@ bazel_dep(name = "rules_flex", version = "0.2.1")
 bazel_dep(name = "rules_m4", version = "0.2.3")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
-bazel_dep(
-    name = "protobuf",
-    version = "21.7",
-)
+bazel_dep(name = "protobuf", version = "21.7")
 
 libprotobuf_mutator_version = "1.1"
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "1b61571daf545b9f55185891a272a773932a4507063ad17fdb02a16f6352b8a9",
+  "moduleFileHash": "cce36aab60697bf068a2835858e7af7557955d647f68c5e8a22ef3d5b6a10ff2",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -55,7 +55,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 88,
+                "line": 83,
                 "column": 13
               }
             },
@@ -81,7 +81,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 135,
+                "line": 130,
                 "column": 13
               }
             }
@@ -95,7 +95,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 104,
+            "line": 99,
             "column": 35
           },
           "imports": {
@@ -112,7 +112,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 150,
+            "line": 145,
             "column": 29
           },
           "imports": {
@@ -129,7 +129,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 162,
+            "line": 157,
             "column": 23
           },
           "imports": {
@@ -145,7 +145,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 163,
+                "line": 158,
                 "column": 17
               }
             }
@@ -156,17 +156,17 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "com_google_absl": "abseil-cpp@20240116.1",
-        "com_googlesource_code_re2": "re2@2024-03-01",
-        "com_google_googletest": "googletest@1.14.0.bcr.1",
-        "com_github_google_benchmark": "google_benchmark@_",
+        "abseil-cpp": "abseil-cpp@20240116.1",
+        "re2": "re2@2024-03-01",
+        "googletest": "googletest@1.14.0.bcr.1",
+        "google_benchmark": "google_benchmark@_",
         "libpfm": "libpfm@_",
         "rules_bison": "rules_bison@0.2.2",
         "rules_flex": "rules_flex@0.2.1",
         "rules_m4": "rules_m4@0.2.3",
         "rules_cc": "rules_cc@0.0.9",
         "rules_proto": "rules_proto@6.0.0-rc2",
-        "com_google_protobuf": "protobuf@21.7",
+        "protobuf": "protobuf@21.7",
         "bazel_clang_tidy": "bazel_clang_tidy@_",
         "hedron_compile_commands": "hedron_compile_commands@_",
         "platforms": "platforms@0.0.8",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "cce36aab60697bf068a2835858e7af7557955d647f68c5e8a22ef3d5b6a10ff2",
+  "moduleFileHash": "f747f3ca0f4cd26f15f1bdb5d4e117245377124dbe291fddc28136aa40a927c4",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -55,7 +55,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 83,
+                "line": 65,
                 "column": 13
               }
             },
@@ -81,7 +81,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 130,
+                "line": 112,
                 "column": 13
               }
             }
@@ -95,7 +95,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 99,
+            "line": 81,
             "column": 35
           },
           "imports": {
@@ -112,7 +112,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 145,
+            "line": 127,
             "column": 29
           },
           "imports": {
@@ -129,7 +129,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 157,
+            "line": 139,
             "column": 23
           },
           "imports": {
@@ -145,7 +145,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 158,
+                "line": 140,
                 "column": 17
               }
             }

--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -82,7 +82,7 @@ for dep in deps:
     # message.
     if repo_base in (
         "@google_benchmark",
-        "@com_github_protocolbuffers_protobuf",
+        "@protobuf",
         "@abseil-cpp",
         "@googletest",
     ):

--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -81,10 +81,10 @@ for dep in deps:
     # exist. Specially diagnose them to try to provide a more helpful
     # message.
     if repo_base in (
-        "@com_github_google_benchmark",
+        "@google_benchmark",
         "@com_github_protocolbuffers_protobuf",
-        "@com_google_absl",
-        "@com_google_googletest",
+        "@abseil-cpp",
+        "@googletest",
     ):
         sys.exit("ERROR: dependency only allowed in test code: %s" % dep)
 

--- a/common/BUILD
+++ b/common/BUILD
@@ -33,7 +33,7 @@ cc_test(
         ":command_line",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -58,7 +58,7 @@ cc_test(
     deps = [
         ":check",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -86,7 +86,7 @@ cc_test(
         ":enum_base_test_def",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -108,7 +108,7 @@ cc_test(
         ":error",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -130,7 +130,7 @@ cc_test(
         ":hashing",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -142,9 +142,9 @@ cc_binary(
     deps = [
         ":check",
         ":hashing",
-        "@com_github_google_benchmark//:benchmark_main",
-        "@com_google_absl//absl/hash",
-        "@com_google_absl//absl/random",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/random",
+        "@google_benchmark//:benchmark_main",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -161,7 +161,7 @@ cc_test(
     deps = [
         ":indirect_value",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -217,7 +217,7 @@ cc_test(
     deps = [
         ":string_helpers",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -234,7 +234,7 @@ cc_test(
     deps = [
         ":struct_reflection",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -256,6 +256,6 @@ cc_test(
         ":vlog",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/explorer/BUILD
+++ b/explorer/BUILD
@@ -60,8 +60,8 @@ cc_binary(
         "//common:check",
         "//testing/base:test_raw_ostream",
         "//testing/file_test:file_test_base",
-        "@com_google_absl//absl/flags:flag",
-        "@com_googlesource_code_re2//:re2",
+        "@abseil-cpp//absl/flags:flag",
+        "@re2",
     ],
 )
 

--- a/explorer/ast/BUILD
+++ b/explorer/ast/BUILD
@@ -79,7 +79,7 @@ cc_library(
     tags = ["no-clang-tidy"],
     deps = [
         ":ast",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -96,7 +96,7 @@ cc_test(
         ":ast_test_matchers",
         "//explorer/base:arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -112,7 +112,7 @@ cc_test(
         ":paren_contents",
         "//explorer/base:arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -149,7 +149,7 @@ cc_test(
         ":paren_contents",
         "//explorer/base:arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -166,7 +166,7 @@ cc_test(
         ":paren_contents",
         "//explorer/base:arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/explorer/base/BUILD
+++ b/explorer/base/BUILD
@@ -28,7 +28,7 @@ cc_test(
     deps = [
         ":arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -53,7 +53,7 @@ cc_test(
     deps = [
         ":decompose",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -81,7 +81,7 @@ cc_test(
         ":source_location",
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -144,7 +144,7 @@ cc_test(
     deps = [
         ":trace_stream",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -159,6 +159,6 @@ cc_test(
         ":source_location",
         ":trace_stream",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/explorer/fuzzing/BUILD
+++ b/explorer/fuzzing/BUILD
@@ -35,7 +35,7 @@ cc_binary(
         "//explorer/base:arena",
         "//explorer/syntax",
         "//testing/fuzzing:carbon_cc_proto",
-        "@com_google_protobuf//:protobuf_headers",
+        "@protobuf//:protobuf_headers",
     ],
 )
 
@@ -60,8 +60,8 @@ cc_test(
         "//testing/base:test_raw_ostream",
         "//testing/fuzzing:carbon_cc_proto",
         "//testing/fuzzing:proto_to_carbon_lib",
-        "@com_google_googletest//:gtest",
-        "@com_google_protobuf//:protobuf_headers",
+        "@googletest//:gtest",
+        "@protobuf//:protobuf_headers",
     ],
 )
 
@@ -81,8 +81,8 @@ cc_library(
         "//testing/fuzzing:carbon_cc_proto",
         "//testing/fuzzing:proto_to_carbon_lib",
         "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_protobuf//:protobuf_headers",
         "@llvm-project//llvm:Support",
+        "@protobuf//:protobuf_headers",
     ],
 )
 
@@ -100,9 +100,9 @@ cc_test(
         ":fuzzer_util",
         "//testing/base:gtest_main",
         "//testing/fuzzing:proto_to_carbon_lib",
-        "@com_google_googletest//:gtest",
-        "@com_google_protobuf//:protobuf_headers",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
+        "@protobuf//:protobuf_headers",
     ],
 )
 

--- a/explorer/parse_and_execute/BUILD
+++ b/explorer/parse_and_execute/BUILD
@@ -38,6 +38,6 @@ cc_test(
     deps = [
         ":parse_and_execute",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/explorer/syntax/BUILD
+++ b/explorer/syntax/BUILD
@@ -27,7 +27,7 @@ cc_test(
         ":syntax",
         "//explorer/base:arena",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -41,7 +41,7 @@ cc_library(
     tags = ["no-clang-tidy"],
     deps = [
         ":syntax",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -173,6 +173,6 @@ cc_test(
         ":syntax",
         "//explorer/ast:ast_test_matchers",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/migrate_cpp/BUILD
+++ b/migrate_cpp/BUILD
@@ -52,7 +52,7 @@ cc_test(
     deps = [
         ":rewriter",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//clang:ast",
         "@llvm-project//clang:frontend",
         "@llvm-project//clang:tooling",

--- a/migrate_cpp/cpp_refactoring/BUILD
+++ b/migrate_cpp/cpp_refactoring/BUILD
@@ -39,7 +39,7 @@ cc_library(
     hdrs = ["matcher_test_base.h"],
     deps = [
         ":matcher",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//clang:ast_matchers",
         "@llvm-project//clang:tooling",
         "@llvm-project//clang:tooling_core",
@@ -66,7 +66,7 @@ cc_test(
         ":fn_inserter",
         ":matcher_test_base",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//clang:tooling",
     ],
 )
@@ -89,7 +89,7 @@ cc_test(
         ":for_range",
         ":matcher_test_base",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//clang:tooling",
     ],
 )
@@ -114,7 +114,7 @@ cc_test(
         ":matcher_test_base",
         ":var_decl",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//clang:tooling",
     ],
 )

--- a/scripts/fix_cc_deps.py
+++ b/scripts/fix_cc_deps.py
@@ -41,7 +41,7 @@ EXTERNAL_REPOS: Dict[str, ExternalRepo] = {
     # :src/google/protobuf/descriptor.h -> google/protobuf/descriptor.h
     # - protobuf_headers is specified because there are multiple overlapping
     #   targets.
-    "@com_google_protobuf": ExternalRepo(
+    "@protobuf": ExternalRepo(
         lambda x: re.sub("^(.*:src)/", "", x),
         ":protobuf_headers",
     ),
@@ -52,11 +52,9 @@ EXTERNAL_REPOS: Dict[str, ExternalRepo] = {
     # tools/cpp/runfiles:runfiles.h -> tools/cpp/runfiles/runfiles.h
     "@bazel_tools": ExternalRepo(lambda x: re.sub(":", "/", x), "..."),
     # absl/flags:flag.h -> absl/flags/flag.h
-    "@com_google_absl": ExternalRepo(lambda x: re.sub(":", "/", x), "..."),
+    "@abseil-cpp": ExternalRepo(lambda x: re.sub(":", "/", x), "..."),
     # :re2/re2.h -> re2/re2.h
-    "@com_googlesource_code_re2": ExternalRepo(
-        lambda x: re.sub(":", "", x), ":re2"
-    ),
+    "@re2": ExternalRepo(lambda x: re.sub(":", "", x), ":re2"),
 }
 
 # TODO: proto rules are aspect-based and their generated files don't show up in
@@ -249,8 +247,8 @@ def main() -> None:
 
     print("Building header map...")
     header_to_rule_map: Dict[str, Set[str]] = {
-        "gmock/gmock.h": {"@com_google_googletest//:gtest"},
-        "gtest/gtest.h": {"@com_google_googletest//:gtest"},
+        "gmock/gmock.h": {"@googletest//:gtest"},
+        "gtest/gtest.h": {"@googletest//:gtest"},
     }
     map_headers(header_to_rule_map, carbon_rules)
     map_headers(header_to_rule_map, external_rules)

--- a/scripts/forbid_llvm_googletest.py
+++ b/scripts/forbid_llvm_googletest.py
@@ -27,7 +27,7 @@ Dependencies on @llvm-project//llvm:gtest are forbidden, but a dependency path
 was detected:
 
 %s
-Carbon uses GoogleTest through @com_google_googletest, which is a different
+Carbon uses GoogleTest through @googletest, which is a different
 version than LLVM uses at @llvm-project//llvm:gtest. As a consequence,
 dependencies on @llvm-project//llvm:gtest must be avoided.
 """

--- a/testing/base/BUILD
+++ b/testing/base/BUILD
@@ -13,15 +13,15 @@ package(default_visibility = ["//visibility:public"])
 # provide stack traces on unexpected exits, because we normally rely on LLVM
 # code for that.
 #
-# This replaces "@com_google_googletest//:gtest_main";
-# "@com_google_googletest//:gtest" should still be used directly.
+# This replaces "@googletest//:gtest_main";
+# "@googletest//:gtest" should still be used directly.
 cc_library(
     name = "gtest_main",
     testonly = 1,
     srcs = ["gtest_main.cpp"],
     deps = [
         "//common:init_llvm",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -31,7 +31,7 @@ cc_library(
     hdrs = ["test_raw_ostream.h"],
     deps = [
         "//common:ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -43,6 +43,6 @@ cc_test(
     deps = [
         ":test_raw_ostream",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/testing/file_test/BUILD
+++ b/testing/file_test/BUILD
@@ -18,9 +18,9 @@ cc_library(
     deps = [
         "//common:check",
         "//common:ostream",
-        "@com_google_absl//absl/strings:string_view",
-        "@com_googlesource_code_re2//:re2",
+        "@abseil-cpp//absl/strings:string_view",
         "@llvm-project//llvm:Support",
+        "@re2",
     ],
 )
 
@@ -35,9 +35,9 @@ cc_library(
         "//common:error",
         "//common:init_llvm",
         "//common:ostream",
-        "@com_google_absl//absl/flags:flag",
-        "@com_google_absl//absl/flags:parse",
-        "@com_google_googletest//:gtest",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -50,7 +50,7 @@ file_test(
     deps = [
         ":file_test_base",
         "//common:ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/testing/file_test/README.md
+++ b/testing/file_test/README.md
@@ -20,7 +20,7 @@ file_test(
     deps = [
         ":my_lib",
         "//testing/file_test:file_test_base",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/testing/fuzzing/BUILD
+++ b/testing/fuzzing/BUILD
@@ -26,8 +26,8 @@ cc_library(
     deps = [
         ":carbon_cc_proto",
         "//common:error",
-        "@com_google_protobuf//:protobuf_headers",
         "@llvm-project//llvm:Support",
+        "@protobuf//:protobuf_headers",
     ],
 )
 
@@ -40,8 +40,8 @@ cc_binary(
         ":proto_to_carbon_lib",
         "//common:bazel_working_dir",
         "//common:error",
-        "@com_google_protobuf//:protobuf_headers",
         "@llvm-project//llvm:Support",
+        "@protobuf//:protobuf_headers",
     ],
 )
 
@@ -54,6 +54,6 @@ cc_test(
         ":proto_to_carbon_lib",
         "//common:error",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/third_party/libprotobuf_mutator/BUILD.txt
+++ b/third_party/libprotobuf_mutator/BUILD.txt
@@ -22,5 +22,5 @@ cc_library(
     hdrs = ["src/libfuzzer/libfuzzer_macro.h"],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:protobuf"],
+    deps = ["@protobuf"],
 )

--- a/toolchain/base/BUILD
+++ b/toolchain/base/BUILD
@@ -44,7 +44,7 @@ cc_test(
         "//testing/base:gtest_main",
         "//testing/base:test_raw_ostream",
         "//toolchain/testing:yaml_test_helpers",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -29,7 +29,7 @@ cc_test(
         ":diagnostic_emitter",
         ":mocks",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -74,7 +74,7 @@ cc_test(
         ":mocks",
         ":sorting_diagnostic_consumer",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -86,7 +86,7 @@ cc_library(
     hdrs = ["mocks.h"],
     deps = [
         ":diagnostic_emitter",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -50,7 +50,7 @@ cc_test(
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/lex:tokenized_buffer_test_helpers",
         "//toolchain/testing:yaml_test_helpers",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Object",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -32,7 +32,7 @@ cc_test(
     deps = [
         ":token_kind",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -61,7 +61,7 @@ cc_library(
         "//common:check",
         "//common:string_helpers",
         "//toolchain/diagnostics:diagnostic_emitter",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -87,7 +87,7 @@ cc_binary(
         ":numeric_literal",
         "//common:check",
         "//toolchain/diagnostics:null_diagnostics",
-        "@com_github_google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark_main",
     ],
 )
 
@@ -102,7 +102,7 @@ cc_test(
         "//common:ostream",
         "//testing/base:gtest_main",
         "//toolchain/diagnostics:diagnostic_emitter",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -140,7 +140,7 @@ cc_binary(
     deps = [
         ":string_literal",
         "//toolchain/diagnostics:null_diagnostics",
-        "@com_github_google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark_main",
     ],
 )
 
@@ -155,7 +155,7 @@ cc_test(
         "//common:ostream",
         "//testing/base:gtest_main",
         "//toolchain/diagnostics:diagnostic_emitter",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -223,7 +223,7 @@ cc_library(
         ":tokenized_buffer",
         "//common:check",
         "//toolchain/base:value_store",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -242,7 +242,7 @@ cc_test(
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:mocks",
         "//toolchain/testing:yaml_test_helpers",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -274,8 +274,8 @@ cc_binary(
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",
-        "@com_github_google_benchmark//:benchmark_main",
-        "@com_google_absl//absl/random",
+        "@abseil-cpp//absl/random",
+        "@google_benchmark//:benchmark_main",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -44,7 +44,7 @@ cc_test(
         "//toolchain/diagnostics:mocks",
         "//toolchain/lex",
         "//toolchain/lex:tokenized_buffer",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -132,7 +132,7 @@ cc_test(
         "//toolchain/lex",
         "//toolchain/lex:tokenized_buffer",
         "//toolchain/testing:yaml_test_helpers",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -182,7 +182,7 @@ cc_test(
         ":precedence",
         "//testing/base:gtest_main",
         "//toolchain/lex:token_kind",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -151,7 +151,7 @@ cc_test(
         ":inst",
         ":inst_kind",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -165,7 +165,7 @@ cc_test(
         "//testing/base:test_raw_ostream",
         "//toolchain/driver",
         "//toolchain/testing:yaml_test_helpers",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/source/BUILD
+++ b/toolchain/source/BUILD
@@ -26,7 +26,7 @@ cc_test(
         "//common:check",
         "//testing/base:gtest_main",
         "//toolchain/diagnostics:diagnostic_emitter",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -36,7 +36,7 @@ cc_library(
     deps = [
         "//common:error",
         "//common:ostream",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )
@@ -48,6 +48,6 @@ cc_test(
     deps = [
         ":yaml_test_helpers",
         "//testing/base:gtest_main",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
     ],
 )


### PR DESCRIPTION
I'd kept these in to separate the bazel module update from the BUILD file changes, then forgot about it. I think all of these can be cleanly removed now. I think it's something we should clean up for consistency with the bazel central repository names; I think it's best to reduce that divergence.

llvm_zlib and llvm_zstd remain because of how llvm depends on the particular names.