### PR TITLE
Explicitly flush stream_consumer

### DIFF
--- a/toolchain/diagnostics/diagnostic_consumer.h
+++ b/toolchain/diagnostics/diagnostic_consumer.h
@@ -43,6 +43,7 @@ class StreamDiagnosticConsumer : public DiagnosticConsumer {
       : stream_(&stream) {}
 
   auto HandleDiagnostic(Diagnostic diagnostic) -> void override;
+  auto Flush() -> void override { stream_->flush(); }
 
  private:
   auto Print(const DiagnosticMessage& message, llvm::StringRef prefix) -> void;

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -662,6 +662,7 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
     for (auto& unit : units) {
       unit->Flush();
     }
+    stream_consumer.Flush();
   });
 
   // Returns a RunResult object. Called whenever Compile returns.


### PR DESCRIPTION
Note I don't think this affects behavior just due to how the implementation is, but I was trying to figure out a bug that was hit during sorting consumer flushing, and this seems like it should be done for consistency.