### PR TITLE
Provide locations for indirectly imported instructions.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -9,6 +9,7 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/import.h"
+#include "toolchain/diagnostics/diagnostic.h"
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/lex/token_kind.h"
 #include "toolchain/parse/node_ids.h"
@@ -38,36 +39,55 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLocation> {
 
   auto ConvertLocation(SemIRLocation loc, ContextFnT context_fn) const
       -> DiagnosticLocation override {
-    // Parse nodes always refer to the current IR.
-    if (!loc.is_inst_id) {
-      CARBON_CHECK(loc.loc_id.is_node_id() || !loc.loc_id.is_valid())
-          << "TODO: Handle non-NodeId locs";
-      return ConvertLocationInFile(sem_ir_, loc.loc_id.node_id(),
-                                   loc.token_only, context_fn);
-    }
-
     const auto* cursor_ir = sem_ir_;
     auto cursor_inst_id = loc.inst_id;
+
+    auto follow_import_ref = [&](SemIR::ImportIRId ir_id,
+                                 SemIR::InstId inst_id) {
+      const auto& import_ir = cursor_ir->import_irs().Get(ir_id);
+      auto context_loc = ConvertLocationInFile(cursor_ir, import_ir.node_id,
+                                               loc.token_only, context_fn);
+      CARBON_DIAGNOSTIC(InImport, Note, "In import.");
+      context_fn(context_loc, InImport);
+      cursor_ir = import_ir.sem_ir;
+      cursor_inst_id = inst_id;
+    };
+
+    auto handle_loc =
+        [&](SemIR::LocationId loc_id) -> std::optional<DiagnosticLocation> {
+      if (loc_id.is_import_ir_inst_id()) {
+        auto import_ir_inst =
+            cursor_ir->import_ir_insts().Get(loc_id.import_ir_inst_id());
+        follow_import_ref(import_ir_inst.ir_id, import_ir_inst.inst_id);
+        return std::nullopt;
+      } else {
+        return ConvertLocationInFile(cursor_ir, loc_id.node_id(),
+                                     loc.token_only, context_fn);
+      }
+    };
+
+    // Parse nodes always refer to the current IR.
+    if (!loc.is_inst_id) {
+      if (auto diag_loc = handle_loc(loc.loc_id)) {
+        return *diag_loc;
+      }
+    }
+
     while (true) {
       // If the parse node is valid, use it for the location.
       if (auto loc_id = cursor_ir->insts().GetLocationId(cursor_inst_id);
           loc_id.is_valid()) {
-        CARBON_CHECK(loc_id.is_node_id()) << "TODO: Handle non-NodeId locs";
-        return ConvertLocationInFile(cursor_ir, loc_id.node_id(),
-                                     loc.token_only, context_fn);
+        if (auto diag_loc = handle_loc(loc_id)) {
+          return *diag_loc;
+        }
+        continue;
       }
 
       // If the parse node was invalid, recurse through import references when
       // possible.
       if (auto import_ref = cursor_ir->insts().TryGetAs<SemIR::AnyImportRef>(
               cursor_inst_id)) {
-        const auto& import_ir = cursor_ir->import_irs().Get(import_ref->ir_id);
-        auto context_loc = ConvertLocationInFile(cursor_ir, import_ir.node_id,
-                                                 loc.token_only, context_fn);
-        CARBON_DIAGNOSTIC(InImport, Note, "In import.");
-        context_fn(context_loc, InImport);
-        cursor_ir = import_ir.sem_ir;
-        cursor_inst_id = import_ref->inst_id;
+        follow_import_ref(import_ref->ir_id, import_ref->inst_id);
         continue;
       }
 

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -67,15 +67,14 @@ class Context {
   // result. Only valid if the LocationId is for a NodeId.
   auto AddInstAndPush(SemIR::LocationIdAndInst loc_id_and_inst) -> void;
 
-  // Replaces the value of the instruction `inst_id` with `loc_id_and_inst`.
-  // The instruction is required to not have been used in any constant
-  // evaluation, either because it's newly created and entirely unused, or
-  // because it's only used in a position that constant evaluation ignores, such
-  // as a return slot.
+  // Replaces the instruction `inst_id` with `loc_id_and_inst`. The instruction
+  // is required to not have been used in any constant evaluation, either
+  // because it's newly created and entirely unused, or because it's only used
+  // in a position that constant evaluation ignores, such as a return slot.
   auto ReplaceLocationIdAndInstBeforeConstantUse(
       SemIR::InstId inst_id, SemIR::LocationIdAndInst loc_id_and_inst) -> void;
 
-  // Replaces the value of the instruction `inst_id` with `inst`.
+  // Replaces the instruction `inst_id` with `inst`, not affecting location.
   // The instruction is required to not have been used in any constant
   // evaluation, either because it's newly created and entirely unused, or
   // because it's only used in a position that constant evaluation ignores, such

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -72,8 +72,15 @@ class Context {
   // evaluation, either because it's newly created and entirely unused, or
   // because it's only used in a position that constant evaluation ignores, such
   // as a return slot.
-  auto ReplaceInstBeforeConstantUse(SemIR::InstId inst_id,
-                                    SemIR::LocationIdAndInst loc_id_and_inst)
+  auto ReplaceLocationIdAndInstBeforeConstantUse(
+      SemIR::InstId inst_id, SemIR::LocationIdAndInst loc_id_and_inst) -> void;
+
+  // Replaces the value of the instruction `inst_id` with `inst`.
+  // The instruction is required to not have been used in any constant
+  // evaluation, either because it's newly created and entirely unused, or
+  // because it's only used in a position that constant evaluation ignores, such
+  // as a return slot.
+  auto ReplaceInstBeforeConstantUse(SemIR::InstId inst_id, SemIR::Inst inst)
       -> void;
 
   // Adds an import_ref instruction for the specified instruction in the

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -108,7 +108,7 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id)
   }
 
   // Write the class ID into the ClassDecl.
-  context.ReplaceInstBeforeConstantUse(class_decl_id, {node_id, class_decl});
+  context.ReplaceInstBeforeConstantUse(class_decl_id, class_decl);
 
   if (is_new_class) {
     // Build the `Self` type using the resulting type constant.

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -198,8 +198,7 @@ static auto BuildFunctionDecl(Context& context,
   }
 
   // Write the function ID into the FunctionDecl.
-  context.ReplaceInstBeforeConstantUse(function_info.decl_id,
-                                       {node_id, function_decl});
+  context.ReplaceInstBeforeConstantUse(function_info.decl_id, function_decl);
 
   if (SemIR::IsEntryPoint(context.sem_ir(), function_decl.function_id)) {
     // TODO: Update this once valid signatures for the entry point are decided.

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -88,8 +88,7 @@ static auto BuildInterfaceDecl(Context& context,
   }
 
   // Write the interface ID into the InterfaceDecl.
-  context.ReplaceInstBeforeConstantUse(interface_decl_id,
-                                       {node_id, interface_decl});
+  context.ReplaceInstBeforeConstantUse(interface_decl_id, interface_decl);
 
   return {interface_decl.interface_id, interface_decl_id};
 }

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -46,7 +46,7 @@ static auto BuildAssociatedConstantDecl(
   // declaration.
   auto name_id =
       context.bind_names().Get(binding_pattern->bind_name_id).name_id;
-  context.ReplaceInstBeforeConstantUse(
+  context.ReplaceLocationIdAndInstBeforeConstantUse(
       pattern_id, {node_id, SemIR::AssociatedConstantDecl{
                                 binding_pattern->type_id, name_id}});
   auto decl_id = pattern_id;
@@ -130,8 +130,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   CARBON_CHECK(!bind_name.value_id.is_valid())
       << "Binding should not already have a value!";
   bind_name.value_id = *value_id;
-  pattern.inst = bind_name;
-  context.ReplaceInstBeforeConstantUse(pattern_id, pattern);
+  context.ReplaceInstBeforeConstantUse(pattern_id, bind_name);
   context.inst_block_stack().AddInstId(pattern_id);
 
   // Add the name of the binding to the current scope.

--- a/toolchain/check/handle_namespace.cpp
+++ b/toolchain/check/handle_namespace.cpp
@@ -28,7 +28,7 @@ auto HandleNamespace(Context& context, Parse::NamespaceId node_id) -> bool {
   namespace_inst.name_scope_id = context.name_scopes().Add(
       namespace_id, name_context.name_id_for_new_inst(),
       name_context.enclosing_scope_id_for_new_inst());
-  context.ReplaceInstBeforeConstantUse(namespace_id, {node_id, namespace_inst});
+  context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
 
   auto existing_inst_id =
       context.decl_name_stack().LookupOrAddName(name_context, namespace_id);

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -102,7 +102,7 @@ static auto AddNamespace(
   auto namespace_id = context.AddPlaceholderInst({node_id, namespace_inst});
   namespace_inst.name_scope_id =
       context.name_scopes().Add(namespace_id, name_id, enclosing_scope_id);
-  context.ReplaceInstBeforeConstantUse(namespace_id, {node_id, namespace_inst});
+  context.ReplaceInstBeforeConstantUse(namespace_id, namespace_inst);
 
   // Diagnose if there's a name conflict, but still produce the namespace to
   // supersede the name conflict in order to avoid repeat diagnostics.

--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -63,17 +63,17 @@ class PendingBlock {
     if (insts_.empty()) {
       // 1) The block is empty. Replace `target_id` with an empty splice
       // pointing at `value_id`.
-      context_.ReplaceInstBeforeConstantUse(
+      context_.ReplaceLocationIdAndInstBeforeConstantUse(
           target_id, {value.loc_id,
                       SemIR::SpliceBlock{value.inst.type_id(),
                                          SemIR::InstBlockId::Empty, value_id}});
     } else if (insts_.size() == 1 && insts_[0] == value_id) {
       // 2) The block is {value_id}. Replace `target_id` with the instruction
       // referred to by `value_id`. This is intended to be the common case.
-      context_.ReplaceInstBeforeConstantUse(target_id, value);
+      context_.ReplaceLocationIdAndInstBeforeConstantUse(target_id, value);
     } else {
       // 3) Anything else: splice it into the IR, replacing `target_id`.
-      context_.ReplaceInstBeforeConstantUse(
+      context_.ReplaceLocationIdAndInstBeforeConstantUse(
           target_id,
           {value.loc_id,
            SemIR::SpliceBlock{value.inst.type_id(),

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -45,10 +45,15 @@ library "extern" api;
 
 import Other library "extern";
 
-// CHECK:STDERR: fail_extern.carbon:[[@LINE+5]]:8: ERROR: Variable has incomplete type `C`.
+// CHECK:STDERR: fail_extern.carbon:[[@LINE+10]]:8: ERROR: Variable has incomplete type `C`.
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
-// CHECK:STDERR: fail_extern.carbon: Class was forward declared here.
+// CHECK:STDERR: fail_extern.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: import Other library "extern";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: other_extern.carbon:5:1: Class was forward declared here.
+// CHECK:STDERR: class C;
+// CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 var c: Other.C = {};
 
@@ -213,7 +218,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc11: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc16: {} = struct_literal ()
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -32,10 +32,15 @@ import library "a";
 class Empty {
 }
 
-// CHECK:STDERR: fail_b.carbon:[[@LINE+4]]:8: ERROR: Variable has incomplete type `Incomplete`.
+// CHECK:STDERR: fail_b.carbon:[[@LINE+9]]:8: ERROR: Variable has incomplete type `Incomplete`.
 // CHECK:STDERR: var a: Incomplete;
 // CHECK:STDERR:        ^~~~~~~~~~
-// CHECK:STDERR: fail_b.carbon: Class was forward declared here.
+// CHECK:STDERR: fail_b.carbon:[[@LINE-18]]:1: In import.
+// CHECK:STDERR: import library "a";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: a.carbon:7:1: Class was forward declared here.
+// CHECK:STDERR: class Incomplete;
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 var a: Incomplete;
 
 // CHECK:STDOUT: --- a.carbon

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -37,16 +37,26 @@ library "def_ownership" api;
 
 import library "a";
 
-// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+5]]:1: ERROR: Only one library can declare function A without `extern`.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function A without `extern`.
 // CHECK:STDERR: fn A() {};
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_def_ownership.carbon: Previously declared here.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: import library "a";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: a.carbon:4:1: Previously declared here.
+// CHECK:STDERR: fn A() {}
+// CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 fn A() {};
-// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+5]]:1: ERROR: Only one library can declare function B without `extern`.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function B without `extern`.
 // CHECK:STDERR: fn B(b: i32) -> i32;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_def_ownership.carbon: Previously declared here.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE-16]]:1: In import.
+// CHECK:STDERR: import library "a";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: a.carbon:5:1: Previously declared here.
+// CHECK:STDERR: fn B(b: i32) -> i32 { return b; }
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn B(b: i32) -> i32;
 
@@ -57,10 +67,15 @@ library "mix_extern_decl" api;
 import library "a";
 
 extern fn D();
-// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+4]]:1: ERROR: Only one library can declare function D without `extern`.
+// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+9]]:1: ERROR: Only one library can declare function D without `extern`.
 // CHECK:STDERR: fn D() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_mix_extern_decl.carbon: Previously declared here.
+// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE-6]]:1: In import.
+// CHECK:STDERR: import library "a";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: a.carbon:7:1: Previously declared here.
+// CHECK:STDERR: fn D();
+// CHECK:STDERR: ^~~~~~~
 fn D() {}
 
 // CHECK:STDOUT: --- a.carbon
@@ -195,8 +210,8 @@ fn D() {}
 // CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+30, unused
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
-// CHECK:STDOUT:     %b.loc17_6.1: i32 = param b
-// CHECK:STDOUT:     %b.loc17_6.2: i32 = bind_name b, %b.loc17_6.1
+// CHECK:STDOUT:     %b.loc27_6.1: i32 = param b
+// CHECK:STDOUT:     %b.loc27_6.2: i32 = bind_name b, %b.loc27_6.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -222,7 +237,7 @@ fn D() {}
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+20, unused
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+30, used [template = imports.%D]
 // CHECK:STDOUT:   %D.loc6: <function> = fn_decl @D [template] {}
-// CHECK:STDOUT:   %D.loc11: <function> = fn_decl @D [template] {}
+// CHECK:STDOUT:   %D.loc16: <function> = fn_decl @D [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @D() {

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -132,10 +132,15 @@ import library "other_ns";
 // CHECK:STDERR:
 import Other library "fn";
 
-// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+5]]:1: ERROR: Only one library can declare function F without `extern`.
+// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function F without `extern`.
 // CHECK:STDERR: fn Other.F() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
-// CHECK:STDERR: fail_main_namespace_conflict.carbon: Previously declared here.
+// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: import Other library "fn";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: other_fn.carbon:4:1: Previously declared here.
+// CHECK:STDERR: fn F() {}
+// CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 fn Other.F() {}
 

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -390,13 +390,15 @@ class InstStore {
     return loc_ids_[inst_id.index];
   }
 
-  // Overwrites a given instruction and location ID with a new value.
+  // Overwrites a given instruction with a new value.
   auto Set(InstId inst_id, Inst inst) -> void { values_.Get(inst_id) = inst; }
 
+  // Overwrites a given instruction's location with a new value.
   auto SetLocationId(InstId inst_id, LocationId loc_id) -> void {
     loc_ids_[inst_id.index] = loc_id;
   }
 
+  // Overwrites a given instruction and location ID with a new value.
   auto SetLocationIdAndInst(InstId inst_id, LocationIdAndInst loc_id_and_inst)
       -> void {
     Set(inst_id, loc_id_and_inst.inst);

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -391,13 +391,16 @@ class InstStore {
   }
 
   // Overwrites a given instruction and location ID with a new value.
-  auto Set(InstId inst_id, LocationIdAndInst loc_id_and_inst) -> void {
-    values_.Get(inst_id) = loc_id_and_inst.inst;
-    loc_ids_[inst_id.index] = loc_id_and_inst.loc_id;
-  }
+  auto Set(InstId inst_id, Inst inst) -> void { values_.Get(inst_id) = inst; }
 
   auto SetLocationId(InstId inst_id, LocationId loc_id) -> void {
     loc_ids_[inst_id.index] = loc_id;
+  }
+
+  auto SetLocationIdAndInst(InstId inst_id, LocationIdAndInst loc_id_and_inst)
+      -> void {
+    Set(inst_id, loc_id_and_inst.inst);
+    SetLocationId(inst_id, loc_id_and_inst.loc_id);
   }
 
   // Reserves space.


### PR DESCRIPTION
This replaces all invalid node IDs in import_ref.cpp with references to the imported instruction.

This splits out ReplaceInstBeforeConstantUse into a separate function when the LocationId is replaced, as for splicing. That's the less common case, whereas others would need to provide the LocationId in order just to not change the value.