### PR TITLE
Move the injection of the prelude compile to the driver.

### DIFF
--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -17,6 +17,7 @@ cc_library(
     name = "driver",
     srcs = ["driver.cpp"],
     hdrs = ["driver.h"],
+    data = ["//core"],
     textual_hdrs = ["flags.def"],
     deps = [
         "//common:command_line",

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -671,7 +671,17 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
   // Prepare CompilationUnits before building scope exit handlers.
   StreamDiagnosticConsumer stream_consumer(error_stream_);
   llvm::SmallVector<std::unique_ptr<CompilationUnit>> units;
-  units.reserve(options.input_filenames.size());
+
+  // Directly insert the core package into the compilation units.
+  // TODO: Should expand this into a more rich system to search for the core
+  // package source code.
+  if (options.prelude_import) {
+    units.push_back(std::make_unique<CompilationUnit>(
+        this, options, &stream_consumer, "core/prelude.carbon"));
+  }
+
+  // Add the input source files.
+  units.reserve(units.size() + options.input_filenames.size());
   for (const auto& input_filename : options.input_filenames) {
     units.push_back(std::make_unique<CompilationUnit>(
         this, options, &stream_consumer, input_filename));

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -671,6 +671,7 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
   // Prepare CompilationUnits before building scope exit handlers.
   StreamDiagnosticConsumer stream_consumer(error_stream_);
   llvm::SmallVector<std::unique_ptr<CompilationUnit>> units;
+  units.reserve(options.prelude_import + options.input_filenames.size());
 
   // Directly insert the core package into the compilation units.
   // TODO: Should expand this into a more rich system to search for the core
@@ -681,7 +682,6 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
   }
 
   // Add the input source files.
-  units.reserve(units.size() + options.input_filenames.size());
   for (const auto& input_filename : options.input_filenames) {
     units.push_back(std::make_unique<CompilationUnit>(
         this, options, &stream_consumer, input_filename));

--- a/toolchain/driver/testdata/dump_shared_values.carbon
+++ b/toolchain/driver/testdata/dump_shared_values.carbon
@@ -16,6 +16,15 @@ var str1: String = "abc";
 var str2: String = "ab'\"c";
 
 // CHECK:STDOUT: ---
+// CHECK:STDOUT: filename:        'core/prelude.carbon'
+// CHECK:STDOUT: shared_values:
+// CHECK:STDOUT:   ints:            {}
+// CHECK:STDOUT:   reals:           {}
+// CHECK:STDOUT:   strings:
+// CHECK:STDOUT:     str0:            Core
+// CHECK:STDOUT:     str1:            prelude
+// CHECK:STDOUT: ...
+// CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        dump_shared_values.carbon
 // CHECK:STDOUT: shared_values:
 // CHECK:STDOUT:   ints:

--- a/toolchain/testing/BUILD
+++ b/toolchain/testing/BUILD
@@ -11,7 +11,6 @@ file_test(
     name = "file_test",
     size = "small",
     srcs = ["file_test.cpp"],
-    data = ["//core"],
     tests = [
         "//toolchain/check:testdata",
         "//toolchain/codegen:testdata",

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -52,11 +52,14 @@ class ToolchainFileTest : public FileTestBase {
     llvm::SmallVector<std::string> args = {"compile",
                                            "--phase=" + component_.str()};
 
+    // For `lex` and `parse`, we don't need to import the prelude. Suppress it
+    // to improve the dump output for the tests.
     if (component_ == "lex") {
-      args.insert(args.end(), {"--dump-tokens", "%s"});
+      args.insert(args.end(), {"--no-prelude-import", "--dump-tokens", "%s"});
       return args;
     } else if (component_ == "parse") {
-      args.insert(args.end(), {"--dump-parse-tree", "%s"});
+      args.insert(args.end(),
+                  {"--no-prelude-import", "--dump-parse-tree", "%s"});
       return args;
     }
 
@@ -69,8 +72,7 @@ class ToolchainFileTest : public FileTestBase {
                      << test_name();
     }
 
-    args.insert(args.end(), {"--exclude-dump-file-prefix=core/",
-                             "core/prelude.carbon", "%s"});
+    args.insert(args.end(), {"--exclude-dump-file-prefix=core/", "%s"});
     return args;
   }
 


### PR DESCRIPTION
The `file_test` layer still adds it to the VFS and filters it from the dump output, but the driver now injects it into the compilation unites depending on the `--import-prelude` file (enabled by default).

This doesn't address improvements to how we find the prelude code, just sinking the needed logic into the driver itself.