### PR TITLE
Special-case api/impl implicit imports and verify relevant redeclarations.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -182,10 +182,10 @@ struct UnitInfo {
   ErrorTrackingDiagnosticConsumer err_tracker;
   DiagnosticEmitter<Parse::NodeLoc> emitter;
 
-  // A map of package names to outgoing imports. If the
-  // import's target isn't available, the unit will be nullptr to assist with
-  // name lookup. Invalid imports (for example, `import Main;`) aren't added
-  // because they won't add identifiers to name lookup.
+  // A map of package names to outgoing imports. If a package includes
+  // unavailable library imports, it has an entry with has_load_error set.
+  // Invalid imports (for example, `import Main;`) aren't added because they
+  // won't add identifiers to name lookup.
   llvm::DenseMap<IdentifierId, PackageImports> package_imports_map;
 
   // The remaining number of imports which must be checked before this unit can
@@ -195,6 +195,10 @@ struct UnitInfo {
   // A list of incoming imports. This will be empty for `impl` files, because
   // imports only touch `api` files.
   llvm::SmallVector<UnitInfo*> incoming_imports;
+
+  // True if this is an `impl` file and an `api` implicit import has
+  // successfully been added. Used for determining the number of import IRs.
+  bool has_api_for_impl = false;
 };
 
 // Add imports to the root block.
@@ -205,6 +209,10 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
   size_t num_irs = context.import_irs().size();
   for (auto& [_, package_imports] : unit_info.package_imports_map) {
     num_irs += package_imports.imports.size();
+  }
+  if (unit_info.has_api_for_impl) {
+    // One of the IRs replaces ImportIRId::ApiForImpl.
+    --num_irs;
   }
   context.import_ir_constant_values().resize(
       num_irs, SemIR::ConstantValueStore(SemIR::ConstantId::Invalid));
@@ -230,10 +238,15 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
   auto self_import = unit_info.package_imports_map.find(IdentifierId::Invalid);
   if (self_import != unit_info.package_imports_map.end()) {
     bool error_in_import = self_import->second.has_load_error;
+    const auto& packaging = context.parse_tree().packaging_directive();
+    auto current_library_id =
+        packaging ? packaging->names.library_id : StringLiteralValueId::Invalid;
     for (const auto& import : self_import->second.imports) {
+      bool is_api_for_impl = current_library_id == import.names.library_id;
       const auto& import_sem_ir = **import.unit_info->unit->sem_ir;
       ImportLibraryFromCurrentPackage(context, namespace_type_id,
-                                      import.names.node_id, import_sem_ir);
+                                      import.names.node_id, is_api_for_impl,
+                                      import_sem_ir);
       error_in_import |= import_sem_ir.name_scopes()
                              .Get(SemIR::NameScopeId::Package)
                              .has_error;
@@ -269,7 +282,8 @@ static auto InitPackageScopeAndImports(Context& context, UnitInfo& unit_info)
   }
 
   CARBON_CHECK(context.import_irs().size() == num_irs)
-      << "Created an unexpected number of IRs";
+      << "Created an unexpected number of IRs: expected " << num_irs
+      << ", have " << context.import_irs().size();
 }
 
 namespace {
@@ -869,6 +883,12 @@ static auto TrackImport(
     package_imports_it->second.imports.push_back({import, api->second});
     ++unit_info.imports_remaining;
     api->second->incoming_imports.push_back(&unit_info);
+
+    // If this is the implicit import, note it was successfully imported.
+    if (!explicit_import_map) {
+      CARBON_CHECK(!import.package_id.is_valid());
+      unit_info.has_api_for_impl = true;
+    }
   } else {
     // The imported api is missing.
     package_imports_it->second.has_load_error = true;
@@ -1035,6 +1055,7 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
     // on a part of it.
     // TODO: Better identify cycles, maybe try to untangle them.
     for (auto& unit_info : unit_infos) {
+      const auto& packaging = unit_info.unit->parse_tree->packaging_directive();
       if (unit_info.imports_remaining > 0) {
         for (auto& [package_id, package_imports] :
              unit_info.package_imports_map) {
@@ -1052,6 +1073,10 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
                                      ImportCycleDetected);
               // Make this look the same as an import which wasn't found.
               package_imports.has_load_error = true;
+              if (packaging && !package_id.is_valid() &&
+                  packaging->names.library_id == import_it->names.library_id) {
+                unit_info.has_api_for_impl = false;
+              }
               import_it = package_imports.imports.erase(import_it);
             }
           }

--- a/toolchain/check/function.h
+++ b/toolchain/check/function.h
@@ -46,7 +46,7 @@ auto MergeFunctionRedecl(Context& context, SemIR::LocId loc_id,
                          SemIR::Function& new_function, bool new_is_import,
                          bool new_is_definition,
                          SemIR::FunctionId prev_function_id,
-                         bool prev_is_imported) -> bool;
+                         SemIR::ImportIRInstId prev_import_ir_inst_id) -> bool;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -169,14 +169,15 @@ static auto BuildFunctionDecl(Context& context,
   auto prev_id =
       context.decl_name_stack().LookupOrAddName(name_context, lookup_result_id);
   if (prev_id.is_valid()) {
-    auto prev_inst = ResolvePrevInstForMerge(context, node_id, prev_id);
+    auto prev_inst_for_merge =
+        ResolvePrevInstForMerge(context, node_id, prev_id);
 
     if (auto existing_function_decl =
-            prev_inst.inst.TryAs<SemIR::FunctionDecl>()) {
+            prev_inst_for_merge.inst.TryAs<SemIR::FunctionDecl>()) {
       if (MergeFunctionRedecl(context, node_id, function_info,
                               /*new_is_import=*/false, is_definition,
                               existing_function_decl->function_id,
-                              prev_inst.is_import)) {
+                              prev_inst_for_merge.import_ir_inst_id)) {
         // When merging, use the existing function rather than adding a new one.
         function_decl.function_id = existing_function_decl->function_id;
       }

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -210,9 +210,19 @@ static auto CopyEnclosingNameScopesFromImportIR(
 auto ImportLibraryFromCurrentPackage(Context& context,
                                      SemIR::TypeId namespace_type_id,
                                      Parse::ImportDirectiveId node_id,
+                                     bool is_api_for_impl,
                                      const SemIR::File& import_sem_ir) -> void {
-  auto ir_id =
-      context.import_irs().Add({.node_id = node_id, .sem_ir = &import_sem_ir});
+  auto ir_id = SemIR::ImportIRId::Invalid;
+  if (is_api_for_impl) {
+    ir_id = SemIR::ImportIRId::ApiForImpl;
+    auto& import_ir = context.import_irs().Get(ir_id);
+    CARBON_CHECK(import_ir.sem_ir == nullptr) << "ApiForImpl is only set once";
+    import_ir = {.node_id = node_id, .sem_ir = &import_sem_ir};
+  } else {
+    ir_id = context.import_irs().Add(
+        {.node_id = node_id, .sem_ir = &import_sem_ir});
+  }
+
   context.import_ir_constant_values()[ir_id.index].Set(
       SemIR::InstId::PackageNamespace,
       context.constant_values().Get(SemIR::InstId::PackageNamespace));

--- a/toolchain/check/import.h
+++ b/toolchain/check/import.h
@@ -17,6 +17,7 @@ namespace Carbon::Check {
 auto ImportLibraryFromCurrentPackage(Context& context,
                                      SemIR::TypeId namespace_type_id,
                                      Parse::ImportDirectiveId node_id,
+                                     bool is_api_for_impl,
                                      const SemIR::File& import_sem_ir) -> void;
 
 // Adds another package's imports to name lookup, with all libraries together.

--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -4,40 +4,46 @@
 
 #include "toolchain/check/merge.h"
 
+#include "toolchain/base/kind_switch.h"
 #include "toolchain/check/function.h"
 #include "toolchain/check/import_ref.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
 
 auto ResolvePrevInstForMerge(Context& context, Parse::NodeId node_id,
-                             SemIR::InstId prev_inst_id) -> PrevInstForMerge {
-  PrevInstForMerge prev_inst{.inst = context.insts().Get(prev_inst_id),
-                             .is_import = false};
-  if (auto import_ref = prev_inst.inst.TryAs<SemIR::ImportRefUsed>()) {
+                             SemIR::InstId prev_inst_id) -> InstForMerge {
+  auto prev_inst = context.insts().Get(prev_inst_id);
+  auto import_ref = prev_inst.TryAs<SemIR::AnyImportRef>();
+  // If not imported, use the instruction directly.
+  if (!import_ref) {
+    return {.inst = prev_inst,
+            .import_ir_inst_id = SemIR::ImportIRInstId::Invalid};
+  }
+
+  // If the import ref was previously used, print a diagnostic.
+  if (auto import_ref_used = prev_inst.TryAs<SemIR::ImportRefUsed>()) {
     CARBON_DIAGNOSTIC(
         RedeclOfUsedImport, Error,
         "Redeclaration of imported entity that was previously used.");
     CARBON_DIAGNOSTIC(UsedImportLoc, Note, "Import used here.");
     context.emitter()
         .Build(node_id, RedeclOfUsedImport)
-        .Note(import_ref->used_id, UsedImportLoc)
+        .Note(import_ref_used->used_id, UsedImportLoc)
         .Emit();
-
-  } else if (!prev_inst.inst.Is<SemIR::ImportRefLoaded>()) {
-    return prev_inst;
   }
 
-  prev_inst.is_import = true;
-  prev_inst.inst = context.insts().Get(
-      context.constant_values().Get(prev_inst_id).inst_id());
-  return prev_inst;
+  // Follow the import ref.
+  return {.inst = context.insts().Get(
+              context.constant_values().Get(prev_inst_id).inst_id()),
+          .import_ir_inst_id = import_ref->import_ir_inst_id};
 }
 
 // Returns the instruction to consider when merging the given inst_id. Returns
 // nullopt if merging is infeasible and no diagnostic should be printed.
 static auto ResolveMergeableInst(Context& context, SemIR::InstId inst_id)
-    -> std::optional<SemIR::Inst> {
+    -> std::optional<InstForMerge> {
   auto inst = context.insts().Get(inst_id);
   switch (inst.kind()) {
     case SemIR::ImportRefUnloaded::Kind:
@@ -51,7 +57,8 @@ static auto ResolveMergeableInst(Context& context, SemIR::InstId inst_id)
 
     case SemIR::Namespace::Kind:
       // Return back the namespace directly.
-      return inst;
+      return {
+          {.inst = inst, .import_ir_inst_id = SemIR::ImportIRInstId::Invalid}};
 
     default:
       CARBON_FATAL() << "Unexpected inst kind passed to ResolveMergeableInst: "
@@ -64,7 +71,9 @@ static auto ResolveMergeableInst(Context& context, SemIR::InstId inst_id)
   if (!const_id.is_constant()) {
     return std::nullopt;
   }
-  return context.insts().Get(const_id.inst_id());
+  return {
+      {.inst = context.insts().Get(const_id.inst_id()),
+       .import_ir_inst_id = inst.As<SemIR::AnyImportRef>().import_ir_inst_id}};
 }
 
 auto ReplacePrevInstForMerge(Context& context, SemIR::NameScopeId scope_id,
@@ -89,23 +98,23 @@ auto MergeImportRef(Context& context, SemIR::InstId new_inst_id,
     return;
   }
 
-  if (new_inst->kind() != prev_inst->kind()) {
+  if (new_inst->inst.kind() != prev_inst->inst.kind()) {
     context.DiagnoseDuplicateName(new_inst_id, prev_inst_id);
     return;
   }
 
-  switch (new_inst->kind()) {
-    case SemIR::FunctionDecl::Kind: {
-      auto new_fn = context.functions().Get(
-          new_inst->As<SemIR::FunctionDecl>().function_id);
-      auto prev_fn_id = prev_inst->As<SemIR::FunctionDecl>().function_id;
+  CARBON_KIND_SWITCH(new_inst->inst) {
+    case CARBON_KIND(SemIR::FunctionDecl new_decl): {
+      auto prev_decl = prev_inst->inst.As<SemIR::FunctionDecl>();
+
+      auto new_fn = context.functions().Get(new_decl.function_id);
       // TODO: May need to "spoil" the new function to prevent it from being
       // emitted, since it will already be added.
       MergeFunctionRedecl(context, context.insts().GetLocId(new_inst_id),
                           new_fn,
                           /*new_is_import=*/true,
-                          /*new_is_definition=*/false, prev_fn_id,
-                          /*prev_is_imported=*/true);
+                          /*new_is_definition=*/false, prev_decl.function_id,
+                          prev_inst->import_ir_inst_id);
       return;
     }
     default:

--- a/toolchain/check/merge.h
+++ b/toolchain/check/merge.h
@@ -15,8 +15,7 @@ struct InstForMerge {
   // The resolved instruction.
   SemIR::Inst inst;
   // The imported instruction, or invalid if not an import. This should
-  // typically only be used for the ImportIRId, but we only resolve that if
-  // needed.
+  // typically only be used for the ImportIRId, but we only load it if needed.
   SemIR::ImportIRInstId import_ir_inst_id;
 };
 

--- a/toolchain/check/merge.h
+++ b/toolchain/check/merge.h
@@ -7,14 +7,17 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/import_ir.h"
 
 namespace Carbon::Check {
 
-struct PrevInstForMerge {
+struct InstForMerge {
   // The resolved instruction.
   SemIR::Inst inst;
-  // Whether an import was encountered during resolution.
-  bool is_import;
+  // The imported instruction, or invalid if not an import. This should
+  // typically only be used for the ImportIRId, but we only resolve that if
+  // needed.
+  SemIR::ImportIRInstId import_ir_inst_id;
 };
 
 // Resolves prev_inst_id for merging (or name conflicts). This handles imports
@@ -22,7 +25,7 @@ struct PrevInstForMerge {
 // previously used, it notes it, although an invalid redeclaration may diagnose
 // for other reasons too.
 auto ResolvePrevInstForMerge(Context& context, Parse::NodeId node_id,
-                             SemIR::InstId prev_inst_id) -> PrevInstForMerge;
+                             SemIR::InstId prev_inst_id) -> InstForMerge;
 
 // When the prior name lookup result is an import and we are successfully
 // merging, replace the name lookup result with the reference in the current

--- a/toolchain/check/testdata/alias/import.carbon
+++ b/toolchain/check/testdata/alias/import.carbon
@@ -52,8 +52,8 @@ var c: i32 = b;
 // CHECK:STDOUT:     .b = %import_ref.2
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir1, inst+7, loc_14
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir2, inst+7, loc_14
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/import_order.carbon
+++ b/toolchain/check/testdata/alias/import_order.carbon
@@ -62,10 +62,10 @@ var i32_val: i32 = a_val;
 // CHECK:STDOUT:     .a_val = %a_val
 // CHECK:STDOUT:     .i32_val = %i32_val
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_32 [template = i32]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+3, loc_25 [template = i32]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+5, loc_18 [template = i32]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref ir1, inst+7, loc_11 [template = i32]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_32 [template = i32]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+3, loc_25 [template = i32]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+5, loc_18 [template = i32]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref ir2, inst+7, loc_11 [template = i32]
 // CHECK:STDOUT:   %d.ref: type = name_ref d, %import_ref.4 [template = i32]
 // CHECK:STDOUT:   %d_val.var: ref i32 = var d_val
 // CHECK:STDOUT:   %d_val: ref i32 = bind_name d_val, %d_val.var

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        builtin_insts.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -68,7 +68,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -53,7 +53,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_and_textual_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+9}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: i32) -> (i32, i32, f64) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 1
+// CHECK:STDOUT:   import_irs_size: 2
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+9}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -165,9 +165,9 @@ var c: Other.C = {};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_14 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_14 [template = constants.%C]
 // CHECK:STDOUT:   %C.decl: invalid = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
@@ -201,7 +201,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+1, loc_14 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir2, inst+1, loc_14 [template = constants.%C]
 // CHECK:STDOUT:   %C.decl: invalid = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref <error> = var c
@@ -235,10 +235,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_19 [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_19 [template = constants.%C.1]
 // CHECK:STDOUT:   %C.decl.1: invalid = class_decl @C.1 [template = constants.%C.1] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+1, loaded [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir3, inst+1, loaded [template = constants.%C.2]
 // CHECK:STDOUT:   %C.decl.2: invalid = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C.1]
 // CHECK:STDOUT:   %c.var: ref C = var c
@@ -278,10 +278,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_19 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_19 [template = constants.%C]
 // CHECK:STDOUT:   %C.decl: invalid = class_decl @C.2 [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+1, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+1, loaded [template = imports.%C]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -82,9 +82,9 @@ var a: Incomplete;
 // CHECK:STDOUT:     .Incomplete = %import_ref.2
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loaded [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+4, loc_15 [template = constants.%Incomplete]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loaded [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+4, loc_15 [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.2] {
 // CHECK:STDOUT:     %Empty.decl: invalid = class_decl @Empty [template = constants.%Empty] {}
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/fail_todo_import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/fail_todo_import_forward_decl.carbon
@@ -56,7 +56,7 @@ class ForwardDecl {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .ForwardDecl = %import_ref
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+1, loaded [template = constants.%ForwardDecl]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir2, inst+1, loaded [template = constants.%ForwardDecl]
 // CHECK:STDOUT:   %.decl: type = class_decl @.1 [template = constants.%.1] {
 // CHECK:STDOUT:     %ForwardDecl.decl: invalid = class_decl @ForwardDecl [template = constants.%ForwardDecl] {}
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -142,20 +142,20 @@ fn Run() {
 // CHECK:STDOUT:     .Incomplete = %import_ref.4
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_16 [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+4, loc_24 [template = constants.%Field]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+11, loc_42 [template = constants.%ForwardDeclared.1]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref ir1, inst+25, loc_71 [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_16 [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+4, loc_24 [template = constants.%Field]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+11, loc_42 [template = constants.%ForwardDeclared.1]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref ir2, inst+25, loc_71 [template = constants.%Incomplete]
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.7: <unbound element of class Field> = import_ref ir1, inst+7, loc_36 [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir1, inst+24, loc_56 [template = imports.%G]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir1, inst+17, loc_50 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+12, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.7: <unbound element of class Field> = import_ref ir2, inst+7, loc_36 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+24, loc_56 [template = imports.%G]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+17, loc_50 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+17, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Empty {

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -116,16 +116,16 @@ fn Run() {
 // CHECK:STDOUT:     .Child = %import_ref.2
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+19, loc_16 [template = constants.%Child]
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+19, loc_16 [template = constants.%Child]
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+6, loc_44 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.5: <unbound element of class Base> = import_ref ir1, inst+12, loc_38 [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+10, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+6, loc_44 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.5: <unbound element of class Base> = import_ref ir2, inst+12, loc_38 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+24, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Child {

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -61,10 +61,10 @@ fn Run() {
 // CHECK:STDOUT:     .Cycle = %import_ref.1
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_16 [template = constants.%Cycle]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_16 [template = constants.%Cycle]
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Cycle {

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -79,11 +79,11 @@ fn Run() {
 // CHECK:STDOUT:     .a = %import_ref.2
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref {.b: Cycle*} = import_ref ir1, inst+11, loc_14
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref {.b: Cycle*} = import_ref ir2, inst+11, loc_14
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.4: <unbound element of class Cycle> = import_ref ir1, inst+18, loc_24 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.4: <unbound element of class Cycle> = import_ref ir2, inst+18, loc_24 [template = imports.%.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Cycle {

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -94,10 +94,10 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:     .arr = %arr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_9 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir1, inst+20, loc_36 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_10 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_9 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_36 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_10 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: invalid = interface_decl @Add [template = constants.%.1] {}
@@ -105,15 +105,15 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 2 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+1, loc_36 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_36 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc10_18.1: <bound method> = bound_method %.loc10_16, %.1 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc10_18.2: init i32 = call %.loc10_18.1(%.loc10_16, %.loc10_20) [template = constants.%.8]
 // CHECK:STDOUT:   %.loc10_21: type = array_type %.loc10_18.2, i32 [template = constants.%.9]
 // CHECK:STDOUT:   %arr.var: ref [i32; 3] = var arr
 // CHECK:STDOUT:   %arr: ref [i32; 3] = bind_name arr, %arr.var
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir1, inst+1, loc_47 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_47 [template = constants.%.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/function/builtin/import.carbon
+++ b/toolchain/check/testdata/function/builtin/import.carbon
@@ -53,7 +53,7 @@ var arr: [i32; Core.Add(1, 2)] = (1, 2, 3);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+6, loc_11 [template = imports.%Add]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+6, loc_11 [template = imports.%Add]
 // CHECK:STDOUT:   %Add.ref: <function> = name_ref Add, %import_ref [template = imports.%Add]
 // CHECK:STDOUT:   %.loc4_25: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc4_28: i32 = int_literal 2 [template = constants.%.2]

--- a/toolchain/check/testdata/function/declaration/implicit_import.carbon
+++ b/toolchain/check/testdata/function/declaration/implicit_import.carbon
@@ -1,0 +1,130 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- basic.carbon
+
+library "basic" api;
+
+fn A();
+
+// --- basic.impl.carbon
+
+library "basic" impl;
+
+fn A();
+
+// --- extern_api.carbon
+
+library "extern_api" api;
+
+extern fn A();
+
+// --- fail_extern_api.impl.carbon
+
+library "extern_api" impl;
+
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: fn A();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: library "extern_api" impl;
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: extern_api.carbon:4:1: Previously declared here.
+// CHECK:STDERR: extern fn A();
+// CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn A();
+
+// --- extern_impl.carbon
+
+library "extern_impl" api;
+
+fn A();
+
+// --- fail_extern_impl.impl.carbon
+
+library "extern_impl" impl;
+
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+9]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: extern fn A();
+// CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: library "extern_impl" impl;
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: extern_impl.carbon:4:1: Previously declared here.
+// CHECK:STDERR: fn A();
+// CHECK:STDERR: ^~~~~~~
+extern fn A();
+
+// CHECK:STDOUT: --- basic.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- basic.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- extern_api.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: extern fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extern_api.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- extern_impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extern_impl.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: extern fn @A();
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -306,15 +306,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loc_24 [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loc_39 [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_53 [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loc_24 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loc_39 [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_53 [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loc_65 [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loc_65 [template = imports.%E]
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -394,15 +394,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loaded [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loaded [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %E
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loaded [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loaded [template = imports.%E]
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
 // CHECK:STDOUT:     %b.loc7_13.1: i32 = param b
@@ -498,15 +498,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loaded [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loaded [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %E
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loaded [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loaded [template = imports.%E]
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
 // CHECK:STDOUT:     %b.loc7_13.1: i32 = param b
@@ -601,20 +601,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_19 [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loc_28 [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loc_43 [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_57 [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_19 [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loc_28 [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loc_43 [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_57 [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loc_69 [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+1, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+5, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+17, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+18, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+20, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loc_69 [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+1, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+5, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+17, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+18, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+20, loaded [template = imports.%E.2]
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -703,20 +703,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loaded [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loaded [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_57 [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loaded [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loaded [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_57 [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = imports.%E.2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loaded [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+1, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+5, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+17, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+18, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+20, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loaded [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+1, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+5, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+17, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+18, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+20, loaded [template = imports.%E.2]
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -797,15 +797,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+20, unloaded
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -838,15 +838,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+20, unloaded
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -883,15 +883,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+20, unloaded
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -919,15 +919,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+20, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- unloaded_extern.carbon
@@ -940,15 +940,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+17, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+17, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+20, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- loaded_merge.carbon
@@ -966,20 +966,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+5, loaded [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+17, loaded [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loaded [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+19, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+5, loaded [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+17, loaded [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loaded [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+19, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+20, loaded [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+1, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+5, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+17, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+18, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+20, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+20, loaded [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+1, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+5, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+17, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+18, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+20, loaded [template = imports.%E.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: extern fn @A.1();

--- a/toolchain/check/testdata/function/definition/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/implicit_import.carbon
@@ -1,0 +1,232 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+// --- basic.carbon
+
+library "basic" api;
+
+fn A();
+
+// --- basic.impl.carbon
+
+library "basic" impl;
+
+fn A() {}
+
+// --- extern_api.carbon
+
+library "extern_api" api;
+
+extern fn A();
+
+// --- fail_extern_api.impl.carbon
+
+library "extern_api" impl;
+
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: fn A() {}
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: library "extern_api" impl;
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: extern_api.carbon:4:1: Previously declared here.
+// CHECK:STDERR: extern fn A();
+// CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn A() {}
+
+// --- extern_impl.carbon
+
+library "extern_impl" api;
+
+fn A();
+
+// --- fail_extern_impl.impl.carbon
+
+library "extern_impl" impl;
+
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+4]]:1: ERROR: `extern` not allowed on `fn` declaration that provides a definition.
+// CHECK:STDERR: extern fn A() {}
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR:
+extern fn A() {}
+
+// --- redecl_after_def.carbon
+
+library "redecl_after_def" api;
+
+fn A() {}
+
+// --- fail_redecl_after_def.impl.carbon
+
+library "redecl_after_def" impl;
+
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+10]]:1: ERROR: Redundant redeclaration of function A.
+// CHECK:STDERR: fn A();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: library "redecl_after_def" impl;
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: redecl_after_def.carbon:4:1: Previously declared here.
+// CHECK:STDERR: fn A() {}
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
+fn A();
+
+// --- redef_after_def.carbon
+
+library "redef_after_def" api;
+
+fn A() {}
+
+// --- fail_redef_after_def.impl.carbon
+
+library "redef_after_def" impl;
+
+// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE+9]]:1: ERROR: Redefinition of function A.
+// CHECK:STDERR: fn A() {}
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: library "redef_after_def" impl;
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: redef_after_def.carbon:4:1: Previously defined here.
+// CHECK:STDERR: fn A() {}
+// CHECK:STDERR: ^~~~~~~~
+fn A() {}
+
+// CHECK:STDOUT: --- basic.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- basic.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- extern_api.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: extern fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extern_api.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- extern_impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_extern_impl.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- redecl_after_def.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_redecl_after_def.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A();
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- redef_after_def.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_redef_after_def.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .A = %A
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @A() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -178,10 +178,10 @@ fn D() {}
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loc_24 [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+20, loc_39 [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loc_24 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+20, loc_39 [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref () = var a
@@ -227,10 +227,10 @@ fn D() {}
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
 // CHECK:STDOUT:     %b.loc27_6.1: i32 = param b
@@ -252,7 +252,7 @@ fn D() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+1, loaded [template = imports.%A]
 // CHECK:STDOUT:   %A.loc6: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -271,10 +271,10 @@ fn D() {}
 // CHECK:STDOUT:     .C = %import_ref.3
 // CHECK:STDOUT:     .D = %D.loc13
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+30, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+30, loaded [template = imports.%D]
 // CHECK:STDOUT:   %D.loc6: <function> = fn_decl @D [template] {}
 // CHECK:STDOUT:   %D.loc13: <function> = fn_decl @D [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/import.carbon
+++ b/toolchain/check/testdata/interface/import.carbon
@@ -154,33 +154,33 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     .UseForwardDeclaredF = %UseForwardDeclaredF
 // CHECK:STDOUT:     .f = %f.loc16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_13 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+4, loc_22 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+15, loc_31 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir1, inst+36, loc_70
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_13 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+4, loc_22 [template = constants.%.3]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+15, loc_31 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir2, inst+36, loc_70
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %UseEmpty: <function> = fn_decl @UseEmpty [template] {
 // CHECK:STDOUT:     %Empty.decl: invalid = interface_decl @Empty [template = constants.%.1] {}
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, %import_ref.1 [template = constants.%.1]
 // CHECK:STDOUT:     %e.loc6_13.1: Empty = param e
 // CHECK:STDOUT:     @UseEmpty.%e: Empty = bind_name e, %e.loc6_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir1, inst+13, loc_48 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir1, inst+9, loc_41 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir2, inst+13, loc_48 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir2, inst+9, loc_41 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+11, unloaded
 // CHECK:STDOUT:   %UseBasic: <function> = fn_decl @UseBasic [template] {
 // CHECK:STDOUT:     %Basic.decl: invalid = interface_decl @Basic [template = constants.%.3] {}
 // CHECK:STDOUT:     %Basic.ref.loc7: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
 // CHECK:STDOUT:     %e.loc7_13.1: Basic = param e
 // CHECK:STDOUT:     @UseBasic.%e: Basic = bind_name e, %e.loc7_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir1, inst+25, loc_62 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir1, inst+21, loc_55 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir1, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+23, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir2, inst+25, loc_62 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir2, inst+21, loc_55 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+23, unloaded
 // CHECK:STDOUT:   %UseForwardDeclared: <function> = fn_decl @UseForwardDeclared [template] {
 // CHECK:STDOUT:     %ForwardDeclared.decl: invalid = interface_decl @ForwardDeclared [template = constants.%.4] {}
 // CHECK:STDOUT:     %ForwardDeclared.ref.loc8: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
@@ -188,19 +188,19 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     @UseForwardDeclared.%f: ForwardDeclared = bind_name f, %f.loc8_23.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Basic.ref.loc10: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir1, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+7, unloaded
 // CHECK:STDOUT:   %T.ref.loc10: <associated type in Basic> = name_ref T, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %UseBasicT: <associated type in Basic> = bind_alias UseBasicT, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %Basic.ref.loc11: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+11, unloaded
 // CHECK:STDOUT:   %F.ref.loc11: <associated <function> in Basic> = name_ref F, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %UseBasicF: <associated <function> in Basic> = bind_alias UseBasicF, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc13: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %T.ref.loc13: <associated type in ForwardDeclared> = name_ref T, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %UseForwardDeclaredT: <associated type in ForwardDeclared> = bind_alias UseForwardDeclaredT, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc14: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir1, inst+23, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+23, unloaded
 // CHECK:STDOUT:   %F.ref.loc14: <associated <function> in ForwardDeclared> = name_ref F, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %UseForwardDeclaredF: <associated <function> in ForwardDeclared> = bind_alias UseForwardDeclaredF, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -56,7 +56,7 @@ fn NS();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc17: <function> = fn_decl @.1 [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
@@ -44,7 +44,7 @@ fn NS.Foo();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -53,7 +53,7 @@ fn NS.Foo();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = %import_ref
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loaded [template = imports.%NS]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+1, loaded [template = imports.%NS]
 // CHECK:STDOUT:   %.loc16: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc24: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -75,13 +75,13 @@ fn NS.Bar() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.2
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+1, loaded [template = imports.%NS]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+1, loaded [template = imports.%NS]
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -75,13 +75,13 @@ fn NS.Bar() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+1, unloaded
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+1, unloaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir3, inst+1, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.3
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+2, unloaded
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -53,7 +53,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
@@ -66,11 +66,11 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+3, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
@@ -83,15 +83,15 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+4, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+5, loaded
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir2, inst+5, loaded
 // CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
@@ -114,19 +114,19 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+4, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+6, loaded
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir2, inst+6, loaded
 // CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+7, loc_23 [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+7, loc_23 [template = imports.%D]
 // CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %e.var: ref () = var e

--- a/toolchain/check/testdata/namespace/merging.carbon
+++ b/toolchain/check/testdata/namespace/merging.carbon
@@ -95,16 +95,16 @@ fn Run() {
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .B1 = %import_ref.3
 // CHECK:STDOUT:     .B2 = %import_ref.4
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+2, loc_33 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+2, loc_39 [template = imports.%B1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+5, loc_45 [template = imports.%B2]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+2, loc_33 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+2, loc_39 [template = imports.%B1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+5, loc_45 [template = imports.%B2]
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C: <function> = fn_decl @C [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: invalid = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitAnd.decl: invalid = interface_decl @BitAnd [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitAnd.ref: type = name_ref BitAnd, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAnd {

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -92,10 +92,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir1, inst+15, loc_50 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir2, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -109,8 +109,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_50 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitComplement {

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitOr.decl: invalid = interface_decl @BitOr [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitOr.ref: type = name_ref BitOr, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOr {

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitXor.decl: invalid = interface_decl @BitXor [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitXor.ref: type = name_ref BitXor, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXor {

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -92,10 +92,10 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir1, inst+14, loc_47 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir2, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -103,8 +103,8 @@ fn TestOp() {
 // CHECK:STDOUT:     %Dec.ref: type = name_ref Dec, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_47 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Dec {

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Div.decl: invalid = interface_decl @Div [template = constants.%.2] {}
 // CHECK:STDOUT:     %Div.ref: type = name_ref Div, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Div {

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -171,12 +171,12 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir1, inst+17, loc_68 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir1, inst+31, loc_88 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir1, inst+15, loc_19 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+30, loc_19 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir2, inst+17, loc_68 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_88 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir2, inst+15, loc_19 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+30, loc_19 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -192,8 +192,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestEqual.%b: C = bind_name b, %b.loc13_20.1
 // CHECK:STDOUT:     %return.var.loc13: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir1, inst+1, loc_68 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_68 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc17_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc17_17.1: C = param a
@@ -203,8 +203,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%b: C = bind_name b, %b.loc17_23.1
 // CHECK:STDOUT:     %return.var.loc17: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_88 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_88 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -310,13 +310,13 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestEqual.%b: D = bind_name b, %b.loc8_20.1
 // CHECK:STDOUT:     %return.var.loc8: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_30 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir1, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir1, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_30 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir2, inst+17, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_20: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_17.1: D = param a
@@ -326,8 +326,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%b: D = bind_name b, %b.loc16_23.1
 // CHECK:STDOUT:     %return.var.loc16: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.8: type = import_ref ir1, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.8: type = import_ref ir2, inst+1, loc_50 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -384,12 +384,12 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_23 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir1, inst+17, loc_73 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir1, inst+31, loc_93 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir1, inst+15, loc_24 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+30, loc_24 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_23 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Eq> = import_ref ir2, inst+17, loc_73 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_93 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir2, inst+15, loc_24 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+30, loc_24 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -405,8 +405,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestRhsBad.%b: D = bind_name b, %b.loc14_21.1
 // CHECK:STDOUT:     %return.var.loc14: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir1, inst+1, loc_73 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_73 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLhsBad: <function> = fn_decl @TestLhsBad [template] {
 // CHECK:STDOUT:     %D.ref.loc25: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc25_15.1: D = param a
@@ -416,8 +416,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestLhsBad.%b: C = bind_name b, %b.loc25_21.1
 // CHECK:STDOUT:     %return.var.loc25: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_93 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_93 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -149,20 +149,20 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir1, inst+14, loc_65 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+12, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+14, loc_65 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Inc.decl: invalid = interface_decl @Inc [template = constants.%.2] {}
 // CHECK:STDOUT:     %Inc.ref: type = name_ref Inc, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+16, loc_38 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir1, inst+34, loc_82 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+32, loc_39 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+16, loc_38 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+34, loc_82 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+32, loc_39 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc11: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc11: <namespace> = name_ref Core, %Core [template = %Core]
@@ -174,8 +174,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %a.loc15_18.1: C = param a
 // CHECK:STDOUT:     @TestIncNonRef.%a: C = bind_name a, %a.loc15_18.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_65 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_65 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT:   %TestAddAssignNonRef: <function> = fn_decl @TestAddAssignNonRef [template] {
 // CHECK:STDOUT:     %C.ref.loc26_27: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc26_24.1: C = param a
@@ -184,8 +184,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %b.loc26_30.1: C = param b
 // CHECK:STDOUT:     @TestAddAssignNonRef.%b: C = bind_name b, %b.loc26_30.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+16, loc_82 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+32, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+16, loc_82 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+32, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -223,11 +223,11 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %C.ref.loc8_23: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestUnary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_25 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir1, inst+11, loc_25 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_25 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+11, loc_25 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+9, unloaded
 // CHECK:STDOUT:   %TestBinary: <function> = fn_decl @TestBinary [template] {
 // CHECK:STDOUT:     %C.ref.loc16_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc16_15.1: C = param a
@@ -238,26 +238,26 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %C.ref.loc16_30: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestBinary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: type = import_ref ir1, inst+13, loc_45 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir1, inst+32, loc_45 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref ir2, inst+13, loc_45 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir2, inst+32, loc_45 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestRef: <function> = fn_decl @TestRef [template] {
 // CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc24_12.1: C = param b
 // CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc24_12.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+34, loc_66 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir1, inst+52, loc_66 [template = constants.%.13]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir1, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir1, inst+54, loc_69 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir1, inst+67, loc_69 [template = constants.%.16]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir1, inst+56, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir1, inst+65, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref ir1, inst+65, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+34, loc_66 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir2, inst+52, loc_66 [template = constants.%.13]
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+36, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+54, loc_69 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir2, inst+67, loc_69 [template = constants.%.16]
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+56, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+65, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref ir2, inst+65, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -160,20 +160,20 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_23 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir1, inst+20, loc_81 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_24 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_23 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_81 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_24 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc9: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: invalid = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir1, inst+40, loc_102 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+40, loc_102 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc12: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc12: <namespace> = name_ref Core, %Core [template = %Core]
@@ -190,15 +190,15 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %C.ref.loc16_24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @Test.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_81 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_81 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %D.ref.loc27: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %b.loc27_15.1: D = param b
 // CHECK:STDOUT:     @TestAssign.%b: D = bind_name b, %b.loc27_15.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_102 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_102 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -92,10 +92,10 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir1, inst+14, loc_47 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -103,8 +103,8 @@ fn TestOp() {
 // CHECK:STDOUT:     %Inc.ref: type = name_ref Inc, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_47 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %LeftShift.decl: invalid = interface_decl @LeftShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %LeftShift.ref: type = name_ref LeftShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShift {

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mod.decl: invalid = interface_decl @Mod [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mod.ref: type = name_ref Mod, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mod {

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mul.decl: invalid = interface_decl @Mul [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mul.ref: type = name_ref Mul, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mul {

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -92,10 +92,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir1, inst+15, loc_50 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -109,8 +109,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_50 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -207,16 +207,16 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir1, inst+17, loc_98 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir1, inst+31, loc_118 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir1, inst+59, loc_158 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir1, inst+45, loc_138 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir1, inst+15, loc_19 [template = imports.%Less]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+30, loc_19 [template = imports.%LessOrEquivalent]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir1, inst+44, loc_19 [template = imports.%Greater]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir1, inst+58, loc_19 [template = imports.%GreaterOrEquivalent]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir2, inst+17, loc_98 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir2, inst+31, loc_118 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir2, inst+59, loc_158 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir2, inst+45, loc_138 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+15, loc_19 [template = imports.%Less]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+30, loc_19 [template = imports.%LessOrEquivalent]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+44, loc_19 [template = imports.%Greater]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+58, loc_19 [template = imports.%GreaterOrEquivalent]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -232,8 +232,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%b: C = bind_name b, %b.loc15_19.1
 // CHECK:STDOUT:     %return.var.loc15: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+1, loc_98 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+1, loc_98 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc19_21: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc19_18.1: C = param a
@@ -243,8 +243,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%b: C = bind_name b, %b.loc19_24.1
 // CHECK:STDOUT:     %return.var.loc19: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.13: type = import_ref ir1, inst+1, loc_118 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.13: type = import_ref ir2, inst+1, loc_118 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %C.ref.loc23_19: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc23_16.1: C = param a
@@ -254,8 +254,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%b: C = bind_name b, %b.loc23_22.1
 // CHECK:STDOUT:     %return.var.loc23: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.15: type = import_ref ir1, inst+1, loc_138 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir1, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.15: type = import_ref ir2, inst+1, loc_138 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+44, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc27_24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc27_21.1: C = param a
@@ -265,8 +265,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%b: C = bind_name b, %b.loc27_27.1
 // CHECK:STDOUT:     %return.var.loc27: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.17: type = import_ref ir1, inst+1, loc_158 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir1, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.17: type = import_ref ir2, inst+1, loc_158 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+58, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
@@ -430,17 +430,17 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%b: D = bind_name b, %b.loc8_19.1
 // CHECK:STDOUT:     %return.var.loc8: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_30 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir1, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir1, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir1, inst+59, loc_90 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir1, inst+45, loc_70 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+44, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+58, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_30 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir2, inst+17, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir2, inst+31, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir2, inst+59, loc_90 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir2, inst+45, loc_70 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_21: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_18.1: D = param a
@@ -450,8 +450,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%b: D = bind_name b, %b.loc16_24.1
 // CHECK:STDOUT:     %return.var.loc16: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.12: type = import_ref ir1, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.12: type = import_ref ir2, inst+1, loc_50 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %D.ref.loc24_19: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc24_16.1: D = param a
@@ -461,8 +461,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%b: D = bind_name b, %b.loc24_22.1
 // CHECK:STDOUT:     %return.var.loc24: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.14: type = import_ref ir1, inst+1, loc_70 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.14: type = import_ref ir2, inst+1, loc_70 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+44, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc32_24: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc32_21.1: D = param a
@@ -472,8 +472,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%b: D = bind_name b, %b.loc32_27.1
 // CHECK:STDOUT:     %return.var.loc32: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir1, inst+1, loc_90 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir1, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+1, loc_90 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+58, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %RightShift.decl: invalid = interface_decl @RightShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %RightShift.ref: type = name_ref RightShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShift {

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir1, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Sub.decl: invalid = interface_decl @Sub [template = constants.%.2] {}
 // CHECK:STDOUT:     %Sub.ref: type = name_ref Sub, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir1, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir1, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir1, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir1, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Sub {

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -238,8 +238,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_22 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+1, loc_28 [template = imports.%F2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_22 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+1, loc_28 [template = imports.%F2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -270,8 +270,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_22 [template = imports.%F.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+1, loaded [template = imports.%F.2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_22 [template = imports.%F.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+1, loaded [template = imports.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -308,8 +308,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loc_22 [template = imports.%F.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+3, loaded [template = imports.%F.2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loc_22 [template = imports.%F.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+3, loaded [template = imports.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -330,9 +330,9 @@ fn Other.G() {}
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Other = %Other
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+1, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+1, loaded
 // CHECK:STDOUT:   %Other: <namespace> = namespace %import_ref.1, [template] {}
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+1, loaded [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+1, loaded [template = imports.%F]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -62,8 +62,8 @@ import library "var";
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+1, loaded [template = imports.%Foo]
-// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+1, loaded [template = imports.%Foo]
+// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir3, inst+2, loaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Foo();

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -105,7 +105,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+1, loc_17 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+1, loc_17 [template = imports.%B]
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %b.var: ref () = var b

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -180,6 +180,7 @@ CARBON_DIAGNOSTIC_KIND(InvalidMainRunSignature)
 CARBON_DIAGNOSTIC_KIND(MissingReturnStatement)
 CARBON_DIAGNOSTIC_KIND(UnknownBuiltinFunctionName)
 CARBON_DIAGNOSTIC_KIND(InvalidBuiltinSignature)
+CARBON_DIAGNOSTIC_KIND(FunctionExternMismatch)
 
 // Class checking.
 CARBON_DIAGNOSTIC_KIND(BaseIsFinal)

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -75,6 +75,11 @@ File::File(SharedValueStores& value_stores, std::string filename,
   CARBON_CHECK(builtins_id == ImportIRId::Builtins)
       << "Builtins must be the first IR";
 
+  auto api_placeholder_id =
+      import_irs_.Add({.node_id = Parse::NodeId::Invalid, .sem_ir = nullptr});
+  CARBON_CHECK(api_placeholder_id == ImportIRId::ApiForImpl)
+      << "ApiForImpl must be the second IR";
+
   insts_.Reserve(BuiltinKind::ValidCount);
   init_builtins();
   CARBON_CHECK(insts_.size() == BuiltinKind::ValidCount)

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -219,8 +219,7 @@ class File : public Printable<File> {
   // Storage for impls.
   ImplStore impls_;
 
-  // Related IRs. There will always be at least one entry, the builtin IR (used
-  // for references of builtins).
+  // Related IRs. There are some fixed entries at the start; see ImportIRId.
   ValueStore<ImportIRId> import_irs_;
 
   // Related IR instructions. These are created for LocIds for instructions

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -32,7 +32,7 @@ struct TypeInfo;
 struct InstId : public IdBase, public Printable<InstId> {
   using ValueType = Inst;
 
-  // An explicitly invalid instruction ID.
+  // An explicitly invalid ID.
   static const InstId Invalid;
 
 // Builtin instruction IDs.
@@ -173,7 +173,7 @@ constexpr ConstantId ConstantId::Invalid = ConstantId(InvalidIndex);
 struct BindNameId : public IdBase, public Printable<BindNameId> {
   using ValueType = BindNameInfo;
 
-  // An explicitly invalid function ID.
+  // An explicitly invalid ID.
   static const BindNameId Invalid;
 
   using IdBase::IdBase;
@@ -189,7 +189,7 @@ constexpr BindNameId BindNameId::Invalid = BindNameId(InvalidIndex);
 struct FunctionId : public IdBase, public Printable<FunctionId> {
   using ValueType = Function;
 
-  // An explicitly invalid function ID.
+  // An explicitly invalid ID.
   static const FunctionId Invalid;
 
   using IdBase::IdBase;
@@ -205,7 +205,7 @@ constexpr FunctionId FunctionId::Invalid = FunctionId(InvalidIndex);
 struct ClassId : public IdBase, public Printable<ClassId> {
   using ValueType = Class;
 
-  // An explicitly invalid class ID.
+  // An explicitly invalid ID.
   static const ClassId Invalid;
 
   using IdBase::IdBase;
@@ -221,7 +221,7 @@ constexpr ClassId ClassId::Invalid = ClassId(InvalidIndex);
 struct InterfaceId : public IdBase, public Printable<InterfaceId> {
   using ValueType = Interface;
 
-  // An explicitly invalid interface ID.
+  // An explicitly invalid ID.
   static const InterfaceId Invalid;
 
   using IdBase::IdBase;
@@ -237,7 +237,7 @@ constexpr InterfaceId InterfaceId::Invalid = InterfaceId(InvalidIndex);
 struct ImplId : public IdBase, public Printable<ImplId> {
   using ValueType = Impl;
 
-  // An explicitly invalid interface ID.
+  // An explicitly invalid ID.
   static const ImplId Invalid;
 
   using IdBase::IdBase;
@@ -253,7 +253,17 @@ constexpr ImplId ImplId::Invalid = ImplId(InvalidIndex);
 struct ImportIRId : public IdBase, public Printable<ImportIRId> {
   using ValueType = ImportIR;
 
+  // An explicitly invalid ID.
+  static const ImportIRId Invalid;
+
+  // The builtin IR's import location.
   static const ImportIRId Builtins;
+
+  // The implicit `api` import, for an `impl` file. A null entry is added if
+  // there is none, as in an `api`, in which case this ID should not show up in
+  // instructions.
+  static const ImportIRId ApiForImpl;
+
   using IdBase::IdBase;
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "ir";
@@ -261,7 +271,9 @@ struct ImportIRId : public IdBase, public Printable<ImportIRId> {
   }
 };
 
+constexpr ImportIRId ImportIRId::Invalid = ImportIRId(InvalidIndex);
 constexpr ImportIRId ImportIRId::Builtins = ImportIRId(0);
+constexpr ImportIRId ImportIRId::ApiForImpl = ImportIRId(1);
 
 // A boolean value.
 struct BoolValue : public IdBase, public Printable<BoolValue> {
@@ -487,8 +499,13 @@ struct ElementIndex : public IndexBase, public Printable<ElementIndex> {
 struct ImportIRInstId : public IdBase, public Printable<InstId> {
   using ValueType = ImportIRInst;
 
+  // An explicitly invalid ID.
+  static const ImportIRInstId Invalid;
+
   using IdBase::IdBase;
 };
+
+constexpr ImportIRInstId ImportIRInstId::Invalid = ImportIRInstId(InvalidIndex);
 
 // A SemIR location used exclusively for diagnostic locations.
 //
@@ -497,7 +514,7 @@ struct ImportIRInstId : public IdBase, public Printable<InstId> {
 // - index < Invalid: An ImportIRInstId.
 // - index == Invalid: Can be used for either.
 struct LocId : public IdBase, public Printable<LocId> {
-  // An explicitly invalid function ID.
+  // An explicitly invalid ID.
   static const LocId Invalid;
 
   using IdBase::IdBase;

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -51,7 +51,7 @@ TEST(SemIRTest, YAML) {
                                          Pair("value_rep", Yaml::Mapping(_)))));
 
   auto file = Yaml::Mapping(ElementsAre(
-      Pair("import_irs_size", "1"),
+      Pair("import_irs_size", "2"),
       Pair("name_scopes", Yaml::Mapping(SizeIs(1))),
       Pair("bind_names", Yaml::Mapping(SizeIs(1))),
       Pair("functions", Yaml::Mapping(SizeIs(1))),


### PR DESCRIPTION
Adds ImportIRId::ApiForImpl to reserve a specific slot for the `api` import, so that the code can trivially determine whether an import is from the same library. This is then used for merging function declarations, because the rules for redeclarations in the same library slightly differ as compared to other imports (note they're also not identical to same-file rules).

The main thing this leaves from the recent #3762 is verifying that entities forward declared in the `impl` file are also defined, but that's not in-scope for merging; it's moreso post-checking validation.

Note, a lot of our `invalid <entity> ID` comments in ids.h were incorrectly copy-pasted, so I've cut `<entity>`.