### PR TITLE
Add more testing of compound member access.

### DIFF
--- a/toolchain/check/testdata/class/base_method_qualified.carbon
+++ b/toolchain/check/testdata/class/base_method_qualified.carbon
@@ -1,0 +1,198 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+class Derived;
+
+base class Base {
+  fn F[self: Self]() -> i32;
+  fn G[self: Derived]() -> i32;
+}
+
+class Derived {
+  extend base: Base;
+
+  fn F[self: Self]();
+  fn G[self: Self]();
+}
+
+fn Call(a: Derived) -> i32 {
+  return a.(Base.F)();
+}
+
+fn CallIndirect(p: Derived*) -> i32 {
+  return p->(Base.F)();
+}
+
+fn PassDerivedToBase(a: Derived) -> i32 {
+  return a.(Base.G)();
+}
+
+fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
+  return p->(Base.G)();
+}
+
+// CHECK:STDOUT: --- base_method_qualified.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Derived: type = class_type @Derived [template]
+// CHECK:STDOUT:   %Base: type = class_type @Base [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT:   %.2: type = tuple_type () [template]
+// CHECK:STDOUT:   %.3: type = ptr_type {} [template]
+// CHECK:STDOUT:   %.4: type = unbound_element_type Derived, Base [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.base: Base} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.base: {}*} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type {.base: Base} [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Derived [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Derived = %Derived.decl.loc7
+// CHECK:STDOUT:     .Base = %Base.decl
+// CHECK:STDOUT:     .Call = %Call
+// CHECK:STDOUT:     .CallIndirect = %CallIndirect
+// CHECK:STDOUT:     .PassDerivedToBase = %PassDerivedToBase
+// CHECK:STDOUT:     .PassDerivedToBaseIndirect = %PassDerivedToBaseIndirect
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Derived.decl.loc7: type = class_decl @Derived [template = constants.%Derived] {}
+// CHECK:STDOUT:   %Base.decl: type = class_decl @Base [template = constants.%Base] {}
+// CHECK:STDOUT:   %Derived.decl.loc14: type = class_decl @Derived [template = constants.%Derived] {}
+// CHECK:STDOUT:   %Call: <function> = fn_decl @Call [template] {
+// CHECK:STDOUT:     %Derived.ref.loc21: type = name_ref Derived, %Derived.decl.loc7 [template = constants.%Derived]
+// CHECK:STDOUT:     %a.loc21_9.1: Derived = param a
+// CHECK:STDOUT:     @Call.%a: Derived = bind_name a, %a.loc21_9.1
+// CHECK:STDOUT:     %return.var.loc21: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %CallIndirect: <function> = fn_decl @CallIndirect [template] {
+// CHECK:STDOUT:     %Derived.ref.loc25: type = name_ref Derived, %Derived.decl.loc7 [template = constants.%Derived]
+// CHECK:STDOUT:     %.loc25: type = ptr_type Derived [template = constants.%.8]
+// CHECK:STDOUT:     %p.loc25_17.1: Derived* = param p
+// CHECK:STDOUT:     @CallIndirect.%p: Derived* = bind_name p, %p.loc25_17.1
+// CHECK:STDOUT:     %return.var.loc25: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %PassDerivedToBase: <function> = fn_decl @PassDerivedToBase [template] {
+// CHECK:STDOUT:     %Derived.ref.loc29: type = name_ref Derived, %Derived.decl.loc7 [template = constants.%Derived]
+// CHECK:STDOUT:     %a.loc29_22.1: Derived = param a
+// CHECK:STDOUT:     @PassDerivedToBase.%a: Derived = bind_name a, %a.loc29_22.1
+// CHECK:STDOUT:     %return.var.loc29: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %PassDerivedToBaseIndirect: <function> = fn_decl @PassDerivedToBaseIndirect [template] {
+// CHECK:STDOUT:     %Derived.ref.loc33: type = name_ref Derived, %Derived.decl.loc7 [template = constants.%Derived]
+// CHECK:STDOUT:     %.loc33: type = ptr_type Derived [template = constants.%.8]
+// CHECK:STDOUT:     %p.loc33_30.1: Derived* = param p
+// CHECK:STDOUT:     @PassDerivedToBaseIndirect.%p: Derived* = bind_name p, %p.loc33_30.1
+// CHECK:STDOUT:     %return.var.loc33: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Derived {
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %.loc15: <unbound element of class Derived> = base_decl Base, element0 [template]
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
+// CHECK:STDOUT:     %Self.ref.loc17: type = name_ref Self, constants.%Derived [template = constants.%Derived]
+// CHECK:STDOUT:     %self.loc17_8.1: Derived = param self
+// CHECK:STDOUT:     %self.loc17_8.2: Derived = bind_name self, %self.loc17_8.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G: <function> = fn_decl @G.2 [template] {
+// CHECK:STDOUT:     %Self.ref.loc18: type = name_ref Self, constants.%Derived [template = constants.%Derived]
+// CHECK:STDOUT:     %self.loc18_8.1: Derived = param self
+// CHECK:STDOUT:     %self.loc18_8.2: Derived = bind_name self, %self.loc18_8.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Derived
+// CHECK:STDOUT:   .base = %.loc15
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   .G = %G
+// CHECK:STDOUT:   extend name_scope1
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Base {
+// CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
+// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Base [template = constants.%Base]
+// CHECK:STDOUT:     %self.loc10_8.1: Base = param self
+// CHECK:STDOUT:     %self.loc10_8.2: Base = bind_name self, %self.loc10_8.1
+// CHECK:STDOUT:     %return.var.loc10: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G: <function> = fn_decl @G.1 [template] {
+// CHECK:STDOUT:     %Derived.ref: type = name_ref Derived, file.%Derived.decl.loc7 [template = constants.%Derived]
+// CHECK:STDOUT:     %self.loc11_8.1: Derived = param self
+// CHECK:STDOUT:     %self.loc11_8.2: Derived = bind_name self, %self.loc11_8.1
+// CHECK:STDOUT:     %return.var.loc11: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Base
+// CHECK:STDOUT:   .F = %F
+// CHECK:STDOUT:   .G = %G
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.1[@Base.%self.loc10_8.2: Base]() -> i32;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G.1[@Base.%self.loc11_8.2: Derived]() -> i32;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F.2[@Derived.%self.loc17_8.2: Derived]();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G.2[@Derived.%self.loc18_8.2: Derived]();
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Call(%a: Derived) -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %a.ref: Derived = name_ref a, %a
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
+// CHECK:STDOUT:   %.loc22_11: <bound method> = bound_method %a.ref, %F.ref
+// CHECK:STDOUT:   %.loc22_20.1: ref Base = class_element_access %a.ref, element0
+// CHECK:STDOUT:   %.loc22_10.1: ref Base = converted %a.ref, %.loc22_20.1
+// CHECK:STDOUT:   %.loc22_10.2: Base = bind_value %.loc22_10.1
+// CHECK:STDOUT:   %.loc22_20.2: init i32 = call %.loc22_11(%.loc22_10.2)
+// CHECK:STDOUT:   %.loc22_22: i32 = value_of_initializer %.loc22_20.2
+// CHECK:STDOUT:   %.loc22_20.3: i32 = converted %.loc22_20.2, %.loc22_22
+// CHECK:STDOUT:   return %.loc22_20.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @CallIndirect(%p: Derived*) -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
+// CHECK:STDOUT:   %.loc26_11.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc26_11.2: <bound method> = bound_method %.loc26_11.1, %F.ref
+// CHECK:STDOUT:   %.loc26_21.1: ref Base = class_element_access %.loc26_11.1, element0
+// CHECK:STDOUT:   %.loc26_11.3: ref Base = converted %.loc26_11.1, %.loc26_21.1
+// CHECK:STDOUT:   %.loc26_11.4: Base = bind_value %.loc26_11.3
+// CHECK:STDOUT:   %.loc26_21.2: init i32 = call %.loc26_11.2(%.loc26_11.4)
+// CHECK:STDOUT:   %.loc26_23: i32 = value_of_initializer %.loc26_21.2
+// CHECK:STDOUT:   %.loc26_21.3: i32 = converted %.loc26_21.2, %.loc26_23
+// CHECK:STDOUT:   return %.loc26_21.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @PassDerivedToBase(%a: Derived) -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %a.ref: Derived = name_ref a, %a
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Base.%G [template = @Base.%G]
+// CHECK:STDOUT:   %.loc30_11: <bound method> = bound_method %a.ref, %G.ref
+// CHECK:STDOUT:   %.loc30_20.1: init i32 = call %.loc30_11(%a.ref)
+// CHECK:STDOUT:   %.loc30_22: i32 = value_of_initializer %.loc30_20.1
+// CHECK:STDOUT:   %.loc30_20.2: i32 = converted %.loc30_20.1, %.loc30_22
+// CHECK:STDOUT:   return %.loc30_20.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @PassDerivedToBaseIndirect(%p: Derived*) -> i32 {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Base.%G [template = @Base.%G]
+// CHECK:STDOUT:   %.loc34_11.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc34_11.2: <bound method> = bound_method %.loc34_11.1, %G.ref
+// CHECK:STDOUT:   %.loc34_11.3: Derived = bind_value %.loc34_11.1
+// CHECK:STDOUT:   %.loc34_21.1: init i32 = call %.loc34_11.2(%.loc34_11.3)
+// CHECK:STDOUT:   %.loc34_23: i32 = value_of_initializer %.loc34_21.1
+// CHECK:STDOUT:   %.loc34_21.2: i32 = converted %.loc34_21.1, %.loc34_23
+// CHECK:STDOUT:   return %.loc34_21.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/class/compound_field.carbon
+++ b/toolchain/check/testdata/class/compound_field.carbon
@@ -25,6 +25,14 @@ fn AccessBase(d: Derived) -> i32 {
   return d.(Base.b);
 }
 
+fn AccessDerivedIndirect(p: Derived*) -> i32* {
+  return &p->(Derived.d);
+}
+
+fn AccessBaseIndirect(p: Derived*) -> i32* {
+  return &p->(Base.b);
+}
+
 // CHECK:STDOUT: --- compound_field.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -39,6 +47,8 @@ fn AccessBase(d: Derived) -> i32 {
 // CHECK:STDOUT:   %.7: type = struct_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
 // CHECK:STDOUT:   %.8: type = ptr_type {.base: {.a: i32, .b: i32, .c: i32}*, .d: i32, .e: i32} [template]
 // CHECK:STDOUT:   %.9: type = ptr_type {.base: Base, .d: i32, .e: i32} [template]
+// CHECK:STDOUT:   %.10: type = ptr_type Derived [template]
+// CHECK:STDOUT:   %.11: type = ptr_type i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,6 +57,8 @@ fn AccessBase(d: Derived) -> i32 {
 // CHECK:STDOUT:     .Derived = %Derived.decl
 // CHECK:STDOUT:     .AccessDerived = %AccessDerived
 // CHECK:STDOUT:     .AccessBase = %AccessBase
+// CHECK:STDOUT:     .AccessDerivedIndirect = %AccessDerivedIndirect
+// CHECK:STDOUT:     .AccessBaseIndirect = %AccessBaseIndirect
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Base.decl: type = class_decl @Base [template = constants.%Base] {}
 // CHECK:STDOUT:   %Derived.decl: type = class_decl @Derived [template = constants.%Derived] {}
@@ -61,6 +73,22 @@ fn AccessBase(d: Derived) -> i32 {
 // CHECK:STDOUT:     %d.loc24_15.1: Derived = param d
 // CHECK:STDOUT:     @AccessBase.%d: Derived = bind_name d, %d.loc24_15.1
 // CHECK:STDOUT:     %return.var.loc24: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %AccessDerivedIndirect: <function> = fn_decl @AccessDerivedIndirect [template] {
+// CHECK:STDOUT:     %Derived.ref.loc28: type = name_ref Derived, %Derived.decl [template = constants.%Derived]
+// CHECK:STDOUT:     %.loc28_36: type = ptr_type Derived [template = constants.%.10]
+// CHECK:STDOUT:     %p.loc28_26.1: Derived* = param p
+// CHECK:STDOUT:     @AccessDerivedIndirect.%p: Derived* = bind_name p, %p.loc28_26.1
+// CHECK:STDOUT:     %.loc28_45: type = ptr_type i32 [template = constants.%.11]
+// CHECK:STDOUT:     %return.var.loc28: ref i32* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %AccessBaseIndirect: <function> = fn_decl @AccessBaseIndirect [template] {
+// CHECK:STDOUT:     %Derived.ref.loc32: type = name_ref Derived, %Derived.decl [template = constants.%Derived]
+// CHECK:STDOUT:     %.loc32_33: type = ptr_type Derived [template = constants.%.10]
+// CHECK:STDOUT:     %p.loc32_23.1: Derived* = param p
+// CHECK:STDOUT:     @AccessBaseIndirect.%p: Derived* = bind_name p, %p.loc32_23.1
+// CHECK:STDOUT:     %.loc32_42: type = ptr_type i32 [template = constants.%.11]
+// CHECK:STDOUT:     %return.var.loc32: ref i32* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -110,5 +138,29 @@ fn AccessBase(d: Derived) -> i32 {
 // CHECK:STDOUT:   %.loc25_11.2: ref i32 = class_element_access %.loc25_10, element1
 // CHECK:STDOUT:   %.loc25_11.3: i32 = bind_value %.loc25_11.2
 // CHECK:STDOUT:   return %.loc25_11.3
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @AccessDerivedIndirect(%p: Derived*) -> i32* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
+// CHECK:STDOUT:   %Derived.ref: type = name_ref Derived, file.%Derived.decl [template = constants.%Derived]
+// CHECK:STDOUT:   %d.ref: <unbound element of class Derived> = name_ref d, @Derived.%.loc16 [template = @Derived.%.loc16]
+// CHECK:STDOUT:   %.loc29_12.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc29_12.2: ref i32 = class_element_access %.loc29_12.1, element1
+// CHECK:STDOUT:   %.loc29_10: i32* = addr_of %.loc29_12.2
+// CHECK:STDOUT:   return %.loc29_10
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @AccessBaseIndirect(%p: Derived*) -> i32* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
+// CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
+// CHECK:STDOUT:   %b.ref: <unbound element of class Base> = name_ref b, @Base.%.loc9 [template = @Base.%.loc9]
+// CHECK:STDOUT:   %.loc33_12.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc33_12.2: ref Base = class_element_access %.loc33_12.1, element0
+// CHECK:STDOUT:   %.loc33_12.3: ref Base = converted %.loc33_12.1, %.loc33_12.2
+// CHECK:STDOUT:   %.loc33_12.4: ref i32 = class_element_access %.loc33_12.3, element1
+// CHECK:STDOUT:   %.loc33_10: i32* = addr_of %.loc33_12.4
+// CHECK:STDOUT:   return %.loc33_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/compound.carbon
+++ b/toolchain/check/testdata/impl/compound.carbon
@@ -22,6 +22,14 @@ fn InstanceCall(n: i32) {
   n.(Simple.G)();
 }
 
+fn NonInstanceCallIndirect(p: i32*) {
+  p->(Simple.F)();
+}
+
+fn InstanceCallIndirect(p: i32*) {
+  p->(Simple.G)();
+}
+
 // CHECK:STDOUT: --- compound.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -31,6 +39,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:   %.4: <associated <function> in Simple> = assoc_entity element1, @Simple.%G [template]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%F, @impl.%G) [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
+// CHECK:STDOUT:   %.7: type = ptr_type i32 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -38,6 +47,8 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:     .Simple = %Simple.decl
 // CHECK:STDOUT:     .NonInstanceCall = %NonInstanceCall
 // CHECK:STDOUT:     .InstanceCall = %InstanceCall
+// CHECK:STDOUT:     .NonInstanceCallIndirect = %NonInstanceCallIndirect
+// CHECK:STDOUT:     .InstanceCallIndirect = %InstanceCallIndirect
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Simple.decl: type = interface_decl @Simple [template = constants.%.1] {}
 // CHECK:STDOUT:   impl_decl @impl {
@@ -50,6 +61,16 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:   %InstanceCall: <function> = fn_decl @InstanceCall [template] {
 // CHECK:STDOUT:     %n.loc21_17.1: i32 = param n
 // CHECK:STDOUT:     @InstanceCall.%n: i32 = bind_name n, %n.loc21_17.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %NonInstanceCallIndirect: <function> = fn_decl @NonInstanceCallIndirect [template] {
+// CHECK:STDOUT:     %.loc25: type = ptr_type i32 [template = constants.%.7]
+// CHECK:STDOUT:     %p.loc25_28.1: i32* = param p
+// CHECK:STDOUT:     @NonInstanceCallIndirect.%p: i32* = bind_name p, %p.loc25_28.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %InstanceCallIndirect: <function> = fn_decl @InstanceCallIndirect [template] {
+// CHECK:STDOUT:     %.loc29: type = ptr_type i32 [template = constants.%.7]
+// CHECK:STDOUT:     %p.loc29_25.1: i32* = param p
+// CHECK:STDOUT:     @InstanceCallIndirect.%p: i32* = bind_name p, %p.loc29_25.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -113,6 +134,30 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element1 [template = @impl.%G]
 // CHECK:STDOUT:   %.loc22_4: <bound method> = bound_method %n.ref, %.1
 // CHECK:STDOUT:   %.loc22_15: init () = call %.loc22_4(%n.ref)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @NonInstanceCallIndirect(%p: i32*) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: i32* = name_ref p, %p
+// CHECK:STDOUT:   %Simple.ref: type = name_ref Simple, file.%Simple.decl [template = constants.%.1]
+// CHECK:STDOUT:   %F.ref: <associated <function> in Simple> = name_ref F, @Simple.%.loc8 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc26_4: ref i32 = deref %p.ref
+// CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%F]
+// CHECK:STDOUT:   %.loc26_16: init () = call %.1()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @InstanceCallIndirect(%p: i32*) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %p.ref: i32* = name_ref p, %p
+// CHECK:STDOUT:   %Simple.ref: type = name_ref Simple, file.%Simple.decl [template = constants.%.1]
+// CHECK:STDOUT:   %G.ref: <associated <function> in Simple> = name_ref G, @Simple.%.loc9_21 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc30_4.1: ref i32 = deref %p.ref
+// CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element1 [template = @impl.%G]
+// CHECK:STDOUT:   %.loc30_4.2: <bound method> = bound_method %.loc30_4.1, %.1
+// CHECK:STDOUT:   %.loc30_4.3: i32 = bind_value %.loc30_4.1
+// CHECK:STDOUT:   %.loc30_16: init () = call %.loc30_4.2(%.loc30_4.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Includes testing of indirect compound member access (`p->(M)`).