### PR TITLE
Update a few switches using InstKind:: to use the more common ::Kind.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -190,6 +190,7 @@ cc_library(
     deps = [
         ":context",
         "//common:check",
+        "//toolchain/base:kind_switch",
         "//toolchain/parse:node_kind",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:ids",

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/import.h"
 
 #include "common/check.h"
+#include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/merge.h"
 #include "toolchain/parse/node_ids.h"
@@ -20,36 +21,35 @@ namespace Carbon::Check {
 static auto GetImportName(const SemIR::File& import_sem_ir,
                           SemIR::Inst import_inst)
     -> std::pair<SemIR::NameId, SemIR::NameScopeId> {
-  switch (import_inst.kind()) {
-    case SemIR::InstKind::BindAlias:
-    case SemIR::InstKind::BindName:
-    case SemIR::InstKind::BindSymbolicName: {
-      const auto& bind_name = import_sem_ir.bind_names().Get(
-          import_inst.As<SemIR::AnyBindName>().bind_name_id);
+  CARBON_KIND_SWITCH(import_inst) {
+    case SemIR::BindAlias::Kind:
+    case SemIR::BindName::Kind:
+    case SemIR::BindSymbolicName::Kind: {
+      auto bind_inst = import_inst.As<SemIR::AnyBindName>();
+      const auto& bind_name =
+          import_sem_ir.bind_names().Get(bind_inst.bind_name_id);
       return {bind_name.name_id, bind_name.enclosing_scope_id};
     }
 
-    case SemIR::InstKind::ClassDecl: {
-      const auto& class_info = import_sem_ir.classes().Get(
-          import_inst.As<SemIR::ClassDecl>().class_id);
+    case CARBON_KIND(SemIR::ClassDecl class_decl): {
+      const auto& class_info = import_sem_ir.classes().Get(class_decl.class_id);
       return {class_info.name_id, class_info.enclosing_scope_id};
     }
 
-    case SemIR::InstKind::FunctionDecl: {
-      const auto& function = import_sem_ir.functions().Get(
-          import_inst.As<SemIR::FunctionDecl>().function_id);
+    case CARBON_KIND(SemIR::FunctionDecl function_decl): {
+      const auto& function =
+          import_sem_ir.functions().Get(function_decl.function_id);
       return {function.name_id, function.enclosing_scope_id};
     }
 
-    case SemIR::InstKind::InterfaceDecl: {
-      const auto& interface = import_sem_ir.interfaces().Get(
-          import_inst.As<SemIR::InterfaceDecl>().interface_id);
+    case CARBON_KIND(SemIR::InterfaceDecl interface_decl): {
+      const auto& interface =
+          import_sem_ir.interfaces().Get(interface_decl.interface_id);
       return {interface.name_id, interface.enclosing_scope_id};
     }
 
-    case SemIR::InstKind::Namespace: {
-      const auto& scope = import_sem_ir.name_scopes().Get(
-          import_inst.As<SemIR::Namespace>().name_scope_id);
+    case CARBON_KIND(SemIR::Namespace ns): {
+      const auto& scope = import_sem_ir.name_scopes().Get(ns.name_scope_id);
       return {scope.name_id, scope.enclosing_scope_id};
     }
 

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -248,7 +248,7 @@ class ImportRefResolver {
           {AddImportIRInst(param_id), SemIR::Param{type_id, name_id}});
       if (bind_inst) {
         switch (bind_inst->kind) {
-          case SemIR::InstKind::BindName: {
+          case SemIR::BindName::Kind: {
             auto bind_name_id = context_.bind_names().Add(
                 {.name_id = name_id,
                  .enclosing_scope_id = SemIR::NameScopeId::Invalid});
@@ -257,7 +257,7 @@ class ImportRefResolver {
                  SemIR::BindName{type_id, bind_name_id, new_param_id}});
             break;
           }
-          case SemIR::InstKind::BindSymbolicName: {
+          case SemIR::BindSymbolicName::Kind: {
             // The symbolic name will be created on first reference, so might
             // already exist. Update the value in it to refer to the parameter.
             auto new_bind_inst =

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -414,10 +414,10 @@ class InstNamer {
 
       case Parse::NodeKind::WhileCondition:
         switch (branch.kind) {
-          case InstKind::BranchIf:
+          case BranchIf::Kind:
             name = "while.body";
             break;
-          case InstKind::Branch:
+          case Branch::Kind:
             name = "while.done";
             break;
           default:


### PR DESCRIPTION
The InstKind is the older approach, and as a consequence I'd missed one of the switches when doing with switch edits.