### PR TITLE
Change Namespace formatting to use the scope's name.

### DIFF
--- a/toolchain/check/testdata/alias/fail_local_in_namespace.carbon
+++ b/toolchain/check/testdata/alias/fail_local_in_namespace.carbon
@@ -28,10 +28,10 @@ fn F() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
@@ -41,7 +41,7 @@ fn F() -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc16_16: bool = bool_literal false [template = constants.%.1]
 // CHECK:STDOUT:   %.loc16_9: <error> = bind_alias <invalid>, <error> [template = <error>]
-// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%.loc7 [template = file.%.loc7]
+// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/in_namespace.carbon
+++ b/toolchain/check/testdata/alias/in_namespace.carbon
@@ -21,19 +21,19 @@ fn F() -> NS.a {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: type = bind_alias a, bool [template = bool]
-// CHECK:STDOUT:   %NS.ref.loc10: <namespace> = name_ref NS, %.loc7 [template = %.loc7]
+// CHECK:STDOUT:   %NS.ref.loc10: <namespace> = name_ref NS, %NS [template = %NS]
 // CHECK:STDOUT:   %a.ref.loc10: type = name_ref a, %a [template = bool]
 // CHECK:STDOUT:   %.loc10: bool = bool_literal false [template = constants.%.1]
 // CHECK:STDOUT:   %b: bool = bind_name b, %.loc10
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %NS.ref.loc12: <namespace> = name_ref NS, %.loc7 [template = %.loc7]
+// CHECK:STDOUT:     %NS.ref.loc12: <namespace> = name_ref NS, %NS [template = %NS]
 // CHECK:STDOUT:     %a.ref.loc12: type = name_ref a, %a [template = bool]
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -43,14 +43,14 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .N = %.loc11
+// CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc11: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %N: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
@@ -66,7 +66,7 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%.loc11 [template = file.%.loc11]
+// CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [template = file.%N]
 // CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign file.%a.var, <error>
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -22,9 +22,9 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
@@ -35,11 +35,11 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.2
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref, [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {
@@ -57,7 +57,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%.2 [template = file.%.2]
+// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc6: init i32 = call %A.ref()
 // CHECK:STDOUT:   assign file.%a.var, %.loc6

--- a/toolchain/check/testdata/namespace/alias.carbon
+++ b/toolchain/check/testdata/namespace/alias.carbon
@@ -24,24 +24,24 @@ fn D() -> i32 { return C(); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .ns = %ns
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %NS.ref.loc9: <namespace> = name_ref NS, %.loc7 [template = %.loc7]
-// CHECK:STDOUT:   %ns: <namespace> = bind_alias ns, %.loc7 [template = %.loc7]
+// CHECK:STDOUT:   %NS.ref.loc9: <namespace> = name_ref NS, %NS [template = %NS]
+// CHECK:STDOUT:   %ns: <namespace> = bind_alias ns, %NS [template = %NS]
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {
 // CHECK:STDOUT:     %return.var.loc11: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
 // CHECK:STDOUT:     %return.var.loc13: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %NS.ref.loc15: <namespace> = name_ref NS, %.loc7 [template = %.loc7]
+// CHECK:STDOUT:   %NS.ref.loc15: <namespace> = name_ref NS, %NS [template = %NS]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, %A [template = %A]
 // CHECK:STDOUT:   %C: <function> = bind_alias C, %A [template = %A]
 // CHECK:STDOUT:   %D: <function> = fn_decl @D [template] {
@@ -57,7 +57,7 @@ fn D() -> i32 { return C(); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %ns.ref: <namespace> = name_ref ns, file.%ns [template = file.%.loc7]
+// CHECK:STDOUT:   %ns.ref: <namespace> = name_ref ns, file.%ns [template = file.%NS]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc13_28.1: init i32 = call %A.ref()
 // CHECK:STDOUT:   %.loc13_30: i32 = value_of_initializer %.loc13_28.1

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -44,20 +44,20 @@ fn NS();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_conflict.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc8_13.1
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.loc8_13.1: <namespace> = namespace %import_ref, [template] {}
-// CHECK:STDOUT:   %.loc8_13.2: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {}
+// CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc16: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:   %.loc20: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc28: <function> = fn_decl @.2 [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
@@ -30,19 +30,19 @@ fn NS.Foo();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_conflict.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.2
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref, [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc12: <function> = fn_decl @.1 [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -36,9 +36,9 @@ fn NS.Bar() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template] {}
@@ -67,10 +67,10 @@ fn NS.Bar() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.2
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.2
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -50,9 +50,9 @@ fn NS.Bar() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc10
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc10: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Foo: <function> = fn_decl @Foo [template] {}
@@ -67,11 +67,11 @@ fn NS.Bar() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.2
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unused
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.2, [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.3
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_decl_in_alias.carbon
+++ b/toolchain/check/testdata/namespace/fail_decl_in_alias.carbon
@@ -25,12 +25,12 @@ fn ns.A() -> i32 { return 0; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .ns = %ns
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, %.loc7 [template = %.loc7]
-// CHECK:STDOUT:   %ns: <namespace> = bind_alias ns, %.loc7 [template = %.loc7]
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, %NS [template = %NS]
+// CHECK:STDOUT:   %ns: <namespace> = bind_alias ns, %NS [template = %NS]
 // CHECK:STDOUT:   %.loc18: <function> = fn_decl @.1 [template] {
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -22,9 +22,9 @@ fn Foo.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Foo = %.loc7
+// CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %Foo: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Baz = %Baz.loc9
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Baz.loc9: <function> = fn_decl @Baz [template] {}

--- a/toolchain/check/testdata/namespace/fail_modifiers.carbon
+++ b/toolchain/check/testdata/namespace/fail_modifiers.carbon
@@ -47,12 +47,12 @@ extern namespace C;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.loc34
-// CHECK:STDOUT:     .B = %.loc39
-// CHECK:STDOUT:     .C = %.loc44
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:     .B = %B
+// CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc34: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc39: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc44: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %A: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %B: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %C: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/function.carbon
+++ b/toolchain/check/testdata/namespace/function.carbon
@@ -25,11 +25,11 @@ fn Bar() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Foo = %.loc7
+// CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:     .Baz = %Baz.loc10
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %Foo: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Baz = %Baz.loc13
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Baz.loc10: <function> = fn_decl @Baz.1 [template] {}
@@ -49,7 +49,7 @@ fn Bar() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Bar() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%.loc7 [template = file.%.loc7]
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %Baz.ref: <function> = name_ref Baz, file.%Baz.loc13 [template = file.%Baz.loc13]
 // CHECK:STDOUT:   %.loc17: init () = call %Baz.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -28,13 +28,13 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .ChildNS = %.loc5
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .ChildNS = %ChildNS
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc5: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %ChildNS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
@@ -53,19 +53,19 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.2
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .package_a = %package_a
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.1, [template] {
-// CHECK:STDOUT:     .ChildNS = %.3
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:     .ChildNS = %ChildNS
 // CHECK:STDOUT:     .A = %import_ref.3
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+2, used
-// CHECK:STDOUT:   %.3: <namespace> = namespace %import_ref.2, [template] {
+// CHECK:STDOUT:   %ChildNS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .B = %import_ref.4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+3, used [template = imports.%A]
@@ -94,23 +94,23 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %NS.ref.loc4: <namespace> = name_ref NS, file.%.2 [template = file.%.2]
+// CHECK:STDOUT:   %NS.ref.loc4: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %A.ref.loc4: <function> = name_ref A, file.%import_ref.3 [template = imports.%A]
 // CHECK:STDOUT:   %.loc4: init () = call %A.ref.loc4()
 // CHECK:STDOUT:   assign file.%a.var, %.loc4
-// CHECK:STDOUT:   %NS.ref.loc5: <namespace> = name_ref NS, file.%.2 [template = file.%.2]
-// CHECK:STDOUT:   %ChildNS.ref.loc5: <namespace> = name_ref ChildNS, file.%.3 [template = file.%.3]
+// CHECK:STDOUT:   %NS.ref.loc5: <namespace> = name_ref NS, file.%NS [template = file.%NS]
+// CHECK:STDOUT:   %ChildNS.ref.loc5: <namespace> = name_ref ChildNS, file.%ChildNS [template = file.%ChildNS]
 // CHECK:STDOUT:   %B.ref.loc5: <function> = name_ref B, file.%import_ref.4 [template = imports.%B]
 // CHECK:STDOUT:   %.loc5: init () = call %B.ref.loc5()
 // CHECK:STDOUT:   assign file.%b.var, %.loc5
 // CHECK:STDOUT:   %package.ref.loc7: <namespace> = name_ref package, package [template = package]
-// CHECK:STDOUT:   %NS.ref.loc7: <namespace> = name_ref NS, file.%.2 [template = file.%.2]
+// CHECK:STDOUT:   %NS.ref.loc7: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %A.ref.loc7: <function> = name_ref A, file.%import_ref.3 [template = imports.%A]
 // CHECK:STDOUT:   %.loc7: init () = call %A.ref.loc7()
 // CHECK:STDOUT:   assign file.%package_a.var, %.loc7
 // CHECK:STDOUT:   %package.ref.loc8: <namespace> = name_ref package, package [template = package]
-// CHECK:STDOUT:   %NS.ref.loc8: <namespace> = name_ref NS, file.%.2 [template = file.%.2]
-// CHECK:STDOUT:   %ChildNS.ref.loc8: <namespace> = name_ref ChildNS, file.%.3 [template = file.%.3]
+// CHECK:STDOUT:   %NS.ref.loc8: <namespace> = name_ref NS, file.%NS [template = file.%NS]
+// CHECK:STDOUT:   %ChildNS.ref.loc8: <namespace> = name_ref ChildNS, file.%ChildNS [template = file.%ChildNS]
 // CHECK:STDOUT:   %B.ref.loc8: <function> = name_ref B, file.%import_ref.4 [template = imports.%B]
 // CHECK:STDOUT:   %.loc8: init () = call %B.ref.loc8()
 // CHECK:STDOUT:   assign file.%package_b.var, %.loc8

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -42,57 +42,57 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.loc4
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %A: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- b.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.2
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref, [template] {
-// CHECK:STDOUT:     .B = %.loc5
+// CHECK:STDOUT:   %A: <namespace> = namespace %import_ref, [template] {
+// CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc5: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %B: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- c.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.2
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.1, [template] {
-// CHECK:STDOUT:     .B = %.3
+// CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+3, used
-// CHECK:STDOUT:   %.3: <namespace> = namespace %import_ref.2, [template] {
-// CHECK:STDOUT:     .C = %.loc5
+// CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
+// CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc5: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %C: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- d.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.2
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.1, [template] {
-// CHECK:STDOUT:     .B = %.3
+// CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, used
-// CHECK:STDOUT:   %.3: <namespace> = namespace %import_ref.2, [template] {
-// CHECK:STDOUT:     .C = %.4
+// CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
+// CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+5, used
-// CHECK:STDOUT:   %.4: <namespace> = namespace %import_ref.3, [template] {
+// CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %D: <function> = fn_decl @D [template] {}
@@ -111,19 +111,19 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.2
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, used
-// CHECK:STDOUT:   %.2: <namespace> = namespace %import_ref.1, [template] {
-// CHECK:STDOUT:     .B = %.3
+// CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, used
-// CHECK:STDOUT:   %.3: <namespace> = namespace %import_ref.2, [template] {
-// CHECK:STDOUT:     .C = %.4
+// CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
+// CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+6, used
-// CHECK:STDOUT:   %.4: <namespace> = namespace %import_ref.3, [template] {
+// CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+7, used [template = imports.%D]
@@ -137,9 +137,9 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, file.%.2 [template = file.%.2]
-// CHECK:STDOUT:   %B.ref: <namespace> = name_ref B, file.%.3 [template = file.%.3]
-// CHECK:STDOUT:   %C.ref: <namespace> = name_ref C, file.%.4 [template = file.%.4]
+// CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %B.ref: <namespace> = name_ref B, file.%B [template = file.%B]
+// CHECK:STDOUT:   %C.ref: <namespace> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D]
 // CHECK:STDOUT:   %.loc5: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%e.var, %.loc5

--- a/toolchain/check/testdata/namespace/merging.carbon
+++ b/toolchain/check/testdata/namespace/merging.carbon
@@ -46,9 +46,9 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
@@ -63,9 +63,9 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B1 = %B1
 // CHECK:STDOUT:     .B2 = %B2
 // CHECK:STDOUT:   }
@@ -92,11 +92,11 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7_13.1
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, used
-// CHECK:STDOUT:   %.loc7_13.1: <namespace> = namespace %import_ref.1, [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .B1 = %import_ref.3
 // CHECK:STDOUT:     .B2 = %import_ref.4
@@ -105,7 +105,7 @@ fn Run() {
 // CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+2, used [template = imports.%A]
 // CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+2, used [template = imports.%B1]
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+5, used [template = imports.%B2]
-// CHECK:STDOUT:   %.loc7_13.2: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C: <function> = fn_decl @C [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
 // CHECK:STDOUT: }
@@ -117,16 +117,16 @@ fn Run() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %NS.ref.loc12: <namespace> = name_ref NS, file.%.loc7_13.1 [template = file.%.loc7_13.1]
+// CHECK:STDOUT:   %NS.ref.loc12: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%import_ref.2 [template = imports.%A]
 // CHECK:STDOUT:   %.loc12: init () = call %A.ref()
-// CHECK:STDOUT:   %NS.ref.loc13: <namespace> = name_ref NS, file.%.loc7_13.1 [template = file.%.loc7_13.1]
+// CHECK:STDOUT:   %NS.ref.loc13: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %B1.ref: <function> = name_ref B1, file.%import_ref.3 [template = imports.%B1]
 // CHECK:STDOUT:   %.loc13: init () = call %B1.ref()
-// CHECK:STDOUT:   %NS.ref.loc14: <namespace> = name_ref NS, file.%.loc7_13.1 [template = file.%.loc7_13.1]
+// CHECK:STDOUT:   %NS.ref.loc14: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %B2.ref: <function> = name_ref B2, file.%import_ref.4 [template = imports.%B2]
 // CHECK:STDOUT:   %.loc14: init () = call %B2.ref()
-// CHECK:STDOUT:   %NS.ref.loc15: <namespace> = name_ref NS, file.%.loc7_13.1 [template = file.%.loc7_13.1]
+// CHECK:STDOUT:   %NS.ref.loc15: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc15: init () = call %C.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/nested.carbon
+++ b/toolchain/check/testdata/namespace/nested.carbon
@@ -22,12 +22,12 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Foo = %.loc7
+// CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .Bar = %.loc8
+// CHECK:STDOUT:   %Foo: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %Bar: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Wiz = %Wiz
 // CHECK:STDOUT:     .Baz = %Baz
 // CHECK:STDOUT:   }
@@ -42,8 +42,8 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Baz() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%.loc7 [template = file.%.loc7]
-// CHECK:STDOUT:   %Bar.ref: <namespace> = name_ref Bar, file.%.loc8 [template = file.%.loc8]
+// CHECK:STDOUT:   %Foo.ref: <namespace> = name_ref Foo, file.%Foo [template = file.%Foo]
+// CHECK:STDOUT:   %Bar.ref: <namespace> = name_ref Bar, file.%Bar [template = file.%Bar]
 // CHECK:STDOUT:   %Wiz.ref: <function> = name_ref Wiz, file.%Wiz [template = file.%Wiz]
 // CHECK:STDOUT:   %.loc14: init () = call %Wiz.ref()
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/namespace/shadow.carbon
+++ b/toolchain/check/testdata/namespace/shadow.carbon
@@ -34,15 +34,15 @@ fn N.M.B() -> i32 {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.loc7
-// CHECK:STDOUT:     .N = %.loc9
+// CHECK:STDOUT:     .N = %N
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A.1 [template] {}
-// CHECK:STDOUT:   %.loc9: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %N: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.loc10
-// CHECK:STDOUT:     .M = %.loc12
+// CHECK:STDOUT:     .M = %M
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.loc10: <function> = fn_decl @A.2 [template] {}
-// CHECK:STDOUT:   %.loc12: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %M: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {

--- a/toolchain/check/testdata/namespace/unqualified_lookup.carbon
+++ b/toolchain/check/testdata/namespace/unqualified_lookup.carbon
@@ -34,16 +34,16 @@ fn OuterN.InnerN.CallABC() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .OuterN = %.loc7
+// CHECK:STDOUT:     .OuterN = %OuterN
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .CallA = %CallA
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .InnerN = %.loc8
+// CHECK:STDOUT:   %OuterN: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .InnerN = %InnerN
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:     .CallAB = %CallAB
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %InnerN: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:     .CallABC = %CallABC
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/package_expr/syntax.carbon
+++ b/toolchain/check/testdata/package_expr/syntax.carbon
@@ -130,10 +130,10 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc4
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Main = %Main
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc4: <namespace> = namespace [template] {
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
@@ -156,7 +156,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %package.ref: <namespace> = name_ref package, package [template = package]
-// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%.loc4 [template = file.%.loc4]
+// CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, @C.%Foo [template = @C.%Foo]
 // CHECK:STDOUT:   %.loc11: init () = call %Foo.ref()

--- a/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -17,16 +17,16 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.loc7
+// CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %A: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, file.%.loc7 [template = file.%.loc7]
+// CHECK:STDOUT:   %A.ref: <namespace> = name_ref A, file.%A [template = file.%A]
 // CHECK:STDOUT:   %.loc13: ref <error> = deref <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/fail_namespace_conflict.carbon
+++ b/toolchain/check/testdata/var/fail_namespace_conflict.carbon
@@ -30,9 +30,9 @@ var A: i32 = 1;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .A = %.loc7
+// CHECK:STDOUT:     .A = %A.loc7
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %A.loc7: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A.var.loc15: ref i32 = var A
 // CHECK:STDOUT:   %A.loc15: ref i32 = bind_name A, %A.var.loc15
 // CHECK:STDOUT:   %A.var.loc23: ref i32 = var A

--- a/toolchain/check/testdata/var/shadowing.carbon
+++ b/toolchain/check/testdata/var/shadowing.carbon
@@ -29,10 +29,10 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
-// CHECK:STDOUT:     .NS = %.loc7
+// CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Main = %Main
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %NS: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Main: <function> = fn_decl @Main [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -531,6 +531,13 @@ class InstNamer {
           add_inst_name_id(inst.As<NameRef>().name_id, ".ref");
           continue;
         }
+        // The namespace is specified here due to the name conflict.
+        case SemIR::Namespace::Kind: {
+          add_inst_name_id(sem_ir_.name_scopes()
+                               .Get(inst.As<SemIR::Namespace>().name_scope_id)
+                               .name_id);
+          continue;
+        }
         case Param::Kind: {
           add_inst_name_id(inst.As<Param>().name_id);
           continue;


### PR DESCRIPTION
This change only affects the generated IR, but I think it's cleaning up an existing issue with namespace name printing.