### PR TITLE
Replace NodeId with a hybrid LocationId in SemIR diagnostics.

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -41,38 +41,39 @@ class Context {
   auto VerifyOnFinish() -> void;
 
   // Adds an instruction to the current block, returning the produced ID.
-  auto AddInst(SemIR::NodeIdAndInst node_id_and_inst) -> SemIR::InstId;
+  auto AddInst(SemIR::LocationIdAndInst loc_id_and_inst) -> SemIR::InstId;
 
   // Adds an instruction in no block, returning the produced ID. Should be used
   // rarely.
-  auto AddInstInNoBlock(SemIR::NodeIdAndInst node_id_and_inst) -> SemIR::InstId;
+  auto AddInstInNoBlock(SemIR::LocationIdAndInst loc_id_and_inst)
+      -> SemIR::InstId;
 
   // Adds an instruction to the current block, returning the produced ID. The
   // instruction is a placeholder that is expected to be replaced by
   // `ReplaceInstBeforeConstantUse`.
-  auto AddPlaceholderInst(SemIR::NodeIdAndInst node_id_and_inst)
+  auto AddPlaceholderInst(SemIR::LocationIdAndInst loc_id_and_inst)
       -> SemIR::InstId;
 
   // Adds an instruction in no block, returning the produced ID. Should be used
   // rarely. The instruction is a placeholder that is expected to be replaced by
   // `ReplaceInstBeforeConstantUse`.
-  auto AddPlaceholderInstInNoBlock(SemIR::NodeIdAndInst node_id_and_inst)
+  auto AddPlaceholderInstInNoBlock(SemIR::LocationIdAndInst loc_id_and_inst)
       -> SemIR::InstId;
 
   // Adds an instruction to the constants block, returning the produced ID.
   auto AddConstant(SemIR::Inst inst, bool is_symbolic) -> SemIR::ConstantId;
 
   // Pushes a parse tree node onto the stack, storing the SemIR::Inst as the
-  // result.
-  auto AddInstAndPush(SemIR::NodeIdAndInst node_id_and_inst) -> void;
+  // result. Only valid if the LocationId is for a NodeId.
+  auto AddInstAndPush(SemIR::LocationIdAndInst loc_id_and_inst) -> void;
 
-  // Replaces the value of the instruction `inst_id` with `node_id_and_inst`.
+  // Replaces the value of the instruction `inst_id` with `loc_id_and_inst`.
   // The instruction is required to not have been used in any constant
   // evaluation, either because it's newly created and entirely unused, or
   // because it's only used in a position that constant evaluation ignores, such
   // as a return slot.
   auto ReplaceInstBeforeConstantUse(SemIR::InstId inst_id,
-                                    SemIR::NodeIdAndInst node_id_and_inst)
+                                    SemIR::LocationIdAndInst loc_id_and_inst)
       -> void;
 
   // Adds an import_ref instruction for the specified instruction in the
