### PR TITLE
Fix toolchain file_test_base multi-file integration.

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -73,11 +73,12 @@ static auto CompareFailPrefix(llvm::StringRef filename, bool success) -> void {
   if (success) {
     EXPECT_FALSE(filename.starts_with("fail_"))
         << "`" << filename
-        << "` succeeded; if this is correct, add a `fail_` prefix.";
+        << "` succeeded; if success is expected, remove the `fail_` "
+           "prefix.";
   } else {
     EXPECT_TRUE(filename.starts_with("fail_"))
         << "`" << filename
-        << "` failed; if this is correct, remove the `fail_` prefix.";
+        << "` failed; if failure is expected, add the `fail_` prefix.";
   }
 }
 

--- a/toolchain/driver/testdata/fail_missing_file.carbon
+++ b/toolchain/driver/testdata/fail_missing_file.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile nonexistent.carbon
+// ARGS: compile not_file.carbon
 //
 // AUTOUPDATE
-// CHECK:STDERR: nonexistent.carbon: ERROR: Error opening file for read: No such file or directory
+// CHECK:STDERR: not_file.carbon: ERROR: Error opening file for read: No such file or directory


### PR DESCRIPTION
test_args will never contain %s; switch to filtering arguments, and handle the edge cases.