### PR TITLE
Add the package and library to an import diagnostic.

### DIFF
--- a/toolchain/check/testdata/packages/fail_api_not_found.carbon
+++ b/toolchain/check/testdata/packages/fail_api_not_found.carbon
@@ -6,7 +6,7 @@
 
 // --- fail_no_api.impl.carbon
 
-// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_no_api.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API for 'Foo' not found.
 // CHECK:STDERR: package Foo impl;
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR:
@@ -14,7 +14,7 @@ package Foo impl;
 
 // --- fail_no_api_lib.impl.carbon
 
-// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_no_api_lib.impl.carbon:[[@LINE+4]]:1: ERROR: Corresponding API for 'Foo//Bar' not found.
 // CHECK:STDERR: package Foo library "Bar" impl;
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR:
@@ -22,7 +22,7 @@ package Foo library "Bar" impl;
 
 // --- fail_no_api_main_lib.impl.carbon
 
-// CHECK:STDERR: fail_no_api_main_lib.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_no_api_main_lib.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API for 'Main//Bar' not found.
 // CHECK:STDERR: library "Bar" impl;
 // CHECK:STDERR: ^~~~~~~
 library "Bar" impl;

--- a/toolchain/check/testdata/packages/fail_import_invalid.carbon
+++ b/toolchain/check/testdata/packages/fail_import_invalid.carbon
@@ -85,7 +85,7 @@ import Implicit library "lib";
 // --- fail_not_found.carbon
 package NotFound api;
 
-// CHECK:STDERR: fail_not_found.carbon:[[@LINE+3]]:1: ERROR: Imported API not found.
+// CHECK:STDERR: fail_not_found.carbon:[[@LINE+3]]:1: ERROR: Imported API 'ImportNotFound' not found.
 // CHECK:STDERR: import ImportNotFound;
 // CHECK:STDERR: ^~~~~~
 import ImportNotFound;

--- a/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
+++ b/toolchain/check/testdata/packages/fail_name_with_import_failure.carbon
@@ -6,7 +6,7 @@
 
 // --- fail_implicit.impl.carbon
 
-// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API not found.
+// CHECK:STDERR: fail_implicit.impl.carbon:[[@LINE+3]]:1: ERROR: Corresponding API for 'Implicit' not found.
 // CHECK:STDERR: package Implicit impl;
 // CHECK:STDERR: ^~~~~~~
 package Implicit impl;


### PR DESCRIPTION
While most of the examples in our tests are made clear by the code snippet, sometimes that's not the case. This makes it more clear when the implicit `Main` package is used for example. I added this because I got an error message without any source code to show in the snippet (importing the prelude for example) and this makes the error much more understandable.