### PR TITLE
Use https://app.stepsecurity.io/secureworkflow to improve workflow security.

### DIFF
--- a/.github/workflows/assign_prs.yaml
+++ b/.github/workflows/assign_prs.yaml
@@ -7,12 +7,20 @@ on:
   pull_request_target:
     types: [opened, ready_for_review]
 
+permissions:
+  pull-requests: write # For gh to edit assignees.
+
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - id: filter
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             leads:
@@ -30,21 +38,21 @@ jobs:
 
       - id: assign-leads
         if: steps.filter.outputs.leads == 'true'
-        uses: hkusu/review-assign-action@v1.3.0
+        uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           reviewers: KateGregory, chandlerc, zygoloid
           max-num-of-reviewers: 1
 
       - id: assign-explorer
         if: steps.filter.outputs.explorer == 'true'
-        uses: hkusu/review-assign-action@v1.3.0
+        uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           reviewers: geoffromer, jonmeow, zygoloid
           max-num-of-reviewers: 1
 
       - id: assign-toolchain
         if: steps.filter.outputs.toolchain == 'true'
-        uses: hkusu/review-assign-action@v1.3.0
+        uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           reviewers: chandlerc, geoffromer, jonmeow, josh11b, zygoloid
           max-num-of-reviewers: 1
@@ -54,7 +62,7 @@ jobs:
           steps.filter.outputs.leads != 'true' &&
           steps.filter.outputs.explorer != 'true' &&
           steps.filter.outputs.toolchain != 'true'
-        uses: hkusu/review-assign-action@v1.3.0
+        uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           reviewers: chandlerc, jonmeow, josh11b, zygoloid
           max-num-of-reviewers: 1

--- a/.github/workflows/discord_wiki.yaml
+++ b/.github/workflows/discord_wiki.yaml
@@ -6,10 +6,19 @@ name: Wiki Changed Discord Notification
 
 on: gollum
 
+permissions: none
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: 'oznu/gh-wiki-edit-discord-notification@v1.0.0'
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses:
+          'oznu/gh-wiki-edit-discord-notification@1f5b688c27310fba606368b20469c81f5ffd9a2f
+          # v1.0.0'
         with:
           discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_WIKI_EDIT }}

--- a/.github/workflows/label_prs.yaml
+++ b/.github/workflows/label_prs.yaml
@@ -7,12 +7,20 @@ on:
   pull_request_target:
     types: [opened, ready_for_review]
 
+permissions:
+  pull-requests: write # For gh to edit labels.
+
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - id: filter
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             documentation:

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -10,13 +10,21 @@ on:
   push:
     branches: [trunk]
 
+permissions:
+  contents: read # For actions/checkout.
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v3.0.0
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
       # We want to automatically create github suggestions for pre-commit file
       # changes for a pull request. But `pull_request` actions never have write
@@ -30,7 +38,7 @@ jobs:
           mkdir -p pre-commit-output
           git diff > pre-commit-output/diff
           cp $GITHUB_EVENT_PATH pre-commit-output/event
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: failure()
         with:
           name: pre-commit output

--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -19,8 +19,9 @@ on:
     types:
       - completed
 
+# Note reviewdog/reviewdog has its own token.
 permissions:
-  pull-requests: write
+  contents: read # For actions/checkout.
 
 jobs:
   pull-request-suggestions:
@@ -31,14 +32,19 @@ jobs:
       github.actor != 'jonmeow'
     runs-on: ubuntu-latest
     steps:
-      - uses: reviewdog/action-setup@v1
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
         with:
           reviewdog_version: latest
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Download pre-commit output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           name: pre-commit output
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proposal_labeled.yaml
+++ b/.github/workflows/proposal_labeled.yaml
@@ -19,10 +19,18 @@ on:
     types:
       - labeled
 
+permissions:
+  pull-requests: write # For gh to edit labels.
+
 jobs:
   proposal_labeled:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: draft
         if: |
           github.event.label.name == 'proposal draft'

--- a/.github/workflows/proposal_ready.yaml
+++ b/.github/workflows/proposal_ready.yaml
@@ -10,11 +10,19 @@ on:
     types:
       - ready_for_review
 
+permissions:
+  pull-requests: write # For gh to edit labels.
+
 jobs:
   proposal_ready:
     if: contains(github.event.pull_request.labels.*.name, 'proposal')
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: rfc
         run: |
           gh pr edit "${PR}" \

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,11 +7,20 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  issues: write # For actions/stale to close stale issues.
+  pull-requests: write # For actions/stale to close stale PRs.
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           stale-issue-message: >
             We triage inactive PRs and issues in order to make it easier to find

