### PR TITLE
Substitute `Self` in associated function signatures before checking them against `impl`s.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -202,6 +202,7 @@ cc_library(
         ":context",
         ":subst",
         "//common:check",
+        "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:ids",
         "//toolchain/sem_ir:inst",

--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -142,6 +142,7 @@ cc_library(
     hdrs = ["function.h"],
     deps = [
         ":context",
+        ":subst",
         "//common:check",
         "//toolchain/sem_ir:file",
     ],
@@ -154,6 +155,7 @@ cc_library(
     deps = [
         ":context",
         ":function",
+        ":subst",
         "//common:check",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/sem_ir:file",
@@ -196,6 +198,22 @@ cc_library(
     name = "member_access",
     srcs = ["member_access.cpp"],
     hdrs = ["member_access.h"],
+    deps = [
+        ":context",
+        ":subst",
+        "//common:check",
+        "//toolchain/sem_ir:file",
+        "//toolchain/sem_ir:ids",
+        "//toolchain/sem_ir:inst",
+        "//toolchain/sem_ir:inst_kind",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "subst",
+    srcs = ["subst.cpp"],
+    hdrs = ["subst.h"],
     deps = [
         ":context",
         "//common:check",

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/function.h"
+#include "toolchain/check/subst.h"
 
 namespace Carbon::Check {
 
@@ -31,7 +32,8 @@ static auto CheckRedeclParam(Context& context,
                              llvm::StringLiteral param_diag_label,
                              int32_t param_index,
                              SemIR::InstId new_param_ref_id,
-                             SemIR::InstId prev_param_ref_id) -> bool {
+                             SemIR::InstId prev_param_ref_id,
+                             Substitutions substitutions) -> bool {
   // TODO: Consider differentiating between type and name mistakes. For now,
   // taking the simpler approach because I also think we may want to refactor
   // params.
@@ -52,7 +54,8 @@ static auto CheckRedeclParam(Context& context,
   auto new_param_ref = context.insts().Get(new_param_ref_id);
   auto prev_param_ref = context.insts().Get(prev_param_ref_id);
   if (new_param_ref.kind() != prev_param_ref.kind() ||
-      new_param_ref.type_id() != prev_param_ref.type_id()) {
+      new_param_ref.type_id() !=
+          SubstType(context, prev_param_ref.type_id(), substitutions)) {
     diagnose();
     return false;
   }
@@ -90,7 +93,8 @@ static auto CheckRedeclParams(Context& context, SemIR::InstId new_decl_id,
                               SemIR::InstBlockId new_param_refs_id,
                               SemIR::InstId prev_decl_id,
                               SemIR::InstBlockId prev_param_refs_id,
-                              llvm::StringLiteral param_diag_label) -> bool {
+                              llvm::StringLiteral param_diag_label,
+                              Substitutions substitutions) -> bool {
   // This will often occur for empty params.
   if (new_param_refs_id == prev_param_refs_id) {
     return true;
@@ -116,7 +120,7 @@ static auto CheckRedeclParams(Context& context, SemIR::InstId new_decl_id,
   for (auto [index, new_param_ref_id, prev_param_ref_id] :
        llvm::enumerate(new_param_ref_ids, prev_param_ref_ids)) {
     if (!CheckRedeclParam(context, param_diag_label, index, new_param_ref_id,
-                          prev_param_ref_id)) {
+                          prev_param_ref_id, substitutions)) {
       return false;
     }
   }
@@ -125,21 +129,26 @@ static auto CheckRedeclParams(Context& context, SemIR::InstId new_decl_id,
 
 // Returns false if the provided function declarations differ.
 static auto CheckRedecl(Context& context, const SemIR::Function& new_function,
-                        const SemIR::Function& prev_function) -> bool {
+                        const SemIR::Function& prev_function,
+                        Substitutions substitutions) -> bool {
   if (FunctionDeclHasError(context, new_function) ||
       FunctionDeclHasError(context, prev_function)) {
     return false;
   }
-  if (!CheckRedeclParams(context, new_function.decl_id,
-                         new_function.implicit_param_refs_id,
-                         prev_function.decl_id,
-                         prev_function.implicit_param_refs_id, "implicit ") ||
+  if (!CheckRedeclParams(
+          context, new_function.decl_id, new_function.implicit_param_refs_id,
+          prev_function.decl_id, prev_function.implicit_param_refs_id,
+          "implicit ", substitutions) ||
       !CheckRedeclParams(context, new_function.decl_id,
                          new_function.param_refs_id, prev_function.decl_id,
-                         prev_function.param_refs_id, "")) {
+                         prev_function.param_refs_id, "", substitutions)) {
     return false;
   }
-  if (new_function.return_type_id != prev_function.return_type_id) {
+  auto prev_return_type_id =
+      prev_function.return_type_id.is_valid()
+          ? SubstType(context, prev_function.return_type_id, substitutions)
+          : SemIR::TypeId::Invalid;
+  if (new_function.return_type_id != prev_return_type_id) {
     CARBON_DIAGNOSTIC(
         FunctionRedeclReturnTypeDiffers, Error,
         "Function redeclaration differs because return type is `{0}`.",
@@ -154,12 +163,12 @@ static auto CheckRedecl(Context& context, const SemIR::Function& new_function,
                                       new_function.return_type_id)
             : context.emitter().Build(new_function.decl_id,
                                       FunctionRedeclReturnTypeDiffersNoReturn);
-    if (prev_function.return_type_id.is_valid()) {
+    if (prev_return_type_id.is_valid()) {
       CARBON_DIAGNOSTIC(FunctionRedeclReturnTypePrevious, Note,
                         "Previously declared with return type `{0}`.",
                         SemIR::TypeId);
       diag.Note(prev_function.decl_id, FunctionRedeclReturnTypePrevious,
-                prev_function.return_type_id);
+                prev_return_type_id);
     } else {
       CARBON_DIAGNOSTIC(FunctionRedeclReturnTypePreviousNoReturn, Note,
                         "Previously declared with no return type.");
@@ -173,10 +182,12 @@ static auto CheckRedecl(Context& context, const SemIR::Function& new_function,
   return true;
 }
 
-auto CheckFunctionRedecl(Context& context, SemIR::FunctionId new_function_id,
-                         SemIR::FunctionId prev_function_id) -> bool {
+auto CheckFunctionTypeMatches(Context& context,
+                              SemIR::FunctionId new_function_id,
+                              SemIR::FunctionId prev_function_id,
+                              Substitutions substitutions) -> bool {
   return CheckRedecl(context, context.functions().Get(new_function_id),
-                     context.functions().Get(prev_function_id));
+                     context.functions().Get(prev_function_id), substitutions);
 }
 
 auto MergeFunctionRedecl(Context& context, Parse::NodeId node_id,
@@ -186,7 +197,7 @@ auto MergeFunctionRedecl(Context& context, Parse::NodeId node_id,
   auto& prev_function = context.functions().Get(prev_function_id);
 
   // TODO: Disallow redeclarations within classes?
-  if (!CheckRedecl(context, new_function, prev_function)) {
+  if (!CheckRedecl(context, new_function, prev_function, {})) {
     return false;
   }
 

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "toolchain/check/function.h"
+
 #include "toolchain/check/subst.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/function.h
+++ b/toolchain/check/function.h
@@ -6,14 +6,20 @@
 #define CARBON_TOOLCHAIN_CHECK_FUNCTION_H_
 
 #include "toolchain/check/context.h"
+#include "toolchain/check/subst.h"
 #include "toolchain/sem_ir/function.h"
 
 namespace Carbon::Check {
 
-// Checks that `new_function_id` does not differ from `prev_function_id`.
-// Prints a suitable diagnostic and returns false if not.
-auto CheckFunctionRedecl(Context& context, SemIR::FunctionId new_function_id,
-                         SemIR::FunctionId prev_function_id) -> bool;
+// Checks that `new_function_id` has the same parameter types and return type as
+// `prev_function_id`, applying the specified set of substitutions to the
+// previous function. Prints a suitable diagnostic and returns false if not.
+// Note that this doesn't include the syntactic check that's performed for
+// redeclarations.
+auto CheckFunctionTypeMatches(Context& context,
+                              SemIR::FunctionId new_function_id,
+                              SemIR::FunctionId prev_function_id,
+                              Substitutions substitutions) -> bool;
 
 // Tries to merge new_function into prev_function_id. Since new_function won't
 // have a definition even if one is upcoming, set is_definition to indicate the

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -133,6 +133,10 @@ static auto Rebuild(Context& context, Worklist& worklist, SemIR::InstId inst_id)
     return inst_id;
   }
 
+  // TODO: Updating the arguments might result in the instruction having a
+  // different type. We should consider either recomputing the type or
+  // substituting into it. In the latter case, consider caching, as we may
+  // substitute into related types repeatedly.
   inst.SetArgs(arg0, arg1);
   auto result_id = TryEvalInst(context, SemIR::InstId::Invalid, inst);
   CARBON_CHECK(result_id.is_constant())

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -12,6 +12,7 @@ namespace Carbon::Check {
 
 namespace {
 
+// Information about an instruction that we are substituting into.
 struct WorklistItem {
   // The instruction that we are substituting into.
   SemIR::InstId inst_id;
@@ -24,6 +25,8 @@ struct WorklistItem {
   int next_index : 31;
 };
 
+// A list of instructions that we're currently in the process of substituting
+// into. For details of the algorithm used here, see `SubstConstant`.
 class Worklist {
  public:
   auto Get(int index) -> WorklistItem& { return worklist[index]; }

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/subst.h"
 
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/cow_block.h"
 #include "toolchain/check/eval.h"
 
 namespace Carbon::Check {
@@ -42,66 +43,30 @@ class Worklist {
   llvm::SmallVector<WorklistItem, 512> worklist;
 };
 
-enum class ArgKind : std::uint8_t {
-  Unimportant,
-  InstId,
-  TypeId,
-  InstBlockId,
-  TypeBlockId,
-};
-
 }  // namespace
 
-// TODO: Move this into SemIR and refactor with `inst_profile.cpp`.
-template<typename InstT, int N>
-static constexpr auto GetArgKind() -> ArgKind {
-  if constexpr (N >= SemIR::Internal::InstLikeTypeInfo<InstT>::NumArgs) {
-    // This argument is not used by this instruction; don't profile it.
-    return ArgKind::Unimportant;
-  } else {
-    using ArgT = SemIR::Internal::InstLikeTypeInfo<InstT>::template ArgType<N>;
-    if (std::is_same_v<ArgT, SemIR::InstId>) {
-      return ArgKind::InstId;
-    } else if (std::is_same_v<ArgT, SemIR::TypeId>) {
-      return ArgKind::TypeId;
-    } else if (std::is_same_v<ArgT, SemIR::InstBlockId>) {
-      return ArgKind::InstBlockId;
-    } else if (std::is_same_v<ArgT, SemIR::TypeBlockId>) {
-      return ArgKind::TypeBlockId;
-    } else {
-      return ArgKind::Unimportant;
-    }
-  }
-}
-
-static constexpr std::pair<ArgKind, ArgKind> ArgKinds[] = {
-#define CARBON_SEM_IR_INST_KIND(KindName) \
-  {GetArgKind<SemIR::KindName, 0>(), GetArgKind<SemIR::KindName, 1>()},
-#include "toolchain/sem_ir/inst_kind.def"
-};
-
 // Pushes the specified operand onto the worklist.
-static auto PushOperand(Context& context, Worklist& worklist, ArgKind kind,
+static auto PushOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
                         int32_t arg) -> void {
   switch (kind) {
-    case ArgKind::Unimportant:
-      break;
-    case ArgKind::InstId:
+    case SemIR::IdKind::For<SemIR::InstId>:
       worklist.Push(static_cast<SemIR::InstId>(arg));
       break;
-    case ArgKind::TypeId:
+    case SemIR::IdKind::For<SemIR::TypeId>:
       worklist.Push(context.types().GetInstId(static_cast<SemIR::TypeId>(arg)));
       break;
-    case ArgKind::InstBlockId:
+    case SemIR::IdKind::For<SemIR::InstBlockId>:
       for (auto inst_id :
            context.inst_blocks().Get(static_cast<SemIR::InstBlockId>(arg))) {
         worklist.Push(inst_id);
       }
       break;
-    case ArgKind::TypeBlockId:
+    case SemIR::IdKind::For<SemIR::TypeBlockId>:
       for (auto type_id : context.type_blocks().Get(static_cast<SemIR::TypeBlockId>(arg))) {
         worklist.Push(context.types().GetInstId(type_id));
       }
+      break;
+    default:
       break;
   }
 }
@@ -111,81 +76,42 @@ static auto PushOperand(Context& context, Worklist& worklist, ArgKind kind,
 static auto ExpandOperands(Context& context, Worklist& worklist,
                            SemIR::InstId inst_id) -> void {
   auto inst = context.insts().Get(inst_id);
-  auto kinds = ArgKinds[inst.kind().AsInt()];
+  auto kinds = inst.ArgKinds();
   PushOperand(context, worklist, kinds.first, inst.arg0());
   PushOperand(context, worklist, kinds.second, inst.arg1());
 }
 
-// TODO: Copied from convert.cpp. Deduplicate!
-namespace {
-// A handle to a new block that may be modified, with copy-on-write semantics.
-//
-// The constructor is given the ID of an existing block that provides the
-// initial contents of the new block. The new block is lazily allocated; if no
-// modifications have been made, the `id()` function will return the original
-// block ID.
-//
-// This is intended to avoid an unnecessary block allocation in the case where
-// the new block ends up being exactly the same as the original block.
-template<typename BlockIdType, auto (SemIR::File::*ValueStore)()>
-class CopyOnWriteBlock {
- public:
-  // Constructs the block. If `source_id` is valid, it is used as the initial
-  // value of the block. Otherwise, uninitialized storage for `size` elements
-  // is allocated.
-  CopyOnWriteBlock(SemIR::File& file, BlockIdType source_id)
-      : file_(file), source_id_(source_id) {}
-
-  auto id() const -> BlockIdType { return id_; }
-
-  auto Set(int i, typename BlockIdType::ElementType value) -> void {
-    if (source_id_.is_valid() && (file_.*ValueStore)().Get(id_)[i] == value) {
-      return;
-    }
-    if (id_ == source_id_) {
-      id_ = (file_.*ValueStore)().Add((file_.*ValueStore)().Get(source_id_));
-    }
-    (file_.*ValueStore)().Get(id_)[i] = value;
-  }
-
- private:
-  SemIR::File& file_;
-  BlockIdType source_id_;
-  BlockIdType id_ = source_id_;
-};
-}  // namespace
-
 // Pops the specified operand from the worklist and returns it.
-static auto PopOperand(Context& context, Worklist& worklist, ArgKind kind,
+static auto PopOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
                        int32_t arg) -> int32_t {
   switch (kind) {
-    case ArgKind::Unimportant:
-      return arg;
-    case ArgKind::InstId:
+    case SemIR::IdKind::For<SemIR::InstId>:
       return worklist.Pop().index;
-    case ArgKind::TypeId:
+    case SemIR::IdKind::For<SemIR::TypeId>:
       return context.GetTypeIdForTypeInst(worklist.Pop()).index;
-    case ArgKind::InstBlockId: {
+    case SemIR::IdKind::For<SemIR::InstBlockId>: {
       auto old_inst_block_id = static_cast<SemIR::InstBlockId>(arg);
       auto size = context.inst_blocks().Get(old_inst_block_id).size();
-      CopyOnWriteBlock<SemIR::InstBlockId, &SemIR::File::inst_blocks>
-          new_inst_block(context.sem_ir(), old_inst_block_id);
+      SemIR::CopyOnWriteInstBlock new_inst_block(context.sem_ir(),
+                                                 old_inst_block_id);
       for (auto i : llvm::index_range(0, size)) {
         new_inst_block.Set(size - i - 1, worklist.Pop());
       }
       return new_inst_block.id().index;
     }
-    case ArgKind::TypeBlockId: {
+    case SemIR::IdKind::For<SemIR::TypeBlockId>: {
       auto old_type_block_id = static_cast<SemIR::TypeBlockId>(arg);
       auto size = context.type_blocks().Get(old_type_block_id).size();
-      CopyOnWriteBlock<SemIR::TypeBlockId, &SemIR::File::type_blocks>
-          new_type_block(context.sem_ir(), old_type_block_id);
+      SemIR::CopyOnWriteTypeBlock new_type_block(context.sem_ir(),
+                                                 old_type_block_id);
       for (auto i : llvm::index_range(0, size)) {
         new_type_block.Set(size - i - 1,
                            context.GetTypeIdForTypeInst(worklist.Pop()));
       }
       return new_type_block.id().index;
     }
+    default:
+      return arg;
   }
 }
 
@@ -194,7 +120,7 @@ static auto PopOperand(Context& context, Worklist& worklist, ArgKind kind,
 static auto Rebuild(Context& context, Worklist& worklist,
                     SemIR::InstId inst_id) -> SemIR::InstId {
   auto inst = context.insts().Get(inst_id);
-  auto kinds = ArgKinds[inst.kind().AsInt()];
+  auto kinds = inst.ArgKinds();
 
   // Note that we pop in reverse order because we pushed them in forwards order.
   int32_t arg1 = PopOperand(context, worklist, kinds.second, inst.arg1());

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -46,8 +46,8 @@ class Worklist {
 }  // namespace
 
 // Pushes the specified operand onto the worklist.
-static auto PushOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
-                        int32_t arg) -> void {
+static auto PushOperand(Context& context, Worklist& worklist,
+                        SemIR::IdKind kind, int32_t arg) -> void {
   switch (kind) {
     case SemIR::IdKind::For<SemIR::InstId>:
       worklist.Push(static_cast<SemIR::InstId>(arg));
@@ -62,7 +62,8 @@ static auto PushOperand(Context& context, Worklist& worklist, SemIR::IdKind kind
       }
       break;
     case SemIR::IdKind::For<SemIR::TypeBlockId>:
-      for (auto type_id : context.type_blocks().Get(static_cast<SemIR::TypeBlockId>(arg))) {
+      for (auto type_id :
+           context.type_blocks().Get(static_cast<SemIR::TypeBlockId>(arg))) {
         worklist.Push(context.types().GetInstId(type_id));
       }
       break;
@@ -117,8 +118,8 @@ static auto PopOperand(Context& context, Worklist& worklist, SemIR::IdKind kind,
 
 // Pops the operands of the specified instruction off the worklist and rebuilds
 // the instruction with the updated operands.
-static auto Rebuild(Context& context, Worklist& worklist,
-                    SemIR::InstId inst_id) -> SemIR::InstId {
+static auto Rebuild(Context& context, Worklist& worklist, SemIR::InstId inst_id)
+    -> SemIR::InstId {
   auto inst = context.insts().Get(inst_id);
   auto kinds = inst.ArgKinds();
 
@@ -198,7 +199,8 @@ auto SubstConstant(Context& context, SemIR::ConstantId const_id,
         }
       }
 
-      // Even if it's not being substituted, don't look through it. Its constant value doesn't spend on its operand.
+      // Even if it's not being substituted, don't look through it. Its constant
+      // value doesn't spend on its operand.
       index = item.next_index;
       continue;
     }
@@ -228,7 +230,7 @@ auto SubstConstant(Context& context, SemIR::ConstantId const_id,
 }
 
 auto SubstType(Context& context, SemIR::TypeId type_id,
-                   Substitutions substitutions) -> SemIR::TypeId {
+               Substitutions substitutions) -> SemIR::TypeId {
   return context.GetTypeIdForTypeConstant(SubstConstant(
       context, context.types().GetConstantId(type_id), substitutions));
 }

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -1,0 +1,308 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/check/subst.h"
+
+#include "toolchain/sem_ir/ids.h"
+#include "toolchain/check/eval.h"
+
+namespace Carbon::Check {
+
+namespace {
+
+struct WorklistItem {
+  // The instruction that we are substituting into.
+  SemIR::InstId inst_id;
+  // Whether the operands of this instruction have been added to the worklist.
+  bool is_expanded : 1;
+  // The index of the worklist item to process after we finish updating this
+  // one. For the final child of an instruction, this is the parent. For any
+  // other child, this is the index of the next child of the parent. For the
+  // root, this is -1.
+  int next_index : 31;
+};
+
+class Worklist {
+ public:
+  auto Get(int index) -> WorklistItem& { return worklist[index]; }
+  auto Size() -> int { return worklist.size(); }
+  auto Push(SemIR::InstId inst_id) -> void {
+    worklist.push_back({.inst_id = inst_id,
+                        .is_expanded = false,
+                        .next_index = static_cast<int>(worklist.size() + 1)});
+    CARBON_CHECK(worklist.back().next_index > 0) << "Constant too large.";
+  }
+  auto Pop() -> SemIR::InstId { return worklist.pop_back_val().inst_id; }
+
+ private:
+  // Constants can get pretty large, so use a large worklist. This should be
+  // about 4KiB, which should be small enough to comfortably fit on the stack,
+  // but large enough that it's unlikely that we'll need a heap allocation.
+  llvm::SmallVector<WorklistItem, 512> worklist;
+};
+
+enum class ArgKind : std::uint8_t {
+  Unimportant,
+  InstId,
+  TypeId,
+  InstBlockId,
+  TypeBlockId,
+};
+
+}  // namespace
+
+// TODO: Move this into SemIR and refactor with `inst_profile.cpp`.
+template<typename InstT, int N>
+static constexpr auto GetArgKind() -> ArgKind {
+  if constexpr (N >= SemIR::Internal::InstLikeTypeInfo<InstT>::NumArgs) {
+    // This argument is not used by this instruction; don't profile it.
+    return ArgKind::Unimportant;
+  } else {
+    using ArgT = SemIR::Internal::InstLikeTypeInfo<InstT>::template ArgType<N>;
+    if (std::is_same_v<ArgT, SemIR::InstId>) {
+      return ArgKind::InstId;
+    } else if (std::is_same_v<ArgT, SemIR::TypeId>) {
+      return ArgKind::TypeId;
+    } else if (std::is_same_v<ArgT, SemIR::InstBlockId>) {
+      return ArgKind::InstBlockId;
+    } else if (std::is_same_v<ArgT, SemIR::TypeBlockId>) {
+      return ArgKind::TypeBlockId;
+    } else {
+      return ArgKind::Unimportant;
+    }
+  }
+}
+
+static constexpr std::pair<ArgKind, ArgKind> ArgKinds[] = {
+#define CARBON_SEM_IR_INST_KIND(KindName) \
+  {GetArgKind<SemIR::KindName, 0>(), GetArgKind<SemIR::KindName, 1>()},
+#include "toolchain/sem_ir/inst_kind.def"
+};
+
+// Pushes the specified operand onto the worklist.
+static auto PushOperand(Context& context, Worklist& worklist, ArgKind kind,
+                        int32_t arg) -> void {
+  switch (kind) {
+    case ArgKind::Unimportant:
+      break;
+    case ArgKind::InstId:
+      worklist.Push(static_cast<SemIR::InstId>(arg));
+      break;
+    case ArgKind::TypeId:
+      worklist.Push(context.types().GetInstId(static_cast<SemIR::TypeId>(arg)));
+      break;
+    case ArgKind::InstBlockId:
+      for (auto inst_id :
+           context.inst_blocks().Get(static_cast<SemIR::InstBlockId>(arg))) {
+        worklist.Push(inst_id);
+      }
+      break;
+    case ArgKind::TypeBlockId:
+      for (auto type_id : context.type_blocks().Get(static_cast<SemIR::TypeBlockId>(arg))) {
+        worklist.Push(context.types().GetInstId(type_id));
+      }
+      break;
+  }
+}
+
+// Converts the operands of this instruction into `InstId`s and pushes them onto
+// the worklist.
+static auto ExpandOperands(Context& context, Worklist& worklist,
+                           SemIR::InstId inst_id) -> void {
+  auto inst = context.insts().Get(inst_id);
+  auto kinds = ArgKinds[inst.kind().AsInt()];
+  PushOperand(context, worklist, kinds.first, inst.arg0());
+  PushOperand(context, worklist, kinds.second, inst.arg1());
+}
+
+// TODO: Copied from convert.cpp. Deduplicate!
+namespace {
+// A handle to a new block that may be modified, with copy-on-write semantics.
+//
+// The constructor is given the ID of an existing block that provides the
+// initial contents of the new block. The new block is lazily allocated; if no
+// modifications have been made, the `id()` function will return the original
+// block ID.
+//
+// This is intended to avoid an unnecessary block allocation in the case where
+// the new block ends up being exactly the same as the original block.
+template<typename BlockIdType, auto (SemIR::File::*ValueStore)()>
+class CopyOnWriteBlock {
+ public:
+  // Constructs the block. If `source_id` is valid, it is used as the initial
+  // value of the block. Otherwise, uninitialized storage for `size` elements
+  // is allocated.
+  CopyOnWriteBlock(SemIR::File& file, BlockIdType source_id)
+      : file_(file), source_id_(source_id) {}
+
+  auto id() const -> BlockIdType { return id_; }
+
+  auto Set(int i, typename BlockIdType::ElementType value) -> void {
+    if (source_id_.is_valid() && (file_.*ValueStore)().Get(id_)[i] == value) {
+      return;
+    }
+    if (id_ == source_id_) {
+      id_ = (file_.*ValueStore)().Add((file_.*ValueStore)().Get(source_id_));
+    }
+    (file_.*ValueStore)().Get(id_)[i] = value;
+  }
+
+ private:
+  SemIR::File& file_;
+  BlockIdType source_id_;
+  BlockIdType id_ = source_id_;
+};
+}  // namespace
+
+// Pops the specified operand from the worklist and returns it.
+static auto PopOperand(Context& context, Worklist& worklist, ArgKind kind,
+                       int32_t arg) -> int32_t {
+  switch (kind) {
+    case ArgKind::Unimportant:
+      return arg;
+    case ArgKind::InstId:
+      return worklist.Pop().index;
+    case ArgKind::TypeId:
+      return context.GetTypeIdForTypeInst(worklist.Pop()).index;
+    case ArgKind::InstBlockId: {
+      auto old_inst_block_id = static_cast<SemIR::InstBlockId>(arg);
+      auto size = context.inst_blocks().Get(old_inst_block_id).size();
+      CopyOnWriteBlock<SemIR::InstBlockId, &SemIR::File::inst_blocks>
+          new_inst_block(context.sem_ir(), old_inst_block_id);
+      for (auto i : llvm::index_range(0, size)) {
+        new_inst_block.Set(size - i - 1, worklist.Pop());
+      }
+      return new_inst_block.id().index;
+    }
+    case ArgKind::TypeBlockId: {
+      auto old_type_block_id = static_cast<SemIR::TypeBlockId>(arg);
+      auto size = context.type_blocks().Get(old_type_block_id).size();
+      CopyOnWriteBlock<SemIR::TypeBlockId, &SemIR::File::type_blocks>
+          new_type_block(context.sem_ir(), old_type_block_id);
+      for (auto i : llvm::index_range(0, size)) {
+        new_type_block.Set(size - i - 1,
+                           context.GetTypeIdForTypeInst(worklist.Pop()));
+      }
+      return new_type_block.id().index;
+    }
+  }
+}
+
+// Pops the operands of the specified instruction off the worklist and rebuilds
+// the instruction with the updated operands.
+static auto Rebuild(Context& context, Worklist& worklist,
+                    SemIR::InstId inst_id) -> SemIR::InstId {
+  auto inst = context.insts().Get(inst_id);
+  auto kinds = ArgKinds[inst.kind().AsInt()];
+
+  // Note that we pop in reverse order because we pushed them in forwards order.
+  int32_t arg1 = PopOperand(context, worklist, kinds.second, inst.arg1());
+  int32_t arg0 = PopOperand(context, worklist, kinds.first, inst.arg0());
+  if (arg0 == inst.arg0() && arg1 == inst.arg1()) {
+    return inst_id;
+  }
+
+  inst.SetArgs(arg0, arg1);
+  auto result_id = TryEvalInst(context, SemIR::InstId::Invalid, inst);
+  CARBON_CHECK(result_id.is_constant())
+      << "Substitution into constant produced non-constant";
+  return result_id.inst_id();
+}
+
+auto SubstConstant(Context& context, SemIR::ConstantId const_id,
+                   Substitutions substitutions) -> SemIR::ConstantId {
+  CARBON_CHECK(const_id.is_constant()) << "Substituting into non-constant";
+
+  if (substitutions.empty()) {
+    // Nothing to substitute.
+    return const_id;
+  }
+
+  if (!const_id.is_symbolic()) {
+    // A template constant can't contain a reference to a symbolic binding.
+    return const_id;
+  }
+
+  Worklist worklist;
+  worklist.Push(const_id.inst_id());
+  worklist.Get(0).next_index = -1;
+
+  // For each instruction that forms part of the constant, we will visit it
+  // twice:
+  //
+  // - First, we visit it with `is_expanded == false`, we add all of its
+  //   operands onto the worklist, and process them by following this same
+  //   process.
+  // - Then, once all operands are processed, we visit the instruction with
+  //   `is_expanded == true`, pop the operands back off the worklist, and if any
+  //   of them changed, rebuild this instruction.
+  //
+  // The second step is skipped if we can detect in the first step that the
+  // instruction will not need to be rebuilt.
+  int index = 0;
+  while (index != -1) {
+    auto& item = worklist.Get(index);
+    if (!item.is_expanded) {
+      if (context.constant_values().Get(item.inst_id).is_template()) {
+        // This instruction is a template constant, so can't contain any
+        // bindings that need to be substituted.
+        index = item.next_index;
+        continue;
+      }
+
+      if (context.insts().Is<SemIR::BindSymbolicName>(item.inst_id)) {
+        // This is a symbolic binding. Check if we're substituting it.
+
+        // TODO: Consider building a hash map for substitutions. We might have a
+        // lot of them.
+        for (auto [bind_id, replacement_id] : substitutions) {
+          if (item.inst_id == bind_id) {
+            // This is the binding we're replacing. Perform substitution.
+            item.inst_id = replacement_id.inst_id();
+            break;
+          }
+        }
+
+        // Even if it's not being substituted, don't look through it. Its constant value doesn't spend on its operand.
+        index = item.next_index;
+        continue;
+      }
+
+      // Extract the operands of this item into the worklist. Note that this
+      // modifies the worklist, so it's not safe to use `item` after
+      // `ExpandOperands` returns.
+      item.is_expanded = true;
+      int first_operand = worklist.Size();
+      int next_index = item.next_index;
+      ExpandOperands(context, worklist, item.inst_id);
+
+      // If there are any operands, go and update them before rebuilding this
+      // item.
+      if (worklist.Size() > first_operand) {
+        worklist.Get(worklist.Size() - 1).next_index = index;
+        index = first_operand;
+      } else {
+        // No need to rebuild this instruction.
+        index = next_index;
+      }
+    } else {
+      // Rebuild this item if necessary. Note that this might pop items from the
+      // worklist but does not reallocate, so does not invalidate `item`.
+      item.inst_id = Rebuild(context, worklist, item.inst_id);
+      index = item.next_index;
+    }
+  }
+
+  CARBON_CHECK(worklist.Size() == 1)
+      << "Unexpected data left behind in work list";
+  return context.constant_values().Get(worklist.Get(0).inst_id);
+}
+
+auto SubstType(Context& context, SemIR::TypeId type_id,
+                   Substitutions substitutions) -> SemIR::TypeId {
+  return context.GetTypeIdForTypeConstant(SubstConstant(
+      context, context.types().GetConstantId(type_id), substitutions));
+}
+
+}  // namespace Carbon::Check

--- a/toolchain/check/subst.h
+++ b/toolchain/check/subst.h
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_CHECK_SUBST_H_
+#define CARBON_TOOLCHAIN_CHECK_SUBST_H_
+
+#include "toolchain/check/context.h"
+#include "toolchain/sem_ir/ids.h"
+
+namespace Carbon::Check {
+
+// A substitution that is being performed.
+struct Substitution {
+  // The ID of a `BindSymbolicName` instruction that is being replaced.
+  SemIR::InstId bind_id;
+  // The replacement constant value to substitute.
+  SemIR::ConstantId replacement_id;
+};
+
+using Substitutions = llvm::ArrayRef<Substitution>;
+
+// Replaces the `BindSymbolicName` instruction `bind_id` with `replacement_id`
+// throughout the constant `const_id`, and returns the substituted value.
+auto SubstConstant(Context& context, SemIR::ConstantId const_id,
+                   Substitutions substitutions) -> SemIR::ConstantId;
+
+// Replaces the `BindSymbolicName` instruction `bind_id` with `replacement_id`
+// throughout the type `type_id`, and returns the substituted value.
+auto SubstType(Context& context, SemIR::TypeId type_id,
+               Substitutions substitutions) -> SemIR::TypeId;
+
+}  // namespace Carbon::Check
+
+#endif  // CARBON_TOOLCHAIN_CHECK_SUBST_H_

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -167,6 +167,34 @@ class FDifferentParamName {
   }
 }
 
+interface SelfNested {
+  fn F(x: (Self*, {.x: Self, .y: i32})) -> [Self; 4];
+}
+
+class SelfNestedBadParam {
+  impl as SelfNested {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:56: ERROR: Function returns incomplete type `[SelfNestedBadParam; 4]`.
+    // CHECK:STDERR:     fn F(x: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> [SelfNestedBadParam; 4];
+    // CHECK:STDERR:                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
+    // CHECK:STDERR: class SelfNestedBadParam {
+    // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F(x: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> [SelfNestedBadParam; 4];
+  }
+}
+
+class SelfNestedBadReturnType {
+  impl as SelfNested {
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `[SelfNestedBadParam; 4]`.
+    // CHECK:STDERR:     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
+    // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-20]]:3: Previously declared with return type `[SelfNestedBadReturnType; 4]`.
+    // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: i32})) -> [Self; 4];
+    // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
+  }
+}
+
 // CHECK:STDOUT: --- fail_impl_bad_assoc_fn.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -176,7 +204,7 @@ class FDifferentParamName {
 // CHECK:STDOUT:   %NoF: type = class_type @NoF [template]
 // CHECK:STDOUT:   %.4: type = struct_type {} [template]
 // CHECK:STDOUT:   %FNotFunction: type = class_type @FNotFunction [template]
-// CHECK:STDOUT:   %F: type = class_type @F.13 [template]
+// CHECK:STDOUT:   %F: type = class_type @F.16 [template]
 // CHECK:STDOUT:   %FAlias: type = class_type @FAlias [template]
 // CHECK:STDOUT:   %FExtraParam: type = class_type @FExtraParam [template]
 // CHECK:STDOUT:   %FExtraImplicitParam: type = class_type @FExtraImplicitParam [template]
@@ -191,6 +219,29 @@ class FDifferentParamName {
 // CHECK:STDOUT:   %FDifferentImplicitParamType: type = class_type @FDifferentImplicitParamType [template]
 // CHECK:STDOUT:   %FDifferentReturnType: type = class_type @FDifferentReturnType [template]
 // CHECK:STDOUT:   %FDifferentParamName: type = class_type @FDifferentParamName [template]
+// CHECK:STDOUT:   %.8: type = interface_type @SelfNested [template]
+// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.10: type = struct_type {.x: Self, .y: i32} [symbolic]
+// CHECK:STDOUT:   %.11: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.12: type = tuple_type (Self*, {.x: Self, .y: i32}) [symbolic]
+// CHECK:STDOUT:   %.13: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.14: type = array_type %.13, Self [symbolic]
+// CHECK:STDOUT:   %.15: type = ptr_type [Self; 4] [symbolic]
+// CHECK:STDOUT:   %.16: type = assoc_entity_type @SelfNested, <function> [template]
+// CHECK:STDOUT:   %.17: <associated <function> in SelfNested> = assoc_entity element0, @SelfNested.%F [template]
+// CHECK:STDOUT:   %SelfNestedBadParam: type = class_type @SelfNestedBadParam [template]
+// CHECK:STDOUT:   %.18: type = ptr_type SelfNestedBadParam [template]
+// CHECK:STDOUT:   %.19: type = struct_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.20: type = tuple_type (SelfNestedBadParam*, {.x: i32, .y: i32}) [template]
+// CHECK:STDOUT:   %.21: type = array_type %.13, SelfNestedBadParam [template]
+// CHECK:STDOUT:   %SelfNestedBadReturnType: type = class_type @SelfNestedBadReturnType [template]
+// CHECK:STDOUT:   %.22: type = ptr_type SelfNestedBadReturnType [template]
+// CHECK:STDOUT:   %.23: type = struct_type {.x: SelfNestedBadReturnType, .y: i32} [template]
+// CHECK:STDOUT:   %.24: type = tuple_type (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) [template]
+// CHECK:STDOUT:   %.25: type = tuple_type () [template]
+// CHECK:STDOUT:   %.26: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.27: type = ptr_type [SelfNestedBadParam; 4] [template]
+// CHECK:STDOUT:   %.28: type = array_type %.13, SelfNestedBadReturnType [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -211,6 +262,9 @@ class FDifferentParamName {
 // CHECK:STDOUT:     .FDifferentImplicitParamType = %FDifferentImplicitParamType.decl
 // CHECK:STDOUT:     .FDifferentReturnType = %FDifferentReturnType.decl
 // CHECK:STDOUT:     .FDifferentParamName = %FDifferentParamName.decl
+// CHECK:STDOUT:     .SelfNested = %SelfNested.decl
+// CHECK:STDOUT:     .SelfNestedBadParam = %SelfNestedBadParam.decl
+// CHECK:STDOUT:     .SelfNestedBadReturnType = %SelfNestedBadReturnType.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%.1] {}
 // CHECK:STDOUT:   %NoF.decl: type = class_decl @NoF [template = constants.%NoF] {}
@@ -228,6 +282,9 @@ class FDifferentParamName {
 // CHECK:STDOUT:   %FDifferentImplicitParamType.decl: type = class_decl @FDifferentImplicitParamType [template = constants.%FDifferentImplicitParamType] {}
 // CHECK:STDOUT:   %FDifferentReturnType.decl: type = class_decl @FDifferentReturnType [template = constants.%FDifferentReturnType] {}
 // CHECK:STDOUT:   %FDifferentParamName.decl: type = class_decl @FDifferentParamName [template = constants.%FDifferentParamName] {}
+// CHECK:STDOUT:   %SelfNested.decl: type = interface_decl @SelfNested [template = constants.%.8] {}
+// CHECK:STDOUT:   %SelfNestedBadParam.decl: type = class_decl @SelfNestedBadParam [template = constants.%SelfNestedBadParam] {}
+// CHECK:STDOUT:   %SelfNestedBadReturnType.decl: type = class_decl @SelfNestedBadReturnType [template = constants.%SelfNestedBadReturnType] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -258,6 +315,36 @@ class FDifferentParamName {
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: interface @SelfNested {
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.13 [template] {
+// CHECK:STDOUT:     %Self.ref.loc171_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_16.1: type = facet_type_access %Self.ref.loc171_12 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_12: type = converted %Self.ref.loc171_12, %.loc171_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_16.2: type = ptr_type Self [symbolic = constants.%.9]
+// CHECK:STDOUT:     %Self.ref.loc171_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_24.1: type = facet_type_access %Self.ref.loc171_24 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_24.2: type = converted %Self.ref.loc171_24, %.loc171_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.10]
+// CHECK:STDOUT:     %.loc171_38.1: (type, type) = tuple_literal (%.loc171_16.2, %.loc171_37)
+// CHECK:STDOUT:     %.loc171_38.2: type = converted %.loc171_38.1, constants.%.12 [symbolic = constants.%.12]
+// CHECK:STDOUT:     %x.loc171_8.1: (Self*, {.x: Self, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc171_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc171_8.1
+// CHECK:STDOUT:     %Self.ref.loc171_45: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_51: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc171_45.1: type = facet_type_access %Self.ref.loc171_45 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_45.2: type = converted %Self.ref.loc171_45, %.loc171_45.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc171_52: type = array_type %.loc171_51, Self [symbolic = constants.%.14]
+// CHECK:STDOUT:     %return.var: ref [Self; 4] = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc171_53: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.17]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .F = %.loc171_53
+// CHECK:STDOUT:   witness = (%F)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.1: NoF as I {
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
@@ -266,7 +353,7 @@ class FDifferentParamName {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.2: FNotFunction as I {
-// CHECK:STDOUT:   %F.decl: type = class_decl @F.13 [template = constants.%F] {}
+// CHECK:STDOUT:   %F.decl: type = class_decl @F.16 [template = constants.%F] {}
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -423,6 +510,49 @@ class FDifferentParamName {
 // CHECK:STDOUT:   witness = %.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.14: SelfNestedBadParam as SelfNested {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.14 [template] {
+// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc182_14: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %.loc182_32: type = ptr_type SelfNestedBadParam [template = constants.%.18]
+// CHECK:STDOUT:     %.loc182_52: type = struct_type {.x: i32, .y: i32} [template = constants.%.19]
+// CHECK:STDOUT:     %.loc182_53.1: (type, type) = tuple_literal (%.loc182_32, %.loc182_52)
+// CHECK:STDOUT:     %.loc182_53.2: type = converted %.loc182_53.1, constants.%.20 [template = constants.%.20]
+// CHECK:STDOUT:     %x.loc182_10.1: (SelfNestedBadParam*, {.x: i32, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc182_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32}) = bind_name x, %x.loc182_10.1
+// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc182_60: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %.loc182_80: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc182_81: type = array_type %.loc182_80, SelfNestedBadParam [template = constants.%.21]
+// CHECK:STDOUT:     %return.var: ref [SelfNestedBadParam; 4] = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.15: SelfNestedBadReturnType as SelfNested {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.15 [template] {
+// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc194_14: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:     %.loc194_37: type = ptr_type SelfNestedBadReturnType [template = constants.%.22]
+// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc194_45: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:     %.loc194_77: type = struct_type {.x: SelfNestedBadReturnType, .y: i32} [template = constants.%.23]
+// CHECK:STDOUT:     %.loc194_78.1: (type, type) = tuple_literal (%.loc194_37, %.loc194_77)
+// CHECK:STDOUT:     %.loc194_78.2: type = converted %.loc194_78.1, constants.%.24 [template = constants.%.24]
+// CHECK:STDOUT:     %x.loc194_10.1: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc194_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = bind_name x, %x.loc194_10.1
+// CHECK:STDOUT:     %SelfNestedBadParam.ref: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %.loc194_105: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc194_106: type = array_type %.loc194_105, SelfNestedBadParam [template = constants.%.21]
+// CHECK:STDOUT:     %return.var: ref [SelfNestedBadParam; 4] = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: class @NoF {
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %I.ref: type = name_ref I, file.%I.decl [template = constants.%.1]
@@ -441,7 +571,7 @@ class FDifferentParamName {
 // CHECK:STDOUT:   .Self = constants.%FNotFunction
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: class @F.13;
+// CHECK:STDOUT: class @F.16;
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @FAlias {
 // CHECK:STDOUT:   impl_decl @impl.3 {
@@ -542,6 +672,24 @@ class FDifferentParamName {
 // CHECK:STDOUT:   .Self = constants.%FDifferentParamName
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: class @SelfNestedBadParam {
+// CHECK:STDOUT:   impl_decl @impl.14 {
+// CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [template = constants.%.8]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%SelfNestedBadParam
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @SelfNestedBadReturnType {
+// CHECK:STDOUT:   impl_decl @impl.15 {
+// CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, file.%SelfNested.decl [template = constants.%.8]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%SelfNestedBadReturnType
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PossiblyF();
@@ -567,4 +715,10 @@ class FDifferentParamName {
 // CHECK:STDOUT: fn @F.11[@impl.12.%self.loc153_10.2: bool](@impl.12.%b.loc153_22.2: bool) -> <error>;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.12[@impl.13.%self.loc166_10.2: bool](@impl.13.%not_b.loc166_22.2: bool) -> bool;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.13(@SelfNested.%x.loc171_8.2: (Self*, {.x: Self, .y: i32})) -> @SelfNested.%return.var: [Self; 4];
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.14(@impl.14.%x.loc182_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> <error>;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.15(@impl.15.%x.loc194_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> @impl.15.%return.var: [SelfNestedBadParam; 4];
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -7,13 +7,12 @@
 class C;
 
 interface I {
-  // TODO: Use `Self` once we perform substitution for it.
-  fn F[self: C]() -> i32;
+  fn F[self: Self]() -> i32;
 }
 
 class C {
   extend impl as I {
-    fn F[self: C]() -> i32;
+    fn F[self: Self]() -> i32;
   }
 }
 
@@ -42,11 +41,11 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl.loc7: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %I.decl: type = interface_decl @I [template = constants.%.1] {}
-// CHECK:STDOUT:   %C.decl.loc14: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT:   %C.decl.loc13: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template] {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl.loc7 [template = constants.%C]
-// CHECK:STDOUT:     %c.loc20_6.1: C = param c
-// CHECK:STDOUT:     @F.3.%c: C = bind_name c, %c.loc20_6.1
+// CHECK:STDOUT:     %c.loc19_6.1: C = param c
+// CHECK:STDOUT:     @F.3.%c: C = bind_name c, %c.loc19_6.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -54,24 +53,26 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: interface @I {
 // CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc7 [template = constants.%C]
-// CHECK:STDOUT:     %self.loc11_8.1: C = param self
-// CHECK:STDOUT:     %self.loc11_8.2: C = bind_name self, %self.loc11_8.1
+// CHECK:STDOUT:     %Self.ref: I = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc10_14.1: type = facet_type_access %Self.ref [symbolic = %Self]
+// CHECK:STDOUT:     %.loc10_14.2: type = converted %Self.ref, %.loc10_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %self.loc10_8.1: Self = param self
+// CHECK:STDOUT:     %self.loc10_8.2: Self = bind_name self, %self.loc10_8.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc11: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_28: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc11
+// CHECK:STDOUT:   .F = %.loc10_28
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as I {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %C.ref: type = name_ref C, file.%C.decl.loc7 [template = constants.%C]
-// CHECK:STDOUT:     %self.loc16_10.1: C = param self
-// CHECK:STDOUT:     %self.loc16_10.2: C = bind_name self, %self.loc16_10.1
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
+// CHECK:STDOUT:     %self.loc15_10.1: C = param self
+// CHECK:STDOUT:     %self.loc15_10.2: C = bind_name self, %self.loc15_10.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.4]
@@ -91,19 +92,19 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.1[@I.%self.loc11_8.2: C]() -> i32;
+// CHECK:STDOUT: fn @F.1[@I.%self.loc10_8.2: Self]() -> i32;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2[@impl.%self.loc16_10.2: C]() -> i32;
+// CHECK:STDOUT: fn @F.2[@impl.%self.loc15_10.2: C]() -> i32;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.3(%c: C) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: C = name_ref c, %c
-// CHECK:STDOUT:   %F.ref: <associated <function> in I> = name_ref F, @I.%.loc11 [template = constants.%.3]
+// CHECK:STDOUT:   %F.ref: <associated <function> in I> = name_ref F, @I.%.loc10_28 [template = constants.%.3]
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%F]
-// CHECK:STDOUT:   %.loc21_11: <bound method> = bound_method %c.ref, %.1
-// CHECK:STDOUT:   %.loc21_13.1: init i32 = call %.loc21_11(%c.ref)
-// CHECK:STDOUT:   %.loc21_15: i32 = value_of_initializer %.loc21_13.1
-// CHECK:STDOUT:   %.loc21_13.2: i32 = converted %.loc21_13.1, %.loc21_15
-// CHECK:STDOUT:   return %.loc21_13.2
+// CHECK:STDOUT:   %.loc20_11: <bound method> = bound_method %c.ref, %.1
+// CHECK:STDOUT:   %.loc20_13.1: init i32 = call %.loc20_11(%c.ref)
+// CHECK:STDOUT:   %.loc20_15: i32 = value_of_initializer %.loc20_13.1
+// CHECK:STDOUT:   %.loc20_13.2: i32 = converted %.loc20_13.1, %.loc20_15
+// CHECK:STDOUT:   return %.loc20_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -12,16 +12,10 @@ class C {}
 
 impl C as UseSelf {
   // TODO: Use `Self` below once it's supported.
-  // CHECK:STDERR: fail_todo_self_in_signature.carbon:[[@LINE+6]]:8: ERROR: Function redeclaration differs at implicit parameter 1.
-  // CHECK:STDERR:   fn F[self: C](x: C) -> C { return {}; }
-  // CHECK:STDERR:        ^~~~
-  // CHECK:STDERR: fail_todo_self_in_signature.carbon:[[@LINE-10]]:8: Previous declaration's corresponding implicit parameter here.
-  // CHECK:STDERR:   fn F[self: Self](x: Self) -> Self;
-  // CHECK:STDERR:        ^~~~
   fn F[self: C](x: C) -> C { return {}; }
 }
 
-// CHECK:STDOUT: --- fail_todo_self_in_signature.carbon
+// CHECK:STDOUT: --- self_in_signature.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
@@ -32,6 +26,7 @@ impl C as UseSelf {
 // CHECK:STDOUT:   %.5: type = tuple_type () [template]
 // CHECK:STDOUT:   %.6: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.7: C = struct_value () [template]
+// CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -75,16 +70,16 @@ impl C as UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as UseSelf {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %C.ref.loc21_14: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %self.loc21_8.1: C = param self
-// CHECK:STDOUT:     %self.loc21_8.2: C = bind_name self, %self.loc21_8.1
-// CHECK:STDOUT:     %C.ref.loc21_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %x.loc21_17.1: C = param x
-// CHECK:STDOUT:     %x.loc21_17.2: C = bind_name x, %x.loc21_17.1
-// CHECK:STDOUT:     %C.ref.loc21_26: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc15_14: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %self.loc15_8.1: C = param self
+// CHECK:STDOUT:     %self.loc15_8.2: C = bind_name self, %self.loc15_8.1
+// CHECK:STDOUT:     %C.ref.loc15_20: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %x.loc15_17.1: C = param x
+// CHECK:STDOUT:     %x.loc15_17.2: C = bind_name x, %x.loc15_17.1
+// CHECK:STDOUT:     %C.ref.loc15_26: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %return.var: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -98,11 +93,11 @@ impl C as UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1[@UseSelf.%self.loc8_8.2: Self](@UseSelf.%x.loc8_20.2: Self) -> Self;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2[@impl.%self.loc21_8.2: C](@impl.%x.loc21_17.2: C) -> @impl.%return.var: C {
+// CHECK:STDOUT: fn @F.2[@impl.%self.loc15_8.2: C](@impl.%x.loc15_17.2: C) -> @impl.%return.var: C {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc21_38.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc21_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_38.3: init C = converted %.loc21_38.1, %.loc21_38.2 [template = constants.%.7]
-// CHECK:STDOUT:   return %.loc21_38.3
+// CHECK:STDOUT:   %.loc15_38.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc15_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
+// CHECK:STDOUT:   %.loc15_38.3: init C = converted %.loc15_38.1, %.loc15_38.2 [template = constants.%.7]
+// CHECK:STDOUT:   return %.loc15_38.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -15,6 +15,14 @@ impl C as UseSelf {
   fn F[self: C](x: C) -> C { return {}; }
 }
 
+interface SelfNested {
+  fn F(x: (Self*, {.x: Self, .y: i32}));
+}
+
+impl C as SelfNested {
+  fn F(x: (C*, {.x: C, .y: i32}));
+}
+
 // CHECK:STDOUT: --- self_in_signature.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -26,19 +34,36 @@ impl C as UseSelf {
 // CHECK:STDOUT:   %.5: type = tuple_type () [template]
 // CHECK:STDOUT:   %.6: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.7: C = struct_value () [template]
-// CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.%F) [template]
+// CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.1.%F) [template]
+// CHECK:STDOUT:   %.9: type = interface_type @SelfNested [template]
+// CHECK:STDOUT:   %.10: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.11: type = struct_type {.x: Self, .y: i32} [symbolic]
+// CHECK:STDOUT:   %.12: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.13: type = tuple_type (Self*, {.x: Self, .y: i32}) [symbolic]
+// CHECK:STDOUT:   %.14: type = assoc_entity_type @SelfNested, <function> [template]
+// CHECK:STDOUT:   %.15: <associated <function> in SelfNested> = assoc_entity element0, @SelfNested.%F [template]
+// CHECK:STDOUT:   %.16: type = ptr_type C [template]
+// CHECK:STDOUT:   %.17: type = struct_type {.x: C, .y: i32} [template]
+// CHECK:STDOUT:   %.18: type = tuple_type (C*, {.x: C, .y: i32}) [template]
+// CHECK:STDOUT:   %.19: <witness> = interface_witness (@impl.2.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .UseSelf = %UseSelf.decl
 // CHECK:STDOUT:     .C = %C.decl
+// CHECK:STDOUT:     .SelfNested = %SelfNested.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %UseSelf.decl: type = interface_decl @UseSelf [template = constants.%.1] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   impl_decl @impl {
-// CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:   impl_decl @impl.1 {
+// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %UseSelf.ref: type = name_ref UseSelf, %UseSelf.decl [template = constants.%.1]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %SelfNested.decl: type = interface_decl @SelfNested [template = constants.%.9] {}
+// CHECK:STDOUT:   impl_decl @impl.2 {
+// CHECK:STDOUT:     %C.ref.loc22: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %SelfNested.ref: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -68,7 +93,31 @@ impl C as UseSelf {
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: impl @impl: C as UseSelf {
+// CHECK:STDOUT: interface @SelfNested {
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template] {
+// CHECK:STDOUT:     %Self.ref.loc19_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_16.1: type = facet_type_access %Self.ref.loc19_12 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_12: type = converted %Self.ref.loc19_12, %.loc19_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_16.2: type = ptr_type Self [symbolic = constants.%.10]
+// CHECK:STDOUT:     %Self.ref.loc19_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_24.1: type = facet_type_access %Self.ref.loc19_24 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_24.2: type = converted %Self.ref.loc19_24, %.loc19_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc19_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.11]
+// CHECK:STDOUT:     %.loc19_38.1: (type, type) = tuple_literal (%.loc19_16.2, %.loc19_37)
+// CHECK:STDOUT:     %.loc19_38.2: type = converted %.loc19_38.1, constants.%.13 [symbolic = constants.%.13]
+// CHECK:STDOUT:     %x.loc19_8.1: (Self*, {.x: Self, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc19_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc19_8.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc19_40: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.15]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = %Self
+// CHECK:STDOUT:   .F = %.loc19_40
+// CHECK:STDOUT:   witness = (%F)
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.1: C as UseSelf {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
 // CHECK:STDOUT:     %C.ref.loc15_14: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %self.loc15_8.1: C = param self
@@ -86,6 +135,24 @@ impl C as UseSelf {
 // CHECK:STDOUT:   witness = %.1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: impl @impl.2: C as SelfNested {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.4 [template] {
+// CHECK:STDOUT:     %C.ref.loc23_12: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc23_13: type = ptr_type C [template = constants.%.16]
+// CHECK:STDOUT:     %C.ref.loc23_21: type = name_ref C, file.%C.decl [template = constants.%C]
+// CHECK:STDOUT:     %.loc23_31: type = struct_type {.x: C, .y: i32} [template = constants.%.17]
+// CHECK:STDOUT:     %.loc23_32.1: (type, type) = tuple_literal (%.loc23_13, %.loc23_31)
+// CHECK:STDOUT:     %.loc23_32.2: type = converted %.loc23_32.1, constants.%.18 [template = constants.%.18]
+// CHECK:STDOUT:     %x.loc23_8.1: (C*, {.x: C, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc23_8.2: (C*, {.x: C, .y: i32}) = bind_name x, %x.loc23_8.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.19]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   witness = %.1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
@@ -93,11 +160,15 @@ impl C as UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.1[@UseSelf.%self.loc8_8.2: Self](@UseSelf.%x.loc8_20.2: Self) -> Self;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2[@impl.%self.loc15_8.2: C](@impl.%x.loc15_17.2: C) -> @impl.%return.var: C {
+// CHECK:STDOUT: fn @F.2[@impl.1.%self.loc15_8.2: C](@impl.1.%x.loc15_17.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc15_38.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc15_38.2: init C = class_init (), @impl.%return.var [template = constants.%.7]
+// CHECK:STDOUT:   %.loc15_38.2: init C = class_init (), @impl.1.%return.var [template = constants.%.7]
 // CHECK:STDOUT:   %.loc15_38.3: init C = converted %.loc15_38.1, %.loc15_38.2 [template = constants.%.7]
 // CHECK:STDOUT:   return %.loc15_38.3
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.3(@SelfNested.%x.loc19_8.2: (Self*, {.x: Self, .y: i32}));
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.4(@impl.2.%x.loc23_8.2: (C*, {.x: C, .y: i32}));
 // CHECK:STDOUT:

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -87,6 +87,15 @@ auto FileContext::GetGlobal(SemIR::InstId inst_id) -> llvm::Value* {
 auto FileContext::BuildFunctionDecl(SemIR::FunctionId function_id)
     -> llvm::Function* {
   const auto& function = sem_ir().functions().Get(function_id);
+
+  // Don't lower associated functions.
+  // TODO: We shouldn't lower any function that has generic parameters.
+  if (sem_ir().insts().Is<SemIR::InterfaceDecl>(
+          sem_ir().name_scopes().GetInstIdIfValid(
+              function.enclosing_scope_id))) {
+    return nullptr;
+  }
+
   const bool has_return_slot = function.return_slot_id.is_valid();
   auto implicit_param_refs =
       sem_ir().inst_blocks().Get(function.implicit_param_refs_id);

--- a/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
+++ b/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
@@ -4,10 +4,8 @@
 //
 // AUTOUPDATE
 
-class A;
-
 interface I {
-  fn F[self: A]() -> i32;
+  fn F[self: Self]() -> i32;
 }
 
 class A {
@@ -28,15 +26,13 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'assoc_fn_alias.carbon'
 // CHECK:STDOUT: source_filename = "assoc_fn_alias.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare i32 @F(ptr)
-// CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F.1(ptr %self) {
+// CHECK:STDOUT: define i32 @F(ptr %self) {
 // CHECK:STDOUT:   %n = getelementptr inbounds { i32 }, ptr %self, i32 0, i32 0
 // CHECK:STDOUT:   %1 = load i32, ptr %n, align 4
 // CHECK:STDOUT:   ret i32 %1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @Call(ptr %a) {
-// CHECK:STDOUT:   %F.1 = call i32 @F.1(ptr %a)
-// CHECK:STDOUT:   ret i32 %F.1
+// CHECK:STDOUT:   %F = call i32 @F(ptr %a)
+// CHECK:STDOUT:   ret i32 %F
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/impl/extend_impl.carbon
+++ b/toolchain/lower/testdata/impl/extend_impl.carbon
@@ -27,18 +27,16 @@ fn InstanceAccess(a: A) -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'extend_impl.carbon'
 // CHECK:STDOUT: source_filename = "extend_impl.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare i32 @F()
-// CHECK:STDOUT:
-// CHECK:STDOUT: define i32 @F.1() {
+// CHECK:STDOUT: define i32 @F() {
 // CHECK:STDOUT:   ret i32 0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @TypeAccess() {
-// CHECK:STDOUT:   %F.1 = call i32 @F.1()
-// CHECK:STDOUT:   ret i32 %F.1
+// CHECK:STDOUT:   %F = call i32 @F()
+// CHECK:STDOUT:   ret i32 %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @InstanceAccess(ptr %a) {
-// CHECK:STDOUT:   %F.1 = call i32 @F.1()
-// CHECK:STDOUT:   ret i32 %F.1
+// CHECK:STDOUT:   %F = call i32 @F()
+// CHECK:STDOUT:   ret i32 %F
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/impl/instance_method.carbon
+++ b/toolchain/lower/testdata/impl/instance_method.carbon
@@ -7,8 +7,7 @@
 class A;
 
 interface GetSelf {
-  // TODO: Use `Self` once that works.
-  fn Get[addr self: A*]() -> A*;
+  fn Get[addr self: Self*]() -> Self*;
 }
 
 class A {
@@ -26,13 +25,11 @@ fn Call(a: A*) -> A* {
 // CHECK:STDOUT: ; ModuleID = 'instance_method.carbon'
 // CHECK:STDOUT: source_filename = "instance_method.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare ptr @Get(ptr)
-// CHECK:STDOUT:
-// CHECK:STDOUT: define ptr @Get.1(ptr %self) {
+// CHECK:STDOUT: define ptr @Get(ptr %self) {
 // CHECK:STDOUT:   ret ptr %self
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define ptr @Call(ptr %a) {
-// CHECK:STDOUT:   %Get.1 = call ptr @Get.1(ptr %a)
-// CHECK:STDOUT:   ret ptr %Get.1
+// CHECK:STDOUT:   %Get = call ptr @Get(ptr %a)
+// CHECK:STDOUT:   ret ptr %Get
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/interface/assoc.carbon
+++ b/toolchain/lower/testdata/interface/assoc.carbon
@@ -13,8 +13,6 @@ fn F() { I.Assoc; }
 // CHECK:STDOUT: ; ModuleID = 'assoc.carbon'
 // CHECK:STDOUT: source_filename = "assoc.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @Assoc()
-// CHECK:STDOUT:
 // CHECK:STDOUT: define void @F() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/interface/basic.carbon
+++ b/toolchain/lower/testdata/interface/basic.carbon
@@ -20,8 +20,6 @@ fn G(T: J) {}
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @Assoc()
-// CHECK:STDOUT:
 // CHECK:STDOUT: define void @F() {
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -21,7 +21,10 @@ class TypeEnum {
   static_assert(NumValues <= 256, "Too many types for raw enum.");
 
   // The underlying raw enumeration type.
-  enum class RawEnumType : uint8_t {
+  //
+  // The enum_extensibility attribute indicates that this enum is intended to
+  // take values that do not correspond to its declared enumerators.
+  enum class [[clang::enum_extensibility(open)]] RawEnumType : uint8_t {
     // The first sizeof...(Types) values correspond to the types.
 
     // An explicitly invalid value.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -24,7 +24,10 @@ class TypeEnum {
   //
   // The enum_extensibility attribute indicates that this enum is intended to
   // take values that do not correspond to its declared enumerators.
-  enum class [[clang::enum_extensibility(open)]] RawEnumType : uint8_t{
+// TODO: Works around a clang-format bug:
+// https://github.com/llvm/llvm-project/issues/85476
+#define CARBON_OPEN_ENUM [[clang::enum_extensibility(open)]]
+  enum class CARBON_OPEN_ENUM RawEnumType : uint8_t {
       // The first sizeof...(Types) values correspond to the types.
 
       // An explicitly invalid value.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -20,13 +20,14 @@ class TypeEnum {
 
   static_assert(NumValues <= 256, "Too many types for raw enum.");
 
+// TODO: Works around a clang-format bug:
+// https://github.com/llvm/llvm-project/issues/85476
+#define CARBON_OPEN_ENUM [[clang::enum_extensibility(open)]]
+
   // The underlying raw enumeration type.
   //
   // The enum_extensibility attribute indicates that this enum is intended to
   // take values that do not correspond to its declared enumerators.
-// TODO: Works around a clang-format bug:
-// https://github.com/llvm/llvm-project/issues/85476
-#define CARBON_OPEN_ENUM [[clang::enum_extensibility(open)]]
   enum class CARBON_OPEN_ENUM RawEnumType : uint8_t {
     // The first sizeof...(Types) values correspond to the types.
 
@@ -34,10 +35,12 @@ class TypeEnum {
     Invalid = NumTypes,
 
     // Indicates that no type should be used.
-    // TODO: This doesn't really fit the model of this type, but it's
-    // convenient for all of its users.
+    // TODO: This doesn't really fit the model of this type, but it's convenient
+    // for all of its users.
     None,
   };
+
+#undef CARBON_OPEN_ENUM
 
   // Accesses the type given an enum value.
   template <RawEnumType K>

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -28,15 +28,15 @@ class TypeEnum {
 // https://github.com/llvm/llvm-project/issues/85476
 #define CARBON_OPEN_ENUM [[clang::enum_extensibility(open)]]
   enum class CARBON_OPEN_ENUM RawEnumType : uint8_t {
-      // The first sizeof...(Types) values correspond to the types.
+    // The first sizeof...(Types) values correspond to the types.
 
-      // An explicitly invalid value.
-      Invalid = NumTypes,
+    // An explicitly invalid value.
+    Invalid = NumTypes,
 
-      // Indicates that no type should be used.
-      // TODO: This doesn't really fit the model of this type, but it's
-      // convenient for all of its users.
-      None,
+    // Indicates that no type should be used.
+    // TODO: This doesn't really fit the model of this type, but it's
+    // convenient for all of its users.
+    None,
   };
 
   // Accesses the type given an enum value.

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -24,16 +24,16 @@ class TypeEnum {
   //
   // The enum_extensibility attribute indicates that this enum is intended to
   // take values that do not correspond to its declared enumerators.
-  enum class [[clang::enum_extensibility(open)]] RawEnumType : uint8_t {
-    // The first sizeof...(Types) values correspond to the types.
+  enum class [[clang::enum_extensibility(open)]] RawEnumType : uint8_t{
+      // The first sizeof...(Types) values correspond to the types.
 
-    // An explicitly invalid value.
-    Invalid = NumTypes,
+      // An explicitly invalid value.
+      Invalid = NumTypes,
 
-    // Indicates that no type should be used.
-    // TODO: This doesn't really fit the model of this type, but it's convenient
-    // for all of its users.
-    None,
+      // Indicates that no type should be used.
+      // TODO: This doesn't really fit the model of this type, but it's
+      // convenient for all of its users.
+      None,
   };
 
   // Accesses the type given an enum value.

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -230,6 +230,12 @@ class Inst : public Printable<Inst> {
   // such argument.
   auto arg1() const -> int32_t { return arg1_; }
 
+  // Sets the arguments of this instruction.
+  auto SetArgs(int32_t arg0, int32_t arg1) {
+    arg0_ = arg0;
+    arg1_ = arg1;
+  }
+
   auto Print(llvm::raw_ostream& out) const -> void;
 
  private:


### PR DESCRIPTION
Add a general substitution mechanism to support substituting symbolic bindings with their values throughout symbolic constants and, more specifically, types. This is done by decomposing the constant instruction into its operands, substituting into the operands, and then rebuilding the constant value by invoking the constant evaluator.