### PR TITLE
Add a custom main library for benchmarks.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -15,6 +15,17 @@ cc_library(
 )
 
 cc_library(
+    name = "benchmark_main",
+    srcs = ["benchmark_main.cpp"],
+    deps = [
+        ":init_llvm",
+        "@abseil-cpp//absl/flags:parse",
+        "@google_benchmark//:benchmark",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "command_line",
     srcs = ["command_line.cpp"],
     hdrs = ["command_line.h"],
@@ -140,11 +151,12 @@ cc_binary(
     testonly = 1,
     srcs = ["hashing_benchmark.cpp"],
     deps = [
+        ":benchmark_main",
         ":check",
         ":hashing",
         "@abseil-cpp//absl/hash",
         "@abseil-cpp//absl/random",
-        "@google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -12,14 +12,16 @@
 auto main(int orig_argc, char** orig_argv) -> int {
   // Inject a flag to override the defaults for benchmarks. This can still be
   // disabled by user arguments.
+  llvm::MutableArrayRef<char*> orig_argv_ref(orig_argv, orig_argc);
   int argc = orig_argc + 1;
   llvm::OwningArrayRef<char*> injected_argv_storage(argc + 2);
   injected_argv_storage[0] = orig_argv[0];
   char injected_flag[] = "--benchmark_counters_tabular";
   injected_argv_storage[1] = injected_flag;
-for (auto [arg, orig_arg] : llvm::zip(injected_argv_storage.slice(2), llvm::ArrayRef(orig_argv).slice(1))) {
-  arg = orig_arg;
-}
+  for (auto [arg, orig_arg] :
+       llvm::zip(injected_argv_storage.slice(2), orig_argv_ref.slice(1))) {
+    arg = orig_arg;
+  }
   char** argv = injected_argv_storage.data();
 
   Carbon::InitLLVM init_llvm(argc, argv);

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -17,11 +17,9 @@ auto main(int orig_argc, char** orig_argv) -> int {
   injected_argv_storage[0] = orig_argv[0];
   char injected_flag[] = "--benchmark_counters_tabular";
   injected_argv_storage[1] = injected_flag;
-  for (auto [index, v] : llvm::enumerate(injected_argv_storage.slice(2))) {
-    // Note that index for the injected array is one further than the original,
-    // but we sliced off the first two elements so this balances out.
-    v = orig_argv[index + 1];
-  }
+for (auto [arg, orig_arg] : llvm::zip(injected_argv_storage.slice(2), llvm::ArrayRef(orig_argv).slice(1))) {
+  arg = orig_arg;
+}
   char** argv = injected_argv_storage.data();
 
   Carbon::InitLLVM init_llvm(argc, argv);

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -1,0 +1,33 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <benchmark/benchmark.h>
+
+#include "absl/flags/parse.h"
+#include "common/init_llvm.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+auto main(int orig_argc, char** orig_argv) -> int {
+  // Inject a flag to override the defaults for benchmarks. This can still be
+  // disabled by user arguments.
+  int argc = orig_argc + 1;
+  llvm::OwningArrayRef<char*> injected_argv_storage(argc + 2);
+  injected_argv_storage[0] = orig_argv[0];
+  char injected_flag[] = "--benchmark_counters_tabular";
+  injected_argv_storage[1] = injected_flag;
+  for (auto [index, v] : llvm::enumerate(injected_argv_storage.slice(2))) {
+    // Note that index for the injected array is one further than the original,
+    // but we sliced off the first two elements so this balances out.
+    v = orig_argv[index + 1];
+  }
+  char** argv = injected_argv_storage.data();
+
+  Carbon::InitLLVM init_llvm(argc, argv);
+  benchmark::Initialize(&argc, argv);
+  absl::ParseCommandLine(argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -12,7 +12,8 @@
 auto main(int orig_argc, char** orig_argv) -> int {
   // Inject a flag to override the defaults for benchmarks. This can still be
   // disabled by user arguments.
-  llvm::SmallVector<char*> injected_argv_storage(orig_argv, orig_argv + orig_argc + 1);
+  llvm::SmallVector<char*> injected_argv_storage(orig_argv,
+                                                 orig_argv + orig_argc + 1);
   char injected_flag[] = "--benchmark_counters_tabular";
   injected_argv_storage.insert(injected_argv_storage.begin() + 1, injected_flag);
   char** argv = injected_argv_storage.data();

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -15,7 +15,8 @@ auto main(int orig_argc, char** orig_argv) -> int {
   llvm::SmallVector<char*> injected_argv_storage(orig_argv,
                                                  orig_argv + orig_argc + 1);
   char injected_flag[] = "--benchmark_counters_tabular";
-  injected_argv_storage.insert(injected_argv_storage.begin() + 1, injected_flag);
+  injected_argv_storage.insert(injected_argv_storage.begin() + 1,
+                               injected_flag);
   char** argv = injected_argv_storage.data();
   int argc = injected_argv_storage.size() - 1;
 

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -10,6 +10,9 @@
 #include "llvm/ADT/StringRef.h"
 
 auto main(int orig_argc, char** orig_argv) -> int {
+  // Do LLVM's initialization first, this will also transform UTF-16 to UTF-8.
+  Carbon::InitLLVM init_llvm(orig_argc, orig_argv);
+
   // Inject a flag to override the defaults for benchmarks. This can still be
   // disabled by user arguments.
   llvm::SmallVector<char*> injected_argv_storage(orig_argv,
@@ -20,7 +23,6 @@ auto main(int orig_argc, char** orig_argv) -> int {
   char** argv = injected_argv_storage.data();
   int argc = injected_argv_storage.size() - 1;
 
-  Carbon::InitLLVM init_llvm(argc, argv);
   benchmark::Initialize(&argc, argv);
   absl::ParseCommandLine(argc, argv);
   benchmark::RunSpecifiedBenchmarks();

--- a/common/benchmark_main.cpp
+++ b/common/benchmark_main.cpp
@@ -12,17 +12,11 @@
 auto main(int orig_argc, char** orig_argv) -> int {
   // Inject a flag to override the defaults for benchmarks. This can still be
   // disabled by user arguments.
-  llvm::MutableArrayRef<char*> orig_argv_ref(orig_argv, orig_argc);
-  int argc = orig_argc + 1;
-  llvm::OwningArrayRef<char*> injected_argv_storage(argc + 2);
-  injected_argv_storage[0] = orig_argv[0];
+  llvm::SmallVector<char*> injected_argv_storage(orig_argv, orig_argv + orig_argc + 1);
   char injected_flag[] = "--benchmark_counters_tabular";
-  injected_argv_storage[1] = injected_flag;
-  for (auto [arg, orig_arg] :
-       llvm::zip(injected_argv_storage.slice(2), orig_argv_ref.slice(1))) {
-    arg = orig_arg;
-  }
+  injected_argv_storage.insert(injected_argv_storage.begin() + 1, injected_flag);
   char** argv = injected_argv_storage.data();
+  int argc = injected_argv_storage.size() - 1;
 
   Carbon::InitLLVM init_llvm(argc, argv);
   benchmark::Initialize(&argc, argv);

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -85,9 +85,10 @@ cc_binary(
     srcs = ["numeric_literal_benchmark.cpp"],
     deps = [
         ":numeric_literal",
+        "//common:benchmark_main",
         "//common:check",
         "//toolchain/diagnostics:null_diagnostics",
-        "@google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -139,8 +140,9 @@ cc_binary(
     srcs = ["string_literal_benchmark.cpp"],
     deps = [
         ":string_literal",
+        "//common:benchmark_main",
         "//toolchain/diagnostics:null_diagnostics",
-        "@google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -271,12 +273,13 @@ cc_binary(
         ":lex",
         ":token_kind",
         ":tokenized_buffer",
+        "//common:benchmark_main",
         "//common:check",
         "//toolchain/base:value_store",
         "//toolchain/diagnostics:diagnostic_emitter",
         "//toolchain/diagnostics:null_diagnostics",
         "@abseil-cpp//absl/random",
-        "@google_benchmark//:benchmark_main",
+        "@google_benchmark//:benchmark",
         "@llvm-project//llvm:Support",
     ],
 )


### PR DESCRIPTION
This largely reproduces the upstream one, but has a few advantages:

1) It initializes LLVM which can be important if we use the backends.
2) It parses commandline flags with Abseil allowing the use of Abseil
   flags in benchmarks.
3) It flips the default for tabular display of results which we use
   pretty heavily.