### PR TITLE
Opt out of pre-commit suggestions

### DIFF
--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -27,7 +27,8 @@ jobs:
     # Only generate suggestions if pre-commit for a PR failed.
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      github.actor != 'jonmeow'
     runs-on: ubuntu-latest
     steps:
       - uses: reviewdog/action-setup@v1


### PR DESCRIPTION
Due to my workflow, I prefer to run `pre-commit` locally when I forget to after an amend. While reviewdog can be helpful in the UI, it's mostly making me mark comments as resolved as part of re-pushing. Rather than continuing with this, maybe opting out is best?