### PR TITLE
Add a minimal SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+# Security policy
+
+# Reporting a vulnerability
+
+Please use
+<https://github.com/carbon-language/carbon-lang/security/advisories/new> to
+report security vulnerabilities.
+
+We use GitHub's vulnerability reporting for intake. We will respond to reports
+within two weeks. For valid issues we will coordinate and disclose on GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Security policy
 
+The Carbon Language is still an
+[experimental project](/README.md#project-status), so please be careful if using
+it in environments with security concerns.
+
 # Reporting a vulnerability
 
 Please use

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Security policy
 
+It's important to us that the Carbon Language provides a secure implementation.
+Thank you for taking the time to report vulnerabilities.
+
 The Carbon Language is still an
 [experimental project](/README.md#project-status), so please be careful if using
-it in environments with security concerns.
+it in security-sensitive environments.
 
 # Reporting a vulnerability
 
@@ -18,3 +21,15 @@ report security vulnerabilities.
 
 We use GitHub's vulnerability reporting for intake. We will respond to reports
 within two weeks. For valid issues we will coordinate and disclose on GitHub.
+
+If you haven't received a response, a couple steps to take are (in order):
+
+1.  Contact individuals directly:
+    -   [Chandler Carruth](mailto:chandlerc@gmail.com)
+    -   [Richard Smith](mailto:richard@metafoo.co.uk)
+    -   [Jon Ross-Perkins](mailto:jperkins@google.com)
+2.  Reach out on
+    [#infra](https://discord.com/channels/655572317891461132/707150492370862090)
+    on Discord ([invite](https://discord.gg/ZjVdShJDAs))
+    -   This is a public forum, so say you're asking for a security contact
+        rather than talking about the security issue directly.


### PR DESCRIPTION
Also mentioned on DIscord [here](https://discord.com/channels/655572317891461132/707150492370862090/1229512261832409238) for context.

The template may seen be people with commit access at https://github.com/carbon-language/carbon-lang/security/policy, by clicking "Start setup". We don't have any releases so I'm eliding support information there.

This stems from the security policy advice at [OSSF](https://github.com/ossf/scorecard/blob/b118c1950f34e9d89237c1c6e69d273a192c490c/docs/checks.md#security-policy).  It's common enough for these to be minimal ([step-security](https://github.com/step-security/harden-runner/security) is just an email address). I considered setting up a security list for Carbon, but not sure we need it at the moment; it seems slightly duplicative of the reporting which was previously enabled.