### PR TITLE
Provide a TypedInstSwitch for simpler cases

### DIFF
--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -156,6 +156,7 @@ cc_library(
     deps = [
         ":inst",
         ":inst_kind",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -102,6 +102,7 @@ cc_library(
         ":inst",
         ":inst_kind",
         ":type_info",
+        ":typed_inst_switch",
         "//common:check",
         "//common:error",
         "//toolchain/base:value_store",
@@ -120,6 +121,7 @@ cc_library(
         ":file",
         ":ids",
         ":inst_kind",
+        ":typed_inst_switch",
         "//common:ostream",
         "//toolchain/base:value_store",
         "//toolchain/lex:tokenized_buffer",
@@ -145,6 +147,15 @@ cc_library(
         ":ids",
         ":inst",
         "//common:ostream",
+    ],
+)
+
+cc_library(
+    name = "typed_inst_switch",
+    hdrs = ["typed_inst_switch.h"],
+    deps = [
+        ":inst",
+        ":inst_kind",
     ],
 )
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -462,41 +462,41 @@ class InstNamer {
 
       bool do_continue = false;
       TypedInstSwitch(inst)
-          .Case<AddrPattern>([&](auto inst) {
+          .Case([&](AddrPattern inst) {
             // TODO: We need to assign names to parameters that appear in
             // function declarations, which may be nested within a pattern.
             // For now, just look through `addr`, but we should find a
             // better way to visit parameters.
             CollectNamesInBlock(scope_id, inst.inner_id);
           })
-          .Case<AssociatedConstantDecl>([&](auto inst) {
+          .Case([&](AssociatedConstantDecl inst) {
             add_inst_name_id(inst.name_id);
             do_continue = true;
           })
-          .Case<AnyBindName>([&](auto inst) {
+          .Case([&](AnyBindName inst) {
             add_inst_name_id(
                 sem_ir_.bind_names().Get(inst.bind_name_id).name_id);
             do_continue = true;
           })
-          .Case<ClassDecl>([&](auto inst) {
+          .Case([&](ClassDecl inst) {
             add_inst_name_id(sem_ir_.classes().Get(inst.class_id).name_id,
                              ".decl");
             CollectNamesInBlock(scope_id, inst.decl_block_id);
             do_continue = true;
           })
-          .Case<ClassType>([&](auto inst) {
+          .Case([&](ClassType inst) {
             add_inst_name_id(sem_ir_.classes().Get(inst.class_id).name_id);
             do_continue = true;
           })
-          .Case<FunctionDecl>([&](auto inst) {
+          .Case([&](FunctionDecl inst) {
             add_inst_name_id(sem_ir_.functions().Get(inst.function_id).name_id);
             CollectNamesInBlock(scope_id, inst.decl_block_id);
             do_continue = true;
           })
-          .Case<ImplDecl>([&](auto inst) {
+          .Case([&](ImplDecl inst) {
             CollectNamesInBlock(scope_id, inst.decl_block_id);
           })
-          .Case<AnyImportRef>([&](auto /*inst*/) {
+          .Case([&](AnyImportRef /*inst*/) {
             add_inst_name("import_ref");
             // When building import refs, we frequently add instructions
             // without a block. Constants that refer to them need to be
@@ -508,29 +508,30 @@ class InstNamer {
             }
             do_continue = true;
           })
-          .Case<InterfaceDecl>([&](auto inst) {
+          .Case([&](InterfaceDecl inst) {
             add_inst_name_id(
                 sem_ir_.interfaces().Get(inst.interface_id).name_id, ".decl");
             CollectNamesInBlock(scope_id, inst.decl_block_id);
             do_continue = true;
           })
-          .Case<NameRef>([&](auto inst) {
+          .Case([&](NameRef inst) {
             add_inst_name_id(inst.name_id, ".ref");
             do_continue = true;
           })
-          .Case<SemIR::Namespace>([&](auto inst) {
+          .Case([&](SemIR::Namespace inst) {
             // The namespace is specified here due to the name conflict.
             add_inst_name_id(
                 sem_ir_.name_scopes().Get(inst.name_scope_id).name_id);
             do_continue = true;
           })
-          .Case<Param>([&](auto inst) {
+          .Case([&](Param inst) {
             add_inst_name_id(inst.name_id);
             do_continue = true;
           })
-          .Case<SpliceBlock>(
-              [&](auto inst) { CollectNamesInBlock(scope_id, inst.block_id); })
-          .Case<VarStorage>([&](auto inst) {
+          .Case([&](SpliceBlock inst) {
+            CollectNamesInBlock(scope_id, inst.block_id);
+          })
+          .Case([&](VarStorage inst) {
             add_inst_name_id(inst.name_id, ".var");
             do_continue = true;
           });
@@ -895,7 +896,7 @@ class Formatter {
   auto FormatInstruction(InstId inst_id, Inst inst) -> void {
     TypedInstSwitch(inst)
 #define CARBON_SEM_IR_INST_KIND(InstT) \
-  .Case<InstT>([&](auto inst) { FormatInstruction(inst_id, inst); })
+  .Case([&](InstT inst) { FormatInstruction(inst_id, inst); })
 #include "toolchain/sem_ir/inst_kind.def"
         ;
   }

--- a/toolchain/sem_ir/typed_inst_switch.h
+++ b/toolchain/sem_ir/typed_inst_switch.h
@@ -1,0 +1,74 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_SWITCH_H_
+#define CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_SWITCH_H_
+
+#include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/typed_insts.h"
+
+namespace Carbon::SemIR {
+
+// Provides switch-like behavior on an instruction, allowing `Case` handling
+// with typed instructions.
+//
+// Usage:
+//   TypedInstSwitch(inst)
+//       .Case<MyInst>([&](auto inst) { ... })
+//       .Cases<OtherInst1, OtherInst2>([&]() { ... })
+//       .Default([&]() { ... });
+//
+// The default is optional.
+//
+// TODO: Should this check for unhandled or duplicate cases?
+class TypedInstSwitch {
+ public:
+  //
+  explicit TypedInstSwitch(const SemIR::Inst& inst) : inst_(inst) {}
+
+  // Not copyable or movable.
+  TypedInstSwitch(const TypedInstSwitch&) = delete;
+  auto operator=(const TypedInstSwitch&) -> TypedInstSwitch& = delete;
+
+  // If an instruction is the provided kind, calls the function with the typed
+  // instruction.
+  template <typename InstT>
+  auto Case(llvm::function_ref<void(InstT)> fn) -> TypedInstSwitch& {
+    if (!done_ && inst_.Is<InstT>()) {
+      fn(inst_.As<InstT>());
+      done_ = true;
+    }
+    return *this;
+  }
+
+  // If an instruction is any of the provided kinds, calls the function. This
+  // doesn't provide a typed instruction because the instruction types aren't
+  // guaranteed to overlap; use `Case<Any*>` for typed instructions if that's
+  // needed.
+  template <typename... InstT>
+  auto Cases(llvm::function_ref<void()> fn) -> TypedInstSwitch& {
+    if (!done_ && (inst_.Is<InstT>() || ...)) {
+      fn();
+      done_ = true;
+    }
+    return *this;
+  }
+
+  // Provides a default handler.
+  auto Default(llvm::function_ref<void()> fn) -> void {
+    if (!done_) {
+      fn();
+    }
+  }
+
+ private:
+  // The instruction being matched.
+  const SemIR::Inst& inst_;
+  // Whether any prior case has matched.
+  bool done_ = false;
+};
+
+}  // namespace Carbon::SemIR
+
+#endif  // CARBON_TOOLCHAIN_SEM_IR_TYPED_INST_SWITCH_H_


### PR DESCRIPTION
We're frequently writing code like:

```
      case ArrayType::Kind: {
        auto array = inst.As<ArrayType>();
```

TypedInstSwitch aims to provide a simpler API for this, loosely inspired by StringSwitch. Although simple compiles will probably be worse, the rough expectation is that the optimizer will close the performance gap for us in cases where it really matters.