### PR TITLE
Refactor pre-merge redeclaration checking for sharing.

### DIFF
--- a/toolchain/check/function.h
+++ b/toolchain/check/function.h
@@ -42,7 +42,7 @@ auto CheckFunctionTypeMatches(Context& context,
 //
 // If merging is successful, updates the FunctionId on new_function and returns
 // true. Otherwise, returns false. Prints a diagnostic when appropriate.
-auto MergeFunctionRedecl(Context& context, SemIR::LocId loc_id,
+auto MergeFunctionRedecl(Context& context, SemIRLoc new_loc,
                          SemIR::Function& new_function, bool new_is_import,
                          bool new_is_definition,
                          SemIR::FunctionId prev_function_id,

--- a/toolchain/check/merge.h
+++ b/toolchain/check/merge.h
@@ -11,6 +11,29 @@
 
 namespace Carbon::Check {
 
+// Information on new and previous declarations for CheckIsAllowedRedecl.
+struct RedeclInfo {
+  // The associated diagnostic location.
+  SemIRLoc loc;
+  // True if a definition.
+  bool is_definition;
+  // True if an `extern` declaration.
+  bool is_extern;
+};
+
+// Checks if a redeclaration is allowed prior to merging. This may emit a
+// diagnostic, but diagnostics do not prevent merging.
+//
+// The kinds of things this verifies are:
+// - A declaration is not redundant.
+// - A definition doesn't redefine a prior definition.
+// - The use of `extern` is consistent within a library.
+// - Multiple libraries do not declare non-`extern`.
+auto CheckIsAllowedRedecl(Context& context, Lex::TokenKind decl_kind,
+                          SemIR::NameId name_id, RedeclInfo new_decl,
+                          RedeclInfo prev_decl,
+                          SemIR::ImportIRInstId prev_import_ir_inst_id) -> void;
+
 struct InstForMerge {
   // The resolved instruction.
   SemIR::Inst inst;

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -65,7 +65,7 @@ import Other library "define";
 // CHECK:STDERR: fail_merge_define_extern.carbon:[[@LINE+6]]:1: In import.
 // CHECK:STDERR: import Other library "extern";
 // CHECK:STDERR: ^~~~~~
-// CHECK:STDERR: other_extern.carbon:5:1: ERROR: Semantics TODO: `Merging not yet supported.`.
+// CHECK:STDERR: other_extern.carbon:5:1: ERROR: Semantics TODO: `Merging ClassType not yet supported.`.
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
 import Other library "extern";

--- a/toolchain/check/testdata/class/fail_method_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_method_redefinition.carbon
@@ -6,7 +6,7 @@
 
 class Class {
   fn F() {}
-  // CHECK:STDERR: fail_method_redefinition.carbon:[[@LINE+6]]:3: ERROR: Redefinition of function F.
+  // CHECK:STDERR: fail_method_redefinition.carbon:[[@LINE+6]]:3: ERROR: Redefinition of `fn F`.
   // CHECK:STDERR:   fn F() {}
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_method_redefinition.carbon:[[@LINE-4]]:3: Previously defined here.

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -19,7 +19,7 @@ class Class {
 // CHECK:STDERR:
 class Class {
   fn G();
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redundant redeclaration of `fn H`.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redeclaration of `fn H` is redundant.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
   // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-16]]:3: Previously declared here.

--- a/toolchain/check/testdata/class/fail_redefinition.carbon
+++ b/toolchain/check/testdata/class/fail_redefinition.carbon
@@ -19,7 +19,7 @@ class Class {
 // CHECK:STDERR:
 class Class {
   fn G();
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redundant redeclaration of function H.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redundant redeclaration of `fn H`.
   // CHECK:STDERR:   fn H();
   // CHECK:STDERR:   ^~~~~~~
   // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-16]]:3: Previously declared here.
@@ -27,7 +27,7 @@ class Class {
   // CHECK:STDERR:   ^~~~~~~
   // CHECK:STDERR:
   fn H();
-  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redefinition of function I.
+  // CHECK:STDERR: fail_redefinition.carbon:[[@LINE+7]]:3: ERROR: Redefinition of `fn I`.
   // CHECK:STDERR:   fn I() {}
   // CHECK:STDERR:   ^~~~~~~~
   // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-23]]:3: Previously defined here.
@@ -40,7 +40,7 @@ class Class {
 fn Class.F() {}
 fn Class.G() {}
 fn Class.H() {}
-// CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function I.
+// CHECK:STDERR: fail_redefinition.carbon:[[@LINE+6]]:1: ERROR: Redefinition of `fn I`.
 // CHECK:STDERR: fn Class.I() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefinition.carbon:[[@LINE-9]]:3: Previously defined here.

--- a/toolchain/check/testdata/function/builtin/fail_redefined.carbon
+++ b/toolchain/check/testdata/function/builtin/fail_redefined.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 
 fn A(n: i32, m: i32) -> i32 = "int.add";
-// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of function A.
+// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of `fn A`.
 // CHECK:STDERR: fn A(n: i32, m: i32) -> i32 { return n; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefined.carbon:[[@LINE-4]]:1: Previously defined here.
@@ -15,7 +15,7 @@ fn A(n: i32, m: i32) -> i32 = "int.add";
 fn A(n: i32, m: i32) -> i32 { return n; }
 
 fn B(n: i32, m: i32) -> i32 { return n; }
-// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of function B.
+// CHECK:STDERR: fail_redefined.carbon:[[@LINE+7]]:1: ERROR: Redefinition of `fn B`.
 // CHECK:STDERR: fn B(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefined.carbon:[[@LINE-4]]:1: Previously defined here.
@@ -25,7 +25,7 @@ fn B(n: i32, m: i32) -> i32 { return n; }
 fn B(n: i32, m: i32) -> i32 = "int.add";
 
 fn C(n: i32, m: i32) -> i32 = "int.add";
-// CHECK:STDERR: fail_redefined.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function C.
+// CHECK:STDERR: fail_redefined.carbon:[[@LINE+6]]:1: ERROR: Redefinition of `fn C`.
 // CHECK:STDERR: fn C(n: i32, m: i32) -> i32 = "int.add";
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redefined.carbon:[[@LINE-4]]:1: Previously defined here.

--- a/toolchain/check/testdata/function/declaration/extern.carbon
+++ b/toolchain/check/testdata/function/declaration/extern.carbon
@@ -15,7 +15,7 @@ extern fn F();
 library "redecl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -29,7 +29,7 @@ extern fn F();
 library "redecl_extern" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE-4]]:1: Previously declared here.

--- a/toolchain/check/testdata/function/declaration/extern.carbon
+++ b/toolchain/check/testdata/function/declaration/extern.carbon
@@ -15,7 +15,7 @@ extern fn F();
 library "redecl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn F` is redundant.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -29,7 +29,7 @@ extern fn F();
 library "redecl_extern" api;
 
 extern fn F();
-// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
+// CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn F` is redundant.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl_extern.carbon:[[@LINE-4]]:1: Previously declared here.

--- a/toolchain/check/testdata/function/declaration/fail_redecl.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_redecl.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 
 fn A();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn A`.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn A` is redundant.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -15,7 +15,7 @@ fn A();
 fn A();
 
 fn B(x: i32);
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn B`.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn B` is redundant.
 // CHECK:STDERR: fn B(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -35,7 +35,7 @@ fn C();
 fn C(x: i32);
 
 fn D() {}
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn D`.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn D` is redundant.
 // CHECK:STDERR: fn D();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.

--- a/toolchain/check/testdata/function/declaration/fail_redecl.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_redecl.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 
 fn A();
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function A.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn A`.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -15,7 +15,7 @@ fn A();
 fn A();
 
 fn B(x: i32);
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function B.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn B`.
 // CHECK:STDERR: fn B(x: i32);
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -35,7 +35,7 @@ fn C();
 fn C(x: i32);
 
 fn D() {}
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function D.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn D`.
 // CHECK:STDERR: fn D();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -45,7 +45,7 @@ fn D() {}
 fn D();
 
 fn E() {}
-// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function E.
+// CHECK:STDERR: fail_redecl.carbon:[[@LINE+6]]:1: ERROR: Redefinition of `fn E`.
 // CHECK:STDERR: fn E() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_redecl.carbon:[[@LINE-4]]:1: Previously defined here.

--- a/toolchain/check/testdata/function/declaration/implicit_import.carbon
+++ b/toolchain/check/testdata/function/declaration/implicit_import.carbon
@@ -26,7 +26,7 @@ extern fn A();
 
 library "extern_api" impl;
 
-// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations of `fn A` in the same library must match use of `extern`.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: In import.
@@ -48,7 +48,7 @@ fn A();
 
 library "extern_impl" impl;
 
-// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+9]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE+9]]:1: ERROR: Redeclarations of `fn A` in the same library must match use of `extern`.
 // CHECK:STDERR: extern fn A();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_extern_impl.impl.carbon:[[@LINE-5]]:1: In import.

--- a/toolchain/check/testdata/function/definition/extern.carbon
+++ b/toolchain/check/testdata/function/definition/extern.carbon
@@ -19,10 +19,10 @@ extern fn F() {}
 library "def_for_extern_decl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+7]]:1: ERROR: Defining `extern fn F` is disallowed.
+// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+7]]:1: ERROR: Redeclarations of `fn F` in the same library must match use of `extern`.
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE-4]]:1: Previously declared `extern` here.
+// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -33,7 +33,7 @@ fn F() {}
 library "extern_diag_suppressed" api;
 
 extern fn F();
-// CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
+// CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE+7]]:1: ERROR: Redeclaration of `fn F` is redundant.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -48,7 +48,7 @@ fn F() {}
 library "extern_decl_after_def" api;
 
 fn F() {}
-// CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of `fn F`.
+// CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE+6]]:1: ERROR: Redeclaration of `fn F` is redundant.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE-4]]:1: Previously declared here.

--- a/toolchain/check/testdata/function/definition/extern.carbon
+++ b/toolchain/check/testdata/function/definition/extern.carbon
@@ -19,7 +19,7 @@ extern fn F() {}
 library "def_for_extern_decl" api;
 
 extern fn F();
-// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+7]]:1: ERROR: Redeclaring `extern` function `F` as non-`extern`.
+// CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE+7]]:1: ERROR: Defining `extern fn F` is disallowed.
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_def_for_extern_decl.carbon:[[@LINE-4]]:1: Previously declared `extern` here.
@@ -33,7 +33,7 @@ fn F() {}
 library "extern_diag_suppressed" api;
 
 extern fn F();
-// CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE+7]]:1: ERROR: Redundant redeclaration of `fn F`.
 // CHECK:STDERR: fn F();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_extern_diag_suppressed.carbon:[[@LINE-4]]:1: Previously declared here.
@@ -48,7 +48,7 @@ fn F() {}
 library "extern_decl_after_def" api;
 
 fn F() {}
-// CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of function F.
+// CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE+6]]:1: ERROR: Redundant redeclaration of `fn F`.
 // CHECK:STDERR: extern fn F();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_extern_decl_after_def.carbon:[[@LINE-4]]:1: Previously declared here.

--- a/toolchain/check/testdata/function/definition/fail_redef.carbon
+++ b/toolchain/check/testdata/function/definition/fail_redef.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 
 fn F() {}
-// CHECK:STDERR: fail_redef.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function F.
+// CHECK:STDERR: fail_redef.carbon:[[@LINE+6]]:1: ERROR: Redefinition of `fn F`.
 // CHECK:STDERR: fn F() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_redef.carbon:[[@LINE-4]]:1: Previously defined here.

--- a/toolchain/check/testdata/function/definition/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/implicit_import.carbon
@@ -26,7 +26,7 @@ extern fn A();
 
 library "extern_api" impl;
 
-// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations in the same library must match use of `extern`.
+// CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclarations of `fn A` in the same library must match use of `extern`.
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_extern_api.impl.carbon:[[@LINE-5]]:1: In import.
@@ -64,7 +64,7 @@ fn A() {}
 
 library "redecl_after_def" impl;
 
-// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+10]]:1: ERROR: Redundant redeclaration of function A.
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+10]]:1: ERROR: Redundant redeclaration of `fn A`.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:1: In import.
@@ -86,7 +86,7 @@ fn A() {}
 
 library "redef_after_def" impl;
 
-// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE+9]]:1: ERROR: Redefinition of function A.
+// CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE+9]]:1: ERROR: Redefinition of `fn A`.
 // CHECK:STDERR: fn A() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_redef_after_def.impl.carbon:[[@LINE-5]]:1: In import.

--- a/toolchain/check/testdata/function/definition/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/implicit_import.carbon
@@ -64,7 +64,7 @@ fn A() {}
 
 library "redecl_after_def" impl;
 
-// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+10]]:1: ERROR: Redundant redeclaration of `fn A`.
+// CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE+10]]:1: ERROR: Redeclaration of `fn A` is redundant.
 // CHECK:STDERR: fn A();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR: fail_redecl_after_def.impl.carbon:[[@LINE-5]]:1: In import.

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -82,10 +82,10 @@ library "mix_extern_decl" api;
 import library "fns";
 
 extern fn D();
-// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+6]]:1: ERROR: Defining `extern fn D` is disallowed.
+// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+6]]:1: ERROR: Redeclarations of `fn D` in the same library must match use of `extern`.
 // CHECK:STDERR: fn D() {}
 // CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE-4]]:1: Previously declared `extern` here.
+// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE-4]]:1: Previously declared here.
 // CHECK:STDERR: extern fn D();
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 fn D() {}

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -43,7 +43,7 @@ library "def_ownership" api;
 
 import library "fns";
 
-// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function A without `extern`.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare `fn A` without `extern`.
 // CHECK:STDERR: fn A() {};
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_def_ownership.carbon:[[@LINE-5]]:1: In import.
@@ -54,7 +54,7 @@ import library "fns";
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 fn A() {};
-// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function B without `extern`.
+// CHECK:STDERR: fail_def_ownership.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare `fn B` without `extern`.
 // CHECK:STDERR: fn B(b: i32) -> i32;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR: fail_def_ownership.carbon:[[@LINE-16]]:1: In import.
@@ -82,7 +82,7 @@ library "mix_extern_decl" api;
 import library "fns";
 
 extern fn D();
-// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+6]]:1: ERROR: Redeclaring `extern` function `D` as non-`extern`.
+// CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE+6]]:1: ERROR: Defining `extern fn D` is disallowed.
 // CHECK:STDERR: fn D() {}
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR: fail_mix_extern_decl.carbon:[[@LINE-4]]:1: Previously declared `extern` here.

--- a/toolchain/check/testdata/namespace/fail_duplicate.carbon
+++ b/toolchain/check/testdata/namespace/fail_duplicate.carbon
@@ -9,7 +9,7 @@ namespace Foo;
 fn Foo.Baz() {
 }
 
-// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+6]]:1: ERROR: Redefinition of function Baz.
+// CHECK:STDERR: fail_duplicate.carbon:[[@LINE+6]]:1: ERROR: Redefinition of `fn Baz`.
 // CHECK:STDERR: fn Foo.Baz() {
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_duplicate.carbon:[[@LINE-6]]:1: Previously defined here.

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -116,7 +116,7 @@ import library "other_ns";
 // CHECK:STDERR:
 import Other library "fn";
 
-// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare function F without `extern`.
+// CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE+10]]:1: ERROR: Only one library can declare `fn F` without `extern`.
 // CHECK:STDERR: fn Other.F() {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_main_namespace_conflict.carbon:[[@LINE-5]]:1: In import.

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -148,8 +148,18 @@ CARBON_DIAGNOSTIC_KIND(ImportSelf)
 CARBON_DIAGNOSTIC_KIND(ExplicitImportApi)
 CARBON_DIAGNOSTIC_KIND(RepeatedImport)
 CARBON_DIAGNOSTIC_KIND(FirstImported)
-CARBON_DIAGNOSTIC_KIND(RedeclOfUsedImport)
 CARBON_DIAGNOSTIC_KIND(UsedImportLoc)
+
+// Merge-related redeclaration checking.
+CARBON_DIAGNOSTIC_KIND(RedeclOfUsedImport)
+CARBON_DIAGNOSTIC_KIND(RedeclPrevDecl)
+CARBON_DIAGNOSTIC_KIND(RedeclRedundant)
+CARBON_DIAGNOSTIC_KIND(RedeclNonExtern)
+CARBON_DIAGNOSTIC_KIND(RedeclPrevDef)
+CARBON_DIAGNOSTIC_KIND(RedeclRedef)
+CARBON_DIAGNOSTIC_KIND(RedeclDefiningExtern)
+CARBON_DIAGNOSTIC_KIND(RedeclPrevExternDecl)
+CARBON_DIAGNOSTIC_KIND(RedeclExternMismatch)
 
 // Function call checking.
 CARBON_DIAGNOSTIC_KIND(AddrSelfIsNonRef)
@@ -162,13 +172,6 @@ CARBON_DIAGNOSTIC_KIND(InCallToFunctionSelf)
 CARBON_DIAGNOSTIC_KIND(MissingObjectInMethodCall)
 
 // Function declaration checking.
-CARBON_DIAGNOSTIC_KIND(FunctionPreviousDecl)
-CARBON_DIAGNOSTIC_KIND(FunctionRedecl)
-CARBON_DIAGNOSTIC_KIND(FunctionNonExternRedecl)
-CARBON_DIAGNOSTIC_KIND(FunctionPreviousDefinition)
-CARBON_DIAGNOSTIC_KIND(FunctionRedefinition)
-CARBON_DIAGNOSTIC_KIND(FunctionDefiningExtern)
-CARBON_DIAGNOSTIC_KIND(FunctionPreviousExternDecl)
 CARBON_DIAGNOSTIC_KIND(FunctionRedeclParamCountDiffers)
 CARBON_DIAGNOSTIC_KIND(FunctionRedeclParamCountPrevious)
 CARBON_DIAGNOSTIC_KIND(FunctionRedeclParamDiffers)
@@ -181,7 +184,6 @@ CARBON_DIAGNOSTIC_KIND(InvalidMainRunSignature)
 CARBON_DIAGNOSTIC_KIND(MissingReturnStatement)
 CARBON_DIAGNOSTIC_KIND(UnknownBuiltinFunctionName)
 CARBON_DIAGNOSTIC_KIND(InvalidBuiltinSignature)
-CARBON_DIAGNOSTIC_KIND(FunctionExternMismatch)
 
 // Class checking.
 CARBON_DIAGNOSTIC_KIND(AdaptWithBase)

--- a/toolchain/diagnostics/diagnostic_kind.def
+++ b/toolchain/diagnostics/diagnostic_kind.def
@@ -157,8 +157,6 @@ CARBON_DIAGNOSTIC_KIND(RedeclRedundant)
 CARBON_DIAGNOSTIC_KIND(RedeclNonExtern)
 CARBON_DIAGNOSTIC_KIND(RedeclPrevDef)
 CARBON_DIAGNOSTIC_KIND(RedeclRedef)
-CARBON_DIAGNOSTIC_KIND(RedeclDefiningExtern)
-CARBON_DIAGNOSTIC_KIND(RedeclPrevExternDecl)
 CARBON_DIAGNOSTIC_KIND(RedeclExternMismatch)
 
 // Function call checking.


### PR DESCRIPTION
I'm poking at adding similar validation for `class` merging; this refactors support so that it can easily be shared.