### PR TITLE
file_name -> filename

### DIFF
--- a/toolchain/diagnostics/diagnostic_emitter.h
+++ b/toolchain/diagnostics/diagnostic_emitter.h
@@ -49,10 +49,10 @@ enum class DiagnosticLevel : int8_t {
 
 // A location for a diagnostic in a file. The lifetime of a DiagnosticLocation
 // is required to be less than SourceBuffer that it refers to due to the
-// contained file_name and line references.
+// contained filename and line references.
 struct DiagnosticLocation {
   // Name of the file or buffer that this diagnostic refers to.
-  llvm::StringRef file_name;
+  llvm::StringRef filename;
   // A reference to the line of the error.
   llvm::StringRef line;
   // 1-based line number.
@@ -395,7 +395,7 @@ class StreamDiagnosticConsumer : public DiagnosticConsumer {
   }
   auto Print(const DiagnosticMessage& message, llvm::StringRef prefix = "")
       -> void {
-    *stream_ << message.location.file_name;
+    *stream_ << message.location.filename;
     if (message.location.line_number > 0) {
       *stream_ << ":" << message.location.line_number;
       if (message.location.column_number > 0) {

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -9,7 +9,7 @@ namespace Carbon {
 void PrintTo(const Diagnostic& diagnostic, std::ostream* os) {
   *os << "Diagnostic{" << diagnostic.message.kind << ", ";
   PrintTo(diagnostic.level, os);
-  *os << ", " << diagnostic.message.location.file_name << ":"
+  *os << ", " << diagnostic.message.location.filename << ":"
       << diagnostic.message.location.line_number << ":"
       << diagnostic.message.location.column_number << ", \""
       << diagnostic.message.format_fn(diagnostic.message) << "\"}";

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -47,11 +47,11 @@ class DriverTest : public testing::Test {
   }
 
   auto MakeTestFile(llvm::StringRef text,
-                    llvm::StringRef file_name = "test_file.carbon")
+                    llvm::StringRef filename = "test_file.carbon")
       -> llvm::StringRef {
-    fs_.addFile(file_name, /*ModificationTime=*/0,
+    fs_.addFile(filename, /*ModificationTime=*/0,
                 llvm::MemoryBuffer::getMemBuffer(text));
-    return file_name;
+    return filename;
   }
 
   // Makes a temp directory and changes the working directory to it. Returns an

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -384,7 +384,7 @@ auto TokenizedBuffer::SourceBufferLocationTranslator::GetLocation(
     }
   }
 
-  return {.file_name = buffer_->source_->filename(),
+  return {.filename = buffer_->source_->filename(),
           .line = line,
           .line_number = line_number + 1,
           .column_number = column_number + 1};

--- a/toolchain/parse/tree_node_location_translator.h
+++ b/toolchain/parse/tree_node_location_translator.h
@@ -49,7 +49,7 @@ class NodeLocationTranslator
     // Support the invalid token as a way to emit only the filename, when there
     // is no line association.
     if (!node_location.node_id().is_valid()) {
-      return {.file_name = filename_};
+      return {.filename = filename_};
     }
 
     if (node_location.token_only()) {

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -13,7 +13,7 @@ namespace Carbon {
 namespace {
 struct FilenameTranslator : DiagnosticLocationTranslator<llvm::StringRef> {
   auto GetLocation(llvm::StringRef filename) -> DiagnosticLocation override {
-    return {.file_name = filename};
+    return {.filename = filename};
   }
 };
 }  // namespace


### PR DESCRIPTION
I wanted to choose one or the other. I think some code has been using each from early on. We're predominately using `filename`, so consolidating on that. This conveniently matches the [Google dev doc style guide](https://developers.google.com/style/word-list#filename) (which we use for docs) which says "filename: Not file name".

In toolchain:

```
╚╡git grep file_name . | wc -l
35
╚╡git grep filename . | wc -l
489
```
