### PR TITLE
Switch Check's TODO to use SemIRLocation

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -50,10 +50,10 @@ Context::Context(const Lex::TokenizedBuffer& tokens, DiagnosticEmitter& emitter,
        SemIR::TypeId::TypeType});
 }
 
-auto Context::TODO(Parse::NodeId node_id, std::string label) -> bool {
+auto Context::TODO(SemIRLocation loc, std::string label) -> bool {
   CARBON_DIAGNOSTIC(SemanticsTodo, Error, "Semantics TODO: `{0}`.",
                     std::string);
-  emitter_->Emit(node_id, SemanticsTodo, std::move(label));
+  emitter_->Emit(loc, SemanticsTodo, std::move(label));
   return false;
 }
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -56,7 +56,7 @@ class Context {
                    SemIR::File& sem_ir, llvm::raw_ostream* vlog_stream);
 
   // Marks an implementation TODO. Always returns false.
-  auto TODO(Parse::NodeId node_id, std::string label) -> bool;
+  auto TODO(SemIRLocation loc, std::string label) -> bool;
 
   // Runs verification that the processing cleanly finished.
   auto VerifyOnFinish() -> void;

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -302,8 +302,7 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
             if (!int_bound) {
               // TODO: Permit symbolic array bounds. This will require fixing
               // callers of `GetArrayBoundValue`.
-              context.TODO(context.insts().GetNodeId(bound_id),
-                           "symbolic array bound");
+              context.TODO(bound_id, "symbolic array bound");
               return false;
             }
             // TODO: We should check that the size of the resulting array type

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -104,7 +104,7 @@ static auto BuildInterfaceWitness(
       }
     } else if (auto const_decl = decl.TryAs<SemIR::AssociatedConstantDecl>()) {
       // TODO: Check we have a value for this constant in the constraint.
-      context.TODO(context.insts().GetNodeId(impl.definition_id),
+      context.TODO(impl.definition_id,
                    "impl of interface with associated constant");
       return SemIR::InstId::BuiltinError;
     } else {
@@ -127,8 +127,7 @@ auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)
   auto interface_type =
       context.types().TryGetAs<SemIR::InterfaceType>(impl.constraint_id);
   if (!interface_type) {
-    context.TODO(context.insts().GetNodeId(impl.definition_id),
-                 "impl as non-interface");
+    context.TODO(impl.definition_id, "impl as non-interface");
     return SemIR::InstId::BuiltinError;
   }
 

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -343,7 +343,7 @@ class ImportRefResolver {
 
       default:
         context_.TODO(
-            Parse::NodeId::Invalid,
+            Parse::NodeId(Parse::NodeId::Invalid),
             llvm::formatv("TryResolveInst on {0}", inst.kind()).str());
         return SemIR::ConstantId::Error;
     }


### PR DESCRIPTION
Allows dropping a few GetNodeId calls for code cleanliness.