### PR TITLE
Fix determination of whether we're in a nested deferred definition scope.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -124,6 +124,7 @@ cc_library(
         "//common:error",
         "//common:ostream",
         "//common:variant_helpers",
+        "//common:vlog",
         "//toolchain/base:pretty_stack_trace_function",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",

--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -161,9 +161,16 @@ class DeclNameStack {
 
   // Peeks the current target scope of the name on top of the stack. Note that
   // if we're still processing the name qualifiers, this can change before the
-  // name is completed.
-  auto PeekTargetScope() -> SemIR::NameScopeId {
+  // name is completed. Also, if the name up to this point was already declared
+  // and is a scope, this will be that scope, rather than the scope enclosing
+  // it.
+  auto PeekTargetScope() const -> SemIR::NameScopeId {
     return decl_name_stack_.back().target_scope_id;
+  }
+
+  // Peeks the enclosing scope index of the name on top of the stack.
+  auto PeekEnclosingScope() const -> ScopeIndex {
+    return decl_name_stack_.back().enclosing_scope;
   }
 
   // Finishes the current declaration name processing, returning the final

--- a/toolchain/check/testdata/class/fail_method_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_method_redefinition.carbon
@@ -1,0 +1,48 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+class Class {
+  fn F() {}
+  // CHECK:STDERR: fail_method_redefinition.carbon:[[@LINE+6]]:3: ERROR: Redefinition of function F.
+  // CHECK:STDERR:   fn F() {}
+  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR: fail_method_redefinition.carbon:[[@LINE-4]]:3: Previously defined here.
+  // CHECK:STDERR:   fn F() {}
+  // CHECK:STDERR:   ^~~~~~~~
+  fn F() {}
+}
+
+// CHECK:STDOUT: --- fail_method_redefinition.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %Class: type = class_type @Class [template]
+// CHECK:STDOUT:   %.1: type = struct_type {} [template]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Class = %Class.decl
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: class @Class {
+// CHECK:STDOUT:   %F.loc8: <function> = fn_decl @F [template] {}
+// CHECK:STDOUT:   %F.loc15: <function> = fn_decl @F [template] {}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !members:
+// CHECK:STDOUT:   .Self = constants.%Class
+// CHECK:STDOUT:   .F = %F.loc8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT:
+// CHECK:STDOUT: !.loc15:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -7,29 +7,46 @@
 class Class {
   fn F();
   fn H();
+  fn I() {}
 }
 
 // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:1: ERROR: Redefinition of class Class.
 // CHECK:STDERR: class Class {
 // CHECK:STDERR: ^~~~~~~~~~~~~
-// CHECK:STDERR: fail_redefinition.carbon:[[@LINE-8]]:1: Previous definition was here.
+// CHECK:STDERR: fail_redefinition.carbon:[[@LINE-9]]:1: Previous definition was here.
 // CHECK:STDERR: class Class {
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR:
 class Class {
   fn G();
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:3: ERROR: Redundant redeclaration of function H.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redundant redeclaration of function H.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-15]]:3: Previously declared here.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-16]]:3: Previously declared here.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
+  // CHECK:STDERR:
   fn H();
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redefinition of function I.
+  // CHECK:STDERR:   fn I() {}
+  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-23]]:3: Previously defined here.
+  // CHECK:STDERR:   fn I() {}
+  // CHECK:STDERR:   ^~~~~~~~
+  // CHECK:STDERR:
+  fn I() {}
 }
 
 fn Class.F() {}
 fn Class.G() {}
 fn Class.H() {}
+// CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function I.
+// CHECK:STDERR: fn Class.I() {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~
+// CHECK:STDERR: fail_redefinition.carbon:[[@LINE-9]]:3: Previously defined here.
+// CHECK:STDERR:   fn I() {}
+// CHECK:STDERR:   ^~~~~~~~
+fn Class.I() {}
 
 // CHECK:STDOUT: --- fail_redefinition.carbon
 // CHECK:STDOUT:
@@ -43,20 +60,23 @@ fn Class.H() {}
 // CHECK:STDOUT:     .Class = %Class.decl.loc7
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Class.decl.loc7: type = class_decl @Class [template = constants.%Class] {}
-// CHECK:STDOUT:   %Class.decl.loc19: type = class_decl @Class [template = constants.%Class] {}
+// CHECK:STDOUT:   %Class.decl.loc20: type = class_decl @Class [template = constants.%Class] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {}
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {}
+// CHECK:STDOUT:   %I: <function> = fn_decl @I [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {}
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {}
+// CHECK:STDOUT:   %I: <function> = fn_decl @I [template] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = constants.%Class
 // CHECK:STDOUT:   .F = <unexpected instref inst+3>
 // CHECK:STDOUT:   .H = <unexpected instref inst+4>
+// CHECK:STDOUT:   .I = <unexpected instref inst+5>
 // CHECK:STDOUT:   .G = %G
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -67,6 +87,17 @@ fn Class.H() {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @I() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT:
+// CHECK:STDOUT: !.loc37:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT:
+// CHECK:STDOUT: !.loc49:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Instead of attempting to reconstruct this based on the properties of the target scope of the declaration name, check whether the enclosing scope of the inner deferred definition scope is the enclosing deferred definition scope.

Also add verbose logging to the deferred definition handling code to make it easier to see when we switch between handling the regular parse nodes and the deferred function bodies.