### PR TITLE
Print a blank line after a diagnostic.

### DIFF
--- a/toolchain/check/testdata/alias/fail_control_flow.carbon
+++ b/toolchain/check/testdata/alias/fail_control_flow.carbon
@@ -4,12 +4,14 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_control_flow.carbon:[[@LINE+9]]:11: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR: fail_control_flow.carbon:[[@LINE+11]]:11: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: alias a = true or false;
 // CHECK:STDERR:           ^~~~~~~
-// CHECK:STDERR: fail_control_flow.carbon:[[@LINE+6]]:11: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_control_flow.carbon:[[@LINE+7]]:11: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: alias a = true or false;
 // CHECK:STDERR:           ^~~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_control_flow.carbon:[[@LINE+3]]:11: ERROR: Alias initializer must be a name reference.
 // CHECK:STDERR: alias a = true or false;
 // CHECK:STDERR:           ^~~~~~~~~~~~~
@@ -23,7 +25,7 @@ alias a = true or false;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   %.loc16: bool = block_arg <unexpected instblockref block4>
+// CHECK:STDOUT:   %.loc18: bool = block_arg <unexpected instblockref block4>
 // CHECK:STDOUT:   %a: <error> = bind_alias a, <error> [template = <error>]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/alias/fail_local_in_namespace.carbon
+++ b/toolchain/check/testdata/alias/fail_local_in_namespace.carbon
@@ -7,12 +7,14 @@
 namespace NS;
 
 fn F() -> bool {
-  // CHECK:STDERR: fail_local_in_namespace.carbon:[[@LINE+6]]:9: ERROR: Name `NS` not found.
+  // CHECK:STDERR: fail_local_in_namespace.carbon:[[@LINE+8]]:9: ERROR: Name `NS` not found.
   // CHECK:STDERR:   alias NS.a = false;
   // CHECK:STDERR:         ^~
-  // CHECK:STDERR: fail_local_in_namespace.carbon:[[@LINE+3]]:16: ERROR: Alias initializer must be a name reference.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_local_in_namespace.carbon:[[@LINE+4]]:16: ERROR: Alias initializer must be a name reference.
   // CHECK:STDERR:   alias NS.a = false;
   // CHECK:STDERR:                ^~~~~
+  // CHECK:STDERR:
   alias NS.a = false;
   // CHECK:STDERR: fail_local_in_namespace.carbon:[[@LINE+3]]:10: ERROR: Name `a` not found.
   // CHECK:STDERR:   return NS.a;
@@ -39,8 +41,8 @@ fn F() -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_16: bool = bool_literal false [template = constants.%.1]
-// CHECK:STDOUT:   %.loc16_9: <error> = bind_alias <invalid>, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc18_16: bool = bool_literal false [template = constants.%.1]
+// CHECK:STDOUT:   %.loc18_9: <error> = bind_alias <invalid>, <error> [template = <error>]
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/alias/fail_modifiers.carbon
+++ b/toolchain/check/testdata/alias/fail_modifiers.carbon
@@ -4,32 +4,37 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+21]]:1: ERROR: `abstract` not allowed on `alias` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+25]]:1: ERROR: `abstract` not allowed on `alias` declaration.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+18]]:10: ERROR: `base` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+21]]:10: ERROR: `base` not allowed on declaration with `abstract`.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR:          ^~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+15]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+18]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+12]]:15: ERROR: `default` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+14]]:15: ERROR: `default` not allowed on declaration with `abstract`.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR:               ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:23: ERROR: `final` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:23: ERROR: `final` not allowed on declaration with `abstract`.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR:                       ^~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract base default final alias A = i32;
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract base default final alias A = i32;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `impl` not allowed on `alias` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `impl` not allowed on `alias` declaration.
 // CHECK:STDERR: impl alias B = i32;
 // CHECK:STDERR: ^~~~
+// CHECK:STDERR:
 impl alias B = i32;
 
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `extern` not allowed on `alias` declaration.

--- a/toolchain/check/testdata/alias/fail_name_conflict.carbon
+++ b/toolchain/check/testdata/alias/fail_name_conflict.carbon
@@ -5,12 +5,13 @@
 // AUTOUPDATE
 
 alias a = i32;
-// CHECK:STDERR: fail_name_conflict.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_name_conflict.carbon:[[@LINE+7]]:5: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: var a: i32 = 1;
 // CHECK:STDERR:     ^
 // CHECK:STDERR: fail_name_conflict.carbon:[[@LINE-4]]:7: Name is previously declared here.
 // CHECK:STDERR: alias a = i32;
 // CHECK:STDERR:       ^
+// CHECK:STDERR:
 var a: i32 = 1;
 
 var b: i32 = 2;
@@ -36,18 +37,18 @@ alias b = i32;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.loc7: type = bind_alias a, i32 [template = i32]
 // CHECK:STDOUT:   %a.var: ref i32 = var a
-// CHECK:STDOUT:   %a.loc14: ref i32 = bind_name a, %a.var
+// CHECK:STDOUT:   %a.loc15: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %b.var: ref i32 = var b
 // CHECK:STDOUT:   %b: ref i32 = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc23: type = bind_alias <invalid>, i32 [template = i32]
+// CHECK:STDOUT:   %.loc24: type = bind_alias <invalid>, i32 [template = i32]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   assign file.%a.var, %.loc14
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   assign file.%b.var, %.loc16
+// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   assign file.%a.var, %.loc15
+// CHECK:STDOUT:   %.loc17: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   assign file.%b.var, %.loc17
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/fail_bound_overflow.carbon
+++ b/toolchain/check/testdata/array/fail_bound_overflow.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_bound_overflow.carbon:[[@LINE+3]]:14: ERROR: Array bound of 39999999999999999993 is too large.
+// CHECK:STDERR: fail_bound_overflow.carbon:[[@LINE+4]]:14: ERROR: Array bound of 39999999999999999993 is too large.
 // CHECK:STDERR: var a: [i32; 39999999999999999993];
 // CHECK:STDERR:              ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 var a: [i32; 39999999999999999993];
 
 // CHECK:STDERR: fail_bound_overflow.carbon:[[@LINE+3]]:9: ERROR: Cannot implicitly convert from `i32` to `type`.
@@ -26,13 +27,13 @@ var b: [1; 39999999999999999993];
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 39999999999999999993 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_34: type = array_type %.loc10_14, i32 [template = <error>]
+// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 39999999999999999993 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11_34: type = array_type %.loc11_14, i32 [template = <error>]
 // CHECK:STDOUT:   %a.var: ref <error> = var a
 // CHECK:STDOUT:   %a: ref <error> = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc15_9: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc15_12: i32 = int_literal 39999999999999999993 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc15_32: type = array_type %.loc15_12, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc16_12: i32 = int_literal 39999999999999999993 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc16_32: type = array_type %.loc16_12, <error> [template = <error>]
 // CHECK:STDOUT:   %b.var: ref <error> = var b
 // CHECK:STDOUT:   %b: ref <error> = bind_name b, %b.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/array/fail_type_mismatch.carbon
@@ -4,20 +4,23 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+3]]:19: ERROR: Cannot implicitly convert from `String` to `i32`.
+// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+4]]:19: ERROR: Cannot implicitly convert from `String` to `i32`.
 // CHECK:STDERR: var a: [i32; 3] = (1, "Hello", "World");
 // CHECK:STDERR:                   ^~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 var a: [i32; 3] = (1, "Hello", "World");
 
 var t1: (i32, String, String);
-// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+3]]:19: ERROR: Cannot implicitly convert from `String` to `i32`.
+// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+4]]:19: ERROR: Cannot implicitly convert from `String` to `i32`.
 // CHECK:STDERR: var b: [i32; 3] = t1;
 // CHECK:STDERR:                   ^~
+// CHECK:STDERR:
 var b: [i32; 3] = t1;
 
-// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+3]]:19: ERROR: Cannot initialize array of 3 element(s) from 2 initializer(s).
+// CHECK:STDERR: fail_type_mismatch.carbon:[[@LINE+4]]:19: ERROR: Cannot initialize array of 3 element(s) from 2 initializer(s).
 // CHECK:STDERR: var c: [i32; 3] = (1, 2);
 // CHECK:STDERR:                   ^~~~~~
+// CHECK:STDERR:
 var c: [i32; 3] = (1, 2);
 
 var t2: (i32, i32);
@@ -57,53 +60,53 @@ var d: [i32; 3] = t2;
 // CHECK:STDOUT:     .t2 = %t2
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc10_14: i32 = int_literal 3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_15: type = array_type %.loc10_14, i32 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_14: i32 = int_literal 3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11_15: type = array_type %.loc11_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 3] = var a
 // CHECK:STDOUT:   %a: ref [i32; 3] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc12_29.1: (type, type, type) = tuple_literal (i32, String, String)
-// CHECK:STDOUT:   %.loc12_29.2: type = converted %.loc12_29.1, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_29.1: (type, type, type) = tuple_literal (i32, String, String)
+// CHECK:STDOUT:   %.loc13_29.2: type = converted %.loc13_29.1, constants.%.8 [template = constants.%.8]
 // CHECK:STDOUT:   %t1.var: ref (i32, String, String) = var t1
 // CHECK:STDOUT:   %t1: ref (i32, String, String) = bind_name t1, %t1.var
-// CHECK:STDOUT:   %.loc16_14: i32 = int_literal 3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc16_15: type = array_type %.loc16_14, i32 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc18_14: i32 = int_literal 3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc18_15: type = array_type %.loc18_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc21_14: i32 = int_literal 3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc21_15: type = array_type %.loc21_14, i32 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc24_14: i32 = int_literal 3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc24_15: type = array_type %.loc24_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %c.var: ref [i32; 3] = var c
 // CHECK:STDOUT:   %c: ref [i32; 3] = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc23_18.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc23_18.2: type = converted %.loc23_18.1, constants.%.15 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc26_18.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc26_18.2: type = converted %.loc26_18.1, constants.%.15 [template = constants.%.15]
 // CHECK:STDOUT:   %t2.var: ref (i32, i32) = var t2
 // CHECK:STDOUT:   %t2: ref (i32, i32) = bind_name t2, %t2.var
-// CHECK:STDOUT:   %.loc27_14: i32 = int_literal 3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc27_15: type = array_type %.loc27_14, i32 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc30_14: i32 = int_literal 3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc30_15: type = array_type %.loc30_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %d.var: ref [i32; 3] = var d
 // CHECK:STDOUT:   %d: ref [i32; 3] = bind_name d, %d.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_23: String = string_literal "Hello" [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_32: String = string_literal "World" [template = constants.%.7]
-// CHECK:STDOUT:   %.loc10_39.1: (i32, String, String) = tuple_literal (%.loc10_20, %.loc10_23, %.loc10_32)
-// CHECK:STDOUT:   %.loc10_39.2: i32 = int_literal 0 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc10_39.3: ref i32 = array_index file.%a.var, %.loc10_39.2
-// CHECK:STDOUT:   %.loc10_39.4: init i32 = initialize_from %.loc10_20 to %.loc10_39.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_20: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_23: String = string_literal "Hello" [template = constants.%.6]
+// CHECK:STDOUT:   %.loc11_32: String = string_literal "World" [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_39.1: (i32, String, String) = tuple_literal (%.loc11_20, %.loc11_23, %.loc11_32)
+// CHECK:STDOUT:   %.loc11_39.2: i32 = int_literal 0 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc11_39.3: ref i32 = array_index file.%a.var, %.loc11_39.2
+// CHECK:STDOUT:   %.loc11_39.4: init i32 = initialize_from %.loc11_20 to %.loc11_39.3 [template = constants.%.4]
 // CHECK:STDOUT:   assign file.%a.var, <error>
 // CHECK:STDOUT:   %t1.ref: ref (i32, String, String) = name_ref t1, file.%t1
-// CHECK:STDOUT:   %.loc16_19.1: ref i32 = tuple_access %t1.ref, element0
-// CHECK:STDOUT:   %.loc16_19.2: i32 = bind_value %.loc16_19.1
-// CHECK:STDOUT:   %.loc16_19.3: i32 = int_literal 0 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc16_19.4: ref i32 = array_index file.%b.var, %.loc16_19.3
-// CHECK:STDOUT:   %.loc16_19.5: init i32 = initialize_from %.loc16_19.2 to %.loc16_19.4
-// CHECK:STDOUT:   %.loc16_19.6: ref String = tuple_access %t1.ref, element1
+// CHECK:STDOUT:   %.loc18_19.1: ref i32 = tuple_access %t1.ref, element0
+// CHECK:STDOUT:   %.loc18_19.2: i32 = bind_value %.loc18_19.1
+// CHECK:STDOUT:   %.loc18_19.3: i32 = int_literal 0 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc18_19.4: ref i32 = array_index file.%b.var, %.loc18_19.3
+// CHECK:STDOUT:   %.loc18_19.5: init i32 = initialize_from %.loc18_19.2 to %.loc18_19.4
+// CHECK:STDOUT:   %.loc18_19.6: ref String = tuple_access %t1.ref, element1
 // CHECK:STDOUT:   assign file.%b.var, <error>
-// CHECK:STDOUT:   %.loc21_20: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc21_23: i32 = int_literal 2 [template = constants.%.14]
-// CHECK:STDOUT:   %.loc21_24: (i32, i32) = tuple_literal (%.loc21_20, %.loc21_23)
+// CHECK:STDOUT:   %.loc24_20: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc24_23: i32 = int_literal 2 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc24_24: (i32, i32) = tuple_literal (%.loc24_20, %.loc24_23)
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   %t2.ref: ref (i32, i32) = name_ref t2, file.%t2
 // CHECK:STDOUT:   assign file.%d.var, <error>

--- a/toolchain/check/testdata/basics/fail_bad_run.carbon
+++ b/toolchain/check/testdata/basics/fail_bad_run.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_bad_run.carbon:[[@LINE+6]]:1: ERROR: Invalid signature for `Main.Run` function. Expected `fn ()` or `fn () -> i32`.
+// CHECK:STDERR: fail_bad_run.carbon:[[@LINE+7]]:1: ERROR: Invalid signature for `Main.Run` function. Expected `fn ()` or `fn () -> i32`.
 // CHECK:STDERR: fn Run() -> String {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_bad_run.carbon:[[@LINE+3]]:21: ERROR: Missing `return` at end of function with declared return type.
 // CHECK:STDERR: fn Run() -> String {}
 // CHECK:STDERR:                     ^

--- a/toolchain/check/testdata/builtins/int_add.carbon
+++ b/toolchain/check/testdata/builtins/int_add.carbon
@@ -23,25 +23,29 @@ fn TooMany(a: i32, b: i32, c: i32) -> i32 = "int.add";
 fn BadReturnType(a: i32, b: i32) -> bool = "int.add";
 fn JustRight(a: i32, b: i32) -> i32 = "int.add";
 
-// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+3]]:20: ERROR: Array bound is not a constant.
+// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+4]]:20: ERROR: Array bound is not a constant.
 // CHECK:STDERR: var too_few: [i32; TooFew(1)];
 // CHECK:STDERR:                    ^~~~~~~
+// CHECK:STDERR:
 var too_few: [i32; TooFew(1)];
-// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+3]]:21: ERROR: Array bound is not a constant.
+// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+4]]:21: ERROR: Array bound is not a constant.
 // CHECK:STDERR: var too_many: [i32; TooMany(1, 2, 3)];
 // CHECK:STDERR:                     ^~~~~~~~
+// CHECK:STDERR:
 var too_many: [i32; TooMany(1, 2, 3)];
-// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+3]]:28: ERROR: Array bound is not a constant.
+// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+4]]:28: ERROR: Array bound is not a constant.
 // CHECK:STDERR: var bad_return_type: [i32; BadReturnType(1, 2)];
 // CHECK:STDERR:                            ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 var bad_return_type: [i32; BadReturnType(1, 2)];
 
-// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+6]]:21: ERROR: 3 argument(s) passed to function expecting 2 argument(s).
+// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE+7]]:21: ERROR: 3 argument(s) passed to function expecting 2 argument(s).
 // CHECK:STDERR: var bad_call: [i32; JustRight(1, 2, 3)];
 // CHECK:STDERR:                     ^~~~~~~~~~
-// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE-18]]:1: Calling function declared here.
+// CHECK:STDERR: fail_bad_decl.carbon:[[@LINE-21]]:1: Calling function declared here.
 // CHECK:STDERR: fn JustRight(a: i32, b: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 var bad_call: [i32; JustRight(1, 2, 3)];
 
 // TODO: We should diagnose these in check rather than failing in lower.
@@ -172,51 +176,51 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:     %return.var.loc7: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TooFew.ref: <function> = name_ref TooFew, %TooFew [template = %TooFew]
-// CHECK:STDOUT:   %.loc12_27: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_26: init i32 = call %TooFew.ref(%.loc12_27)
+// CHECK:STDOUT:   %.loc13_27: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc13_26: init i32 = call %TooFew.ref(%.loc13_27)
 // CHECK:STDOUT:   %too_few.var: ref <error> = var too_few
 // CHECK:STDOUT:   %too_few: ref <error> = bind_name too_few, %too_few.var
 // CHECK:STDOUT:   %TooMany.ref: <function> = name_ref TooMany, %TooMany [template = %TooMany]
-// CHECK:STDOUT:   %.loc16_29: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc16_32: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc16_35: i32 = int_literal 3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc16_28: init i32 = call %TooMany.ref(%.loc16_29, %.loc16_32, %.loc16_35)
+// CHECK:STDOUT:   %.loc18_29: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc18_32: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc18_35: i32 = int_literal 3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc18_28: init i32 = call %TooMany.ref(%.loc18_29, %.loc18_32, %.loc18_35)
 // CHECK:STDOUT:   %too_many.var: ref <error> = var too_many
 // CHECK:STDOUT:   %too_many: ref <error> = bind_name too_many, %too_many.var
 // CHECK:STDOUT:   %BadReturnType.ref: <function> = name_ref BadReturnType, %BadReturnType [template = %BadReturnType]
-// CHECK:STDOUT:   %.loc20_42: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc20_45: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc20_41: init bool = call %BadReturnType.ref(%.loc20_42, %.loc20_45)
+// CHECK:STDOUT:   %.loc23_42: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc23_45: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc23_41: init bool = call %BadReturnType.ref(%.loc23_42, %.loc23_45)
 // CHECK:STDOUT:   %bad_return_type.var: ref <error> = var bad_return_type
 // CHECK:STDOUT:   %bad_return_type: ref <error> = bind_name bad_return_type, %bad_return_type.var
 // CHECK:STDOUT:   %JustRight.ref: <function> = name_ref JustRight, %JustRight [template = %JustRight]
-// CHECK:STDOUT:   %.loc28_31: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc28_34: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc28_37: i32 = int_literal 3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc28_30: init i32 = call %JustRight.ref(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc28_39: type = array_type %.loc28_30, i32 [template = <error>]
+// CHECK:STDOUT:   %.loc32_31: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc32_34: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc32_37: i32 = int_literal 3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc32_30: init i32 = call %JustRight.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc32_39: type = array_type %.loc32_30, i32 [template = <error>]
 // CHECK:STDOUT:   %bad_call.var: ref <error> = var bad_call
 // CHECK:STDOUT:   %bad_call: ref <error> = bind_name bad_call, %bad_call.var
 // CHECK:STDOUT:   %RuntimeCallTooFew: <function> = fn_decl @RuntimeCallTooFew [template] {
-// CHECK:STDOUT:     %a.loc31_22.1: i32 = param a
-// CHECK:STDOUT:     @RuntimeCallTooFew.%a: i32 = bind_name a, %a.loc31_22.1
-// CHECK:STDOUT:     %return.var.loc31: ref i32 = var <return slot>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %RuntimeCallTooMany: <function> = fn_decl @RuntimeCallTooMany [template] {
-// CHECK:STDOUT:     %a.loc35_23.1: i32 = param a
-// CHECK:STDOUT:     @RuntimeCallTooMany.%a: i32 = bind_name a, %a.loc35_23.1
-// CHECK:STDOUT:     %b.loc35_31.1: i32 = param b
-// CHECK:STDOUT:     @RuntimeCallTooMany.%b: i32 = bind_name b, %b.loc35_31.1
-// CHECK:STDOUT:     %c.loc35_39.1: i32 = param c
-// CHECK:STDOUT:     @RuntimeCallTooMany.%c: i32 = bind_name c, %c.loc35_39.1
+// CHECK:STDOUT:     %a.loc35_22.1: i32 = param a
+// CHECK:STDOUT:     @RuntimeCallTooFew.%a: i32 = bind_name a, %a.loc35_22.1
 // CHECK:STDOUT:     %return.var.loc35: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %RuntimeCallTooMany: <function> = fn_decl @RuntimeCallTooMany [template] {
+// CHECK:STDOUT:     %a.loc39_23.1: i32 = param a
+// CHECK:STDOUT:     @RuntimeCallTooMany.%a: i32 = bind_name a, %a.loc39_23.1
+// CHECK:STDOUT:     %b.loc39_31.1: i32 = param b
+// CHECK:STDOUT:     @RuntimeCallTooMany.%b: i32 = bind_name b, %b.loc39_31.1
+// CHECK:STDOUT:     %c.loc39_39.1: i32 = param c
+// CHECK:STDOUT:     @RuntimeCallTooMany.%c: i32 = bind_name c, %c.loc39_39.1
+// CHECK:STDOUT:     %return.var.loc39: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
 // CHECK:STDOUT:   %RuntimeCallBadReturnType: <function> = fn_decl @RuntimeCallBadReturnType [template] {
-// CHECK:STDOUT:     %a.loc39_29.1: i32 = param a
-// CHECK:STDOUT:     @RuntimeCallBadReturnType.%a: i32 = bind_name a, %a.loc39_29.1
-// CHECK:STDOUT:     %b.loc39_37.1: i32 = param b
-// CHECK:STDOUT:     @RuntimeCallBadReturnType.%b: i32 = bind_name b, %b.loc39_37.1
-// CHECK:STDOUT:     %return.var.loc39: ref bool = var <return slot>
+// CHECK:STDOUT:     %a.loc43_29.1: i32 = param a
+// CHECK:STDOUT:     @RuntimeCallBadReturnType.%a: i32 = bind_name a, %a.loc43_29.1
+// CHECK:STDOUT:     %b.loc43_37.1: i32 = param b
+// CHECK:STDOUT:     @RuntimeCallBadReturnType.%b: i32 = bind_name b, %b.loc43_37.1
+// CHECK:STDOUT:     %return.var.loc43: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -232,10 +236,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %TooFew.ref: <function> = name_ref TooFew, file.%TooFew [template = file.%TooFew]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc32_16.1: init i32 = call %TooFew.ref(%a.ref)
-// CHECK:STDOUT:   %.loc32_19: i32 = value_of_initializer %.loc32_16.1
-// CHECK:STDOUT:   %.loc32_16.2: i32 = converted %.loc32_16.1, %.loc32_19
-// CHECK:STDOUT:   return %.loc32_16.2
+// CHECK:STDOUT:   %.loc36_16.1: init i32 = call %TooFew.ref(%a.ref)
+// CHECK:STDOUT:   %.loc36_19: i32 = value_of_initializer %.loc36_16.1
+// CHECK:STDOUT:   %.loc36_16.2: i32 = converted %.loc36_16.1, %.loc36_19
+// CHECK:STDOUT:   return %.loc36_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallTooMany(%a: i32, %b: i32, %c: i32) -> i32 {
@@ -244,10 +248,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
 // CHECK:STDOUT:   %c.ref: i32 = name_ref c, %c
-// CHECK:STDOUT:   %.loc36_17.1: init i32 = call %TooMany.ref(%a.ref, %b.ref, %c.ref)
-// CHECK:STDOUT:   %.loc36_26: i32 = value_of_initializer %.loc36_17.1
-// CHECK:STDOUT:   %.loc36_17.2: i32 = converted %.loc36_17.1, %.loc36_26
-// CHECK:STDOUT:   return %.loc36_17.2
+// CHECK:STDOUT:   %.loc40_17.1: init i32 = call %TooMany.ref(%a.ref, %b.ref, %c.ref)
+// CHECK:STDOUT:   %.loc40_26: i32 = value_of_initializer %.loc40_17.1
+// CHECK:STDOUT:   %.loc40_17.2: i32 = converted %.loc40_17.1, %.loc40_26
+// CHECK:STDOUT:   return %.loc40_17.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallBadReturnType(%a: i32, %b: i32) -> bool {
@@ -255,10 +259,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %BadReturnType.ref: <function> = name_ref BadReturnType, file.%BadReturnType [template = file.%BadReturnType]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc40_23.1: init bool = call %BadReturnType.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc40_29: bool = value_of_initializer %.loc40_23.1
-// CHECK:STDOUT:   %.loc40_23.2: bool = converted %.loc40_23.1, %.loc40_29
-// CHECK:STDOUT:   return %.loc40_23.2
+// CHECK:STDOUT:   %.loc44_23.1: init bool = call %BadReturnType.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc44_29: bool = value_of_initializer %.loc44_23.1
+// CHECK:STDOUT:   %.loc44_23.2: bool = converted %.loc44_23.1, %.loc44_29
+// CHECK:STDOUT:   return %.loc44_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -45,10 +45,11 @@ library "extern" api;
 
 import Other library "extern";
 
-// CHECK:STDERR: fail_extern.carbon:[[@LINE+10]]:8: ERROR: Variable has incomplete type `C`.
+// CHECK:STDERR: fail_extern.carbon:[[@LINE+11]]:8: ERROR: Variable has incomplete type `C`.
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
 // CHECK:STDERR: fail_extern.carbon: Class was forward declared here.
+// CHECK:STDERR:
 // CHECK:STDERR: other_extern.carbon:5:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
@@ -64,9 +65,10 @@ library "fail_merge_define_extern" api;
 import Other library "define";
 import Other library "extern";
 
-// CHECK:STDERR: fail_merge_define_extern.carbon:[[@LINE+9]]:8: In name lookup for `C`.
+// CHECK:STDERR: fail_merge_define_extern.carbon:[[@LINE+10]]:8: In name lookup for `C`.
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: other_conflict.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn C() {}
 // CHECK:STDERR: ^~~~~~~~
@@ -199,7 +201,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc17: {} = struct_literal ()
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -241,10 +243,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc16_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc16_19.3: init C = converted %.loc16_19.1, %.loc16_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc16_19.3
+// CHECK:STDOUT:   %.loc17_19.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc17_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17_19.3: init C = converted %.loc17_19.1, %.loc17_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc17_19.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_not_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_not_self.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 class Class {
-  // CHECK:STDERR: fail_addr_not_self.carbon:[[@LINE+3]]:8: ERROR: `addr` can only be applied to a `self` parameter.
+  // CHECK:STDERR: fail_addr_not_self.carbon:[[@LINE+4]]:8: ERROR: `addr` can only be applied to a `self` parameter.
   // CHECK:STDERR:   fn F[addr a: Class*]();
   // CHECK:STDERR:        ^~~~
+  // CHECK:STDERR:
   fn F[addr a: Class*]();
 
   // CHECK:STDERR: fail_addr_not_self.carbon:[[@LINE+3]]:8: ERROR: `addr` can only be applied to a `self` parameter.
@@ -33,16 +34,16 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %Class.ref.loc11: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc11: type = ptr_type Class [template = constants.%.1]
-// CHECK:STDOUT:     %a.loc11_13.1: Class* = param a
-// CHECK:STDOUT:     %a.loc11_13.2: Class* = bind_name a, %a.loc11_13.1
+// CHECK:STDOUT:     %Class.ref.loc12: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc12: type = ptr_type Class [template = constants.%.1]
+// CHECK:STDOUT:     %a.loc12_13.1: Class* = param a
+// CHECK:STDOUT:     %a.loc12_13.2: Class* = bind_name a, %a.loc12_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %Class.ref.loc16: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc16: type = ptr_type Class [template = constants.%.1]
-// CHECK:STDOUT:     %b.loc16_13.1: Class* = param b
-// CHECK:STDOUT:     %b.loc16_13.2: Class* = bind_name b, %b.loc16_13.1
+// CHECK:STDOUT:     %Class.ref.loc17: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc17: type = ptr_type Class [template = constants.%.1]
+// CHECK:STDOUT:     %b.loc17_13.1: Class* = param b
+// CHECK:STDOUT:     %b.loc17_13.2: Class* = bind_name b, %b.loc17_13.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -51,7 +52,7 @@ class Class {
 // CHECK:STDOUT:   .G = %G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F[@Class.%a.loc11_13.2: Class*]();
+// CHECK:STDOUT: fn @F[@Class.%a.loc12_13.2: Class*]();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(@Class.%b.loc16_13.2: Class*);
+// CHECK:STDOUT: fn @G(@Class.%b.loc17_13.2: Class*);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_addr_self.carbon
+++ b/toolchain/check/testdata/class/fail_addr_self.carbon
@@ -10,20 +10,22 @@ class Class {
 }
 
 fn F(c: Class, p: Class*) {
-  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE+6]]:6: ERROR: `addr self` method cannot be invoked on a value.
+  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE+7]]:6: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   c.F();
   // CHECK:STDERR:      ^
   // CHECK:STDERR: fail_addr_self.carbon:[[@LINE-8]]:13: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn F[addr self: Class*]();
   // CHECK:STDERR:             ^~~~
+  // CHECK:STDERR:
   c.F();
 
-  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE+6]]:6: ERROR: `addr self` method cannot be invoked on a value.
+  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE+7]]:6: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   c.G();
   // CHECK:STDERR:      ^
-  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE-15]]:13: Initializing `addr self` parameter of method declared here.
+  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE-16]]:13: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn G[addr self: Class]();
   // CHECK:STDERR:             ^~~~
+  // CHECK:STDERR:
   c.G();
 
   // This call is OK.
@@ -32,7 +34,7 @@ fn F(c: Class, p: Class*) {
   // CHECK:STDERR: fail_addr_self.carbon:[[@LINE+6]]:3: ERROR: Cannot implicitly convert from `Class*` to `Class`.
   // CHECK:STDERR:   (*p).G();
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE-26]]:13: Initializing `addr self` parameter of method declared here.
+  // CHECK:STDERR: fail_addr_self.carbon:[[@LINE-28]]:13: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn G[addr self: Class]();
   // CHECK:STDERR:             ^~~~
   (*p).G();
@@ -92,26 +94,26 @@ fn F(c: Class, p: Class*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2(%c: Class, %p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %c.ref.loc19: Class = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc19: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc19_4: <bound method> = bound_method %c.ref.loc19, %F.ref.loc19
-// CHECK:STDOUT:   %.loc19_6: init () = call %.loc19_4(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %c.ref.loc27: Class = name_ref c, %c
-// CHECK:STDOUT:   %G.ref.loc27: <function> = name_ref G, @Class.%G [template = @Class.%G]
-// CHECK:STDOUT:   %.loc27_4: <bound method> = bound_method %c.ref.loc27, %G.ref.loc27
-// CHECK:STDOUT:   %.loc27_6: init () = call %.loc27_4(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %p.ref.loc30: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc30_4.1: ref Class = deref %p.ref.loc30
-// CHECK:STDOUT:   %F.ref.loc30: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc30_7: <bound method> = bound_method %.loc30_4.1, %F.ref.loc30
-// CHECK:STDOUT:   %.loc30_4.2: Class* = addr_of %.loc30_4.1
-// CHECK:STDOUT:   %.loc30_9: init () = call %.loc30_7(%.loc30_4.2)
-// CHECK:STDOUT:   %p.ref.loc38: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc38_4.1: ref Class = deref %p.ref.loc38
-// CHECK:STDOUT:   %G.ref.loc38: <function> = name_ref G, @Class.%G [template = @Class.%G]
-// CHECK:STDOUT:   %.loc38_7: <bound method> = bound_method %.loc38_4.1, %G.ref.loc38
-// CHECK:STDOUT:   %.loc38_4.2: Class* = addr_of %.loc38_4.1
-// CHECK:STDOUT:   %.loc38_9: init () = call %.loc38_7(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %c.ref.loc20: Class = name_ref c, %c
+// CHECK:STDOUT:   %F.ref.loc20: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc20_4: <bound method> = bound_method %c.ref.loc20, %F.ref.loc20
+// CHECK:STDOUT:   %.loc20_6: init () = call %.loc20_4(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %c.ref.loc29: Class = name_ref c, %c
+// CHECK:STDOUT:   %G.ref.loc29: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc29_4: <bound method> = bound_method %c.ref.loc29, %G.ref.loc29
+// CHECK:STDOUT:   %.loc29_6: init () = call %.loc29_4(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %p.ref.loc32: Class* = name_ref p, %p
+// CHECK:STDOUT:   %.loc32_4.1: ref Class = deref %p.ref.loc32
+// CHECK:STDOUT:   %F.ref.loc32: <function> = name_ref F, @Class.%F [template = @Class.%F]
+// CHECK:STDOUT:   %.loc32_7: <bound method> = bound_method %.loc32_4.1, %F.ref.loc32
+// CHECK:STDOUT:   %.loc32_4.2: Class* = addr_of %.loc32_4.1
+// CHECK:STDOUT:   %.loc32_9: init () = call %.loc32_7(%.loc32_4.2)
+// CHECK:STDOUT:   %p.ref.loc40: Class* = name_ref p, %p
+// CHECK:STDOUT:   %.loc40_4.1: ref Class = deref %p.ref.loc40
+// CHECK:STDOUT:   %G.ref.loc40: <function> = name_ref G, @Class.%G [template = @Class.%G]
+// CHECK:STDOUT:   %.loc40_7: <bound method> = bound_method %.loc40_4.1, %G.ref.loc40
+// CHECK:STDOUT:   %.loc40_4.2: Class* = addr_of %.loc40_4.1
+// CHECK:STDOUT:   %.loc40_9: init () = call %.loc40_7(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_as_declared_name.carbon
+++ b/toolchain/check/testdata/class/fail_base_as_declared_name.carbon
@@ -6,9 +6,10 @@
 
 namespace N;
 
-// CHECK:STDERR: fail_base_as_declared_name.carbon:[[@LINE+6]]:6: ERROR: Expected identifier after `.`.
+// CHECK:STDERR: fail_base_as_declared_name.carbon:[[@LINE+7]]:6: ERROR: Expected identifier after `.`.
 // CHECK:STDERR: fn N.base() {}
 // CHECK:STDERR:      ^~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_base_as_declared_name.carbon:[[@LINE+3]]:6: ERROR: Semantics TODO: `Error recovery from keyword name.`.
 // CHECK:STDERR: fn N.base() {}
 // CHECK:STDERR:      ^~~~

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -10,9 +10,10 @@ class Final {
 }
 
 class DeriveFromError {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Name `error` not found.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Name `error` not found.
   // CHECK:STDERR:   extend base: error;
   // CHECK:STDERR:                ^~~~~
+  // CHECK:STDERR:
   extend base: error;
 }
 
@@ -20,40 +21,45 @@ class DeriveFromError {
 fn AccessMemberWithInvalidBaseError(p: DeriveFromError*) -> i32 { return (*p).n; }
 
 class DeriveFromNonType {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Cannot implicitly convert from `i32` to `type`.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Cannot implicitly convert from `i32` to `type`.
   // CHECK:STDERR:   extend base: 32;
   // CHECK:STDERR:                ^~
+  // CHECK:STDERR:
   extend base: 32;
 }
 
 fn AccessMemberWithInvalidBasNonType(p: DeriveFromNonType*) -> i32 { return (*p).n; }
 
 class DeriveFromi32 {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Deriving from final type `i32`. Base type must be an `abstract` or `base` class.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Deriving from final type `i32`. Base type must be an `abstract` or `base` class.
   // CHECK:STDERR:   extend base: i32;
   // CHECK:STDERR:                ^~~
+  // CHECK:STDERR:
   extend base: i32;
 }
 
 // It's not really important whether this conversion produces an error or not,
 // but it shouldn't crash.
-// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:53: ERROR: Cannot implicitly convert from `DeriveFromi32*` to `i32*`.
+// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:53: ERROR: Cannot implicitly convert from `DeriveFromi32*` to `i32*`.
 // CHECK:STDERR: fn ConvertToBadBasei32(p: DeriveFromi32*) -> i32* { return p; }
 // CHECK:STDERR:                                                     ^~~~~~~~~
+// CHECK:STDERR:
 fn ConvertToBadBasei32(p: DeriveFromi32*) -> i32* { return p; }
 
 fn AccessMemberWithInvalidBasei32(p: DeriveFromi32*) -> i32 { return (*p).n; }
 
 class DeriveFromTuple {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Deriving from final type `(Base,)`. Base type must be an `abstract` or `base` class.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Deriving from final type `(Base,)`. Base type must be an `abstract` or `base` class.
   // CHECK:STDERR:   extend base: (Base,);
   // CHECK:STDERR:                ^~~~~~~
+  // CHECK:STDERR:
   extend base: (Base,);
 }
 
-// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:61: ERROR: Cannot implicitly convert from `DeriveFromTuple*` to `(Base,)*`.
+// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:61: ERROR: Cannot implicitly convert from `DeriveFromTuple*` to `(Base,)*`.
 // CHECK:STDERR: fn ConvertToBadBaseTuple(p: DeriveFromTuple*) -> (Base,)* { return p; }
 // CHECK:STDERR:                                                             ^~~~~~~~~
+// CHECK:STDERR:
 fn ConvertToBadBaseTuple(p: DeriveFromTuple*) -> (Base,)* { return p; }
 
 fn AccessMemberWithInvalidBaseTuple(p: DeriveFromTuple*) -> i32 { return (*p).n; }
@@ -61,15 +67,17 @@ fn AccessMemberWithInvalidBaseTuple(p: DeriveFromTuple*) -> i32 { return (*p).n;
 // TODO: Should we allow this?
 // We do allow `{.base = {.a: i32, .b: i32}}`.
 class DeriveFromStruct {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Deriving from final type `{.a: i32, .b: i32}`. Base type must be an `abstract` or `base` class.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Deriving from final type `{.a: i32, .b: i32}`. Base type must be an `abstract` or `base` class.
   // CHECK:STDERR:   extend base: {.a: i32, .b: i32};
   // CHECK:STDERR:                ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   extend base: {.a: i32, .b: i32};
 }
 
-// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:74: ERROR: Cannot implicitly convert from `DeriveFromStruct*` to `{.a: i32, .b: i32}*`.
+// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:74: ERROR: Cannot implicitly convert from `DeriveFromStruct*` to `{.a: i32, .b: i32}*`.
 // CHECK:STDERR: fn ConvertToBadBaseStruct(p: DeriveFromStruct*) -> {.a: i32, .b: i32}* { return p; }
 // CHECK:STDERR:                                                                          ^~~~~~~~~
+// CHECK:STDERR:
 fn ConvertToBadBaseStruct(p: DeriveFromStruct*) -> {.a: i32, .b: i32}* { return p; }
 
 // It would be OK to reject this if we start actually looking in the struct type.
@@ -78,26 +86,29 @@ fn AccessMemberWithInvalidBaseStruct(p: DeriveFromStruct*) -> i32 { return (*p).
 base class Incomplete;
 
 class DeriveFromIncomplete {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+6]]:16: ERROR: Base `Incomplete` is an incomplete type.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+7]]:16: ERROR: Base `Incomplete` is an incomplete type.
   // CHECK:STDERR:   extend base: Incomplete;
   // CHECK:STDERR:                ^~~~~~~~~~
   // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE-6]]:1: Class was forward declared here.
   // CHECK:STDERR: base class Incomplete;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   extend base: Incomplete;
 }
 
-// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:74: ERROR: Cannot implicitly convert from `DeriveFromIncomplete*` to `Incomplete*`.
+// CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:74: ERROR: Cannot implicitly convert from `DeriveFromIncomplete*` to `Incomplete*`.
 // CHECK:STDERR: fn ConvertToBadBaseIncomplete(p: DeriveFromIncomplete*) -> Incomplete* { return p; }
 // CHECK:STDERR:                                                                          ^~~~~~~~~
+// CHECK:STDERR:
 fn ConvertToBadBaseIncomplete(p: DeriveFromIncomplete*) -> Incomplete* { return p; }
 
 fn AccessMemberWithInvalidBaseIncomplete(p: DeriveFromIncomplete*) -> i32 { return (*p).n; }
 
 class DeriveFromFinal {
-  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+3]]:16: ERROR: Deriving from final type `Final`. Base type must be an `abstract` or `base` class.
+  // CHECK:STDERR: fail_base_bad_type.carbon:[[@LINE+4]]:16: ERROR: Deriving from final type `Final`. Base type must be an `abstract` or `base` class.
   // CHECK:STDERR:   extend base: Final;
   // CHECK:STDERR:                ^~~~~
+  // CHECK:STDERR:
   extend base: Final;
 }
 
@@ -190,112 +201,112 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:   %DeriveFromError.decl: type = class_decl @DeriveFromError [template = constants.%DeriveFromError] {}
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseError: <function> = fn_decl @AccessMemberWithInvalidBaseError [template] {
 // CHECK:STDOUT:     %DeriveFromError.ref: type = name_ref DeriveFromError, %DeriveFromError.decl [template = constants.%DeriveFromError]
-// CHECK:STDOUT:     %.loc20: type = ptr_type DeriveFromError [template = constants.%.4]
-// CHECK:STDOUT:     %p.loc20_37.1: DeriveFromError* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseError.%p: DeriveFromError* = bind_name p, %p.loc20_37.1
-// CHECK:STDOUT:     %return.var.loc20: ref i32 = var <return slot>
+// CHECK:STDOUT:     %.loc21: type = ptr_type DeriveFromError [template = constants.%.4]
+// CHECK:STDOUT:     %p.loc21_37.1: DeriveFromError* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseError.%p: DeriveFromError* = bind_name p, %p.loc21_37.1
+// CHECK:STDOUT:     %return.var.loc21: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DeriveFromNonType.decl: type = class_decl @DeriveFromNonType [template = constants.%DeriveFromNonType] {}
 // CHECK:STDOUT:   %AccessMemberWithInvalidBasNonType: <function> = fn_decl @AccessMemberWithInvalidBasNonType [template] {
 // CHECK:STDOUT:     %DeriveFromNonType.ref: type = name_ref DeriveFromNonType, %DeriveFromNonType.decl [template = constants.%DeriveFromNonType]
-// CHECK:STDOUT:     %.loc29: type = ptr_type DeriveFromNonType [template = constants.%.6]
-// CHECK:STDOUT:     %p.loc29_38.1: DeriveFromNonType* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBasNonType.%p: DeriveFromNonType* = bind_name p, %p.loc29_38.1
-// CHECK:STDOUT:     %return.var.loc29: ref i32 = var <return slot>
+// CHECK:STDOUT:     %.loc31: type = ptr_type DeriveFromNonType [template = constants.%.6]
+// CHECK:STDOUT:     %p.loc31_38.1: DeriveFromNonType* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBasNonType.%p: DeriveFromNonType* = bind_name p, %p.loc31_38.1
+// CHECK:STDOUT:     %return.var.loc31: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DeriveFromi32.decl: type = class_decl @DeriveFromi32 [template = constants.%DeriveFromi32] {}
 // CHECK:STDOUT:   %ConvertToBadBasei32: <function> = fn_decl @ConvertToBadBasei32 [template] {
-// CHECK:STDOUT:     %DeriveFromi32.ref.loc43: type = name_ref DeriveFromi32, %DeriveFromi32.decl [template = constants.%DeriveFromi32]
-// CHECK:STDOUT:     %.loc43_40: type = ptr_type DeriveFromi32 [template = constants.%.7]
-// CHECK:STDOUT:     %p.loc43_24.1: DeriveFromi32* = param p
-// CHECK:STDOUT:     @ConvertToBadBasei32.%p: DeriveFromi32* = bind_name p, %p.loc43_24.1
-// CHECK:STDOUT:     %.loc43_49: type = ptr_type i32 [template = constants.%.8]
-// CHECK:STDOUT:     %return.var.loc43: ref i32* = var <return slot>
+// CHECK:STDOUT:     %DeriveFromi32.ref.loc47: type = name_ref DeriveFromi32, %DeriveFromi32.decl [template = constants.%DeriveFromi32]
+// CHECK:STDOUT:     %.loc47_40: type = ptr_type DeriveFromi32 [template = constants.%.7]
+// CHECK:STDOUT:     %p.loc47_24.1: DeriveFromi32* = param p
+// CHECK:STDOUT:     @ConvertToBadBasei32.%p: DeriveFromi32* = bind_name p, %p.loc47_24.1
+// CHECK:STDOUT:     %.loc47_49: type = ptr_type i32 [template = constants.%.8]
+// CHECK:STDOUT:     %return.var.loc47: ref i32* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBasei32: <function> = fn_decl @AccessMemberWithInvalidBasei32 [template] {
-// CHECK:STDOUT:     %DeriveFromi32.ref.loc45: type = name_ref DeriveFromi32, %DeriveFromi32.decl [template = constants.%DeriveFromi32]
-// CHECK:STDOUT:     %.loc45: type = ptr_type DeriveFromi32 [template = constants.%.7]
-// CHECK:STDOUT:     %p.loc45_35.1: DeriveFromi32* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBasei32.%p: DeriveFromi32* = bind_name p, %p.loc45_35.1
-// CHECK:STDOUT:     %return.var.loc45: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromi32.ref.loc49: type = name_ref DeriveFromi32, %DeriveFromi32.decl [template = constants.%DeriveFromi32]
+// CHECK:STDOUT:     %.loc49: type = ptr_type DeriveFromi32 [template = constants.%.7]
+// CHECK:STDOUT:     %p.loc49_35.1: DeriveFromi32* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBasei32.%p: DeriveFromi32* = bind_name p, %p.loc49_35.1
+// CHECK:STDOUT:     %return.var.loc49: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DeriveFromTuple.decl: type = class_decl @DeriveFromTuple [template = constants.%DeriveFromTuple] {}
 // CHECK:STDOUT:   %ConvertToBadBaseTuple: <function> = fn_decl @ConvertToBadBaseTuple [template] {
-// CHECK:STDOUT:     %DeriveFromTuple.ref.loc57: type = name_ref DeriveFromTuple, %DeriveFromTuple.decl [template = constants.%DeriveFromTuple]
-// CHECK:STDOUT:     %.loc57_44: type = ptr_type DeriveFromTuple [template = constants.%.14]
-// CHECK:STDOUT:     %p.loc57_26.1: DeriveFromTuple* = param p
-// CHECK:STDOUT:     @ConvertToBadBaseTuple.%p: DeriveFromTuple* = bind_name p, %p.loc57_26.1
+// CHECK:STDOUT:     %DeriveFromTuple.ref.loc63: type = name_ref DeriveFromTuple, %DeriveFromTuple.decl [template = constants.%DeriveFromTuple]
+// CHECK:STDOUT:     %.loc63_44: type = ptr_type DeriveFromTuple [template = constants.%.14]
+// CHECK:STDOUT:     %p.loc63_26.1: DeriveFromTuple* = param p
+// CHECK:STDOUT:     @ConvertToBadBaseTuple.%p: DeriveFromTuple* = bind_name p, %p.loc63_26.1
 // CHECK:STDOUT:     %Base.ref: type = name_ref Base, %Base.decl [template = constants.%Base]
-// CHECK:STDOUT:     %.loc57_56.1: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:     %.loc57_56.2: type = converted %.loc57_56.1, constants.%.10 [template = constants.%.10]
-// CHECK:STDOUT:     %.loc57_57: type = ptr_type (Base,) [template = constants.%.15]
-// CHECK:STDOUT:     %return.var.loc57: ref (Base,)* = var <return slot>
+// CHECK:STDOUT:     %.loc63_56.1: (type,) = tuple_literal (%Base.ref)
+// CHECK:STDOUT:     %.loc63_56.2: type = converted %.loc63_56.1, constants.%.10 [template = constants.%.10]
+// CHECK:STDOUT:     %.loc63_57: type = ptr_type (Base,) [template = constants.%.15]
+// CHECK:STDOUT:     %return.var.loc63: ref (Base,)* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseTuple: <function> = fn_decl @AccessMemberWithInvalidBaseTuple [template] {
-// CHECK:STDOUT:     %DeriveFromTuple.ref.loc59: type = name_ref DeriveFromTuple, %DeriveFromTuple.decl [template = constants.%DeriveFromTuple]
-// CHECK:STDOUT:     %.loc59: type = ptr_type DeriveFromTuple [template = constants.%.14]
-// CHECK:STDOUT:     %p.loc59_37.1: DeriveFromTuple* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseTuple.%p: DeriveFromTuple* = bind_name p, %p.loc59_37.1
-// CHECK:STDOUT:     %return.var.loc59: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromTuple.ref.loc65: type = name_ref DeriveFromTuple, %DeriveFromTuple.decl [template = constants.%DeriveFromTuple]
+// CHECK:STDOUT:     %.loc65: type = ptr_type DeriveFromTuple [template = constants.%.14]
+// CHECK:STDOUT:     %p.loc65_37.1: DeriveFromTuple* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseTuple.%p: DeriveFromTuple* = bind_name p, %p.loc65_37.1
+// CHECK:STDOUT:     %return.var.loc65: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DeriveFromStruct.decl: type = class_decl @DeriveFromStruct [template = constants.%DeriveFromStruct] {}
 // CHECK:STDOUT:   %ConvertToBadBaseStruct: <function> = fn_decl @ConvertToBadBaseStruct [template] {
-// CHECK:STDOUT:     %DeriveFromStruct.ref.loc73: type = name_ref DeriveFromStruct, %DeriveFromStruct.decl [template = constants.%DeriveFromStruct]
-// CHECK:STDOUT:     %.loc73_46: type = ptr_type DeriveFromStruct [template = constants.%.18]
-// CHECK:STDOUT:     %p.loc73_27.1: DeriveFromStruct* = param p
-// CHECK:STDOUT:     @ConvertToBadBaseStruct.%p: DeriveFromStruct* = bind_name p, %p.loc73_27.1
-// CHECK:STDOUT:     %.loc73_69: type = struct_type {.a: i32, .b: i32} [template = constants.%.16]
-// CHECK:STDOUT:     %.loc73_70: type = ptr_type {.a: i32, .b: i32} [template = constants.%.17]
-// CHECK:STDOUT:     %return.var.loc73: ref {.a: i32, .b: i32}* = var <return slot>
+// CHECK:STDOUT:     %DeriveFromStruct.ref.loc81: type = name_ref DeriveFromStruct, %DeriveFromStruct.decl [template = constants.%DeriveFromStruct]
+// CHECK:STDOUT:     %.loc81_46: type = ptr_type DeriveFromStruct [template = constants.%.18]
+// CHECK:STDOUT:     %p.loc81_27.1: DeriveFromStruct* = param p
+// CHECK:STDOUT:     @ConvertToBadBaseStruct.%p: DeriveFromStruct* = bind_name p, %p.loc81_27.1
+// CHECK:STDOUT:     %.loc81_69: type = struct_type {.a: i32, .b: i32} [template = constants.%.16]
+// CHECK:STDOUT:     %.loc81_70: type = ptr_type {.a: i32, .b: i32} [template = constants.%.17]
+// CHECK:STDOUT:     %return.var.loc81: ref {.a: i32, .b: i32}* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseStruct: <function> = fn_decl @AccessMemberWithInvalidBaseStruct [template] {
-// CHECK:STDOUT:     %DeriveFromStruct.ref.loc76: type = name_ref DeriveFromStruct, %DeriveFromStruct.decl [template = constants.%DeriveFromStruct]
-// CHECK:STDOUT:     %.loc76: type = ptr_type DeriveFromStruct [template = constants.%.18]
-// CHECK:STDOUT:     %p.loc76_38.1: DeriveFromStruct* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseStruct.%p: DeriveFromStruct* = bind_name p, %p.loc76_38.1
-// CHECK:STDOUT:     %return.var.loc76: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromStruct.ref.loc84: type = name_ref DeriveFromStruct, %DeriveFromStruct.decl [template = constants.%DeriveFromStruct]
+// CHECK:STDOUT:     %.loc84: type = ptr_type DeriveFromStruct [template = constants.%.18]
+// CHECK:STDOUT:     %p.loc84_38.1: DeriveFromStruct* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseStruct.%p: DeriveFromStruct* = bind_name p, %p.loc84_38.1
+// CHECK:STDOUT:     %return.var.loc84: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Incomplete.decl: type = class_decl @Incomplete [template = constants.%Incomplete] {}
 // CHECK:STDOUT:   %DeriveFromIncomplete.decl: type = class_decl @DeriveFromIncomplete [template = constants.%DeriveFromIncomplete] {}
 // CHECK:STDOUT:   %ConvertToBadBaseIncomplete: <function> = fn_decl @ConvertToBadBaseIncomplete [template] {
-// CHECK:STDOUT:     %DeriveFromIncomplete.ref.loc93: type = name_ref DeriveFromIncomplete, %DeriveFromIncomplete.decl [template = constants.%DeriveFromIncomplete]
-// CHECK:STDOUT:     %.loc93_54: type = ptr_type DeriveFromIncomplete [template = constants.%.19]
-// CHECK:STDOUT:     %p.loc93_31.1: DeriveFromIncomplete* = param p
-// CHECK:STDOUT:     @ConvertToBadBaseIncomplete.%p: DeriveFromIncomplete* = bind_name p, %p.loc93_31.1
+// CHECK:STDOUT:     %DeriveFromIncomplete.ref.loc103: type = name_ref DeriveFromIncomplete, %DeriveFromIncomplete.decl [template = constants.%DeriveFromIncomplete]
+// CHECK:STDOUT:     %.loc103_54: type = ptr_type DeriveFromIncomplete [template = constants.%.19]
+// CHECK:STDOUT:     %p.loc103_31.1: DeriveFromIncomplete* = param p
+// CHECK:STDOUT:     @ConvertToBadBaseIncomplete.%p: DeriveFromIncomplete* = bind_name p, %p.loc103_31.1
 // CHECK:STDOUT:     %Incomplete.ref: type = name_ref Incomplete, %Incomplete.decl [template = constants.%Incomplete]
-// CHECK:STDOUT:     %.loc93_70: type = ptr_type Incomplete [template = constants.%.20]
-// CHECK:STDOUT:     %return.var.loc93: ref Incomplete* = var <return slot>
+// CHECK:STDOUT:     %.loc103_70: type = ptr_type Incomplete [template = constants.%.20]
+// CHECK:STDOUT:     %return.var.loc103: ref Incomplete* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseIncomplete: <function> = fn_decl @AccessMemberWithInvalidBaseIncomplete [template] {
-// CHECK:STDOUT:     %DeriveFromIncomplete.ref.loc95: type = name_ref DeriveFromIncomplete, %DeriveFromIncomplete.decl [template = constants.%DeriveFromIncomplete]
-// CHECK:STDOUT:     %.loc95: type = ptr_type DeriveFromIncomplete [template = constants.%.19]
-// CHECK:STDOUT:     %p.loc95_42.1: DeriveFromIncomplete* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseIncomplete.%p: DeriveFromIncomplete* = bind_name p, %p.loc95_42.1
-// CHECK:STDOUT:     %return.var.loc95: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromIncomplete.ref.loc105: type = name_ref DeriveFromIncomplete, %DeriveFromIncomplete.decl [template = constants.%DeriveFromIncomplete]
+// CHECK:STDOUT:     %.loc105: type = ptr_type DeriveFromIncomplete [template = constants.%.19]
+// CHECK:STDOUT:     %p.loc105_42.1: DeriveFromIncomplete* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseIncomplete.%p: DeriveFromIncomplete* = bind_name p, %p.loc105_42.1
+// CHECK:STDOUT:     %return.var.loc105: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DeriveFromFinal.decl: type = class_decl @DeriveFromFinal [template = constants.%DeriveFromFinal] {}
 // CHECK:STDOUT:   %ConvertToBadBaseFinal: <function> = fn_decl @ConvertToBadBaseFinal [template] {
-// CHECK:STDOUT:     %DeriveFromFinal.ref.loc105: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
-// CHECK:STDOUT:     %.loc105_44: type = ptr_type DeriveFromFinal [template = constants.%.24]
-// CHECK:STDOUT:     %p.loc105_26.1: DeriveFromFinal* = param p
-// CHECK:STDOUT:     @ConvertToBadBaseFinal.%p: DeriveFromFinal* = bind_name p, %p.loc105_26.1
+// CHECK:STDOUT:     %DeriveFromFinal.ref.loc116: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
+// CHECK:STDOUT:     %.loc116_44: type = ptr_type DeriveFromFinal [template = constants.%.24]
+// CHECK:STDOUT:     %p.loc116_26.1: DeriveFromFinal* = param p
+// CHECK:STDOUT:     @ConvertToBadBaseFinal.%p: DeriveFromFinal* = bind_name p, %p.loc116_26.1
 // CHECK:STDOUT:     %Final.ref: type = name_ref Final, %Final.decl [template = constants.%Final]
-// CHECK:STDOUT:     %.loc105_55: type = ptr_type Final [template = constants.%.25]
-// CHECK:STDOUT:     %return.var.loc105: ref Final* = var <return slot>
+// CHECK:STDOUT:     %.loc116_55: type = ptr_type Final [template = constants.%.25]
+// CHECK:STDOUT:     %return.var.loc116: ref Final* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_WithMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_WithMember [template] {
-// CHECK:STDOUT:     %DeriveFromFinal.ref.loc109: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
-// CHECK:STDOUT:     %.loc109: type = ptr_type DeriveFromFinal [template = constants.%.24]
-// CHECK:STDOUT:     %p.loc109_48.1: DeriveFromFinal* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseFinal_WithMember.%p: DeriveFromFinal* = bind_name p, %p.loc109_48.1
-// CHECK:STDOUT:     %return.var.loc109: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromFinal.ref.loc120: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
+// CHECK:STDOUT:     %.loc120: type = ptr_type DeriveFromFinal [template = constants.%.24]
+// CHECK:STDOUT:     %p.loc120_48.1: DeriveFromFinal* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseFinal_WithMember.%p: DeriveFromFinal* = bind_name p, %p.loc120_48.1
+// CHECK:STDOUT:     %return.var.loc120: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseFinal_NoMember: <function> = fn_decl @AccessMemberWithInvalidBaseFinal_NoMember [template] {
-// CHECK:STDOUT:     %DeriveFromFinal.ref.loc113: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
-// CHECK:STDOUT:     %.loc113: type = ptr_type DeriveFromFinal [template = constants.%.24]
-// CHECK:STDOUT:     %p.loc113_46.1: DeriveFromFinal* = param p
-// CHECK:STDOUT:     @AccessMemberWithInvalidBaseFinal_NoMember.%p: DeriveFromFinal* = bind_name p, %p.loc113_46.1
-// CHECK:STDOUT:     %return.var.loc113: ref i32 = var <return slot>
+// CHECK:STDOUT:     %DeriveFromFinal.ref.loc124: type = name_ref DeriveFromFinal, %DeriveFromFinal.decl [template = constants.%DeriveFromFinal]
+// CHECK:STDOUT:     %.loc124: type = ptr_type DeriveFromFinal [template = constants.%.24]
+// CHECK:STDOUT:     %p.loc124_46.1: DeriveFromFinal* = param p
+// CHECK:STDOUT:     @AccessMemberWithInvalidBaseFinal_NoMember.%p: DeriveFromFinal* = bind_name p, %p.loc124_46.1
+// CHECK:STDOUT:     %return.var.loc124: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -314,52 +325,52 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromError {
 // CHECK:STDOUT:   %error.ref: <error> = name_ref error, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc16: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc17: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromError
-// CHECK:STDOUT:   .base = %.loc16
+// CHECK:STDOUT:   .base = %.loc17
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromNonType {
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 32 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc26_18: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc28_16: i32 = int_literal 32 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc28_18: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromNonType
-// CHECK:STDOUT:   .base = %.loc26_18
+// CHECK:STDOUT:   .base = %.loc28_18
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromi32 {
-// CHECK:STDOUT:   %.loc35: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc38: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromi32
-// CHECK:STDOUT:   .base = %.loc35
+// CHECK:STDOUT:   .base = %.loc38
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromTuple {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
-// CHECK:STDOUT:   %.loc51_22.1: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:   %.loc51_22.2: type = converted %.loc51_22.1, constants.%.10 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc51_23: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc56_22.1: (type,) = tuple_literal (%Base.ref)
+// CHECK:STDOUT:   %.loc56_22.2: type = converted %.loc56_22.1, constants.%.10 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc56_23: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromTuple
-// CHECK:STDOUT:   .base = %.loc51_23
+// CHECK:STDOUT:   .base = %.loc56_23
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromStruct {
-// CHECK:STDOUT:   %.loc67_33: type = struct_type {.a: i32, .b: i32} [template = constants.%.16]
-// CHECK:STDOUT:   %.loc67_34: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc74_33: type = struct_type {.a: i32, .b: i32} [template = constants.%.16]
+// CHECK:STDOUT:   %.loc74_34: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromStruct
-// CHECK:STDOUT:   .base = %.loc67_34
+// CHECK:STDOUT:   .base = %.loc74_34
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -367,28 +378,28 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromIncomplete {
 // CHECK:STDOUT:   %Incomplete.ref: type = name_ref Incomplete, file.%Incomplete.decl [template = constants.%Incomplete]
-// CHECK:STDOUT:   %.loc87: <error> = base_decl <error>, element0 [template]
+// CHECK:STDOUT:   %.loc96: <error> = base_decl <error>, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromIncomplete
-// CHECK:STDOUT:   .base = %.loc87
+// CHECK:STDOUT:   .base = %.loc96
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @DeriveFromFinal {
 // CHECK:STDOUT:   %Final.ref: type = name_ref Final, file.%Final.decl [template = constants.%Final]
-// CHECK:STDOUT:   %.loc101: <unbound element of class DeriveFromFinal> = base_decl Final, element0 [template]
+// CHECK:STDOUT:   %.loc112: <unbound element of class DeriveFromFinal> = base_decl Final, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%DeriveFromFinal
-// CHECK:STDOUT:   .base = %.loc101
+// CHECK:STDOUT:   .base = %.loc112
 // CHECK:STDOUT:   extend name_scope2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseError(%p: DeriveFromError*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromError* = name_ref p, %p
-// CHECK:STDOUT:   %.loc20: ref DeriveFromError = deref %p.ref
+// CHECK:STDOUT:   %.loc21: ref DeriveFromError = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -396,7 +407,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBasNonType(%p: DeriveFromNonType*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromNonType* = name_ref p, %p
-// CHECK:STDOUT:   %.loc29: ref DeriveFromNonType = deref %p.ref
+// CHECK:STDOUT:   %.loc31: ref DeriveFromNonType = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -410,7 +421,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBasei32(%p: DeriveFromi32*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromi32* = name_ref p, %p
-// CHECK:STDOUT:   %.loc45: ref DeriveFromi32 = deref %p.ref
+// CHECK:STDOUT:   %.loc49: ref DeriveFromi32 = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -424,7 +435,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseTuple(%p: DeriveFromTuple*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromTuple* = name_ref p, %p
-// CHECK:STDOUT:   %.loc59: ref DeriveFromTuple = deref %p.ref
+// CHECK:STDOUT:   %.loc65: ref DeriveFromTuple = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -438,7 +449,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseStruct(%p: DeriveFromStruct*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromStruct* = name_ref p, %p
-// CHECK:STDOUT:   %.loc76: ref DeriveFromStruct = deref %p.ref
+// CHECK:STDOUT:   %.loc84: ref DeriveFromStruct = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -452,7 +463,7 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseIncomplete(%p: DeriveFromIncomplete*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromIncomplete* = name_ref p, %p
-// CHECK:STDOUT:   %.loc95: ref DeriveFromIncomplete = deref %p.ref
+// CHECK:STDOUT:   %.loc105: ref DeriveFromIncomplete = deref %p.ref
 // CHECK:STDOUT:   %n.ref: <error> = name_ref n, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
@@ -460,29 +471,29 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: fn @ConvertToBadBaseFinal(%p: DeriveFromFinal*) -> Final* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
-// CHECK:STDOUT:   %.loc106_11.1: ref DeriveFromFinal = deref %p.ref
-// CHECK:STDOUT:   %.loc106_11.2: ref Final = class_element_access %.loc106_11.1, element0
-// CHECK:STDOUT:   %.loc106_11.3: Final* = addr_of %.loc106_11.2
-// CHECK:STDOUT:   %.loc106_10: Final* = converted %p.ref, %.loc106_11.3
-// CHECK:STDOUT:   return %.loc106_10
+// CHECK:STDOUT:   %.loc117_11.1: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %.loc117_11.2: ref Final = class_element_access %.loc117_11.1, element0
+// CHECK:STDOUT:   %.loc117_11.3: Final* = addr_of %.loc117_11.2
+// CHECK:STDOUT:   %.loc117_10: Final* = converted %p.ref, %.loc117_11.3
+// CHECK:STDOUT:   return %.loc117_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_WithMember(%p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
-// CHECK:STDOUT:   %.loc110_11.1: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %.loc121_11.1: ref DeriveFromFinal = deref %p.ref
 // CHECK:STDOUT:   %a.ref: <unbound element of class Final> = name_ref a, @Final.%.loc9 [template = @Final.%.loc9]
-// CHECK:STDOUT:   %.loc110_14.1: ref Final = class_element_access %.loc110_11.1, element0
-// CHECK:STDOUT:   %.loc110_11.2: ref Final = converted %.loc110_11.1, %.loc110_14.1
-// CHECK:STDOUT:   %.loc110_14.2: ref i32 = class_element_access %.loc110_11.2, element0
-// CHECK:STDOUT:   %.loc110_14.3: i32 = bind_value %.loc110_14.2
-// CHECK:STDOUT:   return %.loc110_14.3
+// CHECK:STDOUT:   %.loc121_14.1: ref Final = class_element_access %.loc121_11.1, element0
+// CHECK:STDOUT:   %.loc121_11.2: ref Final = converted %.loc121_11.1, %.loc121_14.1
+// CHECK:STDOUT:   %.loc121_14.2: ref i32 = class_element_access %.loc121_11.2, element0
+// CHECK:STDOUT:   %.loc121_14.3: i32 = bind_value %.loc121_14.2
+// CHECK:STDOUT:   return %.loc121_14.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_NoMember(%p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
-// CHECK:STDOUT:   %.loc117: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %.loc128: ref DeriveFromFinal = deref %p.ref
 // CHECK:STDOUT:   %b.ref: <error> = name_ref b, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_base_method_define.carbon
+++ b/toolchain/check/testdata/class/fail_base_method_define.carbon
@@ -16,9 +16,10 @@ class D {
   extend base: B;
 }
 
-// CHECK:STDERR: fail_base_method_define.carbon:[[@LINE+3]]:6: ERROR: Out-of-line declaration requires a declaration in scoped entity.
+// CHECK:STDERR: fail_base_method_define.carbon:[[@LINE+4]]:6: ERROR: Out-of-line declaration requires a declaration in scoped entity.
 // CHECK:STDERR: fn D.F() {}
 // CHECK:STDERR:      ^
+// CHECK:STDERR:
 fn D.F() {}
 
 // CHECK:STDERR: fail_base_method_define.carbon:[[@LINE+3]]:6: ERROR: Name `C` not found.
@@ -47,7 +48,7 @@ fn D.C.F() {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [template = constants.%B] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template] {}
-// CHECK:STDOUT:   %.loc27: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc28: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @B {

--- a/toolchain/check/testdata/class/fail_base_misplaced.carbon
+++ b/toolchain/check/testdata/class/fail_base_misplaced.carbon
@@ -6,15 +6,17 @@
 
 base class B {}
 
-// CHECK:STDERR: fail_base_misplaced.carbon:[[@LINE+3]]:1: ERROR: `base` declaration can only be used in a class.
+// CHECK:STDERR: fail_base_misplaced.carbon:[[@LINE+4]]:1: ERROR: `base` declaration can only be used in a class.
 // CHECK:STDERR: extend base: B;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~
+// CHECK:STDERR:
 extend base: B;
 
 fn F() {
-  // CHECK:STDERR: fail_base_misplaced.carbon:[[@LINE+6]]:3: ERROR: Expected expression.
+  // CHECK:STDERR: fail_base_misplaced.carbon:[[@LINE+7]]:3: ERROR: Expected expression.
   // CHECK:STDERR:   extend base: B;
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_base_misplaced.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `HandleInvalidParse`.
   // CHECK:STDERR:   extend base: B;
   // CHECK:STDERR:   ^~~~~~

--- a/toolchain/check/testdata/class/fail_base_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_base_modifiers.carbon
@@ -7,29 +7,33 @@
 base class B {}
 
 class C1 {
-  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+3]]:3: ERROR: `private` not allowed on `base` declaration.
+  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+4]]:3: ERROR: `private` not allowed on `base` declaration.
   // CHECK:STDERR:   private extend base: B;
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   private extend base: B;
 }
 
 class C2 {
-  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+6]]:3: ERROR: `abstract` not allowed on `base` declaration.
+  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+8]]:3: ERROR: `abstract` not allowed on `base` declaration.
   // CHECK:STDERR:   abstract base: B;
   // CHECK:STDERR:   ^~~~~~~~
-  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+3]]:3: ERROR: Missing `extend` before `base` declaration in class.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+4]]:3: ERROR: Missing `extend` before `base` declaration in class.
   // CHECK:STDERR:   abstract base: B;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   abstract base: B;
 }
 
 class C3 {
-  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+6]]:10: ERROR: `default` not allowed on declaration with `extend`.
+  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+7]]:10: ERROR: `default` not allowed on declaration with `extend`.
   // CHECK:STDERR:   extend default base: B;
   // CHECK:STDERR:          ^~~~~~~
-  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+3]]:3: `extend` previously appeared here.
+  // CHECK:STDERR: fail_base_modifiers.carbon:[[@LINE+4]]:3: `extend` previously appeared here.
   // CHECK:STDERR:   extend default base: B;
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   extend default base: B;
 }
 
@@ -83,40 +87,40 @@ class C4 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C1 {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
-// CHECK:STDOUT:   %.loc13: <unbound element of class C1> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %.loc14: <unbound element of class C1> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C1
-// CHECK:STDOUT:   .base = %.loc13
+// CHECK:STDOUT:   .base = %.loc14
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C2 {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
-// CHECK:STDOUT:   %.loc23: <unbound element of class C2> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %.loc26: <unbound element of class C2> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C2
-// CHECK:STDOUT:   .base = %.loc23
+// CHECK:STDOUT:   .base = %.loc26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C3 {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
-// CHECK:STDOUT:   %.loc33: <unbound element of class C3> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %.loc37: <unbound element of class C3> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C3
-// CHECK:STDOUT:   .base = %.loc33
+// CHECK:STDOUT:   .base = %.loc37
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C4 {
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]
-// CHECK:STDOUT:   %.loc43: <unbound element of class C4> = base_decl B, element0 [template]
+// CHECK:STDOUT:   %.loc47: <unbound element of class C4> = base_decl B, element0 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C4
-// CHECK:STDOUT:   .base = %.loc43
+// CHECK:STDOUT:   .base = %.loc47
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_base_repeated.carbon
+++ b/toolchain/check/testdata/class/fail_base_repeated.carbon
@@ -9,12 +9,13 @@ base class B2 {}
 
 class C {
   extend base: B1;
-  // CHECK:STDERR: fail_base_repeated.carbon:[[@LINE+6]]:3: ERROR: Multiple `base` declarations in class. Multiple inheritance is not permitted.
+  // CHECK:STDERR: fail_base_repeated.carbon:[[@LINE+7]]:3: ERROR: Multiple `base` declarations in class. Multiple inheritance is not permitted.
   // CHECK:STDERR:   extend base: B2;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_base_repeated.carbon:[[@LINE-4]]:3: Previous `base` declaration is here.
   // CHECK:STDERR:   extend base: B1;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   extend base: B2;
 }
 
@@ -80,13 +81,13 @@ class D {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @D {
-// CHECK:STDOUT:   %B1.ref.loc23: type = name_ref B1, file.%B1.decl [template = constants.%B1]
-// CHECK:STDOUT:   %.loc23: <unbound element of class D> = base_decl B1, element0 [template]
-// CHECK:STDOUT:   %B1.ref.loc30: type = name_ref B1, file.%B1.decl [template = constants.%B1]
+// CHECK:STDOUT:   %B1.ref.loc24: type = name_ref B1, file.%B1.decl [template = constants.%B1]
+// CHECK:STDOUT:   %.loc24: <unbound element of class D> = base_decl B1, element0 [template]
+// CHECK:STDOUT:   %B1.ref.loc31: type = name_ref B1, file.%B1.decl [template = constants.%B1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%D
-// CHECK:STDOUT:   .base = %.loc23
+// CHECK:STDOUT:   .base = %.loc24
 // CHECK:STDOUT:   extend name_scope1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_derived_to_base.carbon
+++ b/toolchain/check/testdata/class/fail_derived_to_base.carbon
@@ -17,9 +17,10 @@ class B2 {
   var b: i32;
 }
 
-// CHECK:STDERR: fail_derived_to_base.carbon:[[@LINE+3]]:38: ERROR: Cannot implicitly convert from `B2*` to `A1*`.
+// CHECK:STDERR: fail_derived_to_base.carbon:[[@LINE+4]]:38: ERROR: Cannot implicitly convert from `B2*` to `A1*`.
 // CHECK:STDERR: fn ConvertUnrelated(p: B2*) -> A1* { return p; }
 // CHECK:STDERR:                                      ^~~~~~~~~
+// CHECK:STDERR:
 fn ConvertUnrelated(p: B2*) -> A1* { return p; }
 
 class Incomplete;
@@ -66,22 +67,22 @@ fn ConvertIncomplete(p: Incomplete*) -> A2* { return p; }
 // CHECK:STDOUT:   %B2.decl: type = class_decl @B2 [template = constants.%B2] {}
 // CHECK:STDOUT:   %ConvertUnrelated: <function> = fn_decl @ConvertUnrelated [template] {
 // CHECK:STDOUT:     %B2.ref: type = name_ref B2, %B2.decl [template = constants.%B2]
-// CHECK:STDOUT:     %.loc23_26: type = ptr_type B2 [template = constants.%.8]
-// CHECK:STDOUT:     %p.loc23_21.1: B2* = param p
-// CHECK:STDOUT:     @ConvertUnrelated.%p: B2* = bind_name p, %p.loc23_21.1
+// CHECK:STDOUT:     %.loc24_26: type = ptr_type B2 [template = constants.%.8]
+// CHECK:STDOUT:     %p.loc24_21.1: B2* = param p
+// CHECK:STDOUT:     @ConvertUnrelated.%p: B2* = bind_name p, %p.loc24_21.1
 // CHECK:STDOUT:     %A1.ref: type = name_ref A1, %A1.decl [template = constants.%A1]
-// CHECK:STDOUT:     %.loc23_34: type = ptr_type A1 [template = constants.%.9]
-// CHECK:STDOUT:     %return.var.loc23: ref A1* = var <return slot>
+// CHECK:STDOUT:     %.loc24_34: type = ptr_type A1 [template = constants.%.9]
+// CHECK:STDOUT:     %return.var.loc24: ref A1* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Incomplete.decl: type = class_decl @Incomplete [template = constants.%Incomplete] {}
 // CHECK:STDOUT:   %ConvertIncomplete: <function> = fn_decl @ConvertIncomplete [template] {
 // CHECK:STDOUT:     %Incomplete.ref: type = name_ref Incomplete, %Incomplete.decl [template = constants.%Incomplete]
-// CHECK:STDOUT:     %.loc30_35: type = ptr_type Incomplete [template = constants.%.13]
-// CHECK:STDOUT:     %p.loc30_22.1: Incomplete* = param p
-// CHECK:STDOUT:     @ConvertIncomplete.%p: Incomplete* = bind_name p, %p.loc30_22.1
+// CHECK:STDOUT:     %.loc31_35: type = ptr_type Incomplete [template = constants.%.13]
+// CHECK:STDOUT:     %p.loc31_22.1: Incomplete* = param p
+// CHECK:STDOUT:     @ConvertIncomplete.%p: Incomplete* = bind_name p, %p.loc31_22.1
 // CHECK:STDOUT:     %A2.ref: type = name_ref A2, %A2.decl [template = constants.%A2]
-// CHECK:STDOUT:     %.loc30_43: type = ptr_type A2 [template = constants.%.14]
-// CHECK:STDOUT:     %return.var.loc30: ref A2* = var <return slot>
+// CHECK:STDOUT:     %.loc31_43: type = ptr_type A2 [template = constants.%.14]
+// CHECK:STDOUT:     %return.var.loc31: ref A2* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_field_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_field_modifiers.carbon
@@ -6,19 +6,22 @@
 
 class Class {
 
-  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+3]]:3: ERROR: `default` not allowed on `var` declaration.
+  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+4]]:3: ERROR: `default` not allowed on `var` declaration.
   // CHECK:STDERR:   default var j: i32;
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default var j: i32;
 
-  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+3]]:3: ERROR: `final` not allowed on `var` declaration.
+  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+4]]:3: ERROR: `final` not allowed on `var` declaration.
   // CHECK:STDERR:   final var k: i32;
   // CHECK:STDERR:   ^~~~~
+  // CHECK:STDERR:
   final var k: i32;
 
-  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+3]]:3: ERROR: `default` not allowed on `let` declaration outside of an interface.
+  // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+4]]:3: ERROR: `default` not allowed on `let` declaration outside of an interface.
   // CHECK:STDERR:   default let l: i32 = 0;
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default let l: i32 = 0;
 
   // CHECK:STDERR: fail_field_modifiers.carbon:[[@LINE+3]]:3: ERROR: `final` not allowed on `let` declaration outside of an interface.
@@ -45,16 +48,16 @@ class Class {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %.loc12: <unbound element of class Class> = field_decl j, element0 [template]
-// CHECK:STDOUT:   %.loc17: <unbound element of class Class> = field_decl k, element1 [template]
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %l: i32 = bind_name l, %.loc22
-// CHECK:STDOUT:   %.loc27: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %m: i32 = bind_name m, %.loc27
+// CHECK:STDOUT:   %.loc13: <unbound element of class Class> = field_decl j, element0 [template]
+// CHECK:STDOUT:   %.loc19: <unbound element of class Class> = field_decl k, element1 [template]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   %l: i32 = bind_name l, %.loc25
+// CHECK:STDOUT:   %.loc30: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %m: i32 = bind_name m, %.loc30
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .j = %.loc12
-// CHECK:STDOUT:   .k = %.loc17
+// CHECK:STDOUT:   .j = %.loc13
+// CHECK:STDOUT:   .k = %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -19,12 +19,13 @@ library "b" api;
 
 import library "a";
 
-// CHECK:STDERR: fail_b.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_b.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: class Empty {
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: a.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: class Empty {
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 class Empty {
 }
 

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -6,77 +6,85 @@
 
 class Class;
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:4: ERROR: Cannot declare a member of incomplete class `Class`.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:4: ERROR: Cannot declare a member of incomplete class `Class`.
 // CHECK:STDERR: fn Class.Function() {}
 // CHECK:STDERR:    ^~~~~
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-5]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 fn Class.Function() {}
 
 fn CallClassFunction() {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:3: ERROR: Member access into incomplete class `Class`.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:3: ERROR: Member access into incomplete class `Class`.
   // CHECK:STDERR:   Class.Function();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-14]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-15]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
+  // CHECK:STDERR:
   Class.Function();
 }
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:17: ERROR: Variable has incomplete type `Class`.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:17: ERROR: Variable has incomplete type `Class`.
 // CHECK:STDERR: var global_var: Class;
 // CHECK:STDERR:                 ^~~~~
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-23]]:1: Class was forward declared here.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-25]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 var global_var: Class;
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:24: ERROR: Function returns incomplete type `Class`.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:24: ERROR: Function returns incomplete type `Class`.
 // CHECK:STDERR: fn ConvertFromStruct() -> Class { return {}; }
 // CHECK:STDERR:                        ^~~~~~~~
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-31]]:1: Class was forward declared here.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-34]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 fn ConvertFromStruct() -> Class { return {}; }
 
 fn G(p: Class*) -> i32 {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:10: ERROR: Member access into object of incomplete type `Class`.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:10: ERROR: Member access into object of incomplete type `Class`.
   // CHECK:STDERR:   return p->n;
   // CHECK:STDERR:          ^~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-40]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-44]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
+  // CHECK:STDERR:
   return p->n;
 }
 
 fn MemberAccess(p: Class*) -> i32 {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:11: ERROR: Member access into object of incomplete type `Class`.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:11: ERROR: Member access into object of incomplete type `Class`.
   // CHECK:STDERR:   return (*p).n;
   // CHECK:STDERR:           ^~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-50]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-55]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
+  // CHECK:STDERR:
   return (*p).n;
 }
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:20: ERROR: Function returns incomplete type `Class`.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:20: ERROR: Function returns incomplete type `Class`.
 // CHECK:STDERR: fn Copy(p: Class*) -> Class {
 // CHECK:STDERR:                    ^~~~~~~~
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-59]]:1: Class was forward declared here.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-65]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 fn Copy(p: Class*) -> Class {
   return *p;
 }
 
 fn Let(p: Class*) {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:10: ERROR: `let` binding has incomplete type `Class`.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:10: ERROR: `let` binding has incomplete type `Class`.
   // CHECK:STDERR:   let c: Class = *p;
   // CHECK:STDERR:          ^~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-70]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-77]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
+  // CHECK:STDERR:
   let c: Class = *p;
 }
 
@@ -84,33 +92,35 @@ fn TakeIncomplete(c: Class);
 
 // TODO: We should allow this, and only reject calls to the function.
 //
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+6]]:23: ERROR: Function returns incomplete type `Class`.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:23: ERROR: Function returns incomplete type `Class`.
 // CHECK:STDERR: fn ReturnIncomplete() -> Class;
 // CHECK:STDERR:                       ^~~~~~~~
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-83]]:1: Class was forward declared here.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-91]]:1: Class was forward declared here.
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 fn ReturnIncomplete() -> Class;
 
 fn CallTakeIncomplete(p: Class*) {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+9]]:3: ERROR: Forming value of incomplete type `Class`.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+10]]:3: ERROR: Forming value of incomplete type `Class`.
   // CHECK:STDERR:   TakeIncomplete(*p);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-92]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-101]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-19]]:1: Initializing parameter 1 of function declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-20]]:1: Initializing parameter 1 of function declared here.
   // CHECK:STDERR: fn TakeIncomplete(c: Class);
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   TakeIncomplete(*p);
 
   // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+9]]:3: ERROR: Forming value of incomplete type `Class`.
   // CHECK:STDERR:   TakeIncomplete({});
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-103]]:1: Class was forward declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-113]]:1: Class was forward declared here.
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-30]]:1: Initializing parameter 1 of function declared here.
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-32]]:1: Initializing parameter 1 of function declared here.
   // CHECK:STDERR: fn TakeIncomplete(c: Class);
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
   TakeIncomplete({});
@@ -145,57 +155,57 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:     .CallReturnIncomplete = %CallReturnIncomplete
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {}
-// CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc16: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:   %CallClassFunction: <function> = fn_decl @CallClassFunction [template] {}
-// CHECK:STDOUT:   %Class.ref.loc33: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %Class.ref.loc36: type = name_ref Class, %Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %global_var.var: ref <error> = var global_var
 // CHECK:STDOUT:   %global_var: ref <error> = bind_name global_var, %global_var.var
 // CHECK:STDOUT:   %ConvertFromStruct: <function> = fn_decl @ConvertFromStruct [template] {
-// CHECK:STDOUT:     %Class.ref.loc41: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %return.var.loc41: ref Class = var <return slot>
+// CHECK:STDOUT:     %Class.ref.loc45: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %return.var.loc45: ref Class = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %Class.ref.loc43: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc43: type = ptr_type Class [template = constants.%.2]
-// CHECK:STDOUT:     %p.loc43_6.1: Class* = param p
-// CHECK:STDOUT:     @G.%p: Class* = bind_name p, %p.loc43_6.1
-// CHECK:STDOUT:     %return.var.loc43: ref i32 = var <return slot>
+// CHECK:STDOUT:     %Class.ref.loc47: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc47: type = ptr_type Class [template = constants.%.2]
+// CHECK:STDOUT:     %p.loc47_6.1: Class* = param p
+// CHECK:STDOUT:     @G.%p: Class* = bind_name p, %p.loc47_6.1
+// CHECK:STDOUT:     %return.var.loc47: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %MemberAccess: <function> = fn_decl @MemberAccess [template] {
-// CHECK:STDOUT:     %Class.ref.loc53: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc53: type = ptr_type Class [template = constants.%.2]
-// CHECK:STDOUT:     %p.loc53_17.1: Class* = param p
-// CHECK:STDOUT:     @MemberAccess.%p: Class* = bind_name p, %p.loc53_17.1
-// CHECK:STDOUT:     %return.var.loc53: ref i32 = var <return slot>
+// CHECK:STDOUT:     %Class.ref.loc58: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc58: type = ptr_type Class [template = constants.%.2]
+// CHECK:STDOUT:     %p.loc58_17.1: Class* = param p
+// CHECK:STDOUT:     @MemberAccess.%p: Class* = bind_name p, %p.loc58_17.1
+// CHECK:STDOUT:     %return.var.loc58: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Copy: <function> = fn_decl @Copy [template] {
-// CHECK:STDOUT:     %Class.ref.loc69_12: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc69: type = ptr_type Class [template = constants.%.2]
-// CHECK:STDOUT:     %p.loc69_9.1: Class* = param p
-// CHECK:STDOUT:     @Copy.%p: Class* = bind_name p, %p.loc69_9.1
-// CHECK:STDOUT:     %Class.ref.loc69_23: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %return.var.loc69: ref Class = var <return slot>
+// CHECK:STDOUT:     %Class.ref.loc76_12: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc76: type = ptr_type Class [template = constants.%.2]
+// CHECK:STDOUT:     %p.loc76_9.1: Class* = param p
+// CHECK:STDOUT:     @Copy.%p: Class* = bind_name p, %p.loc76_9.1
+// CHECK:STDOUT:     %Class.ref.loc76_23: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %return.var.loc76: ref Class = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Let: <function> = fn_decl @Let [template] {
-// CHECK:STDOUT:     %Class.ref.loc73: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc73: type = ptr_type Class [template = constants.%.2]
-// CHECK:STDOUT:     %p.loc73_8.1: Class* = param p
-// CHECK:STDOUT:     @Let.%p: Class* = bind_name p, %p.loc73_8.1
+// CHECK:STDOUT:     %Class.ref.loc80: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc80: type = ptr_type Class [template = constants.%.2]
+// CHECK:STDOUT:     %p.loc80_8.1: Class* = param p
+// CHECK:STDOUT:     @Let.%p: Class* = bind_name p, %p.loc80_8.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TakeIncomplete: <function> = fn_decl @TakeIncomplete [template] {
-// CHECK:STDOUT:     %Class.ref.loc83: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %c.loc83_19.1: Class = param c
-// CHECK:STDOUT:     @TakeIncomplete.%c: Class = bind_name c, %c.loc83_19.1
+// CHECK:STDOUT:     %Class.ref.loc91: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %c.loc91_19.1: Class = param c
+// CHECK:STDOUT:     @TakeIncomplete.%c: Class = bind_name c, %c.loc91_19.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %ReturnIncomplete: <function> = fn_decl @ReturnIncomplete [template] {
-// CHECK:STDOUT:     %Class.ref.loc93: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %return.var.loc93: ref Class = var <return slot>
+// CHECK:STDOUT:     %Class.ref.loc102: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %return.var.loc102: ref Class = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallTakeIncomplete: <function> = fn_decl @CallTakeIncomplete [template] {
-// CHECK:STDOUT:     %Class.ref.loc95: type = name_ref Class, %Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %.loc95: type = ptr_type Class [template = constants.%.2]
-// CHECK:STDOUT:     %p.loc95_23.1: Class* = param p
-// CHECK:STDOUT:     @CallTakeIncomplete.%p: Class* = bind_name p, %p.loc95_23.1
+// CHECK:STDOUT:     %Class.ref.loc104: type = name_ref Class, %Class.decl [template = constants.%Class]
+// CHECK:STDOUT:     %.loc104: type = ptr_type Class [template = constants.%.2]
+// CHECK:STDOUT:     %p.loc104_23.1: Class* = param p
+// CHECK:STDOUT:     @CallTakeIncomplete.%p: Class* = bind_name p, %p.loc104_23.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallReturnIncomplete: <function> = fn_decl @CallReturnIncomplete [template] {}
 // CHECK:STDOUT: }
@@ -216,28 +226,28 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertFromStruct() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc41: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc45: {} = struct_literal ()
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%p: Class*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc50: ref Class = deref %p.ref
+// CHECK:STDOUT:   %.loc55: ref Class = deref %p.ref
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MemberAccess(%p: Class*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc60: ref Class = deref %p.ref
+// CHECK:STDOUT:   %.loc66: ref Class = deref %p.ref
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Copy(%p: Class*) -> <error> {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc70: ref Class = deref %p.ref
+// CHECK:STDOUT:   %.loc77: ref Class = deref %p.ref
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -245,7 +255,7 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc80: ref Class = deref %p.ref
+// CHECK:STDOUT:   %.loc88: ref Class = deref %p.ref
 // CHECK:STDOUT:   %c: <error> = bind_name c, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -256,20 +266,20 @@ fn CallReturnIncomplete() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallTakeIncomplete(%p: Class*) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc105: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc115: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
 // CHECK:STDOUT:   %p.ref: Class* = name_ref p, %p
-// CHECK:STDOUT:   %.loc105_18: ref Class = deref %p.ref
-// CHECK:STDOUT:   %.loc105_17: init () = call %TakeIncomplete.ref.loc105(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %TakeIncomplete.ref.loc116: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
-// CHECK:STDOUT:   %.loc116_19: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc116_17: init () = call %TakeIncomplete.ref.loc116(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc115_18: ref Class = deref %p.ref
+// CHECK:STDOUT:   %.loc115_17: init () = call %TakeIncomplete.ref.loc115(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %TakeIncomplete.ref.loc126: <function> = name_ref TakeIncomplete, file.%TakeIncomplete [template = file.%TakeIncomplete]
+// CHECK:STDOUT:   %.loc126_19: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc126_17: init () = call %TakeIncomplete.ref.loc126(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallReturnIncomplete() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %ReturnIncomplete.ref: <function> = name_ref ReturnIncomplete, file.%ReturnIncomplete [template = file.%ReturnIncomplete]
-// CHECK:STDOUT:   %.loc120: init <error> = call %ReturnIncomplete.ref()
+// CHECK:STDOUT:   %.loc130: init <error> = call %ReturnIncomplete.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -10,13 +10,15 @@ class Class {
 }
 
 fn F() {
-  // CHECK:STDERR: fail_init.carbon:[[@LINE+3]]:3: ERROR: Cannot initialize class with 2 field(s) from struct with 1 field(s).
+  // CHECK:STDERR: fail_init.carbon:[[@LINE+4]]:3: ERROR: Cannot initialize class with 2 field(s) from struct with 1 field(s).
   // CHECK:STDERR:   {.a = 1} as Class;
   // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:
   {.a = 1} as Class;
-  // CHECK:STDERR: fail_init.carbon:[[@LINE+3]]:3: ERROR: Missing value for field `b` in struct initialization.
+  // CHECK:STDERR: fail_init.carbon:[[@LINE+4]]:3: ERROR: Missing value for field `b` in struct initialization.
   // CHECK:STDERR:   {.a = 1, .c = 2} as Class;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   {.a = 1, .c = 2} as Class;
   // CHECK:STDERR: fail_init.carbon:[[@LINE+3]]:3: ERROR: Cannot initialize class with 2 field(s) from struct with 3 field(s).
   // CHECK:STDERR:   {.a = 1, .b = 2, .c = 3} as Class;
@@ -60,29 +62,29 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc16_10.1: {.a: i32} = struct_literal (%.loc16_9)
-// CHECK:STDOUT:   %Class.ref.loc16: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:   %.loc16_10.2: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc16_10.3: ref Class = temporary %.loc16_10.2, <error>
-// CHECK:STDOUT:   %.loc16_10.4: ref Class = converted %.loc16_10.1, %.loc16_10.3
-// CHECK:STDOUT:   %.loc20_9: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc20_17: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc20_18.1: {.a: i32, .c: i32} = struct_literal (%.loc20_9, %.loc20_17)
-// CHECK:STDOUT:   %Class.ref.loc20: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:   %.loc20_18.2: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc20_18.3: ref i32 = class_element_access %.loc20_18.2, element0
-// CHECK:STDOUT:   %.loc20_18.4: init i32 = initialize_from %.loc20_9 to %.loc20_18.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc20_18.5: ref Class = temporary %.loc20_18.2, <error>
-// CHECK:STDOUT:   %.loc20_18.6: ref Class = converted %.loc20_18.1, %.loc20_18.5
-// CHECK:STDOUT:   %.loc24_9: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc24_17: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc24_25: i32 = int_literal 3 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc24_26.1: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc24_9, %.loc24_17, %.loc24_25)
-// CHECK:STDOUT:   %Class.ref.loc24: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:   %.loc24_26.2: ref Class = temporary_storage
-// CHECK:STDOUT:   %.loc24_26.3: ref Class = temporary %.loc24_26.2, <error>
-// CHECK:STDOUT:   %.loc24_26.4: ref Class = converted %.loc24_26.1, %.loc24_26.3
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc17_10.1: {.a: i32} = struct_literal (%.loc17_9)
+// CHECK:STDOUT:   %Class.ref.loc17: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %.loc17_10.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc17_10.3: ref Class = temporary %.loc17_10.2, <error>
+// CHECK:STDOUT:   %.loc17_10.4: ref Class = converted %.loc17_10.1, %.loc17_10.3
+// CHECK:STDOUT:   %.loc22_9: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc22_17: i32 = int_literal 2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc22_18.1: {.a: i32, .c: i32} = struct_literal (%.loc22_9, %.loc22_17)
+// CHECK:STDOUT:   %Class.ref.loc22: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %.loc22_18.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc22_18.3: ref i32 = class_element_access %.loc22_18.2, element0
+// CHECK:STDOUT:   %.loc22_18.4: init i32 = initialize_from %.loc22_9 to %.loc22_18.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc22_18.5: ref Class = temporary %.loc22_18.2, <error>
+// CHECK:STDOUT:   %.loc22_18.6: ref Class = converted %.loc22_18.1, %.loc22_18.5
+// CHECK:STDOUT:   %.loc26_9: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc26_17: i32 = int_literal 2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc26_25: i32 = int_literal 3 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc26_26.1: {.a: i32, .b: i32, .c: i32} = struct_literal (%.loc26_9, %.loc26_17, %.loc26_25)
+// CHECK:STDOUT:   %Class.ref.loc26: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %.loc26_26.2: ref Class = temporary_storage
+// CHECK:STDOUT:   %.loc26_26.3: ref Class = temporary %.loc26_26.2, <error>
+// CHECK:STDOUT:   %.loc26_26.4: ref Class = converted %.loc26_26.1, %.loc26_26.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_memaccess_category.carbon
+++ b/toolchain/check/testdata/class/fail_memaccess_category.carbon
@@ -14,12 +14,13 @@ class B {
 
 fn F(s: {.a: A}, b: B) {
   // `s` has only a value representation, so this must be invalid.
-  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+6]]:8: ERROR: `addr self` method cannot be invoked on a value.
+  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+7]]:8: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   s.a.F();
   // CHECK:STDERR:        ^
   // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE-12]]:13: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn F[addr self: A*]();
   // CHECK:STDERR:             ^~~~
+  // CHECK:STDERR:
   s.a.F();
 
   // `b` has an object representation for `A`, but this is still invalid for
@@ -27,7 +28,7 @@ fn F(s: {.a: A}, b: B) {
   // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE+6]]:8: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   b.a.F();
   // CHECK:STDERR:        ^
-  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE-22]]:13: Initializing `addr self` parameter of method declared here.
+  // CHECK:STDERR: fail_memaccess_category.carbon:[[@LINE-23]]:13: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn F[addr self: A*]();
   // CHECK:STDERR:             ^~~~
   b.a.F();
@@ -95,17 +96,17 @@ fn F(s: {.a: A}, b: B) {
 // CHECK:STDOUT: fn @F.2(%s: {.a: A}, %b: B) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.ref: {.a: A} = name_ref s, %s
-// CHECK:STDOUT:   %.loc23_4: A = struct_access %s.ref, element0
-// CHECK:STDOUT:   %F.ref.loc23: <function> = name_ref F, @A.%F [template = @A.%F]
-// CHECK:STDOUT:   %.loc23_6: <bound method> = bound_method %.loc23_4, %F.ref.loc23
-// CHECK:STDOUT:   %.loc23_8: init () = call %.loc23_6(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc24_4: A = struct_access %s.ref, element0
+// CHECK:STDOUT:   %F.ref.loc24: <function> = name_ref F, @A.%F [template = @A.%F]
+// CHECK:STDOUT:   %.loc24_6: <bound method> = bound_method %.loc24_4, %F.ref.loc24
+// CHECK:STDOUT:   %.loc24_8: init () = call %.loc24_6(<invalid>) [template = <error>]
 // CHECK:STDOUT:   %b.ref: B = name_ref b, %b
 // CHECK:STDOUT:   %a.ref: <unbound element of class B> = name_ref a, @B.%.loc12 [template = @B.%.loc12]
-// CHECK:STDOUT:   %.loc33_4.1: ref A = class_element_access %b.ref, element0
-// CHECK:STDOUT:   %.loc33_4.2: A = bind_value %.loc33_4.1
-// CHECK:STDOUT:   %F.ref.loc33: <function> = name_ref F, @A.%F [template = @A.%F]
-// CHECK:STDOUT:   %.loc33_6: <bound method> = bound_method %.loc33_4.2, %F.ref.loc33
-// CHECK:STDOUT:   %.loc33_8: init () = call %.loc33_6(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc34_4.1: ref A = class_element_access %b.ref, element0
+// CHECK:STDOUT:   %.loc34_4.2: A = bind_value %.loc34_4.1
+// CHECK:STDOUT:   %F.ref.loc34: <function> = name_ref F, @A.%F [template = @A.%F]
+// CHECK:STDOUT:   %.loc34_6: <bound method> = bound_method %.loc34_4.2, %F.ref.loc34
+// CHECK:STDOUT:   %.loc34_8: init () = call %.loc34_6(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_method.carbon
+++ b/toolchain/check/testdata/class/fail_method.carbon
@@ -16,25 +16,27 @@ fn F(c: Class) {
   c.WithSelf();
 
   Class.NoSelf();
-  // CHECK:STDERR: fail_method.carbon:[[@LINE+6]]:3: ERROR: Missing object argument in method call.
+  // CHECK:STDERR: fail_method.carbon:[[@LINE+7]]:3: ERROR: Missing object argument in method call.
   // CHECK:STDERR:   Class.WithSelf();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_method.carbon:[[@LINE-13]]:3: Calling function declared here.
   // CHECK:STDERR:   fn WithSelf[self: Class]();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Class.WithSelf();
-  // CHECK:STDERR: fail_method.carbon:[[@LINE+6]]:3: ERROR: 1 argument(s) passed to function expecting 0 argument(s).
+  // CHECK:STDERR: fail_method.carbon:[[@LINE+7]]:3: ERROR: 1 argument(s) passed to function expecting 0 argument(s).
   // CHECK:STDERR:   Class.WithSelf(c);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_method.carbon:[[@LINE-20]]:3: Calling function declared here.
+  // CHECK:STDERR: fail_method.carbon:[[@LINE-21]]:3: Calling function declared here.
   // CHECK:STDERR:   fn WithSelf[self: Class]();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Class.WithSelf(c);
 
   // CHECK:STDERR: fail_method.carbon:[[@LINE+6]]:3: ERROR: Missing object argument in method call.
   // CHECK:STDERR:   A();
   // CHECK:STDERR:   ^~
-  // CHECK:STDERR: fail_method.carbon:[[@LINE-28]]:3: Calling function declared here.
+  // CHECK:STDERR: fail_method.carbon:[[@LINE-30]]:3: Calling function declared here.
   // CHECK:STDERR:   fn WithSelf[self: Class]();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   A();
@@ -96,15 +98,15 @@ fn F(c: Class) {
 // CHECK:STDOUT:   %Class.ref.loc18: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %NoSelf.ref.loc18: <function> = name_ref NoSelf, @Class.%NoSelf [template = @Class.%NoSelf]
 // CHECK:STDOUT:   %.loc18: init () = call %NoSelf.ref.loc18()
-// CHECK:STDOUT:   %Class.ref.loc25: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:   %WithSelf.ref.loc25: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
-// CHECK:STDOUT:   %.loc25: init () = call %WithSelf.ref.loc25(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Class.ref.loc32: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:   %WithSelf.ref.loc32: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
-// CHECK:STDOUT:   %c.ref.loc32: Class = name_ref c, %c
-// CHECK:STDOUT:   %.loc32: init () = call %WithSelf.ref.loc32(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Class.ref.loc26: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc26: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
+// CHECK:STDOUT:   %.loc26: init () = call %WithSelf.ref.loc26(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Class.ref.loc34: type = name_ref Class, file.%Class.decl [template = constants.%Class]
+// CHECK:STDOUT:   %WithSelf.ref.loc34: <function> = name_ref WithSelf, @Class.%WithSelf [template = @Class.%WithSelf]
+// CHECK:STDOUT:   %c.ref.loc34: Class = name_ref c, %c
+// CHECK:STDOUT:   %.loc34: init () = call %WithSelf.ref.loc34(<invalid>) [template = <error>]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = @Class.%WithSelf]
-// CHECK:STDOUT:   %.loc40: init () = call %A.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc42: init () = call %A.ref(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_method_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_method_modifiers.carbon
@@ -6,33 +6,37 @@
 
 class FinalClass {
 
-  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+6]]:3: ERROR: `abstract` not allowed on `fn` declaration in a non-abstract `class` definition.
+  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+7]]:3: ERROR: `abstract` not allowed on `fn` declaration in a non-abstract `class` definition.
   // CHECK:STDERR:   abstract fn Abstract[self: Self]();
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-5]]:1: Containing definition here.
   // CHECK:STDERR: class FinalClass {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   abstract fn Abstract[self: Self]();
 
-  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+6]]:3: ERROR: `virtual` not allowed on `fn` declaration in a non-abstract non-base `class` definition.
+  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+7]]:3: ERROR: `virtual` not allowed on `fn` declaration in a non-abstract non-base `class` definition.
   // CHECK:STDERR:   virtual fn Virtual[self: Self]();
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-13]]:1: Containing definition here.
+  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE-14]]:1: Containing definition here.
   // CHECK:STDERR: class FinalClass {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   virtual fn Virtual[self: Self]();
 }
 
 abstract class AbstractClass {
 
-  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+3]]:3: ERROR: `default` not allowed on `fn` declaration outside of an interface.
+  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+4]]:3: ERROR: `default` not allowed on `fn` declaration outside of an interface.
   // CHECK:STDERR:   default fn Default[self: Self]();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default fn Default[self: Self]();
 
-  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+3]]:3: ERROR: `final` not allowed on `fn` declaration outside of an interface.
+  // CHECK:STDERR: fail_method_modifiers.carbon:[[@LINE+4]]:3: ERROR: `final` not allowed on `fn` declaration outside of an interface.
   // CHECK:STDERR:   final fn Final[self: Self]();
   // CHECK:STDERR:   ^~~~~
+  // CHECK:STDERR:
   final fn Final[self: Self]();
 }
 
@@ -69,14 +73,14 @@ base class BaseClass {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @FinalClass {
 // CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc15: type = name_ref Self, constants.%FinalClass [template = constants.%FinalClass]
-// CHECK:STDOUT:     %self.loc15_24.1: FinalClass = param self
-// CHECK:STDOUT:     %self.loc15_24.2: FinalClass = bind_name self, %self.loc15_24.1
+// CHECK:STDOUT:     %Self.ref.loc16: type = name_ref Self, constants.%FinalClass [template = constants.%FinalClass]
+// CHECK:STDOUT:     %self.loc16_24.1: FinalClass = param self
+// CHECK:STDOUT:     %self.loc16_24.2: FinalClass = bind_name self, %self.loc16_24.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Virtual: <function> = fn_decl @Virtual [template] {
-// CHECK:STDOUT:     %Self.ref.loc23: type = name_ref Self, constants.%FinalClass [template = constants.%FinalClass]
-// CHECK:STDOUT:     %self.loc23_22.1: FinalClass = param self
-// CHECK:STDOUT:     %self.loc23_22.2: FinalClass = bind_name self, %self.loc23_22.1
+// CHECK:STDOUT:     %Self.ref.loc25: type = name_ref Self, constants.%FinalClass [template = constants.%FinalClass]
+// CHECK:STDOUT:     %self.loc25_22.1: FinalClass = param self
+// CHECK:STDOUT:     %self.loc25_22.2: FinalClass = bind_name self, %self.loc25_22.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -87,14 +91,14 @@ base class BaseClass {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @AbstractClass {
 // CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template] {
-// CHECK:STDOUT:     %Self.ref.loc31: type = name_ref Self, constants.%AbstractClass [template = constants.%AbstractClass]
-// CHECK:STDOUT:     %self.loc31_22.1: AbstractClass = param self
-// CHECK:STDOUT:     %self.loc31_22.2: AbstractClass = bind_name self, %self.loc31_22.1
+// CHECK:STDOUT:     %Self.ref.loc34: type = name_ref Self, constants.%AbstractClass [template = constants.%AbstractClass]
+// CHECK:STDOUT:     %self.loc34_22.1: AbstractClass = param self
+// CHECK:STDOUT:     %self.loc34_22.2: AbstractClass = bind_name self, %self.loc34_22.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template] {
-// CHECK:STDOUT:     %Self.ref.loc36: type = name_ref Self, constants.%AbstractClass [template = constants.%AbstractClass]
-// CHECK:STDOUT:     %self.loc36_18.1: AbstractClass = param self
-// CHECK:STDOUT:     %self.loc36_18.2: AbstractClass = bind_name self, %self.loc36_18.1
+// CHECK:STDOUT:     %Self.ref.loc40: type = name_ref Self, constants.%AbstractClass [template = constants.%AbstractClass]
+// CHECK:STDOUT:     %self.loc40_18.1: AbstractClass = param self
+// CHECK:STDOUT:     %self.loc40_18.2: AbstractClass = bind_name self, %self.loc40_18.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -106,8 +110,8 @@ base class BaseClass {
 // CHECK:STDOUT: class @BaseClass {
 // CHECK:STDOUT:   %Abstract: <function> = fn_decl @Abstract.2 [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%BaseClass [template = constants.%BaseClass]
-// CHECK:STDOUT:     %self.loc47_24.1: BaseClass = param self
-// CHECK:STDOUT:     %self.loc47_24.2: BaseClass = bind_name self, %self.loc47_24.1
+// CHECK:STDOUT:     %self.loc51_24.1: BaseClass = param self
+// CHECK:STDOUT:     %self.loc51_24.2: BaseClass = bind_name self, %self.loc51_24.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -115,13 +119,13 @@ base class BaseClass {
 // CHECK:STDOUT:   .Abstract = %Abstract
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Abstract.1[@FinalClass.%self.loc15_24.2: FinalClass]();
+// CHECK:STDOUT: fn @Abstract.1[@FinalClass.%self.loc16_24.2: FinalClass]();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Virtual[@FinalClass.%self.loc23_22.2: FinalClass]();
+// CHECK:STDOUT: fn @Virtual[@FinalClass.%self.loc25_22.2: FinalClass]();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Default[@AbstractClass.%self.loc31_22.2: AbstractClass]();
+// CHECK:STDOUT: fn @Default[@AbstractClass.%self.loc34_22.2: AbstractClass]();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Final[@AbstractClass.%self.loc36_18.2: AbstractClass]();
+// CHECK:STDOUT: fn @Final[@AbstractClass.%self.loc40_18.2: AbstractClass]();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Abstract.2[@BaseClass.%self.loc47_24.2: BaseClass]();
+// CHECK:STDOUT: fn @Abstract.2[@BaseClass.%self.loc51_24.2: BaseClass]();
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_modifiers.carbon
@@ -4,64 +4,74 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: Semantics TODO: `access modifier`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: Semantics TODO: `access modifier`.
 // CHECK:STDERR: private abstract private class DuplicatePrivate;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:18: ERROR: `private` repeated on declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:18: ERROR: `private` repeated on declaration.
 // CHECK:STDERR: private abstract private class DuplicatePrivate;
 // CHECK:STDERR:                  ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `private` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `private` previously appeared here.
 // CHECK:STDERR: private abstract private class DuplicatePrivate;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 private abstract private class DuplicatePrivate;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: Semantics TODO: `access modifier`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: Semantics TODO: `access modifier`.
 // CHECK:STDERR: private base protected class TwoAccess {}
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:14: ERROR: `protected` not allowed on declaration with `private`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:14: ERROR: `protected` not allowed on declaration with `private`.
 // CHECK:STDERR: private base protected class TwoAccess {}
 // CHECK:STDERR:              ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `private` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `private` previously appeared here.
 // CHECK:STDERR: private base protected class TwoAccess {}
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 private base protected class TwoAccess {}
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:10: ERROR: `abstract` repeated on declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:10: ERROR: `abstract` repeated on declaration.
 // CHECK:STDERR: abstract abstract class TwoAbstract;
 // CHECK:STDERR:          ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract abstract class TwoAbstract;
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract abstract class TwoAbstract;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+12]]:1: ERROR: `protected` not allowed on `class` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+15]]:1: ERROR: `protected` not allowed on `class` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected virtual base class Virtual {}
 // CHECK:STDERR: ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:11: ERROR: `virtual` not allowed on `class` declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:11: ERROR: `virtual` not allowed on `class` declaration.
 // CHECK:STDERR: protected virtual base class Virtual {}
 // CHECK:STDERR:           ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:19: ERROR: `base` not allowed on declaration with `virtual`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:19: ERROR: `base` not allowed on declaration with `virtual`.
 // CHECK:STDERR: protected virtual base class Virtual {}
 // CHECK:STDERR:                   ^~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:11: `virtual` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:11: `virtual` previously appeared here.
 // CHECK:STDERR: protected virtual base class Virtual {}
 // CHECK:STDERR:           ^~~~~~~
+// CHECK:STDERR:
 protected virtual base class Virtual {}
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:10: ERROR: `protected` must appear before `abstract`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:10: ERROR: `protected` must appear before `abstract`.
 // CHECK:STDERR: abstract protected class WrongOrder;
 // CHECK:STDERR:          ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract protected class WrongOrder;
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract protected class WrongOrder;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:10: ERROR: `base` not allowed on declaration with `abstract`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:10: ERROR: `base` not allowed on declaration with `abstract`.
 // CHECK:STDERR: abstract base class AbstractAndBase {}
 // CHECK:STDERR:          ^~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract base class AbstractAndBase {}
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract base class AbstractAndBase {}
 
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `extern` not allowed on `class` declaration.

--- a/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
+++ b/toolchain/check/testdata/class/fail_redeclaration_introducer.carbon
@@ -5,71 +5,78 @@
 // AUTOUPDATE
 
 class A;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class A {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class A;
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 base class A {}
 
 class B;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class B {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class B;
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract class B {}
 
 base class C;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: class C {}
 // CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: base class C;
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 class C {}
 
 base class D;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class D {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: base class D;
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 abstract class D {}
 
 abstract class E;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: class E {}
 // CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: abstract class E;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 class E {}
 
 abstract class F;
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class F {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: abstract class F;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 base class F {}
 
 class G {}
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+7]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: abstract class G;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: class G {}
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 abstract class G;
 // CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE+6]]:1: ERROR: Class redeclared with different inheritance kind.
 // CHECK:STDERR: base class G;
 // CHECK:STDERR: ^~~~~~~~~~~~~
-// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-11]]:1: Previously declared here.
+// CHECK:STDERR: fail_redeclaration_introducer.carbon:[[@LINE-12]]:1: Previously declared here.
 // CHECK:STDERR: class G {}
 // CHECK:STDERR: ^~~~~~~~~
 base class G;
@@ -90,28 +97,28 @@ base class G;
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.decl.loc7
-// CHECK:STDOUT:     .B = %B.decl.loc16
-// CHECK:STDOUT:     .C = %C.decl.loc25
-// CHECK:STDOUT:     .D = %D.decl.loc34
-// CHECK:STDOUT:     .E = %E.decl.loc43
-// CHECK:STDOUT:     .F = %F.decl.loc52
-// CHECK:STDOUT:     .G = %G.decl.loc61
+// CHECK:STDOUT:     .B = %B.decl.loc17
+// CHECK:STDOUT:     .C = %C.decl.loc27
+// CHECK:STDOUT:     .D = %D.decl.loc37
+// CHECK:STDOUT:     .E = %E.decl.loc47
+// CHECK:STDOUT:     .F = %F.decl.loc57
+// CHECK:STDOUT:     .G = %G.decl.loc67
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl.loc7: type = class_decl @A [template = constants.%A] {}
-// CHECK:STDOUT:   %A.decl.loc14: type = class_decl @A [template = constants.%A] {}
-// CHECK:STDOUT:   %B.decl.loc16: type = class_decl @B [template = constants.%B] {}
-// CHECK:STDOUT:   %B.decl.loc23: type = class_decl @B [template = constants.%B] {}
-// CHECK:STDOUT:   %C.decl.loc25: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %C.decl.loc32: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %D.decl.loc34: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %D.decl.loc41: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %E.decl.loc43: type = class_decl @E [template = constants.%E] {}
-// CHECK:STDOUT:   %E.decl.loc50: type = class_decl @E [template = constants.%E] {}
-// CHECK:STDOUT:   %F.decl.loc52: type = class_decl @F [template = constants.%F] {}
-// CHECK:STDOUT:   %F.decl.loc59: type = class_decl @F [template = constants.%F] {}
-// CHECK:STDOUT:   %G.decl.loc61: type = class_decl @G [template = constants.%G] {}
-// CHECK:STDOUT:   %G.decl.loc68: type = class_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:   %A.decl.loc15: type = class_decl @A [template = constants.%A] {}
+// CHECK:STDOUT:   %B.decl.loc17: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %B.decl.loc25: type = class_decl @B [template = constants.%B] {}
+// CHECK:STDOUT:   %C.decl.loc27: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT:   %C.decl.loc35: type = class_decl @C [template = constants.%C] {}
+// CHECK:STDOUT:   %D.decl.loc37: type = class_decl @D [template = constants.%D] {}
+// CHECK:STDOUT:   %D.decl.loc45: type = class_decl @D [template = constants.%D] {}
+// CHECK:STDOUT:   %E.decl.loc47: type = class_decl @E [template = constants.%E] {}
+// CHECK:STDOUT:   %E.decl.loc55: type = class_decl @E [template = constants.%E] {}
+// CHECK:STDOUT:   %F.decl.loc57: type = class_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:   %F.decl.loc65: type = class_decl @F [template = constants.%F] {}
+// CHECK:STDOUT:   %G.decl.loc67: type = class_decl @G [template = constants.%G] {}
 // CHECK:STDOUT:   %G.decl.loc75: type = class_decl @G [template = constants.%G] {}
+// CHECK:STDOUT:   %G.decl.loc82: type = class_decl @G [template = constants.%G] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @A {

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -9,18 +9,19 @@ class Class {
   fn H();
 }
 
-// CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:1: ERROR: Redefinition of class Class.
+// CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:1: ERROR: Redefinition of class Class.
 // CHECK:STDERR: class Class {
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-8]]:1: Previous definition was here.
 // CHECK:STDERR: class Class {
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 class Class {
   fn G();
   // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:3: ERROR: Redundant redeclaration of function H.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-14]]:3: Previously declared here.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-15]]:3: Previously declared here.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
   fn H();
@@ -42,7 +43,7 @@ fn Class.H() {}
 // CHECK:STDOUT:     .Class = %Class.decl.loc7
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.decl.loc7: type = class_decl @Class [template = constants.%Class] {}
-// CHECK:STDOUT:   %Class.decl.loc18: type = class_decl @Class [template = constants.%Class] {}
+// CHECK:STDOUT:   %Class.decl.loc19: type = class_decl @Class [template = constants.%Class] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {}
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {}

--- a/toolchain/check/testdata/class/fail_reorder.carbon
+++ b/toolchain/check/testdata/class/fail_reorder.carbon
@@ -8,12 +8,13 @@ class Class {
   fn G() -> i32 {
     // TODO: This should find the member function `F` even though it's declared
     // later.
-    // CHECK:STDERR: fail_reorder.carbon:[[@LINE+9]]:12: ERROR: Member access into incomplete class `Class`.
+    // CHECK:STDERR: fail_reorder.carbon:[[@LINE+10]]:12: ERROR: Member access into incomplete class `Class`.
     // CHECK:STDERR:     return Class.F();
     // CHECK:STDERR:            ^~~~~~~
     // CHECK:STDERR: fail_reorder.carbon:[[@LINE-7]]:1: Class is incomplete within its definition.
     // CHECK:STDERR: class Class {
     // CHECK:STDERR: ^~~~~~~~~~~~~
+    // CHECK:STDERR:
     // CHECK:STDERR: fail_reorder.carbon:[[@LINE+3]]:12: ERROR: Name `F` not found.
     // CHECK:STDERR:     return Class.F();
     // CHECK:STDERR:            ^~~~~~~
@@ -45,7 +46,7 @@ class Class {
 // CHECK:STDOUT:     %return.var.loc8: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %return.var.loc23: ref i32 = var <return slot>
+// CHECK:STDOUT:     %return.var.loc24: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -63,7 +64,7 @@ class Class {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   return %.loc24
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   return %.loc25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self.carbon
+++ b/toolchain/check/testdata/class/fail_self.carbon
@@ -5,34 +5,39 @@
 // AUTOUPDATE
 
 class Class {
-  // CHECK:STDERR: fail_self.carbon:[[@LINE+3]]:8: ERROR: `self` can only be declared in an implicit parameter list.
+  // CHECK:STDERR: fail_self.carbon:[[@LINE+4]]:8: ERROR: `self` can only be declared in an implicit parameter list.
   // CHECK:STDERR:   fn F(self: Self);
   // CHECK:STDERR:        ^~~~~~~~~~
+  // CHECK:STDERR:
   fn F(self: Self);
 
-  // CHECK:STDERR: fail_self.carbon:[[@LINE+6]]:10: ERROR: Function returns incomplete type `Class`.
+  // CHECK:STDERR: fail_self.carbon:[[@LINE+7]]:10: ERROR: Function returns incomplete type `Class`.
   // CHECK:STDERR:   fn G() -> Self;
   // CHECK:STDERR:          ^~~~~~~
-  // CHECK:STDERR: fail_self.carbon:[[@LINE-9]]:1: Class is incomplete within its definition.
+  // CHECK:STDERR: fail_self.carbon:[[@LINE-10]]:1: Class is incomplete within its definition.
   // CHECK:STDERR: class Class {
   // CHECK:STDERR: ^~~~~~~~~~~~~
+  // CHECK:STDERR:
   fn G() -> Self;
 }
 
-// CHECK:STDERR: fail_self.carbon:[[@LINE+3]]:12: ERROR: `self` can only be declared in an implicit parameter list.
+// CHECK:STDERR: fail_self.carbon:[[@LINE+4]]:12: ERROR: `self` can only be declared in an implicit parameter list.
 // CHECK:STDERR: fn Class.F(self: Self) {
 // CHECK:STDERR:            ^~~~~~~~~~
+// CHECK:STDERR:
 fn Class.F(self: Self) {
 }
 
 fn Class.G() -> Self {
-  // CHECK:STDERR: fail_self.carbon:[[@LINE+3]]:7: ERROR: `self` can only be declared in an implicit parameter list.
+  // CHECK:STDERR: fail_self.carbon:[[@LINE+4]]:7: ERROR: `self` can only be declared in an implicit parameter list.
   // CHECK:STDERR:   var self: Self;
   // CHECK:STDERR:       ^~~~~~~~~~
+  // CHECK:STDERR:
   var self: Self;
-  // CHECK:STDERR: fail_self.carbon:[[@LINE+3]]:10: ERROR: Cannot copy value of type `Class`.
+  // CHECK:STDERR: fail_self.carbon:[[@LINE+4]]:10: ERROR: Cannot copy value of type `Class`.
   // CHECK:STDERR:   return self;
   // CHECK:STDERR:          ^~~~
+  // CHECK:STDERR:
   return self;
 }
 
@@ -68,30 +73,30 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc25: type = name_ref Self, constants.%Class [template = constants.%Class]
-// CHECK:STDOUT:     %self.loc25_12.1: Class = param self
-// CHECK:STDOUT:     @F.1.%self: Class = bind_name self, %self.loc25_12.1
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc28: <function> = fn_decl @.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc28: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:     %self.loc28_12.1: Class = param self
+// CHECK:STDOUT:     @F.1.%self: Class = bind_name self, %self.loc28_12.1
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc31: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %Self.ref.loc31: type = name_ref Self, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:     @.1.%return: ref Class = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %WrongSelf.decl: type = class_decl @WrongSelf [template = constants.%WrongSelf] {}
 // CHECK:STDOUT:   %CallWrongSelf: <function> = fn_decl @CallWrongSelf [template] {
 // CHECK:STDOUT:     %WrongSelf.ref: type = name_ref WrongSelf, %WrongSelf.decl [template = constants.%WrongSelf]
-// CHECK:STDOUT:     %ws.loc43_18.1: WrongSelf = param ws
-// CHECK:STDOUT:     @CallWrongSelf.%ws: WrongSelf = bind_name ws, %ws.loc43_18.1
+// CHECK:STDOUT:     %ws.loc48_18.1: WrongSelf = param ws
+// CHECK:STDOUT:     @CallWrongSelf.%ws: WrongSelf = bind_name ws, %ws.loc48_18.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc11: type = name_ref Self, constants.%Class [template = constants.%Class]
-// CHECK:STDOUT:     %self.loc11_8.1: Class = param self
-// CHECK:STDOUT:     %self.loc11_8.2: Class = bind_name self, %self.loc11_8.1
+// CHECK:STDOUT:     %Self.ref.loc12: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:     %self.loc12_8.1: Class = param self
+// CHECK:STDOUT:     %self.loc12_8.2: Class = bind_name self, %self.loc12_8.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %Self.ref.loc19: type = name_ref Self, constants.%Class [template = constants.%Class]
+// CHECK:STDOUT:     %Self.ref.loc21: type = name_ref Self, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:     %return.var: ref Class = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
@@ -104,8 +109,8 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT: class @WrongSelf {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
 // CHECK:STDOUT:     %Class.ref: type = name_ref Class, file.%Class.decl [template = constants.%Class]
-// CHECK:STDOUT:     %self.loc40_8.1: Class = param self
-// CHECK:STDOUT:     %self.loc40_8.2: Class = bind_name self, %self.loc40_8.1
+// CHECK:STDOUT:     %self.loc45_8.1: Class = param self
+// CHECK:STDOUT:     %self.loc45_8.2: Class = bind_name self, %self.loc45_8.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -126,18 +131,18 @@ fn CallWrongSelf(ws: WrongSelf) {
 // CHECK:STDOUT:   %self.var: ref Class = var self
 // CHECK:STDOUT:   %self: ref Class = bind_name self, %self.var
 // CHECK:STDOUT:   %self.ref: ref Class = name_ref self, %self
-// CHECK:STDOUT:   %.loc36: Class = bind_value %self.ref
+// CHECK:STDOUT:   %.loc41: Class = bind_value %self.ref
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2[@WrongSelf.%self.loc40_8.2: Class]();
+// CHECK:STDOUT: fn @F.2[@WrongSelf.%self.loc45_8.2: Class]();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallWrongSelf(%ws: WrongSelf) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %ws.ref: WrongSelf = name_ref ws, %ws
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @WrongSelf.%F [template = @WrongSelf.%F]
-// CHECK:STDOUT:   %.loc50_5: <bound method> = bound_method %ws.ref, %F.ref
-// CHECK:STDOUT:   %.loc50_7: init () = call %.loc50_5(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc55_5: <bound method> = bound_method %ws.ref, %F.ref
+// CHECK:STDOUT:   %.loc55_7: init () = call %.loc55_5(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_self_type_member.carbon
+++ b/toolchain/check/testdata/class/fail_self_type_member.carbon
@@ -10,9 +10,10 @@ class Class {
 
 fn F() -> bool {
   var c1: Class = {.b = true};
-  // CHECK:STDERR: fail_self_type_member.carbon:[[@LINE+6]]:17: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_self_type_member.carbon:[[@LINE+7]]:17: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   var c2: Class.Self = c1;
   // CHECK:STDERR:                 ^~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_self_type_member.carbon:[[@LINE+3]]:17: ERROR: Semantics TODO: `Error recovery from keyword name.`.
   // CHECK:STDERR:   var c2: Class.Self = c1;
   // CHECK:STDERR:                 ^~~~

--- a/toolchain/check/testdata/class/fail_todo_generic.carbon
+++ b/toolchain/check/testdata/class/fail_todo_generic.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+6]]:1: ERROR: Semantics TODO: `generic class`.
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+7]]:1: ERROR: Semantics TODO: `generic class`.
 // CHECK:STDERR: class C[]();
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic class`.
 // CHECK:STDERR: class C[]();
 // CHECK:STDERR: ^~~~~~~~~~~~

--- a/toolchain/check/testdata/class/fail_todo_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_todo_generic_method.carbon
@@ -4,20 +4,22 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic class`.
+// CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE+4]]:1: ERROR: Semantics TODO: `generic class`.
 // CHECK:STDERR: class Class(T:! type) {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 class Class(T:! type) {
   var a: T;
   fn F[self: Self](n: T);
 }
 
-// CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE+9]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE+10]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE-8]]:1: Name is previously declared here.
 // CHECK:STDERR: class Class(T:! type) {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_todo_generic_method.carbon:[[@LINE+3]]:19: ERROR: `fn` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDERR:                   ^
@@ -36,34 +38,34 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:     .Class = %Class.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {
-// CHECK:STDOUT:     %T.loc10_13.1: type = param T
-// CHECK:STDOUT:     %T.loc10_13.2: type = bind_symbolic_name T, %T.loc10_13.1 [symbolic]
+// CHECK:STDOUT:     %T.loc11_13.1: type = param T
+// CHECK:STDOUT:     %T.loc11_13.2: type = bind_symbolic_name T, %T.loc11_13.1 [symbolic]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc24: <function> = fn_decl @.1 [template] {
-// CHECK:STDOUT:     %T.loc24_10.1: type = param T
-// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T, %T.loc24_10.1 [symbolic]
+// CHECK:STDOUT:   %.loc26: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %T.loc26_10.1: type = param T
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T, %T.loc26_10.1 [symbolic]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %T.ref.loc11: type = name_ref T, file.%T.loc10_13.2 [symbolic = file.%T.loc10_13.2]
-// CHECK:STDOUT:   %.loc11: <unbound element of class Class> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %T.ref.loc12: type = name_ref T, file.%T.loc11_13.2 [symbolic = file.%T.loc11_13.2]
+// CHECK:STDOUT:   %.loc12: <unbound element of class Class> = field_decl a, element0 [template]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Class [template = constants.%Class]
-// CHECK:STDOUT:     %self.loc12_8.1: Class = param self
-// CHECK:STDOUT:     %self.loc12_8.2: Class = bind_name self, %self.loc12_8.1
-// CHECK:STDOUT:     %T.ref.loc12: type = name_ref T, file.%T.loc10_13.2 [symbolic = file.%T.loc10_13.2]
-// CHECK:STDOUT:     %n.loc12_20.1: T = param n
-// CHECK:STDOUT:     %n.loc12_20.2: T = bind_name n, %n.loc12_20.1
+// CHECK:STDOUT:     %self.loc13_8.1: Class = param self
+// CHECK:STDOUT:     %self.loc13_8.2: Class = bind_name self, %self.loc13_8.1
+// CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, file.%T.loc11_13.2 [symbolic = file.%T.loc11_13.2]
+// CHECK:STDOUT:     %n.loc13_20.1: T = param n
+// CHECK:STDOUT:     %n.loc13_20.2: T = bind_name n, %n.loc13_20.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
-// CHECK:STDOUT:   .a = %.loc11
+// CHECK:STDOUT:   .a = %.loc12
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F[@Class.%self.loc12_8.2: Class](@Class.%n.loc12_20.2: T);
+// CHECK:STDOUT: fn @F[@Class.%self.loc13_8.2: Class](@Class.%n.loc13_20.2: T);
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1(%T: type);
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/class/fail_todo_modifiers.carbon
@@ -6,50 +6,58 @@
 
 class Access {
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `access modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `access modifier`.
   // CHECK:STDERR:   private fn F();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   private fn F();
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `access modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `access modifier`.
   // CHECK:STDERR:   protected fn G();
   // CHECK:STDERR:   ^~~~~~~~~
+  // CHECK:STDERR:
   protected fn G();
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `access modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `access modifier`.
   // CHECK:STDERR:   private var k: i32;
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   private var k: i32;
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `access modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `access modifier`.
   // CHECK:STDERR:   protected var l: i32;
   // CHECK:STDERR:   ^~~~~~~~~
+  // CHECK:STDERR:
   protected var l: i32;
 }
 
 base class Base {
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `method modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `method modifier`.
   // CHECK:STDERR:   virtual fn H();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   virtual fn H();
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `method modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `method modifier`.
   // CHECK:STDERR:   impl fn I();
   // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR:
   impl fn I();
 }
 
 abstract class Abstract {
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `method modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `method modifier`.
   // CHECK:STDERR:   abstract fn J();
   // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:
   abstract fn J();
 
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `method modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `method modifier`.
   // CHECK:STDERR:   virtual fn K();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   virtual fn K();
 
   // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `method modifier`.
@@ -83,15 +91,15 @@ abstract class Abstract {
 // CHECK:STDOUT: class @Access {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {}
-// CHECK:STDOUT:   %.loc22: <unbound element of class Access> = field_decl k, element0 [template]
-// CHECK:STDOUT:   %.loc27: <unbound element of class Access> = field_decl l, element1 [template]
+// CHECK:STDOUT:   %.loc25: <unbound element of class Access> = field_decl k, element0 [template]
+// CHECK:STDOUT:   %.loc31: <unbound element of class Access> = field_decl l, element1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Access
 // CHECK:STDOUT:   .F = %F
 // CHECK:STDOUT:   .G = %G
-// CHECK:STDOUT:   .k = %.loc22
-// CHECK:STDOUT:   .l = %.loc27
+// CHECK:STDOUT:   .k = %.loc25
+// CHECK:STDOUT:   .l = %.loc31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Base {

--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -7,9 +7,10 @@
 class Class {
   var field: i32;
   fn F() -> i32 {
-    // CHECK:STDERR: fail_unbound_field.carbon:[[@LINE+3]]:12: ERROR: Expression cannot be used as a value.
+    // CHECK:STDERR: fail_unbound_field.carbon:[[@LINE+4]]:12: ERROR: Expression cannot be used as a value.
     // CHECK:STDERR:     return field;
     // CHECK:STDERR:            ^~~~~
+    // CHECK:STDERR:
     return field;
   }
 }

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_collapse.carbon:[[@LINE+3]]:9: `const` applied repeatedly to the same type has no additional effect.
+// CHECK:STDERR: fail_collapse.carbon:[[@LINE+4]]:9: `const` applied repeatedly to the same type has no additional effect.
 // CHECK:STDERR: fn G(p: const (const i32)**) -> i32** {
 // CHECK:STDERR:         ^~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn G(p: const (const i32)**) -> i32** {
   // CHECK:STDERR: fail_collapse.carbon:[[@LINE+3]]:3: ERROR: Cannot implicitly convert from `const i32**` to `i32**`.
   // CHECK:STDERR:   return p;
@@ -29,14 +30,14 @@ fn G(p: const (const i32)**) -> i32** {
 // CHECK:STDOUT:     .G = %G
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %.loc10_16: type = const_type i32 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc10_9: type = const_type const i32 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc10_26: type = ptr_type const i32 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc10_27: type = ptr_type const i32* [template = constants.%.3]
-// CHECK:STDOUT:     %p.loc10_6.1: const i32** = param p
-// CHECK:STDOUT:     @G.%p: const i32** = bind_name p, %p.loc10_6.1
-// CHECK:STDOUT:     %.loc10_36: type = ptr_type i32 [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_37: type = ptr_type i32* [template = constants.%.5]
+// CHECK:STDOUT:     %.loc11_16: type = const_type i32 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_9: type = const_type const i32 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_26: type = ptr_type const i32 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc11_27: type = ptr_type const i32* [template = constants.%.3]
+// CHECK:STDOUT:     %p.loc11_6.1: const i32** = param p
+// CHECK:STDOUT:     @G.%p: const i32** = bind_name p, %p.loc11_6.1
+// CHECK:STDOUT:     %.loc11_36: type = ptr_type i32 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc11_37: type = ptr_type i32* [template = constants.%.5]
 // CHECK:STDOUT:     %return.var: ref i32** = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/builtin/fail_redefined.carbon
+++ b/toolchain/check/testdata/function/builtin/fail_redefined.carbon
@@ -5,21 +5,23 @@
 // AUTOUPDATE
 
 fn A(n: i32, m: i32) -> i32 = "int.add";
-// CHECK:STDERR: fail_redefined.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function A.
+// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of function A.
 // CHECK:STDERR: fn A(n: i32, m: i32) -> i32 { return n; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefined.carbon:[[@LINE-4]]:1: Previously defined here.
 // CHECK:STDERR: fn A(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn A(n: i32, m: i32) -> i32 { return n; }
 
 fn B(n: i32, m: i32) -> i32 { return n; }
-// CHECK:STDERR: fail_redefined.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function B.
+// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of function B.
 // CHECK:STDERR: fn B(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefined.carbon:[[@LINE-4]]:1: Previously defined here.
 // CHECK:STDERR: fn B(n: i32, m: i32) -> i32 { return n; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn B(n: i32, m: i32) -> i32 = "int.add";
 
 fn C(n: i32, m: i32) -> i32 = "int.add";
@@ -36,8 +38,8 @@ fn C(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.loc7
-// CHECK:STDOUT:     .B = %B.loc16
-// CHECK:STDOUT:     .C = %C.loc25
+// CHECK:STDOUT:     .B = %B.loc17
+// CHECK:STDOUT:     .C = %C.loc27
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A [template] {
 // CHECK:STDOUT:     %n.loc7_6.1: i32 = param n
@@ -46,46 +48,46 @@ fn C(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDOUT:     @A.%m: i32 = bind_name m, %m.loc7_14.1
 // CHECK:STDOUT:     %return.var.loc7: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %A.loc14: <function> = fn_decl @A [template] {
-// CHECK:STDOUT:     %n.loc14_6.1: i32 = param n
-// CHECK:STDOUT:     %n.loc14_6.2: i32 = bind_name n, %n.loc14_6.1
-// CHECK:STDOUT:     %m.loc14_14.1: i32 = param m
-// CHECK:STDOUT:     %m.loc14_14.2: i32 = bind_name m, %m.loc14_14.1
-// CHECK:STDOUT:     %return.var.loc14: ref i32 = var <return slot>
+// CHECK:STDOUT:   %A.loc15: <function> = fn_decl @A [template] {
+// CHECK:STDOUT:     %n.loc15_6.1: i32 = param n
+// CHECK:STDOUT:     %n.loc15_6.2: i32 = bind_name n, %n.loc15_6.1
+// CHECK:STDOUT:     %m.loc15_14.1: i32 = param m
+// CHECK:STDOUT:     %m.loc15_14.2: i32 = bind_name m, %m.loc15_14.1
+// CHECK:STDOUT:     %return.var.loc15: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.loc16: <function> = fn_decl @B [template] {
-// CHECK:STDOUT:     %n.loc16_6.1: i32 = param n
-// CHECK:STDOUT:     @B.%n: i32 = bind_name n, %n.loc16_6.1
-// CHECK:STDOUT:     %m.loc16_14.1: i32 = param m
-// CHECK:STDOUT:     @B.%m: i32 = bind_name m, %m.loc16_14.1
-// CHECK:STDOUT:     %return.var.loc16: ref i32 = var <return slot>
+// CHECK:STDOUT:   %B.loc17: <function> = fn_decl @B [template] {
+// CHECK:STDOUT:     %n.loc17_6.1: i32 = param n
+// CHECK:STDOUT:     @B.%n: i32 = bind_name n, %n.loc17_6.1
+// CHECK:STDOUT:     %m.loc17_14.1: i32 = param m
+// CHECK:STDOUT:     @B.%m: i32 = bind_name m, %m.loc17_14.1
+// CHECK:STDOUT:     %return.var.loc17: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.loc23: <function> = fn_decl @B [template] {
-// CHECK:STDOUT:     %n.loc23_6.1: i32 = param n
-// CHECK:STDOUT:     %n.loc23_6.2: i32 = bind_name n, %n.loc23_6.1
-// CHECK:STDOUT:     %m.loc23_14.1: i32 = param m
-// CHECK:STDOUT:     %m.loc23_14.2: i32 = bind_name m, %m.loc23_14.1
-// CHECK:STDOUT:     %return.var.loc23: ref i32 = var <return slot>
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.loc25: <function> = fn_decl @C [template] {
+// CHECK:STDOUT:   %B.loc25: <function> = fn_decl @B [template] {
 // CHECK:STDOUT:     %n.loc25_6.1: i32 = param n
-// CHECK:STDOUT:     @C.%n: i32 = bind_name n, %n.loc25_6.1
+// CHECK:STDOUT:     %n.loc25_6.2: i32 = bind_name n, %n.loc25_6.1
 // CHECK:STDOUT:     %m.loc25_14.1: i32 = param m
-// CHECK:STDOUT:     @C.%m: i32 = bind_name m, %m.loc25_14.1
+// CHECK:STDOUT:     %m.loc25_14.2: i32 = bind_name m, %m.loc25_14.1
 // CHECK:STDOUT:     %return.var.loc25: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %C.loc32: <function> = fn_decl @C [template] {
-// CHECK:STDOUT:     %n.loc32_6.1: i32 = param n
-// CHECK:STDOUT:     %n.loc32_6.2: i32 = bind_name n, %n.loc32_6.1
-// CHECK:STDOUT:     %m.loc32_14.1: i32 = param m
-// CHECK:STDOUT:     %m.loc32_14.2: i32 = bind_name m, %m.loc32_14.1
-// CHECK:STDOUT:     %return.var.loc32: ref i32 = var <return slot>
+// CHECK:STDOUT:   %C.loc27: <function> = fn_decl @C [template] {
+// CHECK:STDOUT:     %n.loc27_6.1: i32 = param n
+// CHECK:STDOUT:     @C.%n: i32 = bind_name n, %n.loc27_6.1
+// CHECK:STDOUT:     %m.loc27_14.1: i32 = param m
+// CHECK:STDOUT:     @C.%m: i32 = bind_name m, %m.loc27_14.1
+// CHECK:STDOUT:     %return.var.loc27: ref i32 = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %C.loc34: <function> = fn_decl @C [template] {
+// CHECK:STDOUT:     %n.loc34_6.1: i32 = param n
+// CHECK:STDOUT:     %n.loc34_6.2: i32 = bind_name n, %n.loc34_6.1
+// CHECK:STDOUT:     %m.loc34_14.1: i32 = param m
+// CHECK:STDOUT:     %m.loc34_14.2: i32 = bind_name m, %m.loc34_14.1
+// CHECK:STDOUT:     %return.var.loc34: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A(%n: i32, %m: i32) -> i32 = "int.add" {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref: i32 = name_ref n, file.%n.loc14_6.2
+// CHECK:STDOUT:   %n.ref: i32 = name_ref n, file.%n.loc15_6.2
 // CHECK:STDOUT:   return %n.ref
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/fail_param_count.carbon
+++ b/toolchain/check/testdata/function/call/fail_param_count.carbon
@@ -9,47 +9,52 @@ fn Run1(a: i32) {}
 fn Run2(a: i32, b: i32) {}
 
 fn Main() {
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 1 argument(s) passed to function expecting 0 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+7]]:3: ERROR: 1 argument(s) passed to function expecting 0 argument(s).
   // CHECK:STDERR:   Run0(1);
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE-8]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run0() {}
   // CHECK:STDERR: ^~~~~~~~~~~
+  // CHECK:STDERR:
   Run0(1);
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 2 argument(s) passed to function expecting 0 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+7]]:3: ERROR: 2 argument(s) passed to function expecting 0 argument(s).
   // CHECK:STDERR:   Run0(0, 1);
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-15]]:1: Calling function declared here.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-16]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run0() {}
   // CHECK:STDERR: ^~~~~~~~~~~
+  // CHECK:STDERR:
   Run0(0, 1);
 
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 0 argument(s) passed to function expecting 1 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+7]]:3: ERROR: 0 argument(s) passed to function expecting 1 argument(s).
   // CHECK:STDERR:   Run1();
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-22]]:1: Calling function declared here.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-24]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run1(a: i32) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Run1();
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 2 argument(s) passed to function expecting 1 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+7]]:3: ERROR: 2 argument(s) passed to function expecting 1 argument(s).
   // CHECK:STDERR:   Run1(0, 1);
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-29]]:1: Calling function declared here.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-32]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run1(a: i32) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Run1(0, 1);
 
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 0 argument(s) passed to function expecting 2 argument(s).
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE+7]]:3: ERROR: 0 argument(s) passed to function expecting 2 argument(s).
   // CHECK:STDERR:   Run2();
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-36]]:1: Calling function declared here.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-40]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run2(a: i32, b: i32) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Run2();
   // CHECK:STDERR: fail_param_count.carbon:[[@LINE+6]]:3: ERROR: 1 argument(s) passed to function expecting 2 argument(s).
   // CHECK:STDERR:   Run2(0);
   // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-43]]:1: Calling function declared here.
+  // CHECK:STDERR: fail_param_count.carbon:[[@LINE-48]]:1: Calling function declared here.
   // CHECK:STDERR: fn Run2(a: i32, b: i32) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   Run2(0);
@@ -101,24 +106,24 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Run0.ref.loc18: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
-// CHECK:STDOUT:   %.loc18_8: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc18_7: init () = call %Run0.ref.loc18(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Run0.ref.loc25: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
-// CHECK:STDOUT:   %.loc25_8: i32 = int_literal 0 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc25_11: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc25_7: init () = call %Run0.ref.loc25(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Run1.ref.loc33: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
-// CHECK:STDOUT:   %.loc33: init () = call %Run1.ref.loc33(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Run1.ref.loc40: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
-// CHECK:STDOUT:   %.loc40_8: i32 = int_literal 0 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc40_11: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc40_7: init () = call %Run1.ref.loc40(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Run2.ref.loc48: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
-// CHECK:STDOUT:   %.loc48: init () = call %Run2.ref.loc48(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %Run2.ref.loc55: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
-// CHECK:STDOUT:   %.loc55_8: i32 = int_literal 0 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc55_7: init () = call %Run2.ref.loc55(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run0.ref.loc19: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
+// CHECK:STDOUT:   %.loc19_8: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc19_7: init () = call %Run0.ref.loc19(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run0.ref.loc27: <function> = name_ref Run0, file.%Run0 [template = file.%Run0]
+// CHECK:STDOUT:   %.loc27_8: i32 = int_literal 0 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc27_11: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc27_7: init () = call %Run0.ref.loc27(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run1.ref.loc36: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
+// CHECK:STDOUT:   %.loc36: init () = call %Run1.ref.loc36(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run1.ref.loc44: <function> = name_ref Run1, file.%Run1 [template = file.%Run1]
+// CHECK:STDOUT:   %.loc44_8: i32 = int_literal 0 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc44_11: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc44_7: init () = call %Run1.ref.loc44(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run2.ref.loc53: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
+// CHECK:STDOUT:   %.loc53: init () = call %Run2.ref.loc53(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %Run2.ref.loc60: <function> = name_ref Run2, file.%Run2 [template = file.%Run2]
+// CHECK:STDOUT:   %.loc60_8: i32 = int_literal 0 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc60_7: init () = call %Run2.ref.loc60(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/extern.carbon
+++ b/toolchain/check/testdata/function/declaration/extern.carbon
@@ -15,12 +15,13 @@ extern fn F();
 library "redecl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function F.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 extern fn F();
 
 // --- fail_redecl_extern.carbon
@@ -28,20 +29,22 @@ extern fn F();
 library "redecl_extern" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function F.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn F();
 
 // --- fail_member_extern.carbon
 
 class C {
-  // CHECK:STDERR: fail_member_extern.carbon:[[@LINE+3]]:3: ERROR: `extern` not allowed on `fn` declaration that is a member.
+  // CHECK:STDERR: fail_member_extern.carbon:[[@LINE+4]]:3: ERROR: `extern` not allowed on `fn` declaration that is a member.
   // CHECK:STDERR:   extern fn F();
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   extern fn F();
   // CHECK:STDERR: fail_member_extern.carbon:[[@LINE+3]]:3: ERROR: `extern` not allowed on `fn` declaration that is a member.
   // CHECK:STDERR:   extern fn G[self: Self]();
@@ -67,7 +70,7 @@ class C {
 // CHECK:STDOUT:     .F = %F.loc4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.loc4: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %F.loc11: <function> = fn_decl @F [template] {}
+// CHECK:STDOUT:   %F.loc12: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -79,7 +82,7 @@ class C {
 // CHECK:STDOUT:     .F = %F.loc4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.loc4: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %F.loc11: <function> = fn_decl @F [template] {}
+// CHECK:STDOUT:   %F.loc12: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -102,8 +105,8 @@ class C {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%C [template = constants.%C]
-// CHECK:STDOUT:     %self.loc10_15.1: C = param self
-// CHECK:STDOUT:     %self.loc10_15.2: C = bind_name self, %self.loc10_15.1
+// CHECK:STDOUT:     %self.loc11_15.1: C = param self
+// CHECK:STDOUT:     %self.loc11_15.2: C = bind_name self, %self.loc11_15.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -114,5 +117,5 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G[@C.%self.loc10_15.2: C]();
+// CHECK:STDOUT: fn @G[@C.%self.loc11_15.2: C]();
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/fail_modifiers.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_modifiers.carbon
@@ -4,75 +4,88 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `default` not allowed on `fn` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `default` not allowed on `fn` declaration outside of an interface.
 // CHECK:STDERR: default protected fn WrongOrder();
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `protected` must appear before `default`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `protected` must appear before `default`.
 // CHECK:STDERR: default protected fn WrongOrder();
 // CHECK:STDERR:         ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `default` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `default` previously appeared here.
 // CHECK:STDERR: default protected fn WrongOrder();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default protected fn WrongOrder();
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `virtual` not allowed on `fn` declaration outside of a class.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `virtual` not allowed on `fn` declaration outside of a class.
 // CHECK:STDERR: virtual virtual fn DuplicateVirtual() {}
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `virtual` repeated on declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `virtual` repeated on declaration.
 // CHECK:STDERR: virtual virtual fn DuplicateVirtual() {}
 // CHECK:STDERR:         ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `virtual` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `virtual` previously appeared here.
 // CHECK:STDERR: virtual virtual fn DuplicateVirtual() {}
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 virtual virtual fn DuplicateVirtual() {}
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: Semantics TODO: `access modifier`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: Semantics TODO: `access modifier`.
 // CHECK:STDERR: private protected fn TwoAccess();
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `protected` not allowed on declaration with `private`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `protected` not allowed on declaration with `private`.
 // CHECK:STDERR: private protected fn TwoAccess();
 // CHECK:STDERR:         ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `private` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `private` previously appeared here.
 // CHECK:STDERR: private protected fn TwoAccess();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 private protected fn TwoAccess();
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `abstract` not allowed on `fn` declaration outside of a class.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `abstract` not allowed on `fn` declaration outside of a class.
 // CHECK:STDERR: abstract virtual fn ModifiersConflict() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:10: ERROR: `virtual` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:10: ERROR: `virtual` not allowed on declaration with `abstract`.
 // CHECK:STDERR: abstract virtual fn ModifiersConflict() {}
 // CHECK:STDERR:          ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `abstract` previously appeared here.
 // CHECK:STDERR: abstract virtual fn ModifiersConflict() {}
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract virtual fn ModifiersConflict() {}
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `base` not allowed on `fn` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `base` not allowed on `fn` declaration.
 // CHECK:STDERR: base fn InvalidModifier();
 // CHECK:STDERR: ^~~~
+// CHECK:STDERR:
 base fn InvalidModifier();
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+15]]:1: ERROR: `default` not allowed on `fn` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+18]]:1: ERROR: `default` not allowed on `fn` declaration outside of an interface.
 // CHECK:STDERR: default final virtual fn ModifiersConflict2() {}
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+12]]:9: ERROR: `final` not allowed on declaration with `default`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+14]]:9: ERROR: `final` not allowed on declaration with `default`.
 // CHECK:STDERR: default final virtual fn ModifiersConflict2() {}
 // CHECK:STDERR:         ^~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: `default` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: `default` previously appeared here.
 // CHECK:STDERR: default final virtual fn ModifiersConflict2() {}
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:15: ERROR: `virtual` not allowed on declaration with `default`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:15: ERROR: `virtual` not allowed on declaration with `default`.
 // CHECK:STDERR: default final virtual fn ModifiersConflict2() {}
 // CHECK:STDERR:               ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `default` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `default` previously appeared here.
 // CHECK:STDERR: default final virtual fn ModifiersConflict2() {}
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default final virtual fn ModifiersConflict2() {}
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `extern` not allowed on `fn` declaration that provides a definition.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+10]]:1: ERROR: `extern` not allowed on `fn` declaration that provides a definition.
 // CHECK:STDERR: extern private fn ExternOrderAndConflict() {}
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:8: ERROR: `private` must appear before `extern`.
 // CHECK:STDERR: extern private fn ExternOrderAndConflict() {}
 // CHECK:STDERR:        ^~~~~~~

--- a/toolchain/check/testdata/function/declaration/fail_redecl.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_redecl.carbon
@@ -5,39 +5,43 @@
 // AUTOUPDATE
 
 fn A();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function A.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function A.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 fn A();
 
 fn B(x: i32);
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function B.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function B.
 // CHECK:STDERR: fn B(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: fn B(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 fn B(x: i32);
 
 fn C();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Function redeclaration differs because of parameter count of 1.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because of parameter count of 1.
 // CHECK:STDERR: fn C(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared with parameter count of 0.
 // CHECK:STDERR: fn C();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 fn C(x: i32);
 
 fn D() {}
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function D.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function D.
 // CHECK:STDERR: fn D();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: fn D() {}
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 fn D();
 
 fn E() {}
@@ -54,30 +58,30 @@ fn E() {}
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.loc7
-// CHECK:STDOUT:     .B = %B.loc16
+// CHECK:STDOUT:     .B = %B.loc17
 // CHECK:STDOUT:     .C = %C
-// CHECK:STDOUT:     .D = %D.loc34
-// CHECK:STDOUT:     .E = %E.loc43
+// CHECK:STDOUT:     .D = %D.loc37
+// CHECK:STDOUT:     .E = %E.loc47
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A [template] {}
-// CHECK:STDOUT:   %A.loc14: <function> = fn_decl @A [template] {}
-// CHECK:STDOUT:   %B.loc16: <function> = fn_decl @B [template] {
-// CHECK:STDOUT:     %x.loc16_6.1: i32 = param x
-// CHECK:STDOUT:     @B.%x: i32 = bind_name x, %x.loc16_6.1
+// CHECK:STDOUT:   %A.loc15: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT:   %B.loc17: <function> = fn_decl @B [template] {
+// CHECK:STDOUT:     %x.loc17_6.1: i32 = param x
+// CHECK:STDOUT:     @B.%x: i32 = bind_name x, %x.loc17_6.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %B.loc23: <function> = fn_decl @B [template] {
-// CHECK:STDOUT:     %x.loc23_6.1: i32 = param x
-// CHECK:STDOUT:     %x.loc23_6.2: i32 = bind_name x, %x.loc23_6.1
+// CHECK:STDOUT:   %B.loc25: <function> = fn_decl @B [template] {
+// CHECK:STDOUT:     %x.loc25_6.1: i32 = param x
+// CHECK:STDOUT:     %x.loc25_6.2: i32 = bind_name x, %x.loc25_6.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C: <function> = fn_decl @C [template] {}
-// CHECK:STDOUT:   %.loc32: <function> = fn_decl @.1 [template] {
-// CHECK:STDOUT:     %x.loc32_6.1: i32 = param x
-// CHECK:STDOUT:     @.1.%x: i32 = bind_name x, %x.loc32_6.1
+// CHECK:STDOUT:   %.loc35: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %x.loc35_6.1: i32 = param x
+// CHECK:STDOUT:     @.1.%x: i32 = bind_name x, %x.loc35_6.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %D.loc34: <function> = fn_decl @D [template] {}
-// CHECK:STDOUT:   %D.loc41: <function> = fn_decl @D [template] {}
-// CHECK:STDOUT:   %E.loc43: <function> = fn_decl @E [template] {}
-// CHECK:STDOUT:   %E.loc50: <function> = fn_decl @E [template] {}
+// CHECK:STDOUT:   %D.loc37: <function> = fn_decl @D [template] {}
+// CHECK:STDOUT:   %D.loc45: <function> = fn_decl @D [template] {}
+// CHECK:STDOUT:   %E.loc47: <function> = fn_decl @E [template] {}
+// CHECK:STDOUT:   %E.loc54: <function> = fn_decl @E [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A();
@@ -97,7 +101,7 @@ fn E() {}
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT:
-// CHECK:STDOUT: !.loc50:
+// CHECK:STDOUT: !.loc54:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/extern.carbon
+++ b/toolchain/check/testdata/function/definition/extern.carbon
@@ -8,9 +8,10 @@
 
 library "extern_def" api;
 
-// CHECK:STDERR: fail_extern_def.carbon:[[@LINE+3]]:1: ERROR: `extern` not allowed on `fn` declaration that provides a definition.
+// CHECK:STDERR: fail_extern_def.carbon:[[@LINE+4]]:1: ERROR: `extern` not allowed on `fn` declaration that provides a definition.
 // CHECK:STDERR: extern fn F() {}
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 extern fn F() {}
 
 // --- fail_def_for_extern_decl.carbon
@@ -18,12 +19,13 @@ extern fn F() {}
 library "def_for_extern_decl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+6]]:1: ERROR: Cannot define `extern` function `F`.
+// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+7]]:1: ERROR: Cannot define `extern` function `F`.
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE-4]]:1: Previously declared `extern` here.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn F() {}
 
 // --- fail_extern_decl_after_def.carbon
@@ -60,7 +62,7 @@ extern fn F();
 // CHECK:STDOUT:     .F = %F.loc4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.loc4: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %F.loc11: <function> = fn_decl @F [template] {}
+// CHECK:STDOUT:   %F.loc12: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {

--- a/toolchain/check/testdata/function/definition/fail_decl_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/definition/fail_decl_param_mismatch.carbon
@@ -5,48 +5,53 @@
 // AUTOUPDATE
 
 fn F();
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+6]]:1: ERROR: Function redeclaration differs because of parameter count of 1.
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because of parameter count of 1.
 // CHECK:STDERR: fn F(x: i32) {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE-4]]:1: Previously declared with parameter count of 0.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 fn F(x: i32) {}
 
 fn G(x: i32);
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+6]]:1: ERROR: Function redeclaration differs because of parameter count of 0.
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because of parameter count of 0.
 // CHECK:STDERR: fn G() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE-4]]:1: Previously declared with parameter count of 1.
 // CHECK:STDERR: fn G(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 fn G() {}
 
 fn H(x: i32);
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+6]]:6: ERROR: Function redeclaration differs at parameter 1.
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+7]]:6: ERROR: Function redeclaration differs at parameter 1.
 // CHECK:STDERR: fn H(x: bool) {}
 // CHECK:STDERR:      ^
 // CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE-4]]:6: Previous declaration's corresponding parameter here.
 // CHECK:STDERR: fn H(x: i32);
 // CHECK:STDERR:      ^
+// CHECK:STDERR:
 fn H(x: bool) {}
 
 fn I();
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+6]]:1: ERROR: Function redeclaration differs because return type is `i32`.
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because return type is `i32`.
 // CHECK:STDERR: fn I() -> i32 { return 0; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE-4]]:1: Previously declared with no return type.
 // CHECK:STDERR: fn I();
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 fn I() -> i32 { return 0; }
 
 fn J() -> i32;
-// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+6]]:1: ERROR: Function redeclaration differs because no return type is provided.
+// CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because no return type is provided.
 // CHECK:STDERR: fn J() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_decl_param_mismatch.carbon:[[@LINE-4]]:1: Previously declared with return type `i32`.
 // CHECK:STDERR: fn J() -> i32;
 // CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn J() {}
 
 fn K() -> i32;
@@ -75,36 +80,36 @@ fn K() -> bool { return false; }
 // CHECK:STDOUT:     .K = %K
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %.loc14: <function> = fn_decl @.1 [template] {
-// CHECK:STDOUT:     %x.loc14_6.1: i32 = param x
-// CHECK:STDOUT:     @.1.%x: i32 = bind_name x, %x.loc14_6.1
+// CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %x.loc15_6.1: i32 = param x
+// CHECK:STDOUT:     @.1.%x: i32 = bind_name x, %x.loc15_6.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %x.loc16_6.1: i32 = param x
-// CHECK:STDOUT:     @G.%x: i32 = bind_name x, %x.loc16_6.1
+// CHECK:STDOUT:     %x.loc17_6.1: i32 = param x
+// CHECK:STDOUT:     @G.%x: i32 = bind_name x, %x.loc17_6.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc23: <function> = fn_decl @.2 [template] {}
+// CHECK:STDOUT:   %.loc25: <function> = fn_decl @.2 [template] {}
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {
-// CHECK:STDOUT:     %x.loc25_6.1: i32 = param x
-// CHECK:STDOUT:     @H.%x: i32 = bind_name x, %x.loc25_6.1
+// CHECK:STDOUT:     %x.loc27_6.1: i32 = param x
+// CHECK:STDOUT:     @H.%x: i32 = bind_name x, %x.loc27_6.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc32: <function> = fn_decl @.3 [template] {
-// CHECK:STDOUT:     %x.loc32_6.1: bool = param x
-// CHECK:STDOUT:     @.3.%x: bool = bind_name x, %x.loc32_6.1
+// CHECK:STDOUT:   %.loc35: <function> = fn_decl @.3 [template] {
+// CHECK:STDOUT:     %x.loc35_6.1: bool = param x
+// CHECK:STDOUT:     @.3.%x: bool = bind_name x, %x.loc35_6.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I: <function> = fn_decl @I [template] {}
-// CHECK:STDOUT:   %.loc41: <function> = fn_decl @.4 [template] {
-// CHECK:STDOUT:     %return.var.loc41: ref i32 = var <return slot>
+// CHECK:STDOUT:   %.loc45: <function> = fn_decl @.4 [template] {
+// CHECK:STDOUT:     %return.var.loc45: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %J: <function> = fn_decl @J [template] {
-// CHECK:STDOUT:     %return.var.loc43: ref i32 = var <return slot>
+// CHECK:STDOUT:     %return.var.loc47: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc50: <function> = fn_decl @.5 [template] {}
+// CHECK:STDOUT:   %.loc55: <function> = fn_decl @.5 [template] {}
 // CHECK:STDOUT:   %K: <function> = fn_decl @K [template] {
-// CHECK:STDOUT:     %return.var.loc52: ref i32 = var <return slot>
+// CHECK:STDOUT:     %return.var.loc57: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc59: <function> = fn_decl @.6 [template] {
-// CHECK:STDOUT:     %return.var.loc59: ref bool = var <return slot>
+// CHECK:STDOUT:   %.loc64: <function> = fn_decl @.6 [template] {
+// CHECK:STDOUT:     %return.var.loc64: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -133,8 +138,8 @@ fn K() -> bool { return false; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.4() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc41: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   return %.loc41
+// CHECK:STDOUT:   %.loc45: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   return %.loc45
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @J() -> i32;
@@ -148,7 +153,7 @@ fn K() -> bool { return false; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.6() -> bool {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc59: bool = bool_literal false [template = constants.%.2]
-// CHECK:STDOUT:   return %.loc59
+// CHECK:STDOUT:   %.loc64: bool = bool_literal false [template = constants.%.2]
+// CHECK:STDOUT:   return %.loc64
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
+++ b/toolchain/check/testdata/if/fail_reachable_fallthrough.carbon
@@ -9,9 +9,10 @@ fn If1(b: bool) -> i32 {
     return 1;
   } else {
   }
-// CHECK:STDERR: fail_reachable_fallthrough.carbon:[[@LINE+3]]:1: ERROR: Missing `return` at end of function with declared return type.
+// CHECK:STDERR: fail_reachable_fallthrough.carbon:[[@LINE+4]]:1: ERROR: Missing `return` at end of function with declared return type.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 }
 
 fn If2(b: bool) -> i32 {
@@ -19,9 +20,10 @@ fn If2(b: bool) -> i32 {
   } else {
     return 2;
   }
-// CHECK:STDERR: fail_reachable_fallthrough.carbon:[[@LINE+3]]:1: ERROR: Missing `return` at end of function with declared return type.
+// CHECK:STDERR: fail_reachable_fallthrough.carbon:[[@LINE+4]]:1: ERROR: Missing `return` at end of function with declared return type.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 }
 
 fn If3(b: bool) -> i32 {
@@ -52,14 +54,14 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:     %return.var.loc7: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %If2: <function> = fn_decl @If2 [template] {
-// CHECK:STDOUT:     %b.loc17_8.1: bool = param b
-// CHECK:STDOUT:     @If2.%b: bool = bind_name b, %b.loc17_8.1
-// CHECK:STDOUT:     %return.var.loc17: ref i32 = var <return slot>
+// CHECK:STDOUT:     %b.loc18_8.1: bool = param b
+// CHECK:STDOUT:     @If2.%b: bool = bind_name b, %b.loc18_8.1
+// CHECK:STDOUT:     %return.var.loc18: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %If3: <function> = fn_decl @If3 [template] {
-// CHECK:STDOUT:     %b.loc27_8.1: bool = param b
-// CHECK:STDOUT:     @If3.%b: bool = bind_name b, %b.loc27_8.1
-// CHECK:STDOUT:     %return.var.loc27: ref i32 = var <return slot>
+// CHECK:STDOUT:     %b.loc29_8.1: bool = param b
+// CHECK:STDOUT:     @If3.%b: bool = bind_name b, %b.loc29_8.1
+// CHECK:STDOUT:     %return.var.loc29: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -87,8 +89,8 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   br !if.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   return %.loc20
+// CHECK:STDOUT:   %.loc21: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   return %.loc21
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.done:
 // CHECK:STDOUT: }
@@ -99,8 +101,8 @@ fn If3(b: bool) -> i32 {
 // CHECK:STDOUT:   if %b.ref br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
-// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   return %.loc29
+// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   return %.loc31
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
+++ b/toolchain/check/testdata/if_expr/fail_not_in_function.carbon
@@ -5,28 +5,34 @@
 // AUTOUPDATE
 
 // TODO: Should work with compile-time evaluation.
-// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+9]]:14: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+12]]:14: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: let x: i32 = if true then 1 else 0;
 // CHECK:STDERR:              ^~~~~~~
-// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+6]]:14: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+8]]:14: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: let x: i32 = if true then 1 else 0;
 // CHECK:STDERR:              ^~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+3]]:22: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+4]]:22: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: let x: i32 = if true then 1 else 0;
 // CHECK:STDERR:                      ^~~~~~
+// CHECK:STDERR:
 let x: i32 = if true then 1 else 0;
 
 class C {
   // TODO: Should work with compile-time evaluation.
-  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+12]]:10: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+15]]:10: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
   // CHECK:STDERR:   var n: if true then i32 else f64;
   // CHECK:STDERR:          ^~~~~~~
-  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+9]]:10: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+11]]:10: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
   // CHECK:STDERR:   var n: if true then i32 else f64;
   // CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+6]]:10: ERROR: Cannot evaluate type expression.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+7]]:10: ERROR: Cannot evaluate type expression.
   // CHECK:STDERR:   var n: if true then i32 else f64;
   // CHECK:STDERR:          ^~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_not_in_function.carbon:[[@LINE+3]]:18: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
   // CHECK:STDERR:   var n: if true then i32 else f64;
   // CHECK:STDERR:                  ^~~~~~~~
@@ -43,14 +49,14 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   %.loc17: i32 = block_arg <unexpected instblockref block6>
-// CHECK:STDOUT:   %x: i32 = bind_name x, %.loc17
+// CHECK:STDOUT:   %.loc20: i32 = block_arg <unexpected instblockref block6>
+// CHECK:STDOUT:   %x: i32 = bind_name x, %.loc20
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc33: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   if %.loc33 br !if.expr.then else br !if.expr.else
+// CHECK:STDOUT:   %.loc39: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   if %.loc39 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -4,20 +4,23 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic interface`.
+// CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+4]]:1: ERROR: Semantics TODO: `generic interface`.
 // CHECK:STDERR: interface GenericInterface(T:! type) {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 interface GenericInterface(T:! type) {
   fn F(x: T);
 }
 
 class C {
-  // CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+9]]:3: ERROR: Cannot `extend` a parameterized `impl`.
+  // CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+11]]:3: ERROR: Cannot `extend` a parameterized `impl`.
   // CHECK:STDERR:   extend impl forall [T:! type] as GenericInterface(T) {
   // CHECK:STDERR:   ^~~~~~
-  // CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+6]]:3: ERROR: Semantics TODO: `impl as non-interface`.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+7]]:3: ERROR: Semantics TODO: `impl as non-interface`.
   // CHECK:STDERR:   extend impl forall [T:! type] as GenericInterface(T) {
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_extend_impl_forall.carbon:[[@LINE+3]]:36: ERROR: Value of type `type` is not callable.
   // CHECK:STDERR:   extend impl forall [T:! type] as GenericInterface(T) {
   // CHECK:STDERR:                                    ^~~~~~~~~~~~~~~~~
@@ -42,8 +45,8 @@ class C {
 // CHECK:STDOUT:     .C = %C.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %GenericInterface.decl: type = interface_decl @GenericInterface [template = constants.%.1] {
-// CHECK:STDOUT:     %T.loc10_28.1: type = param T
-// CHECK:STDOUT:     %T.loc10_28.2: type = bind_symbolic_name T, %T.loc10_28.1 [symbolic]
+// CHECK:STDOUT:     %T.loc11_28.1: type = param T
+// CHECK:STDOUT:     %T.loc11_28.2: type = bind_symbolic_name T, %T.loc11_28.1 [symbolic]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT: }
@@ -51,23 +54,23 @@ class C {
 // CHECK:STDOUT: interface @GenericInterface {
 // CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, file.%T.loc10_28.2 [symbolic = file.%T.loc10_28.2]
-// CHECK:STDOUT:     %x.loc11_8.1: T = param x
-// CHECK:STDOUT:     %x.loc11_8.2: T = bind_name x, %x.loc11_8.1
+// CHECK:STDOUT:     %T.ref: type = name_ref T, file.%T.loc11_28.2 [symbolic = file.%T.loc11_28.2]
+// CHECK:STDOUT:     %x.loc12_8.1: T = param x
+// CHECK:STDOUT:     %x.loc12_8.2: T = bind_name x, %x.loc12_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc11: <associated <function> in GenericInterface> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12: <associated <function> in GenericInterface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc11
+// CHECK:STDOUT:   .F = %.loc12
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as <error> {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, @C.%T.loc24_23.2 [symbolic = @C.%T.loc24_23.2]
-// CHECK:STDOUT:     %x.loc25_10.1: T = param x
-// CHECK:STDOUT:     %x.loc25_10.2: T = bind_name x, %x.loc25_10.1
+// CHECK:STDOUT:     %T.ref: type = name_ref T, @C.%T.loc27_23.2 [symbolic = @C.%T.loc27_23.2]
+// CHECK:STDOUT:     %x.loc28_10.1: T = param x
+// CHECK:STDOUT:     %x.loc28_10.2: T = bind_name x, %x.loc28_10.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -77,10 +80,10 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   impl_decl @impl {
-// CHECK:STDOUT:     %T.loc24_23.1: type = param T
-// CHECK:STDOUT:     %T.loc24_23.2: type = bind_symbolic_name T, %T.loc24_23.1 [symbolic]
+// CHECK:STDOUT:     %T.loc27_23.1: type = param T
+// CHECK:STDOUT:     %T.loc27_23.2: type = bind_symbolic_name T, %T.loc27_23.1 [symbolic]
 // CHECK:STDOUT:     %GenericInterface.ref: type = name_ref GenericInterface, file.%GenericInterface.decl [template = constants.%.1]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc24_23.2 [symbolic = %T.loc24_23.2]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc27_23.2 [symbolic = %T.loc27_23.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -88,9 +91,9 @@ class C {
 // CHECK:STDOUT:   has_error
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.1(@GenericInterface.%x.loc11_8.2: T);
+// CHECK:STDOUT: fn @F.1(@GenericInterface.%x.loc12_8.2: T);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2(@impl.%x.loc25_10.2: T) {
+// CHECK:STDOUT: fn @F.2(@impl.%x.loc28_10.2: T) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
@@ -7,19 +7,21 @@
 interface I {}
 
 class C {
-  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+3]]:3: ERROR: Cannot `extend` an `impl` with an explicit self type.
+  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+4]]:3: ERROR: Cannot `extend` an `impl` with an explicit self type.
   // CHECK:STDERR:   extend impl i32 as I {}
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   extend impl i32 as I {}
 }
 
 class D {
-  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+6]]:3: ERROR: Cannot `extend` an `impl` with an explicit self type.
+  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+7]]:3: ERROR: Cannot `extend` an `impl` with an explicit self type.
   // CHECK:STDERR:   extend impl D as I;
   // CHECK:STDERR:   ^~~~~~
-  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+3]]:15: Remove the explicit `Self` type here.
+  // CHECK:STDERR: fail_extend_impl_type_as.carbon:[[@LINE+4]]:15: Remove the explicit `Self` type here.
   // CHECK:STDERR:   extend impl D as I;
   // CHECK:STDERR:               ^
+  // CHECK:STDERR:
   extend impl D as I;
 }
 

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -7,23 +7,25 @@
 interface I { fn F(); }
 
 class NoF {
-  // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:3: ERROR: Missing implementation of F in impl of interface I.
+  // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:3: ERROR: Missing implementation of F in impl of interface I.
   // CHECK:STDERR:   impl as I {}
   // CHECK:STDERR:   ^~~~~~~~~~~
   // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-6]]:15: Associated function F declared here.
   // CHECK:STDERR: interface I { fn F(); }
   // CHECK:STDERR:               ^~~~~~~
+  // CHECK:STDERR:
   impl as I {}
 }
 
 class FNotFunction {
   impl as I {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Associated function F implemented by non-function.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Associated function F implemented by non-function.
     // CHECK:STDERR:     class F;
     // CHECK:STDERR:     ^~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-17]]:15: Associated function F declared here.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-18]]:15: Associated function F declared here.
     // CHECK:STDERR: interface I { fn F(); }
     // CHECK:STDERR:               ^~~~~~~
+    // CHECK:STDERR:
     class F;
   }
 }
@@ -33,36 +35,39 @@ fn PossiblyF();
 // TODO: Should this be permitted?
 class FAlias {
   impl as I {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:11: ERROR: Associated function F implemented by non-function.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:11: ERROR: Associated function F implemented by non-function.
     // CHECK:STDERR:     alias F = PossiblyF;
     // CHECK:STDERR:           ^
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-32]]:15: Associated function F declared here.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-34]]:15: Associated function F declared here.
     // CHECK:STDERR: interface I { fn F(); }
     // CHECK:STDERR:               ^~~~~~~
+    // CHECK:STDERR:
     alias F = PossiblyF;
   }
 }
 
 class FExtraParam {
   impl as I {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of parameter count of 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because of parameter count of 1.
     // CHECK:STDERR:     fn F(b: bool);
     // CHECK:STDERR:     ^~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-44]]:15: Previously declared with parameter count of 0.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-47]]:15: Previously declared with parameter count of 0.
     // CHECK:STDERR: interface I { fn F(); }
     // CHECK:STDERR:               ^~~~~~~
+    // CHECK:STDERR:
     fn F(b: bool);
   }
 }
 
 class FExtraImplicitParam {
   impl as I {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 1.
     // CHECK:STDERR:     fn F[self: Self]();
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-56]]:15: Previously declared with implicit parameter count of 0.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-60]]:15: Previously declared with implicit parameter count of 0.
     // CHECK:STDERR: interface I { fn F(); }
     // CHECK:STDERR:               ^~~~~~~
+    // CHECK:STDERR:
     fn F[self: Self]();
   }
 }
@@ -70,12 +75,13 @@ class FExtraImplicitParam {
 // TODO: Should this be permitted?
 class FExtraReturnType {
   impl as I {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `bool`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because return type is `bool`.
     // CHECK:STDERR:     fn F() -> bool;
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-69]]:15: Previously declared with no return type.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-74]]:15: Previously declared with no return type.
     // CHECK:STDERR: interface I { fn F(); }
     // CHECK:STDERR:               ^~~~~~~
+    // CHECK:STDERR:
     fn F() -> bool;
   }
 }
@@ -84,72 +90,78 @@ interface J { fn F[self: bool](b: bool) -> bool; }
 
 class FMissingParam {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of parameter count of 0.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because of parameter count of 0.
     // CHECK:STDERR:     fn F[self: bool]() -> bool;
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
     // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-7]]:15: Previously declared with parameter count of 1.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     fn F[self: bool]() -> bool;
   }
 }
 
 class FMissingImplicitParam {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 0.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because of implicit parameter count of 0.
     // CHECK:STDERR:     fn F(b: bool) -> bool;
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-19]]:15: Previously declared with implicit parameter count of 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-20]]:15: Previously declared with implicit parameter count of 1.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     fn F(b: bool) -> bool;
   }
 }
 
 class FMissingReturnType {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because no return type is provided.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:5: ERROR: Function redeclaration differs because no return type is provided.
     // CHECK:STDERR:     fn F[self: bool](b: bool);
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-31]]:15: Previously declared with return type `bool`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-33]]:15: Previously declared with return type `bool`.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     fn F[self: bool](b: bool);
   }
 }
 
 class FDifferentParamType {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:22: ERROR: Function redeclaration differs at parameter 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:22: ERROR: Function redeclaration differs at parameter 1.
     // CHECK:STDERR:     fn F[self: bool](b: Self) -> bool;
     // CHECK:STDERR:                      ^
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-43]]:32: Previous declaration's corresponding parameter here.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-46]]:32: Previous declaration's corresponding parameter here.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:                                ^
+    // CHECK:STDERR:
     fn F[self: bool](b: Self) -> bool;
   }
 }
 
 class FDifferentImplicitParamType {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:10: ERROR: Function redeclaration differs at implicit parameter 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:10: ERROR: Function redeclaration differs at implicit parameter 1.
     // CHECK:STDERR:     fn F[self: Self](b: bool) -> bool;
     // CHECK:STDERR:          ^~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-55]]:20: Previous declaration's corresponding implicit parameter here.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-59]]:20: Previous declaration's corresponding implicit parameter here.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:                    ^~~~
+    // CHECK:STDERR:
     fn F[self: Self](b: bool) -> bool;
   }
 }
 
 class FDifferentReturnType {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:31: ERROR: Function returns incomplete type `FDifferentReturnType`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:31: ERROR: Function returns incomplete type `FDifferentReturnType`.
     // CHECK:STDERR:     fn F[self: bool](b: bool) -> Self;
     // CHECK:STDERR:                               ^~~~~~~
     // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
     // CHECK:STDERR: class FDifferentReturnType {
     // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     fn F[self: bool](b: bool) -> Self;
   }
 }
@@ -157,12 +169,13 @@ class FDifferentReturnType {
 // TODO: This should probably be permitted.
 class FDifferentParamName {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:22: ERROR: Function redeclaration differs at parameter 1.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:22: ERROR: Function redeclaration differs at parameter 1.
     // CHECK:STDERR:     fn F[self: bool](not_b: bool) -> bool;
     // CHECK:STDERR:                      ^~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-80]]:32: Previous declaration's corresponding parameter here.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-86]]:32: Previous declaration's corresponding parameter here.
     // CHECK:STDERR: interface J { fn F[self: bool](b: bool) -> bool; }
     // CHECK:STDERR:                                ^
+    // CHECK:STDERR:
     fn F[self: bool](not_b: bool) -> bool;
   }
 }
@@ -173,12 +186,13 @@ interface SelfNested {
 
 class SelfNestedBadParam {
   impl as SelfNested {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:56: ERROR: Function returns incomplete type `[SelfNestedBadParam; 4]`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+7]]:56: ERROR: Function returns incomplete type `[SelfNestedBadParam; 4]`.
     // CHECK:STDERR:     fn F(x: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> [SelfNestedBadParam; 4];
     // CHECK:STDERR:                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
     // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-5]]:1: Class is incomplete within its definition.
     // CHECK:STDERR: class SelfNestedBadParam {
     // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+    // CHECK:STDERR:
     fn F(x: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> [SelfNestedBadParam; 4];
   }
 }
@@ -188,7 +202,7 @@ class SelfNestedBadReturnType {
     // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+6]]:5: ERROR: Function redeclaration differs because return type is `[SelfNestedBadParam; 4]`.
     // CHECK:STDERR:     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-20]]:3: Previously declared with return type `[SelfNestedBadReturnType; 4]`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE-21]]:3: Previously declared with return type `[SelfNestedBadReturnType; 4]`.
     // CHECK:STDERR:   fn F(x: (Self*, {.x: Self, .y: i32})) -> [Self; 4];
     // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     fn F(x: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> [SelfNestedBadParam; 4];
@@ -301,47 +315,47 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: interface @J {
 // CHECK:STDOUT:   %Self: J = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.5 [template] {
-// CHECK:STDOUT:     %self.loc83_20.1: bool = param self
-// CHECK:STDOUT:     %self.loc83_20.2: bool = bind_name self, %self.loc83_20.1
-// CHECK:STDOUT:     %b.loc83_32.1: bool = param b
-// CHECK:STDOUT:     %b.loc83_32.2: bool = bind_name b, %b.loc83_32.1
+// CHECK:STDOUT:     %self.loc89_20.1: bool = param self
+// CHECK:STDOUT:     %self.loc89_20.2: bool = bind_name self, %self.loc89_20.1
+// CHECK:STDOUT:     %b.loc89_32.1: bool = param b
+// CHECK:STDOUT:     %b.loc89_32.2: bool = bind_name b, %b.loc89_32.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc83: <associated <function> in J> = assoc_entity element0, %F [template = constants.%.7]
+// CHECK:STDOUT:   %.loc89: <associated <function> in J> = assoc_entity element0, %F [template = constants.%.7]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc83
+// CHECK:STDOUT:   .F = %.loc89
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SelfNested {
 // CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.13 [template] {
-// CHECK:STDOUT:     %Self.ref.loc171_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_16.1: type = facet_type_access %Self.ref.loc171_12 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_12: type = converted %Self.ref.loc171_12, %.loc171_16.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_16.2: type = ptr_type Self [symbolic = constants.%.9]
-// CHECK:STDOUT:     %Self.ref.loc171_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_24.1: type = facet_type_access %Self.ref.loc171_24 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_24.2: type = converted %Self.ref.loc171_24, %.loc171_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.10]
-// CHECK:STDOUT:     %.loc171_38.1: (type, type) = tuple_literal (%.loc171_16.2, %.loc171_37)
-// CHECK:STDOUT:     %.loc171_38.2: type = converted %.loc171_38.1, constants.%.12 [symbolic = constants.%.12]
-// CHECK:STDOUT:     %x.loc171_8.1: (Self*, {.x: Self, .y: i32}) = param x
-// CHECK:STDOUT:     %x.loc171_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc171_8.1
-// CHECK:STDOUT:     %Self.ref.loc171_45: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_51: i32 = int_literal 4 [template = constants.%.13]
-// CHECK:STDOUT:     %.loc171_45.1: type = facet_type_access %Self.ref.loc171_45 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_45.2: type = converted %Self.ref.loc171_45, %.loc171_45.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc171_52: type = array_type %.loc171_51, Self [symbolic = constants.%.14]
+// CHECK:STDOUT:     %Self.ref.loc184_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_16.1: type = facet_type_access %Self.ref.loc184_12 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_12: type = converted %Self.ref.loc184_12, %.loc184_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_16.2: type = ptr_type Self [symbolic = constants.%.9]
+// CHECK:STDOUT:     %Self.ref.loc184_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_24.1: type = facet_type_access %Self.ref.loc184_24 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_24.2: type = converted %Self.ref.loc184_24, %.loc184_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.10]
+// CHECK:STDOUT:     %.loc184_38.1: (type, type) = tuple_literal (%.loc184_16.2, %.loc184_37)
+// CHECK:STDOUT:     %.loc184_38.2: type = converted %.loc184_38.1, constants.%.12 [symbolic = constants.%.12]
+// CHECK:STDOUT:     %x.loc184_8.1: (Self*, {.x: Self, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc184_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc184_8.1
+// CHECK:STDOUT:     %Self.ref.loc184_45: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_51: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc184_45.1: type = facet_type_access %Self.ref.loc184_45 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_45.2: type = converted %Self.ref.loc184_45, %.loc184_45.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_52: type = array_type %.loc184_51, Self [symbolic = constants.%.14]
 // CHECK:STDOUT:     %return.var: ref [Self; 4] = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc171_53: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.17]
+// CHECK:STDOUT:   %.loc184_53: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.17]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc171_53
+// CHECK:STDOUT:   .F = %.loc184_53
 // CHECK:STDOUT:   witness = (%F)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -373,8 +387,8 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.4: FExtraParam as I {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %b.loc54_10.1: bool = param b
-// CHECK:STDOUT:     %b.loc54_10.2: bool = bind_name b, %b.loc54_10.1
+// CHECK:STDOUT:     %b.loc58_10.1: bool = param b
+// CHECK:STDOUT:     %b.loc58_10.2: bool = bind_name b, %b.loc58_10.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
@@ -386,8 +400,8 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: impl @impl.5: FExtraImplicitParam as I {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.3 [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FExtraImplicitParam [template = constants.%FExtraImplicitParam]
-// CHECK:STDOUT:     %self.loc66_10.1: FExtraImplicitParam = param self
-// CHECK:STDOUT:     %self.loc66_10.2: FExtraImplicitParam = bind_name self, %self.loc66_10.1
+// CHECK:STDOUT:     %self.loc71_10.1: FExtraImplicitParam = param self
+// CHECK:STDOUT:     %self.loc71_10.2: FExtraImplicitParam = bind_name self, %self.loc71_10.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
@@ -409,8 +423,8 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.7: FMissingParam as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.6 [template] {
-// CHECK:STDOUT:     %self.loc93_10.1: bool = param self
-// CHECK:STDOUT:     %self.loc93_10.2: bool = bind_name self, %self.loc93_10.1
+// CHECK:STDOUT:     %self.loc100_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc100_10.2: bool = bind_name self, %self.loc100_10.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -422,8 +436,8 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.8: FMissingImplicitParam as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.7 [template] {
-// CHECK:STDOUT:     %b.loc105_10.1: bool = param b
-// CHECK:STDOUT:     %b.loc105_10.2: bool = bind_name b, %b.loc105_10.1
+// CHECK:STDOUT:     %b.loc113_10.1: bool = param b
+// CHECK:STDOUT:     %b.loc113_10.2: bool = bind_name b, %b.loc113_10.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -435,10 +449,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.9: FMissingReturnType as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.8 [template] {
-// CHECK:STDOUT:     %self.loc117_10.1: bool = param self
-// CHECK:STDOUT:     %self.loc117_10.2: bool = bind_name self, %self.loc117_10.1
-// CHECK:STDOUT:     %b.loc117_22.1: bool = param b
-// CHECK:STDOUT:     %b.loc117_22.2: bool = bind_name b, %b.loc117_22.1
+// CHECK:STDOUT:     %self.loc126_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc126_10.2: bool = bind_name self, %self.loc126_10.1
+// CHECK:STDOUT:     %b.loc126_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc126_22.2: bool = bind_name b, %b.loc126_22.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
 // CHECK:STDOUT:
@@ -449,11 +463,11 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.10: FDifferentParamType as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.9 [template] {
-// CHECK:STDOUT:     %self.loc129_10.1: bool = param self
-// CHECK:STDOUT:     %self.loc129_10.2: bool = bind_name self, %self.loc129_10.1
+// CHECK:STDOUT:     %self.loc139_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc139_10.2: bool = bind_name self, %self.loc139_10.1
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentParamType [template = constants.%FDifferentParamType]
-// CHECK:STDOUT:     %b.loc129_22.1: FDifferentParamType = param b
-// CHECK:STDOUT:     %b.loc129_22.2: FDifferentParamType = bind_name b, %b.loc129_22.1
+// CHECK:STDOUT:     %b.loc139_22.1: FDifferentParamType = param b
+// CHECK:STDOUT:     %b.loc139_22.2: FDifferentParamType = bind_name b, %b.loc139_22.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -466,10 +480,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: impl @impl.11: FDifferentImplicitParamType as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.10 [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentImplicitParamType [template = constants.%FDifferentImplicitParamType]
-// CHECK:STDOUT:     %self.loc141_10.1: FDifferentImplicitParamType = param self
-// CHECK:STDOUT:     %self.loc141_10.2: FDifferentImplicitParamType = bind_name self, %self.loc141_10.1
-// CHECK:STDOUT:     %b.loc141_22.1: bool = param b
-// CHECK:STDOUT:     %b.loc141_22.2: bool = bind_name b, %b.loc141_22.1
+// CHECK:STDOUT:     %self.loc152_10.1: FDifferentImplicitParamType = param self
+// CHECK:STDOUT:     %self.loc152_10.2: FDifferentImplicitParamType = bind_name self, %self.loc152_10.1
+// CHECK:STDOUT:     %b.loc152_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc152_22.2: bool = bind_name b, %b.loc152_22.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -481,10 +495,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.12: FDifferentReturnType as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.11 [template] {
-// CHECK:STDOUT:     %self.loc153_10.1: bool = param self
-// CHECK:STDOUT:     %self.loc153_10.2: bool = bind_name self, %self.loc153_10.1
-// CHECK:STDOUT:     %b.loc153_22.1: bool = param b
-// CHECK:STDOUT:     %b.loc153_22.2: bool = bind_name b, %b.loc153_22.1
+// CHECK:STDOUT:     %self.loc165_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc165_10.2: bool = bind_name self, %self.loc165_10.1
+// CHECK:STDOUT:     %b.loc165_22.1: bool = param b
+// CHECK:STDOUT:     %b.loc165_22.2: bool = bind_name b, %b.loc165_22.1
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%FDifferentReturnType [template = constants.%FDifferentReturnType]
 // CHECK:STDOUT:     %return.var: ref FDifferentReturnType = var <return slot>
 // CHECK:STDOUT:   }
@@ -497,10 +511,10 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.13: FDifferentParamName as J {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.12 [template] {
-// CHECK:STDOUT:     %self.loc166_10.1: bool = param self
-// CHECK:STDOUT:     %self.loc166_10.2: bool = bind_name self, %self.loc166_10.1
-// CHECK:STDOUT:     %not_b.loc166_22.1: bool = param not_b
-// CHECK:STDOUT:     %not_b.loc166_22.2: bool = bind_name not_b, %not_b.loc166_22.1
+// CHECK:STDOUT:     %self.loc179_10.1: bool = param self
+// CHECK:STDOUT:     %self.loc179_10.2: bool = bind_name self, %self.loc179_10.1
+// CHECK:STDOUT:     %not_b.loc179_22.1: bool = param not_b
+// CHECK:STDOUT:     %not_b.loc179_22.2: bool = bind_name not_b, %not_b.loc179_22.1
 // CHECK:STDOUT:     %return.var: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -512,16 +526,16 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.14: SelfNestedBadParam as SelfNested {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.14 [template] {
-// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc182_14: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
-// CHECK:STDOUT:     %.loc182_32: type = ptr_type SelfNestedBadParam [template = constants.%.18]
-// CHECK:STDOUT:     %.loc182_52: type = struct_type {.x: i32, .y: i32} [template = constants.%.19]
-// CHECK:STDOUT:     %.loc182_53.1: (type, type) = tuple_literal (%.loc182_32, %.loc182_52)
-// CHECK:STDOUT:     %.loc182_53.2: type = converted %.loc182_53.1, constants.%.20 [template = constants.%.20]
-// CHECK:STDOUT:     %x.loc182_10.1: (SelfNestedBadParam*, {.x: i32, .y: i32}) = param x
-// CHECK:STDOUT:     %x.loc182_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32}) = bind_name x, %x.loc182_10.1
-// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc182_60: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
-// CHECK:STDOUT:     %.loc182_80: i32 = int_literal 4 [template = constants.%.13]
-// CHECK:STDOUT:     %.loc182_81: type = array_type %.loc182_80, SelfNestedBadParam [template = constants.%.21]
+// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc196_14: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %.loc196_32: type = ptr_type SelfNestedBadParam [template = constants.%.18]
+// CHECK:STDOUT:     %.loc196_52: type = struct_type {.x: i32, .y: i32} [template = constants.%.19]
+// CHECK:STDOUT:     %.loc196_53.1: (type, type) = tuple_literal (%.loc196_32, %.loc196_52)
+// CHECK:STDOUT:     %.loc196_53.2: type = converted %.loc196_53.1, constants.%.20 [template = constants.%.20]
+// CHECK:STDOUT:     %x.loc196_10.1: (SelfNestedBadParam*, {.x: i32, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc196_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32}) = bind_name x, %x.loc196_10.1
+// CHECK:STDOUT:     %SelfNestedBadParam.ref.loc196_60: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
+// CHECK:STDOUT:     %.loc196_80: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc196_81: type = array_type %.loc196_80, SelfNestedBadParam [template = constants.%.21]
 // CHECK:STDOUT:     %return.var: ref [SelfNestedBadParam; 4] = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -533,17 +547,17 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl.15: SelfNestedBadReturnType as SelfNested {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.15 [template] {
-// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc194_14: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
-// CHECK:STDOUT:     %.loc194_37: type = ptr_type SelfNestedBadReturnType [template = constants.%.22]
-// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc194_45: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
-// CHECK:STDOUT:     %.loc194_77: type = struct_type {.x: SelfNestedBadReturnType, .y: i32} [template = constants.%.23]
-// CHECK:STDOUT:     %.loc194_78.1: (type, type) = tuple_literal (%.loc194_37, %.loc194_77)
-// CHECK:STDOUT:     %.loc194_78.2: type = converted %.loc194_78.1, constants.%.24 [template = constants.%.24]
-// CHECK:STDOUT:     %x.loc194_10.1: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = param x
-// CHECK:STDOUT:     %x.loc194_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = bind_name x, %x.loc194_10.1
+// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc208_14: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:     %.loc208_37: type = ptr_type SelfNestedBadReturnType [template = constants.%.22]
+// CHECK:STDOUT:     %SelfNestedBadReturnType.ref.loc208_45: type = name_ref SelfNestedBadReturnType, file.%SelfNestedBadReturnType.decl [template = constants.%SelfNestedBadReturnType]
+// CHECK:STDOUT:     %.loc208_77: type = struct_type {.x: SelfNestedBadReturnType, .y: i32} [template = constants.%.23]
+// CHECK:STDOUT:     %.loc208_78.1: (type, type) = tuple_literal (%.loc208_37, %.loc208_77)
+// CHECK:STDOUT:     %.loc208_78.2: type = converted %.loc208_78.1, constants.%.24 [template = constants.%.24]
+// CHECK:STDOUT:     %x.loc208_10.1: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = param x
+// CHECK:STDOUT:     %x.loc208_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32}) = bind_name x, %x.loc208_10.1
 // CHECK:STDOUT:     %SelfNestedBadParam.ref: type = name_ref SelfNestedBadParam, file.%SelfNestedBadParam.decl [template = constants.%SelfNestedBadParam]
-// CHECK:STDOUT:     %.loc194_105: i32 = int_literal 4 [template = constants.%.13]
-// CHECK:STDOUT:     %.loc194_106: type = array_type %.loc194_105, SelfNestedBadParam [template = constants.%.21]
+// CHECK:STDOUT:     %.loc208_105: i32 = int_literal 4 [template = constants.%.13]
+// CHECK:STDOUT:     %.loc208_106: type = array_type %.loc208_105, SelfNestedBadParam [template = constants.%.21]
 // CHECK:STDOUT:     %return.var: ref [SelfNestedBadParam; 4] = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.1: <witness> = interface_witness (<error>) [template = <error>]
@@ -694,31 +708,31 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PossiblyF();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.2(@impl.4.%b.loc54_10.2: bool);
+// CHECK:STDOUT: fn @F.2(@impl.4.%b.loc58_10.2: bool);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.3[@impl.5.%self.loc66_10.2: FExtraImplicitParam]();
+// CHECK:STDOUT: fn @F.3[@impl.5.%self.loc71_10.2: FExtraImplicitParam]();
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.4() -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.5[@J.%self.loc83_20.2: bool](@J.%b.loc83_32.2: bool) -> bool;
+// CHECK:STDOUT: fn @F.5[@J.%self.loc89_20.2: bool](@J.%b.loc89_32.2: bool) -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.6[@impl.7.%self.loc93_10.2: bool]() -> bool;
+// CHECK:STDOUT: fn @F.6[@impl.7.%self.loc100_10.2: bool]() -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.7(@impl.8.%b.loc105_10.2: bool) -> bool;
+// CHECK:STDOUT: fn @F.7(@impl.8.%b.loc113_10.2: bool) -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.8[@impl.9.%self.loc117_10.2: bool](@impl.9.%b.loc117_22.2: bool);
+// CHECK:STDOUT: fn @F.8[@impl.9.%self.loc126_10.2: bool](@impl.9.%b.loc126_22.2: bool);
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.9[@impl.10.%self.loc129_10.2: bool](@impl.10.%b.loc129_22.2: FDifferentParamType) -> bool;
+// CHECK:STDOUT: fn @F.9[@impl.10.%self.loc139_10.2: bool](@impl.10.%b.loc139_22.2: FDifferentParamType) -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.10[@impl.11.%self.loc141_10.2: FDifferentImplicitParamType](@impl.11.%b.loc141_22.2: bool) -> bool;
+// CHECK:STDOUT: fn @F.10[@impl.11.%self.loc152_10.2: FDifferentImplicitParamType](@impl.11.%b.loc152_22.2: bool) -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.11[@impl.12.%self.loc153_10.2: bool](@impl.12.%b.loc153_22.2: bool) -> <error>;
+// CHECK:STDOUT: fn @F.11[@impl.12.%self.loc165_10.2: bool](@impl.12.%b.loc165_22.2: bool) -> <error>;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.12[@impl.13.%self.loc166_10.2: bool](@impl.13.%not_b.loc166_22.2: bool) -> bool;
+// CHECK:STDOUT: fn @F.12[@impl.13.%self.loc179_10.2: bool](@impl.13.%not_b.loc179_22.2: bool) -> bool;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.13(@SelfNested.%x.loc171_8.2: (Self*, {.x: Self, .y: i32})) -> @SelfNested.%return.var: [Self; 4];
+// CHECK:STDOUT: fn @F.13(@SelfNested.%x.loc184_8.2: (Self*, {.x: Self, .y: i32})) -> @SelfNested.%return.var: [Self; 4];
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.14(@impl.14.%x.loc182_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> <error>;
+// CHECK:STDOUT: fn @F.14(@impl.14.%x.loc196_10.2: (SelfNestedBadParam*, {.x: i32, .y: i32})) -> <error>;
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F.15(@impl.15.%x.loc194_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> @impl.15.%return.var: [SelfNestedBadParam; 4];
+// CHECK:STDOUT: fn @F.15(@impl.15.%x.loc208_10.2: (SelfNestedBadReturnType*, {.x: SelfNestedBadReturnType, .y: i32})) -> @impl.15.%return.var: [SelfNestedBadParam; 4];
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_interface.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_impl_bad_interface.carbon:[[@LINE+6]]:1: ERROR: Semantics TODO: `impl as non-interface`.
+// CHECK:STDERR: fail_impl_bad_interface.carbon:[[@LINE+7]]:1: ERROR: Semantics TODO: `impl as non-interface`.
 // CHECK:STDERR: impl i32 as false {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_impl_bad_interface.carbon:[[@LINE+3]]:13: ERROR: Cannot implicitly convert from `bool` to `type`.
 // CHECK:STDERR: impl i32 as false {}
 // CHECK:STDERR:             ^~~~~
@@ -21,7 +22,7 @@ impl i32 as false {}
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   impl_decl @impl {
-// CHECK:STDOUT:     %.loc13: bool = bool_literal false [template = constants.%.1]
+// CHECK:STDOUT:     %.loc14: bool = bool_literal false [template = constants.%.1]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -13,9 +13,10 @@ class C {
 }
 
 fn F(c: C) {
-  // CHECK:STDERR: fail_alias_impl_not_found.carbon:[[@LINE+3]]:3: ERROR: Cannot access member of interface I in type C that does not implement that interface.
+  // CHECK:STDERR: fail_alias_impl_not_found.carbon:[[@LINE+4]]:3: ERROR: Cannot access member of interface I in type C that does not implement that interface.
   // CHECK:STDERR:   C.F();
   // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
   C.F();
   // CHECK:STDERR: fail_alias_impl_not_found.carbon:[[@LINE+3]]:3: ERROR: Cannot access member of interface I in type C that does not implement that interface.
   // CHECK:STDERR:   c.F();
@@ -76,9 +77,9 @@ fn F(c: C) {
 // CHECK:STDOUT: fn @F.2(%c: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:   %F.ref.loc19: <associated <function> in I> = name_ref F, @C.%F [template = constants.%.3]
+// CHECK:STDOUT:   %F.ref.loc20: <associated <function> in I> = name_ref F, @C.%F [template = constants.%.3]
 // CHECK:STDOUT:   %c.ref: C = name_ref c, %c
-// CHECK:STDOUT:   %F.ref.loc23: <associated <function> in I> = name_ref F, @C.%F [template = constants.%.3]
+// CHECK:STDOUT:   %F.ref.loc24: <associated <function> in I> = name_ref F, @C.%F [template = constants.%.3]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_expr_category.carbon
+++ b/toolchain/check/testdata/index/fail_expr_category.carbon
@@ -8,20 +8,23 @@ fn F() -> [i32; 3];
 
 fn G(b: [i32; 3]) {
   // Indexing an array value gives a value.
-  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+3]]:18: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+4]]:18: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   var pb: i32* = &b[0];
   // CHECK:STDERR:                  ^
+  // CHECK:STDERR:
   var pb: i32* = &b[0];
-  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   b[0] = 4;
   // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR:
   b[0] = 4;
 
   // Indexing an ephemeral reference (materialized from an initializing
   // expression) gives a value.
-  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+3]]:18: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+4]]:18: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   var pf: i32* = &F()[0];
   // CHECK:STDERR:                  ^
+  // CHECK:STDERR:
   var pf: i32* = &F()[0];
   // CHECK:STDERR: fail_expr_category.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   F()[0] = 4;
@@ -62,44 +65,44 @@ fn G(b: [i32; 3]) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%b: [i32; 3]) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_14: type = ptr_type i32 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc15_14: type = ptr_type i32 [template = constants.%.4]
 // CHECK:STDOUT:   %pb.var: ref i32* = var pb
 // CHECK:STDOUT:   %pb: ref i32* = bind_name pb, %pb.var
-// CHECK:STDOUT:   %b.ref.loc14: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc14_21: i32 = int_literal 0 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc14_22.1: ref [i32; 3] = value_as_ref %b.ref.loc14
-// CHECK:STDOUT:   %.loc14_22.2: ref i32 = array_index %.loc14_22.1, %.loc14_21
-// CHECK:STDOUT:   %.loc14_22.3: i32 = bind_value %.loc14_22.2
-// CHECK:STDOUT:   %.loc14_18: i32* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   assign %pb.var, %.loc14_18
-// CHECK:STDOUT:   %b.ref.loc18: [i32; 3] = name_ref b, %b
-// CHECK:STDOUT:   %.loc18_5: i32 = int_literal 0 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc18_6.1: ref [i32; 3] = value_as_ref %b.ref.loc18
-// CHECK:STDOUT:   %.loc18_6.2: ref i32 = array_index %.loc18_6.1, %.loc18_5
-// CHECK:STDOUT:   %.loc18_6.3: i32 = bind_value %.loc18_6.2
-// CHECK:STDOUT:   %.loc18_10: i32 = int_literal 4 [template = constants.%.6]
-// CHECK:STDOUT:   assign %.loc18_6.3, %.loc18_10
-// CHECK:STDOUT:   %.loc25_14: type = ptr_type i32 [template = constants.%.4]
+// CHECK:STDOUT:   %b.ref.loc15: [i32; 3] = name_ref b, %b
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc15_22.1: ref [i32; 3] = value_as_ref %b.ref.loc15
+// CHECK:STDOUT:   %.loc15_22.2: ref i32 = array_index %.loc15_22.1, %.loc15_21
+// CHECK:STDOUT:   %.loc15_22.3: i32 = bind_value %.loc15_22.2
+// CHECK:STDOUT:   %.loc15_18: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   assign %pb.var, %.loc15_18
+// CHECK:STDOUT:   %b.ref.loc20: [i32; 3] = name_ref b, %b
+// CHECK:STDOUT:   %.loc20_5: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_6.1: ref [i32; 3] = value_as_ref %b.ref.loc20
+// CHECK:STDOUT:   %.loc20_6.2: ref i32 = array_index %.loc20_6.1, %.loc20_5
+// CHECK:STDOUT:   %.loc20_6.3: i32 = bind_value %.loc20_6.2
+// CHECK:STDOUT:   %.loc20_10: i32 = int_literal 4 [template = constants.%.6]
+// CHECK:STDOUT:   assign %.loc20_6.3, %.loc20_10
+// CHECK:STDOUT:   %.loc28_14: type = ptr_type i32 [template = constants.%.4]
 // CHECK:STDOUT:   %pf.var: ref i32* = var pf
 // CHECK:STDOUT:   %pf: ref i32* = bind_name pf, %pf.var
-// CHECK:STDOUT:   %F.ref.loc25: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc25_20.1: ref [i32; 3] = temporary_storage
-// CHECK:STDOUT:   %.loc25_20.2: init [i32; 3] = call %F.ref.loc25() to %.loc25_20.1
-// CHECK:STDOUT:   %.loc25_23: i32 = int_literal 0 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc25_20.3: ref [i32; 3] = temporary %.loc25_20.1, %.loc25_20.2
-// CHECK:STDOUT:   %.loc25_24.1: ref i32 = array_index %.loc25_20.3, %.loc25_23
-// CHECK:STDOUT:   %.loc25_24.2: i32 = bind_value %.loc25_24.1
-// CHECK:STDOUT:   %.loc25_18: i32* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   assign %pf.var, %.loc25_18
-// CHECK:STDOUT:   %F.ref.loc29: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc29_4.1: ref [i32; 3] = temporary_storage
-// CHECK:STDOUT:   %.loc29_4.2: init [i32; 3] = call %F.ref.loc29() to %.loc29_4.1
-// CHECK:STDOUT:   %.loc29_7: i32 = int_literal 0 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc29_4.3: ref [i32; 3] = temporary %.loc29_4.1, %.loc29_4.2
-// CHECK:STDOUT:   %.loc29_8.1: ref i32 = array_index %.loc29_4.3, %.loc29_7
-// CHECK:STDOUT:   %.loc29_8.2: i32 = bind_value %.loc29_8.1
-// CHECK:STDOUT:   %.loc29_12: i32 = int_literal 4 [template = constants.%.6]
-// CHECK:STDOUT:   assign %.loc29_8.2, %.loc29_12
+// CHECK:STDOUT:   %F.ref.loc28: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %.loc28_20.1: ref [i32; 3] = temporary_storage
+// CHECK:STDOUT:   %.loc28_20.2: init [i32; 3] = call %F.ref.loc28() to %.loc28_20.1
+// CHECK:STDOUT:   %.loc28_23: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc28_20.3: ref [i32; 3] = temporary %.loc28_20.1, %.loc28_20.2
+// CHECK:STDOUT:   %.loc28_24.1: ref i32 = array_index %.loc28_20.3, %.loc28_23
+// CHECK:STDOUT:   %.loc28_24.2: i32 = bind_value %.loc28_24.1
+// CHECK:STDOUT:   %.loc28_18: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   assign %pf.var, %.loc28_18
+// CHECK:STDOUT:   %F.ref.loc32: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %.loc32_4.1: ref [i32; 3] = temporary_storage
+// CHECK:STDOUT:   %.loc32_4.2: init [i32; 3] = call %F.ref.loc32() to %.loc32_4.1
+// CHECK:STDOUT:   %.loc32_7: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc32_4.3: ref [i32; 3] = temporary %.loc32_4.1, %.loc32_4.2
+// CHECK:STDOUT:   %.loc32_8.1: ref i32 = array_index %.loc32_4.3, %.loc32_7
+// CHECK:STDOUT:   %.loc32_8.2: i32 = bind_value %.loc32_8.1
+// CHECK:STDOUT:   %.loc32_12: i32 = int_literal 4 [template = constants.%.6]
+// CHECK:STDOUT:   assign %.loc32_8.2, %.loc32_12
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -9,20 +9,23 @@
 // properly.
 
 namespace N;
-// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+3]]:14: ERROR: Expression cannot be used as a value.
+// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+4]]:14: ERROR: Expression cannot be used as a value.
 // CHECK:STDERR: var a: i32 = N[0];
 // CHECK:STDERR:              ^
+// CHECK:STDERR:
 var a: i32 = N[0];
 
 fn F();
-// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+3]]:14: ERROR: Expression cannot be used as a value.
+// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+4]]:14: ERROR: Expression cannot be used as a value.
 // CHECK:STDERR: var b: i32 = F[1];
 // CHECK:STDERR:              ^
+// CHECK:STDERR:
 var b: i32 = F[1];
 
-// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+3]]:14: ERROR: Type `{.a: i32, .b: i32}` does not support indexing.
+// CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+4]]:14: ERROR: Type `{.a: i32, .b: i32}` does not support indexing.
 // CHECK:STDERR: var c: i32 = {.a = 1, .b = 2}[0];
 // CHECK:STDERR:              ^~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 var c: i32 = {.a = 1, .b = 2}[0];
 
 // CHECK:STDERR: fail_invalid_base.carbon:[[@LINE+3]]:14: ERROR: Type `type` does not support indexing.
@@ -67,20 +70,20 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %N.ref: <namespace> = name_ref N, file.%N [template = file.%N]
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign file.%a.var, <error>
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc21: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   assign file.%b.var, <error>
-// CHECK:STDOUT:   %.loc26_20: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc26_28: i32 = int_literal 2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc26_29.1: {.a: i32, .b: i32} = struct_literal (%.loc26_20, %.loc26_28)
-// CHECK:STDOUT:   %.loc26_31: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc26_29.2: {.a: i32, .b: i32} = struct_value (%.loc26_20, %.loc26_28) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc26_29.3: {.a: i32, .b: i32} = converted %.loc26_29.1, %.loc26_29.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc29_20: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc29_28: i32 = int_literal 2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc29_29.1: {.a: i32, .b: i32} = struct_literal (%.loc29_20, %.loc29_28)
+// CHECK:STDOUT:   %.loc29_31: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc29_29.2: {.a: i32, .b: i32} = struct_value (%.loc29_20, %.loc29_28) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc29_29.3: {.a: i32, .b: i32} = converted %.loc29_29.1, %.loc29_29.2 [template = constants.%.6]
 // CHECK:STDOUT:   assign file.%c.var, <error>
-// CHECK:STDOUT:   %.loc31_31: type = struct_type {.a: i32, .b: i32} [template = constants.%.4]
-// CHECK:STDOUT:   %.loc31_33: i32 = int_literal 0 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc34_31: type = struct_type {.a: i32, .b: i32} [template = constants.%.4]
+// CHECK:STDOUT:   %.loc34_33: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign file.%d.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
+++ b/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
@@ -6,17 +6,19 @@
 
 interface Interface { }
 
-// CHECK:STDERR: fail_add_member_outside_definition.carbon:[[@LINE+3]]:14: ERROR: Out-of-line declaration requires a declaration in scoped entity.
+// CHECK:STDERR: fail_add_member_outside_definition.carbon:[[@LINE+4]]:14: ERROR: Out-of-line declaration requires a declaration in scoped entity.
 // CHECK:STDERR: fn Interface.F() {}
 // CHECK:STDERR:              ^
+// CHECK:STDERR:
 fn Interface.F() {}
 
 // Nesting interfaces like this is not valid, but make sure we don't crash.
 interface Outer {
   interface Inner {
-    // CHECK:STDERR: fail_add_member_outside_definition.carbon:[[@LINE+3]]:8: ERROR: Name `Outer` not found.
+    // CHECK:STDERR: fail_add_member_outside_definition.carbon:[[@LINE+4]]:8: ERROR: Name `Outer` not found.
     // CHECK:STDERR:     fn Outer.F();
     // CHECK:STDERR:        ^~~~~
+    // CHECK:STDERR:
     fn Outer.F();
   }
   // CHECK:STDERR: fail_add_member_outside_definition.carbon:[[@LINE+3]]:12: ERROR: Out-of-line declaration requires a declaration in scoped entity.
@@ -65,7 +67,7 @@ interface Outer {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inner {
 // CHECK:STDOUT:   %Self: Inner = bind_symbolic_name Self [symbolic]
-// CHECK:STDOUT:   %.loc20: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -6,24 +6,26 @@
 
 interface Interface { }
 
-// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+6]]:1: ERROR: Redefinition of interface Interface.
+// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+7]]:1: ERROR: Redefinition of interface Interface.
 // CHECK:STDERR: interface Interface {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-5]]:1: Previous definition was here.
 // CHECK:STDERR: interface Interface { }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 interface Interface {
   fn F();
 }
 
 fn Function();
 
-// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: interface Function;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: fn Function();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
 interface Function;
 
 class Class;
@@ -52,11 +54,11 @@ interface Class { }
 // CHECK:STDOUT:     .Class = %Class.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Interface.decl.loc7: type = interface_decl @Interface [template = constants.%.1] {}
-// CHECK:STDOUT:   %Interface.decl.loc15: type = interface_decl @Interface [template = constants.%.1] {}
+// CHECK:STDOUT:   %Interface.decl.loc16: type = interface_decl @Interface [template = constants.%.1] {}
 // CHECK:STDOUT:   %Function: <function> = fn_decl @Function [template] {}
-// CHECK:STDOUT:   %.decl.loc27: type = interface_decl @.1 [template = constants.%.2] {}
+// CHECK:STDOUT:   %.decl.loc29: type = interface_decl @.1 [template = constants.%.2] {}
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {}
-// CHECK:STDOUT:   %.decl.loc37: type = interface_decl @.2 [template = constants.%.3] {}
+// CHECK:STDOUT:   %.decl.loc39: type = interface_decl @.2 [template = constants.%.3] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {

--- a/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
@@ -6,34 +6,38 @@
 
 interface Undefined;
 
-// CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+6]]:4: ERROR: Cannot declare a member of undefined interface `Undefined`.
+// CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+7]]:4: ERROR: Cannot declare a member of undefined interface `Undefined`.
 // CHECK:STDERR: fn Undefined.F();
 // CHECK:STDERR:    ^~~~~~~~~
 // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-5]]:1: Interface was forward declared here.
 // CHECK:STDERR: interface Undefined;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn Undefined.F();
 
 fn Test() {
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+6]]:3: ERROR: Member access into undefined interface `Undefined`.
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+7]]:3: ERROR: Member access into undefined interface `Undefined`.
   // CHECK:STDERR:   Undefined.G();
   // CHECK:STDERR:   ^~~~~~~~~~~
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-14]]:1: Interface was forward declared here.
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-15]]:1: Interface was forward declared here.
   // CHECK:STDERR: interface Undefined;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   Undefined.G();
 }
 
 interface BeingDefined {
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+9]]:13: ERROR: Member access into undefined interface `BeingDefined`.
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+11]]:13: ERROR: Member access into undefined interface `BeingDefined`.
   // CHECK:STDERR:   fn H() -> BeingDefined.T;
   // CHECK:STDERR:             ^~~~~~~~~~~~~~
   // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-4]]:1: Interface is currently being defined.
   // CHECK:STDERR: interface BeingDefined {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+3]]:13: ERROR: Name `T` not found.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+4]]:13: ERROR: Name `T` not found.
   // CHECK:STDERR:   fn H() -> BeingDefined.T;
   // CHECK:STDERR:             ^~~~~~~~~~~~~~
+  // CHECK:STDERR:
   fn H() -> BeingDefined.T;
   // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+3]]:6: ERROR: Name `BeingDefined` not found.
   // CHECK:STDERR:   fn BeingDefined.I();
@@ -57,7 +61,7 @@ interface BeingDefined {
 // CHECK:STDOUT:     .BeingDefined = %BeingDefined.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Undefined.decl: type = interface_decl @Undefined [template = constants.%.1] {}
-// CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc16: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:   %Test: <function> = fn_decl @Test [template] {}
 // CHECK:STDOUT:   %BeingDefined.decl: type = interface_decl @BeingDefined [template = constants.%.2] {}
 // CHECK:STDOUT: }
@@ -71,12 +75,12 @@ interface BeingDefined {
 // CHECK:STDOUT:     %T.ref: <error> = name_ref T, <error> [template = <error>]
 // CHECK:STDOUT:     %return.var: ref <error> = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc37: <associated <function> in BeingDefined> = assoc_entity element0, %H [template = constants.%.4]
-// CHECK:STDOUT:   %.loc41: <function> = fn_decl @.2 [template] {}
+// CHECK:STDOUT:   %.loc41: <associated <function> in BeingDefined> = assoc_entity element0, %H [template = constants.%.4]
+// CHECK:STDOUT:   %.loc45: <function> = fn_decl @.2 [template] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .H = %.loc37
+// CHECK:STDOUT:   .H = %.loc41
 // CHECK:STDOUT:   witness = (%H)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_member_lookup.carbon
@@ -11,9 +11,10 @@ interface Interface {
 }
 
 fn F() {
-  // CHECK:STDERR: fail_member_lookup.carbon:[[@LINE+3]]:3: ERROR: Value of type `<associated <function> in Interface>` is not callable.
+  // CHECK:STDERR: fail_member_lookup.carbon:[[@LINE+4]]:3: ERROR: Value of type `<associated <function> in Interface>` is not callable.
   // CHECK:STDERR:   Interface.F();
   // CHECK:STDERR:   ^~~~~~~~~~~~
+  // CHECK:STDERR:
   Interface.F();
 
   // CHECK:STDERR: fail_member_lookup.carbon:[[@LINE+3]]:10: ERROR: Cannot implicitly convert from `<associated type in Interface>` to `type`.
@@ -59,9 +60,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %Interface.ref.loc17: type = name_ref Interface, file.%Interface.decl [template = constants.%.1]
+// CHECK:STDOUT:   %Interface.ref.loc18: type = name_ref Interface, file.%Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:   %F.ref: <associated <function> in Interface> = name_ref F, @Interface.%.loc8 [template = constants.%.3]
-// CHECK:STDOUT:   %Interface.ref.loc22: type = name_ref Interface, file.%Interface.decl [template = constants.%.1]
+// CHECK:STDOUT:   %Interface.ref.loc23: type = name_ref Interface, file.%Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:   %T.ref: <associated type in Interface> = name_ref T, @Interface.%.loc10 [template = constants.%.5]
 // CHECK:STDOUT:   %v.var: ref <error> = var v
 // CHECK:STDOUT:   %v: ref <error> = bind_name v, %v.var

--- a/toolchain/check/testdata/interface/fail_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_modifiers.carbon
@@ -4,20 +4,23 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `abstract` not allowed on `interface` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `abstract` not allowed on `interface` declaration.
 // CHECK:STDERR: abstract interface Abstract {
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 abstract interface Abstract {
 }
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `default` not allowed on `interface` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `default` not allowed on `interface` declaration.
 // CHECK:STDERR: default interface Default;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default interface Default;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `virtual` not allowed on `interface` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `virtual` not allowed on `interface` declaration.
 // CHECK:STDERR: virtual interface Virtual {
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 virtual interface Virtual {
 }
 

--- a/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 interface I {
-  // CHECK:STDERR: fail_todo_assoc_const_default.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_assoc_const_default.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default let T:! type = (i32, i32);
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default let T:! type = (i32, i32);
   // CHECK:STDERR: fail_todo_assoc_const_default.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default let N:! i32 = 42;
@@ -37,18 +38,18 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
 // CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
-// CHECK:STDOUT:   %.loc11_35.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc11_35.2: type = converted %.loc11_35.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_35.1: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc12_35.2: type = converted %.loc12_35.1, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
-// CHECK:STDOUT:   %.loc11_36: <associated type in I> = assoc_entity element0, %T [template = constants.%.5]
-// CHECK:STDOUT:   %.loc15_25: i32 = int_literal 42 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_36: <associated type in I> = assoc_entity element0, %T [template = constants.%.5]
+// CHECK:STDOUT:   %.loc16_25: i32 = int_literal 42 [template = constants.%.6]
 // CHECK:STDOUT:   %N: i32 = assoc_const_decl N [template]
-// CHECK:STDOUT:   %.loc15_27: <associated i32 in I> = assoc_entity element1, %N [template = constants.%.8]
+// CHECK:STDOUT:   %.loc16_27: <associated i32 in I> = assoc_entity element1, %N [template = constants.%.8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T = %.loc11_36
-// CHECK:STDOUT:   .N = %.loc15_27
+// CHECK:STDOUT:   .T = %.loc12_36
+// CHECK:STDOUT:   .N = %.loc16_27
 // CHECK:STDOUT:   witness = (%T, %N)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 interface Interface {
-  // CHECK:STDERR: fail_todo_define_default_fn_inline.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_define_default_fn_inline.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default fn F() {}
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default fn F() {}
 
   // CHECK:STDERR: fail_todo_define_default_fn_inline.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
@@ -35,20 +36,20 @@ interface Interface {
 // CHECK:STDOUT: interface @Interface {
 // CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %.loc11: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %a.loc16_16.1: i32 = param a
-// CHECK:STDOUT:     %a.loc16_16.2: i32 = bind_name a, %a.loc16_16.1
-// CHECK:STDOUT:     %b.loc16_24.1: i32 = param b
-// CHECK:STDOUT:     %b.loc16_24.2: i32 = bind_name b, %b.loc16_24.1
+// CHECK:STDOUT:     %a.loc17_16.1: i32 = param a
+// CHECK:STDOUT:     %a.loc17_16.2: i32 = bind_name a, %a.loc17_16.1
+// CHECK:STDOUT:     %b.loc17_24.1: i32 = param b
+// CHECK:STDOUT:     %b.loc17_24.2: i32 = bind_name b, %b.loc17_24.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc16: <associated <function> in Interface> = assoc_entity element1, %G [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17: <associated <function> in Interface> = assoc_entity element1, %G [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc11
-// CHECK:STDOUT:   .G = %.loc16
+// CHECK:STDOUT:   .F = %.loc12
+// CHECK:STDOUT:   .G = %.loc17
 // CHECK:STDOUT:   witness = (%F, %G)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -57,5 +58,5 @@ interface Interface {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(@Interface.%a.loc16_16.2: i32, @Interface.%b.loc16_24.2: i32) -> i32 = "int.add";
+// CHECK:STDOUT: fn @G(@Interface.%a.loc17_16.2: i32, @Interface.%b.loc17_24.2: i32) -> i32 = "int.add";
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -5,29 +5,32 @@
 // AUTOUPDATE
 
 interface Interface {
-  // CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default fn F();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default fn F();
 
-  // CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default fn G(a: i32, b: i32) -> i32;
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default fn G(a: i32, b: i32) -> i32;
 }
 
-// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn Interface.F() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE-11]]:3: Name is previously declared here.
+// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE-12]]:3: Name is previously declared here.
 // CHECK:STDERR:   default fn F();
 // CHECK:STDERR:   ^~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn Interface.F() {}
 
 // CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn Interface.G(a: i32, b: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE-14]]:3: Name is previously declared here.
+// CHECK:STDERR: fail_todo_define_default_fn_out_of_line.carbon:[[@LINE-15]]:3: Name is previously declared here.
 // CHECK:STDERR:   default fn G(a: i32, b: i32) -> i32;
 // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fn Interface.G(a: i32, b: i32) -> i32 = "int.add";
@@ -46,12 +49,12 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.add";
 // CHECK:STDOUT:     .Interface = %Interface.decl
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Interface.decl: type = interface_decl @Interface [template = constants.%.1] {}
-// CHECK:STDOUT:   %.loc25: <function> = fn_decl @.1 [template] {}
-// CHECK:STDOUT:   %.loc33: <function> = fn_decl @.2 [template] {
-// CHECK:STDOUT:     %a.loc33_16.1: i32 = param a
-// CHECK:STDOUT:     @.2.%a: i32 = bind_name a, %a.loc33_16.1
-// CHECK:STDOUT:     %b.loc33_24.1: i32 = param b
-// CHECK:STDOUT:     @.2.%b: i32 = bind_name b, %b.loc33_24.1
+// CHECK:STDOUT:   %.loc28: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc36: <function> = fn_decl @.2 [template] {
+// CHECK:STDOUT:     %a.loc36_16.1: i32 = param a
+// CHECK:STDOUT:     @.2.%a: i32 = bind_name a, %a.loc36_16.1
+// CHECK:STDOUT:     %b.loc36_24.1: i32 = param b
+// CHECK:STDOUT:     @.2.%b: i32 = bind_name b, %b.loc36_24.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -59,26 +62,26 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.add";
 // CHECK:STDOUT: interface @Interface {
 // CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
-// CHECK:STDOUT:   %.loc11: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
-// CHECK:STDOUT:     %a.loc16_16.1: i32 = param a
-// CHECK:STDOUT:     %a.loc16_16.2: i32 = bind_name a, %a.loc16_16.1
-// CHECK:STDOUT:     %b.loc16_24.1: i32 = param b
-// CHECK:STDOUT:     %b.loc16_24.2: i32 = bind_name b, %b.loc16_24.1
+// CHECK:STDOUT:     %a.loc18_16.1: i32 = param a
+// CHECK:STDOUT:     %a.loc18_16.2: i32 = bind_name a, %a.loc18_16.1
+// CHECK:STDOUT:     %b.loc18_24.1: i32 = param b
+// CHECK:STDOUT:     %b.loc18_24.2: i32 = bind_name b, %b.loc18_24.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc16: <associated <function> in Interface> = assoc_entity element1, %G [template = constants.%.4]
+// CHECK:STDOUT:   %.loc18: <associated <function> in Interface> = assoc_entity element1, %G [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .F = %.loc11
-// CHECK:STDOUT:   .G = %.loc16
+// CHECK:STDOUT:   .F = %.loc12
+// CHECK:STDOUT:   .G = %.loc18
 // CHECK:STDOUT:   witness = (%F, %G)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @G(@Interface.%a.loc16_16.2: i32, @Interface.%b.loc16_24.2: i32) -> i32;
+// CHECK:STDOUT: fn @G(@Interface.%a.loc18_16.2: i32, @Interface.%b.loc18_24.2: i32) -> i32;
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1() {
 // CHECK:STDOUT: !entry:

--- a/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
@@ -7,9 +7,10 @@
 interface Interface { fn F(); }
 
 fn CallStatic(T:! Interface) {
-  // CHECK:STDERR: fail_todo_facet_lookup.carbon:[[@LINE+3]]:3: ERROR: Value of type `<associated <function> in Interface>` is not callable.
+  // CHECK:STDERR: fail_todo_facet_lookup.carbon:[[@LINE+4]]:3: ERROR: Value of type `<associated <function> in Interface>` is not callable.
   // CHECK:STDERR:   T.F();
   // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR:
   T.F();
 }
 
@@ -42,14 +43,14 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:     @CallStatic.%T: Interface = bind_symbolic_name T, %T.loc9_15.1 [symbolic]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallFacet: <function> = fn_decl @CallFacet [template] {
-// CHECK:STDOUT:     %Interface.ref.loc16: type = name_ref Interface, %Interface.decl [template = constants.%.1]
-// CHECK:STDOUT:     %T.loc16_14.1: Interface = param T
-// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T, %T.loc16_14.1 [symbolic]
+// CHECK:STDOUT:     %Interface.ref.loc17: type = name_ref Interface, %Interface.decl [template = constants.%.1]
+// CHECK:STDOUT:     %T.loc17_14.1: Interface = param T
+// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T, %T.loc17_14.1 [symbolic]
 // CHECK:STDOUT:     %T.ref: Interface = name_ref T, @CallFacet.%T [symbolic = @CallFacet.%T]
-// CHECK:STDOUT:     %.loc16_32.1: type = facet_type_access %T.ref [symbolic = @CallFacet.%T]
-// CHECK:STDOUT:     %.loc16_32.2: type = converted %T.ref, %.loc16_32.1 [symbolic = @CallFacet.%T]
-// CHECK:STDOUT:     %x.loc16_29.1: T = param x
-// CHECK:STDOUT:     @CallFacet.%x: T = bind_name x, %x.loc16_29.1
+// CHECK:STDOUT:     %.loc17_32.1: type = facet_type_access %T.ref [symbolic = @CallFacet.%T]
+// CHECK:STDOUT:     %.loc17_32.2: type = converted %T.ref, %.loc17_32.1 [symbolic = @CallFacet.%T]
+// CHECK:STDOUT:     %x.loc17_29.1: T = param x
+// CHECK:STDOUT:     @CallFacet.%x: T = bind_name x, %x.loc17_29.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_generic.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_generic.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+6]]:1: ERROR: Semantics TODO: `generic interface`.
+// CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+7]]:1: ERROR: Semantics TODO: `generic interface`.
 // CHECK:STDERR: interface I[]();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `generic interface`.
 // CHECK:STDERR: interface I[]();
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~

--- a/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
@@ -5,13 +5,15 @@
 // AUTOUPDATE
 
 interface Modifiers {
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   final fn Final() { }
   // CHECK:STDERR:   ^~~~~
+  // CHECK:STDERR:
   final fn Final() { }
-  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+3]]:3: ERROR: Semantics TODO: `interface modifier`.
+  // CHECK:STDERR: fail_todo_modifiers.carbon:[[@LINE+4]]:3: ERROR: Semantics TODO: `interface modifier`.
   // CHECK:STDERR:   default fn Default() { }
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   default fn Default() { }
 }
 
@@ -43,14 +45,14 @@ private interface Private {
 // CHECK:STDOUT: interface @Modifiers {
 // CHECK:STDOUT:   %Self: Modifiers = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template] {}
-// CHECK:STDOUT:   %.loc11: <associated <function> in Modifiers> = assoc_entity element0, %Final [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12: <associated <function> in Modifiers> = assoc_entity element0, %Final [template = constants.%.3]
 // CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template] {}
-// CHECK:STDOUT:   %.loc15: <associated <function> in Modifiers> = assoc_entity element1, %Default [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17: <associated <function> in Modifiers> = assoc_entity element1, %Default [template = constants.%.4]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .Final = %.loc11
-// CHECK:STDOUT:   .Default = %.loc15
+// CHECK:STDOUT:   .Final = %.loc12
+// CHECK:STDOUT:   .Default = %.loc17
 // CHECK:STDOUT:   witness = (%Final, %Default)
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -7,9 +7,10 @@
 // TODO: Should this be valid?
 fn F(a: i32) -> i32 {
   let T:! type = i32;
-  // CHECK:STDERR: fail_generic.carbon:[[@LINE+3]]:3: ERROR: Cannot implicitly convert from `i32` to `T`.
+  // CHECK:STDERR: fail_generic.carbon:[[@LINE+4]]:3: ERROR: Cannot implicitly convert from `i32` to `T`.
   // CHECK:STDERR:   let x: T = 5;
   // CHECK:STDERR:   ^~~~~~~~~~~~~
+  // CHECK:STDERR:
   let x: T = 5;
   // CHECK:STDERR: fail_generic.carbon:[[@LINE+3]]:3: ERROR: Cannot implicitly convert from `T` to `i32`.
   // CHECK:STDERR:   return x;
@@ -38,7 +39,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
-// CHECK:STDOUT:   %.loc13: i32 = int_literal 5 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc14: i32 = int_literal 5 [template = constants.%.1]
 // CHECK:STDOUT:   %x: T = bind_name x, <error>
 // CHECK:STDOUT:   %x.ref: T = name_ref x, %x
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/let/fail_missing_value.carbon
+++ b/toolchain/check/testdata/let/fail_missing_value.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_missing_value.carbon:[[@LINE+3]]:11: ERROR: Expected `=`; `let` declaration must have an initializer.
+// CHECK:STDERR: fail_missing_value.carbon:[[@LINE+4]]:11: ERROR: Expected `=`; `let` declaration must have an initializer.
 // CHECK:STDERR: let n: i32;
 // CHECK:STDERR:           ^
+// CHECK:STDERR:
 let n: i32;
 
 fn F() {

--- a/toolchain/check/testdata/let/fail_modifiers.carbon
+++ b/toolchain/check/testdata/let/fail_modifiers.carbon
@@ -4,62 +4,73 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected let b: i32 = 1;
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 protected let b: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
 // CHECK:STDERR: default let c: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default let c: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `final` not allowed on `let` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `final` not allowed on `let` declaration outside of an interface.
 // CHECK:STDERR: final let d: i32 = 1;
 // CHECK:STDERR: ^~~~~
+// CHECK:STDERR:
 final let d: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `virtual` not allowed on `let` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `virtual` not allowed on `let` declaration.
 // CHECK:STDERR: virtual let e: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 virtual let e: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
 // CHECK:STDERR: default final let f: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `final` not allowed on declaration with `default`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `final` not allowed on declaration with `default`.
 // CHECK:STDERR: default final let f: i32 = 1;
 // CHECK:STDERR:         ^~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `default` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `default` previously appeared here.
 // CHECK:STDERR: default final let f: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default final let f: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `default` not allowed on `let` declaration outside of an interface.
 // CHECK:STDERR: default default let g: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `default` repeated on declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `default` repeated on declaration.
 // CHECK:STDERR: default default let g: i32 = 1;
 // CHECK:STDERR:         ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `default` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `default` previously appeared here.
 // CHECK:STDERR: default default let g: i32 = 1;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 default default let g: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected private let h: i32 = 1;
 // CHECK:STDERR: ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:11: ERROR: `private` not allowed on declaration with `protected`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:11: ERROR: `private` not allowed on declaration with `protected`.
 // CHECK:STDERR: protected private let h: i32 = 1;
 // CHECK:STDERR:           ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `protected` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `protected` previously appeared here.
 // CHECK:STDERR: protected private let h: i32 = 1;
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 protected private let h: i32 = 1;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+10]]:1: ERROR: `protected` not allowed on `let` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected protected let i: i32 = 1;
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:11: ERROR: `protected` repeated on declaration.
 // CHECK:STDERR: protected protected let i: i32 = 1;
 // CHECK:STDERR:           ^~~~~~~~~
@@ -76,21 +87,21 @@ protected protected let i: i32 = 1;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc10: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %b: i32 = bind_name b, %.loc10
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc15
-// CHECK:STDOUT:   %.loc20: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %d: i32 = bind_name d, %.loc20
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %e: i32 = bind_name e, %.loc25
-// CHECK:STDOUT:   %.loc36: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %f: i32 = bind_name f, %.loc36
-// CHECK:STDOUT:   %.loc47: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %g: i32 = bind_name g, %.loc47
-// CHECK:STDOUT:   %.loc58: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %h: i32 = bind_name h, %.loc58
-// CHECK:STDOUT:   %.loc69: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %i: i32 = bind_name i, %.loc69
+// CHECK:STDOUT:   %.loc11: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %b: i32 = bind_name b, %.loc11
+// CHECK:STDOUT:   %.loc17: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc17
+// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %d: i32 = bind_name d, %.loc23
+// CHECK:STDOUT:   %.loc29: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %e: i32 = bind_name e, %.loc29
+// CHECK:STDOUT:   %.loc42: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %f: i32 = bind_name f, %.loc42
+// CHECK:STDOUT:   %.loc55: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %g: i32 = bind_name g, %.loc55
+// CHECK:STDOUT:   %.loc68: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %h: i32 = bind_name h, %.loc68
+// CHECK:STDOUT:   %.loc80: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %i: i32 = bind_name i, %.loc80
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -20,12 +20,13 @@ import library "namespace";
 // imported declaration.
 namespace NS;
 
-// CHECK:STDERR: fail_conflict.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_conflict.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn NS();
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_conflict.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace NS;
 // CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
 fn NS();
 
 // The second conflict diagnostic should still point at the earlier declaration;
@@ -35,7 +36,7 @@ namespace NS;
 // CHECK:STDERR: fail_conflict.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn NS();
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_conflict.carbon:[[@LINE-17]]:1: Name is previously declared here.
+// CHECK:STDERR: fail_conflict.carbon:[[@LINE-18]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace NS;
 // CHECK:STDERR: ^~~~~~~~~~~~~
 fn NS();
@@ -58,9 +59,9 @@ fn NS();
 // CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, used
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc16: <function> = fn_decl @.1 [template] {}
-// CHECK:STDOUT:   %.loc20: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc28: <function> = fn_decl @.2 [template] {}
+// CHECK:STDOUT:   %.loc17: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc21: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %.loc29: <function> = fn_decl @.2 [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.1();

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -16,12 +16,13 @@ package Example api;
 
 import library "fn";
 
-// CHECK:STDERR: fail_conflict.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_conflict.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: namespace NS;
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fn.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: fn NS();
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 namespace NS;
 
 // CHECK:STDERR: fail_conflict.carbon:[[@LINE+6]]:7: ERROR: Name qualifiers are only allowed for entities that provide a scope.
@@ -50,8 +51,8 @@ fn NS.Foo();
 // CHECK:STDOUT:     .NS = %import_ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, used [template = imports.%NS]
-// CHECK:STDOUT:   %.loc12: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc20: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc13: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %.loc21: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @NS();

--- a/toolchain/check/testdata/namespace/fail_modifiers.carbon
+++ b/toolchain/check/testdata/namespace/fail_modifiers.carbon
@@ -4,38 +4,45 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+27]]:1: ERROR: `private` not allowed on `namespace` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+33]]:1: ERROR: `private` not allowed on `namespace` declaration.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+24]]:9: ERROR: `extern` not allowed on `namespace` declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+29]]:9: ERROR: `extern` not allowed on `namespace` declaration.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:         ^~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+21]]:16: ERROR: `abstract` not allowed on `namespace` declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+25]]:16: ERROR: `abstract` not allowed on `namespace` declaration.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+18]]:25: ERROR: `base` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+21]]:25: ERROR: `base` not allowed on declaration with `abstract`.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                         ^~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+15]]:16: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+18]]:16: `abstract` previously appeared here.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+12]]:30: ERROR: `default` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+14]]:30: ERROR: `default` not allowed on declaration with `abstract`.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                              ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:16: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:16: `abstract` previously appeared here.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                ^~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:38: ERROR: `final` not allowed on declaration with `abstract`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:38: ERROR: `final` not allowed on declaration with `abstract`.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                                      ^~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:16: `abstract` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:16: `abstract` previously appeared here.
 // CHECK:STDERR: private extern abstract base default final namespace A;
 // CHECK:STDERR:                ^~~~~~~~
+// CHECK:STDERR:
 private extern abstract base default final namespace A;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `impl` not allowed on `namespace` declaration.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `impl` not allowed on `namespace` declaration.
 // CHECK:STDERR: impl namespace B;
 // CHECK:STDERR: ^~~~
+// CHECK:STDERR:
 impl namespace B;
 
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `extern` not allowed on `namespace` declaration.

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
@@ -10,23 +10,28 @@ fn F(b: bool) -> type {
 }
 
 // TODO: Short-circuit operators should be permitted outside functions.
-// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+9]]:11: ERROR: Cannot evaluate type expression.
+// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+12]]:11: ERROR: Cannot evaluate type expression.
 // CHECK:STDERR: var and_: F(true and true);
 // CHECK:STDERR:           ^~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+6]]:13: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+8]]:13: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: var and_: F(true and true);
 // CHECK:STDERR:             ^~~~~~~~
-// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+3]]:13: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+4]]:13: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: var and_: F(true and true);
 // CHECK:STDERR:             ^~~~~~~~~~~~~
+// CHECK:STDERR:
 var and_: F(true and true);
 
-// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+9]]:10: ERROR: Cannot evaluate type expression.
+// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+11]]:10: ERROR: Cannot evaluate type expression.
 // CHECK:STDERR: var or_: F(true or true);
 // CHECK:STDERR:          ^~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+6]]:12: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+7]]:12: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: var or_: F(true or true);
 // CHECK:STDERR:            ^~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_and_or_not_in_function.carbon:[[@LINE+3]]:12: ERROR: Semantics TODO: `Control flow expressions are currently only supported inside functions.`.
 // CHECK:STDERR: var or_: F(true or true);
 // CHECK:STDERR:            ^~~~~~~~~~~~
@@ -40,10 +45,10 @@ var or_: F(true or true);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
-// CHECK:STDOUT:   %.loc33_17: bool = block_arg <unexpected instblockref block14>
-// CHECK:STDOUT:   %.loc33_11.1: init type = call <unexpected instref inst+27>(%.loc33_17)
-// CHECK:STDOUT:   %.loc33_24: type = value_of_initializer %.loc33_11.1
-// CHECK:STDOUT:   %.loc33_11.2: type = converted %.loc33_11.1, %.loc33_24
+// CHECK:STDOUT:   %.loc38_17: bool = block_arg <unexpected instblockref block14>
+// CHECK:STDOUT:   %.loc38_11.1: init type = call <unexpected instref inst+27>(%.loc38_17)
+// CHECK:STDOUT:   %.loc38_24: type = value_of_initializer %.loc38_11.1
+// CHECK:STDOUT:   %.loc38_11.2: type = converted %.loc38_11.1, %.loc38_24
 // CHECK:STDOUT:   %or_.var: ref <error> = var or_
 // CHECK:STDOUT:   %or_: ref <error> = bind_name or_, %or_.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_error.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_error.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 fn Main() {
-  // CHECK:STDERR: fail_assignment_to_error.carbon:[[@LINE+3]]:3: ERROR: Name `undeclared` not found.
+  // CHECK:STDERR: fail_assignment_to_error.carbon:[[@LINE+4]]:3: ERROR: Name `undeclared` not found.
   // CHECK:STDERR:   undeclared = 42;
   // CHECK:STDERR:   ^~~~~~~~~~
+  // CHECK:STDERR:
   undeclared = 42;
   // CHECK:STDERR: fail_assignment_to_error.carbon:[[@LINE+3]]:4: ERROR: Name `also_undeclared` not found.
   // CHECK:STDERR:   *also_undeclared = 42;
@@ -31,12 +32,12 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %undeclared.ref: <error> = name_ref undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 42 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 42 [template = constants.%.1]
 // CHECK:STDOUT:   assign %undeclared.ref, <error>
 // CHECK:STDOUT:   %also_undeclared.ref: <error> = name_ref also_undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc15_3: ref <error> = deref <error>
-// CHECK:STDOUT:   %.loc15_22: i32 = int_literal 42 [template = constants.%.1]
-// CHECK:STDOUT:   assign %.loc15_3, <error>
+// CHECK:STDOUT:   %.loc16_3: ref <error> = deref <error>
+// CHECK:STDOUT:   %.loc16_22: i32 = int_literal 42 [template = constants.%.1]
+// CHECK:STDOUT:   assign %.loc16_3, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
@@ -7,34 +7,41 @@
 fn F() -> i32;
 
 fn Main() {
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   1 = 2;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   1 = 2;
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   F() = 1;
   // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
   F() = 1;
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   (1, 2) = (3, 4);
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   (1, 2) = (3, 4);
   var n: i32 = 0;
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   (n, n) = (1, 2);
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   (n, n) = (1, 2);
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   i32 = i32*;
   // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
   i32 = i32*;
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   {.x = 1, .y = 2} = {.x = 3, .y = 4};
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   {.x = 1, .y = 2} = {.x = 3, .y = 4};
-  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+3]]:3: ERROR: Expression is not assignable.
+  // CHECK:STDERR: fail_assignment_to_non_assignable.carbon:[[@LINE+4]]:3: ERROR: Expression is not assignable.
   // CHECK:STDERR:   (if true then 1 else 2) = 3;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   (if true then 1 else 2) = 3;
 
   // Under #911, if expressions are never reference expressions.
@@ -81,100 +88,100 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc13_3: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc13_7: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   assign %.loc13_3, %.loc13_7
+// CHECK:STDOUT:   %.loc14_3: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc14_7: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   assign %.loc14_3, %.loc14_7
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc17_4: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
-// CHECK:STDOUT:   %.loc21_4: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc21_7: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc21_8.1: (i32, i32) = tuple_literal (%.loc21_4, %.loc21_7)
-// CHECK:STDOUT:   %.loc21_13: i32 = int_literal 3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc21_16: i32 = int_literal 4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc21_17.1: (i32, i32) = tuple_literal (%.loc21_13, %.loc21_16)
-// CHECK:STDOUT:   %.loc21_17.2: i32 = tuple_access %.loc21_8.1, element0
-// CHECK:STDOUT:   %.loc21_17.3: init i32 = initialize_from %.loc21_13 to %.loc21_17.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc21_17.4: i32 = tuple_access %.loc21_8.1, element1
-// CHECK:STDOUT:   %.loc21_17.5: init i32 = initialize_from %.loc21_16 to %.loc21_17.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc21_17.6: init (i32, i32) = tuple_init (%.loc21_17.3, %.loc21_17.5) to %.loc21_8.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_17.7: init (i32, i32) = converted %.loc21_17.1, %.loc21_17.6 [template = constants.%.7]
-// CHECK:STDOUT:   assign %.loc21_8.1, %.loc21_17.7
-// CHECK:STDOUT:   %.loc21_8.2: (i32, i32) = tuple_value (%.loc21_4, %.loc21_7) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc21_8.3: (i32, i32) = converted %.loc21_8.1, %.loc21_8.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc19_4: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc19_9: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   assign %.loc19_4, %.loc19_9
+// CHECK:STDOUT:   %.loc24_4: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc24_7: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc24_8.1: (i32, i32) = tuple_literal (%.loc24_4, %.loc24_7)
+// CHECK:STDOUT:   %.loc24_13: i32 = int_literal 3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc24_16: i32 = int_literal 4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc24_17.1: (i32, i32) = tuple_literal (%.loc24_13, %.loc24_16)
+// CHECK:STDOUT:   %.loc24_17.2: i32 = tuple_access %.loc24_8.1, element0
+// CHECK:STDOUT:   %.loc24_17.3: init i32 = initialize_from %.loc24_13 to %.loc24_17.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc24_17.4: i32 = tuple_access %.loc24_8.1, element1
+// CHECK:STDOUT:   %.loc24_17.5: init i32 = initialize_from %.loc24_16 to %.loc24_17.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc24_17.6: init (i32, i32) = tuple_init (%.loc24_17.3, %.loc24_17.5) to %.loc24_8.1 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc24_17.7: init (i32, i32) = converted %.loc24_17.1, %.loc24_17.6 [template = constants.%.7]
+// CHECK:STDOUT:   assign %.loc24_8.1, %.loc24_17.7
+// CHECK:STDOUT:   %.loc24_8.2: (i32, i32) = tuple_value (%.loc24_4, %.loc24_7) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc24_8.3: (i32, i32) = converted %.loc24_8.1, %.loc24_8.2 [template = constants.%.8]
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc22: i32 = int_literal 0 [template = constants.%.9]
-// CHECK:STDOUT:   assign %n.var, %.loc22
-// CHECK:STDOUT:   %n.ref.loc26_4: ref i32 = name_ref n, %n
-// CHECK:STDOUT:   %n.ref.loc26_7: ref i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc26_8.1: (i32, i32) = tuple_literal (%n.ref.loc26_4, %n.ref.loc26_7)
-// CHECK:STDOUT:   %.loc26_13: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc26_16: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc26_17.1: (i32, i32) = tuple_literal (%.loc26_13, %.loc26_16)
-// CHECK:STDOUT:   %.loc26_17.2: i32 = tuple_access %.loc26_8.1, element0
-// CHECK:STDOUT:   %.loc26_17.3: init i32 = initialize_from %.loc26_13 to %.loc26_17.2 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc26_17.4: i32 = tuple_access %.loc26_8.1, element1
-// CHECK:STDOUT:   %.loc26_17.5: init i32 = initialize_from %.loc26_16 to %.loc26_17.4 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc26_17.6: init (i32, i32) = tuple_init (%.loc26_17.3, %.loc26_17.5) to %.loc26_8.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc26_17.7: init (i32, i32) = converted %.loc26_17.1, %.loc26_17.6 [template = constants.%.8]
-// CHECK:STDOUT:   assign %.loc26_8.1, %.loc26_17.7
-// CHECK:STDOUT:   %.loc26_4: i32 = bind_value %n.ref.loc26_4
-// CHECK:STDOUT:   %.loc26_7: i32 = bind_value %n.ref.loc26_7
-// CHECK:STDOUT:   %.loc26_8.2: (i32, i32) = tuple_value (%.loc26_4, %.loc26_7)
-// CHECK:STDOUT:   %.loc26_8.3: (i32, i32) = converted %.loc26_8.1, %.loc26_8.2
-// CHECK:STDOUT:   %.loc30: type = ptr_type i32 [template = constants.%.10]
-// CHECK:STDOUT:   assign i32, %.loc30
-// CHECK:STDOUT:   %.loc34_9: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc34_17: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc34_18.1: {.x: i32, .y: i32} = struct_literal (%.loc34_9, %.loc34_17)
-// CHECK:STDOUT:   %.loc34_28: i32 = int_literal 3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc34_36: i32 = int_literal 4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc34_37.1: {.x: i32, .y: i32} = struct_literal (%.loc34_28, %.loc34_36)
-// CHECK:STDOUT:   %.loc34_37.2: i32 = struct_access %.loc34_18.1, element0
-// CHECK:STDOUT:   %.loc34_37.3: init i32 = initialize_from %.loc34_28 to %.loc34_37.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc34_37.4: i32 = struct_access %.loc34_18.1, element1
-// CHECK:STDOUT:   %.loc34_37.5: init i32 = initialize_from %.loc34_36 to %.loc34_37.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc34_37.6: init {.x: i32, .y: i32} = struct_init (%.loc34_37.3, %.loc34_37.5) to %.loc34_18.1 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc34_37.7: init {.x: i32, .y: i32} = converted %.loc34_37.1, %.loc34_37.6 [template = constants.%.13]
-// CHECK:STDOUT:   assign %.loc34_18.1, %.loc34_37.7
-// CHECK:STDOUT:   %.loc34_18.2: {.x: i32, .y: i32} = struct_value (%.loc34_9, %.loc34_17) [template = constants.%.14]
-// CHECK:STDOUT:   %.loc34_18.3: {.x: i32, .y: i32} = converted %.loc34_18.1, %.loc34_18.2 [template = constants.%.14]
-// CHECK:STDOUT:   %.loc38_7: bool = bool_literal true [template = constants.%.15]
-// CHECK:STDOUT:   if %.loc38_7 br !if.expr.then.loc38 else br !if.expr.else.loc38
-// CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.then.loc38:
-// CHECK:STDOUT:   %.loc38_17: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_17)
-// CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.else.loc38:
-// CHECK:STDOUT:   %.loc38_24: i32 = int_literal 2 [template = constants.%.2]
-// CHECK:STDOUT:   br !if.expr.result.loc38(%.loc38_24)
-// CHECK:STDOUT:
-// CHECK:STDOUT: !if.expr.result.loc38:
-// CHECK:STDOUT:   %.loc38_4: i32 = block_arg !if.expr.result.loc38
-// CHECK:STDOUT:   %.loc38_29: i32 = int_literal 3 [template = constants.%.4]
-// CHECK:STDOUT:   assign %.loc38_4, %.loc38_29
-// CHECK:STDOUT:   %a.var: ref i32 = var a
-// CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template = constants.%.9]
+// CHECK:STDOUT:   assign %n.var, %.loc25
+// CHECK:STDOUT:   %n.ref.loc30_4: ref i32 = name_ref n, %n
+// CHECK:STDOUT:   %n.ref.loc30_7: ref i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc30_8.1: (i32, i32) = tuple_literal (%n.ref.loc30_4, %n.ref.loc30_7)
+// CHECK:STDOUT:   %.loc30_13: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc30_16: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc30_17.1: (i32, i32) = tuple_literal (%.loc30_13, %.loc30_16)
+// CHECK:STDOUT:   %.loc30_17.2: i32 = tuple_access %.loc30_8.1, element0
+// CHECK:STDOUT:   %.loc30_17.3: init i32 = initialize_from %.loc30_13 to %.loc30_17.2 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc30_17.4: i32 = tuple_access %.loc30_8.1, element1
+// CHECK:STDOUT:   %.loc30_17.5: init i32 = initialize_from %.loc30_16 to %.loc30_17.4 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc30_17.6: init (i32, i32) = tuple_init (%.loc30_17.3, %.loc30_17.5) to %.loc30_8.1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc30_17.7: init (i32, i32) = converted %.loc30_17.1, %.loc30_17.6 [template = constants.%.8]
+// CHECK:STDOUT:   assign %.loc30_8.1, %.loc30_17.7
+// CHECK:STDOUT:   %.loc30_4: i32 = bind_value %n.ref.loc30_4
+// CHECK:STDOUT:   %.loc30_7: i32 = bind_value %n.ref.loc30_7
+// CHECK:STDOUT:   %.loc30_8.2: (i32, i32) = tuple_value (%.loc30_4, %.loc30_7)
+// CHECK:STDOUT:   %.loc30_8.3: (i32, i32) = converted %.loc30_8.1, %.loc30_8.2
+// CHECK:STDOUT:   %.loc35: type = ptr_type i32 [template = constants.%.10]
+// CHECK:STDOUT:   assign i32, %.loc35
+// CHECK:STDOUT:   %.loc40_9: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc40_17: i32 = int_literal 2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc40_18.1: {.x: i32, .y: i32} = struct_literal (%.loc40_9, %.loc40_17)
+// CHECK:STDOUT:   %.loc40_28: i32 = int_literal 3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc40_36: i32 = int_literal 4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc40_37.1: {.x: i32, .y: i32} = struct_literal (%.loc40_28, %.loc40_36)
+// CHECK:STDOUT:   %.loc40_37.2: i32 = struct_access %.loc40_18.1, element0
+// CHECK:STDOUT:   %.loc40_37.3: init i32 = initialize_from %.loc40_28 to %.loc40_37.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc40_37.4: i32 = struct_access %.loc40_18.1, element1
+// CHECK:STDOUT:   %.loc40_37.5: init i32 = initialize_from %.loc40_36 to %.loc40_37.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc40_37.6: init {.x: i32, .y: i32} = struct_init (%.loc40_37.3, %.loc40_37.5) to %.loc40_18.1 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc40_37.7: init {.x: i32, .y: i32} = converted %.loc40_37.1, %.loc40_37.6 [template = constants.%.13]
+// CHECK:STDOUT:   assign %.loc40_18.1, %.loc40_37.7
+// CHECK:STDOUT:   %.loc40_18.2: {.x: i32, .y: i32} = struct_value (%.loc40_9, %.loc40_17) [template = constants.%.14]
+// CHECK:STDOUT:   %.loc40_18.3: {.x: i32, .y: i32} = converted %.loc40_18.1, %.loc40_18.2 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.15]
 // CHECK:STDOUT:   if %.loc45_7 br !if.expr.then.loc45 else br !if.expr.else.loc45
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc45:
-// CHECK:STDOUT:   %a.ref.loc45_17: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc45_17: i32 = bind_value %a.ref.loc45_17
+// CHECK:STDOUT:   %.loc45_17: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   br !if.expr.result.loc45(%.loc45_17)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc45:
-// CHECK:STDOUT:   %a.ref.loc45_24: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc45_24: i32 = bind_value %a.ref.loc45_24
+// CHECK:STDOUT:   %.loc45_24: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   br !if.expr.result.loc45(%.loc45_24)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc45:
 // CHECK:STDOUT:   %.loc45_4: i32 = block_arg !if.expr.result.loc45
-// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 10 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc45_29: i32 = int_literal 3 [template = constants.%.4]
 // CHECK:STDOUT:   assign %.loc45_4, %.loc45_29
+// CHECK:STDOUT:   %a.var: ref i32 = var a
+// CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
+// CHECK:STDOUT:   %.loc52_7: bool = bool_literal true [template = constants.%.15]
+// CHECK:STDOUT:   if %.loc52_7 br !if.expr.then.loc52 else br !if.expr.else.loc52
+// CHECK:STDOUT:
+// CHECK:STDOUT: !if.expr.then.loc52:
+// CHECK:STDOUT:   %a.ref.loc52_17: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc52_17: i32 = bind_value %a.ref.loc52_17
+// CHECK:STDOUT:   br !if.expr.result.loc52(%.loc52_17)
+// CHECK:STDOUT:
+// CHECK:STDOUT: !if.expr.else.loc52:
+// CHECK:STDOUT:   %a.ref.loc52_24: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc52_24: i32 = bind_value %a.ref.loc52_24
+// CHECK:STDOUT:   br !if.expr.result.loc52(%.loc52_24)
+// CHECK:STDOUT:
+// CHECK:STDOUT: !if.expr.result.loc52:
+// CHECK:STDOUT:   %.loc52_4: i32 = block_arg !if.expr.result.loc52
+// CHECK:STDOUT:   %.loc52_29: i32 = int_literal 10 [template = constants.%.16]
+// CHECK:STDOUT:   assign %.loc52_4, %.loc52_29
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_redundant_compound_access.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_redundant_compound_access.carbon
@@ -8,9 +8,10 @@ fn F() -> i32 { return 0; }
 
 fn Main() {
   var a: i32 = 3;
-  // CHECK:STDERR: fail_redundant_compound_access.carbon:[[@LINE+3]]:7: ERROR: Member name of type `i32` in compound member access is not an instance member or an interface member.
+  // CHECK:STDERR: fail_redundant_compound_access.carbon:[[@LINE+4]]:7: ERROR: Member name of type `i32` in compound member access is not an instance member or an interface member.
   // CHECK:STDERR:   a = a.(a);
   // CHECK:STDERR:       ^~~~~
+  // CHECK:STDERR:
   a = a.(a);
   // CHECK:STDERR: fail_redundant_compound_access.carbon:[[@LINE+3]]:7: ERROR: Member name of type `<function>` in compound member access is not an instance member or an interface member.
   // CHECK:STDERR:   a = a.(F)();
@@ -48,16 +49,16 @@ fn Main() {
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc10: i32 = int_literal 3 [template = constants.%.2]
 // CHECK:STDOUT:   assign %a.var, %.loc10
-// CHECK:STDOUT:   %a.ref.loc14_3: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc14_7: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc14_10: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc14: i32 = bind_value %a.ref.loc14_10
-// CHECK:STDOUT:   assign %a.ref.loc14_3, %.loc14
-// CHECK:STDOUT:   %a.ref.loc18_3: ref i32 = name_ref a, %a
-// CHECK:STDOUT:   %a.ref.loc18_7: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc15_3: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc15_7: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc15_10: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %.loc15: i32 = bind_value %a.ref.loc15_10
+// CHECK:STDOUT:   assign %a.ref.loc15_3, %.loc15
+// CHECK:STDOUT:   %a.ref.loc19_3: ref i32 = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc19_7: ref i32 = name_ref a, %a
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc18: init i32 = call %F.ref()
-// CHECK:STDOUT:   assign %a.ref.loc18_3, %.loc18
+// CHECK:STDOUT:   %.loc19: init i32 = call %F.ref()
+// CHECK:STDOUT:   assign %a.ref.loc19_3, %.loc19
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/fail_type_mismatch_once.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_type_mismatch_once.carbon
@@ -7,9 +7,10 @@
 fn Main() -> i32 {
   // The following line has two mismatches, but after the first, it shouldn't
   // keep erroring.
-  // CHECK:STDERR: fail_type_mismatch_once.carbon:[[@LINE+6]]:10: ERROR: Semantics TODO: `missing or invalid operator interface`.
+  // CHECK:STDERR: fail_type_mismatch_once.carbon:[[@LINE+7]]:10: ERROR: Semantics TODO: `missing or invalid operator interface`.
   // CHECK:STDERR:   return 12 + 3.4 + 12;
   // CHECK:STDERR:          ^~~~~~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_type_mismatch_once.carbon:[[@LINE+3]]:10: ERROR: Semantics TODO: `missing or invalid operator interface`.
   // CHECK:STDERR:   return 12 + 3.4 + 12;
   // CHECK:STDERR:          ^~~~~~~~~~~~~
@@ -34,9 +35,9 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Main() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc16_10: i32 = int_literal 12 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc16_15: f64 = real_literal 34e-1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc16_21: i32 = int_literal 12 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc17_10: i32 = int_literal 12 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc17_15: f64 = real_literal 34e-1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc17_21: i32 = int_literal 12 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -43,16 +43,18 @@ import Core;
 class D {};
 
 fn TestEqual(a: D, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Eq in type D that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Eq in type D that does not implement that interface.
   // CHECK:STDERR:   return a == b;
   // CHECK:STDERR:          ^~~~~~
+  // CHECK:STDERR:
   return a == b;
 }
 
 fn TestNotEqual(a: D, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Eq in type D that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Eq in type D that does not implement that interface.
   // CHECK:STDERR:   return a != b;
   // CHECK:STDERR:          ^~~~~~
+  // CHECK:STDERR:
   return a != b;
 }
 
@@ -71,12 +73,13 @@ impl C as Core.Eq {
 }
 
 fn TestRhsBad(a: C, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl_for_args.carbon:[[@LINE+6]]:10: ERROR: Cannot implicitly convert from `D` to `C`.
+  // CHECK:STDERR: fail_no_impl_for_args.carbon:[[@LINE+7]]:10: ERROR: Cannot implicitly convert from `D` to `C`.
   // CHECK:STDERR:   return a == b;
   // CHECK:STDERR:          ^~~~~~
   // CHECK:STDERR: fail_no_impl_for_args.carbon:[[@LINE-8]]:3: Initializing parameter 1 of function declared here.
   // CHECK:STDERR:   fn Equal[self: C](other: C) -> bool;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   return a == b;
 }
 
@@ -315,13 +318,13 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+30, unused
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+15, unused
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
-// CHECK:STDOUT:     %D.ref.loc15_20: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %a.loc15_17.1: D = param a
-// CHECK:STDOUT:     @TestNotEqual.%a: D = bind_name a, %a.loc15_17.1
-// CHECK:STDOUT:     %D.ref.loc15_26: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %b.loc15_23.1: D = param b
-// CHECK:STDOUT:     @TestNotEqual.%b: D = bind_name b, %b.loc15_23.1
-// CHECK:STDOUT:     %return.var.loc15: ref bool = var <return slot>
+// CHECK:STDOUT:     %D.ref.loc16_20: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %a.loc16_17.1: D = param a
+// CHECK:STDOUT:     @TestNotEqual.%a: D = bind_name a, %a.loc16_17.1
+// CHECK:STDOUT:     %D.ref.loc16_26: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %b.loc16_23.1: D = param b
+// CHECK:STDOUT:     @TestNotEqual.%b: D = bind_name b, %b.loc16_23.1
+// CHECK:STDOUT:     %return.var.loc16: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.8: type = import_ref ir1, inst+1, used [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+30, unused
@@ -405,13 +408,13 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %import_ref.7: type = import_ref ir1, inst+1, used [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+15, unused
 // CHECK:STDOUT:   %TestLhsBad: <function> = fn_decl @TestLhsBad [template] {
-// CHECK:STDOUT:     %D.ref.loc24: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %a.loc24_15.1: D = param a
-// CHECK:STDOUT:     @TestLhsBad.%a: D = bind_name a, %a.loc24_15.1
-// CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %b.loc24_21.1: C = param b
-// CHECK:STDOUT:     @TestLhsBad.%b: C = bind_name b, %b.loc24_21.1
-// CHECK:STDOUT:     %return.var.loc24: ref bool = var <return slot>
+// CHECK:STDOUT:     %D.ref.loc25: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %a.loc25_15.1: D = param a
+// CHECK:STDOUT:     @TestLhsBad.%a: D = bind_name a, %a.loc25_15.1
+// CHECK:STDOUT:     %C.ref.loc25: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %b.loc25_21.1: C = param b
+// CHECK:STDOUT:     @TestLhsBad.%b: C = bind_name b, %b.loc25_21.1
+// CHECK:STDOUT:     %return.var.loc25: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, used [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+30, unused
@@ -475,11 +478,11 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: D = name_ref b, %b
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Equal]
-// CHECK:STDOUT:   %.loc21_12.1: <bound method> = bound_method %a.ref, %.1
-// CHECK:STDOUT:   %.loc21_12.2: init bool = call %.loc21_12.1(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc21_16: bool = value_of_initializer %.loc21_12.2 [template = <error>]
-// CHECK:STDOUT:   %.loc21_12.3: bool = converted %.loc21_12.2, %.loc21_16 [template = <error>]
-// CHECK:STDOUT:   return %.loc21_12.3
+// CHECK:STDOUT:   %.loc22_12.1: <bound method> = bound_method %a.ref, %.1
+// CHECK:STDOUT:   %.loc22_12.2: init bool = call %.loc22_12.1(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc22_16: bool = value_of_initializer %.loc22_12.2 [template = <error>]
+// CHECK:STDOUT:   %.loc22_12.3: bool = converted %.loc22_12.2, %.loc22_16 [template = <error>]
+// CHECK:STDOUT:   return %.loc22_12.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestLhsBad(%a: D, %b: C) -> bool {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -31,12 +31,13 @@ impl C as Core.AddAssign {
 }
 
 fn TestIncNonRef(a: C) {
-  // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE+6]]:3: ERROR: `addr self` method cannot be invoked on a value.
+  // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE+7]]:3: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   ++a;
   // CHECK:STDERR:   ^~
   // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE-10]]:14: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn Op[addr self: C*]();
   // CHECK:STDERR:              ^~~~
+  // CHECK:STDERR:
   ++a;
 }
 
@@ -44,7 +45,7 @@ fn TestAddAssignNonRef(a: C, b: C) {
   // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE+6]]:5: ERROR: `addr self` method cannot be invoked on a value.
   // CHECK:STDERR:   a += b;
   // CHECK:STDERR:     ^~
-  // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE-17]]:14: Initializing `addr self` parameter of method declared here.
+  // CHECK:STDERR: fail_assign_non_ref.carbon:[[@LINE-18]]:14: Initializing `addr self` parameter of method declared here.
   // CHECK:STDERR:   fn Op[addr self: C*](other: C);
   // CHECK:STDERR:              ^~~~
   a += b;
@@ -176,12 +177,12 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, used [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+12, unused
 // CHECK:STDOUT:   %TestAddAssignNonRef: <function> = fn_decl @TestAddAssignNonRef [template] {
-// CHECK:STDOUT:     %C.ref.loc25_27: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %a.loc25_24.1: C = param a
-// CHECK:STDOUT:     @TestAddAssignNonRef.%a: C = bind_name a, %a.loc25_24.1
-// CHECK:STDOUT:     %C.ref.loc25_33: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %b.loc25_30.1: C = param b
-// CHECK:STDOUT:     @TestAddAssignNonRef.%b: C = bind_name b, %b.loc25_30.1
+// CHECK:STDOUT:     %C.ref.loc26_27: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %a.loc26_24.1: C = param a
+// CHECK:STDOUT:     @TestAddAssignNonRef.%a: C = bind_name a, %a.loc26_24.1
+// CHECK:STDOUT:     %C.ref.loc26_33: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %b.loc26_30.1: C = param b
+// CHECK:STDOUT:     @TestAddAssignNonRef.%b: C = bind_name b, %b.loc26_30.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+16, used [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+32, unused
@@ -251,8 +252,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.1.%.1, element0 [template = @impl.1.%Op]
-// CHECK:STDOUT:   %.loc22_3.1: <bound method> = bound_method %a.ref, %.1
-// CHECK:STDOUT:   %.loc22_3.2: init () = call %.loc22_3.1(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc23_3.1: <bound method> = bound_method %a.ref, %.1
+// CHECK:STDOUT:   %.loc23_3.2: init () = call %.loc23_3.1(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -261,8 +262,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: C = name_ref b, %b
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.2.%.1, element0 [template = @impl.2.%Op]
-// CHECK:STDOUT:   %.loc32_5.1: <bound method> = bound_method %a.ref, %.1
-// CHECK:STDOUT:   %.loc32_5.2: init () = call %.loc32_5.1(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc33_5.1: <bound method> = bound_method %a.ref, %.1
+// CHECK:STDOUT:   %.loc33_5.2: init () = call %.loc33_5.1(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -30,24 +30,27 @@ import Core;
 class C {};
 
 fn TestUnary(a: C) -> C {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Negate in type C that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Negate in type C that does not implement that interface.
   // CHECK:STDERR:   return -a;
   // CHECK:STDERR:          ^~
+  // CHECK:STDERR:
   return -a;
 }
 
 fn TestBinary(a: C, b: C) -> C {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Add in type C that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Add in type C that does not implement that interface.
   // CHECK:STDERR:   return a + b;
   // CHECK:STDERR:          ^~~~~
+  // CHECK:STDERR:
   return a + b;
 }
 
 fn TestRef(b: C) {
   var a: C = {};
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:3: ERROR: Cannot access member of interface AddAssign in type C that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:3: ERROR: Cannot access member of interface AddAssign in type C that does not implement that interface.
   // CHECK:STDERR:   a += b;
   // CHECK:STDERR:   ^~~~~~
+  // CHECK:STDERR:
   a += b;
   // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:3: ERROR: Cannot access member of interface Inc in type C that does not implement that interface.
   // CHECK:STDERR:   ++a;
@@ -226,13 +229,13 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+9, unused
 // CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+9, unused
 // CHECK:STDOUT:   %TestBinary: <function> = fn_decl @TestBinary [template] {
-// CHECK:STDOUT:     %C.ref.loc15_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %a.loc15_15.1: C = param a
-// CHECK:STDOUT:     @TestBinary.%a: C = bind_name a, %a.loc15_15.1
-// CHECK:STDOUT:     %C.ref.loc15_24: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %b.loc15_21.1: C = param b
-// CHECK:STDOUT:     @TestBinary.%b: C = bind_name b, %b.loc15_21.1
-// CHECK:STDOUT:     %C.ref.loc15_30: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %C.ref.loc16_18: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %a.loc16_15.1: C = param a
+// CHECK:STDOUT:     @TestBinary.%a: C = bind_name a, %a.loc16_15.1
+// CHECK:STDOUT:     %C.ref.loc16_24: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %b.loc16_21.1: C = param b
+// CHECK:STDOUT:     @TestBinary.%b: C = bind_name b, %b.loc16_21.1
+// CHECK:STDOUT:     %C.ref.loc16_30: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestBinary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.6: type = import_ref ir1, inst+13, used [template = constants.%.7]
@@ -241,9 +244,9 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+30, unused
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+30, unused
 // CHECK:STDOUT:   %TestRef: <function> = fn_decl @TestRef [template] {
-// CHECK:STDOUT:     %C.ref.loc22: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %b.loc22_12.1: C = param b
-// CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc22_12.1
+// CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, %C.decl [template = constants.%C]
+// CHECK:STDOUT:     %b.loc24_12.1: C = param b
+// CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc24_12.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+34, used [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir1, inst+52, used [template = constants.%.13]
@@ -310,14 +313,14 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %a.var: ref C = var a
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc23_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc23_15.2: init C = class_init (), %a.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc23_15.3: init C = converted %.loc23_15.1, %.loc23_15.2 [template = constants.%.10]
-// CHECK:STDOUT:   assign %a.var, %.loc23_15.3
-// CHECK:STDOUT:   %a.ref.loc27: ref C = name_ref a, %a
+// CHECK:STDOUT:   %.loc25_15.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc25_15.2: init C = class_init (), %a.var [template = constants.%.10]
+// CHECK:STDOUT:   %.loc25_15.3: init C = converted %.loc25_15.1, %.loc25_15.2 [template = constants.%.10]
+// CHECK:STDOUT:   assign %a.var, %.loc25_15.3
+// CHECK:STDOUT:   %a.ref.loc30: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: C = name_ref b, %b
 // CHECK:STDOUT:   %AddAssign.decl: invalid = interface_decl @AddAssign [template = constants.%.11] {}
-// CHECK:STDOUT:   %a.ref.loc31: ref C = name_ref a, %a
+// CHECK:STDOUT:   %a.ref.loc34: ref C = name_ref a, %a
 // CHECK:STDOUT:   %Inc.decl: invalid = interface_decl @Inc [template = constants.%.14] {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -32,12 +32,13 @@ impl C as Core.AddAssign {
 }
 
 fn Test(a: C, b: D) -> C {
-  // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE+6]]:10: ERROR: Cannot implicitly convert from `D` to `C`.
+  // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE+7]]:10: ERROR: Cannot implicitly convert from `D` to `C`.
   // CHECK:STDERR:   return a + b;
   // CHECK:STDERR:          ^~~~~
   // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE-10]]:3: Initializing parameter 1 of function declared here.
   // CHECK:STDERR:   fn Op[self: C](other: C) -> C;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   return a + b;
 }
 
@@ -46,7 +47,7 @@ fn TestAssign(b: D) {
   // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE+6]]:3: ERROR: Cannot implicitly convert from `D` to `C`.
   // CHECK:STDERR:   a += b;
   // CHECK:STDERR:   ^~~~~~
-  // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE-18]]:3: Initializing parameter 1 of function declared here.
+  // CHECK:STDERR: fail_no_impl_for_arg.carbon:[[@LINE-19]]:3: Initializing parameter 1 of function declared here.
   // CHECK:STDERR:   fn Op[addr self: C*](other: C);
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   a += b;
@@ -192,9 +193,9 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, used [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unused
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
-// CHECK:STDOUT:     %D.ref.loc26: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %b.loc26_15.1: D = param b
-// CHECK:STDOUT:     @TestAssign.%b: D = bind_name b, %b.loc26_15.1
+// CHECK:STDOUT:     %D.ref.loc27: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %b.loc27_15.1: D = param b
+// CHECK:STDOUT:     @TestAssign.%b: D = bind_name b, %b.loc27_15.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, used [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unused
@@ -273,10 +274,10 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: D = name_ref b, %b
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.1.%.1, element0 [template = @impl.1.%Op]
-// CHECK:STDOUT:   %.loc23_12.1: <bound method> = bound_method %a.ref, %.1
-// CHECK:STDOUT:   %.loc23_12.2: ref C = temporary_storage
-// CHECK:STDOUT:   %.loc23_12.3: init C = call %.loc23_12.1(<invalid>) [template = <error>]
-// CHECK:STDOUT:   return %.loc23_12.3
+// CHECK:STDOUT:   %.loc24_12.1: <bound method> = bound_method %a.ref, %.1
+// CHECK:STDOUT:   %.loc24_12.2: ref C = temporary_storage
+// CHECK:STDOUT:   %.loc24_12.3: init C = call %.loc24_12.1(<invalid>) [template = <error>]
+// CHECK:STDOUT:   return %.loc24_12.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestAssign(%b: D) {
@@ -284,16 +285,16 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %a.var: ref C = var a
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc27_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc27_15.2: init C = class_init (), %a.var [template = constants.%.12]
-// CHECK:STDOUT:   %.loc27_15.3: init C = converted %.loc27_15.1, %.loc27_15.2 [template = constants.%.12]
-// CHECK:STDOUT:   assign %a.var, %.loc27_15.3
+// CHECK:STDOUT:   %.loc28_15.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc28_15.2: init C = class_init (), %a.var [template = constants.%.12]
+// CHECK:STDOUT:   %.loc28_15.3: init C = converted %.loc28_15.1, %.loc28_15.2 [template = constants.%.12]
+// CHECK:STDOUT:   assign %a.var, %.loc28_15.3
 // CHECK:STDOUT:   %a.ref: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: D = name_ref b, %b
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.2.%.1, element0 [template = @impl.2.%Op]
-// CHECK:STDOUT:   %.loc34_5.1: <bound method> = bound_method %a.ref, %.1
-// CHECK:STDOUT:   %.loc34_3: C* = addr_of %a.ref
-// CHECK:STDOUT:   %.loc34_5.2: init () = call %.loc34_5.1(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc35_5.1: <bound method> = bound_method %a.ref, %.1
+// CHECK:STDOUT:   %.loc35_3: C* = addr_of %a.ref
+// CHECK:STDOUT:   %.loc35_5.2: init () = call %.loc35_5.1(<invalid>) [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -56,23 +56,26 @@ import Core;
 class D {};
 
 fn TestLess(a: D, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
   // CHECK:STDERR:   return a < b;
   // CHECK:STDERR:          ^~~~~
+  // CHECK:STDERR:
   return a < b;
 }
 
 fn TestLessEqual(a: D, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
   // CHECK:STDERR:   return a <= b;
   // CHECK:STDERR:          ^~~~~~
+  // CHECK:STDERR:
   return a <= b;
 }
 
 fn TestGreater(a: D, b: D) -> bool {
-  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+3]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
+  // CHECK:STDERR: fail_no_impl.carbon:[[@LINE+4]]:10: ERROR: Cannot access member of interface Ordered in type D that does not implement that interface.
   // CHECK:STDERR:   return a > b;
   // CHECK:STDERR:          ^~~~~
+  // CHECK:STDERR:
   return a > b;
 }
 
@@ -439,35 +442,35 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+58, unused
 // CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+15, unused
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
-// CHECK:STDOUT:     %D.ref.loc15_21: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %a.loc15_18.1: D = param a
-// CHECK:STDOUT:     @TestLessEqual.%a: D = bind_name a, %a.loc15_18.1
-// CHECK:STDOUT:     %D.ref.loc15_27: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %b.loc15_24.1: D = param b
-// CHECK:STDOUT:     @TestLessEqual.%b: D = bind_name b, %b.loc15_24.1
-// CHECK:STDOUT:     %return.var.loc15: ref bool = var <return slot>
+// CHECK:STDOUT:     %D.ref.loc16_21: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %a.loc16_18.1: D = param a
+// CHECK:STDOUT:     @TestLessEqual.%a: D = bind_name a, %a.loc16_18.1
+// CHECK:STDOUT:     %D.ref.loc16_27: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %b.loc16_24.1: D = param b
+// CHECK:STDOUT:     @TestLessEqual.%b: D = bind_name b, %b.loc16_24.1
+// CHECK:STDOUT:     %return.var.loc16: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.12: type = import_ref ir1, inst+1, used [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+30, unused
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
-// CHECK:STDOUT:     %D.ref.loc22_19: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %a.loc22_16.1: D = param a
-// CHECK:STDOUT:     @TestGreater.%a: D = bind_name a, %a.loc22_16.1
-// CHECK:STDOUT:     %D.ref.loc22_25: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %b.loc22_22.1: D = param b
-// CHECK:STDOUT:     @TestGreater.%b: D = bind_name b, %b.loc22_22.1
-// CHECK:STDOUT:     %return.var.loc22: ref bool = var <return slot>
+// CHECK:STDOUT:     %D.ref.loc24_19: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %a.loc24_16.1: D = param a
+// CHECK:STDOUT:     @TestGreater.%a: D = bind_name a, %a.loc24_16.1
+// CHECK:STDOUT:     %D.ref.loc24_25: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %b.loc24_22.1: D = param b
+// CHECK:STDOUT:     @TestGreater.%b: D = bind_name b, %b.loc24_22.1
+// CHECK:STDOUT:     %return.var.loc24: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.14: type = import_ref ir1, inst+1, used [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+44, unused
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
-// CHECK:STDOUT:     %D.ref.loc29_24: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %a.loc29_21.1: D = param a
-// CHECK:STDOUT:     @TestGreaterEqual.%a: D = bind_name a, %a.loc29_21.1
-// CHECK:STDOUT:     %D.ref.loc29_30: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %b.loc29_27.1: D = param b
-// CHECK:STDOUT:     @TestGreaterEqual.%b: D = bind_name b, %b.loc29_27.1
-// CHECK:STDOUT:     %return.var.loc29: ref bool = var <return slot>
+// CHECK:STDOUT:     %D.ref.loc32_24: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %a.loc32_21.1: D = param a
+// CHECK:STDOUT:     @TestGreaterEqual.%a: D = bind_name a, %a.loc32_21.1
+// CHECK:STDOUT:     %D.ref.loc32_30: type = name_ref D, %D.decl [template = constants.%D]
+// CHECK:STDOUT:     %b.loc32_27.1: D = param b
+// CHECK:STDOUT:     @TestGreaterEqual.%b: D = bind_name b, %b.loc32_27.1
+// CHECK:STDOUT:     %return.var.loc32: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.16: type = import_ref ir1, inst+1, used [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.17 = import_ref ir1, inst+58, unused

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -69,9 +69,10 @@ import Other library "fn";
 import Other library "fn_extern";
 
 fn Run() {
-  // CHECK:STDERR: fail_main_use_other_extern.carbon:[[@LINE+9]]:3: In name lookup for `F`.
+  // CHECK:STDERR: fail_main_use_other_extern.carbon:[[@LINE+10]]:3: In name lookup for `F`.
   // CHECK:STDERR:   Other.F();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: other_fn_conflict.carbon:4:1: ERROR: Duplicate name being declared in the same scope.
   // CHECK:STDERR: fn F(x: i32) {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~
@@ -96,9 +97,10 @@ import Other library "fn";
 import Other library "fn_conflict";
 
 fn Run() {
-  // CHECK:STDERR: fail_main_use_other_ambiguous.carbon:[[@LINE+3]]:3: In name lookup for `F`.
+  // CHECK:STDERR: fail_main_use_other_ambiguous.carbon:[[@LINE+4]]:3: In name lookup for `F`.
   // CHECK:STDERR:   Other.F();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   Other.F();
 }
 
@@ -107,20 +109,22 @@ fn Run() {
 library "namespace_conflict" api;
 
 import library "other_ns";
-// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: import Other library "fn";
 // CHECK:STDERR: ^~~~~~
 // CHECK:STDERR: main_other_ns.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: namespace Other;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 import Other library "fn";
 
-// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+6]]:1: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+7]]:1: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: fn Other.F() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: other_fn.carbon:4:1: Name is previously declared here.
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 fn Other.F() {}
 
 // --- fail_main_reopen_other.carbon
@@ -129,12 +133,13 @@ library "reopen_other" api;
 
 import Other library "fn";
 
-// CHECK:STDERR: fail_main_reopen_other.carbon:[[@LINE+6]]:11: ERROR: Imported packages cannot be used for declarations.
+// CHECK:STDERR: fail_main_reopen_other.carbon:[[@LINE+7]]:11: ERROR: Imported packages cannot be used for declarations.
 // CHECK:STDERR: namespace Other;
 // CHECK:STDERR:           ^~~~~
 // CHECK:STDERR: fail_main_reopen_other.carbon:[[@LINE-5]]:1: Package imported here.
 // CHECK:STDERR: import Other library "fn";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 namespace Other;
 
 // This is not diagnosed after the diagnostic on `namespace Other;`.
@@ -272,7 +277,7 @@ fn Other.G() {}
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, file.%Other [template = file.%Other]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%import_ref.1 [template = imports.%F.1]
-// CHECK:STDOUT:   %.loc17: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc18: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -310,7 +315,7 @@ fn Other.G() {}
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, file.%Other [template = file.%Other]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%import_ref.1 [template = imports.%F.1]
-// CHECK:STDOUT:   %.loc11: init () = call %F.ref()
+// CHECK:STDOUT:   %.loc12: init () = call %F.ref()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -327,7 +332,7 @@ fn Other.G() {}
 // CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, used
 // CHECK:STDOUT:   %Other: <namespace> = namespace %import_ref.1, [template] {}
 // CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+1, used [template = imports.%F]
-// CHECK:STDOUT:   %.loc19: <function> = fn_decl @.1 [template] {}
+// CHECK:STDOUT:   %.loc21: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F();
@@ -346,7 +351,7 @@ fn Other.G() {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .G = %G
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc12: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %.loc13: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -6,16 +6,18 @@
 
 // --- fail_no_api.impl.carbon
 
-// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API not found.
 // CHECK:STDERR: package Foo impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Foo impl;
 
 // --- fail_no_api_lib.impl.carbon
 
-// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API not found.
 // CHECK:STDERR: package Foo library "Bar" impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Foo library "Bar" impl;
 
 // --- fail_no_api_main_lib.impl.carbon

--- a/toolchain/check/testdata/packages/fail_cycle.carbon
+++ b/toolchain/check/testdata/packages/fail_cycle.carbon
@@ -8,34 +8,38 @@
 
 package A api;
 
-// CHECK:STDERR: fail_a.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
+// CHECK:STDERR: fail_a.carbon:[[@LINE+4]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import B;
 
 // --- fail_b.carbon
 
 package B api;
 
-// CHECK:STDERR: fail_b.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
+// CHECK:STDERR: fail_b.carbon:[[@LINE+4]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import C;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import C;
 
 // --- fail_c.carbon
 
 package C api;
 
-// CHECK:STDERR: fail_c.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
+// CHECK:STDERR: fail_c.carbon:[[@LINE+4]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: import A;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import A;
 
 // --- fail_c.impl.carbon
 
-// CHECK:STDERR: fail_c.impl.carbon:[[@LINE+3]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
+// CHECK:STDERR: fail_c.impl.carbon:[[@LINE+4]]:1: ERROR: Import cannot be used due to a cycle. Cycle must be fixed to import.
 // CHECK:STDERR: package C impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package C impl;
 
 // --- fail_cycle_child.carbon

--- a/toolchain/check/testdata/packages/fail_duplicate_api.carbon
+++ b/toolchain/check/testdata/packages/fail_duplicate_api.carbon
@@ -4,6 +4,7 @@
 //
 // AUTOUPDATE
 // CHECK:STDERR: fail_main2.carbon: ERROR: Main//default previously provided by `main1.carbon`.
+// CHECK:STDERR:
 
 // --- main1.carbon
 
@@ -15,9 +16,10 @@ library "lib" api;
 
 // --- fail_main_lib2.carbon
 
-// CHECK:STDERR: fail_main_lib2.carbon:[[@LINE+3]]:1: ERROR: Library's API previously provided by `main_lib1.carbon`.
+// CHECK:STDERR: fail_main_lib2.carbon:[[@LINE+4]]:1: ERROR: Library's API previously provided by `main_lib1.carbon`.
 // CHECK:STDERR: library "lib" api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 library "lib" api;
 
 // --- package1.carbon
@@ -26,9 +28,10 @@ package Package api;
 
 // --- fail_package2.carbon
 
-// CHECK:STDERR: fail_package2.carbon:[[@LINE+3]]:1: ERROR: Library's API previously provided by `package1.carbon`.
+// CHECK:STDERR: fail_package2.carbon:[[@LINE+4]]:1: ERROR: Library's API previously provided by `package1.carbon`.
 // CHECK:STDERR: package Package api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Package api;
 
 // --- package_lib1.carbon

--- a/toolchain/check/testdata/packages/fail_extension.carbon
+++ b/toolchain/check/testdata/packages/fail_extension.carbon
@@ -4,9 +4,12 @@
 //
 // AUTOUPDATE
 // CHECK:STDERR: fail_main.incorrect: ERROR: File extension of `.carbon` required for `api`.
+// CHECK:STDERR:
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: ERROR: Main//default previously provided by `fail_main.incorrect`.
+// CHECK:STDERR:
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: fail_main_redundant_with_swapped_ext.impl.carbon: File extension of `.impl.carbon` only allowed for `impl`.
+// CHECK:STDERR:
 
 // --- fail_main.incorrect
 
@@ -14,52 +17,59 @@
 
 // --- fail_main_lib.incorrect
 
-// CHECK:STDERR: fail_main_lib.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.carbon` required for `api`.
+// CHECK:STDERR: fail_main_lib.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: library "lib" api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 library "lib" api;
 
 // --- fail_main_lib_impl.incorrect
 
-// CHECK:STDERR: fail_main_lib_impl.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
+// CHECK:STDERR: fail_main_lib_impl.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
 // CHECK:STDERR: library "lib" impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 library "lib" impl;
 
 // --- fail_package.incorrect
 
-// CHECK:STDERR: fail_package.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.carbon` required for `api`.
+// CHECK:STDERR: fail_package.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: package Package api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Package api;
 
 // --- fail_package_impl.incorrect
 
-// CHECK:STDERR: fail_package_impl.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
+// CHECK:STDERR: fail_package_impl.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
 // CHECK:STDERR: package Package impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Package impl;
 
 // --- fail_package_lib.incorrect
 
-// CHECK:STDERR: fail_package_lib.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.carbon` required for `api`.
+// CHECK:STDERR: fail_package_lib.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: package Package library "lib" api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Package library "lib" api;
 
 // --- fail_package_lib_impl.incorrect
 
-// CHECK:STDERR: fail_package_lib_impl.incorrect:[[@LINE+3]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
+// CHECK:STDERR: fail_package_lib_impl.incorrect:[[@LINE+4]]:1: ERROR: File extension of `.impl.carbon` required for `impl`.
 // CHECK:STDERR: package Package library "lib" impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Package library "lib" impl;
 
 // --- fail_swapped_ext.impl.carbon
 
-// CHECK:STDERR: fail_swapped_ext.impl.carbon:[[@LINE+4]]:1: ERROR: File extension of `.carbon` required for `api`.
+// CHECK:STDERR: fail_swapped_ext.impl.carbon:[[@LINE+5]]:1: ERROR: File extension of `.carbon` required for `api`.
 // CHECK:STDERR: package SwappedExt api;
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_swapped_ext.impl.carbon: File extension of `.impl.carbon` only allowed for `impl`.
+// CHECK:STDERR:
 package SwappedExt api;
 
 // --- fail_swapped_ext.carbon

--- a/toolchain/check/testdata/packages/fail_import_default.carbon
+++ b/toolchain/check/testdata/packages/fail_import_default.carbon
@@ -8,25 +8,28 @@
 
 package A api;
 
-// CHECK:STDERR: fail_default_api.carbon:[[@LINE+3]]:1: ERROR: File cannot import itself.
+// CHECK:STDERR: fail_default_api.carbon:[[@LINE+4]]:1: ERROR: File cannot import itself.
 // CHECK:STDERR: import library default;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import library default;
 
 // --- fail_default.impl.carbon
 
 package A impl;
 
-// CHECK:STDERR: fail_default.impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
+// CHECK:STDERR: fail_default.impl.carbon:[[@LINE+4]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import library default;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import library default;
 
 // --- fail_main_import_default.carbon
 
-// CHECK:STDERR: fail_main_import_default.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
+// CHECK:STDERR: fail_main_import_default.carbon:[[@LINE+4]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import library default;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import library default;
 
 // --- fail_main_lib_import_default.carbon

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -6,46 +6,52 @@
 
 // --- fail_main.carbon
 
-// CHECK:STDERR: fail_main.carbon:[[@LINE+3]]:1: ERROR: Imports from the current package must omit the package name.
+// CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: ERROR: Imports from the current package must omit the package name.
 // CHECK:STDERR: import Main;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Main;
 
-// CHECK:STDERR: fail_main.carbon:[[@LINE+3]]:1: ERROR: Imports from the current package must omit the package name.
+// CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: ERROR: Imports from the current package must omit the package name.
 // CHECK:STDERR: import Main library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Main library "lib";
 
 // --- fail_not_main.carbon
 
 package NotMain api;
 
-// CHECK:STDERR: fail_not_main.carbon:[[@LINE+3]]:1: ERROR: Cannot import `Main` from other packages.
+// CHECK:STDERR: fail_not_main.carbon:[[@LINE+4]]:1: ERROR: Cannot import `Main` from other packages.
 // CHECK:STDERR: import Main;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Main;
 
-// CHECK:STDERR: fail_not_main.carbon:[[@LINE+3]]:1: ERROR: Cannot import `Main` from other packages.
+// CHECK:STDERR: fail_not_main.carbon:[[@LINE+4]]:1: ERROR: Cannot import `Main` from other packages.
 // CHECK:STDERR: import Main library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Main library "lib";
 
 // --- fail_this.carbon
 
 package This api;
 
-// CHECK:STDERR: fail_this.carbon:[[@LINE+3]]:1: ERROR: File cannot import itself.
+// CHECK:STDERR: fail_this.carbon:[[@LINE+4]]:1: ERROR: File cannot import itself.
 // CHECK:STDERR: import This;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import This;
 
 // --- fail_this_lib.carbon
 
 package This library "lib" api;
 
-// CHECK:STDERR: fail_this_lib.carbon:[[@LINE+3]]:1: ERROR: File cannot import itself.
+// CHECK:STDERR: fail_this_lib.carbon:[[@LINE+4]]:1: ERROR: File cannot import itself.
 // CHECK:STDERR: import library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import library "lib";
 
 // --- implicit_api.carbon
@@ -56,9 +62,10 @@ package Implicit api;
 
 package Implicit impl;
 
-// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
+// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+4]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Implicit;
 
 // --- implicit_lib_api.carbon
@@ -69,9 +76,10 @@ package Implicit library "lib" api;
 
 package Implicit library "lib" impl;
 
-// CHECK:STDERR: fail_implicit_lib.impl.carbon:[[@LINE+3]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
+// CHECK:STDERR: fail_implicit_lib.impl.carbon:[[@LINE+4]]:1: ERROR: Explicit import of `api` from `impl` file is redundant with implicit import.
 // CHECK:STDERR: import Implicit library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Implicit library "lib";
 
 // --- fail_not_found.carbon

--- a/toolchain/check/testdata/packages/fail_import_repeat.carbon
+++ b/toolchain/check/testdata/packages/fail_import_repeat.carbon
@@ -19,30 +19,33 @@ library "lib" api;
 // --- fail_import.carbon
 
 import Api;
-// CHECK:STDERR: fail_import.carbon:[[@LINE+6]]:1: ERROR: Library imported more than once.
+// CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: ERROR: Library imported more than once.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: First import here.
 // CHECK:STDERR: import Api;
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Api;
 
 import Api library "lib";
-// CHECK:STDERR: fail_import.carbon:[[@LINE+6]]:1: ERROR: Library imported more than once.
+// CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: ERROR: Library imported more than once.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: First import here.
 // CHECK:STDERR: import Api library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import Api library "lib";
 
 import library "lib";
-// CHECK:STDERR: fail_import.carbon:[[@LINE+6]]:1: ERROR: Library imported more than once.
+// CHECK:STDERR: fail_import.carbon:[[@LINE+7]]:1: ERROR: Library imported more than once.
 // CHECK:STDERR: import library "lib";
 // CHECK:STDERR: ^~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-4]]:1: First import here.
 // CHECK:STDERR: import library "lib";
 // CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
 import library "lib";
 
 // --- fail_default_import.carbon

--- a/toolchain/check/testdata/packages/fail_import_type_error.carbon
+++ b/toolchain/check/testdata/packages/fail_import_type_error.carbon
@@ -8,17 +8,20 @@
 
 package Implicit api;
 
-// CHECK:STDERR: fail_implicit.carbon:[[@LINE+3]]:12: ERROR: Name `x` not found.
+// CHECK:STDERR: fail_implicit.carbon:[[@LINE+4]]:12: ERROR: Name `x` not found.
 // CHECK:STDERR: var a_ref: x;
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 var a_ref: x;
-// CHECK:STDERR: fail_implicit.carbon:[[@LINE+3]]:18: ERROR: Name `x` not found.
+// CHECK:STDERR: fail_implicit.carbon:[[@LINE+4]]:18: ERROR: Name `x` not found.
 // CHECK:STDERR: var b_ref: {.a = x};
 // CHECK:STDERR:                  ^
+// CHECK:STDERR:
 var b_ref: {.a = x};
-// CHECK:STDERR: fail_implicit.carbon:[[@LINE+3]]:13: ERROR: Name `x` not found.
+// CHECK:STDERR: fail_implicit.carbon:[[@LINE+4]]:13: ERROR: Name `x` not found.
 // CHECK:STDERR: var c_ref: (x,);
 // CHECK:STDERR:             ^
+// CHECK:STDERR:
 var c_ref: (x,);
 // CHECK:STDERR: fail_implicit.carbon:[[@LINE+3]]:12: ERROR: Name `x` not found.
 // CHECK:STDERR: var d_ref: x*;
@@ -45,19 +48,19 @@ var d: i32 = d_ref;
 // CHECK:STDOUT:     .c_ref = %c_ref
 // CHECK:STDOUT:     .d_ref = %d_ref
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %x.ref.loc7: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %x.ref.loc8: <error> = name_ref x, <error> [template = <error>]
 // CHECK:STDOUT:   %a_ref.var: ref <error> = var a_ref
 // CHECK:STDOUT:   %a_ref: ref <error> = bind_name a_ref, %a_ref.var
-// CHECK:STDOUT:   %x.ref.loc11: <error> = name_ref x, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc11: <error> = struct_literal (%x.ref.loc11)
+// CHECK:STDOUT:   %x.ref.loc13: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc13: <error> = struct_literal (%x.ref.loc13)
 // CHECK:STDOUT:   %b_ref.var: ref <error> = var b_ref
 // CHECK:STDOUT:   %b_ref: ref <error> = bind_name b_ref, %b_ref.var
-// CHECK:STDOUT:   %x.ref.loc15: <error> = name_ref x, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc15: <error> = tuple_literal (%x.ref.loc15)
+// CHECK:STDOUT:   %x.ref.loc18: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc18: <error> = tuple_literal (%x.ref.loc18)
 // CHECK:STDOUT:   %c_ref.var: ref <error> = var c_ref
 // CHECK:STDOUT:   %c_ref: ref <error> = bind_name c_ref, %c_ref.var
-// CHECK:STDOUT:   %x.ref.loc19: <error> = name_ref x, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc19: type = ptr_type <error> [template = <error>]
+// CHECK:STDOUT:   %x.ref.loc22: <error> = name_ref x, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc22: type = ptr_type <error> [template = <error>]
 // CHECK:STDOUT:   %d_ref.var: ref <error> = var d_ref
 // CHECK:STDOUT:   %d_ref: ref <error> = bind_name d_ref, %d_ref.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/packages/fail_package_main.carbon
+++ b/toolchain/check/testdata/packages/fail_package_main.carbon
@@ -6,24 +6,27 @@
 
 // --- fail_main.carbon
 
-// CHECK:STDERR: fail_main.carbon:[[@LINE+3]]:1: ERROR: `Main//default` must omit `package` directive.
+// CHECK:STDERR: fail_main.carbon:[[@LINE+4]]:1: ERROR: `Main//default` must omit `package` directive.
 // CHECK:STDERR: package Main api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Main api;
 
 // --- fail_main_impl.carbon
 
-// CHECK:STDERR: fail_main_impl.carbon:[[@LINE+3]]:1: ERROR: `Main//default` must omit `package` directive.
+// CHECK:STDERR: fail_main_impl.carbon:[[@LINE+4]]:1: ERROR: `Main//default` must omit `package` directive.
 // CHECK:STDERR: package Main impl;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package Main impl;
 
 // --- fail_raw_main.carbon
 
 // `Main` isn't a keyword, so this fails the same way.
-// CHECK:STDERR: fail_raw_main.carbon:[[@LINE+3]]:1: ERROR: `Main//default` must omit `package` directive.
+// CHECK:STDERR: fail_raw_main.carbon:[[@LINE+4]]:1: ERROR: `Main//default` must omit `package` directive.
 // CHECK:STDERR: package r#Main api;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 package r#Main api;
 
 // --- fail_main_lib.carbon

--- a/toolchain/check/testdata/pointer/fail_address_of_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_error.carbon
@@ -5,13 +5,15 @@
 // AUTOUPDATE
 
 fn Test() {
-  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+3]]:4: ERROR: Name `undeclared` not found.
+  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+4]]:4: ERROR: Name `undeclared` not found.
   // CHECK:STDERR:   &undeclared;
   // CHECK:STDERR:    ^~~~~~~~~~
+  // CHECK:STDERR:
   &undeclared;
-  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+6]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+7]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &(&undeclared);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_address_of_error.carbon:[[@LINE+3]]:6: ERROR: Name `undeclared` not found.
   // CHECK:STDERR:   &(&undeclared);
   // CHECK:STDERR:      ^~~~~~~~~~
@@ -29,11 +31,11 @@ fn Test() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Test() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %undeclared.ref.loc11: <error> = name_ref undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc11: <error> = addr_of %undeclared.ref.loc11 [template = <error>]
-// CHECK:STDOUT:   %undeclared.ref.loc18: <error> = name_ref undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc18_5: <error> = addr_of %undeclared.ref.loc18 [template = <error>]
-// CHECK:STDOUT:   %.loc18_3: <error> = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc12: <error> = name_ref undeclared, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc12: <error> = addr_of %undeclared.ref.loc12 [template = <error>]
+// CHECK:STDOUT:   %undeclared.ref.loc20: <error> = name_ref undeclared, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc20_5: <error> = addr_of %undeclared.ref.loc20 [template = <error>]
+// CHECK:STDOUT:   %.loc20_3: <error> = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -9,69 +9,82 @@ fn G() -> i32;
 fn H() -> {.a: i32};
 
 fn AddressOfLiteral() {
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &0;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &0;
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &true;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &true;
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &1.0;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &1.0;
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &"Hello";
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &"Hello";
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &(1, 2);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &(1, 2);
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &{.a = 5};
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &{.a = 5};
 }
 
 fn AddressOfOperator() {
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &(true and false);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &(true and false);
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of a temporary object.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of a temporary object.
   // CHECK:STDERR:   &H().a;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &H().a;
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &(not true);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &(not true);
 }
 
 fn AddressOfCall() {
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &G();
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &G();
 }
 
 fn AddressOfType() {
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &i32;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &i32;
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &(const i32*);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &(const i32*);
 }
 
 fn AddressOfTupleElementValue() {
-  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+3]]:3: ERROR: Cannot take the address of non-reference expression.
+  // CHECK:STDERR: fail_address_of_value.carbon:[[@LINE+4]]:3: ERROR: Cannot take the address of non-reference expression.
   // CHECK:STDERR:   &((1, 2)[0]);
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   &((1, 2)[0]);
 }
 
@@ -131,8 +144,8 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %AddressOfType: <function> = fn_decl @AddressOfType [template] {}
 // CHECK:STDOUT:   %AddressOfTupleElementValue: <function> = fn_decl @AddressOfTupleElementValue [template] {}
 // CHECK:STDOUT:   %AddressOfParam: <function> = fn_decl @AddressOfParam [template] {
-// CHECK:STDOUT:     %param.loc78_19.1: i32 = param param
-// CHECK:STDOUT:     @AddressOfParam.%param: i32 = bind_name param, %param.loc78_19.1
+// CHECK:STDOUT:     %param.loc91_19.1: i32 = param param
+// CHECK:STDOUT:     @AddressOfParam.%param: i32 = bind_name param, %param.loc91_19.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -142,87 +155,87 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfLiteral() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc15_4: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc15_3: i32* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc19_4: bool = bool_literal true [template = constants.%.4]
-// CHECK:STDOUT:   %.loc19_3: bool* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc23_4: f64 = real_literal 10e-1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc23_3: f64* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc27_4: String = string_literal "Hello" [template = constants.%.9]
-// CHECK:STDOUT:   %.loc27_3: String* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc31_5: i32 = int_literal 1 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc31_8: i32 = int_literal 2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc31_9: (i32, i32) = tuple_literal (%.loc31_5, %.loc31_8)
-// CHECK:STDOUT:   %.loc31_3: (i32, i32)* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc35_10: i32 = int_literal 5 [template = constants.%.14]
-// CHECK:STDOUT:   %.loc35_11: {.a: i32} = struct_literal (%.loc35_10)
-// CHECK:STDOUT:   %.loc35_3: {.a: i32}* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc16_4: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc16_3: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc21_4: bool = bool_literal true [template = constants.%.4]
+// CHECK:STDOUT:   %.loc21_3: bool* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc26_4: f64 = real_literal 10e-1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc26_3: f64* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc31_4: String = string_literal "Hello" [template = constants.%.9]
+// CHECK:STDOUT:   %.loc31_3: String* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc36_5: i32 = int_literal 1 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc36_8: i32 = int_literal 2 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc36_9: (i32, i32) = tuple_literal (%.loc36_5, %.loc36_8)
+// CHECK:STDOUT:   %.loc36_3: (i32, i32)* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc41_10: i32 = int_literal 5 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc41_11: {.a: i32} = struct_literal (%.loc41_10)
+// CHECK:STDOUT:   %.loc41_3: {.a: i32}* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfOperator() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc42_5: bool = bool_literal true [template = constants.%.4]
-// CHECK:STDOUT:   %.loc42_10.1: bool = bool_literal false [template = constants.%.16]
-// CHECK:STDOUT:   if %.loc42_5 br !and.rhs else br !and.result(%.loc42_10.1)
+// CHECK:STDOUT:   %.loc49_5: bool = bool_literal true [template = constants.%.4]
+// CHECK:STDOUT:   %.loc49_10.1: bool = bool_literal false [template = constants.%.16]
+// CHECK:STDOUT:   if %.loc49_5 br !and.rhs else br !and.result(%.loc49_10.1)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
-// CHECK:STDOUT:   %.loc42_14: bool = bool_literal false [template = constants.%.16]
-// CHECK:STDOUT:   br !and.result(%.loc42_14)
+// CHECK:STDOUT:   %.loc49_14: bool = bool_literal false [template = constants.%.16]
+// CHECK:STDOUT:   br !and.result(%.loc49_14)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc42_10.2: bool = block_arg !and.result
-// CHECK:STDOUT:   %.loc42_3: bool* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc49_10.2: bool = block_arg !and.result
+// CHECK:STDOUT:   %.loc49_3: bool* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
-// CHECK:STDOUT:   %.loc46_5.1: init {.a: i32} = call %H.ref()
-// CHECK:STDOUT:   %.loc46_5.2: ref {.a: i32} = temporary_storage
-// CHECK:STDOUT:   %.loc46_5.3: ref {.a: i32} = temporary %.loc46_5.2, %.loc46_5.1
-// CHECK:STDOUT:   %.loc46_7: ref i32 = struct_access %.loc46_5.3, element0
-// CHECK:STDOUT:   %.loc46_3: i32* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc50_9: bool = bool_literal true [template = constants.%.4]
-// CHECK:STDOUT:   %.loc50_5: bool = not %.loc50_9 [template = constants.%.16]
-// CHECK:STDOUT:   %.loc50_3: bool* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc54_5.1: init {.a: i32} = call %H.ref()
+// CHECK:STDOUT:   %.loc54_5.2: ref {.a: i32} = temporary_storage
+// CHECK:STDOUT:   %.loc54_5.3: ref {.a: i32} = temporary %.loc54_5.2, %.loc54_5.1
+// CHECK:STDOUT:   %.loc54_7: ref i32 = struct_access %.loc54_5.3, element0
+// CHECK:STDOUT:   %.loc54_3: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc59_9: bool = bool_literal true [template = constants.%.4]
+// CHECK:STDOUT:   %.loc59_5: bool = not %.loc59_9 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc59_3: bool* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfCall() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc57_5: init i32 = call %G.ref()
-// CHECK:STDOUT:   %.loc57_3: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc67_5: init i32 = call %G.ref()
+// CHECK:STDOUT:   %.loc67_3: i32* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfType() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc64: type* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   %.loc68_5: type = const_type i32 [template = constants.%.18]
-// CHECK:STDOUT:   %.loc68_14: type = ptr_type const i32 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc68_3: type* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc75: type* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc80_5: type = const_type i32 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc80_14: type = ptr_type const i32 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc80_3: type* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfTupleElementValue() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc75_6: i32 = int_literal 1 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc75_9: i32 = int_literal 2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc75_10.1: (i32, i32) = tuple_literal (%.loc75_6, %.loc75_9)
-// CHECK:STDOUT:   %.loc75_12: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc75_10.2: (i32, i32) = tuple_value (%.loc75_6, %.loc75_9) [template = constants.%.20]
-// CHECK:STDOUT:   %.loc75_10.3: (i32, i32) = converted %.loc75_10.1, %.loc75_10.2 [template = constants.%.20]
-// CHECK:STDOUT:   %.loc75_13: i32 = tuple_index %.loc75_10.3, %.loc75_12 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc75_3: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   %.loc88_6: i32 = int_literal 1 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc88_9: i32 = int_literal 2 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc88_10.1: (i32, i32) = tuple_literal (%.loc88_6, %.loc88_9)
+// CHECK:STDOUT:   %.loc88_12: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc88_10.2: (i32, i32) = tuple_value (%.loc88_6, %.loc88_9) [template = constants.%.20]
+// CHECK:STDOUT:   %.loc88_10.3: (i32, i32) = converted %.loc88_10.1, %.loc88_10.2 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc88_13: i32 = tuple_index %.loc88_10.3, %.loc88_12 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc88_3: i32* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AddressOfParam(%param: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc82_22: type = ptr_type i32 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc95_22: type = ptr_type i32 [template = constants.%.3]
 // CHECK:STDOUT:   %param_addr.var: ref i32* = var param_addr
 // CHECK:STDOUT:   %param_addr: ref i32* = bind_name param_addr, %param_addr.var
 // CHECK:STDOUT:   %param.ref: i32 = name_ref param, %param
-// CHECK:STDOUT:   %.loc82_26: i32* = addr_of <error> [template = <error>]
-// CHECK:STDOUT:   assign %param_addr.var, %.loc82_26
+// CHECK:STDOUT:   %.loc95_26: i32* = addr_of <error> [template = <error>]
+// CHECK:STDOUT:   assign %param_addr.var, %.loc95_26
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_error.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_error.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_deref_error.carbon:[[@LINE+3]]:15: ERROR: Name `undeclared` not found.
+// CHECK:STDERR: fail_deref_error.carbon:[[@LINE+4]]:15: ERROR: Name `undeclared` not found.
 // CHECK:STDERR: let n: i32 = *undeclared;
 // CHECK:STDERR:               ^~~~~~~~~~
+// CHECK:STDERR:
 let n: i32 = *undeclared;
 // CHECK:STDERR: fail_deref_error.carbon:[[@LINE+3]]:15: ERROR: Name `undeclared` not found.
 // CHECK:STDERR: let n2: i32 = undeclared->foo;
@@ -17,11 +18,11 @@ let n2: i32 = undeclared->foo;
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %undeclared.ref.loc10: <error> = name_ref undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc10: ref <error> = deref <error>
+// CHECK:STDOUT:   %undeclared.ref.loc11: <error> = name_ref undeclared, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc11: ref <error> = deref <error>
 // CHECK:STDOUT:   %n: i32 = bind_name n, <error>
-// CHECK:STDOUT:   %undeclared.ref.loc14: <error> = name_ref undeclared, <error> [template = <error>]
-// CHECK:STDOUT:   %.loc14: ref <error> = deref <error>
+// CHECK:STDOUT:   %undeclared.ref.loc15: <error> = name_ref undeclared, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc15: ref <error> = deref <error>
 // CHECK:STDOUT:   %n2: i32 = bind_name n2, <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_function.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_function.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 fn A() {
-  // CHECK:STDERR: fail_deref_function.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
+  // CHECK:STDERR: fail_deref_function.carbon:[[@LINE+4]]:4: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   *A;
   // CHECK:STDERR:    ^
+  // CHECK:STDERR:
   *A;
   // CHECK:STDERR: fail_deref_function.carbon:[[@LINE+3]]:3: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   A->foo;
@@ -26,10 +27,10 @@ fn A() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref.loc11: <function> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc11: ref <error> = deref <error>
-// CHECK:STDOUT:   %A.ref.loc15: <function> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc15: ref <error> = deref <error>
+// CHECK:STDOUT:   %A.ref.loc12: <function> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc12: ref <error> = deref <error>
+// CHECK:STDOUT:   %A.ref.loc16: <function> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc16: ref <error> = deref <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_namespace.carbon
@@ -7,9 +7,10 @@
 namespace A;
 
 fn F() {
-  // CHECK:STDERR: fail_deref_namespace.carbon:[[@LINE+3]]:4: ERROR: Expression cannot be used as a value.
+  // CHECK:STDERR: fail_deref_namespace.carbon:[[@LINE+4]]:4: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   *A;
   // CHECK:STDERR:    ^
+  // CHECK:STDERR:
   *A;
   // CHECK:STDERR: fail_deref_namespace.carbon:[[@LINE+3]]:3: ERROR: Expression cannot be used as a value.
   // CHECK:STDERR:   A->foo;
@@ -30,10 +31,10 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %A.ref.loc13: <namespace> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc13: ref <error> = deref <error>
-// CHECK:STDOUT:   %A.ref.loc17: <namespace> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc17: ref <error> = deref <error>
+// CHECK:STDOUT:   %A.ref.loc14: <namespace> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc14: ref <error> = deref <error>
+// CHECK:STDOUT:   %A.ref.loc18: <namespace> = name_ref A, file.%A [template = file.%A]
+// CHECK:STDOUT:   %.loc18: ref <error> = deref <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -5,25 +5,30 @@
 // AUTOUPDATE
 
 fn Deref(n: i32) {
-  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:3: ERROR: Cannot dereference operand of non-pointer type `i32`.
+  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+4]]:3: ERROR: Cannot dereference operand of non-pointer type `i32`.
   // CHECK:STDERR:   *n;
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   *n;
-  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:4: ERROR: Cannot apply `->` operator to non-pointer type `i32`.
+  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+4]]:4: ERROR: Cannot apply `->` operator to non-pointer type `i32`.
   // CHECK:STDERR:   n->foo;
   // CHECK:STDERR:    ^~
+  // CHECK:STDERR:
   n->foo;
-  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:3: ERROR: Cannot dereference operand of non-pointer type `()`.
+  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+4]]:3: ERROR: Cannot dereference operand of non-pointer type `()`.
   // CHECK:STDERR:   *();
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   *();
-  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:5: ERROR: Cannot apply `->` operator to non-pointer type `()`.
+  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+4]]:5: ERROR: Cannot apply `->` operator to non-pointer type `()`.
   // CHECK:STDERR:   ()->foo;
   // CHECK:STDERR:     ^~
+  // CHECK:STDERR:
   ()->foo;
-  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:3: ERROR: Cannot dereference operand of non-pointer type `{}`.
+  // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+4]]:3: ERROR: Cannot dereference operand of non-pointer type `{}`.
   // CHECK:STDERR:   *{};
   // CHECK:STDERR:   ^
+  // CHECK:STDERR:
   *{};
   // CHECK:STDERR: fail_deref_not_pointer.carbon:[[@LINE+3]]:5: ERROR: Cannot apply `->` operator to non-pointer type `{}`.
   // CHECK:STDERR:   {}->foo;
@@ -52,26 +57,26 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Deref(%n: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %n.ref.loc11: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc11: ref <error> = deref %n.ref.loc11
-// CHECK:STDOUT:   %n.ref.loc15: i32 = name_ref n, %n
-// CHECK:STDOUT:   %.loc15: ref <error> = deref %n.ref.loc15
-// CHECK:STDOUT:   %.loc19_5.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc19_5.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc19_5.3: () = converted %.loc19_5.1, %.loc19_5.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc19_3: ref <error> = deref %.loc19_5.3
-// CHECK:STDOUT:   %.loc23_4.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc23_4.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc23_4.3: () = converted %.loc23_4.1, %.loc23_4.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc23_5: ref <error> = deref %.loc23_4.3
-// CHECK:STDOUT:   %.loc27_5.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc27_5.2: {} = struct_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc27_5.3: {} = converted %.loc27_5.1, %.loc27_5.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc27_3: ref <error> = deref %.loc27_5.3
-// CHECK:STDOUT:   %.loc31_4.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc31_4.2: {} = struct_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc31_4.3: {} = converted %.loc31_4.1, %.loc31_4.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc31_5: ref <error> = deref %.loc31_4.3
+// CHECK:STDOUT:   %n.ref.loc12: i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc12: ref <error> = deref %n.ref.loc12
+// CHECK:STDOUT:   %n.ref.loc17: i32 = name_ref n, %n
+// CHECK:STDOUT:   %.loc17: ref <error> = deref %n.ref.loc17
+// CHECK:STDOUT:   %.loc22_5.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_5.2: () = tuple_value () [template = constants.%.2]
+// CHECK:STDOUT:   %.loc22_5.3: () = converted %.loc22_5.1, %.loc22_5.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc22_3: ref <error> = deref %.loc22_5.3
+// CHECK:STDOUT:   %.loc27_4.1: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc27_4.2: () = tuple_value () [template = constants.%.2]
+// CHECK:STDOUT:   %.loc27_4.3: () = converted %.loc27_4.1, %.loc27_4.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc27_5: ref <error> = deref %.loc27_4.3
+// CHECK:STDOUT:   %.loc32_5.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc32_5.2: {} = struct_value () [template = constants.%.4]
+// CHECK:STDOUT:   %.loc32_5.3: {} = converted %.loc32_5.1, %.loc32_5.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc32_3: ref <error> = deref %.loc32_5.3
+// CHECK:STDOUT:   %.loc36_4.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc36_4.2: {} = struct_value () [template = constants.%.4]
+// CHECK:STDOUT:   %.loc36_4.3: {} = converted %.loc36_4.1, %.loc36_4.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc36_5: ref <error> = deref %.loc36_4.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/fail_deref_type.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_type.carbon
@@ -4,12 +4,13 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_deref_type.carbon:[[@LINE+6]]:8: ERROR: Cannot dereference operand of non-pointer type `type`.
+// CHECK:STDERR: fail_deref_type.carbon:[[@LINE+7]]:8: ERROR: Cannot dereference operand of non-pointer type `type`.
 // CHECK:STDERR: var p: *i32;
 // CHECK:STDERR:        ^
-// CHECK:STDERR: fail_deref_type.carbon:[[@LINE+3]]:8: To form a pointer type, write the `*` after the pointee type.
+// CHECK:STDERR: fail_deref_type.carbon:[[@LINE+4]]:8: To form a pointer type, write the `*` after the pointee type.
 // CHECK:STDERR: var p: *i32;
 // CHECK:STDERR:        ^
+// CHECK:STDERR:
 var p: *i32;
 // CHECK:STDERR: fail_deref_type.carbon:[[@LINE+3]]:12: ERROR: Cannot apply `->` operator to non-pointer type `type`.
 // CHECK:STDERR: var p2: i32->foo;
@@ -23,10 +24,10 @@ var p2: i32->foo;
 // CHECK:STDOUT:     .p = %p
 // CHECK:STDOUT:     .p2 = %p2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc13: ref <error> = deref i32
+// CHECK:STDOUT:   %.loc14: ref <error> = deref i32
 // CHECK:STDOUT:   %p.var: ref <error> = var p
 // CHECK:STDOUT:   %p: ref <error> = bind_name p, %p.var
-// CHECK:STDOUT:   %.loc17: ref <error> = deref i32
+// CHECK:STDOUT:   %.loc18: ref <error> = deref i32
 // CHECK:STDOUT:   %p2.var: ref <error> = var p2
 // CHECK:STDOUT:   %p2: ref <error> = bind_name p2, %p2.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -5,16 +5,18 @@
 // AUTOUPDATE
 
 let x: type = i32;
-// CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+3]]:13: ERROR: Cannot evaluate type expression.
+// CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:13: ERROR: Cannot evaluate type expression.
 // CHECK:STDERR: fn Six() -> x { return 6; }
 // CHECK:STDERR:             ^
+// CHECK:STDERR:
 fn Six() -> x { return 6; }
 
 // TODO: This should probably work.
 let y:! type = i32;
-// CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+3]]:23: ERROR: Cannot implicitly convert from `i32` to `y`.
+// CHECK:STDERR: fail_let_in_type.carbon:[[@LINE+4]]:23: ERROR: Cannot implicitly convert from `i32` to `y`.
 // CHECK:STDERR: fn HalfDozen() -> y { return 6; }
 // CHECK:STDERR:                       ^~~~~~~~~
+// CHECK:STDERR:
 fn HalfDozen() -> y { return 6; }
 
 // TODO: This should work.
@@ -34,13 +36,13 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Six() -> <error> {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc12: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @HalfDozen() -> y {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 6 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc20: i32 = int_literal 6 [template = constants.%.1]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -6,12 +6,13 @@
 
 fn F() -> i32 {
   returned var v: i32 = 0;
-  // CHECK:STDERR: fail_return_with_returned_var.carbon:[[@LINE+6]]:3: ERROR: Can only `return var;` in the scope of a `returned var`.
+  // CHECK:STDERR: fail_return_with_returned_var.carbon:[[@LINE+7]]:3: ERROR: Can only `return var;` in the scope of a `returned var`.
   // CHECK:STDERR:   return 1;
   // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR: fail_return_with_returned_var.carbon:[[@LINE-4]]:16: `returned var` was declared here.
   // CHECK:STDERR:   returned var v: i32 = 0;
   // CHECK:STDERR:                ^
+  // CHECK:STDERR:
   return 1;
 }
 
@@ -57,13 +58,13 @@ fn G() -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {
-// CHECK:STDOUT:   %.loc18_16: <unbound element of class C> = field_decl a, element0 [template]
-// CHECK:STDOUT:   %.loc18_28: <unbound element of class C> = field_decl b, element1 [template]
+// CHECK:STDOUT:   %.loc19_16: <unbound element of class C> = field_decl a, element0 [template]
+// CHECK:STDOUT:   %.loc19_28: <unbound element of class C> = field_decl b, element1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%C
-// CHECK:STDOUT:   .a = %.loc18_16
-// CHECK:STDOUT:   .b = %.loc18_28
+// CHECK:STDOUT:   .a = %.loc19_16
+// CHECK:STDOUT:   .b = %.loc19_28
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {
@@ -72,7 +73,7 @@ fn G() -> C {
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %v.var, %.loc8
-// CHECK:STDOUT:   %.loc15: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -80,16 +81,16 @@ fn G() -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %c: ref C = bind_name c, %return
-// CHECK:STDOUT:   %.loc20_29: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc20_37: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc20_38.1: {.a: i32, .b: i32} = struct_literal (%.loc20_29, %.loc20_37)
-// CHECK:STDOUT:   %.loc20_38.2: ref i32 = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc20_38.3: init i32 = initialize_from %.loc20_29 to %.loc20_38.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc20_38.4: ref i32 = class_element_access %return, element1
-// CHECK:STDOUT:   %.loc20_38.5: init i32 = initialize_from %.loc20_37 to %.loc20_38.4 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc20_38.6: init C = class_init (%.loc20_38.3, %.loc20_38.5), %return [template = constants.%.7]
-// CHECK:STDOUT:   %.loc20_38.7: init C = converted %.loc20_38.1, %.loc20_38.6 [template = constants.%.7]
-// CHECK:STDOUT:   assign %return, %.loc20_38.7
+// CHECK:STDOUT:   %.loc21_29: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc21_37: i32 = int_literal 2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc21_38.1: {.a: i32, .b: i32} = struct_literal (%.loc21_29, %.loc21_37)
+// CHECK:STDOUT:   %.loc21_38.2: ref i32 = class_element_access %return, element0
+// CHECK:STDOUT:   %.loc21_38.3: init i32 = initialize_from %.loc21_29 to %.loc21_38.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc21_38.4: ref i32 = class_element_access %return, element1
+// CHECK:STDOUT:   %.loc21_38.5: init i32 = initialize_from %.loc21_37 to %.loc21_38.4 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc21_38.6: init C = class_init (%.loc21_38.3, %.loc21_38.5), %return [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_38.7: init C = converted %.loc21_38.1, %.loc21_38.6 [template = constants.%.7]
+// CHECK:STDOUT:   assign %return, %.loc21_38.7
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
+++ b/toolchain/check/testdata/return/fail_returned_var_shadow.carbon
@@ -7,12 +7,13 @@
 fn SameScope() -> i32 {
   if (true) {
     returned var v: i32 = 0;
-    // CHECK:STDERR: fail_returned_var_shadow.carbon:[[@LINE+6]]:18: ERROR: Cannot declare a `returned var` in the scope of another `returned var`.
+    // CHECK:STDERR: fail_returned_var_shadow.carbon:[[@LINE+7]]:18: ERROR: Cannot declare a `returned var` in the scope of another `returned var`.
     // CHECK:STDERR:     returned var w: i32 = 1;
     // CHECK:STDERR:                  ^
     // CHECK:STDERR: fail_returned_var_shadow.carbon:[[@LINE-4]]:18: `returned var` was declared here.
     // CHECK:STDERR:     returned var v: i32 = 0;
     // CHECK:STDERR:                  ^
+    // CHECK:STDERR:
     returned var w: i32 = 1;
   }
   return 0;
@@ -51,7 +52,7 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT:     %return.var.loc7: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %DifferentScopes: <function> = fn_decl @DifferentScopes [template] {
-// CHECK:STDOUT:     %return.var.loc21: ref i32 = var <return slot>
+// CHECK:STDOUT:     %return.var.loc22: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -67,40 +68,40 @@ fn DifferentScopes() -> i32 {
 // CHECK:STDOUT:   assign %v.var, %.loc9
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc16: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   assign %w.var, %.loc16
+// CHECK:STDOUT:   %.loc17: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   assign %w.var, %.loc17
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else:
-// CHECK:STDOUT:   %.loc18: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   return %.loc18
+// CHECK:STDOUT:   %.loc19: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   return %.loc19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @DifferentScopes() -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc22: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   if %.loc22 br !if.then.loc22 else br !if.else.loc22
+// CHECK:STDOUT:   %.loc23: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   if %.loc23 br !if.then.loc23 else br !if.else.loc23
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.then.loc22:
+// CHECK:STDOUT: !if.then.loc23:
 // CHECK:STDOUT:   %v.var: ref i32 = var v
 // CHECK:STDOUT:   %v: ref i32 = bind_name v, %v.var
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   assign %v.var, %.loc23
-// CHECK:STDOUT:   %.loc24: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   if %.loc24 br !if.then.loc24 else br !if.else.loc24
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   assign %v.var, %.loc24
+// CHECK:STDOUT:   %.loc25: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   if %.loc25 br !if.then.loc25 else br !if.else.loc25
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.then.loc24:
+// CHECK:STDOUT: !if.then.loc25:
 // CHECK:STDOUT:   %w.var: ref i32 = var w
 // CHECK:STDOUT:   %w: ref i32 = bind_name w, %w.var
-// CHECK:STDOUT:   %.loc31: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   assign %w.var, %.loc31
-// CHECK:STDOUT:   br !if.else.loc24
+// CHECK:STDOUT:   %.loc32: i32 = int_literal 1 [template = constants.%.3]
+// CHECK:STDOUT:   assign %w.var, %.loc32
+// CHECK:STDOUT:   br !if.else.loc25
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.else.loc24:
-// CHECK:STDOUT:   br !if.else.loc22
+// CHECK:STDOUT: !if.else.loc25:
+// CHECK:STDOUT:   br !if.else.loc23
 // CHECK:STDOUT:
-// CHECK:STDOUT: !if.else.loc22:
-// CHECK:STDOUT:   %.loc34: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   return %.loc34
+// CHECK:STDOUT: !if.else.loc23:
+// CHECK:STDOUT:   %.loc35: i32 = int_literal 0 [template = constants.%.2]
+// CHECK:STDOUT:   return %.loc35
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_duplicate_name.carbon
+++ b/toolchain/check/testdata/struct/fail_duplicate_name.carbon
@@ -4,36 +4,40 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+6]]:42: ERROR: Duplicated field name `abc` in struct type literal.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+7]]:42: ERROR: Duplicated field name `abc` in struct type literal.
 // CHECK:STDERR: fn F() -> {.d: i32, .abc: i32, .e: i32, .abc: i32, .f: i32};
 // CHECK:STDERR:                                          ^~~
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+3]]:22: Field with the same name here.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+4]]:22: Field with the same name here.
 // CHECK:STDERR: fn F() -> {.d: i32, .abc: i32, .e: i32, .abc: i32, .f: i32};
 // CHECK:STDERR:                      ^~~
+// CHECK:STDERR:
 fn F() -> {.d: i32, .abc: i32, .e: i32, .abc: i32, .f: i32};
 
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+6]]:19: ERROR: Duplicated field name `a` in struct type literal.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+7]]:19: ERROR: Duplicated field name `a` in struct type literal.
 // CHECK:STDERR: let v: {.a: i32, .a: i32} = {.a = 1};
 // CHECK:STDERR:                   ^
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+3]]:10: Field with the same name here.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+4]]:10: Field with the same name here.
 // CHECK:STDERR: let v: {.a: i32, .a: i32} = {.a = 1};
 // CHECK:STDERR:          ^
+// CHECK:STDERR:
 let v: {.a: i32, .a: i32} = {.a = 1};
 
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+6]]:26: ERROR: Duplicated field name `def` in struct literal.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+7]]:26: ERROR: Duplicated field name `def` in struct literal.
 // CHECK:STDERR: let w: i32 = {.def = 1, .def = 2}.def;
 // CHECK:STDERR:                          ^~~
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+3]]:16: Field with the same name here.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+4]]:16: Field with the same name here.
 // CHECK:STDERR: let w: i32 = {.def = 1, .def = 2}.def;
 // CHECK:STDERR:                ^~~
+// CHECK:STDERR:
 let w: i32 = {.def = 1, .def = 2}.def;
 
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+6]]:30: ERROR: Duplicated field name `a` in struct literal.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+7]]:30: ERROR: Duplicated field name `a` in struct literal.
 // CHECK:STDERR: var x: {.a: i32} = {.a = 1, .a = 2};
 // CHECK:STDERR:                              ^
-// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+3]]:22: Field with the same name here.
+// CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+4]]:22: Field with the same name here.
 // CHECK:STDERR: var x: {.a: i32} = {.a = 1, .a = 2};
 // CHECK:STDERR:                      ^
+// CHECK:STDERR:
 var x: {.a: i32} = {.a = 1, .a = 2};
 
 // CHECK:STDERR: fail_duplicate_name.carbon:[[@LINE+6]]:39: ERROR: Duplicated field name `b` in struct literal.
@@ -65,16 +69,16 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %return.var: ref <error> = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc21_35: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc21_36: {.a: i32} = struct_literal (%.loc21_35)
+// CHECK:STDOUT:   %.loc23_35: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc23_36: {.a: i32} = struct_literal (%.loc23_35)
 // CHECK:STDOUT:   %v: <error> = bind_name v, <error>
-// CHECK:STDOUT:   %.loc29_22: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc29_32: i32 = int_literal 2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc32_22: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc32_32: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %w: i32 = bind_name w, <error>
-// CHECK:STDOUT:   %.loc37: type = struct_type {.a: i32} [template = constants.%.2]
+// CHECK:STDOUT:   %.loc41: type = struct_type {.a: i32} [template = constants.%.2]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc45: type = struct_type {.b: i32, .c: i32} [template = constants.%.4]
+// CHECK:STDOUT:   %.loc49: type = struct_type {.b: i32, .c: i32} [template = constants.%.4]
 // CHECK:STDOUT:   %y.var: ref {.b: i32, .c: i32} = var y
 // CHECK:STDOUT:   %y: ref {.b: i32, .c: i32} = bind_name y, %y.var
 // CHECK:STDOUT: }
@@ -83,11 +87,11 @@ var y: {.b: i32, .c: i32} = {.b = 3, .b = 4};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc37_26: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc37_34: i32 = int_literal 2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc41_26: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc41_34: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   assign file.%x.var, <error>
-// CHECK:STDOUT:   %.loc45_35: i32 = int_literal 3 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc45_43: i32 = int_literal 4 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc49_35: i32 = int_literal 3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc49_43: i32 = int_literal 4 [template = constants.%.7]
 // CHECK:STDOUT:   assign file.%y.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
+++ b/toolchain/check/testdata/struct/fail_field_name_mismatch.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_field_name_mismatch.carbon:[[@LINE+3]]:20: ERROR: Missing value for field `a` in struct initialization.
+// CHECK:STDERR: fail_field_name_mismatch.carbon:[[@LINE+4]]:20: ERROR: Missing value for field `a` in struct initialization.
 // CHECK:STDERR: var x: {.a: i32} = {.b = 1};
 // CHECK:STDERR:                    ^~~~~~~~
+// CHECK:STDERR:
 var x: {.a: i32} = {.b = 1};
 
 // CHECK:STDERR: fail_field_name_mismatch.carbon:[[@LINE+3]]:20: ERROR: Cannot convert from struct type `{.a: i32}` to `{.b: i32}`: missing field `b` in source type.
@@ -27,18 +28,18 @@ var y: {.b: i32} = x;
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:     .y = %y
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc10: type = struct_type {.a: i32} [template = constants.%.1]
+// CHECK:STDOUT:   %.loc11: type = struct_type {.a: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %x.var: ref {.a: i32} = var x
 // CHECK:STDOUT:   %x: ref {.a: i32} = bind_name x, %x.var
-// CHECK:STDOUT:   %.loc15: type = struct_type {.b: i32} [template = constants.%.3]
+// CHECK:STDOUT:   %.loc16: type = struct_type {.b: i32} [template = constants.%.3]
 // CHECK:STDOUT:   %y.var: ref {.b: i32} = var y
 // CHECK:STDOUT:   %y: ref {.b: i32} = bind_name y, %y.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_27: {.b: i32} = struct_literal (%.loc10_26)
+// CHECK:STDOUT:   %.loc11_26: i32 = int_literal 1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_27: {.b: i32} = struct_literal (%.loc11_26)
 // CHECK:STDOUT:   assign file.%x.var, <error>
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   assign file.%y.var, <error>

--- a/toolchain/check/testdata/struct/fail_keyword_name.carbon
+++ b/toolchain/check/testdata/struct/fail_keyword_name.carbon
@@ -4,12 +4,14 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_keyword_name.carbon:[[@LINE+6]]:13: ERROR: Expected identifier after `.`.
+// CHECK:STDERR: fail_keyword_name.carbon:[[@LINE+8]]:13: ERROR: Expected identifier after `.`.
 // CHECK:STDERR: fn F() -> {.class: i32};
 // CHECK:STDERR:             ^~~~~
-// CHECK:STDERR: fail_keyword_name.carbon:[[@LINE+3]]:13: ERROR: Semantics TODO: `Error recovery from keyword name.`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_keyword_name.carbon:[[@LINE+4]]:13: ERROR: Semantics TODO: `Error recovery from keyword name.`.
 // CHECK:STDERR: fn F() -> {.class: i32};
 // CHECK:STDERR:             ^~~~~
+// CHECK:STDERR:
 fn F() -> {.class: i32};
 
 // CHECK:STDERR: fail_keyword_name.carbon:[[@LINE+3]]:19: ERROR: Expected identifier after `.`.

--- a/toolchain/check/testdata/var/fail_modifiers.carbon
+++ b/toolchain/check/testdata/var/fail_modifiers.carbon
@@ -4,31 +4,36 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `protected` not allowed on `var` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: ERROR: `protected` not allowed on `var` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected var b: i32;
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 protected var b: i32;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: Semantics TODO: `access modifier`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: Semantics TODO: `access modifier`.
 // CHECK:STDERR: private protected var c: i32;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:9: ERROR: `protected` not allowed on declaration with `private`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:9: ERROR: `protected` not allowed on declaration with `private`.
 // CHECK:STDERR: private protected var c: i32;
 // CHECK:STDERR:         ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `private` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `private` previously appeared here.
 // CHECK:STDERR: private protected var c: i32;
 // CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 private protected var c: i32;
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+9]]:1: ERROR: `protected` not allowed on `var` declaration at file scope, `protected` is only allowed on class members.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+11]]:1: ERROR: `protected` not allowed on `var` declaration at file scope, `protected` is only allowed on class members.
 // CHECK:STDERR: protected protected var d: i32;
 // CHECK:STDERR: ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:11: ERROR: `protected` repeated on declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:11: ERROR: `protected` repeated on declaration.
 // CHECK:STDERR: protected protected var d: i32;
 // CHECK:STDERR:           ^~~~~~~~~
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: `protected` previously appeared here.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+4]]:1: `protected` previously appeared here.
 // CHECK:STDERR: protected protected var d: i32;
 // CHECK:STDERR: ^~~~~~~~~
+// CHECK:STDERR:
 protected protected var d: i32;
 
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:1: ERROR: `abstract` not allowed on `var` declaration.

--- a/toolchain/check/testdata/var/fail_namespace_conflict.carbon
+++ b/toolchain/check/testdata/var/fail_namespace_conflict.carbon
@@ -6,18 +6,19 @@
 
 namespace A;
 
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+7]]:5: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: var A: i32;
 // CHECK:STDERR:     ^
 // CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-5]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace A;
 // CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 var A: i32;
 
 // CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE+6]]:5: ERROR: Duplicate name being declared in the same scope.
 // CHECK:STDERR: var A: i32 = 1;
 // CHECK:STDERR:     ^
-// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-13]]:1: Name is previously declared here.
+// CHECK:STDERR: fail_namespace_conflict.carbon:[[@LINE-14]]:1: Name is previously declared here.
 // CHECK:STDERR: namespace A;
 // CHECK:STDERR: ^~~~~~~~~~~~
 var A: i32 = 1;
@@ -33,16 +34,16 @@ var A: i32 = 1;
 // CHECK:STDOUT:     .A = %A.loc7
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.loc7: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %A.var.loc15: ref i32 = var A
-// CHECK:STDOUT:   %A.loc15: ref i32 = bind_name A, %A.var.loc15
-// CHECK:STDOUT:   %A.var.loc23: ref i32 = var A
-// CHECK:STDOUT:   %A.loc23: ref i32 = bind_name A, %A.var.loc23
+// CHECK:STDOUT:   %A.var.loc16: ref i32 = var A
+// CHECK:STDOUT:   %A.loc16: ref i32 = bind_name A, %A.var.loc16
+// CHECK:STDOUT:   %A.var.loc24: ref i32 = var A
+// CHECK:STDOUT:   %A.loc24: ref i32 = bind_name A, %A.var.loc24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc23: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   assign file.%A.var.loc23, %.loc23
+// CHECK:STDOUT:   %.loc24: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   assign file.%A.var.loc24, %.loc24
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/var/fail_not_copyable.carbon
+++ b/toolchain/check/testdata/var/fail_not_copyable.carbon
@@ -10,9 +10,10 @@ class X {
 fn F(x: X) {
   // TODO: Strings should eventually be copyable, once we decide how to
   // represent them.
-  // CHECK:STDERR: fail_not_copyable.carbon:[[@LINE+3]]:19: ERROR: Cannot copy value of type `String`.
+  // CHECK:STDERR: fail_not_copyable.carbon:[[@LINE+4]]:19: ERROR: Cannot copy value of type `String`.
   // CHECK:STDERR:   var s: String = "hello";
   // CHECK:STDERR:                   ^~~~~~~
+  // CHECK:STDERR:
   var s: String = "hello";
 
   // TODO: Decide on rules for when classes are copyable.
@@ -55,7 +56,7 @@ fn F(x: X) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %s.var: ref String = var s
 // CHECK:STDOUT:   %s: ref String = bind_name s, %s.var
-// CHECK:STDOUT:   %.loc16: String = string_literal "hello" [template = constants.%.5]
+// CHECK:STDOUT:   %.loc17: String = string_literal "hello" [template = constants.%.5]
 // CHECK:STDOUT:   assign %s.var, <error>
 // CHECK:STDOUT:   %X.ref: type = name_ref X, file.%X.decl [template = constants.%X]
 // CHECK:STDOUT:   %y.var: ref X = var y

--- a/toolchain/check/testdata/while/fail_break_continue.carbon
+++ b/toolchain/check/testdata/while/fail_break_continue.carbon
@@ -5,21 +5,24 @@
 // AUTOUPDATE
 
 fn While() {
-  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+3]]:3: ERROR: `continue` can only be used in a loop.
+  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+4]]:3: ERROR: `continue` can only be used in a loop.
   // CHECK:STDERR:   continue;
   // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:
   continue;
-  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+3]]:3: ERROR: `break` can only be used in a loop.
+  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+4]]:3: ERROR: `break` can only be used in a loop.
   // CHECK:STDERR:   break;
   // CHECK:STDERR:   ^~~~~
+  // CHECK:STDERR:
   break;
   while (false) {
     continue;
     break;
   }
-  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+3]]:3: ERROR: `continue` can only be used in a loop.
+  // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+4]]:3: ERROR: `continue` can only be used in a loop.
   // CHECK:STDERR:   continue;
   // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:
   continue;
   // CHECK:STDERR: fail_break_continue.carbon:[[@LINE+3]]:3: ERROR: `break` can only be used in a loop.
   // CHECK:STDERR:   break;

--- a/toolchain/diagnostics/diagnostic_consumer.cpp
+++ b/toolchain/diagnostics/diagnostic_consumer.cpp
@@ -10,6 +10,12 @@
 namespace Carbon {
 
 auto StreamDiagnosticConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
+  if (printed_diagnostic_) {
+    *stream_ << "\n";
+  } else {
+    printed_diagnostic_ = true;
+  }
+
   for (const auto& message : diagnostic.messages) {
     *stream_ << message.location.filename;
     if (message.location.line_number > 0) {

--- a/toolchain/diagnostics/diagnostic_consumer.h
+++ b/toolchain/diagnostics/diagnostic_consumer.h
@@ -48,6 +48,8 @@ class StreamDiagnosticConsumer : public DiagnosticConsumer {
   auto Print(const DiagnosticMessage& message, llvm::StringRef prefix) -> void;
 
   llvm::raw_ostream* stream_;
+  // Whethere we've printed a diagnostic. Used for printing separators.
+  bool printed_diagnostic_ = false;
 };
 
 // Returns a diagnostic consumer instance that prints to stderr.

--- a/toolchain/driver/testdata/fail_errors_in_two_files.carbon
+++ b/toolchain/driver/testdata/fail_errors_in_two_files.carbon
@@ -8,9 +8,10 @@
 
 // --- fail_file1.carbon
 
-// CHECK:STDERR: fail_file1.carbon:[[@LINE+3]]:24: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR: fail_file1.carbon:[[@LINE+4]]:24: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: fn run(String program) {
 // CHECK:STDERR:                        ^
+// CHECK:STDERR:
 fn run(String program) {
   return True;
 

--- a/toolchain/driver/testdata/fail_errors_sorted.carbon
+++ b/toolchain/driver/testdata/fail_errors_sorted.carbon
@@ -6,9 +6,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_errors_sorted.carbon:[[@LINE+3]]:24: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR: fail_errors_sorted.carbon:[[@LINE+4]]:24: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: fn run(String program) {
 // CHECK:STDERR:                        ^
+// CHECK:STDERR:
 fn run(String program) {
   return True;
 

--- a/toolchain/driver/testdata/fail_errors_streamed.carbon
+++ b/toolchain/driver/testdata/fail_errors_streamed.carbon
@@ -9,10 +9,11 @@
 fn run(String program) {
   return True;
 
-// CHECK:STDERR: fail_errors_streamed.carbon:[[@LINE+6]]:10: ERROR: Invalid digit 'a' in decimal numeric literal.
+// CHECK:STDERR: fail_errors_streamed.carbon:[[@LINE+7]]:10: ERROR: Invalid digit 'a' in decimal numeric literal.
 // CHECK:STDERR: var x = 3a;
 // CHECK:STDERR:          ^
-// CHECK:STDERR: fail_errors_streamed.carbon:[[@LINE-6]]:24: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_errors_streamed.carbon:[[@LINE-7]]:24: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: fn run(String program) {
 // CHECK:STDERR:                        ^
 var x = 3a;

--- a/toolchain/driver/testdata/fail_flush_errors.carbon
+++ b/toolchain/driver/testdata/fail_flush_errors.carbon
@@ -9,18 +9,20 @@
 fn F() {
   // Create diagnostics containing string references, and trigger reallocation
   // of the string table.
-  // CHECK:STDERR: fail_flush_errors.carbon:[[@LINE+3]]:3: ERROR: Name `undeclared1` not found.
+  // CHECK:STDERR: fail_flush_errors.carbon:[[@LINE+4]]:3: ERROR: Name `undeclared1` not found.
   // CHECK:STDERR:   undeclared1;
   // CHECK:STDERR:   ^~~~~~~~~~~
+  // CHECK:STDERR:
   undeclared1;
 
   // Add the name into the string table from the tokenized buffer's string
   // literal storage. Use a hex escape to ensure that the tokenized buffer
   // allocates separate storage for the result.
   "undec\x6Cared2";
-  // CHECK:STDERR: fail_flush_errors.carbon:[[@LINE+3]]:3: ERROR: Name `undeclared2` not found.
+  // CHECK:STDERR: fail_flush_errors.carbon:[[@LINE+4]]:3: ERROR: Name `undeclared2` not found.
   // CHECK:STDERR:   undeclared2;
   // CHECK:STDERR:   ^~~~~~~~~~~
+  // CHECK:STDERR:
   undeclared2;
 
   // Add the name into the string table via a declaration rather than an expression.

--- a/toolchain/lex/testdata/fail_bad_comment_introducers.carbon
+++ b/toolchain/lex/testdata/fail_bad_comment_introducers.carbon
@@ -9,29 +9,33 @@
 //
 
 // Comments have to have whitespace after `//` currently.
-// CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+3]]:3: ERROR: Whitespace is required after '//'.
+// CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+4]]:3: ERROR: Whitespace is required after '//'.
 // CHECK:STDERR: //abc
 // CHECK:STDERR:   ^
+// CHECK:STDERR:
 //abc
 
-    // CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+3]]:7: ERROR: Whitespace is required after '//'.
+    // CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+4]]:7: ERROR: Whitespace is required after '//'.
     // CHECK:STDERR:     //indented
     // CHECK:STDERR:       ^
+    // CHECK:STDERR:
     //indented
 
 // We only want to diagnose these on the first line of a block of similarly
 // indented comments.
 
-// CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+3]]:3: ERROR: Whitespace is required after '//'.
+// CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+4]]:3: ERROR: Whitespace is required after '//'.
 // CHECK:STDERR: //abc
 // CHECK:STDERR:   ^
+// CHECK:STDERR:
 //abc
 //123
 //dce
 
-        // CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+3]]:11: ERROR: Whitespace is required after '//'.
+        // CHECK:STDERR: fail_bad_comment_introducers.carbon:[[@LINE+4]]:11: ERROR: Whitespace is required after '//'.
         // CHECK:STDERR:         //indented block
         // CHECK:STDERR:           ^
+        // CHECK:STDERR:
         //indented block
         //indented block
         //indented block

--- a/toolchain/lex/testdata/fail_bad_comment_introducers_mid_block_indent_change.carbon
+++ b/toolchain/lex/testdata/fail_bad_comment_introducers_mid_block_indent_change.carbon
@@ -22,10 +22,12 @@
 // CHECK:STDERR: fail_bad_comment_introducers_mid_block_indent_change.carbon:[[@LINE-13]]:3: ERROR: Whitespace is required after '//'.
 // CHECK:STDERR: //abc
 // CHECK:STDERR:   ^
-// CHECK:STDERR: fail_bad_comment_introducers_mid_block_indent_change.carbon:[[@LINE-13]]:5: ERROR: Whitespace is required after '//'.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_bad_comment_introducers_mid_block_indent_change.carbon:[[@LINE-14]]:5: ERROR: Whitespace is required after '//'.
 // CHECK:STDERR:   //abc
 // CHECK:STDERR:     ^
-// CHECK:STDERR: fail_bad_comment_introducers_mid_block_indent_change.carbon:[[@LINE-13]]:3: ERROR: Whitespace is required after '//'.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_bad_comment_introducers_mid_block_indent_change.carbon:[[@LINE-15]]:3: ERROR: Whitespace is required after '//'.
 // CHECK:STDERR: //abc
 // CHECK:STDERR:   ^
 // CHECK:STDOUT: - filename: fail_bad_comment_introducers_mid_block_indent_change.carbon

--- a/toolchain/lex/testdata/fail_bad_raw_identifier.carbon
+++ b/toolchain/lex/testdata/fail_bad_raw_identifier.carbon
@@ -8,17 +8,19 @@
 // CHECK:STDOUT:     { index: 0, kind:  'FileStart', line: {{ *\d+}}, column:  1, indent: 1, spelling: '', has_trailing_space: true },
 
 // Missing the character after `#`.
-// CHECK:STDERR: fail_bad_raw_identifier.carbon:[[@LINE+3]]:2: ERROR: Encountered unrecognized characters while parsing.
+// CHECK:STDERR: fail_bad_raw_identifier.carbon:[[@LINE+4]]:2: ERROR: Encountered unrecognized characters while parsing.
 // CHECK:STDERR: r#
 // CHECK:STDERR:  ^
+// CHECK:STDERR:
 r#
 // CHECK:STDOUT:     { index: 1, kind: 'Identifier', line: {{ *}}[[@LINE-1]], column:  1, indent: 1, spelling: 'r', identifier: 0 },
 // CHECK:STDOUT:     { index: 2, kind:      'Error', line: {{ *}}[[@LINE-2]], column:  2, indent: 1, spelling: '#', has_trailing_space: true },
 
 // Not a valid identifier.
-// CHECK:STDERR: fail_bad_raw_identifier.carbon:[[@LINE+3]]:2: ERROR: Encountered unrecognized characters while parsing.
+// CHECK:STDERR: fail_bad_raw_identifier.carbon:[[@LINE+4]]:2: ERROR: Encountered unrecognized characters while parsing.
 // CHECK:STDERR: r#3
 // CHECK:STDERR:  ^
+// CHECK:STDERR:
 r#3
 // CHECK:STDOUT:     { index: 3, kind: 'Identifier', line: {{ *}}[[@LINE-1]], column:  1, indent: 1, spelling: 'r', identifier: 0 },
 // CHECK:STDOUT:     { index: 4, kind:      'Error', line: {{ *}}[[@LINE-2]], column:  2, indent: 1, spelling: '#' },

--- a/toolchain/lex/testdata/fail_block_string_second_line.carbon
+++ b/toolchain/lex/testdata/fail_block_string_second_line.carbon
@@ -1,24 +1,26 @@
 // Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-// An autoupdate wants to put the CHECK in the middle of the block string.
-// NOAUTOUPDATE
-// CHECK:STDOUT: - filename: fail_block_string_second_line.carbon
-// CHECK:STDOUT:   tokens: [
 
-// CHECK:STDERR: fail_block_string_second_line.carbon:[[@LINE+4]]:3: ERROR: Only whitespace is permitted before the closing `'''` of a multi-line string.
-// CHECK:STDERR:   error here: '''
-// CHECK:STDERR:   ^
 var s: String = '''
   error here: '''
-// CHECK:STDOUT:     { index: 0, kind:         'FileStart', line:  1, column:  1, indent: 1, spelling: '', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 1, kind:               'Var', line: {{ *}}[[@LINE-3]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 2, kind:        'Identifier', line: {{ *}}[[@LINE-4]], column:  5, indent: 1, spelling: 's', identifier: 0 },
-// CHECK:STDOUT:     { index: 3, kind:             'Colon', line: {{ *}}[[@LINE-5]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 4, kind: 'StringTypeLiteral', line: {{ *}}[[@LINE-6]], column:  8, indent: 1, spelling: 'String', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 5, kind:             'Equal', line: {{ *}}[[@LINE-7]], column: 15, indent: 1, spelling: '=', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 6, kind:     'StringLiteral', line: {{ *}}[[@LINE-8]], column: 17, indent: 1, spelling: ''''
+
+// Put all autoupdates below because otherwise is puts a CHECK in the middle of
+// the block string.
+//
+// AUTOUPDATE
+// CHECK:STDERR: fail_block_string_second_line.carbon:[[@LINE-6]]:3: ERROR: Only whitespace is permitted before the closing `'''` of a multi-line string.
+// CHECK:STDERR:   error here: '''
+// CHECK:STDERR:   ^
+// CHECK:STDOUT: - filename: fail_block_string_second_line.carbon
+// CHECK:STDOUT:   tokens: [
+// CHECK:STDOUT:     { index: 0, kind:         'FileStart', line: {{ *\d+}}, column:  1, indent: 1, spelling: '', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 1, kind:               'Var', line: {{ *}}[[@LINE-13]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 2, kind:        'Identifier', line: {{ *}}[[@LINE-14]], column:  5, indent: 1, spelling: 's', identifier: 0 },
+// CHECK:STDOUT:     { index: 3, kind:             'Colon', line: {{ *}}[[@LINE-15]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 4, kind: 'StringTypeLiteral', line: {{ *}}[[@LINE-16]], column:  8, indent: 1, spelling: 'String', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 5, kind:             'Equal', line: {{ *}}[[@LINE-17]], column: 15, indent: 1, spelling: '=', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 6, kind:     'StringLiteral', line: {{ *}}[[@LINE-18]], column: 17, indent: 1, spelling: ''''
 // CHECK:STDOUT:   error here: '''', value: `error here: `, has_trailing_space: true },
 
 // CHECK:STDOUT:     { index: 7, kind:           'FileEnd', line: {{ *}}[[@LINE+1]], column: {{ *\d+}}, indent: 1, spelling: '' },

--- a/toolchain/lex/testdata/fail_mismatched_brackets.carbon
+++ b/toolchain/lex/testdata/fail_mismatched_brackets.carbon
@@ -7,15 +7,17 @@
 // CHECK:STDOUT:   tokens: [
 // CHECK:STDOUT:     { index: 0, kind:  'FileStart', line: {{ *\d+}}, column:  1, indent: 1, spelling: '', has_trailing_space: true },
 
-// CHECK:STDERR: fail_mismatched_brackets.carbon:[[@LINE+3]]:1: ERROR: Closing symbol without a corresponding opening symbol.
+// CHECK:STDERR: fail_mismatched_brackets.carbon:[[@LINE+4]]:1: ERROR: Closing symbol without a corresponding opening symbol.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 }
 // CHECK:STDOUT:     { index: 1, kind:      'Error', line: {{ *}}[[@LINE-1]], column:  1, indent: 1, spelling: '}', has_trailing_space: true },
 
-// CHECK:STDERR: fail_mismatched_brackets.carbon:[[@LINE+3]]:3: ERROR: Closing symbol without a corresponding opening symbol.
+// CHECK:STDERR: fail_mismatched_brackets.carbon:[[@LINE+4]]:3: ERROR: Closing symbol without a corresponding opening symbol.
 // CHECK:STDERR: ( } )
 // CHECK:STDERR:   ^
+// CHECK:STDERR:
 ( } )
 // CHECK:STDOUT:     { index: 2, kind:  'OpenParen', line: {{ *}}[[@LINE-1]], column:  1, indent: 1, spelling: '(', closing_token: 4, has_trailing_space: true },
 // CHECK:STDOUT:     { index: 3, kind:      'Error', line: {{ *}}[[@LINE-2]], column:  3, indent: 1, spelling: '}', has_trailing_space: true },

--- a/toolchain/lex/testdata/fail_multifile.carbon
+++ b/toolchain/lex/testdata/fail_multifile.carbon
@@ -8,9 +8,10 @@
 // CHECK:STDOUT: - filename: fail_a.carbon
 // CHECK:STDOUT:   tokens: [
 // CHECK:STDOUT:     { index: 0, kind: 'FileStart', line: {{ *\d+}}, column:  1, indent: 1, spelling: '', has_trailing_space: true },
-// CHECK:STDERR: fail_a.carbon:[[@LINE+3]]:3: ERROR: Empty digit sequence in numeric literal.
+// CHECK:STDERR: fail_a.carbon:[[@LINE+4]]:3: ERROR: Empty digit sequence in numeric literal.
 // CHECK:STDERR: 1.a
 // CHECK:STDERR:   ^
+// CHECK:STDERR:
 1.a
 // CHECK:STDOUT:     { index: 1, kind:     'Error', line: {{ *}}[[@LINE-1]], column:  1, indent: 1, spelling: '1.a', has_trailing_space: true },
 

--- a/toolchain/lex/testdata/fail_trailing_comments.carbon
+++ b/toolchain/lex/testdata/fail_trailing_comments.carbon
@@ -15,36 +15,38 @@ var c: i32 = 0.4; // still more trailing comment
 // CHECK:STDERR: fail_trailing_comments.carbon:[[@LINE-7]]:19: ERROR: Trailing comments are not permitted.
 // CHECK:STDERR: var a: i32 = 1;   // trailing comment
 // CHECK:STDERR:                   ^
-// CHECK:STDERR: fail_trailing_comments.carbon:[[@LINE-9]]:19: ERROR: Trailing comments are not permitted.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_trailing_comments.carbon:[[@LINE-10]]:19: ERROR: Trailing comments are not permitted.
 // CHECK:STDERR: var b: 32 = 13;   // more trailing comment
 // CHECK:STDERR:                   ^
-// CHECK:STDERR: fail_trailing_comments.carbon:[[@LINE-11]]:19: ERROR: Trailing comments are not permitted.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_trailing_comments.carbon:[[@LINE-13]]:19: ERROR: Trailing comments are not permitted.
 // CHECK:STDERR: var c: i32 = 0.4; // still more trailing comment
 // CHECK:STDERR:                   ^
 // CHECK:STDOUT: - filename: fail_trailing_comments.carbon
 // CHECK:STDOUT:   tokens: [
 // CHECK:STDOUT:     { index:  0, kind:      'FileStart', line: {{ *\d+}}, column:  1, indent: 1, spelling: '', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  1, kind:            'Var', line: {{ *}}[[@LINE-19]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  2, kind:     'Identifier', line: {{ *}}[[@LINE-20]], column:  5, indent: 1, spelling: 'a', identifier: 0 },
-// CHECK:STDOUT:     { index:  3, kind:          'Colon', line: {{ *}}[[@LINE-21]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  4, kind: 'IntTypeLiteral', line: {{ *}}[[@LINE-22]], column:  8, indent: 1, spelling: 'i32', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  5, kind:          'Equal', line: {{ *}}[[@LINE-23]], column: 12, indent: 1, spelling: '=', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  6, kind:     'IntLiteral', line: {{ *}}[[@LINE-24]], column: 14, indent: 1, spelling: '1', value: `1` },
-// CHECK:STDOUT:     { index:  7, kind:           'Semi', line: {{ *}}[[@LINE-25]], column: 15, indent: 1, spelling: ';', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  8, kind:            'Var', line: {{ *}}[[@LINE-25]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
-// CHECK:STDOUT:     { index:  9, kind:     'Identifier', line: {{ *}}[[@LINE-26]], column:  5, indent: 1, spelling: 'b', identifier: 1 },
-// CHECK:STDOUT:     { index: 10, kind:          'Colon', line: {{ *}}[[@LINE-27]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 11, kind:     'IntLiteral', line: {{ *}}[[@LINE-28]], column:  8, indent: 1, spelling: '32', value: `32`, has_trailing_space: true },
-// CHECK:STDOUT:     { index: 12, kind:          'Equal', line: {{ *}}[[@LINE-29]], column: 11, indent: 1, spelling: '=', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 13, kind:     'IntLiteral', line: {{ *}}[[@LINE-30]], column: 13, indent: 1, spelling: '13', value: `13` },
-// CHECK:STDOUT:     { index: 14, kind:           'Semi', line: {{ *}}[[@LINE-31]], column: 15, indent: 1, spelling: ';', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 15, kind:            'Var', line: {{ *}}[[@LINE-31]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 16, kind:     'Identifier', line: {{ *}}[[@LINE-32]], column:  5, indent: 1, spelling: 'c', identifier: 2 },
-// CHECK:STDOUT:     { index: 17, kind:          'Colon', line: {{ *}}[[@LINE-33]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 18, kind: 'IntTypeLiteral', line: {{ *}}[[@LINE-34]], column:  8, indent: 1, spelling: 'i32', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 19, kind:          'Equal', line: {{ *}}[[@LINE-35]], column: 12, indent: 1, spelling: '=', has_trailing_space: true },
-// CHECK:STDOUT:     { index: 20, kind:    'RealLiteral', line: {{ *}}[[@LINE-36]], column: 14, indent: 1, spelling: '0.4', value: `4*10^-1` },
-// CHECK:STDOUT:     { index: 21, kind:           'Semi', line: {{ *}}[[@LINE-37]], column: 17, indent: 1, spelling: ';', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  1, kind:            'Var', line: {{ *}}[[@LINE-21]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  2, kind:     'Identifier', line: {{ *}}[[@LINE-22]], column:  5, indent: 1, spelling: 'a', identifier: 0 },
+// CHECK:STDOUT:     { index:  3, kind:          'Colon', line: {{ *}}[[@LINE-23]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  4, kind: 'IntTypeLiteral', line: {{ *}}[[@LINE-24]], column:  8, indent: 1, spelling: 'i32', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  5, kind:          'Equal', line: {{ *}}[[@LINE-25]], column: 12, indent: 1, spelling: '=', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  6, kind:     'IntLiteral', line: {{ *}}[[@LINE-26]], column: 14, indent: 1, spelling: '1', value: `1` },
+// CHECK:STDOUT:     { index:  7, kind:           'Semi', line: {{ *}}[[@LINE-27]], column: 15, indent: 1, spelling: ';', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  8, kind:            'Var', line: {{ *}}[[@LINE-27]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
+// CHECK:STDOUT:     { index:  9, kind:     'Identifier', line: {{ *}}[[@LINE-28]], column:  5, indent: 1, spelling: 'b', identifier: 1 },
+// CHECK:STDOUT:     { index: 10, kind:          'Colon', line: {{ *}}[[@LINE-29]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 11, kind:     'IntLiteral', line: {{ *}}[[@LINE-30]], column:  8, indent: 1, spelling: '32', value: `32`, has_trailing_space: true },
+// CHECK:STDOUT:     { index: 12, kind:          'Equal', line: {{ *}}[[@LINE-31]], column: 11, indent: 1, spelling: '=', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 13, kind:     'IntLiteral', line: {{ *}}[[@LINE-32]], column: 13, indent: 1, spelling: '13', value: `13` },
+// CHECK:STDOUT:     { index: 14, kind:           'Semi', line: {{ *}}[[@LINE-33]], column: 15, indent: 1, spelling: ';', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 15, kind:            'Var', line: {{ *}}[[@LINE-33]], column:  1, indent: 1, spelling: 'var', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 16, kind:     'Identifier', line: {{ *}}[[@LINE-34]], column:  5, indent: 1, spelling: 'c', identifier: 2 },
+// CHECK:STDOUT:     { index: 17, kind:          'Colon', line: {{ *}}[[@LINE-35]], column:  6, indent: 1, spelling: ':', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 18, kind: 'IntTypeLiteral', line: {{ *}}[[@LINE-36]], column:  8, indent: 1, spelling: 'i32', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 19, kind:          'Equal', line: {{ *}}[[@LINE-37]], column: 12, indent: 1, spelling: '=', has_trailing_space: true },
+// CHECK:STDOUT:     { index: 20, kind:    'RealLiteral', line: {{ *}}[[@LINE-38]], column: 14, indent: 1, spelling: '0.4', value: `4*10^-1` },
+// CHECK:STDOUT:     { index: 21, kind:           'Semi', line: {{ *}}[[@LINE-39]], column: 17, indent: 1, spelling: ';', has_trailing_space: true },
 
 // CHECK:STDOUT:     { index: 22, kind:        'FileEnd', line: {{ *}}[[@LINE+1]], column: {{ *\d+}}, indent: 1, spelling: '' },
 // CHECK:STDOUT:   ]

--- a/toolchain/lower/testdata/basics/fail_before_lowering.carbon
+++ b/toolchain/lower/testdata/basics/fail_before_lowering.carbon
@@ -5,9 +5,10 @@
 // This validates that earlier errors prevent lowering, without crashing.
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_before_lowering.carbon:[[@LINE+6]]:1: ERROR: Unrecognized declaration introducer.
+// CHECK:STDERR: fail_before_lowering.carbon:[[@LINE+7]]:1: ERROR: Unrecognized declaration introducer.
 // CHECK:STDERR: a;
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_before_lowering.carbon:[[@LINE+3]]:1: ERROR: Semantics TODO: `HandleInvalidParseStart`.
 // CHECK:STDERR: a;
 // CHECK:STDERR: ^

--- a/toolchain/parse/testdata/alias/fail_syntax.carbon
+++ b/toolchain/parse/testdata/alias/fail_syntax.carbon
@@ -4,56 +4,66 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:7: ERROR: `alias` introducer should be followed by a name.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:7: ERROR: `alias` introducer should be followed by a name.
 // CHECK:STDERR: alias = b;
 // CHECK:STDERR:       ^
+// CHECK:STDERR:
 alias = b;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:9: ERROR: `alias` requires a `=` for the source.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:9: ERROR: `alias` requires a `=` for the source.
 // CHECK:STDERR: alias a b;
 // CHECK:STDERR:         ^
+// CHECK:STDERR:
 alias a b;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:10: ERROR: Expected expression.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:10: ERROR: Expected expression.
 // CHECK:STDERR: alias a =;
 // CHECK:STDERR:          ^
+// CHECK:STDERR:
 alias a =;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:8: ERROR: `alias` requires a `=` for the source.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:8: ERROR: `alias` requires a `=` for the source.
 // CHECK:STDERR: alias a;
 // CHECK:STDERR:        ^
+// CHECK:STDERR:
 alias a;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:7: ERROR: `alias` introducer should be followed by a name.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:7: ERROR: `alias` introducer should be followed by a name.
 // CHECK:STDERR: alias =;
 // CHECK:STDERR:       ^
+// CHECK:STDERR:
 alias =;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:9: ERROR: `alias` requires a `=` for the source.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:9: ERROR: `alias` requires a `=` for the source.
 // CHECK:STDERR: alias a b c = d;
 // CHECK:STDERR:         ^
+// CHECK:STDERR:
 alias a b c = d;
 
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:13: ERROR: `alias` declarations must end with a `;`.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:13: ERROR: `alias` declarations must end with a `;`.
 // CHECK:STDERR: alias a = b c d;
 // CHECK:STDERR:             ^
+// CHECK:STDERR:
 alias a = b c d;
 
 fn F() {
-  // CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:8: ERROR: `alias` introducer should be followed by a name.
+  // CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:8: ERROR: `alias` introducer should be followed by a name.
   // CHECK:STDERR:   alias;
   // CHECK:STDERR:        ^
+  // CHECK:STDERR:
   alias;
 
-  // CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:12: ERROR: Expected expression.
+  // CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:12: ERROR: Expected expression.
   // CHECK:STDERR:   alias a =;
   // CHECK:STDERR:            ^
+  // CHECK:STDERR:
   alias a =;
 
   alias a =
-// CHECK:STDERR: fail_syntax.carbon:[[@LINE+3]]:1: ERROR: Expected expression.
+// CHECK:STDERR: fail_syntax.carbon:[[@LINE+4]]:1: ERROR: Expected expression.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 }
 
 alias a = b

--- a/toolchain/parse/testdata/array/fail_require_close_bracket.carbon
+++ b/toolchain/parse/testdata/array/fail_require_close_bracket.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 // TODO: It should emit only one error message.
 
-// CHECK:STDERR: fail_require_close_bracket.carbon:[[@LINE+6]]:8: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR: fail_require_close_bracket.carbon:[[@LINE+7]]:8: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: var x: [i32;;
 // CHECK:STDERR:        ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_require_close_bracket.carbon:[[@LINE+3]]:8: ERROR: Expected expression.
 // CHECK:STDERR: var x: [i32;;
 // CHECK:STDERR:        ^

--- a/toolchain/parse/testdata/array/fail_syntax.carbon
+++ b/toolchain/parse/testdata/array/fail_syntax.carbon
@@ -6,54 +6,66 @@
 
 // --- fail_type.carbon
 
-// CHECK:STDERR: fail_type.carbon:[[@LINE+3]]:12: ERROR: Expected `;` in array type.
+// CHECK:STDERR: fail_type.carbon:[[@LINE+4]]:12: ERROR: Expected `;` in array type.
 // CHECK:STDERR: var x: [i32];
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 var x: [i32];
 
 // --- fail_invalid_char.carbon
 
-// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+12]]:12: ERROR: Expected expression.
+// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+16]]:12: ERROR: Expected expression.
 // CHECK:STDERR: fn X() -> [:];
 // CHECK:STDERR:            ^
-// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+9]]:12: ERROR: Expected `;` in array type.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+12]]:12: ERROR: Expected `;` in array type.
 // CHECK:STDERR: fn X() -> [:];
 // CHECK:STDERR:            ^
-// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+6]]:12: ERROR: Expected expression.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+8]]:12: ERROR: Expected expression.
 // CHECK:STDERR: fn X() -> [:];
 // CHECK:STDERR:            ^
-// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+3]]:12: ERROR: Unexpected tokens before `]`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_invalid_char.carbon:[[@LINE+4]]:12: ERROR: Unexpected tokens before `]`.
 // CHECK:STDERR: fn X() -> [:];
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 fn X() -> [:];
 
 // --- fail_unlexed_expr.carbon
 
-// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+15]]:9: ERROR: Encountered unrecognized characters while parsing.
+// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+20]]:9: ERROR: Encountered unrecognized characters while parsing.
 // CHECK:STDERR: var y: [`];
 // CHECK:STDERR:         ^
-// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+12]]:9: ERROR: Expected expression.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+16]]:9: ERROR: Expected expression.
 // CHECK:STDERR: var y: [`];
 // CHECK:STDERR:         ^
-// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+9]]:9: ERROR: Expected `;` in array type.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+12]]:9: ERROR: Expected `;` in array type.
 // CHECK:STDERR: var y: [`];
 // CHECK:STDERR:         ^
-// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+6]]:9: ERROR: Expected expression.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+8]]:9: ERROR: Expected expression.
 // CHECK:STDERR: var y: [`];
 // CHECK:STDERR:         ^
-// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+3]]:9: ERROR: Unexpected tokens before `]`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_unlexed_expr.carbon:[[@LINE+4]]:9: ERROR: Unexpected tokens before `]`.
 // CHECK:STDERR: var y: [`];
 // CHECK:STDERR:         ^
+// CHECK:STDERR:
 var y: [`];
 
 // --- fail_no_close_bracket.carbon
 
-// CHECK:STDERR: fail_no_close_bracket.carbon:[[@LINE+6]]:8: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR: fail_no_close_bracket.carbon:[[@LINE+8]]:8: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: var x: [i32;;
 // CHECK:STDERR:        ^
-// CHECK:STDERR: fail_no_close_bracket.carbon:[[@LINE+3]]:8: ERROR: Expected expression.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_no_close_bracket.carbon:[[@LINE+4]]:8: ERROR: Expected expression.
 // CHECK:STDERR: var x: [i32;;
 // CHECK:STDERR:        ^
+// CHECK:STDERR:
 var x: [i32;;
 
 // --- fail_no_semi.carbon

--- a/toolchain/parse/testdata/basics/fail_invalid_designators.carbon
+++ b/toolchain/parse/testdata/basics/fail_invalid_designators.carbon
@@ -6,13 +6,15 @@
 
 // NOTE: Move to its own directory when more tests are added.
 fn F() {
-  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+4]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.;
   // CHECK:STDERR:     ^
+  // CHECK:STDERR:
   a.;
-  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+4]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.fn;
   // CHECK:STDERR:     ^~
+  // CHECK:STDERR:
   a.fn;
   // CHECK:STDERR: fail_invalid_designators.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.42;

--- a/toolchain/parse/testdata/basics/fail_paren_match_regression.carbon
+++ b/toolchain/parse/testdata/basics/fail_paren_match_regression.carbon
@@ -4,12 +4,14 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+6]]:5: ERROR: Expected binding pattern.
+// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+8]]:5: ERROR: Expected binding pattern.
 // CHECK:STDERR: var = (foo {})
 // CHECK:STDERR:     ^
-// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+3]]:12: ERROR: Expected `,` or `)`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+4]]:12: ERROR: Expected `,` or `)`.
 // CHECK:STDERR: var = (foo {})
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 var = (foo {})
 
 // CHECK:STDERR: fail_paren_match_regression.carbon:[[@LINE+16]]:21: ERROR: `var` declarations must end with a `;`.

--- a/toolchain/parse/testdata/choice/fail_invalid_alternative_identifier.carbon
+++ b/toolchain/parse/testdata/choice/fail_invalid_alternative_identifier.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 choice InvalidAlternativeIdentifier {
-    // CHECK:STDERR: fail_invalid_alternative_identifier.carbon:[[@LINE+3]]:5: ERROR: Expected choice alternative name.
+    // CHECK:STDERR: fail_invalid_alternative_identifier.carbon:[[@LINE+4]]:5: ERROR: Expected choice alternative name.
     // CHECK:STDERR:     ,Some,
     // CHECK:STDERR:     ^
+    // CHECK:STDERR:
     ,Some,
     // CHECK:STDERR: fail_invalid_alternative_identifier.carbon:[[@LINE+3]]:5: ERROR: Expected choice alternative name.
     // CHECK:STDERR:     42,

--- a/toolchain/parse/testdata/choice/fail_invalid_braces.carbon
+++ b/toolchain/parse/testdata/choice/fail_invalid_braces.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_invalid_braces.carbon:[[@LINE+3]]:22: ERROR: Choice definition expected.
+// CHECK:STDERR: fail_invalid_braces.carbon:[[@LINE+4]]:22: ERROR: Choice definition expected.
 // CHECK:STDERR: choice InvalidBraces |
 // CHECK:STDERR:                      ^
+// CHECK:STDERR:
 choice InvalidBraces |
   Some
 // CHECK:STDERR: fail_invalid_braces.carbon:[[@LINE+3]]:1: ERROR: Unrecognized declaration introducer.

--- a/toolchain/parse/testdata/class/fail_base.carbon
+++ b/toolchain/parse/testdata/class/fail_base.carbon
@@ -5,14 +5,16 @@
 // AUTOUPDATE
 
 class A {
-  // CHECK:STDERR: fail_base.carbon:[[@LINE+3]]:7: ERROR: `class` or `:` expected after `base`.
+  // CHECK:STDERR: fail_base.carbon:[[@LINE+4]]:7: ERROR: `class` or `:` expected after `base`.
   // CHECK:STDERR:   base;
   // CHECK:STDERR:       ^
+  // CHECK:STDERR:
   base;
 
-  // CHECK:STDERR: fail_base.carbon:[[@LINE+3]]:9: ERROR: Expected expression.
+  // CHECK:STDERR: fail_base.carbon:[[@LINE+4]]:9: ERROR: Expected expression.
   // CHECK:STDERR:   base: ;
   // CHECK:STDERR:         ^
+  // CHECK:STDERR:
   base: ;
 
   // CHECK:STDERR: fail_base.carbon:[[@LINE+3]]:7: ERROR: Unrecognized declaration introducer.

--- a/toolchain/parse/testdata/class/fail_modifiers.carbon
+++ b/toolchain/parse/testdata/class/fail_modifiers.carbon
@@ -6,9 +6,10 @@
 
 virtual class B
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:1: ERROR: `virtual` declarations must either end with a `;` or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:1: ERROR: `virtual` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: impl class
 // CHECK:STDERR: ^~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:6: ERROR: `class` introducer should be followed by a name.
 // CHECK:STDERR: impl class
 // CHECK:STDERR:      ^~~~~

--- a/toolchain/parse/testdata/for/fail_missing_cond.carbon
+++ b/toolchain/parse/testdata/for/fail_missing_cond.carbon
@@ -5,17 +5,20 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+6]]:7: ERROR: Expected `(` after `for`.
+  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+8]]:7: ERROR: Expected `(` after `for`.
   // CHECK:STDERR:   for {
   // CHECK:STDERR:       ^
-  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+3]]:7: ERROR: Expected `var` declaration.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+4]]:7: ERROR: Expected `var` declaration.
   // CHECK:STDERR:   for {
   // CHECK:STDERR:       ^
+  // CHECK:STDERR:
   for {
   }
-// CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+6]]:1: ERROR: Expected braced code block.
+// CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+7]]:1: ERROR: Expected braced code block.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_missing_cond.carbon:[[@LINE+3]]:1: ERROR: Expected expression.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^

--- a/toolchain/parse/testdata/for/fail_square_brackets.carbon
+++ b/toolchain/parse/testdata/for/fail_square_brackets.carbon
@@ -5,15 +5,18 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+12]]:7: ERROR: Expected `(` after `for`.
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+15]]:7: ERROR: Expected `(` after `for`.
   // CHECK:STDERR:   for [] {
   // CHECK:STDERR:       ^
-  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+9]]:7: ERROR: Expected `var` declaration.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+11]]:7: ERROR: Expected `var` declaration.
   // CHECK:STDERR:   for [] {
   // CHECK:STDERR:       ^
-  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+6]]:8: ERROR: Expected expression.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+7]]:8: ERROR: Expected expression.
   // CHECK:STDERR:   for [] {
   // CHECK:STDERR:        ^
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+3]]:8: ERROR: Expected `;` in array type.
   // CHECK:STDERR:   for [] {
   // CHECK:STDERR:        ^

--- a/toolchain/parse/testdata/function/declaration/fail_missing_implicit_close.carbon
+++ b/toolchain/parse/testdata/function/declaration/fail_missing_implicit_close.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 // Fix and uncomment this to test error handling.
-// CHECK:STDERR: fail_missing_implicit_close.carbon:[[@LINE+6]]:7: ERROR: Opening symbol without a corresponding closing symbol.
+// CHECK:STDERR: fail_missing_implicit_close.carbon:[[@LINE+7]]:7: ERROR: Opening symbol without a corresponding closing symbol.
 // CHECK:STDERR: fn Div[();
 // CHECK:STDERR:       ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_missing_implicit_close.carbon:[[@LINE+3]]:7: ERROR: `fn` requires a `(` for parameters.
 // CHECK:STDERR: fn Div[();
 // CHECK:STDERR:       ^

--- a/toolchain/parse/testdata/function/definition/fail_builtin.carbon
+++ b/toolchain/parse/testdata/function/definition/fail_builtin.carbon
@@ -4,13 +4,15 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_builtin.carbon:[[@LINE+3]]:18: ERROR: Expected builtin function name after `=`.
+// CHECK:STDERR: fail_builtin.carbon:[[@LINE+4]]:18: ERROR: Expected builtin function name after `=`.
 // CHECK:STDERR: fn NotString() = banana;
 // CHECK:STDERR:                  ^~~~~~
+// CHECK:STDERR:
 fn NotString() = banana;
-// CHECK:STDERR: fail_builtin.carbon:[[@LINE+3]]:32: ERROR: `fn` declarations must end with a `;`.
+// CHECK:STDERR: fail_builtin.carbon:[[@LINE+4]]:32: ERROR: `fn` declarations must end with a `;`.
 // CHECK:STDERR: fn JunkAfterString() = "hello" "world";
 // CHECK:STDERR:                                ^~~~~~~
+// CHECK:STDERR:
 fn JunkAfterString() = "hello" "world";
 
 // CHECK:STDERR: fail_builtin.carbon:[[@LINE+3]]:23: ERROR: Expected builtin function name after `=`.

--- a/toolchain/parse/testdata/generics/deduced_params/fail_no_parens.carbon
+++ b/toolchain/parse/testdata/generics/deduced_params/fail_no_parens.carbon
@@ -4,19 +4,22 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+3]]:12: ERROR: A `(` for parameters is required after implicit parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+4]]:12: ERROR: A `(` for parameters is required after implicit parameters.
 // CHECK:STDERR: class Foo[];
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 class Foo[];
 
-// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+3]]:18: ERROR: A `(` for parameters is required after implicit parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+4]]:18: ERROR: A `(` for parameters is required after implicit parameters.
 // CHECK:STDERR: class Foo[a: i32];
 // CHECK:STDERR:                  ^
+// CHECK:STDERR:
 class Foo[a: i32];
 
-// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+3]]:17: ERROR: A `(` for parameters is required after implicit parameters.
+// CHECK:STDERR: fail_no_parens.carbon:[[@LINE+4]]:17: ERROR: A `(` for parameters is required after implicit parameters.
 // CHECK:STDERR: interface Bar[] {}
 // CHECK:STDERR:                 ^
+// CHECK:STDERR:
 interface Bar[] {}
 
 // CHECK:STDERR: fail_no_parens.carbon:[[@LINE+3]]:23: ERROR: A `(` for parameters is required after implicit parameters.

--- a/toolchain/parse/testdata/generics/impl/fail_impl.carbon
+++ b/toolchain/parse/testdata/generics/impl/fail_impl.carbon
@@ -4,75 +4,90 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:10: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:10: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl foo bar;
 // CHECK:STDERR:          ^~~
+// CHECK:STDERR:
 impl foo bar;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:12: ERROR: Expected expression.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:12: ERROR: Expected expression.
 // CHECK:STDERR: impl i32 as;
 // CHECK:STDERR:            ^
+// CHECK:STDERR:
 impl i32 as;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:18: ERROR: `impl` declarations must either end with a `;` or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:18: ERROR: `impl` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: impl bool as bar unexpected;
 // CHECK:STDERR:                  ^~~~~~~~~~
+// CHECK:STDERR:
 impl bool as bar unexpected;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:6: ERROR: Expected expression.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:6: ERROR: Expected expression.
 // CHECK:STDERR: impl return as A;
 // CHECK:STDERR:      ^~~~~~
+// CHECK:STDERR:
 impl return as A;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:6: ERROR: Expected expression.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:6: ERROR: Expected expression.
 // CHECK:STDERR: impl return B;
 // CHECK:STDERR:      ^~~~~~
+// CHECK:STDERR:
 impl return B;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+6]]:13: ERROR: Expected `[` after `forall` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+8]]:13: ERROR: Expected `[` after `forall` in `impl` declaration.
 // CHECK:STDERR: impl forall f32;
 // CHECK:STDERR:             ^~~
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:16: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:16: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl forall f32;
 // CHECK:STDERR:                ^
+// CHECK:STDERR:
 impl forall f32;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:19: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:19: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl forall [] u32;
 // CHECK:STDERR:                   ^
+// CHECK:STDERR:
 impl forall [] u32;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+6]]:21: ERROR: Expected binding pattern.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+8]]:21: ERROR: Expected binding pattern.
 // CHECK:STDERR: impl forall [invalid] i8;
 // CHECK:STDERR:                     ^
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:25: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:25: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl forall [invalid] i8;
 // CHECK:STDERR:                         ^
+// CHECK:STDERR:
 impl forall [invalid] i8;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:13: ERROR: Expected `[` after `forall` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:13: ERROR: Expected `[` after `forall` in `impl` declaration.
 // CHECK:STDERR: impl forall f16 as Quux;
 // CHECK:STDERR:             ^~~
+// CHECK:STDERR:
 impl forall f16 as Quux;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:30: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:30: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl forall [T:! type] String;
 // CHECK:STDERR:                              ^
+// CHECK:STDERR:
 impl forall [T:! type] String;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:26: ERROR: Expected `as` in `impl` declaration.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:26: ERROR: Expected `as` in `impl` declaration.
 // CHECK:STDERR: impl forall [T:! type] T missing_as;
 // CHECK:STDERR:                          ^~~~~~~~~~
+// CHECK:STDERR:
 impl forall [T:! type] T missing_as;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:39: ERROR: `impl` declarations must either end with a `;` or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:39: ERROR: `impl` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: impl forall [T:! type] T as Interface extra;
 // CHECK:STDERR:                                       ^~~~~
+// CHECK:STDERR:
 impl forall [T:! type] T as Interface extra;
 
-// CHECK:STDERR: fail_impl.carbon:[[@LINE+3]]:5: ERROR: Expected expression.
+// CHECK:STDERR: fail_impl.carbon:[[@LINE+4]]:5: ERROR: Expected expression.
 // CHECK:STDERR: impl;
 // CHECK:STDERR:     ^
+// CHECK:STDERR:
 impl;
 
 impl

--- a/toolchain/parse/testdata/generics/impl/fail_out_of_line_member.carbon
+++ b/toolchain/parse/testdata/generics/impl/fail_out_of_line_member.carbon
@@ -14,9 +14,10 @@ impl bool as Interface {
   fn F();
 }
 
-// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+3]]:4: ERROR: `fn` introducer should be followed by a name.
+// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+4]]:4: ERROR: `fn` introducer should be followed by a name.
 // CHECK:STDERR: fn (bool as Interface).F() {}
 // CHECK:STDERR:    ^
+// CHECK:STDERR:
 fn (bool as Interface).F() {}
 
 class C {
@@ -27,12 +28,14 @@ class C {
 
 // TODO: The error recovery here is not very good. The `(` is treated as
 // starting the function parameter list.
-// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+9]]:6: ERROR: Expected identifier after `.`.
+// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+11]]:6: ERROR: Expected identifier after `.`.
 // CHECK:STDERR: fn C.(Self as Interface).F() {}
 // CHECK:STDERR:      ^
-// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+6]]:7: ERROR: Expected binding pattern.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+7]]:7: ERROR: Expected binding pattern.
 // CHECK:STDERR: fn C.(Self as Interface).F() {}
 // CHECK:STDERR:       ^~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_out_of_line_member.carbon:[[@LINE+3]]:25: ERROR: `fn` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: fn C.(Self as Interface).F() {}
 // CHECK:STDERR:                         ^

--- a/toolchain/parse/testdata/generics/interface/fail_missing_open_curly.carbon
+++ b/toolchain/parse/testdata/generics/interface/fail_missing_open_curly.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_missing_open_curly.carbon:[[@LINE+3]]:15: ERROR: `interface` declarations must either end with a `;` or have a `{ ... }` block for a definition.
+// CHECK:STDERR: fail_missing_open_curly.carbon:[[@LINE+4]]:15: ERROR: `interface` declarations must either end with a `;` or have a `{ ... }` block for a definition.
 // CHECK:STDERR: interface Bar Baz {}
 // CHECK:STDERR:               ^~~
+// CHECK:STDERR:
 interface Bar Baz {}
 
 interface Foo

--- a/toolchain/parse/testdata/generics/interface/fail_self_param_syntax.carbon
+++ b/toolchain/parse/testdata/generics/interface/fail_self_param_syntax.carbon
@@ -5,9 +5,10 @@
 // AUTOUPDATE
 
 interface Foo {
-  // CHECK:STDERR: fail_self_param_syntax.carbon:[[@LINE+3]]:13: ERROR: Expected binding pattern.
+  // CHECK:STDERR: fail_self_param_syntax.carbon:[[@LINE+4]]:13: ERROR: Expected binding pattern.
   // CHECK:STDERR:   fn Sub[me Self](b: Self) -> Self;
   // CHECK:STDERR:             ^~~~
+  // CHECK:STDERR:
   fn Sub[me Self](b: Self) -> Self;
 
   // CHECK:STDERR: fail_self_param_syntax.carbon:[[@LINE+3]]:10: ERROR: Expected binding pattern.

--- a/toolchain/parse/testdata/generics/named_constraint/fail_incomplete.carbon
+++ b/toolchain/parse/testdata/generics/named_constraint/fail_incomplete.carbon
@@ -4,9 +4,10 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:12: ERROR: `constraint` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:12: ERROR: `constraint` introducer should be followed by a name.
 // CHECK:STDERR: constraint "Foo"
 // CHECK:STDERR:            ^~~~~
+// CHECK:STDERR:
 constraint "Foo"
 
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:1: ERROR: `constraint` introducer should be followed by a name.

--- a/toolchain/parse/testdata/if/fail_else_unbraced.carbon
+++ b/toolchain/parse/testdata/if/fail_else_unbraced.carbon
@@ -6,18 +6,21 @@
 
 fn F() {
   if (a)
-    // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+3]]:5: ERROR: Expected braced code block.
+    // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+4]]:5: ERROR: Expected braced code block.
     // CHECK:STDERR:     if (b)
     // CHECK:STDERR:     ^~
+    // CHECK:STDERR:
     if (b)
-      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+3]]:7: ERROR: Expected braced code block.
+      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+4]]:7: ERROR: Expected braced code block.
       // CHECK:STDERR:       c;
       // CHECK:STDERR:       ^
+      // CHECK:STDERR:
       c;
     else
-      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+3]]:7: ERROR: Expected braced code block.
+      // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+4]]:7: ERROR: Expected braced code block.
       // CHECK:STDERR:       d;
       // CHECK:STDERR:       ^
+      // CHECK:STDERR:
       d;
   else
     // CHECK:STDERR: fail_else_unbraced.carbon:[[@LINE+3]]:5: ERROR: Expected braced code block.

--- a/toolchain/parse/testdata/if/fail_errors.carbon
+++ b/toolchain/parse/testdata/if/fail_errors.carbon
@@ -5,22 +5,26 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_errors.carbon:[[@LINE+3]]:6: ERROR: Expected `(` after `if`.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+4]]:6: ERROR: Expected `(` after `if`.
   // CHECK:STDERR:   if a {}
   // CHECK:STDERR:      ^
+  // CHECK:STDERR:
   if a {}
-  // CHECK:STDERR: fail_errors.carbon:[[@LINE+3]]:7: ERROR: Expected expression.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+4]]:7: ERROR: Expected expression.
   // CHECK:STDERR:   if () {}
   // CHECK:STDERR:       ^
+  // CHECK:STDERR:
   if () {}
-  // CHECK:STDERR: fail_errors.carbon:[[@LINE+3]]:9: ERROR: Unexpected tokens before `)`.
+  // CHECK:STDERR: fail_errors.carbon:[[@LINE+4]]:9: ERROR: Unexpected tokens before `)`.
   // CHECK:STDERR:   if (b c) {}
   // CHECK:STDERR:         ^
+  // CHECK:STDERR:
   if (b c) {}
   if (d)
-// CHECK:STDERR: fail_errors.carbon:[[@LINE+6]]:1: ERROR: Expected braced code block.
+// CHECK:STDERR: fail_errors.carbon:[[@LINE+7]]:1: ERROR: Expected braced code block.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_errors.carbon:[[@LINE+3]]:1: ERROR: Expected expression.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^

--- a/toolchain/parse/testdata/if/fail_square_brackets.carbon
+++ b/toolchain/parse/testdata/if/fail_square_brackets.carbon
@@ -5,12 +5,14 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+9]]:6: ERROR: Expected `(` after `if`.
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+11]]:6: ERROR: Expected `(` after `if`.
   // CHECK:STDERR:   if [] {}
   // CHECK:STDERR:      ^
-  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+6]]:7: ERROR: Expected expression.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+7]]:7: ERROR: Expected expression.
   // CHECK:STDERR:   if [] {}
   // CHECK:STDERR:       ^
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_square_brackets.carbon:[[@LINE+3]]:7: ERROR: Expected `;` in array type.
   // CHECK:STDERR:   if [] {}
   // CHECK:STDERR:       ^

--- a/toolchain/parse/testdata/if/fail_unbraced.carbon
+++ b/toolchain/parse/testdata/if/fail_unbraced.carbon
@@ -7,13 +7,15 @@
 
 fn F() {
   if (a)
-    // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+3]]:5: ERROR: Expected braced code block.
+    // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+4]]:5: ERROR: Expected braced code block.
     // CHECK:STDERR:     if (b)
     // CHECK:STDERR:     ^~
+    // CHECK:STDERR:
     if (b)
-      // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+3]]:7: ERROR: Expected braced code block.
+      // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+4]]:7: ERROR: Expected braced code block.
       // CHECK:STDERR:       if (c)
       // CHECK:STDERR:       ^~
+      // CHECK:STDERR:
       if (c)
         // CHECK:STDERR: fail_unbraced.carbon:[[@LINE+3]]:9: ERROR: Expected braced code block.
         // CHECK:STDERR:         d;

--- a/toolchain/parse/testdata/if_expr/fail_top_level_if.carbon
+++ b/toolchain/parse/testdata/if_expr/fail_top_level_if.carbon
@@ -5,12 +5,14 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_top_level_if.carbon:[[@LINE+9]]:6: ERROR: Expected `(` after `if`.
+  // CHECK:STDERR: fail_top_level_if.carbon:[[@LINE+11]]:6: ERROR: Expected `(` after `if`.
   // CHECK:STDERR:   if true then 1 else 2;
   // CHECK:STDERR:      ^~~~
-  // CHECK:STDERR: fail_top_level_if.carbon:[[@LINE+6]]:11: ERROR: Expected braced code block.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_top_level_if.carbon:[[@LINE+7]]:11: ERROR: Expected braced code block.
   // CHECK:STDERR:   if true then 1 else 2;
   // CHECK:STDERR:           ^~~~
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_top_level_if.carbon:[[@LINE+3]]:11: ERROR: Expected expression.
   // CHECK:STDERR:   if true then 1 else 2;
   // CHECK:STDERR:           ^~~~

--- a/toolchain/parse/testdata/let/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/let/fail_no_semi.carbon
@@ -6,9 +6,10 @@
 
 let
 
-// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+15]]:21: ERROR: Expected binding pattern.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+16]]:21: ERROR: Expected binding pattern.
 // CHECK:STDERR: // CHECK:STDOUT:   ]
 // CHECK:STDERR:                     ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+12]]:21: ERROR: `let` declarations must end with a `;`.
 // CHECK:STDERR: // CHECK:STDOUT:   ]
 // CHECK:STDERR:                     ^

--- a/toolchain/parse/testdata/match/fail_cases_after_default.carbon
+++ b/toolchain/parse/testdata/match/fail_cases_after_default.carbon
@@ -8,13 +8,15 @@ fn f() -> i32 {
   var x: i32 = 3;
   match (x) {
     default => { return 1; }
-    // CHECK:STDERR: fail_cases_after_default.carbon:[[@LINE+3]]:5: ERROR: Unreachable case; `case` occurs after the `default`
+    // CHECK:STDERR: fail_cases_after_default.carbon:[[@LINE+4]]:5: ERROR: Unreachable case; `case` occurs after the `default`
     // CHECK:STDERR:     case a: i32 => { return 2; }
     // CHECK:STDERR:     ^~~~
+    // CHECK:STDERR:
     case a: i32 => { return 2; }
-    // CHECK:STDERR: fail_cases_after_default.carbon:[[@LINE+3]]:5: ERROR: Unreachable case; `default` occurs after the `default`
+    // CHECK:STDERR: fail_cases_after_default.carbon:[[@LINE+4]]:5: ERROR: Unreachable case; `default` occurs after the `default`
     // CHECK:STDERR:     default => { return 3; }
     // CHECK:STDERR:     ^~~~~~~
+    // CHECK:STDERR:
     default => { return 3; }
     // CHECK:STDERR: fail_cases_after_default.carbon:[[@LINE+3]]:5: ERROR: Unreachable case; `case` occurs after the `default`
     // CHECK:STDERR:     case (a: i32) if (a == 4) => { return 4; }

--- a/toolchain/parse/testdata/match/fail_missing_case_arrow.carbon
+++ b/toolchain/parse/testdata/match/fail_missing_case_arrow.carbon
@@ -6,9 +6,10 @@
 
 fn f() -> i32 {
   match (3) {
-    // CHECK:STDERR: fail_missing_case_arrow.carbon:[[@LINE+3]]:17: ERROR: Expected `=>` introducing statement block.
+    // CHECK:STDERR: fail_missing_case_arrow.carbon:[[@LINE+4]]:17: ERROR: Expected `=>` introducing statement block.
     // CHECK:STDERR:     case x: i32 { return 2; }
     // CHECK:STDERR:                 ^
+    // CHECK:STDERR:
     case x: i32 { return 2; }
     // CHECK:STDERR: fail_missing_case_arrow.carbon:[[@LINE+3]]:29: ERROR: Expected `=>` introducing statement block.
     // CHECK:STDERR:     case x: i32 if (x == 3) { return 3; }

--- a/toolchain/parse/testdata/match/fail_unexpected_tokens_in_cases_block.carbon
+++ b/toolchain/parse/testdata/match/fail_unexpected_tokens_in_cases_block.carbon
@@ -7,32 +7,37 @@
 fn f() -> i32 {
   var x: i32 = 3;
   match (x) {
-    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `let`; expected `case`, `default` or `}`.
+    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+4]]:5: ERROR: Unexpected `let`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     let u: i32 =
     // CHECK:STDERR:     ^~~
+    // CHECK:STDERR:
     let u: i32 =
     case y: i32 if (y > 2) => { return 1; }
-    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `if`; expected `case`, `default` or `}`.
+    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+4]]:5: ERROR: Unexpected `if`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     if (true) {
     // CHECK:STDERR:     ^~
+    // CHECK:STDERR:
     if (true) {
       return 2;
     }
-    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `var`; expected `case`, `default` or `}`.
+    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+4]]:5: ERROR: Unexpected `var`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     var w
     // CHECK:STDERR:     ^~~
+    // CHECK:STDERR:
     var w
     case z: i32 if (z == 3) => { return 3; }
-    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `{`; expected `case`, `default` or `}`.
+    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+4]]:5: ERROR: Unexpected `{`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     {
     // CHECK:STDERR:     ^
+    // CHECK:STDERR:
     {
       break;
     }
     default => { return 3; }
-    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `return`; expected `case`, `default` or `}`.
+    // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+4]]:5: ERROR: Unexpected `return`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     return 1;
     // CHECK:STDERR:     ^~~~~~
+    // CHECK:STDERR:
     return 1;
     // CHECK:STDERR: fail_unexpected_tokens_in_cases_block.carbon:[[@LINE+3]]:5: ERROR: Unexpected `(`; expected `case`, `default` or `}`.
     // CHECK:STDERR:     ((), (), ())

--- a/toolchain/parse/testdata/member_access/fail_keyword.carbon
+++ b/toolchain/parse/testdata/member_access/fail_keyword.carbon
@@ -5,25 +5,30 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+4]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.self;
   // CHECK:STDERR:     ^~~~
+  // CHECK:STDERR:
   a.self;
-  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+4]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.Self;
   // CHECK:STDERR:     ^~~~
+  // CHECK:STDERR:
   a.Self;
-  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:5: ERROR: Expected identifier after `.`.
+  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+4]]:5: ERROR: Expected identifier after `.`.
   // CHECK:STDERR:   a.for;
   // CHECK:STDERR:     ^~~
+  // CHECK:STDERR:
   a.for;
-  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:6: ERROR: Expected identifier after `->`.
+  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+4]]:6: ERROR: Expected identifier after `->`.
   // CHECK:STDERR:   p->self;
   // CHECK:STDERR:      ^~~~
+  // CHECK:STDERR:
   p->self;
-  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:6: ERROR: Expected identifier after `->`.
+  // CHECK:STDERR: fail_keyword.carbon:[[@LINE+4]]:6: ERROR: Expected identifier after `->`.
   // CHECK:STDERR:   p->Self;
   // CHECK:STDERR:      ^~~~
+  // CHECK:STDERR:
   p->Self;
   // CHECK:STDERR: fail_keyword.carbon:[[@LINE+3]]:6: ERROR: Expected identifier after `->`.
   // CHECK:STDERR:   p->while;

--- a/toolchain/parse/testdata/namespace/fail_incomplete.carbon
+++ b/toolchain/parse/testdata/namespace/fail_incomplete.carbon
@@ -4,29 +4,34 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace 123
 // CHECK:STDERR:           ^~~
+// CHECK:STDERR:
 namespace 123
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace ""
 // CHECK:STDERR:           ^~
+// CHECK:STDERR:
 namespace ""
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace +
 // CHECK:STDERR:           ^
+// CHECK:STDERR:
 namespace +
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace bool
 // CHECK:STDERR:           ^~~~
+// CHECK:STDERR:
 namespace bool
 
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace namespace namespace namespace namespace
 // CHECK:STDERR:           ^~~~~~~~~
+// CHECK:STDERR:
 namespace namespace namespace namespace namespace
 
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+3]]:1: ERROR: `namespace` introducer should be followed by a name.

--- a/toolchain/parse/testdata/namespace/fail_modifiers.carbon
+++ b/toolchain/parse/testdata/namespace/fail_modifiers.carbon
@@ -6,9 +6,10 @@
 
 virtual namespace B
 
-// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+6]]:1: ERROR: `namespace` declarations must end with a `;`.
+// CHECK:STDERR: fail_modifiers.carbon:[[@LINE+7]]:1: ERROR: `namespace` declarations must end with a `;`.
 // CHECK:STDERR: impl namespace
 // CHECK:STDERR: ^~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_modifiers.carbon:[[@LINE+3]]:6: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: impl namespace
 // CHECK:STDERR:      ^~~~~~~~~

--- a/toolchain/parse/testdata/operators/fail_invalid_infix.carbon
+++ b/toolchain/parse/testdata/operators/fail_invalid_infix.carbon
@@ -4,17 +4,20 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+3]]:19: ERROR: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+4]]:19: ERROR: Expected expression.
 // CHECK:STDERR: var a: i32 = n == ;
 // CHECK:STDERR:                   ^
+// CHECK:STDERR:
 var a: i32 = n == ;
-// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+3]]:14: ERROR: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+4]]:14: ERROR: Expected expression.
 // CHECK:STDERR: var b: i32 = == n;
 // CHECK:STDERR:              ^~
+// CHECK:STDERR:
 var b: i32 = == n;
-// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+6]]:14: ERROR: Expected expression.
+// CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+7]]:14: ERROR: Expected expression.
 // CHECK:STDERR: var c: i32 = == ;
 // CHECK:STDERR:              ^~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_invalid_infix.carbon:[[@LINE+3]]:17: ERROR: Expected expression.
 // CHECK:STDERR: var c: i32 = == ;
 // CHECK:STDERR:                 ^

--- a/toolchain/parse/testdata/operators/fail_postincrement.carbon
+++ b/toolchain/parse/testdata/operators/fail_postincrement.carbon
@@ -7,9 +7,10 @@
 fn F() {
   var n: i32 = 0;
   // TODO: It'd be nice to produce a custom diagnostic here.
-  // CHECK:STDERR: fail_postincrement.carbon:[[@LINE+3]]:4: ERROR: Expected `;` after expression statement.
+  // CHECK:STDERR: fail_postincrement.carbon:[[@LINE+4]]:4: ERROR: Expected `;` after expression statement.
   // CHECK:STDERR:   n++;
   // CHECK:STDERR:    ^~
+  // CHECK:STDERR:
   n++;
   // CHECK:STDERR: fail_postincrement.carbon:[[@LINE+3]]:4: ERROR: Expected `;` after expression statement.
   // CHECK:STDERR:   n--;

--- a/toolchain/parse/testdata/operators/fail_precedence_as.carbon
+++ b/toolchain/parse/testdata/operators/fail_precedence_as.carbon
@@ -6,15 +6,17 @@
 
 fn F(n: i32) {
   // No ordering between `not` and `as`.
-  // CHECK:STDERR: fail_precedence_as.carbon:[[@LINE+3]]:12: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_precedence_as.carbon:[[@LINE+4]]:12: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   not true as bool;
   // CHECK:STDERR:            ^~
+  // CHECK:STDERR:
   not true as bool;
 
   // No ordering between most binary operators and `as`.
-  // CHECK:STDERR: fail_precedence_as.carbon:[[@LINE+3]]:9: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_precedence_as.carbon:[[@LINE+4]]:9: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   1 + 1 as i32;
   // CHECK:STDERR:         ^~
+  // CHECK:STDERR:
   1 + 1 as i32;
   // CHECK:STDERR: fail_precedence_as.carbon:[[@LINE+3]]:9: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   5 % 2 as i32;

--- a/toolchain/parse/testdata/operators/fail_precedence_assign.carbon
+++ b/toolchain/parse/testdata/operators/fail_precedence_assign.carbon
@@ -8,20 +8,24 @@ fn F() {
   var a: i32;
   // Assignment can only appear as an expression statement, not as a subexpression.
   // TODO: Produce the "can only be used as a complete statement" diagnostic in each of these cases.
-  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+3]]:10: ERROR: Expected `,` or `)`.
+  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+4]]:10: ERROR: Expected `,` or `)`.
   // CHECK:STDERR:   1 + (a = 1);
   // CHECK:STDERR:          ^
+  // CHECK:STDERR:
   1 + (a = 1);
-  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+6]]:19: ERROR: Expected `else` after `if ... then ...`.
+  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+8]]:19: ERROR: Expected `else` after `if ... then ...`.
   // CHECK:STDERR:   (if true then a += 1 else a /= 2);
   // CHECK:STDERR:                   ^~
-  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+3]]:19: ERROR: Expected `,` or `)`.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+4]]:19: ERROR: Expected `,` or `)`.
   // CHECK:STDERR:   (if true then a += 1 else a /= 2);
   // CHECK:STDERR:                   ^~
+  // CHECK:STDERR:
   (if true then a += 1 else a /= 2);
-  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+3]]:7: ERROR: Operator `++` can only be used as a complete statement.
+  // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+4]]:7: ERROR: Operator `++` can only be used as a complete statement.
   // CHECK:STDERR:   a + ++a;
   // CHECK:STDERR:       ^~
+  // CHECK:STDERR:
   a + ++a;
   // CHECK:STDERR: fail_precedence_assign.carbon:[[@LINE+3]]:5: ERROR: Parentheses are required around this unary `if` operator.
   // CHECK:STDERR:   ++if c then a else b;

--- a/toolchain/parse/testdata/operators/fail_variety.carbon
+++ b/toolchain/parse/testdata/operators/fail_variety.carbon
@@ -5,18 +5,22 @@
 // AUTOUPDATE
 
 fn F() {
-  // CHECK:STDERR: fail_variety.carbon:[[@LINE+15]]:21: ERROR: Operator `=` can only be used as a complete statement.
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+19]]:21: ERROR: Operator `=` can only be used as a complete statement.
   // CHECK:STDERR:   n = a * b + c * d = d * d << e & f - not g;
   // CHECK:STDERR:                     ^
-  // CHECK:STDERR: fail_variety.carbon:[[@LINE+12]]:29: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+15]]:29: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   n = a * b + c * d = d * d << e & f - not g;
   // CHECK:STDERR:                             ^~
-  // CHECK:STDERR: fail_variety.carbon:[[@LINE+9]]:34: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+11]]:34: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   n = a * b + c * d = d * d << e & f - not g;
   // CHECK:STDERR:                                  ^
-  // CHECK:STDERR: fail_variety.carbon:[[@LINE+6]]:38: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_variety.carbon:[[@LINE+7]]:38: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   n = a * b + c * d = d * d << e & f - not g;
   // CHECK:STDERR:                                      ^
+  // CHECK:STDERR:
   // CHECK:STDERR: fail_variety.carbon:[[@LINE+3]]:40: ERROR: Parentheses are required around this unary `not` operator.
   // CHECK:STDERR:   n = a * b + c * d = d * d << e & f - not g;
   // CHECK:STDERR:                                        ^~~

--- a/toolchain/parse/testdata/package_expr/fail_in_name.carbon
+++ b/toolchain/parse/testdata/package_expr/fail_in_name.carbon
@@ -4,14 +4,16 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:5: ERROR: Expected binding pattern.
+// CHECK:STDERR: fail_in_name.carbon:[[@LINE+4]]:5: ERROR: Expected binding pattern.
 // CHECK:STDERR: var package.val: i32;
 // CHECK:STDERR:     ^~~~~~~
+// CHECK:STDERR:
 var package.val: i32;
 
-// CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:11: ERROR: `namespace` introducer should be followed by a name.
+// CHECK:STDERR: fail_in_name.carbon:[[@LINE+4]]:11: ERROR: `namespace` introducer should be followed by a name.
 // CHECK:STDERR: namespace package.NS;
 // CHECK:STDERR:           ^~~~~~~
+// CHECK:STDERR:
 namespace package.NS;
 
 // CHECK:STDERR: fail_in_name.carbon:[[@LINE+3]]:7: ERROR: `class` introducer should be followed by a name.

--- a/toolchain/parse/testdata/packages/import/fail_after_decl_repeated.carbon
+++ b/toolchain/parse/testdata/packages/import/fail_after_decl_repeated.carbon
@@ -6,22 +6,24 @@
 
 fn A();
 
-// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE+6]]:1: ERROR: `import` directives must come after the `package` directive (if present) and before any other entities in the file.
+// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE+7]]:1: ERROR: `import` directives must come after the `package` directive (if present) and before any other entities in the file.
 // CHECK:STDERR: import B;
 // CHECK:STDERR: ^~~~~~
 // CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE-5]]:1: First declaration is here.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~
+// CHECK:STDERR:
 import B;
 // Note this is still invalid, but doesn't warn because it's sequential.
 import C;
 
-// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE+6]]:1: ERROR: The `package` directive must be the first non-comment line.
+// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE+7]]:1: ERROR: The `package` directive must be the first non-comment line.
 // CHECK:STDERR: package D;
 // CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE-15]]:1: First non-comment line is here.
+// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE-16]]:1: First non-comment line is here.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~
+// CHECK:STDERR:
 package D;
 
 fn E();
@@ -29,7 +31,7 @@ fn E();
 // CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE+6]]:1: ERROR: `import` directives must come after the `package` directive (if present) and before any other entities in the file.
 // CHECK:STDERR: import F;
 // CHECK:STDERR: ^~~~~~
-// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE-25]]:1: First declaration is here.
+// CHECK:STDERR: fail_after_decl_repeated.carbon:[[@LINE-27]]:1: First declaration is here.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~
 import F;

--- a/toolchain/parse/testdata/packages/library/fail_invalid_name.carbon
+++ b/toolchain/parse/testdata/packages/library/fail_invalid_name.carbon
@@ -6,30 +6,34 @@
 
 // --- fail_identifier.carbon
 
-// CHECK:STDERR: fail_identifier.carbon:[[@LINE+3]]:9: ERROR: Expected `default` or a string literal to specify the library name.
+// CHECK:STDERR: fail_identifier.carbon:[[@LINE+4]]:9: ERROR: Expected `default` or a string literal to specify the library name.
 // CHECK:STDERR: library Shapes api;
 // CHECK:STDERR:         ^~~~~~
+// CHECK:STDERR:
 library Shapes api;
 
 // --- fail_raw_identifier.carbon
 
-// CHECK:STDERR: fail_raw_identifier.carbon:[[@LINE+3]]:9: ERROR: Expected `default` or a string literal to specify the library name.
+// CHECK:STDERR: fail_raw_identifier.carbon:[[@LINE+4]]:9: ERROR: Expected `default` or a string literal to specify the library name.
 // CHECK:STDERR: library r#default api;
 // CHECK:STDERR:         ^~~~~~~
+// CHECK:STDERR:
 library r#default api;
 
 // --- fail_missing.carbon
 
-// CHECK:STDERR: fail_missing.carbon:[[@LINE+3]]:8: ERROR: Expected `default` or a string literal to specify the library name.
+// CHECK:STDERR: fail_missing.carbon:[[@LINE+4]]:8: ERROR: Expected `default` or a string literal to specify the library name.
 // CHECK:STDERR: library;
 // CHECK:STDERR:        ^
+// CHECK:STDERR:
 library;
 
 // --- fail_missing_with_api.carbon
 
-// CHECK:STDERR: fail_missing_with_api.carbon:[[@LINE+3]]:9: ERROR: Expected `default` or a string literal to specify the library name.
+// CHECK:STDERR: fail_missing_with_api.carbon:[[@LINE+4]]:9: ERROR: Expected `default` or a string literal to specify the library name.
 // CHECK:STDERR: library api;
 // CHECK:STDERR:         ^~~
+// CHECK:STDERR:
 library api;
 
 // --- fail_no_semi.carbon

--- a/toolchain/parse/testdata/pointer/fail_pointer_type_in_expr.carbon
+++ b/toolchain/parse/testdata/pointer/fail_pointer_type_in_expr.carbon
@@ -9,19 +9,22 @@ fn F() -> i32 {
   // error, so that it's clear what ambiguity we're referring to.
   // TODO: Improve error recovery so that we recover as `3 * (i32*) * 4`, not
   // as `(3 * i32)* * 4`, to suppress the second error here.
-  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+6]]:17: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+8]]:17: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   return 3 * i32* * 4;
   // CHECK:STDERR:                 ^
-  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+3]]:19: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+4]]:19: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   return 3 * i32* * 4;
   // CHECK:STDERR:                   ^
+  // CHECK:STDERR:
   return 3 * i32* * 4;
 }
 
 fn G() -> i32 {
-  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+3]]:15: ERROR: Parentheses are required to disambiguate operator precedence.
+  // CHECK:STDERR: fail_pointer_type_in_expr.carbon:[[@LINE+4]]:15: ERROR: Parentheses are required to disambiguate operator precedence.
   // CHECK:STDERR:   return i32* + 4;
   // CHECK:STDERR:               ^
+  // CHECK:STDERR:
   return i32* + 4;
 }
 

--- a/toolchain/parse/testdata/return/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/return/fail_no_semi.carbon
@@ -6,9 +6,10 @@
 
 fn F() {
   return
-// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+6]]:1: ERROR: Expected expression.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+7]]:1: ERROR: Expected expression.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+3]]:1: ERROR: `return` statements must end with a `;`.
 // CHECK:STDERR: }
 // CHECK:STDERR: ^

--- a/toolchain/parse/testdata/struct/fail_mix_with_unknown.carbon
+++ b/toolchain/parse/testdata/struct/fail_mix_with_unknown.carbon
@@ -4,17 +4,20 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+6]]:25: ERROR: Expected `.field = value`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+8]]:25: ERROR: Expected `.field = value`.
 // CHECK:STDERR: var x: i32 = {.a = 1, .b, .c: i32};
 // CHECK:STDERR:                         ^
-// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+3]]:29: ERROR: Expected `.field = value`.
+// CHECK:STDERR:
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+4]]:29: ERROR: Expected `.field = value`.
 // CHECK:STDERR: var x: i32 = {.a = 1, .b, .c: i32};
 // CHECK:STDERR:                             ^
+// CHECK:STDERR:
 var x: i32 = {.a = 1, .b, .c: i32};
 
-// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+6]]:26: ERROR: Expected `.field: field_type`.
+// CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+7]]:26: ERROR: Expected `.field: field_type`.
 // CHECK:STDERR: var x: i32 = {.a: i32, .b, .c = 1};
 // CHECK:STDERR:                          ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_mix_with_unknown.carbon:[[@LINE+3]]:31: ERROR: Expected `.field: field_type`.
 // CHECK:STDERR: var x: i32 = {.a: i32, .b, .c = 1};
 // CHECK:STDERR:                               ^

--- a/toolchain/parse/testdata/var/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/var/fail_no_semi.carbon
@@ -6,9 +6,10 @@
 
 var
 
-// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+15]]:21: ERROR: Expected binding pattern.
+// CHECK:STDERR: fail_no_semi.carbon:[[@LINE+16]]:21: ERROR: Expected binding pattern.
 // CHECK:STDERR: // CHECK:STDOUT:   ]
 // CHECK:STDERR:                     ^
+// CHECK:STDERR:
 // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+12]]:21: ERROR: `var` declarations must end with a `;`.
 // CHECK:STDERR: // CHECK:STDOUT:   ]
 // CHECK:STDERR:                     ^

--- a/toolchain/parse/testdata/while/fail_no_semi.carbon
+++ b/toolchain/parse/testdata/while/fail_no_semi.carbon
@@ -8,9 +8,10 @@ fn F() {
   while (a) {
     if (b) {
       break
-    // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+3]]:5: ERROR: `break` statements must end with a `;`.
+    // CHECK:STDERR: fail_no_semi.carbon:[[@LINE+4]]:5: ERROR: `break` statements must end with a `;`.
     // CHECK:STDERR:     }
     // CHECK:STDERR:     ^
+    // CHECK:STDERR:
     }
     if (c) {
       continue


### PR DESCRIPTION
The purpose of the newline is to make it clearer where a given diagnostic begins and ends, particularly as the first message of a diagnostic may not be the error.

This is a trivial code change, but ripples edits through test files.