--- a/.github/workflows/sync_repos.yaml
+++ b/.github/workflows/sync_repos.yaml
@@ -24,12 +24,12 @@ jobs:
   sync-repos:
     runs-on: ubuntu-latest
     steps:
-      # Checkout our main repository.
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit
 
+      # Checkout our main repository.
       - name: Checkout the main repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/sync_repos.yaml
+++ b/.github/workflows/sync_repos.yaml
@@ -16,13 +16,22 @@ on:
       - '.github/workflows/sync_repos.yaml'
       - 'scripts/sync_repos.sh'
 
+# Note the sync script has its own token.
+permissions:
+  contents: read # For actions/checkout.
+
 jobs:
   sync-repos:
     runs-on: ubuntu-latest
     steps:
       # Checkout our main repository.
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: Checkout the main repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # Run the sync script.
       - name: Sync to other repositories

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,10 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read # For actions/checkout.
+  pull-requests: read # For dorny/paths-filter to read pull requests.
+
 # Cancel previous workflows on the PR when there are multiple fast commits.
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 concurrency:
@@ -39,43 +43,46 @@ jobs:
     steps:
       # Ubuntu images start with 23GB available, and this adds 14GB more. For
       # comparison, MacOS images have >100GB free.
+      #
+      # Although we could delete more, if we run into a limit, not deleting
+      # everything provides a little flexibility to get space while trying
+      # to shrink the build.
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: Free up disk space (Ubuntu)
         if: env.os == 'ubuntu'
-        uses: jlumbroso/free-disk-space@v1.2.0
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: true
           dotnet: true
           haskell: true
-          # Although we could delete more, if we run into a limit, it provides a
-          # little flexibility to get space while trying to shrink the build.
-          # There's also support for docker images at head (1.2.0 is still
-          # the latest release).
-          large-packages: false
-          swap-storage: false
 
       # Checkout the pull request head or the branch.
       - name: Checkout pull request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # Tests should only run on applicable paths, but we still need to have an
       # action run for the merge queue. We filter steps based on the paths here,
       # and condition steps on the output.
       - id: filter
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             has_code:
               - '!{**/*.md,LICENSE,CODEOWNERS,.git*}'
 
       # Setup Python and related tools.
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         if: steps.filter.outputs.has_code == 'true'
         with:
           # Match the min version listed in docs/project/contribution_tools.md
@@ -89,7 +96,7 @@ jobs:
       - name: Cache Homebrew (macOS)
         if: steps.filter.outputs.has_code == 'true' && env.os == 'macos'
         id: cache-homebrew-macos
-        uses: actions/cache@v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
           cache-name: cache-homebrew
         with:
@@ -154,7 +161,7 @@ jobs:
       - name: Cache LLVM and Clang installation (Ubuntu)
         if: steps.filter.outputs.has_code == 'true' && env.os == 'ubuntu'
         id: cache-llvm-ubuntu
-        uses: actions/cache@v3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
           cache-name: cache-llvm
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,17 +41,17 @@ jobs:
       os: ${{ startsWith(matrix.runner, 'ubuntu') && 'ubuntu' || 'macos' }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       # Ubuntu images start with 23GB available, and this adds 14GB more. For
       # comparison, MacOS images have >100GB free.
       #
       # Although we could delete more, if we run into a limit, not deleting
       # everything provides a little flexibility to get space while trying
       # to shrink the build.
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-
       - name: Free up disk space (Ubuntu)
         if: env.os == 'ubuntu'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION
This is coming out of advice from https://securityscorecards.dev/viewer/?uri=github.com/carbon-language/carbon-lang

Updates action versions and pins by checksum. This is something we already do in other places, and doing it with actions just seems consistent.

Trying to add token permissions at the same time.

step-security/harden-runner is being set up to monitor network traffic for actions, with the idea that we'd set it to block unexpected traffic in the future.

Note, https://app.stepsecurity.io/secureworkflow generates the pinned checksums and adds the harden-runner. In some cases it added token permissions, but we have a couple it doesn't recognize (`gh` executions, other custom commands, jlumbroso/free-disk-space, reviewdog/action-setup as examples) so I'm trying to guess my best.

Because these are workflows, testing is limited.