### PR TITLE
Update calls to std::fstream constructors

### DIFF
--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -49,7 +49,7 @@ using ::testing::StrEq;
 
 // Reads a file to string.
 static auto ReadFile(std::string_view path) -> std::string {
-  std::ifstream proto_file(path);
+  std::ifstream proto_file{std::string(path)};
   std::stringstream buffer;
   buffer << proto_file.rdbuf();
   proto_file.close();


### PR DESCRIPTION
Constructing types like `std::ifstream` with `std::string_view` is no longer allowed; one must pass a different type, such as `std::string`. A recent libc++ change requires this: https://github.com/llvm/llvm-project/commit/4761e74a276ee1f38596f4849daa9d633929f2ae