### PR TITLE
Refactor member lookup in preparation for adding impl lookup.

### DIFF
--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -5,7 +5,6 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/member_access.h"
 #include "toolchain/lex/token_kind.h"
-#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/member_access.h"
 #include "toolchain/lex/token_kind.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -91,10 +91,12 @@ static auto IsInstanceMethod(const SemIR::File& sem_ir,
   return false;
 }
 
-static auto LookupMemberNameInScope(
-    Context& context, Parse::MemberAccessExprId node_id,
-    SemIR::InstId /*base_id*/, SemIR::NameId name_id,
-    SemIR::NameScopeId name_scope_id) -> SemIR::InstId {
+static auto LookupMemberNameInScope(Context& context,
+                                    Parse::MemberAccessExprId node_id,
+                                    SemIR::InstId /*base_id*/,
+                                    SemIR::NameId name_id,
+                                    SemIR::NameScopeId name_scope_id)
+    -> SemIR::InstId {
   auto inst_id = name_scope_id.is_valid() ? context.LookupQualifiedName(
                                                 node_id, name_id, name_scope_id)
                                           : SemIR::InstId::BuiltinError;
@@ -166,8 +168,8 @@ static auto PerformInstanceBinding(Context& context,
 }
 
 auto PerformMemberAccess(Context& context, Parse::MemberAccessExprId node_id,
-                         SemIR::InstId base_id,
-                         SemIR::NameId name_id) -> SemIR::InstId {
+                         SemIR::InstId base_id, SemIR::NameId name_id)
+    -> SemIR::InstId {
   // If the base is a name scope, such as a class or namespace, perform lookup
   // into that scope.
   if (auto name_scope_id = GetAsNameScope(context, base_id)) {

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -110,11 +110,14 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: fn @Access(%d: Derived) -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %d.ref.loc22_11: Derived = name_ref d, %d
+// CHECK:STDOUT:   %d.ref.loc22_12: <unbound element of class Derived> = name_ref d, @Derived.%.loc14 [template = @Derived.%.loc14]
 // CHECK:STDOUT:   %.loc22_12.1: ref i32 = class_element_access %d.ref.loc22_11, element1
 // CHECK:STDOUT:   %.loc22_12.2: i32 = bind_value %.loc22_12.1
 // CHECK:STDOUT:   %d.ref.loc22_16: Derived = name_ref d, %d
+// CHECK:STDOUT:   %base.ref: <unbound element of class Derived> = name_ref base, @Derived.%.loc12 [template = @Derived.%.loc12]
 // CHECK:STDOUT:   %.loc22_17.1: ref Base = class_element_access %d.ref.loc22_16, element0
 // CHECK:STDOUT:   %.loc22_17.2: Base = bind_value %.loc22_17.1
+// CHECK:STDOUT:   %b.ref: <unbound element of class Base> = name_ref b, @Base.%.loc8 [template = @Base.%.loc8]
 // CHECK:STDOUT:   %.loc22_22.1: ref i32 = class_element_access %.loc22_17.2, element0
 // CHECK:STDOUT:   %.loc22_22.2: i32 = bind_value %.loc22_22.1
 // CHECK:STDOUT:   %.loc22_24.1: (i32, i32) = tuple_literal (%.loc22_12.2, %.loc22_22.2)

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -87,6 +87,7 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
 // CHECK:STDOUT:   %.loc21_12.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %c.ref: <unbound element of class Base> = name_ref c, @Base.%.loc10 [template = @Base.%.loc10]
 // CHECK:STDOUT:   %.loc21_15.1: ref Base = class_element_access %.loc21_12.1, element0
 // CHECK:STDOUT:   %.loc21_12.2: ref Base = converted %.loc21_12.1, %.loc21_15.1
 // CHECK:STDOUT:   %.loc21_15.2: ref i32 = class_element_access %.loc21_12.2, element2

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -93,6 +93,7 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc14_4: ref Base = deref %self.ref
+// CHECK:STDOUT:   %a.ref: <unbound element of class Base> = name_ref a, @Base.%.loc8 [template = @Base.%.loc8]
 // CHECK:STDOUT:   %.loc14_10: ref i32 = class_element_access %.loc14_4, element0
 // CHECK:STDOUT:   %.loc14_15: i32 = int_literal 1 [template = constants.%.5]
 // CHECK:STDOUT:   assign %.loc14_10, %.loc14_15
@@ -103,7 +104,8 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
 // CHECK:STDOUT:   %.loc22_4.1: ref Derived = deref %p.ref
-// CHECK:STDOUT:   %.loc22_7: <bound method> = bound_method %.loc22_4.1, @Base.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
+// CHECK:STDOUT:   %.loc22_7: <bound method> = bound_method %.loc22_4.1, %F.ref
 // CHECK:STDOUT:   %.loc22_4.2: Derived* = addr_of %.loc22_4.1
 // CHECK:STDOUT:   %.loc22_9.1: ref Derived = deref %.loc22_4.2
 // CHECK:STDOUT:   %.loc22_9.2: ref Base = class_element_access %.loc22_9.1, element0

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -156,22 +156,26 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: A* = name_ref a, %a
 // CHECK:STDOUT:   %.loc26_4.1: ref A = deref %a.ref
-// CHECK:STDOUT:   %.loc26_7: <bound method> = bound_method %.loc26_4.1, @A.%F
+// CHECK:STDOUT:   %F.ref.loc26: <function> = name_ref F, @A.%F [template = @A.%F]
+// CHECK:STDOUT:   %.loc26_7: <bound method> = bound_method %.loc26_4.1, %F.ref.loc26
 // CHECK:STDOUT:   %.loc26_4.2: A* = addr_of %.loc26_4.1
 // CHECK:STDOUT:   %.loc26_9: init () = call %.loc26_7(%.loc26_4.2)
 // CHECK:STDOUT:   %b.ref: B* = name_ref b, %b
 // CHECK:STDOUT:   %.loc27_4.1: ref B = deref %b.ref
-// CHECK:STDOUT:   %.loc27_7: <bound method> = bound_method %.loc27_4.1, @B.%F
+// CHECK:STDOUT:   %F.ref.loc27: <function> = name_ref F, @B.%F [template = @B.%F]
+// CHECK:STDOUT:   %.loc27_7: <bound method> = bound_method %.loc27_4.1, %F.ref.loc27
 // CHECK:STDOUT:   %.loc27_4.2: B* = addr_of %.loc27_4.1
 // CHECK:STDOUT:   %.loc27_9: init () = call %.loc27_7(%.loc27_4.2)
 // CHECK:STDOUT:   %c.ref: C* = name_ref c, %c
 // CHECK:STDOUT:   %.loc28_4.1: ref C = deref %c.ref
-// CHECK:STDOUT:   %.loc28_7: <bound method> = bound_method %.loc28_4.1, @C.%F
+// CHECK:STDOUT:   %F.ref.loc28: <function> = name_ref F, @C.%F [template = @C.%F]
+// CHECK:STDOUT:   %.loc28_7: <bound method> = bound_method %.loc28_4.1, %F.ref.loc28
 // CHECK:STDOUT:   %.loc28_4.2: C* = addr_of %.loc28_4.1
 // CHECK:STDOUT:   %.loc28_9: init () = call %.loc28_7(%.loc28_4.2)
 // CHECK:STDOUT:   %d.ref: D* = name_ref d, %d
 // CHECK:STDOUT:   %.loc29_4.1: ref D = deref %d.ref
-// CHECK:STDOUT:   %.loc29_7: <bound method> = bound_method %.loc29_4.1, @B.%F
+// CHECK:STDOUT:   %F.ref.loc29: <function> = name_ref F, @B.%F [template = @B.%F]
+// CHECK:STDOUT:   %.loc29_7: <bound method> = bound_method %.loc29_4.1, %F.ref.loc29
 // CHECK:STDOUT:   %.loc29_4.2: D* = addr_of %.loc29_4.1
 // CHECK:STDOUT:   %.loc29_9.1: ref D = deref %.loc29_4.2
 // CHECK:STDOUT:   %.loc29_9.2: ref B = class_element_access %.loc29_9.1, element0

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -103,11 +103,14 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT: fn @Access(%d: Derived) -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %d.ref.loc26_11: Derived = name_ref d, %d
+// CHECK:STDOUT:   %d.ref.loc26_12: <unbound element of class Derived> = name_ref d, @Derived.%.loc14 [template = @Derived.%.loc14]
 // CHECK:STDOUT:   %.loc26_12.1: ref i32 = class_element_access %d.ref.loc26_11, element1
 // CHECK:STDOUT:   %.loc26_12.2: i32 = bind_value %.loc26_12.1
 // CHECK:STDOUT:   %d.ref.loc26_16: Derived = name_ref d, %d
+// CHECK:STDOUT:   %base.ref: <unbound element of class Derived> = name_ref base, @Derived.%.loc12 [template = @Derived.%.loc12]
 // CHECK:STDOUT:   %.loc26_17.1: ref Abstract = class_element_access %d.ref.loc26_16, element0
 // CHECK:STDOUT:   %.loc26_17.2: Abstract = bind_value %.loc26_17.1
+// CHECK:STDOUT:   %a.ref: <unbound element of class Abstract> = name_ref a, @Abstract.%.loc8 [template = @Abstract.%.loc8]
 // CHECK:STDOUT:   %.loc26_22.1: ref i32 = class_element_access %.loc26_17.2, element0
 // CHECK:STDOUT:   %.loc26_22.2: i32 = bind_value %.loc26_22.1
 // CHECK:STDOUT:   %.loc26_24.1: (i32, i32) = tuple_literal (%.loc26_12.2, %.loc26_22.2)

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -93,19 +93,23 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT: fn @F.2(%c: Class, %p: Class*) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref.loc19: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc19_4: <bound method> = bound_method %c.ref.loc19, @Class.%F
+// CHECK:STDOUT:   %F.ref.loc19: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc19_4: <bound method> = bound_method %c.ref.loc19, %F.ref.loc19
 // CHECK:STDOUT:   %.loc19_6: init () = call %.loc19_4(<invalid>)
 // CHECK:STDOUT:   %c.ref.loc27: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc27_4: <bound method> = bound_method %c.ref.loc27, @Class.%G
+// CHECK:STDOUT:   %G.ref.loc27: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc27_4: <bound method> = bound_method %c.ref.loc27, %G.ref.loc27
 // CHECK:STDOUT:   %.loc27_6: init () = call %.loc27_4(<invalid>)
 // CHECK:STDOUT:   %p.ref.loc30: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc30_4.1: ref Class = deref %p.ref.loc30
-// CHECK:STDOUT:   %.loc30_7: <bound method> = bound_method %.loc30_4.1, @Class.%F
+// CHECK:STDOUT:   %F.ref.loc30: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc30_7: <bound method> = bound_method %.loc30_4.1, %F.ref.loc30
 // CHECK:STDOUT:   %.loc30_4.2: Class* = addr_of %.loc30_4.1
 // CHECK:STDOUT:   %.loc30_9: init () = call %.loc30_7(%.loc30_4.2)
 // CHECK:STDOUT:   %p.ref.loc38: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc38_4.1: ref Class = deref %p.ref.loc38
-// CHECK:STDOUT:   %.loc38_7: <bound method> = bound_method %.loc38_4.1, @Class.%G
+// CHECK:STDOUT:   %G.ref.loc38: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc38_7: <bound method> = bound_method %.loc38_4.1, %G.ref.loc38
 // CHECK:STDOUT:   %.loc38_4.2: Class* = addr_of %.loc38_4.1
 // CHECK:STDOUT:   %.loc38_9: init () = call %.loc38_7(<invalid>)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -471,6 +471,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
 // CHECK:STDOUT:   %.loc110_11.1: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %a.ref: <unbound element of class Final> = name_ref a, @Final.%.loc9 [template = @Final.%.loc9]
 // CHECK:STDOUT:   %.loc110_14.1: ref Final = class_element_access %.loc110_11.1, element0
 // CHECK:STDOUT:   %.loc110_11.2: ref Final = converted %.loc110_11.1, %.loc110_14.1
 // CHECK:STDOUT:   %.loc110_14.2: ref i32 = class_element_access %.loc110_11.2, element0

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -96,12 +96,15 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.ref: {.a: A} = name_ref s, %s
 // CHECK:STDOUT:   %.loc23_4: A = struct_access %s.ref, element0
-// CHECK:STDOUT:   %.loc23_6: <bound method> = bound_method %.loc23_4, @A.%F
+// CHECK:STDOUT:   %F.ref.loc23: <function> = name_ref F, @A.%F [template = @A.%F]
+// CHECK:STDOUT:   %.loc23_6: <bound method> = bound_method %.loc23_4, %F.ref.loc23
 // CHECK:STDOUT:   %.loc23_8: init () = call %.loc23_6(<invalid>)
 // CHECK:STDOUT:   %b.ref: B = name_ref b, %b
+// CHECK:STDOUT:   %a.ref: <unbound element of class B> = name_ref a, @B.%.loc12 [template = @B.%.loc12]
 // CHECK:STDOUT:   %.loc33_4.1: ref A = class_element_access %b.ref, element0
 // CHECK:STDOUT:   %.loc33_4.2: A = bind_value %.loc33_4.1
-// CHECK:STDOUT:   %.loc33_6: <bound method> = bound_method %.loc33_4.2, @A.%F
+// CHECK:STDOUT:   %F.ref.loc33: <function> = name_ref F, @A.%F [template = @A.%F]
+// CHECK:STDOUT:   %.loc33_6: <bound method> = bound_method %.loc33_4.2, %F.ref.loc33
 // CHECK:STDOUT:   %.loc33_8: init () = call %.loc33_6(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -90,7 +90,8 @@ fn F(c: Class) {
 // CHECK:STDOUT:   %NoSelf.ref.loc15: <function> = name_ref NoSelf, @Class.%NoSelf [template = @Class.%NoSelf]
 // CHECK:STDOUT:   %.loc15: init () = call %NoSelf.ref.loc15()
 // CHECK:STDOUT:   %c.ref.loc16: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc16_4: <bound method> = bound_method %c.ref.loc16, @Class.%WithSelf
+// CHECK:STDOUT:   %WithSelf.ref.loc16: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
+// CHECK:STDOUT:   %.loc16_4: <bound method> = bound_method %c.ref.loc16, %WithSelf.ref.loc16
 // CHECK:STDOUT:   %.loc16_13: init () = call %.loc16_4(%c.ref.loc16)
 // CHECK:STDOUT:   %Class.ref.loc18: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %NoSelf.ref.loc18: <function> = name_ref NoSelf, @Class.%NoSelf [template = @Class.%NoSelf]

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -135,7 +135,8 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: fn @CallWrongSelf(%ws: WrongSelf) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %ws.ref: WrongSelf = name_ref ws, %ws
-// CHECK:STDOUT:   %.loc50_5: <bound method> = bound_method %ws.ref, @WrongSelf.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @WrongSelf.%F [template = @WrongSelf.%F]
+// CHECK:STDOUT:   %.loc50_5: <bound method> = bound_method %ws.ref, %F.ref
 // CHECK:STDOUT:   %.loc50_7: init () = call %.loc50_5(<invalid>)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/field_access.carbon
+++ b/toolchain/check/testdata/class/field_access.carbon
@@ -53,22 +53,26 @@ fn Run() {
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref.loc14: ref Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc14: <unbound element of class Class> = name_ref j, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   %.loc14_4: ref i32 = class_element_access %c.ref.loc14, element0
 // CHECK:STDOUT:   %.loc14_9: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc14_4, %.loc14_9
 // CHECK:STDOUT:   %c.ref.loc15: ref Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc15: <unbound element of class Class> = name_ref k, @Class.%.loc9 [template = @Class.%.loc9]
 // CHECK:STDOUT:   %.loc15_4: ref i32 = class_element_access %c.ref.loc15, element1
 // CHECK:STDOUT:   %.loc15_9: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   assign %.loc15_4, %.loc15_9
 // CHECK:STDOUT:   %cj.var: ref i32 = var cj
 // CHECK:STDOUT:   %cj: ref i32 = bind_name cj, %cj.var
 // CHECK:STDOUT:   %c.ref.loc16: ref Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc16: <unbound element of class Class> = name_ref j, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   %.loc16_18.1: ref i32 = class_element_access %c.ref.loc16, element0
 // CHECK:STDOUT:   %.loc16_18.2: i32 = bind_value %.loc16_18.1
 // CHECK:STDOUT:   assign %cj.var, %.loc16_18.2
 // CHECK:STDOUT:   %ck.var: ref i32 = var ck
 // CHECK:STDOUT:   %ck: ref i32 = bind_name ck, %ck.var
 // CHECK:STDOUT:   %c.ref.loc17: ref Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc17: <unbound element of class Class> = name_ref k, @Class.%.loc9 [template = @Class.%.loc9]
 // CHECK:STDOUT:   %.loc17_18.1: ref i32 = class_element_access %c.ref.loc17, element1
 // CHECK:STDOUT:   %.loc17_18.2: i32 = bind_value %.loc17_18.1
 // CHECK:STDOUT:   assign %ck.var, %.loc17_18.2

--- a/toolchain/check/testdata/class/field_access_in_value.carbon
+++ b/toolchain/check/testdata/class/field_access_in_value.carbon
@@ -54,10 +54,12 @@ fn Test() {
 // CHECK:STDOUT:   %cv.var: ref Class = var cv
 // CHECK:STDOUT:   %cv: ref Class = bind_name cv, %cv.var
 // CHECK:STDOUT:   %cv.ref.loc14: ref Class = name_ref cv, %cv
+// CHECK:STDOUT:   %j.ref.loc14: <unbound element of class Class> = name_ref j, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   %.loc14_5: ref i32 = class_element_access %cv.ref.loc14, element0
 // CHECK:STDOUT:   %.loc14_10: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc14_5, %.loc14_10
 // CHECK:STDOUT:   %cv.ref.loc15: ref Class = name_ref cv, %cv
+// CHECK:STDOUT:   %k.ref.loc15: <unbound element of class Class> = name_ref k, @Class.%.loc9 [template = @Class.%.loc9]
 // CHECK:STDOUT:   %.loc15_5: ref i32 = class_element_access %cv.ref.loc15, element1
 // CHECK:STDOUT:   %.loc15_10: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   assign %.loc15_5, %.loc15_10
@@ -68,12 +70,14 @@ fn Test() {
 // CHECK:STDOUT:   %cj.var: ref i32 = var cj
 // CHECK:STDOUT:   %cj: ref i32 = bind_name cj, %cj.var
 // CHECK:STDOUT:   %c.ref.loc17: Class = name_ref c, %c
+// CHECK:STDOUT:   %j.ref.loc17: <unbound element of class Class> = name_ref j, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   %.loc17_18.1: ref i32 = class_element_access %c.ref.loc17, element0
 // CHECK:STDOUT:   %.loc17_18.2: i32 = bind_value %.loc17_18.1
 // CHECK:STDOUT:   assign %cj.var, %.loc17_18.2
 // CHECK:STDOUT:   %ck.var: ref i32 = var ck
 // CHECK:STDOUT:   %ck: ref i32 = bind_name ck, %ck.var
 // CHECK:STDOUT:   %c.ref.loc18: Class = name_ref c, %c
+// CHECK:STDOUT:   %k.ref.loc18: <unbound element of class Class> = name_ref k, @Class.%.loc9 [template = @Class.%.loc9]
 // CHECK:STDOUT:   %.loc18_18.1: ref i32 = class_element_access %c.ref.loc18, element1
 // CHECK:STDOUT:   %.loc18_18.2: i32 = bind_value %.loc18_18.1
 // CHECK:STDOUT:   assign %ck.var, %.loc18_18.2

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -199,6 +199,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc9_25.5: init Field = converted %.loc9_25.1, %.loc9_25.4 [template = constants.%.8]
 // CHECK:STDOUT:   assign %b.var, %.loc9_25.5
 // CHECK:STDOUT:   %b.ref: ref Field = name_ref b, %b
+// CHECK:STDOUT:   %x.ref: <unbound element of class Field> = name_ref x, @Field.%import_ref.2 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_4: ref i32 = class_element_access %b.ref, element0
 // CHECK:STDOUT:   %.loc10_9: i32 = int_literal 2 [template = constants.%.10]
 // CHECK:STDOUT:   assign %.loc10_4, %.loc10_9
@@ -211,11 +212,13 @@ fn Run() {
 // CHECK:STDOUT:   %.loc12_29.3: init ForwardDeclared = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%.11]
 // CHECK:STDOUT:   assign %c.var, %.loc12_29.3
 // CHECK:STDOUT:   %c.ref.loc13: ref ForwardDeclared = name_ref c, %c
-// CHECK:STDOUT:   %.loc13_4: <bound method> = bound_method %c.ref.loc13, @ForwardDeclared.%import_ref.3
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @ForwardDeclared.%import_ref.3 [template = imports.%F]
+// CHECK:STDOUT:   %.loc13_4: <bound method> = bound_method %c.ref.loc13, %F.ref
 // CHECK:STDOUT:   %.loc13_3: ForwardDeclared = bind_value %c.ref.loc13
 // CHECK:STDOUT:   %.loc13_6: init () = call %.loc13_4(%.loc13_3)
 // CHECK:STDOUT:   %c.ref.loc14: ref ForwardDeclared = name_ref c, %c
-// CHECK:STDOUT:   %.loc14_4: <bound method> = bound_method %c.ref.loc14, @ForwardDeclared.%import_ref.2
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @ForwardDeclared.%import_ref.2 [template = imports.%G]
+// CHECK:STDOUT:   %.loc14_4: <bound method> = bound_method %c.ref.loc14, %G.ref
 // CHECK:STDOUT:   %.loc14_3: ForwardDeclared* = addr_of %c.ref.loc14
 // CHECK:STDOUT:   %.loc14_6: init () = call %.loc14_4(%.loc14_3)
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, file.%import_ref.3 [template = constants.%ForwardDeclared]

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -168,13 +168,15 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_48.4: init Child = converted %.loc7_48.1, %.loc7_48.3 [template = constants.%.11]
 // CHECK:STDOUT:   assign %a.var, %.loc7_48.4
 // CHECK:STDOUT:   %a.ref.loc8: ref Child = name_ref a, %a
+// CHECK:STDOUT:   %x.ref: <unbound element of class Base> = name_ref x, @Base.%import_ref.3 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_4.1: ref Base = class_element_access %a.ref.loc8, element0
 // CHECK:STDOUT:   %.loc8_3: ref Base = converted %a.ref.loc8, %.loc8_4.1
 // CHECK:STDOUT:   %.loc8_4.2: ref i32 = class_element_access %.loc8_3, element0
 // CHECK:STDOUT:   %.loc8_9: i32 = int_literal 2 [template = constants.%.13]
 // CHECK:STDOUT:   assign %.loc8_4.2, %.loc8_9
 // CHECK:STDOUT:   %a.ref.loc9: ref Child = name_ref a, %a
-// CHECK:STDOUT:   %.loc9_4: <bound method> = bound_method %a.ref.loc9, @Base.%import_ref.1
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%import_ref.1 [template = imports.%F]
+// CHECK:STDOUT:   %.loc9_4: <bound method> = bound_method %a.ref.loc9, %F.ref
 // CHECK:STDOUT:   %.loc9_6.1: ref Base = class_element_access %a.ref.loc9, element0
 // CHECK:STDOUT:   %.loc9_3.1: ref Base = converted %a.ref.loc9, %.loc9_6.1
 // CHECK:STDOUT:   %.loc9_3.2: Base = bind_value %.loc9_3.1

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -102,6 +102,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_12.1: ref Cycle* = struct_access %a.ref.loc7_11, element0
 // CHECK:STDOUT:   %.loc7_12.2: Cycle* = bind_value %.loc7_12.1
 // CHECK:STDOUT:   %.loc7_10: ref Cycle = deref %.loc7_12.2
+// CHECK:STDOUT:   %c.ref: <unbound element of class Cycle> = name_ref c, @Cycle.%import_ref.2 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc7_15: ref {.b: Cycle*} = class_element_access %.loc7_10, element0
 // CHECK:STDOUT:   %.loc7_17.1: ref Cycle* = struct_access %.loc7_15, element0
 // CHECK:STDOUT:   %.loc7_17.2: Cycle* = bind_value %.loc7_17.1

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -60,6 +60,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc13_26.7: init Class = class_init (%.loc13_26.4, %.loc13_26.6), %.loc13_26.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc13_26.8: ref Class = temporary %.loc13_26.2, %.loc13_26.7
 // CHECK:STDOUT:   %.loc13_26.9: ref Class = converted %.loc13_26.1, %.loc13_26.8
+// CHECK:STDOUT:   %a.ref: <unbound element of class Class> = name_ref a, @Class.%.loc8 [template = @Class.%.loc8]
 // CHECK:STDOUT:   %.loc13_37.1: ref i32 = class_element_access %.loc13_26.9, element0
 // CHECK:STDOUT:   %.loc13_37.2: i32 = bind_value %.loc13_37.1
 // CHECK:STDOUT:   return %.loc13_37.2

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -160,6 +160,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Class = name_ref self, %self
+// CHECK:STDOUT:   %k.ref: <unbound element of class Class> = name_ref k, @Class.%.loc13 [template = @Class.%.loc13]
 // CHECK:STDOUT:   %.loc17_14.1: ref i32 = class_element_access %self.ref, element0
 // CHECK:STDOUT:   %.loc17_14.2: i32 = bind_value %.loc17_14.1
 // CHECK:STDOUT:   return %.loc17_14.2
@@ -170,7 +171,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: fn @Call(%c: Class) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc23_11: <bound method> = bound_method %c.ref, @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc23_11: <bound method> = bound_method %c.ref, %F.ref
 // CHECK:STDOUT:   %.loc23_13.1: init i32 = call %.loc23_11(%c.ref)
 // CHECK:STDOUT:   %.loc23_15: i32 = value_of_initializer %.loc23_13.1
 // CHECK:STDOUT:   %.loc23_13.2: i32 = converted %.loc23_13.1, %.loc23_15
@@ -180,7 +182,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: fn @CallAlias(%c: Class) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc27_11: <bound method> = bound_method %c.ref, @Class.%A
+// CHECK:STDOUT:   %A.ref: <function> = name_ref A, @Class.%A [template = @Class.%F]
+// CHECK:STDOUT:   %.loc27_11: <bound method> = bound_method %c.ref, %A.ref
 // CHECK:STDOUT:   %.loc27_13.1: init i32 = call %.loc27_11(%c.ref)
 // CHECK:STDOUT:   %.loc27_15: i32 = value_of_initializer %.loc27_13.1
 // CHECK:STDOUT:   %.loc27_13.2: i32 = converted %.loc27_13.1, %.loc27_15
@@ -198,7 +201,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc31_18.5: init Class = class_init (%.loc31_18.4), %.loc31_18.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc31_18.6: ref Class = temporary %.loc31_18.2, %.loc31_18.5
 // CHECK:STDOUT:   %.loc31_18.7: ref Class = converted %.loc31_18.1, %.loc31_18.6
-// CHECK:STDOUT:   %.loc31_29: <bound method> = bound_method %.loc31_18.7, @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc31_29: <bound method> = bound_method %.loc31_18.7, %F.ref
 // CHECK:STDOUT:   %.loc31_18.8: Class = bind_value %.loc31_18.7
 // CHECK:STDOUT:   %.loc31_31.1: init i32 = call %.loc31_29(%.loc31_18.8)
 // CHECK:STDOUT:   %.loc31_33: i32 = value_of_initializer %.loc31_31.1
@@ -212,7 +216,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %c.var: ref Class = var c
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc36_11: <bound method> = bound_method %c.ref, @Class.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc36_11: <bound method> = bound_method %c.ref, %G.ref
 // CHECK:STDOUT:   %.loc36_10: Class* = addr_of %c.ref
 // CHECK:STDOUT:   %.loc36_13.1: init i32 = call %.loc36_11(%.loc36_10)
 // CHECK:STDOUT:   %.loc36_15: i32 = value_of_initializer %.loc36_13.1
@@ -224,7 +229,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc40_11.1: ref Class = deref %p.ref
-// CHECK:STDOUT:   %.loc40_14: <bound method> = bound_method %.loc40_11.1, @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc40_14: <bound method> = bound_method %.loc40_11.1, %F.ref
 // CHECK:STDOUT:   %.loc40_11.2: Class = bind_value %.loc40_11.1
 // CHECK:STDOUT:   %.loc40_16.1: init i32 = call %.loc40_14(%.loc40_11.2)
 // CHECK:STDOUT:   %.loc40_18: i32 = value_of_initializer %.loc40_16.1
@@ -236,7 +242,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
 // CHECK:STDOUT:   %.loc44_11.1: ref Class = deref %p.ref
-// CHECK:STDOUT:   %.loc44_14: <bound method> = bound_method %.loc44_11.1, @Class.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc44_14: <bound method> = bound_method %.loc44_11.1, %G.ref
 // CHECK:STDOUT:   %.loc44_11.2: Class* = addr_of %.loc44_11.1
 // CHECK:STDOUT:   %.loc44_16.1: init i32 = call %.loc44_14(%.loc44_11.2)
 // CHECK:STDOUT:   %.loc44_18: i32 = value_of_initializer %.loc44_16.1
@@ -252,7 +259,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc50_14.1: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc50_14.2: init Class = call %Make.ref() to %.loc50_14.1
 // CHECK:STDOUT:   %.loc50_14.3: ref Class = temporary %.loc50_14.1, %.loc50_14.2
-// CHECK:STDOUT:   %.loc50_16: <bound method> = bound_method %.loc50_14.3, @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc50_16: <bound method> = bound_method %.loc50_14.3, %F.ref
 // CHECK:STDOUT:   %.loc50_14.4: Class = bind_value %.loc50_14.3
 // CHECK:STDOUT:   %.loc50_18.1: init i32 = call %.loc50_16(%.loc50_14.4)
 // CHECK:STDOUT:   %.loc50_20: i32 = value_of_initializer %.loc50_18.1
@@ -266,7 +274,8 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc54_14.1: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc54_14.2: init Class = call %Make.ref() to %.loc54_14.1
 // CHECK:STDOUT:   %.loc54_14.3: ref Class = temporary %.loc54_14.1, %.loc54_14.2
-// CHECK:STDOUT:   %.loc54_16: <bound method> = bound_method %.loc54_14.3, @Class.%G
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc54_16: <bound method> = bound_method %.loc54_14.3, %G.ref
 // CHECK:STDOUT:   %.loc54_14.4: Class* = addr_of %.loc54_14.3
 // CHECK:STDOUT:   %.loc54_18.1: init i32 = call %.loc54_16(%.loc54_14.4)
 // CHECK:STDOUT:   %.loc54_20: i32 = value_of_initializer %.loc54_18.1

--- a/toolchain/check/testdata/class/nested.carbon
+++ b/toolchain/check/testdata/class/nested.carbon
@@ -103,45 +103,55 @@ fn F(a: Outer*) {
 // CHECK:STDOUT:   %.loc20_21: type = ptr_type Inner [template = constants.%.1]
 // CHECK:STDOUT:   %a.ref.loc20: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc20_26: ref Outer = deref %a.ref.loc20
+// CHECK:STDOUT:   %pi.ref.loc20: <unbound element of class Outer> = name_ref pi, @Outer.%.loc16_9 [template = @Outer.%.loc16_9]
 // CHECK:STDOUT:   %.loc20_29.1: ref Inner* = class_element_access %.loc20_26, element2
 // CHECK:STDOUT:   %.loc20_29.2: Inner* = bind_value %.loc20_29.1
 // CHECK:STDOUT:   %b: Inner* = bind_name b, %.loc20_29.2
 // CHECK:STDOUT:   %a.ref.loc22_5: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc22_4: ref Outer = deref %a.ref.loc22_5
+// CHECK:STDOUT:   %po.ref.loc22: <unbound element of class Outer> = name_ref po, @Outer.%.loc14_9 [template = @Outer.%.loc14_9]
 // CHECK:STDOUT:   %.loc22_7: ref Outer* = class_element_access %.loc22_4, element0
 // CHECK:STDOUT:   %a.ref.loc22_13: Outer* = name_ref a, %a
 // CHECK:STDOUT:   assign %.loc22_7, %a.ref.loc22_13
 // CHECK:STDOUT:   %a.ref.loc23_5: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc23_4: ref Outer = deref %a.ref.loc23_5
+// CHECK:STDOUT:   %qo.ref: <unbound element of class Outer> = name_ref qo, @Outer.%.loc15_9 [template = @Outer.%.loc15_9]
 // CHECK:STDOUT:   %.loc23_7: ref Outer* = class_element_access %.loc23_4, element1
 // CHECK:STDOUT:   %a.ref.loc23_13: Outer* = name_ref a, %a
 // CHECK:STDOUT:   assign %.loc23_7, %a.ref.loc23_13
 // CHECK:STDOUT:   %a.ref.loc24_5: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc24_4: ref Outer = deref %a.ref.loc24_5
+// CHECK:STDOUT:   %pi.ref.loc24_7: <unbound element of class Outer> = name_ref pi, @Outer.%.loc16_9 [template = @Outer.%.loc16_9]
 // CHECK:STDOUT:   %.loc24_7: ref Inner* = class_element_access %.loc24_4, element2
 // CHECK:STDOUT:   %a.ref.loc24_15: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc24_14: ref Outer = deref %a.ref.loc24_15
+// CHECK:STDOUT:   %pi.ref.loc24_17: <unbound element of class Outer> = name_ref pi, @Outer.%.loc16_9 [template = @Outer.%.loc16_9]
 // CHECK:STDOUT:   %.loc24_17.1: ref Inner* = class_element_access %.loc24_14, element2
 // CHECK:STDOUT:   %.loc24_17.2: Inner* = bind_value %.loc24_17.1
 // CHECK:STDOUT:   assign %.loc24_7, %.loc24_17.2
 // CHECK:STDOUT:   %b.ref.loc25: Inner* = name_ref b, %b
 // CHECK:STDOUT:   %.loc25_4: ref Inner = deref %b.ref.loc25
+// CHECK:STDOUT:   %po.ref.loc25: <unbound element of class Inner> = name_ref po, @Inner.%.loc10_11 [template = @Inner.%.loc10_11]
 // CHECK:STDOUT:   %.loc25_7: ref Outer* = class_element_access %.loc25_4, element1
 // CHECK:STDOUT:   %a.ref.loc25: Outer* = name_ref a, %a
 // CHECK:STDOUT:   assign %.loc25_7, %a.ref.loc25
 // CHECK:STDOUT:   %b.ref.loc26: Inner* = name_ref b, %b
 // CHECK:STDOUT:   %.loc26_4: ref Inner = deref %b.ref.loc26
+// CHECK:STDOUT:   %pi.ref.loc26_7: <unbound element of class Inner> = name_ref pi, @Inner.%.loc9_11 [template = @Inner.%.loc9_11]
 // CHECK:STDOUT:   %.loc26_7: ref Inner* = class_element_access %.loc26_4, element0
 // CHECK:STDOUT:   %a.ref.loc26: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc26_14: ref Outer = deref %a.ref.loc26
+// CHECK:STDOUT:   %pi.ref.loc26_17: <unbound element of class Outer> = name_ref pi, @Outer.%.loc16_9 [template = @Outer.%.loc16_9]
 // CHECK:STDOUT:   %.loc26_17.1: ref Inner* = class_element_access %.loc26_14, element2
 // CHECK:STDOUT:   %.loc26_17.2: Inner* = bind_value %.loc26_17.1
 // CHECK:STDOUT:   assign %.loc26_7, %.loc26_17.2
 // CHECK:STDOUT:   %b.ref.loc27: Inner* = name_ref b, %b
 // CHECK:STDOUT:   %.loc27_4: ref Inner = deref %b.ref.loc27
+// CHECK:STDOUT:   %qi.ref: <unbound element of class Inner> = name_ref qi, @Inner.%.loc11_11 [template = @Inner.%.loc11_11]
 // CHECK:STDOUT:   %.loc27_7: ref Inner* = class_element_access %.loc27_4, element2
 // CHECK:STDOUT:   %a.ref.loc27: Outer* = name_ref a, %a
 // CHECK:STDOUT:   %.loc27_14: ref Outer = deref %a.ref.loc27
+// CHECK:STDOUT:   %pi.ref.loc27: <unbound element of class Outer> = name_ref pi, @Outer.%.loc16_9 [template = @Outer.%.loc16_9]
 // CHECK:STDOUT:   %.loc27_17.1: ref Inner* = class_element_access %.loc27_14, element2
 // CHECK:STDOUT:   %.loc27_17.2: Inner* = bind_value %.loc27_17.1
 // CHECK:STDOUT:   assign %.loc27_7, %.loc27_17.2

--- a/toolchain/check/testdata/class/nested_name.carbon
+++ b/toolchain/check/testdata/class/nested_name.carbon
@@ -71,6 +71,7 @@ fn G(o: Outer) {
 // CHECK:STDOUT: fn @F(%oi: Inner) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %oi.ref: Inner = name_ref oi, %oi
+// CHECK:STDOUT:   %n.ref: <unbound element of class Inner> = name_ref n, @Inner.%.loc9 [template = @Inner.%.loc9]
 // CHECK:STDOUT:   %.loc14_12.1: ref i32 = class_element_access %oi.ref, element0
 // CHECK:STDOUT:   %.loc14_12.2: i32 = bind_value %.loc14_12.1
 // CHECK:STDOUT:   return %.loc14_12.2

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -90,6 +90,7 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref.loc14_5: Class* = name_ref self, %self.loc13_17
 // CHECK:STDOUT:   %.loc14_4: ref Class = deref %self.ref.loc14_5
+// CHECK:STDOUT:   %n.ref: <unbound element of class Class> = name_ref n, @Class.%.loc10 [template = @Class.%.loc10]
 // CHECK:STDOUT:   %.loc14_10: ref i32 = class_element_access %.loc14_4, element0
 // CHECK:STDOUT:   %self.ref.loc14_15: i32 = name_ref r#self, %self.loc13_30
 // CHECK:STDOUT:   assign %.loc14_10, %self.ref.loc14_15
@@ -99,6 +100,7 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT: fn @G[%self.loc17_12: Class](%self.loc17_24: i32) -> %return: (i32, i32) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref.loc18_11: Class = name_ref self, %self.loc17_12
+// CHECK:STDOUT:   %n.ref: <unbound element of class Class> = name_ref n, @Class.%.loc10 [template = @Class.%.loc10]
 // CHECK:STDOUT:   %.loc18_15.1: ref i32 = class_element_access %self.ref.loc18_11, element0
 // CHECK:STDOUT:   %.loc18_15.2: i32 = bind_value %.loc18_15.1
 // CHECK:STDOUT:   %self.ref.loc18_19: i32 = name_ref r#self, %self.loc17_24

--- a/toolchain/check/testdata/class/self.carbon
+++ b/toolchain/check/testdata/class/self.carbon
@@ -77,6 +77,7 @@ fn Class.G[addr self: Self*]() -> i32 {
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Class = name_ref self, %self
+// CHECK:STDOUT:   %n.ref: <unbound element of class Class> = name_ref n, @Class.%.loc11 [template = @Class.%.loc11]
 // CHECK:STDOUT:   %.loc15_14.1: ref i32 = class_element_access %self.ref, element0
 // CHECK:STDOUT:   %.loc15_14.2: i32 = bind_value %.loc15_14.1
 // CHECK:STDOUT:   return %.loc15_14.2
@@ -86,6 +87,7 @@ fn Class.G[addr self: Self*]() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Class* = name_ref self, %self
 // CHECK:STDOUT:   %.loc19_11: ref Class = deref %self.ref
+// CHECK:STDOUT:   %n.ref: <unbound element of class Class> = name_ref n, @Class.%.loc11 [template = @Class.%.loc11]
 // CHECK:STDOUT:   %.loc19_17.1: ref i32 = class_element_access %.loc19_11, element0
 // CHECK:STDOUT:   %.loc19_17.2: i32 = bind_value %.loc19_17.1
 // CHECK:STDOUT:   return %.loc19_17.2

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -112,6 +112,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: fn @SelfBase[%self: Base]() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Base = name_ref self, %self
+// CHECK:STDOUT:   %a.ref: <unbound element of class Base> = name_ref a, @Base.%.loc8 [template = @Base.%.loc8]
 // CHECK:STDOUT:   %.loc19_14.1: ref i32 = class_element_access %self.ref, element0
 // CHECK:STDOUT:   %.loc19_14.2: i32 = bind_value %.loc19_14.1
 // CHECK:STDOUT:   return %.loc19_14.2
@@ -121,6 +122,7 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Base* = name_ref self, %self
 // CHECK:STDOUT:   %.loc23_4: ref Base = deref %self.ref
+// CHECK:STDOUT:   %a.ref: <unbound element of class Base> = name_ref a, @Base.%.loc8 [template = @Base.%.loc8]
 // CHECK:STDOUT:   %.loc23_10: ref i32 = class_element_access %.loc23_4, element0
 // CHECK:STDOUT:   %.loc23_15: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   assign %.loc23_10, %.loc23_15
@@ -131,7 +133,8 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref.loc27: Derived* = name_ref p, %p
 // CHECK:STDOUT:   %.loc27_4.1: ref Derived = deref %p.ref.loc27
-// CHECK:STDOUT:   %.loc27_7: <bound method> = bound_method %.loc27_4.1, @Derived.%AddrSelfBase
+// CHECK:STDOUT:   %AddrSelfBase.ref: <function> = name_ref AddrSelfBase, @Derived.%AddrSelfBase [template = @Derived.%AddrSelfBase]
+// CHECK:STDOUT:   %.loc27_7: <bound method> = bound_method %.loc27_4.1, %AddrSelfBase.ref
 // CHECK:STDOUT:   %.loc27_4.2: Derived* = addr_of %.loc27_4.1
 // CHECK:STDOUT:   %.loc27_20.1: ref Derived = deref %.loc27_4.2
 // CHECK:STDOUT:   %.loc27_20.2: ref Base = class_element_access %.loc27_20.1, element0
@@ -140,7 +143,8 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %.loc27_20.4: init () = call %.loc27_7(%.loc27_4.3)
 // CHECK:STDOUT:   %p.ref.loc28: Derived* = name_ref p, %p
 // CHECK:STDOUT:   %.loc28_11.1: ref Derived = deref %p.ref.loc28
-// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11.1, @Derived.%SelfBase
+// CHECK:STDOUT:   %SelfBase.ref: <function> = name_ref SelfBase, @Derived.%SelfBase [template = @Derived.%SelfBase]
+// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11.1, %SelfBase.ref
 // CHECK:STDOUT:   %.loc28_23.1: ref Base = class_element_access %.loc28_11.1, element0
 // CHECK:STDOUT:   %.loc28_11.2: ref Base = converted %.loc28_11.1, %.loc28_23.1
 // CHECK:STDOUT:   %.loc28_11.3: Base = bind_value %.loc28_11.2

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -56,10 +56,12 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT: fn @F[%self: Class]() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %self.ref: Class = name_ref self, %self
+// CHECK:STDOUT:   %p.ref: <unbound element of class Class> = name_ref p, @Class.%.loc9_8 [template = @Class.%.loc9_8]
 // CHECK:STDOUT:   %.loc13_16.1: ref Class* = class_element_access %self.ref, element0
 // CHECK:STDOUT:   %.loc13_16.2: Class* = bind_value %.loc13_16.1
 // CHECK:STDOUT:   %.loc13_11.1: ref Class = deref %.loc13_16.2
-// CHECK:STDOUT:   %.loc13_19: <bound method> = bound_method %.loc13_11.1, @Class.%F
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc13_19: <bound method> = bound_method %.loc13_11.1, %F.ref
 // CHECK:STDOUT:   %.loc13_11.2: Class = bind_value %.loc13_11.1
 // CHECK:STDOUT:   %.loc13_21.1: init i32 = call %.loc13_19(%.loc13_11.2)
 // CHECK:STDOUT:   %.loc13_23: i32 = value_of_initializer %.loc13_21.1

--- a/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
@@ -7,9 +7,9 @@
 interface Interface { fn F(); }
 
 fn CallStatic(T:! Interface) {
-  // CHECK:STDERR: fail_todo_facet_lookup.carbon:[[@LINE+3]]:3: ERROR: Type `Interface` does not support qualified expressions.
+  // CHECK:STDERR: fail_todo_facet_lookup.carbon:[[@LINE+3]]:3: ERROR: Value of type `<associated <function> in Interface>` is not callable.
   // CHECK:STDERR:   T.F();
-  // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:   ^~~~
   T.F();
 }
 
@@ -69,6 +69,7 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT: fn @CallStatic(%T: Interface) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %T.ref: Interface = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %F.ref: <associated <function> in Interface> = name_ref F, @Interface.%.loc7 [template = constants.%.3]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -67,7 +67,8 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id) -> llvm::Value* {
     return GetFunction(function_decl->function_id);
   }
 
-  if (target.Is<SemIR::AssociatedEntity>()) {
+  if (target.Is<SemIR::AssociatedEntity>() || target.Is<SemIR::FieldDecl>() ||
+      target.Is<SemIR::BaseDecl>()) {
     return llvm::ConstantStruct::getAnon(llvm_context(), {});
   }
 


### PR DESCRIPTION
A couple of minor functional changes here:

- We now always create a `name_ref` for the name referred to by the right-hand operand of member access. Previously we skipped creating this instruction if the referenced name was a field, and just created the field access instruction. This makes our processing of member accesses and our SemIR representation a bit more uniform.
- We now perform lookup into the type of the left-hand operand if it's any type with a scope, not just for classes. This means we do lookup into interface types. However, doing so isn't really useful yet because it always finds an associated entity that isn't usable by itself. This changes the diagnostic in `toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon`.