### PR TITLE
Run clang-format over def files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       - id: clang-format
         name: clang-format
         entry: clang-format
-        types_or: [c++, proto]
+        types_or: [c++, proto, def]
         language: python
         args: ['-i']
         additional_dependencies: ['clang-format==17.0.1']

--- a/toolchain/parse/state.def
+++ b/toolchain/parse/state.def
@@ -1188,7 +1188,8 @@ CARBON_PARSE_STATE_VARIANTS3(TypeAfterIntroducer, Class, Interface,
 // class/impl/interface/constraint name ( ... ) ???
 //                                              ^
 //   (state done)
-CARBON_PARSE_STATE_VARIANTS4(DeclOrDefinition, Class, Impl, Interface, NamedConstraint)
+CARBON_PARSE_STATE_VARIANTS4(DeclOrDefinition, Class, Impl, Interface,
+                             NamedConstraint)
 
 // Handles processing of a completed `base: B` declaration.
 //
@@ -1358,8 +1359,8 @@ CARBON_PARSE_STATE(ChoiceDefinitionStart)
 //   1. ChoiceAlternativeFinish
 CARBON_PARSE_STATE(ChoiceAlternative)
 
-// Finishes parsing a choice's alternative, including the optional trailing `,`. If there
-// are more alternatives, enqueues another alternative parsing state.
+// Finishes parsing a choice's alternative, including the optional trailing `,`.
+// If there are more alternatives, enqueues another alternative parsing state.
 //
 // ... , }
 //     ^


### PR DESCRIPTION
Noticed an unexpected format change in #3850, it's probably because pre-commit needs to explicitly include def files. The def change here is a consequence of `pre-commit run -a` with this change.