### PR TITLE
Associate cross-file errors with the file being compiled.

### DIFF
--- a/testing/file_test/autoupdate.cpp
+++ b/testing/file_test/autoupdate.cpp
@@ -15,8 +15,12 @@
 
 namespace Carbon::Testing {
 
-// Converts a matched line number to an int, trimming whitespace.
+// Converts a matched line number to an int, trimming whitespace. Returns -1 if
+// no line number was matched.
 static auto ParseLineNumber(absl::string_view matched_line_number) -> int {
+  if (matched_line_number.empty()) {
+    return -1;
+  }
   llvm::StringRef trimmed = matched_line_number;
   trimmed = trimmed.trim();
   // NOLINTNEXTLINE(google-runtime-int): API requirement.
@@ -41,7 +45,6 @@ auto FileTestAutoupdater::CheckLine::RemapLineNumbers(
     return;
   }
 
-  bool found_one = false;
   // Use a cursor for the line so that we can't keep matching the same
   // content, which may occur when we keep a literal line number.
   int line_offset = 0;
@@ -60,10 +63,8 @@ auto FileTestAutoupdater::CheckLine::RemapLineNumbers(
       RE2::PartialMatch(line_cursor, *replacement_->re, &matched_line_number);
     }
     if (matched_line_number.empty()) {
-      CARBON_CHECK(found_one) << line_;
       return;
     }
-    found_one = true;
 
     // Update the cursor offset from the match.
     line_offset = matched_line_number.begin() - line_.c_str();

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -240,7 +240,7 @@ auto FileTestBase::GetLineNumberReplacements(
     -> llvm::SmallVector<LineNumberReplacement> {
   return {{.has_file = true,
            .re = std::make_shared<RE2>(
-               llvm::formatv(R"(({0}):(\d+))", llvm::join(filenames, "|"))),
+               llvm::formatv(R"(({0}):(\d+)?)", llvm::join(filenames, "|"))),
            .line_formatv = R"({0})"}};
 }
 

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -131,6 +131,15 @@ class FileTestBaseTest : public FileTestBase {
       result.per_file_success.push_back({"a.carbon", true});
       result.per_file_success.push_back({"fail_b.carbon", false});
       return result;
+    } else if (filename == "fail_no_line.carbon") {
+      stderr << "In fail_no_line.carbon:\nan error\n";
+      return {{.success = false}};
+    } else if (filename == "fail_multi_no_line.carbon") {
+      stderr << "In b.carbon:\n"
+             << "an error\n"
+             << "In c.carbon:\n"
+             << "c.carbon:5: an error\n";
+      return {{.success = false}};
     } else {
       return ErrorBuilder() << "Unexpected file: " << filename;
     }

--- a/testing/file_test/testdata/fail_multi_no_line.carbon
+++ b/testing/file_test/testdata/fail_multi_no_line.carbon
@@ -1,0 +1,24 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// AUTOUPDATE
+
+// --- a.carbon
+a
+
+// --- b.carbon
+// CHECK:STDERR: In b.carbon:
+// CHECK:STDERR: an error
+b
+
+// --- c.carbon
+// CHECK:STDERR: In c.carbon:
+c1
+c2
+// CHECK:STDERR: c.carbon:[[@LINE+1]]: an error
+c3
+c4
+c5
+
+// CHECK:STDOUT: 4 args: `default_args`, `a.carbon`, `b.carbon`, `c.carbon`

--- a/testing/file_test/testdata/fail_no_line.carbon
+++ b/testing/file_test/testdata/fail_no_line.carbon
@@ -1,0 +1,11 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// AUTOUPDATE
+// CHECK:STDERR: In fail_no_line.carbon:
+// CHECK:STDERR: an error
+a
+b
+
+// CHECK:STDOUT: 2 args: `default_args`, `fail_no_line.carbon`

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -45,37 +45,39 @@ library "extern" api;
 
 import Other library "extern";
 
-// CHECK:STDERR: fail_extern.carbon:[[@LINE+10]]:8: ERROR: Variable has incomplete type `C`.
+// CHECK:STDERR: fail_extern.carbon:[[@LINE+4]]:8: ERROR: Variable has incomplete type `C`.
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
 // CHECK:STDERR: fail_extern.carbon: Class was forward declared here.
+var c: Other.C = {};
+
+// --- fail_merge_define_extern.carbon
+// CHECK:STDERR: While compiling fail_merge_define_extern.carbon:
 // CHECK:STDERR: other_extern.carbon:5:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: other_define.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
-var c: Other.C = {};
-
-// --- fail_merge_define_extern.carbon
 
 library "fail_merge_define_extern" api;
 
 import Other library "define";
 import Other library "extern";
 
-// CHECK:STDERR: fail_merge_define_extern.carbon:[[@LINE+9]]:8: In name lookup for `C`.
+// CHECK:STDERR: fail_merge_define_extern.carbon:[[@LINE+3]]:8: In name lookup for `C`.
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
+var c: Other.C = {};
+
+// --- fail_conflict.carbon
+// CHECK:STDERR: While compiling fail_conflict.carbon:
 // CHECK:STDERR: other_conflict.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn C() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: other_define.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
-var c: Other.C = {};
-
-// --- fail_conflict.carbon
 
 library "conflict" api;
 
@@ -200,7 +202,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc10: {} = struct_literal ()
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -243,10 +245,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc16_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc16_19.3: init C = converted %.loc16_19.1, %.loc16_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc16_19.3
+// CHECK:STDOUT:   %.loc17_19.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc17_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17_19.3: init C = converted %.loc17_19.1, %.loc17_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc17_19.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -286,10 +288,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_19.3: init C = converted %.loc10_19.1, %.loc10_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc10_19.3
+// CHECK:STDOUT:   %.loc17_19.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc17_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17_19.3: init C = converted %.loc17_19.1, %.loc17_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc17_19.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_import.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_import.carbon
@@ -3,14 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
-// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
 
 // --- a.carbon
 
@@ -34,6 +26,14 @@ interface ForwardDeclared {
 var f_ref: {.f: ForwardDeclared};
 
 // --- fail_b.carbon
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntityType`.
+// CHECK:STDERR: fail_b.carbon: ERROR: Semantics TODO: `TryResolveInst on AssociatedEntity`.
 
 library "b" api;
 
@@ -152,7 +152,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     .UseBasicF = %UseBasicF
 // CHECK:STDOUT:     .UseForwardDeclaredT = %UseForwardDeclaredT
 // CHECK:STDOUT:     .UseForwardDeclaredF = %UseForwardDeclaredF
-// CHECK:STDOUT:     .f = %f.loc16
+// CHECK:STDOUT:     .f = %f.loc24
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, used [template = constants.%.1]
 // CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+4, used [template = constants.%.3]
@@ -161,37 +161,37 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:   %UseEmpty: <function> = fn_decl @UseEmpty [template] {
 // CHECK:STDOUT:     %Empty.decl: invalid = interface_decl @Empty [template = constants.%.1] {}
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, %import_ref.1 [template = constants.%.1]
-// CHECK:STDOUT:     %e.loc6_13.1: Empty = param e
-// CHECK:STDOUT:     @UseEmpty.%e: Empty = bind_name e, %e.loc6_13.1
+// CHECK:STDOUT:     %e.loc14_13.1: Empty = param e
+// CHECK:STDOUT:     @UseEmpty.%e: Empty = bind_name e, %e.loc14_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %UseBasic: <function> = fn_decl @UseBasic [template] {
 // CHECK:STDOUT:     %Basic.decl: invalid = interface_decl @Basic [template = constants.%.3] {}
-// CHECK:STDOUT:     %Basic.ref.loc7: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:     %e.loc7_13.1: Basic = param e
-// CHECK:STDOUT:     @UseBasic.%e: Basic = bind_name e, %e.loc7_13.1
+// CHECK:STDOUT:     %Basic.ref.loc15: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
+// CHECK:STDOUT:     %e.loc15_13.1: Basic = param e
+// CHECK:STDOUT:     @UseBasic.%e: Basic = bind_name e, %e.loc15_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %UseForwardDeclared: <function> = fn_decl @UseForwardDeclared [template] {
 // CHECK:STDOUT:     %ForwardDeclared.decl: invalid = interface_decl @ForwardDeclared [template = constants.%.4] {}
-// CHECK:STDOUT:     %ForwardDeclared.ref.loc8: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:     %f.loc8_23.1: ForwardDeclared = param f
-// CHECK:STDOUT:     @UseForwardDeclared.%f: ForwardDeclared = bind_name f, %f.loc8_23.1
+// CHECK:STDOUT:     %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
+// CHECK:STDOUT:     %f.loc16_23.1: ForwardDeclared = param f
+// CHECK:STDOUT:     @UseForwardDeclared.%f: ForwardDeclared = bind_name f, %f.loc16_23.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Basic.ref.loc10: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %T.ref.loc10: <error> = name_ref T, @Basic.%import_ref.3 [template = <error>]
+// CHECK:STDOUT:   %Basic.ref.loc18: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
+// CHECK:STDOUT:   %T.ref.loc18: <error> = name_ref T, @Basic.%import_ref.3 [template = <error>]
 // CHECK:STDOUT:   %UseBasicT: <error> = bind_alias UseBasicT, @Basic.%import_ref.3 [template = <error>]
-// CHECK:STDOUT:   %Basic.ref.loc11: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %F.ref.loc11: <error> = name_ref F, @Basic.%import_ref.2 [template = <error>]
+// CHECK:STDOUT:   %Basic.ref.loc19: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
+// CHECK:STDOUT:   %F.ref.loc19: <error> = name_ref F, @Basic.%import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %UseBasicF: <error> = bind_alias UseBasicF, @Basic.%import_ref.2 [template = <error>]
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc13: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %T.ref.loc13: <error> = name_ref T, @ForwardDeclared.%import_ref.3 [template = <error>]
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc21: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
+// CHECK:STDOUT:   %T.ref.loc21: <error> = name_ref T, @ForwardDeclared.%import_ref.3 [template = <error>]
 // CHECK:STDOUT:   %UseForwardDeclaredT: <error> = bind_alias UseForwardDeclaredT, @ForwardDeclared.%import_ref.3 [template = <error>]
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc14: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %F.ref.loc14: <error> = name_ref F, @ForwardDeclared.%import_ref.2 [template = <error>]
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc22: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
+// CHECK:STDOUT:   %F.ref.loc22: <error> = name_ref F, @ForwardDeclared.%import_ref.2 [template = <error>]
 // CHECK:STDOUT:   %UseForwardDeclaredF: <error> = bind_alias UseForwardDeclaredF, @ForwardDeclared.%import_ref.2 [template = <error>]
-// CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc16: type = ptr_type ForwardDeclared [template = constants.%.5]
+// CHECK:STDOUT:   %ForwardDeclared.ref.loc24: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc24: type = ptr_type ForwardDeclared [template = constants.%.5]
 // CHECK:STDOUT:   %f.var: ref ForwardDeclared* = var f
-// CHECK:STDOUT:   %f.loc16: ref ForwardDeclared* = bind_name f, %f.var
+// CHECK:STDOUT:   %f.loc24: ref ForwardDeclared* = bind_name f, %f.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
@@ -248,9 +248,9 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %f_ref.ref: ref {.f: ForwardDeclared} = name_ref f_ref, file.%import_ref.4
-// CHECK:STDOUT:   %.loc16_33: ref ForwardDeclared = struct_access %f_ref.ref, element0
-// CHECK:STDOUT:   %.loc16_27: ForwardDeclared* = addr_of %.loc16_33
-// CHECK:STDOUT:   assign file.%f.var, %.loc16_27
+// CHECK:STDOUT:   %.loc24_33: ref ForwardDeclared = struct_access %f_ref.ref, element0
+// CHECK:STDOUT:   %.loc24_27: ForwardDeclared* = addr_of %.loc24_33
+// CHECK:STDOUT:   assign file.%f.var, %.loc24_27
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -15,15 +15,16 @@ fn NS.Foo() {}
 
 package Example library "fn" api;
 
-// CHECK:STDERR: fn.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+fn NS() {}
+
+// --- fail_conflict.carbon
+// CHECK:STDERR: While compiling fail_conflict.carbon:
+// CHECK:STDERR: fn.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn NS() {}
 // CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR: namespace.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: namespace NS;
 // CHECK:STDERR: ^~~~~~~~~~~~~
-fn NS() {}
-
-// --- fail_conflict.carbon
 
 package Example library "namespace_then_fn" api;
 

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -14,16 +14,17 @@ fn NS() {}
 
 package Example library "namespace" api;
 
-// CHECK:STDERR: namespace.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+namespace NS;
+fn NS.Foo() {}
+
+// --- fail_conflict.carbon
+// CHECK:STDERR: While compiling fail_conflict.carbon:
+// CHECK:STDERR: namespace.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: namespace NS;
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fn.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: fn NS() {}
 // CHECK:STDERR: ^~~~~~~~~
-namespace NS;
-fn NS.Foo() {}
-
-// --- fail_conflict.carbon
 
 package Example library "fn_then_namespace" api;
 

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -19,12 +19,6 @@ fn F() {}
 package Other library "fn_extern" api;
 
 // TODO: Mark extern
-// CHECK:STDERR: other_fn_extern.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
-// CHECK:STDERR: fn F();
-// CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: other_fn.carbon:4:1: Name is previously declared here.
-// CHECK:STDERR: fn F() {}
-// CHECK:STDERR: ^~~~~~~~
 fn F();
 
 // --- other_fn_conflict.carbon
@@ -62,6 +56,13 @@ fn Run() {
 }
 
 // --- fail_main_use_other_extern.carbon
+// CHECK:STDERR: While compiling fail_main_use_other_extern.carbon:
+// CHECK:STDERR: other_fn_extern.carbon:5:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fn F();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: other_fn.carbon:4:1: Name is previously declared here.
+// CHECK:STDERR: fn F() {}
+// CHECK:STDERR: ^~~~~~~~
 
 library "use_other_extern" api;
 
@@ -69,15 +70,9 @@ import Other library "fn";
 import Other library "fn_extern";
 
 fn Run() {
-  // CHECK:STDERR: fail_main_use_other_extern.carbon:[[@LINE+9]]:3: In name lookup for `F`.
+  // CHECK:STDERR: fail_main_use_other_extern.carbon:[[@LINE+3]]:3: In name lookup for `F`.
   // CHECK:STDERR:   Other.F();
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: other_fn_conflict.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
-  // CHECK:STDERR: fn F(x: i32) {}
-  // CHECK:STDERR: ^~~~~~~~~~~~~~
-  // CHECK:STDERR: other_fn.carbon:4:1: Name is previously declared here.
-  // CHECK:STDERR: fn F() {}
-  // CHECK:STDERR: ^~~~~~~~
   Other.F();
 }
 
@@ -89,6 +84,13 @@ import Other library "fn";
 import Other library "fn_conflict";
 
 // --- fail_main_use_other_ambiguous.carbon
+// CHECK:STDERR: While compiling fail_main_use_other_ambiguous.carbon:
+// CHECK:STDERR: other_fn_conflict.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fn F(x: i32) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR: other_fn.carbon:4:1: Name is previously declared here.
+// CHECK:STDERR: fn F() {}
+// CHECK:STDERR: ^~~~~~~~
 
 library "use_other_ambiguous" api;
 
@@ -272,7 +274,7 @@ fn Other.G() {}
 // CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, used [template = imports.%F.1]
 // CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+1, used [template = imports.%F.2]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, %import_ref.1 [template = imports.%F.1]
-// CHECK:STDOUT:   %.loc17: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc18: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -310,7 +312,7 @@ fn Other.G() {}
 // CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, used [template = imports.%F.1]
 // CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+3, used [template = imports.%F.2]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, %import_ref.1 [template = imports.%F.1]
-// CHECK:STDOUT:   %.loc11: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc18: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -14,15 +14,16 @@ fn Foo();
 
 package Example library "var" api;
 
-// CHECK:STDERR: var.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+var Foo: i32;
+
+// --- fail_conflict.carbon
+// CHECK:STDERR: While compiling fail_conflict.carbon:
+// CHECK:STDERR: var.carbon:4:5: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: var Foo: i32;
 // CHECK:STDERR:     ^~~
 // CHECK:STDERR: fn.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: fn Foo();
 // CHECK:STDERR: ^~~~~~~~~
-var Foo: i32;
-
-// --- fail_conflict.carbon
 
 package Example library "conflict" api;
 

--- a/toolchain/check/testdata/packages/fail_duplicate_api.carbon
+++ b/toolchain/check/testdata/packages/fail_duplicate_api.carbon
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
-// CHECK:STDERR: fail_main2.carbon: ERROR: Main//default previously provided by `main1.carbon`.
 
 // --- main1.carbon
 
 // --- fail_main2.carbon
+// CHECK:STDERR: fail_main2.carbon: ERROR: Main//default previously provided by `main1.carbon`.
 
 // --- main_lib1.carbon
 

--- a/toolchain/check/testdata/packages/fail_extension.carbon
+++ b/toolchain/check/testdata/packages/fail_extension.carbon
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // AUTOUPDATE
+
+// --- fail_main.incorrect
 // CHECK:STDERR: fail_main.incorrect: ERROR: File extension of `.carbon` required for `api`.
+
+// --- fail_main_redundant_with_swapped_ext.impl.carbon
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: ERROR: Main//default previously provided by `fail_main.incorrect`.
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: File extension of `.impl.carbon` only allowed for `impl`.
-
-// --- fail_main.incorrect
-
-// --- fail_main_redundant_with_swapped_ext.impl.carbon
 
 // --- fail_main_lib.incorrect
 

--- a/toolchain/diagnostics/diagnostic_emitter_test.cpp
+++ b/toolchain/diagnostics/diagnostic_emitter_test.cpp
@@ -23,7 +23,7 @@ struct FakeDiagnosticLocationTranslator : DiagnosticLocationTranslator<int> {
 
 class DiagnosticEmitterTest : public ::testing::Test {
  protected:
-  DiagnosticEmitterTest() : emitter_(translator_, consumer_) {}
+  DiagnosticEmitterTest() : emitter_("unused", translator_, consumer_) {}
 
   FakeDiagnosticLocationTranslator translator_;
   Testing::MockDiagnosticConsumer consumer_;

--- a/toolchain/diagnostics/null_diagnostics.h
+++ b/toolchain/diagnostics/null_diagnostics.h
@@ -32,7 +32,8 @@ inline auto NullDiagnosticConsumer() -> DiagnosticConsumer& {
 template <typename LocationT>
 inline auto NullDiagnosticEmitter() -> DiagnosticEmitter<LocationT>& {
   static auto* emitter = new DiagnosticEmitter<LocationT>(
-      NullDiagnosticLocationTranslator<LocationT>(), NullDiagnosticConsumer());
+      "<null>", NullDiagnosticLocationTranslator<LocationT>(),
+      NullDiagnosticConsumer());
   return *emitter;
 }
 

--- a/toolchain/diagnostics/sorting_diagnostic_consumer.h
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer.h
@@ -33,13 +33,15 @@ class SortingDiagnosticConsumer : public DiagnosticConsumer {
 
   // Sorts and flushes buffered diagnostics.
   void Flush() override {
-    llvm::stable_sort(diagnostics_,
-                      [](const Diagnostic& lhs, const Diagnostic& rhs) {
-                        return std::tie(lhs.message.location.line_number,
-                                        lhs.message.location.column_number) <
-                               std::tie(rhs.message.location.line_number,
-                                        rhs.message.location.column_number);
-                      });
+    llvm::stable_sort(
+        diagnostics_, [](const Diagnostic& lhs, const Diagnostic& rhs) {
+          return std::tie(lhs.filename, lhs.message.location.filename,
+                          lhs.message.location.line_number,
+                          lhs.message.location.column_number) <
+                 std::tie(rhs.filename, rhs.message.location.filename,
+                          rhs.message.location.line_number,
+                          rhs.message.location.column_number);
+        });
     for (auto& diag : diagnostics_) {
       next_consumer_->HandleDiagnostic(std::move(diag));
     }

--- a/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
+++ b/toolchain/diagnostics/sorting_diagnostic_consumer_test.cpp
@@ -30,7 +30,8 @@ TEST(SortedDiagnosticEmitterTest, SortErrors) {
   FakeDiagnosticLocationTranslator translator;
   Testing::MockDiagnosticConsumer consumer;
   SortingDiagnosticConsumer sorting_consumer(consumer);
-  DiagnosticEmitter<DiagnosticLocation> emitter(translator, sorting_consumer);
+  DiagnosticEmitter<DiagnosticLocation> emitter("f", translator,
+                                                sorting_consumer);
 
   emitter.Emit({"f", "line", 2, 1}, TestDiagnostic, "M1");
   emitter.Emit({"f", "line", 1, 1}, TestDiagnostic, "M2");

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -78,9 +78,9 @@ class [[clang::internal_linkage]] Lexer {
       : buffer_(value_stores, source),
         consumer_(consumer),
         translator_(&buffer_),
-        emitter_(translator_, consumer_),
+        emitter_(source.filename(), translator_, consumer_),
         token_translator_(&buffer_),
-        token_emitter_(token_translator_, consumer_) {}
+        token_emitter_(source.filename(), token_translator_, consumer_) {}
 
   // Find all line endings and create the line data structures.
   //

--- a/toolchain/lex/numeric_literal_test.cpp
+++ b/toolchain/lex/numeric_literal_test.cpp
@@ -34,7 +34,7 @@ class NumericLiteralTest : public ::testing::Test {
 
   auto Parse(llvm::StringRef text) -> NumericLiteral::Value {
     Testing::SingleTokenDiagnosticTranslator translator(text);
-    DiagnosticEmitter<const char*> emitter(translator, error_tracker);
+    DiagnosticEmitter<const char*> emitter("unused", translator, error_tracker);
     return Lex(text).ComputeValue(emitter);
   }
 

--- a/toolchain/lex/string_literal_test.cpp
+++ b/toolchain/lex/string_literal_test.cpp
@@ -28,7 +28,7 @@ class StringLiteralTest : public ::testing::Test {
   auto Parse(llvm::StringRef text) -> llvm::StringRef {
     StringLiteral token = Lex(text);
     Testing::SingleTokenDiagnosticTranslator translator(text);
-    DiagnosticEmitter<const char*> emitter(translator, error_tracker);
+    DiagnosticEmitter<const char*> emitter("unused", translator, error_tracker);
     return token.ComputeValue(allocator, emitter);
   }
 

--- a/toolchain/parse/parse.cpp
+++ b/toolchain/parse/parse.cpp
@@ -21,7 +21,8 @@ auto HandleInvalid(Context& context) -> void {
 auto Parse(Lex::TokenizedBuffer& tokens, DiagnosticConsumer& consumer,
            llvm::raw_ostream* vlog_stream) -> Tree {
   Lex::TokenLocationTranslator translator(&tokens);
-  Lex::TokenDiagnosticEmitter emitter(translator, consumer);
+  Lex::TokenDiagnosticEmitter emitter(tokens.source().filename(), translator,
+                                      consumer);
 
   // Delegate to the parser.
   Tree tree(tokens);

--- a/toolchain/source/source_buffer.cpp
+++ b/toolchain/source/source_buffer.cpp
@@ -29,7 +29,7 @@ auto SourceBuffer::MakeFromFile(llvm::vfs::FileSystem& fs,
                                 DiagnosticConsumer& consumer)
     -> std::optional<SourceBuffer> {
   FilenameTranslator translator;
-  DiagnosticEmitter<llvm::StringRef> emitter(translator, consumer);
+  DiagnosticEmitter<llvm::StringRef> emitter(filename, translator, consumer);
 
   llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> file =
       fs.openFileForRead(filename);
@@ -64,7 +64,7 @@ auto SourceBuffer::MakeFromMemoryBuffer(
     llvm::StringRef filename, bool is_regular_file,
     DiagnosticConsumer& consumer) -> std::optional<SourceBuffer> {
   FilenameTranslator translator;
-  DiagnosticEmitter<llvm::StringRef> emitter(translator, consumer);
+  DiagnosticEmitter<llvm::StringRef> emitter(filename, translator, consumer);
 
   if (buffer.getError()) {
     CARBON_DIAGNOSTIC(ErrorReadingFile, Error, "Error reading file: {0}",


### PR DESCRIPTION
Import-related compilation failures can be associated with lines in other files. As we move to have multiple tests in a given file, this can be particularly confusing because errors can end up associated with the wrong file.

This adds a message in front of the compilation error to indicate what was being compiled, before getting into the error. Putting it first allows the test infrastructure to file-associate the full error message. This is not the same as a Note diagnostic because it's at the start of the diagnostic, rather than at the end.

I'm associating the filename with each emitter because it felt a little more appropriate than having it as an api on the location translator. I think having Emit/Build take an additional Location for the source would be a fair alternative, since we do need this information on the start of a message, although that would require changing each message. Setting up an annotator-style approach for this doesn't feel quite right to me (i.e., setting the location on each parse node, before calling out to the handler).

Format-wise I considered moving the ERROR prefix but thought that might not be considered the "right" thing to flag for a human trying to read these diagnostics. I could hide this note with a flag, keeping it primarily for tests, but thought we might want something like this for developers. That said, if we want a note at the end of the diagnostic for developers (versus in addition to), that would get me back to the flag approach because a note wouldn't quite offer the right context to achieve what's done here.