@@ -87,7 +88,7 @@ class Context {
   // remain const.
   auto SetNamespaceNodeId(SemIR::InstId inst_id, Parse::NodeId node_id)
       -> void {
-    sem_ir().insts().SetNodeId(inst_id, node_id);
+    sem_ir().insts().SetLocationId(inst_id, SemIR::LocationId(node_id));
   }
 
   // Adds a name to name lookup. Prints a diagnostic for name conflicts.
@@ -96,7 +97,7 @@ class Context {
   // Performs name lookup in a specified scope for a name appearing in a
   // declaration, returning the referenced instruction. If scope_id is invalid,
   // uses the current contextual scope.
-  auto LookupNameInDecl(Parse::NodeId node_id, SemIR::NameId name_id,
+  auto LookupNameInDecl(SemIR::LocationId loc_id, SemIR::NameId name_id,
                         SemIR::NameScopeId scope_id) -> SemIR::InstId;
 
   // Performs an unqualified name lookup, returning the referenced instruction.
@@ -120,7 +121,7 @@ class Context {
       -> void;
 
   // Prints a diagnostic for a missing name.
-  auto DiagnoseNameNotFound(Parse::NodeId node_id, SemIR::NameId name_id)
+  auto DiagnoseNameNotFound(SemIR::LocationId loc_id, SemIR::NameId name_id)
       -> void;
 
   // Adds a note to a diagnostic explaining that a class is incomplete.
@@ -322,6 +323,9 @@ class Context {
   auto impls() -> SemIR::ImplStore& { return sem_ir().impls(); }
   auto import_irs() -> ValueStore<SemIR::ImportIRId>& {
     return sem_ir().import_irs();
+  }
+  auto import_ir_insts() -> ValueStore<SemIR::ImportIRInstId>& {
+    return sem_ir().import_ir_insts();
   }
   auto names() -> SemIR::NameStoreWrapper { return sem_ir().names(); }
   auto name_scopes() -> SemIR::NameScopeStore& {

--- a/toolchain/check/convert.h
+++ b/toolchain/check/convert.h
@@ -50,13 +50,13 @@ struct ConversionTarget {
 };
 
 // Convert a value to another type and expression category.
-auto Convert(Context& context, Parse::NodeId node_id, SemIR::InstId expr_id,
+auto Convert(Context& context, SemIR::LocationId loc_id, SemIR::InstId expr_id,
              ConversionTarget target) -> SemIR::InstId;
 
 // Performs initialization of `target_id` from `value_id`. Returns the
 // possibly-converted initializing expression, which should be assigned to the
 // target using a suitable node for the kind of initialization.
-auto Initialize(Context& context, Parse::NodeId node_id,
+auto Initialize(Context& context, SemIR::LocationId loc_id,
                 SemIR::InstId target_id, SemIR::InstId value_id)
     -> SemIR::InstId;
 
@@ -70,18 +70,18 @@ auto ConvertToValueOrRefExpr(Context& context, SemIR::InstId expr_id)
     -> SemIR::InstId;
 
 // Converts `expr_id` to a value expression of type `type_id`.
-auto ConvertToValueOfType(Context& context, Parse::NodeId node_id,
+auto ConvertToValueOfType(Context& context, SemIR::LocationId loc_id,
                           SemIR::InstId expr_id, SemIR::TypeId type_id)
     -> SemIR::InstId;
 
 // Convert the given expression to a value or reference expression of the given
 // type.
-auto ConvertToValueOrRefOfType(Context& context, Parse::NodeId node_id,
+auto ConvertToValueOrRefOfType(Context& context, SemIR::LocationId loc_id,
                                SemIR::InstId expr_id, SemIR::TypeId type_id)
     -> SemIR::InstId;
 
 // Converts `value_id` to a value expression of type `bool`.
-auto ConvertToBoolValue(Context& context, Parse::NodeId node_id,
+auto ConvertToBoolValue(Context& context, SemIR::LocationId loc_id,
                         SemIR::InstId value_id) -> SemIR::InstId;
 
 // Converts `value_id` to type `type_id` for an `as` expression.
@@ -92,7 +92,7 @@ auto ConvertForExplicitAs(Context& context, Parse::NodeId as_node,
 // Implicitly converts a set of arguments to match the parameter types in a
 // function call. Returns a block containing the converted implicit and explicit
 // argument values.
-auto ConvertCallArgs(Context& context, Parse::NodeId call_node_id,
+auto ConvertCallArgs(Context& context, SemIR::LocationId call_loc_id,
                      SemIR::InstId self_id,
                      llvm::ArrayRef<SemIR::InstId> arg_refs,
                      SemIR::InstId return_storage_id, SemIR::InstId callee_id,
@@ -100,8 +100,8 @@ auto ConvertCallArgs(Context& context, Parse::NodeId call_node_id,
                      SemIR::InstBlockId param_refs_id) -> SemIR::InstBlockId;
 
 // Converts an expression for use as a type.
-auto ExprAsType(Context& context, Parse::NodeId node_id, SemIR::InstId value_id)
-    -> SemIR::TypeId;
+auto ExprAsType(Context& context, SemIR::LocationId loc_id,
+                SemIR::InstId value_id) -> SemIR::TypeId;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -7,7 +7,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/scope_index.h"
-#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
@@ -124,8 +123,8 @@ class DeclNameStack {
     // should be used.
     SemIR::NameScopeId target_scope_id;
 
-    // The last parse node used.
-    Parse::NodeId node_id = Parse::NodeId::Invalid;
+    // The last location ID used.
+    SemIR::LocationId loc_id = SemIR::LocationId::Invalid;
 
     union {
       // The ID of a resolved qualifier, including both identifiers and
@@ -177,13 +176,14 @@ class DeclNameStack {
   // unqualified name in the current context. This is suitable for adding to
   // name lookup in situations where a qualified name is not permitted, such as
   // a pattern binding.
-  auto MakeUnqualifiedName(Parse::NodeId node_id, SemIR::NameId name_id)
+  auto MakeUnqualifiedName(SemIR::LocationId loc_id, SemIR::NameId name_id)
       -> NameContext;
 
   // Applies a Name from the name stack to the top of the declaration name
   // stack. This will enter the scope corresponding to the name if the name
   // describes an existing scope, such as a namespace or a defined class.
-  auto ApplyNameQualifier(Parse::NodeId node_id, SemIR::NameId name_id) -> void;
+  auto ApplyNameQualifier(SemIR::LocationId loc_id, SemIR::NameId name_id)
+      -> void;
 
   // Adds a name to name lookup. Prints a diagnostic for name conflicts.
   auto AddNameToLookup(NameContext name_context, SemIR::InstId target_id)
@@ -199,12 +199,12 @@ class DeclNameStack {
   auto MakeEmptyNameContext() -> NameContext;
 
   // Applies a Name from the name stack to given name context.
-  auto ApplyNameQualifierTo(NameContext& name_context, Parse::NodeId node_id,
+  auto ApplyNameQualifierTo(NameContext& name_context, SemIR::LocationId loc_id,
                             SemIR::NameId name_id, bool is_unqualified) -> void;
 
   // Returns true if the context is in a state where it can resolve qualifiers.
   // Updates name_context as needed.
-  auto TryResolveQualifier(NameContext& name_context, Parse::NodeId node_id)
+  auto TryResolveQualifier(NameContext& name_context, SemIR::LocationId loc_id)
       -> bool;
 
   // Updates the scope on name_context as needed. This is called after

--- a/toolchain/check/diagnostic_helpers.h
+++ b/toolchain/check/diagnostic_helpers.h
@@ -16,22 +16,30 @@ namespace Carbon::Check {
 // directly, or an inst ID which is later translated to a parse node.
 struct SemIRLocation {
   // NOLINTNEXTLINE(google-explicit-constructor)
-  SemIRLocation(SemIR::InstId inst_id) : inst_id(inst_id), is_inst_id(true) {}
+  SemIRLocation(SemIR::InstId inst_id)
+      : inst_id(inst_id), is_inst_id(true), token_only(false) {}
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  SemIRLocation(Parse::NodeLocation node_location)
-      : node_location(node_location), is_inst_id(false) {}
+  SemIRLocation(Parse::NodeId node_id) : SemIRLocation(node_id, false) {}
+
   // NOLINTNEXTLINE(google-explicit-constructor)
-  SemIRLocation(Parse::NodeId node_id)
-      : SemIRLocation(Parse::NodeLocation(node_id)) {}
+  SemIRLocation(SemIR::LocationId loc_id) : SemIRLocation(loc_id, false) {}
+
+  explicit SemIRLocation(SemIR::LocationId loc_id, bool token_only)
+      : loc_id(loc_id), is_inst_id(false), token_only(token_only) {}
 
   union {
     SemIR::InstId inst_id;
-    Parse::NodeLocation node_location;
+    SemIR::LocationId loc_id;
   };
 
   bool is_inst_id;
+  bool token_only;
 };
+
+inline auto TokenOnly(SemIR::LocationId loc_id) -> SemIRLocation {
+  return SemIRLocation(loc_id, true);
+}
 
 // An integer value together with its type. The type is used to determine how to
 // format the value in diagnostics.

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -48,20 +48,20 @@ auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
     // TODO: Look into handling `false`, this doesn't do it right now because it
     // sees a value instruction instead of a builtin.
     alias_id = context.AddInst(
-        {name_context.node_id,
+        {name_context.loc_id,
          SemIR::BindAlias{context.insts().Get(expr_id).type_id(), bind_name_id,
                           expr_id}});
   } else if (auto inst = context.insts().TryGetAs<SemIR::NameRef>(expr_id)) {
     // Pass through name references, albeit changing the name in use.
     alias_id = context.AddInst(
-        {name_context.node_id,
+        {name_context.loc_id,
          SemIR::BindAlias{inst->type_id, bind_name_id, inst->value_id}});
   } else {
     CARBON_DIAGNOSTIC(AliasRequiresNameRef, Error,
                       "Alias initializer must be a name reference.");
     context.emitter().Emit(expr_node, AliasRequiresNameRef);
     alias_id =
-        context.AddInst({name_context.node_id,
+        context.AddInst({name_context.loc_id,
                          SemIR::BindAlias{SemIR::TypeId::Error, bind_name_id,
                                           SemIR::InstId::BuiltinError}});
   }

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -19,8 +19,9 @@ auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   auto [name_node, name_id] = context.node_stack().PopNameWithNodeId();
 
   // Create the appropriate kind of binding for this pattern.
-  auto make_bind_name = [&](SemIR::TypeId type_id,
-                            SemIR::InstId value_id) -> SemIR::NodeIdAndInst {
+  auto make_bind_name =
+      [&](SemIR::TypeId type_id,
+          SemIR::InstId value_id) -> SemIR::LocationIdAndInst {
     // TODO: Eventually the name will need to support associations with other
     // scopes, but right now we don't support qualified names here.
     auto bind_name_id = context.bind_names().Add(

--- a/toolchain/check/handle_expr_statement.cpp
+++ b/toolchain/check/handle_expr_statement.cpp
@@ -15,7 +15,7 @@ static auto HandleDiscardedExpr(Context& context, SemIR::InstId expr_id)
   // If we discard an initializing expression, convert it to a value or
   // reference so that it has something to initialize.
   auto expr = context.insts().Get(expr_id);
-  Convert(context, context.insts().GetNodeId(expr_id), expr_id,
+  Convert(context, context.insts().GetLocationId(expr_id), expr_id,
           {.kind = ConversionTarget::Discarded, .type_id = expr.type_id()});
 
   // TODO: This will eventually need to do some "do not discard" analysis.

--- a/toolchain/check/handle_index.cpp
+++ b/toolchain/check/handle_index.cpp
@@ -45,7 +45,7 @@ auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
   switch (operand_type_inst.kind()) {
     case SemIR::ArrayType::Kind: {
       auto array_type = operand_type_inst.As<SemIR::ArrayType>();
-      auto index_node_id = context.insts().GetNodeId(index_inst_id);
+      auto index_node_id = context.insts().GetLocationId(index_inst_id);
       auto cast_index_id = ConvertToValueOfType(
           context, index_node_id, index_inst_id,
           context.GetBuiltinType(SemIR::BuiltinKind::IntType));
@@ -74,7 +74,7 @@ auto HandleIndexExpr(Context& context, Parse::IndexExprId node_id) -> bool {
     }
     case SemIR::TupleType::Kind: {
       SemIR::TypeId element_type_id = SemIR::TypeId::Error;
-      auto index_node_id = context.insts().GetNodeId(index_inst_id);
+      auto index_node_id = context.insts().GetLocationId(index_inst_id);
       index_inst_id = ConvertToValueOfType(
           context, index_node_id, index_inst_id,
           context.GetBuiltinType(SemIR::BuiltinKind::IntType));

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -28,7 +28,7 @@ auto HandleLetInitializer(Context& context, Parse::LetInitializerId node_id)
 
 static auto BuildAssociatedConstantDecl(
     Context& context, Parse::LetDeclId node_id, SemIR::InstId pattern_id,
-    SemIR::NodeIdAndInst pattern, SemIR::InterfaceId interface_id) -> void {
+    SemIR::LocationIdAndInst pattern, SemIR::InterfaceId interface_id) -> void {
   auto& interface_info = context.interfaces().Get(interface_id);
 
   auto binding_pattern = pattern.inst.TryAs<SemIR::BindSymbolicName>();
@@ -36,7 +36,7 @@ static auto BuildAssociatedConstantDecl(
     CARBON_DIAGNOSTIC(ExpectedSymbolicBindingInAssociatedConstant, Error,
                       "Pattern in associated constant declaration must be a "
                       "single `:!` binding.");
-    context.emitter().Emit(pattern.node_id,
+    context.emitter().Emit(pattern.loc_id,
                            ExpectedSymbolicBindingInAssociatedConstant);
     context.name_scopes().Get(interface_info.scope_id).has_error = true;
     return;
@@ -55,7 +55,7 @@ static auto BuildAssociatedConstantDecl(
   // Add an associated entity name to the interface scope.
   auto assoc_id = BuildAssociatedEntity(context, interface_id, decl_id);
   auto name_context =
-      context.decl_name_stack().MakeUnqualifiedName(pattern.node_id, name_id);
+      context.decl_name_stack().MakeUnqualifiedName(pattern.loc_id, name_id);
   context.decl_name_stack().AddNameToLookup(name_context, assoc_id);
 }
 
@@ -98,7 +98,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   }
   context.decl_state_stack().Pop(DeclState::Let);
 
-  auto pattern = context.insts().GetWithNodeId(pattern_id);
+  auto pattern = context.insts().GetWithLocationId(pattern_id);
   auto interface_scope = context.GetCurrentScopeAs<SemIR::InterfaceDecl>();
 
   if (value_id) {
@@ -119,8 +119,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
     CARBON_DIAGNOSTIC(
         ExpectedInitializerAfterLet, Error,
         "Expected `=`; `let` declaration must have an initializer.");
-    context.emitter().Emit(Parse::TokenOnly(node_id),
-                           ExpectedInitializerAfterLet);
+    context.emitter().Emit(TokenOnly(node_id), ExpectedInitializerAfterLet);
     value_id = SemIR::InstId::BuiltinError;
   }
 

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -37,10 +37,10 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
     // previous declaration. Otherwise, diagnose the issue.
     if (auto existing =
             context.insts().TryGetAs<SemIR::Namespace>(existing_inst_id)) {
-      // When the name conflict is an imported namespace, fill the parse node
+      // When the name conflict is an imported namespace, fill the location ID
       // so that future diagnostics point at this declaration.
       if (existing->import_id.is_valid() &&
-          !context.insts().GetNodeId(existing_inst_id).is_valid()) {
+          !context.insts().GetLocationId(existing_inst_id).is_valid()) {
         context.SetNamespaceNodeId(existing_inst_id, node_id);
       }
     } else {

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -55,7 +55,7 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
     // Form a corresponding name in the current context, and bind the name to
     // the variable.
     auto name_context = context.decl_name_stack().MakeUnqualifiedName(
-        context.insts().GetNodeId(value_id),
+        context.insts().GetLocationId(value_id),
         context.bind_names().Get(bind_name->bind_name_id).name_id);
     context.decl_name_stack().AddNameToLookup(name_context, value_id);
     value_id = bind_name->value_id;
@@ -63,7 +63,7 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
                  context.insts().TryGetAs<SemIR::FieldDecl>(value_id)) {
     // Introduce the field name into the class.
     auto name_context = context.decl_name_stack().MakeUnqualifiedName(
-        context.insts().GetNodeId(value_id), field_decl->name_id);
+        context.insts().GetLocationId(value_id), field_decl->name_id);
     context.decl_name_stack().AddNameToLookup(name_context, value_id);
   }
   // TODO: Handle other kinds of pattern.

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -29,7 +29,7 @@ auto BuildAssociatedEntity(Context& context, SemIR::InterfaceId interface_id,
   // not the declaration itself.
   auto type_id = context.GetAssociatedEntityType(
       interface_id, context.insts().Get(decl_id).type_id());
-  return context.AddInst({context.insts().GetNodeId(decl_id),
+  return context.AddInst({context.insts().GetLocationId(decl_id),
                           SemIR::AssociatedEntity{type_id, index, decl_id}});
 }
 

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -11,17 +11,17 @@ namespace Carbon::Check {
 static auto ReportNotAllowed(Context& context, Parse::NodeId modifier_node,
                              Lex::TokenKind decl_kind,
                              llvm::StringRef context_string,
-                             Parse::NodeId context_node) -> void {
+                             SemIR::LocationId context_loc_id) -> void {
   CARBON_DIAGNOSTIC(ModifierNotAllowedOn, Error,
                     "`{0}` not allowed on `{1}` declaration{2}.",
                     Lex::TokenKind, Lex::TokenKind, std::string);
   auto diag = context.emitter().Build(modifier_node, ModifierNotAllowedOn,
                                       context.token_kind(modifier_node),
                                       decl_kind, context_string.str());
-  if (context_node.is_valid()) {
+  if (context_loc_id.is_valid()) {
     CARBON_DIAGNOSTIC(ModifierNotInContext, Note,
                       "Containing definition here.");
-    diag.Note(context_node, ModifierNotInContext);
+    diag.Note(context_loc_id, ModifierNotInContext);
   }
   diag.Emit();
 }
@@ -41,7 +41,7 @@ static auto ModifierOrderAsSet(ModifierOrder order) -> KeywordModifierSet {
 auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
                            Lex::TokenKind decl_kind,
                            llvm::StringRef context_string,
-                           Parse::NodeId context_node) -> void {
+                           SemIR::LocationId context_loc_id) -> void {
   auto& s = context.decl_state_stack().innermost();
   auto not_allowed = s.modifier_set & forbidden;
   if (!not_allowed) {
@@ -53,7 +53,7 @@ auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
     auto order = static_cast<ModifierOrder>(order_index);
     if (!!(not_allowed & ModifierOrderAsSet(order))) {
       ReportNotAllowed(context, s.modifier_node_id(order), decl_kind,
-                       context_string, context_node);
+                       context_string, context_loc_id);
       s.set_modifier_node_id(order, Parse::NodeId::Invalid);
     }
   }
@@ -121,12 +121,12 @@ auto CheckMethodModifiersOnFunction(Context& context,
       if (inheritance_kind == SemIR::Class::Final) {
         ForbidModifiersOnDecl(context, KeywordModifierSet::Virtual, decl_kind,
                               " in a non-abstract non-base `class` definition",
-                              context.insts().GetNodeId(target_id));
+                              context.insts().GetLocationId(target_id));
       }
       if (inheritance_kind != SemIR::Class::Abstract) {
         ForbidModifiersOnDecl(context, KeywordModifierSet::Abstract, decl_kind,
                               " in a non-abstract `class` definition",
-                              context.insts().GetNodeId(target_id));
+                              context.insts().GetLocationId(target_id));
       }
       return;
     }

--- a/toolchain/check/modifiers.h
+++ b/toolchain/check/modifiers.h
@@ -26,14 +26,13 @@ auto CheckMethodModifiersOnFunction(Context& context,
                                     SemIR::NameScopeId target_scope_id) -> void;
 
 // Like `LimitModifiersOnDecl`, except says which modifiers are forbidden, and a
-// `context_string` (and optional `context_node`) specifying the context in
+// `context_string` (and optional `context_loc_id`) specifying the context in
 // which those modifiers are forbidden.
 // TODO: Take another look at diagnostic phrasing for callers.
-auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
-                           Lex::TokenKind decl_kind,
-                           llvm::StringRef context_string,
-                           Parse::NodeId context_node = Parse::NodeId::Invalid)
-    -> void;
+auto ForbidModifiersOnDecl(
+    Context& context, KeywordModifierSet forbidden, Lex::TokenKind decl_kind,
+    llvm::StringRef context_string,
+    SemIR::LocationId context_loc_id = SemIR::LocationId::Invalid) -> void;
 
 // Reports a diagnostic (using `decl_kind`) if modifiers on this declaration are
 // not in `allowed`. Updates the declaration state in

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -39,8 +39,8 @@ class PendingBlock {
     size_t size_;
   };
 
-  auto AddInst(SemIR::NodeIdAndInst node_id_and_inst) -> SemIR::InstId {
-    auto inst_id = context_.AddInstInNoBlock(node_id_and_inst);
+  auto AddInst(SemIR::LocationIdAndInst loc_id_and_inst) -> SemIR::InstId {
+    auto inst_id = context_.AddInstInNoBlock(loc_id_and_inst);
     insts_.push_back(inst_id);
     return inst_id;
   }
@@ -56,7 +56,7 @@ class PendingBlock {
   // Replace the instruction at target_id with the instructions in this block.
   // The new value for target_id should be value_id.
   auto MergeReplacing(SemIR::InstId target_id, SemIR::InstId value_id) -> void {
-    auto value = context_.insts().GetWithNodeId(value_id);
+    auto value = context_.insts().GetWithLocationId(value_id);
 
     // There are three cases here:
 
@@ -64,7 +64,7 @@ class PendingBlock {
       // 1) The block is empty. Replace `target_id` with an empty splice
       // pointing at `value_id`.
       context_.ReplaceInstBeforeConstantUse(
-          target_id, {value.node_id,
+          target_id, {value.loc_id,
                       SemIR::SpliceBlock{value.inst.type_id(),
                                          SemIR::InstBlockId::Empty, value_id}});
     } else if (insts_.size() == 1 && insts_[0] == value_id) {
@@ -75,7 +75,7 @@ class PendingBlock {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
       context_.ReplaceInstBeforeConstantUse(
           target_id,
-          {value.node_id,
+          {value.loc_id,
            SemIR::SpliceBlock{value.inst.type_id(),
                               context_.inst_blocks().Add(insts_), value_id}});
     }

--- a/toolchain/parse/tree_node_diagnostic_converter.h
+++ b/toolchain/parse/tree_node_diagnostic_converter.h
@@ -30,10 +30,6 @@ class NodeLocation {
   bool token_only_;
 };
 
-inline auto TokenOnly(NodeId node_id) -> NodeLocation {
-  return NodeLocation(node_id, true);
-}
-
 class NodeLocationConverter : public DiagnosticConverter<NodeLocation> {
  public:
   explicit NodeLocationConverter(const Lex::TokenizedBuffer* tokens,

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//toolchain/base:index_base",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
+        "//toolchain/parse:node_kind",
         "//toolchain/sem_ir:builtin_kind",
     ],
 )
@@ -92,6 +93,7 @@ cc_library(
         "file.h",
         "function.h",
         "impl.h",
+        "import_ir.h",
         "interface.h",
         "name.h",
         "name_scope.h",

--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -26,7 +26,7 @@ auto ConstantStore::GetOrAdd(Inst inst, bool is_symbolic) -> ConstantId {
 
   // Create the new inst and insert the new node.
   auto inst_id = constants_.getContext()->insts().AddInNoBlock(
-      NodeIdAndInst::Untyped(Parse::NodeId::Invalid, inst));
+      LocationIdAndInst::Untyped(Parse::NodeId::Invalid, inst));
   auto constant_id = is_symbolic
                          ? SemIR::ConstantId::ForSymbolicConstant(inst_id)
                          : SemIR::ConstantId::ForTemplateConstant(inst_id);

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -17,6 +17,7 @@
 #include "toolchain/sem_ir/function.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/impl.h"
+#include "toolchain/sem_ir/import_ir.h"
 #include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/interface.h"
 #include "toolchain/sem_ir/name.h"
@@ -39,15 +40,6 @@ struct BindNameInfo : public Printable<BindNameInfo> {
 };
 
 class File;
-
-struct ImportIR : public Printable<ImportIR> {
-  auto Print(llvm::raw_ostream& out) const -> void { out << node_id; }
-
-  // The node ID for the import.
-  Parse::ImportDirectiveId node_id;
-  // The imported IR.
-  const File* sem_ir;
-};
 
 // Provides semantic analysis on a Parse::Tree.
 class File : public Printable<File> {
@@ -149,6 +141,12 @@ class File : public Printable<File> {
   auto import_irs() const -> const ValueStore<ImportIRId>& {
     return import_irs_;
   }
+  auto import_ir_insts() -> ValueStore<ImportIRInstId>& {
+    return import_ir_insts_;
+  }
+  auto import_ir_insts() const -> const ValueStore<ImportIRInstId>& {
+    return import_ir_insts_;
+  }
   auto names() const -> NameStoreWrapper {
     return NameStoreWrapper(&identifiers());
   }
@@ -224,6 +222,10 @@ class File : public Printable<File> {
   // Related IRs. There will always be at least one entry, the builtin IR (used
   // for references of builtins).
   ValueStore<ImportIRId> import_irs_;
+
+  // Related IR instructions. These are created for LocationIds for instructions
+  // that are import-related.
+  ValueStore<ImportIRInstId> import_ir_insts_;
 
   // Storage for name scopes.
   NameScopeStore name_scopes_;

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -490,9 +490,12 @@ struct ImportIRInstId : public IdBase, public Printable<InstId> {
   using IdBase::IdBase;
 };
 
-// A SemIR location used exclusively for diagnostic locations. If positive, it
-// corresponds to a Parse::NodeId in the current IR. If valid and negative, it
-// corresponds to an ImportIRInstId.
+// A SemIR location used exclusively for diagnostic locations.
+//
+// Contents:
+// - index > Invalid: A Parse::NodeId in the current IR.
+// - index == Invalid: Can be used for either.
+// - index < Invalid: An ImportIRInstId.
 struct LocationId : public IdBase, public Printable<FunctionId> {
   // An explicitly invalid function ID.
   static const LocationId Invalid;

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -494,8 +494,8 @@ struct ImportIRInstId : public IdBase, public Printable<InstId> {
 //
 // Contents:
 // - index > Invalid: A Parse::NodeId in the current IR.
-// - index == Invalid: Can be used for either.
 // - index < Invalid: An ImportIRInstId.
+// - index == Invalid: Can be used for either.
 struct LocationId : public IdBase, public Printable<FunctionId> {
   // An explicitly invalid function ID.
   static const LocationId Invalid;

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -10,6 +10,7 @@
 #include "toolchain/base/index_base.h"
 #include "toolchain/base/value_store.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
+#include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/builtin_kind.h"
 
 namespace Carbon::SemIR {
@@ -21,6 +22,7 @@ struct BindNameInfo;
 struct Class;
 struct Function;
 struct ImportIR;
+struct ImportIRInst;
 struct Interface;
 struct Impl;
 struct NameScope;
@@ -480,6 +482,64 @@ struct ElementIndex : public IndexBase, public Printable<ElementIndex> {
     IndexBase::Print(out);
   }
 };
+
+// The ID of an ImportIRInst.
+struct ImportIRInstId : public IdBase, public Printable<InstId> {
+  using ValueType = ImportIRInst;
+
+  using IdBase::IdBase;
+};
+
+// A SemIR location used exclusively for diagnostic locations. If positive, it
+// corresponds to a Parse::NodeId in the current IR. If valid and negative, it
+// corresponds to an ImportIRInstId.
+struct LocationId : public IdBase, public Printable<FunctionId> {
+  // An explicitly invalid function ID.
+  static const LocationId Invalid;
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr LocationId(Parse::InvalidNodeId /*invalid*/)
+      : IdBase(InvalidIndex) {}
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr LocationId(Parse::NodeId node_id) : IdBase(node_id.index) {
+    CARBON_CHECK(node_id.is_valid() == is_valid());
+  }
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr LocationId(ImportIRInstId inst_id)
+      : IdBase(InvalidIndex + ImportIRInstId::InvalidIndex - inst_id.index) {
+    CARBON_CHECK(inst_id.is_valid() == is_valid());
+  }
+
+  auto is_node_id() const -> bool { return index > InvalidIndex; }
+  auto is_import_ir_inst_id() const -> bool { return index < InvalidIndex; }
+
+  // This is allowed to return an invalid NodeId, but should never be used for a
+  // valid InstId.
+  auto node_id() const -> Parse::NodeId {
+    CARBON_CHECK(is_node_id() || !is_valid());
+    return Parse::NodeId(index);
+  }
+
+  // This is allowed to return an invalid InstId, but should never be used for a
+  // valid NodeId.
+  auto import_ir_inst_id() const -> ImportIRInstId {
+    CARBON_CHECK(is_import_ir_inst_id() || !is_valid());
+    return ImportIRInstId(InvalidIndex + ImportIRInstId::InvalidIndex - index);
+  }
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "loc_";
+    if (is_node_id() || !is_valid()) {
+      out << node_id();
+    } else {
+      out << import_ir_inst_id();
+    }
+  }
+};
+
+constexpr LocationId LocationId::Invalid = LocationId(Parse::NodeId::Invalid);
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/import_ir.h
+++ b/toolchain/sem_ir/import_ir.h
@@ -1,0 +1,37 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEM_IR_IMPORT_IR_H_
+#define CARBON_TOOLCHAIN_SEM_IR_IMPORT_IR_H_
+
+#include "llvm/ADT/FoldingSet.h"
+#include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst.h"
+
+namespace Carbon::SemIR {
+
+// A reference to an imported IR.
+struct ImportIR : public Printable<ImportIR> {
+  auto Print(llvm::raw_ostream& out) const -> void { out << node_id; }
+
+  // The node ID for the import.
+  Parse::ImportDirectiveId node_id;
+  // The imported IR.
+  const File* sem_ir;
+};
+
+// A reference to an instruction in an imported IR. Used for diagnostics with
+// LocationId.
+struct ImportIRInst : public Printable<ImportIRInst> {
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << ir_id << ":" << inst_id;
+  }
+
+  ImportIRId ir_id;
+  InstId inst_id;
+};
+
+}  // namespace Carbon::SemIR
+
+#endif  // CARBON_TOOLCHAIN_SEM_IR_IMPORT_IR_H_

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -290,13 +290,13 @@ inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
 
 // Associates a NodeId and Inst in order to provide type-checking that the
 // TypedNodeId corresponds to the InstT.
-struct NodeIdAndInst {
-  // In cases where the NodeId is untyped or the InstT is unknown, the check
-  // can't be done at compile time.
+struct LocationIdAndInst {
+  // In cases where the NodeId is untyped, an inst_id, or the InstT is unknown,
+  // the NodeId check can't be done at compile time.
   // TODO: Consider runtime validation that InstT::Kind::TypedNodeId
   // corresponds.
-  static auto Untyped(Parse::NodeId node_id, Inst inst) -> NodeIdAndInst {
-    return NodeIdAndInst(node_id, inst, /*is_untyped=*/true);
+  static auto Untyped(LocationId loc_id, Inst inst) -> LocationIdAndInst {
+    return LocationIdAndInst(loc_id, inst, /*is_untyped=*/true);
   }
 
   // For the common case, support construction as:
@@ -304,22 +304,32 @@ struct NodeIdAndInst {
   template <typename InstT>
     requires(Internal::HasNodeId<InstT>)
   // NOLINTNEXTLINE(google-explicit-constructor)
-  NodeIdAndInst(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
-      : node_id(node_id), inst(inst) {}
+  LocationIdAndInst(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
+      : loc_id(node_id), inst(inst) {}
 
   // For cases with no parse node, support construction as:
   //   context.AddInst({SemIR::MyInst{...}});
   template <typename InstT>
     requires(!Internal::HasNodeId<InstT>)
   // NOLINTNEXTLINE(google-explicit-constructor)
-  NodeIdAndInst(InstT inst) : node_id(Parse::NodeId::Invalid), inst(inst) {}
+  LocationIdAndInst(InstT inst) : loc_id(Parse::NodeId::Invalid), inst(inst) {}
 
-  Parse::NodeId node_id;
+  // If TypedNodeId is Parse::NodeId, allow construction with a LocationId
+  // rather than requiring Untyped.
+  // TODO: This is somewhat historical due to fetching the NodeId from insts()
+  // for things like Temporary; should we require Untyped in these cases?
+  template <typename InstT>
+    requires(std::same_as<typename decltype(InstT::Kind)::TypedNodeId,
+                          Parse::NodeId>)
+  LocationIdAndInst(LocationId loc_id, InstT inst)
+      : loc_id(loc_id), inst(inst) {}
+
+  LocationId loc_id;
   Inst inst;
 
  private:
-  explicit NodeIdAndInst(Parse::NodeId node_id, Inst inst, bool /*is_untyped*/)
-      : node_id(node_id), inst(inst) {}
+  explicit LocationIdAndInst(LocationId loc_id, Inst inst, bool /*is_untyped*/)
+      : loc_id(loc_id), inst(inst) {}
 };
 
 // Provides a ValueStore wrapper for an API specific to instructions.
@@ -330,17 +340,17 @@ class InstStore {
   // instruction block. Check::Context::AddInst or InstBlockStack::AddInst
   // should usually be used instead, to add the instruction to the current
   // block.
-  auto AddInNoBlock(NodeIdAndInst node_id_and_inst) -> InstId {
-    node_ids_.push_back(node_id_and_inst.node_id);
-    return values_.Add(node_id_and_inst.inst);
+  auto AddInNoBlock(LocationIdAndInst loc_id_and_inst) -> InstId {
+    loc_ids_.push_back(loc_id_and_inst.loc_id);
+    return values_.Add(loc_id_and_inst.inst);
   }
 
   // Returns the requested instruction.
   auto Get(InstId inst_id) const -> Inst { return values_.Get(inst_id); }
 
-  // Returns the requested instruction and its parse node.
-  auto GetWithNodeId(InstId inst_id) const -> NodeIdAndInst {
-    return NodeIdAndInst::Untyped(GetNodeId(inst_id), Get(inst_id));
+  // Returns the requested instruction and its location ID.
+  auto GetWithLocationId(InstId inst_id) const -> LocationIdAndInst {
+    return LocationIdAndInst::Untyped(GetLocationId(inst_id), Get(inst_id));
   }
 
   // Returns whether the requested instruction is the specified type.
@@ -373,23 +383,26 @@ class InstStore {
     return TryGetAs<InstT>(inst_id);
   }
 
-  auto GetNodeId(InstId inst_id) const -> Parse::NodeId {
-    return node_ids_[inst_id.index];
+  auto GetLocationId(InstId inst_id) const -> LocationId {
+    CARBON_CHECK(inst_id.index >= 0) << inst_id.index;
+    CARBON_CHECK(inst_id.index < (int)loc_ids_.size())
+        << inst_id.index << " " << loc_ids_.size();
+    return loc_ids_[inst_id.index];
   }
 
-  // Overwrites a given instruction and parse node with a new value.
-  auto Set(InstId inst_id, NodeIdAndInst node_id_and_inst) -> void {
-    values_.Get(inst_id) = node_id_and_inst.inst;
-    node_ids_[inst_id.index] = node_id_and_inst.node_id;
+  // Overwrites a given instruction and location ID with a new value.
+  auto Set(InstId inst_id, LocationIdAndInst loc_id_and_inst) -> void {
+    values_.Get(inst_id) = loc_id_and_inst.inst;
+    loc_ids_[inst_id.index] = loc_id_and_inst.loc_id;
   }
 
-  auto SetNodeId(InstId inst_id, Parse::NodeId node_id) -> void {
-    node_ids_[inst_id.index] = node_id;
+  auto SetLocationId(InstId inst_id, LocationId loc_id) -> void {
+    loc_ids_[inst_id.index] = loc_id;
   }
 
   // Reserves space.
   auto Reserve(size_t size) -> void {
-    node_ids_.reserve(size);
+    loc_ids_.reserve(size);
     values_.Reserve(size);
   }
 
@@ -397,7 +410,7 @@ class InstStore {
   auto size() const -> int { return values_.size(); }
 
  private:
-  llvm::SmallVector<Parse::NodeId> node_ids_;
+  llvm::SmallVector<LocationId> loc_ids_;
   ValueStore<InstId> values_;
 };
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -288,7 +288,7 @@ inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
   return out;
 }
 
-// Associates a NodeId and Inst in order to provide type-checking that the
+// Associates a LocationId and Inst in order to provide type-checking that the
 // TypedNodeId corresponds to the InstT.
 struct LocationIdAndInst {
   // In cases where the NodeId is untyped, an inst_id, or the InstT is unknown,


### PR DESCRIPTION
The purpose of this change is to allow something such as a FunctionDecl instruction to note an imported instruction as the "loc_id". Note that doesn't occur here: this change is already very sweeping in edits. There is no testdata affected, intended to show equivalent behavior.

We might want to consolidate NodeId references towards LocationId, but if that's preferred, I'd still like to split it out. A lot of this just piping through LocationId where it's a build error otherwise, enough that imports should be able to start using it for diagnostics. ValueStores are added but still unused -- just flushing out structure for review.

Restructuring SemIRLocation is necessary to use LocationId this way. For TokenOnly, it's not getting used in Parse, so I migrated it to Check and it's now specific to SemIRLocation.

I also considered making LocationId reference an InstId (which would need to be an ImportRef) instead of an ImportIRInstId. However, that would've required import.cpp to add instructions for decls which are reached during resolution -- we typically don't have an inst ready for use. An extra inst is essentially 16 bytes in InstId's ValueStore + 4 bytes in LocationId's ValueStore, whereas this is 8 bytes per.