### PR TITLE
Rename functions which only print a diagnostic to Diagnose*

### DIFF
--- a/toolchain/check/handle_modifier.cpp
+++ b/toolchain/check/handle_modifier.cpp
@@ -11,8 +11,8 @@ namespace Carbon::Check {
 CARBON_DIAGNOSTIC(ModifierPrevious, Note, "`{0}` previously appeared here.",
                   Lex::TokenKind);
 
-static auto EmitRepeatedDiagnostic(Context& context, Parse::NodeId first_node,
-                                   Parse::NodeId second_node) -> void {
+static auto DiagnoseRepeated(Context& context, Parse::NodeId first_node,
+                             Parse::NodeId second_node) -> void {
   CARBON_DIAGNOSTIC(ModifierRepeated, Error, "`{0}` repeated on declaration.",
                     Lex::TokenKind);
   context.emitter()
@@ -21,9 +21,8 @@ static auto EmitRepeatedDiagnostic(Context& context, Parse::NodeId first_node,
       .Emit();
 }
 
-static auto EmitNotAllowedWithDiagnostic(Context& context,
-                                         Parse::NodeId first_node,
-                                         Parse::NodeId second_node) -> void {
+static auto DiagnoseNotAllowedWith(Context& context, Parse::NodeId first_node,
+                                   Parse::NodeId second_node) -> void {
   CARBON_DIAGNOSTIC(ModifierNotAllowedWith, Error,
                     "`{0}` not allowed on declaration with `{1}`.",
                     Lex::TokenKind, Lex::TokenKind);
@@ -53,9 +52,9 @@ static auto HandleModifier(Context& context, Parse::NodeId node_id,
 
   auto current_modifier_node_id = s.modifier_node_id(order);
   if (!!(s.modifier_set & keyword)) {
-    EmitRepeatedDiagnostic(context, current_modifier_node_id, node_id);
+    DiagnoseRepeated(context, current_modifier_node_id, node_id);
   } else if (current_modifier_node_id.is_valid()) {
-    EmitNotAllowedWithDiagnostic(context, current_modifier_node_id, node_id);
+    DiagnoseNotAllowedWith(context, current_modifier_node_id, node_id);
   } else if (auto later_modifier_set = s.modifier_set & later_modifiers;
              !!later_modifier_set) {
     // At least one later modifier is present. Diagnose using the closest.

--- a/toolchain/check/modifiers.cpp
+++ b/toolchain/check/modifiers.cpp
@@ -8,10 +8,10 @@
 
 namespace Carbon::Check {
 
-static auto ReportNotAllowed(Context& context, Parse::NodeId modifier_node,
-                             Lex::TokenKind decl_kind,
-                             llvm::StringRef context_string,
-                             SemIR::LocId context_loc_id) -> void {
+static auto DiagnoseNotAllowed(Context& context, Parse::NodeId modifier_node,
+                               Lex::TokenKind decl_kind,
+                               llvm::StringRef context_string,
+                               SemIR::LocId context_loc_id) -> void {
   CARBON_DIAGNOSTIC(ModifierNotAllowedOn, Error,
                     "`{0}` not allowed on `{1}` declaration{2}.",
                     Lex::TokenKind, Lex::TokenKind, std::string);
@@ -52,8 +52,8 @@ auto ForbidModifiersOnDecl(Context& context, KeywordModifierSet forbidden,
        order_index <= static_cast<int8_t>(ModifierOrder::Last); ++order_index) {
     auto order = static_cast<ModifierOrder>(order_index);
     if (!!(not_allowed & ModifierOrderAsSet(order))) {
-      ReportNotAllowed(context, s.modifier_node_id(order), decl_kind,
-                       context_string, context_loc_id);
+      DiagnoseNotAllowed(context, s.modifier_node_id(order), decl_kind,
+                         context_string, context_loc_id);
       s.set_modifier_node_id(order, Parse::NodeId::Invalid);
     }
   }

--- a/toolchain/parse/context.cpp
+++ b/toolchain/parse/context.cpp
@@ -412,13 +412,13 @@ auto Context::RecoverFromDeclError(StateStackEntry state, NodeKind node_kind,
           /*has_error=*/true);
 }
 
-auto Context::EmitExpectedDeclSemi(Lex::TokenKind expected_kind) -> void {
+auto Context::DiagnoseExpectedDeclSemi(Lex::TokenKind expected_kind) -> void {
   CARBON_DIAGNOSTIC(ExpectedDeclSemi, Error,
                     "`{0}` declarations must end with a `;`.", Lex::TokenKind);
   emitter().Emit(*position(), ExpectedDeclSemi, expected_kind);
 }
 
-auto Context::EmitExpectedDeclSemiOrDefinition(Lex::TokenKind expected_kind)
+auto Context::DiagnoseExpectedDeclSemiOrDefinition(Lex::TokenKind expected_kind)
     -> void {
   CARBON_DIAGNOSTIC(ExpectedDeclSemiOrDefinition, Error,
                     "`{0}` declarations must either end with a `;` or "

--- a/toolchain/parse/context.h
+++ b/toolchain/parse/context.h
@@ -282,10 +282,11 @@ class Context {
   auto ReturnErrorOnState() -> void { state_stack_.back().has_error = true; }
 
   // Emits a diagnostic for a declaration missing a semi.
-  auto EmitExpectedDeclSemi(Lex::TokenKind expected_kind) -> void;
+  auto DiagnoseExpectedDeclSemi(Lex::TokenKind expected_kind) -> void;
 
   // Emits a diagnostic for a declaration missing a semi or definition.
-  auto EmitExpectedDeclSemiOrDefinition(Lex::TokenKind expected_kind) -> void;
+  auto DiagnoseExpectedDeclSemiOrDefinition(Lex::TokenKind expected_kind)
+      -> void;
 
   // Handles error recovery in a declaration, particularly before any possible
   // definition has started (although one could be present). Recover to a

--- a/toolchain/parse/handle_adapt.cpp
+++ b/toolchain/parse/handle_adapt.cpp
@@ -15,7 +15,7 @@ auto HandleAdaptDecl(Context& context) -> void {
 
   auto semi = context.ConsumeIf(Lex::TokenKind::Semi);
   if (!semi && !state.has_error) {
-    context.EmitExpectedDeclSemi(context.tokens().GetKind(state.token));
+    context.DiagnoseExpectedDeclSemi(context.tokens().GetKind(state.token));
     state.has_error = true;
   }
 

--- a/toolchain/parse/handle_alias.cpp
+++ b/toolchain/parse/handle_alias.cpp
@@ -52,7 +52,7 @@ auto HandleAliasFinish(Context& context) -> void {
     context.AddNode(NodeKind::Alias, *semi, state.subtree_start,
                     state.has_error);
   } else {
-    context.EmitExpectedDeclSemi(Lex::TokenKind::Alias);
+    context.DiagnoseExpectedDeclSemi(Lex::TokenKind::Alias);
     context.RecoverFromDeclError(state, NodeKind::Alias,
                                  /*skip_past_likely_end=*/true);
   }

--- a/toolchain/parse/handle_base.cpp
+++ b/toolchain/parse/handle_base.cpp
@@ -12,7 +12,7 @@ auto HandleBaseDecl(Context& context) -> void {
 
   auto semi = context.ConsumeIf(Lex::TokenKind::Semi);
   if (!semi && !state.has_error) {
-    context.EmitExpectedDeclSemi(context.tokens().GetKind(state.token));
+    context.DiagnoseExpectedDeclSemi(context.tokens().GetKind(state.token));
     state.has_error = true;
   }
 

--- a/toolchain/parse/handle_decl_definition.cpp
+++ b/toolchain/parse/handle_decl_definition.cpp
@@ -25,7 +25,7 @@ static auto HandleDeclOrDefinition(Context& context, NodeKind decl_kind,
   }
 
   if (!context.PositionIs(Lex::TokenKind::OpenCurlyBrace)) {
-    context.EmitExpectedDeclSemiOrDefinition(
+    context.DiagnoseExpectedDeclSemiOrDefinition(
         context.tokens().GetKind(state.token));
     context.RecoverFromDeclError(state, decl_kind,
                                  /*skip_past_likely_end=*/true);

--- a/toolchain/parse/handle_function.cpp
+++ b/toolchain/parse/handle_function.cpp
@@ -64,7 +64,7 @@ auto HandleFunctionSignatureFinish(Context& context) -> void {
       }
       auto semi = context.ConsumeIf(Lex::TokenKind::Semi);
       if (!semi && !state.has_error) {
-        context.EmitExpectedDeclSemi(context.tokens().GetKind(state.token));
+        context.DiagnoseExpectedDeclSemi(context.tokens().GetKind(state.token));
         state.has_error = true;
       }
       if (state.has_error) {
@@ -78,7 +78,7 @@ auto HandleFunctionSignatureFinish(Context& context) -> void {
     }
     default: {
       if (!state.has_error) {
-        context.EmitExpectedDeclSemiOrDefinition(Lex::TokenKind::Fn);
+        context.DiagnoseExpectedDeclSemiOrDefinition(Lex::TokenKind::Fn);
       }
       // Only need to skip if we've not already found a new line.
       bool skip_past_likely_end =

--- a/toolchain/parse/handle_import_and_package.cpp
+++ b/toolchain/parse/handle_import_and_package.cpp
@@ -152,7 +152,7 @@ static auto HandleDirectiveContent(Context& context,
 
     context.AddNode(directive, *semi, state.subtree_start, state.has_error);
   } else {
-    context.EmitExpectedDeclSemi(context.tokens().GetKind(state.token));
+    context.DiagnoseExpectedDeclSemi(context.tokens().GetKind(state.token));
     on_parse_error();
   }
 }

--- a/toolchain/parse/handle_let.cpp
+++ b/toolchain/parse/handle_let.cpp
@@ -40,7 +40,7 @@ auto HandleLetFinish(Context& context) -> void {
   if (context.PositionIs(Lex::TokenKind::Semi)) {
     end_token = context.Consume();
   } else {
-    context.EmitExpectedDeclSemi(Lex::TokenKind::Let);
+    context.DiagnoseExpectedDeclSemi(Lex::TokenKind::Let);
     state.has_error = true;
     end_token = context.SkipPastLikelyEnd(state.token);
   }

--- a/toolchain/parse/handle_namespace.cpp
+++ b/toolchain/parse/handle_namespace.cpp
@@ -25,7 +25,7 @@ auto HandleNamespaceFinish(Context& context) -> void {
     context.AddNode(NodeKind::Namespace, *semi, state.subtree_start,
                     state.has_error);
   } else {
-    context.EmitExpectedDeclSemi(Lex::TokenKind::Namespace);
+    context.DiagnoseExpectedDeclSemi(Lex::TokenKind::Namespace);
     context.RecoverFromDeclError(state, NodeKind::Namespace,
                                  /*skip_past_likely_end=*/true);
   }

--- a/toolchain/parse/handle_var.cpp
+++ b/toolchain/parse/handle_var.cpp
@@ -80,7 +80,7 @@ auto HandleVarFinishAsDecl(Context& context) -> void {
     end_token = context.Consume();
   } else {
     // TODO: Disambiguate between statement and member declaration.
-    context.EmitExpectedDeclSemi(Lex::TokenKind::Var);
+    context.DiagnoseExpectedDeclSemi(Lex::TokenKind::Var);
     state.has_error = true;
     end_token = context.SkipPastLikelyEnd(state.token);
   }


### PR DESCRIPTION
This is something I noticed working on https://github.com/carbon-language/carbon-lang/pull/3884; I think we have more functions named Diagnose* at present than Emit* or Report*, so just trying to consolidate. Note a couple Diagnose* functions do a little more validation, but maybe those should actually be renamed away (zygoloid had mentioned wanting to generally split out diagnostics to their own function, and then we'd have it be a more common pattern).