### PR TITLE
Add infrastructure for distinguishing between signed and unsigned integer types.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -83,10 +83,8 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLocation> {
       return sem_ir_->StringifyType(*type_id);
     }
     if (auto* typed_int = llvm::any_cast<TypedInt>(&arg)) {
-      // TODO: Once unsigned integers are supported, compute the signedness
-      // here.
-      constexpr bool IsUnsigned = false;
-      return llvm::APSInt(typed_int->value, IsUnsigned);
+      return llvm::APSInt(typed_int->value,
+                          !sem_ir_->types().IsSignedInt(typed_int->type));
     }
     return DiagnosticConverter<SemIRLocation>::ConvertArg(arg);
   }

--- a/toolchain/check/testdata/array/fail_bound_negative.carbon
+++ b/toolchain/check/testdata/array/fail_bound_negative.carbon
@@ -15,7 +15,7 @@ var a: [i32; Negate(1)];
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 4294967295 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal -1 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_add.carbon
+++ b/toolchain/check/testdata/builtins/int_add.carbon
@@ -289,7 +289,7 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %.1: i32 = int_literal 2147483647 [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.4: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_div.carbon
+++ b/toolchain/check/testdata/builtins/int_div.carbon
@@ -115,10 +115,10 @@ let b: i32 = Div(0, 0);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 2147483647 [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 2147483649 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal -2147483647 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.4: i32 = int_literal 4294967295 [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal -1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_mod.carbon
+++ b/toolchain/check/testdata/builtins/int_mod.carbon
@@ -118,11 +118,11 @@ let b: i32 = Mod(0, 0);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 2147483647 [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 2147483649 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal -2147483647 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.4: i32 = int_literal 4294967295 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal -1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.6: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_mul.carbon
+++ b/toolchain/check/testdata/builtins/int_mul.carbon
@@ -92,7 +92,7 @@ let b: i32 = Mul(0x8000, 0x10000);
 // CHECK:STDOUT:   %.2: i32 = int_literal 65536 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 2147418112 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 32768 [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_negate.carbon
+++ b/toolchain/check/testdata/builtins/int_negate.carbon
@@ -116,7 +116,7 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 4294967295 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal -1 [template]
 // CHECK:STDOUT:   %.3: type = array_type %.1, i32 [template]
 // CHECK:STDOUT:   %.4: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT: }
@@ -306,9 +306,9 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 2147483647 [template]
-// CHECK:STDOUT:   %.2: i32 = int_literal 2147483649 [template]
+// CHECK:STDOUT:   %.2: i32 = int_literal -2147483647 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.4: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {

--- a/toolchain/check/testdata/builtins/int_sub.carbon
+++ b/toolchain/check/testdata/builtins/int_sub.carbon
@@ -91,9 +91,9 @@ let c: i32 = Sub(Sub(0, 0x7FFFFFFF), 2);
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 2147483647 [template]
-// CHECK:STDOUT:   %.3: i32 = int_literal 2147483649 [template]
+// CHECK:STDOUT:   %.3: i32 = int_literal -2147483647 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 2147483648 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal -2147483648 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -172,6 +172,8 @@ auto HandleBuiltin(FunctionContext& /*context*/, SemIR::InstId /*inst_id*/,
 static auto HandleBuiltinCall(FunctionContext& context, SemIR::InstId inst_id,
                               SemIR::BuiltinFunctionKind builtin_kind,
                               llvm::ArrayRef<SemIR::InstId> arg_ids) -> void {
+  // TODO: Consider setting this to true in the performance build mode if the
+  // result type is a signed integer type.
   constexpr bool SignedOverflowIsUB = false;
 
   switch (builtin_kind) {

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1150,6 +1150,13 @@ class Formatter {
     FormatTrailingBlock(inst.decl_block_id);
   }
 
+  auto FormatInstructionRHS(IntLiteral inst) -> void {
+    out_ << " ";
+    sem_ir_.ints()
+        .Get(inst.int_id)
+        .print(out_, sem_ir_.types().IsSignedInt(inst.type_id));
+  }
+
   auto FormatInstructionRHS(ImportRefUnused inst) -> void {
     // Don't format the inst_id because it refers to a different IR.
     // TODO: Consider a better way to format the InstID from other IRs.
@@ -1212,6 +1219,7 @@ class Formatter {
   auto FormatArg(ImportIRId id) -> void { out_ << id; }
 
   auto FormatArg(IntId id) -> void {
+    // We don't know the signedness to use here. Default to unsigned.
     sem_ir_.ints().Get(id).print(out_, /*isSigned=*/false);
   }
 

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -83,6 +83,11 @@ class TypeStore : public ValueStore<TypeId> {
     return GetValueRepr(type_id).kind != ValueRepr::Unknown;
   }
 
+  // Determines whether the given type is a signed integer type.
+  auto IsSignedInt(TypeId int_type_id) const -> bool {
+    return GetInstId(int_type_id) == InstId::BuiltinIntType;
+  }
+
  private:
   InstStore* insts_;
 };


### PR DESCRIPTION
Because we don't have any unsigned integer types yet, this is mostly a no-op change, except that we now format negative values in SemIR properly.