### PR TITLE
Fix location of `converted` inst for explicit `as` conversion.

### DIFF
--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -923,8 +923,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
   // Track that we performed a type conversion, if we did so.
   if (orig_expr_id != expr_id) {
     expr_id = context.AddInst(
-        {context.insts().GetLocId(orig_expr_id),
-         SemIR::Converted{target.type_id, orig_expr_id, expr_id}});
+        {loc_id, SemIR::Converted{target.type_id, orig_expr_id, expr_id}});
   }
 
   // For `as`, don't perform any value category conversions. In particular, an

--- a/toolchain/check/testdata/alias/alias_of_alias.carbon
+++ b/toolchain/check/testdata/alias/alias_of_alias.carbon
@@ -45,9 +45,9 @@ let d: c = {.v = 0};
 // CHECK:STDOUT:   %.loc11_19.4: init i32 = initialize_from %.loc11_18 to %.loc11_19.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_19.5: init C = class_init (%.loc11_19.4), %.loc11_19.2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc11_19.6: ref C = temporary %.loc11_19.2, %.loc11_19.5
-// CHECK:STDOUT:   %.loc11_19.7: ref C = converted %.loc11_19.1, %.loc11_19.6
-// CHECK:STDOUT:   %.loc11_19.8: C = bind_value %.loc11_19.7
-// CHECK:STDOUT:   %d: C = bind_name d, %.loc11_19.8
+// CHECK:STDOUT:   %.loc11_20.1: ref C = converted %.loc11_19.1, %.loc11_19.6
+// CHECK:STDOUT:   %.loc11_20.2: C = bind_value %.loc11_20.1
+// CHECK:STDOUT:   %d: C = bind_name d, %.loc11_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C {

--- a/toolchain/check/testdata/alias/import_order.carbon
+++ b/toolchain/check/testdata/alias/import_order.carbon
@@ -123,8 +123,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc7_23.2: ref i32 = class_element_access file.%d_val.var, element0
 // CHECK:STDOUT:   %.loc7_23.3: init i32 = initialize_from %.loc7_22 to %.loc7_23.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_23.4: init C = class_init (%.loc7_23.3), file.%d_val.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_23.5: init C = converted %.loc7_23.1, %.loc7_23.4 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%d_val.var, %.loc7_23.5
+// CHECK:STDOUT:   %.loc7_24: init C = converted %.loc7_23.1, %.loc7_23.4 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%d_val.var, %.loc7_24
 // CHECK:STDOUT:   %d_val.ref: ref C = name_ref d_val, file.%d_val
 // CHECK:STDOUT:   %v.ref.loc8: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_27.1: ref i32 = class_element_access %d_val.ref, element0
@@ -133,8 +133,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc8_29.2: ref i32 = class_element_access file.%c_val.var, element0
 // CHECK:STDOUT:   %.loc8_29.3: init i32 = initialize_from %.loc8_27.2 to %.loc8_29.2
 // CHECK:STDOUT:   %.loc8_29.4: init C = class_init (%.loc8_29.3), file.%c_val.var
-// CHECK:STDOUT:   %.loc8_29.5: init C = converted %.loc8_29.1, %.loc8_29.4
-// CHECK:STDOUT:   assign file.%c_val.var, %.loc8_29.5
+// CHECK:STDOUT:   %.loc8_30: init C = converted %.loc8_29.1, %.loc8_29.4
+// CHECK:STDOUT:   assign file.%c_val.var, %.loc8_30
 // CHECK:STDOUT:   %c_val.ref: ref C = name_ref c_val, file.%c_val
 // CHECK:STDOUT:   %v.ref.loc9: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc9_27.1: ref i32 = class_element_access %c_val.ref, element0
@@ -143,8 +143,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc9_29.2: ref i32 = class_element_access file.%b_val.var, element0
 // CHECK:STDOUT:   %.loc9_29.3: init i32 = initialize_from %.loc9_27.2 to %.loc9_29.2
 // CHECK:STDOUT:   %.loc9_29.4: init C = class_init (%.loc9_29.3), file.%b_val.var
-// CHECK:STDOUT:   %.loc9_29.5: init C = converted %.loc9_29.1, %.loc9_29.4
-// CHECK:STDOUT:   assign file.%b_val.var, %.loc9_29.5
+// CHECK:STDOUT:   %.loc9_30: init C = converted %.loc9_29.1, %.loc9_29.4
+// CHECK:STDOUT:   assign file.%b_val.var, %.loc9_30
 // CHECK:STDOUT:   %b_val.ref: ref C = name_ref b_val, file.%b_val
 // CHECK:STDOUT:   %v.ref.loc10: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_27.1: ref i32 = class_element_access %b_val.ref, element0
@@ -153,8 +153,8 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc10_29.2: ref i32 = class_element_access file.%a_val.var, element0
 // CHECK:STDOUT:   %.loc10_29.3: init i32 = initialize_from %.loc10_27.2 to %.loc10_29.2
 // CHECK:STDOUT:   %.loc10_29.4: init C = class_init (%.loc10_29.3), file.%a_val.var
-// CHECK:STDOUT:   %.loc10_29.5: init C = converted %.loc10_29.1, %.loc10_29.4
-// CHECK:STDOUT:   assign file.%a_val.var, %.loc10_29.5
+// CHECK:STDOUT:   %.loc10_30: init C = converted %.loc10_29.1, %.loc10_29.4
+// CHECK:STDOUT:   assign file.%a_val.var, %.loc10_30
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/alias/in_namespace.carbon
+++ b/toolchain/check/testdata/alias/in_namespace.carbon
@@ -49,9 +49,9 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   %.loc12_22.4: init i32 = initialize_from %.loc12_21 to %.loc12_22.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc12_22.5: init C = class_init (%.loc12_22.4), %.loc12_22.2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_22.6: ref C = temporary %.loc12_22.2, %.loc12_22.5
-// CHECK:STDOUT:   %.loc12_22.7: ref C = converted %.loc12_22.1, %.loc12_22.6
-// CHECK:STDOUT:   %.loc12_22.8: C = bind_value %.loc12_22.7
-// CHECK:STDOUT:   %b: C = bind_name b, %.loc12_22.8
+// CHECK:STDOUT:   %.loc12_23.1: ref C = converted %.loc12_22.1, %.loc12_22.6
+// CHECK:STDOUT:   %.loc12_23.2: C = bind_value %.loc12_23.1
+// CHECK:STDOUT:   %b: C = bind_name b, %.loc12_23.2
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %NS.ref.loc14: <namespace> = name_ref NS, %NS [template = %NS]
 // CHECK:STDOUT:     %a.ref.loc14: type = name_ref a, %a [template = constants.%C]
@@ -74,7 +74,7 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   %.loc15_17.2: ref i32 = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc15_17.3: init i32 = initialize_from %.loc15_16 to %.loc15_17.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc15_17.4: init C = class_init (%.loc15_17.3), %return [template = constants.%.5]
-// CHECK:STDOUT:   %.loc15_17.5: init C = converted %.loc15_17.1, %.loc15_17.4 [template = constants.%.5]
-// CHECK:STDOUT:   return %.loc15_17.5
+// CHECK:STDOUT:   %.loc15_18: init C = converted %.loc15_17.1, %.loc15_17.4 [template = constants.%.5]
+// CHECK:STDOUT:   return %.loc15_18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/array_in_place.carbon
+++ b/toolchain/check/testdata/array/array_in_place.carbon
@@ -63,8 +63,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_40: init (i32, i32, i32) = call %F.ref.loc10_39() to %.loc10_42.6
 // CHECK:STDOUT:   %.loc10_42.7: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_35, %.loc10_40)
 // CHECK:STDOUT:   %.loc10_42.8: init [(i32, i32, i32); 2] = array_init (%.loc10_35, %.loc10_40) to %v.var
-// CHECK:STDOUT:   %.loc10_42.9: init [(i32, i32, i32); 2] = converted %.loc10_42.7, %.loc10_42.8
-// CHECK:STDOUT:   assign %v.var, %.loc10_42.9
+// CHECK:STDOUT:   %.loc10_43: init [(i32, i32, i32); 2] = converted %.loc10_42.7, %.loc10_42.8
+// CHECK:STDOUT:   assign %v.var, %.loc10_43
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/array_vs_tuple.carbon
+++ b/toolchain/check/testdata/array/array_vs_tuple.carbon
@@ -55,8 +55,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc9_29.9: ref i32 = array_index %a.var, %.loc9_29.8
 // CHECK:STDOUT:   %.loc9_29.10: init i32 = initialize_from %.loc9_28 to %.loc9_29.9 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_29.11: init [i32; 3] = array_init (%.loc9_29.4, %.loc9_29.7, %.loc9_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_29.12: init [i32; 3] = converted %.loc9_29.1, %.loc9_29.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign %a.var, %.loc9_29.12
+// CHECK:STDOUT:   %.loc9_30: init [i32; 3] = converted %.loc9_29.1, %.loc9_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign %a.var, %.loc9_30
 // CHECK:STDOUT:   %.loc10_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_24.2: type = converted %.loc10_24.1, constants.%.6 [template = constants.%.6]
 // CHECK:STDOUT:   %b.var: ref (i32, i32, i32) = var b
@@ -72,8 +72,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_36.6: ref i32 = tuple_access %b.var, element2
 // CHECK:STDOUT:   %.loc10_36.7: init i32 = initialize_from %.loc10_35 to %.loc10_36.6 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_36.8: init (i32, i32, i32) = tuple_init (%.loc10_36.3, %.loc10_36.5, %.loc10_36.7) to %b.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc10_36.9: init (i32, i32, i32) = converted %.loc10_36.1, %.loc10_36.8 [template = constants.%.11]
-// CHECK:STDOUT:   assign %b.var, %.loc10_36.9
+// CHECK:STDOUT:   %.loc10_37: init (i32, i32, i32) = converted %.loc10_36.1, %.loc10_36.8 [template = constants.%.11]
+// CHECK:STDOUT:   assign %b.var, %.loc10_37
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -42,8 +42,8 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
 // CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
-// CHECK:STDOUT:   return %.loc7_30.3
+// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
+// CHECK:STDOUT:   return %.loc7_31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -62,8 +62,8 @@ fn Run() {
 // CHECK:STDOUT:   %.loc10_22.7: ref i32 = array_index %t.var, %.loc10_22.6
 // CHECK:STDOUT:   %.loc10_22.8: init i32 = initialize_from %.loc10_22.5 to %.loc10_22.7
 // CHECK:STDOUT:   %.loc10_22.9: init [i32; 1] = array_init (%.loc10_22.8) to %t.var
-// CHECK:STDOUT:   %.loc10_22.10: init [i32; 1] = converted %.loc10_22.1, %.loc10_22.9
-// CHECK:STDOUT:   assign %t.var, %.loc10_22.10
+// CHECK:STDOUT:   %.loc10_24: init [i32; 1] = converted %.loc10_22.1, %.loc10_22.9
+// CHECK:STDOUT:   assign %t.var, %.loc10_24
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -52,8 +52,8 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc7_34.6: ref i32 = tuple_access file.%a.var, element2
 // CHECK:STDOUT:   %.loc7_34.7: init i32 = initialize_from %.loc7_33 to %.loc7_34.6 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_34.9: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8 [template = constants.%.7]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_34.9
+// CHECK:STDOUT:   %.loc7_35: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8 [template = constants.%.7]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_35
 // CHECK:STDOUT:   %a.ref: ref (i32, i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_19.1: ref i32 = tuple_access %a.ref, element0
 // CHECK:STDOUT:   %.loc8_19.2: i32 = bind_value %.loc8_19.1
@@ -71,8 +71,8 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc8_19.14: ref i32 = array_index file.%b.var, %.loc8_19.13
 // CHECK:STDOUT:   %.loc8_19.15: init i32 = initialize_from %.loc8_19.12 to %.loc8_19.14
 // CHECK:STDOUT:   %.loc8_19.16: init [i32; 3] = array_init (%.loc8_19.5, %.loc8_19.10, %.loc8_19.15) to file.%b.var
-// CHECK:STDOUT:   %.loc8_19.17: init [i32; 3] = converted %a.ref, %.loc8_19.16
-// CHECK:STDOUT:   assign file.%b.var, %.loc8_19.17
+// CHECK:STDOUT:   %.loc8_20: init [i32; 3] = converted %a.ref, %.loc8_19.16
+// CHECK:STDOUT:   assign file.%b.var, %.loc8_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -67,8 +67,8 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc7_22.3: ref i32 = array_index file.%a.var, %.loc7_22.2
 // CHECK:STDOUT:   %.loc7_22.4: init i32 = initialize_from %.loc7_20 to %.loc7_22.3 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init (%.loc7_22.4) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_22.6: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_22.6
+// CHECK:STDOUT:   %.loc7_23: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_23
 // CHECK:STDOUT:   %.loc8_20: f64 = real_literal 111e-1 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc8_26: f64 = real_literal 22e-1 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc8_30.1: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
@@ -79,8 +79,8 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc8_30.6: ref f64 = array_index file.%b.var, %.loc8_30.5
 // CHECK:STDOUT:   %.loc8_30.7: init f64 = initialize_from %.loc8_26 to %.loc8_30.6 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init (%.loc8_30.4, %.loc8_30.7) to file.%b.var [template = constants.%.13]
-// CHECK:STDOUT:   %.loc8_30.9: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8 [template = constants.%.13]
-// CHECK:STDOUT:   assign file.%b.var, %.loc8_30.9
+// CHECK:STDOUT:   %.loc8_31: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8 [template = constants.%.13]
+// CHECK:STDOUT:   assign file.%b.var, %.loc8_31
 // CHECK:STDOUT:   %.loc9_20.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_24.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_28.1: () = tuple_literal ()
@@ -90,26 +90,26 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc9_38.2: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_38.3: ref () = array_index file.%c.var, %.loc9_38.2
 // CHECK:STDOUT:   %.loc9_20.2: init () = tuple_init () to %.loc9_38.3 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_20.3: init () = converted %.loc9_20.1, %.loc9_20.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.4: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_38.5: ref () = array_index file.%c.var, %.loc9_38.4
-// CHECK:STDOUT:   %.loc9_24.2: init () = tuple_init () to %.loc9_38.5 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_24.3: init () = converted %.loc9_24.1, %.loc9_24.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.6: i32 = int_literal 2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_38.7: ref () = array_index file.%c.var, %.loc9_38.6
-// CHECK:STDOUT:   %.loc9_28.2: init () = tuple_init () to %.loc9_38.7 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_28.3: init () = converted %.loc9_28.1, %.loc9_28.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.8: i32 = int_literal 3 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc9_38.4: init () = converted %.loc9_20.1, %.loc9_20.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.5: i32 = int_literal 1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc9_38.6: ref () = array_index file.%c.var, %.loc9_38.5
+// CHECK:STDOUT:   %.loc9_24.2: init () = tuple_init () to %.loc9_38.6 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.7: init () = converted %.loc9_24.1, %.loc9_24.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.8: i32 = int_literal 2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc9_38.9: ref () = array_index file.%c.var, %.loc9_38.8
-// CHECK:STDOUT:   %.loc9_32.2: init () = tuple_init () to %.loc9_38.9 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_32.3: init () = converted %.loc9_32.1, %.loc9_32.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.10: i32 = int_literal 4 [template = constants.%.21]
-// CHECK:STDOUT:   %.loc9_38.11: ref () = array_index file.%c.var, %.loc9_38.10
-// CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init () to %.loc9_38.11 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_36.3: init () = converted %.loc9_36.1, %.loc9_36.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.12: init [(); 5] = array_init (%.loc9_20.3, %.loc9_24.3, %.loc9_28.3, %.loc9_32.3, %.loc9_36.3) to file.%c.var [template = constants.%.22]
-// CHECK:STDOUT:   %.loc9_38.13: init [(); 5] = converted %.loc9_38.1, %.loc9_38.12 [template = constants.%.22]
-// CHECK:STDOUT:   assign file.%c.var, %.loc9_38.13
+// CHECK:STDOUT:   %.loc9_28.2: init () = tuple_init () to %.loc9_38.9 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.10: init () = converted %.loc9_28.1, %.loc9_28.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.11: i32 = int_literal 3 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc9_38.12: ref () = array_index file.%c.var, %.loc9_38.11
+// CHECK:STDOUT:   %.loc9_32.2: init () = tuple_init () to %.loc9_38.12 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.13: init () = converted %.loc9_32.1, %.loc9_32.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.14: i32 = int_literal 4 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc9_38.15: ref () = array_index file.%c.var, %.loc9_38.14
+// CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init () to %.loc9_38.15 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.16: init () = converted %.loc9_36.1, %.loc9_36.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_38.17: init [(); 5] = array_init (%.loc9_38.4, %.loc9_38.7, %.loc9_38.10, %.loc9_38.13, %.loc9_38.16) to file.%c.var [template = constants.%.22]
+// CHECK:STDOUT:   %.loc9_39: init [(); 5] = converted %.loc9_38.1, %.loc9_38.17 [template = constants.%.22]
+// CHECK:STDOUT:   assign file.%c.var, %.loc9_39
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/canonicalize_index.carbon
+++ b/toolchain/check/testdata/array/canonicalize_index.carbon
@@ -69,8 +69,8 @@ let b: [i32; 3]* = &a;
 // CHECK:STDOUT:   %.loc9_35.9: ref i32 = array_index file.%a.var, %.loc9_35.8
 // CHECK:STDOUT:   %.loc9_35.10: init i32 = initialize_from %.loc9_34 to %.loc9_35.9 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc9_35.11: init [i32; 3] = array_init (%.loc9_35.4, %.loc9_35.7, %.loc9_35.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_35.12: init [i32; 3] = converted %.loc9_35.1, %.loc9_35.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign file.%a.var, %.loc9_35.12
+// CHECK:STDOUT:   %.loc9_36: init [i32; 3] = converted %.loc9_35.1, %.loc9_35.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign file.%a.var, %.loc9_36
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/fail_out_of_bound_non_literal.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound_non_literal.carbon
@@ -56,8 +56,8 @@ var b: i32 = a[{.index = 3}.index];
 // CHECK:STDOUT:   %.loc7_27.9: ref i32 = array_index file.%a.var, %.loc7_27.8
 // CHECK:STDOUT:   %.loc7_27.10: init i32 = initialize_from %.loc7_26 to %.loc7_27.9 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_27.12: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.12
+// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_26: i32 = int_literal 3 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_27.1: {.index: i32} = struct_literal (%.loc11_26)

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -75,12 +75,12 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc12_20.10: ref i32 = array_index %.loc12_20.2, %.loc12_20.9
 // CHECK:STDOUT:   %.loc12_20.11: init i32 = initialize_from %.loc12_19 to %.loc12_20.10 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc12_20.12: init [i32; 3] = array_init (%.loc12_20.5, %.loc12_20.8, %.loc12_20.11) to %.loc12_20.2 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_20.13: init [i32; 3] = converted %.loc12_20.1, %.loc12_20.12 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_20.14: ref [i32; 3] = temporary %.loc12_20.2, %.loc12_20.13
-// CHECK:STDOUT:   %.loc12_20.15: [i32; 3] = bind_value %.loc12_20.14
-// CHECK:STDOUT:   %.loc12_11.1: init i32 = call %F.ref(%.loc12_20.15, %.loc12_23)
-// CHECK:STDOUT:   %.loc12_25: i32 = value_of_initializer %.loc12_11.1
-// CHECK:STDOUT:   %.loc12_11.2: i32 = converted %.loc12_11.1, %.loc12_25
-// CHECK:STDOUT:   return %.loc12_11.2
+// CHECK:STDOUT:   %.loc12_11.1: init [i32; 3] = converted %.loc12_20.1, %.loc12_20.12 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc12_11.2: ref [i32; 3] = temporary %.loc12_20.2, %.loc12_11.1
+// CHECK:STDOUT:   %.loc12_11.3: [i32; 3] = bind_value %.loc12_11.2
+// CHECK:STDOUT:   %.loc12_11.4: init i32 = call %F.ref(%.loc12_11.3, %.loc12_23)
+// CHECK:STDOUT:   %.loc12_25.1: i32 = value_of_initializer %.loc12_11.4
+// CHECK:STDOUT:   %.loc12_25.2: i32 = converted %.loc12_11.4, %.loc12_25.1
+// CHECK:STDOUT:   return %.loc12_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/index_not_literal.carbon
+++ b/toolchain/check/testdata/array/index_not_literal.carbon
@@ -53,8 +53,8 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.loc7_27.9: ref i32 = array_index file.%a.var, %.loc7_27.8
 // CHECK:STDOUT:   %.loc7_27.10: init i32 = initialize_from %.loc7_26 to %.loc7_27.9 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_27.12: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.12
+// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_26: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc8_27.1: {.index: i32} = struct_literal (%.loc8_26)

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -77,8 +77,8 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.loc7_45.27: ref i32 = array_index file.%a.var, %.loc7_45.26
 // CHECK:STDOUT:   %.loc7_45.28: init i32 = initialize_from %.loc7_44 to %.loc7_45.27 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_45.29: init [i32; 9] = array_init (%.loc7_45.4, %.loc7_45.7, %.loc7_45.10, %.loc7_45.13, %.loc7_45.16, %.loc7_45.19, %.loc7_45.22, %.loc7_45.25, %.loc7_45.28) to file.%a.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc7_45.30: init [i32; 9] = converted %.loc7_45.1, %.loc7_45.29 [template = constants.%.14]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_45.30
+// CHECK:STDOUT:   %.loc7_46: init [i32; 9] = converted %.loc7_45.1, %.loc7_45.29 [template = constants.%.14]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_46
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/as_type.carbon
+++ b/toolchain/check/testdata/as/as_type.carbon
@@ -18,8 +18,8 @@ let t: type = (i32, i32) as type;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc7_24.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_24.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_24.2
+// CHECK:STDOUT:   %.loc7_24: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_26: type = converted %.loc7_24, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %t: type = bind_name t, %.loc7_26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/as/tuple.carbon
+++ b/toolchain/check/testdata/as/tuple.carbon
@@ -80,8 +80,8 @@ fn Var() {
 // CHECK:STDOUT:   %.loc15_32.3: ref X = temporary %.loc15_32.1, %.loc15_32.2
 // CHECK:STDOUT:   %.loc15_32.4: X = bind_value %.loc15_32.3
 // CHECK:STDOUT:   %.loc15_34.2: (X, X) = tuple_value (%.loc15_24.4, %.loc15_32.4)
-// CHECK:STDOUT:   %.loc15_34.3: (X, X) = converted %.loc15_34.1, %.loc15_34.2
-// CHECK:STDOUT:   %a: (X, X) = bind_name a, %.loc15_34.3
+// CHECK:STDOUT:   %.loc15_45: (X, X) = converted %.loc15_34.1, %.loc15_34.2
+// CHECK:STDOUT:   %a: (X, X) = bind_name a, %.loc15_45
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -105,8 +105,8 @@ fn Var() {
 // CHECK:STDOUT:   %.loc20_44.1: (type, type) = tuple_literal (%X.ref.loc20_40, %X.ref.loc20_43)
 // CHECK:STDOUT:   %.loc20_44.2: type = converted %.loc20_44.1, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc20_34.4: init (X, X) = tuple_init (%.loc20_24, %.loc20_32) to %b.var
-// CHECK:STDOUT:   %.loc20_34.5: init (X, X) = converted %.loc20_34.3, %.loc20_34.4
-// CHECK:STDOUT:   assign %b.var, %.loc20_34.5
+// CHECK:STDOUT:   %.loc20_45: init (X, X) = converted %.loc20_34.3, %.loc20_34.4
+// CHECK:STDOUT:   assign %b.var, %.loc20_45
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -98,8 +98,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc17_3.18: ref i32 = array_index %ints.var, %.loc17_3.17
 // CHECK:STDOUT:   %.loc17_3.19: init i32 = initialize_from %.loc16 to %.loc17_3.18 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc17_3.20: init [i32; 6] = array_init (%.loc17_3.4, %.loc17_3.7, %.loc17_3.10, %.loc17_3.13, %.loc17_3.16, %.loc17_3.19) to %ints.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc17_3.21: init [i32; 6] = converted %.loc17_3.1, %.loc17_3.20 [template = constants.%.14]
-// CHECK:STDOUT:   assign %ints.var, %.loc17_3.21
+// CHECK:STDOUT:   %.loc17_4: init [i32; 6] = converted %.loc17_3.1, %.loc17_3.20 [template = constants.%.14]
+// CHECK:STDOUT:   assign %ints.var, %.loc17_4
 // CHECK:STDOUT:   %.loc18_21: i32 = int_literal 7 [template = constants.%.15]
 // CHECK:STDOUT:   %.loc18_22: type = array_type %.loc18_21, f64 [template = constants.%.16]
 // CHECK:STDOUT:   %floats.var: ref [f64; 7] = var floats
@@ -134,8 +134,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc26_3.21: ref f64 = array_index %floats.var, %.loc26_3.20
 // CHECK:STDOUT:   %.loc26_3.22: init f64 = initialize_from %.loc25 to %.loc26_3.21 [template = constants.%.24]
 // CHECK:STDOUT:   %.loc26_3.23: init [f64; 7] = array_init (%.loc26_3.4, %.loc26_3.7, %.loc26_3.10, %.loc26_3.13, %.loc26_3.16, %.loc26_3.19, %.loc26_3.22) to %floats.var [template = constants.%.26]
-// CHECK:STDOUT:   %.loc26_3.24: init [f64; 7] = converted %.loc26_3.1, %.loc26_3.23 [template = constants.%.26]
-// CHECK:STDOUT:   assign %floats.var, %.loc26_3.24
+// CHECK:STDOUT:   %.loc26_4: init [f64; 7] = converted %.loc26_3.1, %.loc26_3.23 [template = constants.%.26]
+// CHECK:STDOUT:   assign %floats.var, %.loc26_4
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -167,12 +167,12 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     %.loc11_12.2: type = converted %.loc11_12.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:     %n.loc11_8.1: () = param n
 // CHECK:STDOUT:     @Foo.%n: () = bind_name n, %n.loc11_8.1
-// CHECK:STDOUT:     %.loc11_20.1: () = tuple_literal ()
-// CHECK:STDOUT:     %.loc11_24.1: () = tuple_literal ()
-// CHECK:STDOUT:     %.loc11_25.1: ((), ()) = tuple_literal (%.loc11_20.1, %.loc11_24.1)
-// CHECK:STDOUT:     %.loc11_20.2: type = converted %.loc11_20.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc11_24.2: type = converted %.loc11_24.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc11_25.2: type = converted %.loc11_25.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc11_20: () = tuple_literal ()
+// CHECK:STDOUT:     %.loc11_24: () = tuple_literal ()
+// CHECK:STDOUT:     %.loc11_25.1: ((), ()) = tuple_literal (%.loc11_20, %.loc11_24)
+// CHECK:STDOUT:     %.loc11_25.2: type = converted %.loc11_20, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_25.3: type = converted %.loc11_24, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_25.4: type = converted %.loc11_25.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:     @Foo.%return: ref ((), ()) = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -183,13 +183,13 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.loc12_15.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_16.1: ((), ()) = tuple_literal (%n.ref, %.loc12_15.1)
 // CHECK:STDOUT:   %.loc12_16.2: ref () = tuple_access %return, element0
-// CHECK:STDOUT:   %.loc12_11.1: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_11.2: init () = converted %n.ref, %.loc12_11.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.3: ref () = tuple_access %return, element1
-// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_15.3: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.4: init ((), ()) = tuple_init (%.loc12_11.2, %.loc12_15.3) to %return [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_16.5: init ((), ()) = converted %.loc12_16.1, %.loc12_16.4 [template = constants.%.5]
-// CHECK:STDOUT:   return %.loc12_16.5
+// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.4: ref () = tuple_access %return, element1
+// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%.5]
+// CHECK:STDOUT:   return %.loc12_17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/textual_ir.carbon
@@ -31,12 +31,12 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:     %.loc11_12.2: type = converted %.loc11_12.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:     %n.loc11_8.1: () = param n
 // CHECK:STDOUT:     @Foo.%n: () = bind_name n, %n.loc11_8.1
-// CHECK:STDOUT:     %.loc11_20.1: () = tuple_literal ()
-// CHECK:STDOUT:     %.loc11_24.1: () = tuple_literal ()
-// CHECK:STDOUT:     %.loc11_25.1: ((), ()) = tuple_literal (%.loc11_20.1, %.loc11_24.1)
-// CHECK:STDOUT:     %.loc11_20.2: type = converted %.loc11_20.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc11_24.2: type = converted %.loc11_24.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc11_25.2: type = converted %.loc11_25.1, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc11_20: () = tuple_literal ()
+// CHECK:STDOUT:     %.loc11_24: () = tuple_literal ()
+// CHECK:STDOUT:     %.loc11_25.1: ((), ()) = tuple_literal (%.loc11_20, %.loc11_24)
+// CHECK:STDOUT:     %.loc11_25.2: type = converted %.loc11_20, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_25.3: type = converted %.loc11_24, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc11_25.4: type = converted %.loc11_25.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:     @Foo.%return: ref ((), ()) = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -47,13 +47,13 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.loc12_15.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_16.1: ((), ()) = tuple_literal (%n.ref, %.loc12_15.1)
 // CHECK:STDOUT:   %.loc12_16.2: ref () = tuple_access %return, element0
-// CHECK:STDOUT:   %.loc12_11.1: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_11.2: init () = converted %n.ref, %.loc12_11.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.3: ref () = tuple_access %return, element1
-// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_15.3: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.4: init ((), ()) = tuple_init (%.loc12_11.2, %.loc12_15.3) to %return [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_16.5: init ((), ()) = converted %.loc12_16.1, %.loc12_16.4 [template = constants.%.5]
-// CHECK:STDOUT:   return %.loc12_16.5
+// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.4: ref () = tuple_access %return, element1
+// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%.5]
+// CHECK:STDOUT:   return %.loc12_17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/bool/make_type.carbon
+++ b/toolchain/check/testdata/builtins/bool/make_type.carbon
@@ -48,9 +48,9 @@ var b: Bool() = false;
 // CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+3, loc_11 [template = imports.%Bool]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Bool.ref: <function> = name_ref Bool, %import_ref [template = imports.%Bool]
-// CHECK:STDOUT:   %.loc6_12.1: init type = call %Bool.ref() [template = bool]
-// CHECK:STDOUT:   %.loc6_13: type = value_of_initializer %.loc6_12.1 [template = bool]
-// CHECK:STDOUT:   %.loc6_12.2: type = converted %.loc6_12.1, %.loc6_13 [template = bool]
+// CHECK:STDOUT:   %.loc6_12: init type = call %Bool.ref() [template = bool]
+// CHECK:STDOUT:   %.loc6_13.1: type = value_of_initializer %.loc6_12 [template = bool]
+// CHECK:STDOUT:   %.loc6_13.2: type = converted %.loc6_12, %.loc6_13.1 [template = bool]
 // CHECK:STDOUT:   %b.var: ref bool = var b
 // CHECK:STDOUT:   %b: ref bool = bind_name b, %b.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/builtins/float/make_type.carbon
+++ b/toolchain/check/testdata/builtins/float/make_type.carbon
@@ -75,9 +75,9 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Float.ref: <function> = name_ref Float, %import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %.loc6_14: i32 = int_literal 64 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc6_13.1: init type = call %Float.ref(%.loc6_14) [template = f64]
-// CHECK:STDOUT:   %.loc6_16: type = value_of_initializer %.loc6_13.1 [template = f64]
-// CHECK:STDOUT:   %.loc6_13.2: type = converted %.loc6_13.1, %.loc6_16 [template = f64]
+// CHECK:STDOUT:   %.loc6_13: init type = call %Float.ref(%.loc6_14) [template = f64]
+// CHECK:STDOUT:   %.loc6_16.1: type = value_of_initializer %.loc6_13 [template = f64]
+// CHECK:STDOUT:   %.loc6_16.2: type = converted %.loc6_13, %.loc6_16.1 [template = f64]
 // CHECK:STDOUT:   %f.var: ref f64 = var f
 // CHECK:STDOUT:   %f: ref f64 = bind_name f, %f.var
 // CHECK:STDOUT:   %GetFloat: <function> = fn_decl @GetFloat [template] {
@@ -93,10 +93,10 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Float.ref: <function> = name_ref Float, file.%import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %dyn_size.ref: i32 = name_ref dyn_size, %dyn_size
-// CHECK:STDOUT:   %.loc9_15.1: init type = call %Float.ref(%dyn_size.ref)
-// CHECK:STDOUT:   %.loc9_25: type = value_of_initializer %.loc9_15.1
-// CHECK:STDOUT:   %.loc9_15.2: type = converted %.loc9_15.1, %.loc9_25
-// CHECK:STDOUT:   return %.loc9_15.2
+// CHECK:STDOUT:   %.loc9_15: init type = call %Float.ref(%dyn_size.ref)
+// CHECK:STDOUT:   %.loc9_25.1: type = value_of_initializer %.loc9_15
+// CHECK:STDOUT:   %.loc9_25.2: type = converted %.loc9_15, %.loc9_25.1
+// CHECK:STDOUT:   return %.loc9_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
@@ -125,9 +125,9 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Float.ref.loc10: <function> = name_ref Float, %import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 32 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_25.1: init type = call %Float.ref.loc10(%.loc10_26) [template = <error>]
-// CHECK:STDOUT:   %.loc10_28: type = value_of_initializer %.loc10_25.1 [template = <error>]
-// CHECK:STDOUT:   %.loc10_25.2: type = converted %.loc10_25.1, %.loc10_28 [template = <error>]
+// CHECK:STDOUT:   %.loc10_25: init type = call %Float.ref.loc10(%.loc10_26) [template = <error>]
+// CHECK:STDOUT:   %.loc10_28.1: type = value_of_initializer %.loc10_25 [template = <error>]
+// CHECK:STDOUT:   %.loc10_28.2: type = converted %.loc10_25, %.loc10_28.1 [template = <error>]
 // CHECK:STDOUT:   %invalid_float.var: ref <error> = var invalid_float
 // CHECK:STDOUT:   %invalid_float: ref <error> = bind_name invalid_float, %invalid_float.var
 // CHECK:STDOUT:   %dyn_size.var: ref i32 = var dyn_size
@@ -135,9 +135,9 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:   %Float.ref.loc16: <function> = name_ref Float, %import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %dyn_size.ref: ref i32 = name_ref dyn_size, %dyn_size
 // CHECK:STDOUT:   %.loc16_16: i32 = bind_value %dyn_size.ref
-// CHECK:STDOUT:   %.loc16_15.1: init type = call %Float.ref.loc16(%.loc16_16)
-// CHECK:STDOUT:   %.loc16_24: type = value_of_initializer %.loc16_15.1
-// CHECK:STDOUT:   %.loc16_15.2: type = converted %.loc16_15.1, %.loc16_24
+// CHECK:STDOUT:   %.loc16_15: init type = call %Float.ref.loc16(%.loc16_16)
+// CHECK:STDOUT:   %.loc16_24.1: type = value_of_initializer %.loc16_15
+// CHECK:STDOUT:   %.loc16_24.2: type = converted %.loc16_15, %.loc16_24.1
 // CHECK:STDOUT:   %dyn.var: ref <error> = var dyn
 // CHECK:STDOUT:   %dyn: ref <error> = bind_name dyn, %dyn.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/builtins/int/add.carbon
+++ b/toolchain/check/testdata/builtins/int/add.carbon
@@ -139,10 +139,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %Add.ref: <function> = name_ref Add, file.%Add [template = file.%Add]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Add.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Add.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_decl.carbon
@@ -258,10 +258,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %TooFew.ref: <function> = name_ref TooFew, file.%TooFew [template = file.%TooFew]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc47_16.1: init i32 = call %TooFew.ref(%a.ref)
-// CHECK:STDOUT:   %.loc47_19: i32 = value_of_initializer %.loc47_16.1
-// CHECK:STDOUT:   %.loc47_16.2: i32 = converted %.loc47_16.1, %.loc47_19
-// CHECK:STDOUT:   return %.loc47_16.2
+// CHECK:STDOUT:   %.loc47_16: init i32 = call %TooFew.ref(%a.ref)
+// CHECK:STDOUT:   %.loc47_19.1: i32 = value_of_initializer %.loc47_16
+// CHECK:STDOUT:   %.loc47_19.2: i32 = converted %.loc47_16, %.loc47_19.1
+// CHECK:STDOUT:   return %.loc47_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallTooMany(%a: i32, %b: i32, %c: i32) -> i32 {
@@ -270,10 +270,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
 // CHECK:STDOUT:   %c.ref: i32 = name_ref c, %c
-// CHECK:STDOUT:   %.loc51_17.1: init i32 = call %TooMany.ref(%a.ref, %b.ref, %c.ref)
-// CHECK:STDOUT:   %.loc51_26: i32 = value_of_initializer %.loc51_17.1
-// CHECK:STDOUT:   %.loc51_17.2: i32 = converted %.loc51_17.1, %.loc51_26
-// CHECK:STDOUT:   return %.loc51_17.2
+// CHECK:STDOUT:   %.loc51_17: init i32 = call %TooMany.ref(%a.ref, %b.ref, %c.ref)
+// CHECK:STDOUT:   %.loc51_26.1: i32 = value_of_initializer %.loc51_17
+// CHECK:STDOUT:   %.loc51_26.2: i32 = converted %.loc51_17, %.loc51_26.1
+// CHECK:STDOUT:   return %.loc51_26.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallBadReturnType(%a: i32, %b: i32) -> bool {
@@ -281,10 +281,10 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %BadReturnType.ref: <function> = name_ref BadReturnType, file.%BadReturnType [template = file.%BadReturnType]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc55_23.1: init bool = call %BadReturnType.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc55_29: bool = value_of_initializer %.loc55_23.1
-// CHECK:STDOUT:   %.loc55_23.2: bool = converted %.loc55_23.1, %.loc55_29
-// CHECK:STDOUT:   return %.loc55_23.2
+// CHECK:STDOUT:   %.loc55_23: init bool = call %BadReturnType.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc55_29.1: bool = value_of_initializer %.loc55_23
+// CHECK:STDOUT:   %.loc55_29.2: bool = converted %.loc55_23, %.loc55_29.1
+// CHECK:STDOUT:   return %.loc55_29.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -312,17 +312,17 @@ let b: i32 = Add(0x7FFFFFFF, 1);
 // CHECK:STDOUT:   %Add.ref.loc6: <function> = name_ref Add, %Add [template = %Add]
 // CHECK:STDOUT:   %.loc6_18: i32 = int_literal 2147483647 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc6_30: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc6_17.1: init i32 = call %Add.ref.loc6(%.loc6_18, %.loc6_30) [template = constants.%.1]
-// CHECK:STDOUT:   %.loc6_32: i32 = value_of_initializer %.loc6_17.1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc6_17.2: i32 = converted %.loc6_17.1, %.loc6_32 [template = constants.%.1]
-// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_17.2
+// CHECK:STDOUT:   %.loc6_17: init i32 = call %Add.ref.loc6(%.loc6_18, %.loc6_30) [template = constants.%.1]
+// CHECK:STDOUT:   %.loc6_32.1: i32 = value_of_initializer %.loc6_17 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc6_32.2: i32 = converted %.loc6_17, %.loc6_32.1 [template = constants.%.1]
+// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_32.2
 // CHECK:STDOUT:   %Add.ref.loc10: <function> = name_ref Add, %Add [template = %Add]
 // CHECK:STDOUT:   %.loc10_18: i32 = int_literal 2147483647 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_30: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc10_17.1: init i32 = call %Add.ref.loc10(%.loc10_18, %.loc10_30) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_32: i32 = value_of_initializer %.loc10_17.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_17.2: i32 = converted %.loc10_17.1, %.loc10_32 [template = constants.%.4]
-// CHECK:STDOUT:   %b.loc10: i32 = bind_name b, %.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17: init i32 = call %Add.ref.loc10(%.loc10_18, %.loc10_30) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_32.1: i32 = value_of_initializer %.loc10_17 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_32.2: i32 = converted %.loc10_17, %.loc10_32.1 [template = constants.%.4]
+// CHECK:STDOUT:   %b.loc10: i32 = bind_name b, %.loc10_32.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Add(%a: i32, %b: i32) -> i32 = "int.add";

--- a/toolchain/check/testdata/builtins/int/and.carbon
+++ b/toolchain/check/testdata/builtins/int/and.carbon
@@ -69,9 +69,9 @@ fn RuntimeCall(a: i32, b: i32) -> i32 {
 // CHECK:STDOUT:   %And.ref: <function> = name_ref And, file.%And [template = file.%And]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %And.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %And.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/complement.carbon
+++ b/toolchain/check/testdata/builtins/int/complement.carbon
@@ -51,12 +51,12 @@ fn RuntimeCall(a: i32) -> i32 {
 // CHECK:STDOUT:   %And.ref: <function> = name_ref And, %And [template = %And]
 // CHECK:STDOUT:   %Complement.ref: <function> = name_ref Complement, %Complement [template = %Complement]
 // CHECK:STDOUT:   %.loc5_31: i32 = int_literal 1193046 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc5_30.1: init i32 = call %Complement.ref(%.loc5_31) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc5_30: init i32 = call %Complement.ref(%.loc5_31) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc5_42: i32 = int_literal 16777215 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc5_19.1: i32 = value_of_initializer %.loc5_30.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc5_30.2: i32 = converted %.loc5_30.1, %.loc5_19.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc5_19.2: init i32 = call %And.ref(%.loc5_30.2, %.loc5_42) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_51: type = array_type %.loc5_19.2, i32 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc5_19.1: i32 = value_of_initializer %.loc5_30 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc5_19.2: i32 = converted %.loc5_30, %.loc5_19.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc5_19.3: init i32 = call %And.ref(%.loc5_19.2, %.loc5_42) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc5_51: type = array_type %.loc5_19.3, i32 [template = constants.%.5]
 // CHECK:STDOUT:   %arr.var: ref [i32; 15584169] = var arr
 // CHECK:STDOUT:   %arr: ref [i32; 15584169] = bind_name arr, %arr.var
 // CHECK:STDOUT:   %.loc6_18: i32 = int_literal 15584169 [template = constants.%.4]
@@ -80,9 +80,9 @@ fn RuntimeCall(a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Complement.ref: <function> = name_ref Complement, file.%Complement [template = file.%Complement]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc9_20.1: init i32 = call %Complement.ref(%a.ref)
-// CHECK:STDOUT:   %.loc9_23: i32 = value_of_initializer %.loc9_20.1
-// CHECK:STDOUT:   %.loc9_20.2: i32 = converted %.loc9_20.1, %.loc9_23
-// CHECK:STDOUT:   return %.loc9_20.2
+// CHECK:STDOUT:   %.loc9_20: init i32 = call %Complement.ref(%a.ref)
+// CHECK:STDOUT:   %.loc9_23.1: i32 = value_of_initializer %.loc9_20
+// CHECK:STDOUT:   %.loc9_23.2: i32 = converted %.loc9_20, %.loc9_23.1
+// CHECK:STDOUT:   return %.loc9_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/div.carbon
+++ b/toolchain/check/testdata/builtins/int/div.carbon
@@ -107,10 +107,10 @@ let b: i32 = Div(0, 0);
 // CHECK:STDOUT:   %Div.ref: <function> = name_ref Div, file.%Div [template = file.%Div]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Div.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Div.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -153,54 +153,54 @@ let b: i32 = Div(0, 0);
 // CHECK:STDOUT:   %Div.ref.loc9: <function> = name_ref Div, %Div [template = %Div]
 // CHECK:STDOUT:   %Negate.ref.loc9_18: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc9_25: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_24.1: init i32 = call %Negate.ref.loc9_18(%.loc9_25) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_24: init i32 = call %Negate.ref.loc9_18(%.loc9_25) [template = constants.%.2]
 // CHECK:STDOUT:   %Negate.ref.loc9_39: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc9_46: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc9_45.1: init i32 = call %Negate.ref.loc9_39(%.loc9_46) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_17.1: i32 = value_of_initializer %.loc9_24.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc9_24.2: i32 = converted %.loc9_24.1, %.loc9_17.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc9_17.2: i32 = value_of_initializer %.loc9_45.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_45.2: i32 = converted %.loc9_45.1, %.loc9_17.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_17.3: init i32 = call %Div.ref.loc9(%.loc9_24.2, %.loc9_45.2) [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_49: i32 = value_of_initializer %.loc9_17.3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_17.4: i32 = converted %.loc9_17.3, %.loc9_49 [template = constants.%.1]
-// CHECK:STDOUT:   %a.loc9: i32 = bind_name a, %.loc9_17.4
+// CHECK:STDOUT:   %.loc9_45: init i32 = call %Negate.ref.loc9_39(%.loc9_46) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.1: i32 = value_of_initializer %.loc9_24 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_17.2: i32 = converted %.loc9_24, %.loc9_17.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_17.3: i32 = value_of_initializer %.loc9_45 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.4: i32 = converted %.loc9_45, %.loc9_17.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.5: init i32 = call %Div.ref.loc9(%.loc9_17.2, %.loc9_17.4) [template = constants.%.1]
+// CHECK:STDOUT:   %.loc9_49.1: i32 = value_of_initializer %.loc9_17.5 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc9_49.2: i32 = converted %.loc9_17.5, %.loc9_49.1 [template = constants.%.1]
+// CHECK:STDOUT:   %a.loc9: i32 = bind_name a, %.loc9_49.2
 // CHECK:STDOUT:   %Div.ref.loc12: <function> = name_ref Div, %Div [template = %Div]
 // CHECK:STDOUT:   %Sub.ref.loc12: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc12_29: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_28.1: init i32 = call %Negate.ref.loc12(%.loc12_29) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_28: init i32 = call %Negate.ref.loc12(%.loc12_29) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc12_43: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_21.1: i32 = value_of_initializer %.loc12_28.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_28.2: i32 = converted %.loc12_28.1, %.loc12_21.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_21.2: init i32 = call %Sub.ref.loc12(%.loc12_28.2, %.loc12_43) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_21.1: i32 = value_of_initializer %.loc12_28 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_21.2: i32 = converted %.loc12_28, %.loc12_21.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_21.3: init i32 = call %Sub.ref.loc12(%.loc12_21.2, %.loc12_43) [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_47: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_17.1: i32 = value_of_initializer %.loc12_21.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_21.3: i32 = converted %.loc12_21.2, %.loc12_17.1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_17.2: init i32 = call %Div.ref.loc12(%.loc12_21.3, %.loc12_47) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_49: i32 = value_of_initializer %.loc12_17.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_17.3: i32 = converted %.loc12_17.2, %.loc12_49 [template = constants.%.5]
-// CHECK:STDOUT:   %b.loc12: i32 = bind_name b, %.loc12_17.3
+// CHECK:STDOUT:   %.loc12_17.1: i32 = value_of_initializer %.loc12_21.3 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_17.2: i32 = converted %.loc12_21.3, %.loc12_17.1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_17.3: init i32 = call %Div.ref.loc12(%.loc12_17.2, %.loc12_47) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_49.1: i32 = value_of_initializer %.loc12_17.3 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_49.2: i32 = converted %.loc12_17.3, %.loc12_49.1 [template = constants.%.5]
+// CHECK:STDOUT:   %b.loc12: i32 = bind_name b, %.loc12_49.2
 // CHECK:STDOUT:   %Div.ref.loc19: <function> = name_ref Div, %Div [template = %Div]
 // CHECK:STDOUT:   %Sub.ref.loc19: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Negate.ref.loc19_22: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc19_29: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc19_28.1: init i32 = call %Negate.ref.loc19_22(%.loc19_29) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc19_28: init i32 = call %Negate.ref.loc19_22(%.loc19_29) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc19_43: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc19_21.1: i32 = value_of_initializer %.loc19_28.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc19_28.2: i32 = converted %.loc19_28.1, %.loc19_21.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc19_21.2: init i32 = call %Sub.ref.loc19(%.loc19_28.2, %.loc19_43) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc19_21.1: i32 = value_of_initializer %.loc19_28 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc19_21.2: i32 = converted %.loc19_28, %.loc19_21.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc19_21.3: init i32 = call %Sub.ref.loc19(%.loc19_21.2, %.loc19_43) [template = constants.%.5]
 // CHECK:STDOUT:   %Negate.ref.loc19_47: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc19_54: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc19_53.1: init i32 = call %Negate.ref.loc19_47(%.loc19_54) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc19_17.1: i32 = value_of_initializer %.loc19_21.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc19_21.3: i32 = converted %.loc19_21.2, %.loc19_17.1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc19_17.2: i32 = value_of_initializer %.loc19_53.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc19_53.2: i32 = converted %.loc19_53.1, %.loc19_17.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc19_17.3: init i32 = call %Div.ref.loc19(%.loc19_21.3, %.loc19_53.2) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc19_57: i32 = value_of_initializer %.loc19_17.3 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc19_17.4: i32 = converted %.loc19_17.3, %.loc19_57 [template = constants.%.5]
-// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc19_17.4
+// CHECK:STDOUT:   %.loc19_53: init i32 = call %Negate.ref.loc19_47(%.loc19_54) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_17.1: i32 = value_of_initializer %.loc19_21.3 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc19_17.2: i32 = converted %.loc19_21.3, %.loc19_17.1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc19_17.3: i32 = value_of_initializer %.loc19_53 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_17.4: i32 = converted %.loc19_53, %.loc19_17.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_17.5: init i32 = call %Div.ref.loc19(%.loc19_17.2, %.loc19_17.4) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc19_57.1: i32 = value_of_initializer %.loc19_17.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc19_57.2: i32 = converted %.loc19_17.5, %.loc19_57.1 [template = constants.%.5]
+// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc19_57.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Div(%a: i32, %b: i32) -> i32 = "int.div";
@@ -232,17 +232,17 @@ let b: i32 = Div(0, 0);
 // CHECK:STDOUT:   %Div.ref.loc10: <function> = name_ref Div, %Div [template = %Div]
 // CHECK:STDOUT:   %.loc10_18: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_21: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_17.1: init i32 = call %Div.ref.loc10(%.loc10_18, %.loc10_21) [template = <error>]
-// CHECK:STDOUT:   %.loc10_23: i32 = value_of_initializer %.loc10_17.1 [template = <error>]
-// CHECK:STDOUT:   %.loc10_17.2: i32 = converted %.loc10_17.1, %.loc10_23 [template = <error>]
-// CHECK:STDOUT:   %a.loc10: i32 = bind_name a, %.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17: init i32 = call %Div.ref.loc10(%.loc10_18, %.loc10_21) [template = <error>]
+// CHECK:STDOUT:   %.loc10_23.1: i32 = value_of_initializer %.loc10_17 [template = <error>]
+// CHECK:STDOUT:   %.loc10_23.2: i32 = converted %.loc10_17, %.loc10_23.1 [template = <error>]
+// CHECK:STDOUT:   %a.loc10: i32 = bind_name a, %.loc10_23.2
 // CHECK:STDOUT:   %Div.ref.loc15: <function> = name_ref Div, %Div [template = %Div]
 // CHECK:STDOUT:   %.loc15_18: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc15_17.1: init i32 = call %Div.ref.loc15(%.loc15_18, %.loc15_21) [template = <error>]
-// CHECK:STDOUT:   %.loc15_23: i32 = value_of_initializer %.loc15_17.1 [template = <error>]
-// CHECK:STDOUT:   %.loc15_17.2: i32 = converted %.loc15_17.1, %.loc15_23 [template = <error>]
-// CHECK:STDOUT:   %b.loc15: i32 = bind_name b, %.loc15_17.2
+// CHECK:STDOUT:   %.loc15_17: init i32 = call %Div.ref.loc15(%.loc15_18, %.loc15_21) [template = <error>]
+// CHECK:STDOUT:   %.loc15_23.1: i32 = value_of_initializer %.loc15_17 [template = <error>]
+// CHECK:STDOUT:   %.loc15_23.2: i32 = converted %.loc15_17, %.loc15_23.1 [template = <error>]
+// CHECK:STDOUT:   %b.loc15: i32 = bind_name b, %.loc15_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Div(%a: i32, %b: i32) -> i32 = "int.div";

--- a/toolchain/check/testdata/builtins/int/eq.carbon
+++ b/toolchain/check/testdata/builtins/int/eq.carbon
@@ -97,10 +97,10 @@ fn WrongResult(a: i32, b: i32) -> i32 = "int.eq";
 // CHECK:STDOUT:   %Eq.ref.loc8: <function> = name_ref Eq, file.%Eq [template = file.%Eq]
 // CHECK:STDOUT:   %.loc8_19: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_22: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_18.1: init bool = call %Eq.ref.loc8(%.loc8_19, %.loc8_22) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_13.1: bool = value_of_initializer %.loc8_18.1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_18.2: bool = converted %.loc8_18.1, %.loc8_13.1 [template = constants.%.5]
-// CHECK:STDOUT:   if %.loc8_18.2 br !if.expr.then.loc8 else br !if.expr.else.loc8
+// CHECK:STDOUT:   %.loc8_18: init bool = call %Eq.ref.loc8(%.loc8_19, %.loc8_22) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_13.1: bool = value_of_initializer %.loc8_18 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_13.2: bool = converted %.loc8_18, %.loc8_13.1 [template = constants.%.5]
+// CHECK:STDOUT:   if %.loc8_13.2 br !if.expr.then.loc8 else br !if.expr.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8:
 // CHECK:STDOUT:   %True.ref.loc8: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -111,15 +111,15 @@ fn WrongResult(a: i32, b: i32) -> i32 = "int.eq";
 // CHECK:STDOUT:   br !if.expr.result.loc8(%False.ref.loc8)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8:
-// CHECK:STDOUT:   %.loc8_13.2: type = block_arg !if.expr.result.loc8 [template = constants.%True]
+// CHECK:STDOUT:   %.loc8_13.3: type = block_arg !if.expr.result.loc8 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Eq.ref.loc9: <function> = name_ref Eq, file.%Eq [template = file.%Eq]
 // CHECK:STDOUT:   %.loc9_20: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_19.1: init bool = call %Eq.ref.loc9(%.loc9_20, %.loc9_23) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_19.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_19.2: bool = converted %.loc9_19.1, %.loc9_14.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc9_19.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_19: init bool = call %Eq.ref.loc9(%.loc9_20, %.loc9_23) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_19 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_14.2: bool = converted %.loc9_19, %.loc9_14.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc9_14.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -130,7 +130,7 @@ fn WrongResult(a: i32, b: i32) -> i32 = "int.eq";
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_14.2: type = block_arg !if.expr.result.loc9 [template = constants.%False]
+// CHECK:STDOUT:   %.loc9_14.3: type = block_arg !if.expr.result.loc9 [template = constants.%False]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -139,10 +139,10 @@ fn WrongResult(a: i32, b: i32) -> i32 = "int.eq";
 // CHECK:STDOUT:   %Eq.ref: <function> = name_ref Eq, file.%Eq [template = file.%Eq]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc13_12.1: init bool = call %Eq.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc13_18: bool = value_of_initializer %.loc13_12.1
-// CHECK:STDOUT:   %.loc13_12.2: bool = converted %.loc13_12.1, %.loc13_18
-// CHECK:STDOUT:   return %.loc13_12.2
+// CHECK:STDOUT:   %.loc13_12: init bool = call %Eq.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc13_18.1: bool = value_of_initializer %.loc13_12
+// CHECK:STDOUT:   %.loc13_18.2: bool = converted %.loc13_12, %.loc13_18.1
+// CHECK:STDOUT:   return %.loc13_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_decl.carbon

--- a/toolchain/check/testdata/builtins/int/greater.carbon
+++ b/toolchain/check/testdata/builtins/int/greater.carbon
@@ -102,10 +102,10 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Greater.ref.loc9: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %.loc9_25: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_28: i32 = int_literal 2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_24.1: init bool = call %Greater.ref.loc9(%.loc9_25, %.loc9_28) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_24.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_24.2: bool = converted %.loc9_24.1, %.loc9_14.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc9_24.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_24: init bool = call %Greater.ref.loc9(%.loc9_25, %.loc9_28) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_24 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_14.2: bool = converted %.loc9_24, %.loc9_14.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc9_14.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -116,15 +116,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_14.2: type = block_arg !if.expr.result.loc9 [template = constants.%False]
+// CHECK:STDOUT:   %.loc9_14.3: type = block_arg !if.expr.result.loc9 [template = constants.%False]
 // CHECK:STDOUT:   %false_.ref.loc10: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Greater.ref.loc10: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %.loc10_25: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_28: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_24.1: init bool = call %Greater.ref.loc10(%.loc10_25, %.loc10_28) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14.1: bool = value_of_initializer %.loc10_24.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_24.2: bool = converted %.loc10_24.1, %.loc10_14.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc10_24.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
+// CHECK:STDOUT:   %.loc10_24: init bool = call %Greater.ref.loc10(%.loc10_25, %.loc10_28) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_14.1: bool = value_of_initializer %.loc10_24 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_14.2: bool = converted %.loc10_24, %.loc10_14.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc10_14.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc10:
 // CHECK:STDOUT:   %True.ref.loc10: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -135,15 +135,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc10(%False.ref.loc10)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc10:
-// CHECK:STDOUT:   %.loc10_14.2: type = block_arg !if.expr.result.loc10 [template = constants.%False]
+// CHECK:STDOUT:   %.loc10_14.3: type = block_arg !if.expr.result.loc10 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc11: True = name_ref true_, %true_
 // CHECK:STDOUT:   %Greater.ref.loc11: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_27: i32 = int_literal 0 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_23.1: init bool = call %Greater.ref.loc11(%.loc11_24, %.loc11_27) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_13.1: bool = value_of_initializer %.loc11_23.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_23.2: bool = converted %.loc11_23.1, %.loc11_13.1 [template = constants.%.8]
-// CHECK:STDOUT:   if %.loc11_23.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
+// CHECK:STDOUT:   %.loc11_23: init bool = call %Greater.ref.loc11(%.loc11_24, %.loc11_27) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_13.1: bool = value_of_initializer %.loc11_23 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_13.2: bool = converted %.loc11_23, %.loc11_13.1 [template = constants.%.8]
+// CHECK:STDOUT:   if %.loc11_13.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc11:
 // CHECK:STDOUT:   %True.ref.loc11: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -154,19 +154,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc11(%False.ref.loc11)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc11:
-// CHECK:STDOUT:   %.loc11_13.2: type = block_arg !if.expr.result.loc11 [template = constants.%True]
+// CHECK:STDOUT:   %.loc11_13.3: type = block_arg !if.expr.result.loc11 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc12: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Greater.ref.loc12: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc12_32: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_31.1: init i32 = call %Negate.ref.loc12(%.loc12_32) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_31: init i32 = call %Negate.ref.loc12(%.loc12_32) [template = constants.%.9]
 // CHECK:STDOUT:   %.loc12_36: i32 = int_literal 0 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc12_24.1: i32 = value_of_initializer %.loc12_31.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_31.2: i32 = converted %.loc12_31.1, %.loc12_24.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_24.2: init bool = call %Greater.ref.loc12(%.loc12_31.2, %.loc12_36) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_14.1: bool = value_of_initializer %.loc12_24.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_24.3: bool = converted %.loc12_24.2, %.loc12_14.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc12_24.3 br !if.expr.then.loc12 else br !if.expr.else.loc12
+// CHECK:STDOUT:   %.loc12_24.1: i32 = value_of_initializer %.loc12_31 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_24.2: i32 = converted %.loc12_31, %.loc12_24.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_24.3: init bool = call %Greater.ref.loc12(%.loc12_24.2, %.loc12_36) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_14.1: bool = value_of_initializer %.loc12_24.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_14.2: bool = converted %.loc12_24.3, %.loc12_14.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc12_14.2 br !if.expr.then.loc12 else br !if.expr.else.loc12
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc12:
 // CHECK:STDOUT:   %True.ref.loc12: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -177,19 +177,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc12(%False.ref.loc12)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc12:
-// CHECK:STDOUT:   %.loc12_14.2: type = block_arg !if.expr.result.loc12 [template = constants.%False]
+// CHECK:STDOUT:   %.loc12_14.3: type = block_arg !if.expr.result.loc12 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc13: True = name_ref true_, %true_
 // CHECK:STDOUT:   %Greater.ref.loc13: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %.loc13_24: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %Negate.ref.loc13: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_33.1: init i32 = call %Negate.ref.loc13(%.loc13_34) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_23.1: i32 = value_of_initializer %.loc13_33.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_33.2: i32 = converted %.loc13_33.1, %.loc13_23.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_23.2: init bool = call %Greater.ref.loc13(%.loc13_24, %.loc13_33.2) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_13.1: bool = value_of_initializer %.loc13_23.2 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_23.3: bool = converted %.loc13_23.2, %.loc13_13.1 [template = constants.%.8]
-// CHECK:STDOUT:   if %.loc13_23.3 br !if.expr.then.loc13 else br !if.expr.else.loc13
+// CHECK:STDOUT:   %.loc13_33: init i32 = call %Negate.ref.loc13(%.loc13_34) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.1: i32 = value_of_initializer %.loc13_33 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.2: i32 = converted %.loc13_33, %.loc13_23.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.3: init bool = call %Greater.ref.loc13(%.loc13_24, %.loc13_23.2) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_13.1: bool = value_of_initializer %.loc13_23.3 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_13.2: bool = converted %.loc13_23.3, %.loc13_13.1 [template = constants.%.8]
+// CHECK:STDOUT:   if %.loc13_13.2 br !if.expr.then.loc13 else br !if.expr.else.loc13
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc13:
 // CHECK:STDOUT:   %True.ref.loc13: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -200,7 +200,7 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc13(%False.ref.loc13)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc13:
-// CHECK:STDOUT:   %.loc13_13.2: type = block_arg !if.expr.result.loc13 [template = constants.%True]
+// CHECK:STDOUT:   %.loc13_13.3: type = block_arg !if.expr.result.loc13 [template = constants.%True]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -209,9 +209,9 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Greater.ref: <function> = name_ref Greater, file.%Greater [template = file.%Greater]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc17_17.1: init bool = call %Greater.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc17_23: bool = value_of_initializer %.loc17_17.1
-// CHECK:STDOUT:   %.loc17_17.2: bool = converted %.loc17_17.1, %.loc17_23
-// CHECK:STDOUT:   return %.loc17_17.2
+// CHECK:STDOUT:   %.loc17_17: init bool = call %Greater.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc17_23.1: bool = value_of_initializer %.loc17_17
+// CHECK:STDOUT:   %.loc17_23.2: bool = converted %.loc17_17, %.loc17_23.1
+// CHECK:STDOUT:   return %.loc17_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/greater_eq.carbon
+++ b/toolchain/check/testdata/builtins/int/greater_eq.carbon
@@ -102,10 +102,10 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %GreaterEq.ref.loc9: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %.loc9_27: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_30: i32 = int_literal 2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_26.1: init bool = call %GreaterEq.ref.loc9(%.loc9_27, %.loc9_30) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_26.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_26.2: bool = converted %.loc9_26.1, %.loc9_14.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc9_26.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_26: init bool = call %GreaterEq.ref.loc9(%.loc9_27, %.loc9_30) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_14.1: bool = value_of_initializer %.loc9_26 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_14.2: bool = converted %.loc9_26, %.loc9_14.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc9_14.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -116,15 +116,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_14.2: type = block_arg !if.expr.result.loc9 [template = constants.%False]
+// CHECK:STDOUT:   %.loc9_14.3: type = block_arg !if.expr.result.loc9 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc10: True = name_ref true_, %true_
 // CHECK:STDOUT:   %GreaterEq.ref.loc10: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_29: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_25.1: init bool = call %GreaterEq.ref.loc10(%.loc10_26, %.loc10_29) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc10_13.1: bool = value_of_initializer %.loc10_25.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc10_25.2: bool = converted %.loc10_25.1, %.loc10_13.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc10_25.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
+// CHECK:STDOUT:   %.loc10_25: init bool = call %GreaterEq.ref.loc10(%.loc10_26, %.loc10_29) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc10_13.1: bool = value_of_initializer %.loc10_25 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc10_13.2: bool = converted %.loc10_25, %.loc10_13.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc10_13.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc10:
 // CHECK:STDOUT:   %True.ref.loc10: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -135,15 +135,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc10(%False.ref.loc10)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc10:
-// CHECK:STDOUT:   %.loc10_13.2: type = block_arg !if.expr.result.loc10 [template = constants.%True]
+// CHECK:STDOUT:   %.loc10_13.3: type = block_arg !if.expr.result.loc10 [template = constants.%True]
 // CHECK:STDOUT:   %true_.ref.loc11: True = name_ref true_, %true_
 // CHECK:STDOUT:   %GreaterEq.ref.loc11: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %.loc11_26: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_29: i32 = int_literal 0 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_25.1: init bool = call %GreaterEq.ref.loc11(%.loc11_26, %.loc11_29) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_13.1: bool = value_of_initializer %.loc11_25.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_25.2: bool = converted %.loc11_25.1, %.loc11_13.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc11_25.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
+// CHECK:STDOUT:   %.loc11_25: init bool = call %GreaterEq.ref.loc11(%.loc11_26, %.loc11_29) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_13.1: bool = value_of_initializer %.loc11_25 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_13.2: bool = converted %.loc11_25, %.loc11_13.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc11_13.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc11:
 // CHECK:STDOUT:   %True.ref.loc11: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -154,19 +154,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc11(%False.ref.loc11)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc11:
-// CHECK:STDOUT:   %.loc11_13.2: type = block_arg !if.expr.result.loc11 [template = constants.%True]
+// CHECK:STDOUT:   %.loc11_13.3: type = block_arg !if.expr.result.loc11 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc12: False = name_ref false_, %false_
 // CHECK:STDOUT:   %GreaterEq.ref.loc12: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc12_34: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_33.1: init i32 = call %Negate.ref.loc12(%.loc12_34) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_33: init i32 = call %Negate.ref.loc12(%.loc12_34) [template = constants.%.9]
 // CHECK:STDOUT:   %.loc12_38: i32 = int_literal 0 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_26.1: i32 = value_of_initializer %.loc12_33.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_33.2: i32 = converted %.loc12_33.1, %.loc12_26.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_26.2: init bool = call %GreaterEq.ref.loc12(%.loc12_33.2, %.loc12_38) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_14.1: bool = value_of_initializer %.loc12_26.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_26.3: bool = converted %.loc12_26.2, %.loc12_14.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc12_26.3 br !if.expr.then.loc12 else br !if.expr.else.loc12
+// CHECK:STDOUT:   %.loc12_26.1: i32 = value_of_initializer %.loc12_33 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_26.2: i32 = converted %.loc12_33, %.loc12_26.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_26.3: init bool = call %GreaterEq.ref.loc12(%.loc12_26.2, %.loc12_38) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_14.1: bool = value_of_initializer %.loc12_26.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_14.2: bool = converted %.loc12_26.3, %.loc12_14.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc12_14.2 br !if.expr.then.loc12 else br !if.expr.else.loc12
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc12:
 // CHECK:STDOUT:   %True.ref.loc12: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -177,19 +177,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc12(%False.ref.loc12)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc12:
-// CHECK:STDOUT:   %.loc12_14.2: type = block_arg !if.expr.result.loc12 [template = constants.%False]
+// CHECK:STDOUT:   %.loc12_14.3: type = block_arg !if.expr.result.loc12 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc13: True = name_ref true_, %true_
 // CHECK:STDOUT:   %GreaterEq.ref.loc13: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %.loc13_26: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %Negate.ref.loc13: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc13_36: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_35.1: init i32 = call %Negate.ref.loc13(%.loc13_36) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_25.1: i32 = value_of_initializer %.loc13_35.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_35.2: i32 = converted %.loc13_35.1, %.loc13_25.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_25.2: init bool = call %GreaterEq.ref.loc13(%.loc13_26, %.loc13_35.2) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc13_13.1: bool = value_of_initializer %.loc13_25.2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc13_25.3: bool = converted %.loc13_25.2, %.loc13_13.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc13_25.3 br !if.expr.then.loc13 else br !if.expr.else.loc13
+// CHECK:STDOUT:   %.loc13_35: init i32 = call %Negate.ref.loc13(%.loc13_36) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_25.1: i32 = value_of_initializer %.loc13_35 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_25.2: i32 = converted %.loc13_35, %.loc13_25.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_25.3: init bool = call %GreaterEq.ref.loc13(%.loc13_26, %.loc13_25.2) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc13_13.1: bool = value_of_initializer %.loc13_25.3 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc13_13.2: bool = converted %.loc13_25.3, %.loc13_13.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc13_13.2 br !if.expr.then.loc13 else br !if.expr.else.loc13
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc13:
 // CHECK:STDOUT:   %True.ref.loc13: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -200,7 +200,7 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc13(%False.ref.loc13)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc13:
-// CHECK:STDOUT:   %.loc13_13.2: type = block_arg !if.expr.result.loc13 [template = constants.%True]
+// CHECK:STDOUT:   %.loc13_13.3: type = block_arg !if.expr.result.loc13 [template = constants.%True]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -209,9 +209,9 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %GreaterEq.ref: <function> = name_ref GreaterEq, file.%GreaterEq [template = file.%GreaterEq]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc17_19.1: init bool = call %GreaterEq.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc17_25: bool = value_of_initializer %.loc17_19.1
-// CHECK:STDOUT:   %.loc17_19.2: bool = converted %.loc17_19.1, %.loc17_25
-// CHECK:STDOUT:   return %.loc17_19.2
+// CHECK:STDOUT:   %.loc17_19: init bool = call %GreaterEq.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc17_25.1: bool = value_of_initializer %.loc17_19
+// CHECK:STDOUT:   %.loc17_25.2: bool = converted %.loc17_19, %.loc17_25.1
+// CHECK:STDOUT:   return %.loc17_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/left_shift.carbon
+++ b/toolchain/check/testdata/builtins/int/left_shift.carbon
@@ -113,10 +113,10 @@ let negative: i32 = LeftShift(1, Negate(1));
 // CHECK:STDOUT:   %LeftShift.ref: <function> = name_ref LeftShift, file.%LeftShift [template = file.%LeftShift]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_19.1: init i32 = call %LeftShift.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_25: i32 = value_of_initializer %.loc8_19.1
-// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_19.1, %.loc8_25
-// CHECK:STDOUT:   return %.loc8_19.2
+// CHECK:STDOUT:   %.loc8_19: init i32 = call %LeftShift.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_25.1: i32 = value_of_initializer %.loc8_19
+// CHECK:STDOUT:   %.loc8_25.2: i32 = converted %.loc8_19, %.loc8_25.1
+// CHECK:STDOUT:   return %.loc8_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_shift.carbon
@@ -154,63 +154,63 @@ let negative: i32 = LeftShift(1, Negate(1));
 // CHECK:STDOUT:   %LeftShift.ref.loc8: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc8_29: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc8_32: i32 = int_literal 31 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_28.1: init i32 = call %LeftShift.ref.loc8(%.loc8_29, %.loc8_32) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_35: i32 = value_of_initializer %.loc8_28.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_28.2: i32 = converted %.loc8_28.1, %.loc8_35 [template = constants.%.3]
-// CHECK:STDOUT:   %size_1: i32 = bind_name size_1, %.loc8_28.2
+// CHECK:STDOUT:   %.loc8_28: init i32 = call %LeftShift.ref.loc8(%.loc8_29, %.loc8_32) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_35.1: i32 = value_of_initializer %.loc8_28 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_35.2: i32 = converted %.loc8_28, %.loc8_35.1 [template = constants.%.3]
+// CHECK:STDOUT:   %size_1: i32 = bind_name size_1, %.loc8_35.2
 // CHECK:STDOUT:   %LeftShift.ref.loc13: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc13_29: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc13_32: i32 = int_literal 32 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_28.1: init i32 = call %LeftShift.ref.loc13(%.loc13_29, %.loc13_32) [template = <error>]
-// CHECK:STDOUT:   %.loc13_35: i32 = value_of_initializer %.loc13_28.1 [template = <error>]
-// CHECK:STDOUT:   %.loc13_28.2: i32 = converted %.loc13_28.1, %.loc13_35 [template = <error>]
-// CHECK:STDOUT:   %size_2: i32 = bind_name size_2, %.loc13_28.2
+// CHECK:STDOUT:   %.loc13_28: init i32 = call %LeftShift.ref.loc13(%.loc13_29, %.loc13_32) [template = <error>]
+// CHECK:STDOUT:   %.loc13_35.1: i32 = value_of_initializer %.loc13_28 [template = <error>]
+// CHECK:STDOUT:   %.loc13_35.2: i32 = converted %.loc13_28, %.loc13_35.1 [template = <error>]
+// CHECK:STDOUT:   %size_2: i32 = bind_name size_2, %.loc13_35.2
 // CHECK:STDOUT:   %LeftShift.ref.loc18: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc18_29: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc18_32: i32 = int_literal 33 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc18_28.1: init i32 = call %LeftShift.ref.loc18(%.loc18_29, %.loc18_32) [template = <error>]
-// CHECK:STDOUT:   %.loc18_35: i32 = value_of_initializer %.loc18_28.1 [template = <error>]
-// CHECK:STDOUT:   %.loc18_28.2: i32 = converted %.loc18_28.1, %.loc18_35 [template = <error>]
-// CHECK:STDOUT:   %size_3: i32 = bind_name size_3, %.loc18_28.2
+// CHECK:STDOUT:   %.loc18_28: init i32 = call %LeftShift.ref.loc18(%.loc18_29, %.loc18_32) [template = <error>]
+// CHECK:STDOUT:   %.loc18_35.1: i32 = value_of_initializer %.loc18_28 [template = <error>]
+// CHECK:STDOUT:   %.loc18_35.2: i32 = converted %.loc18_28, %.loc18_35.1 [template = <error>]
+// CHECK:STDOUT:   %size_3: i32 = bind_name size_3, %.loc18_35.2
 // CHECK:STDOUT:   %LeftShift.ref.loc21: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc21_33: i32 = int_literal 1000 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc21_39: i32 = int_literal 31 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc21_32.1: init i32 = call %LeftShift.ref.loc21(%.loc21_33, %.loc21_39) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_42: i32 = value_of_initializer %.loc21_32.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_32.2: i32 = converted %.loc21_32.1, %.loc21_42 [template = constants.%.7]
-// CHECK:STDOUT:   %overflow_1: i32 = bind_name overflow_1, %.loc21_32.2
+// CHECK:STDOUT:   %.loc21_32: init i32 = call %LeftShift.ref.loc21(%.loc21_33, %.loc21_39) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_42.1: i32 = value_of_initializer %.loc21_32 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_42.2: i32 = converted %.loc21_32, %.loc21_42.1 [template = constants.%.7]
+// CHECK:STDOUT:   %overflow_1: i32 = bind_name overflow_1, %.loc21_42.2
 // CHECK:STDOUT:   %LeftShift.ref.loc26: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc26_33: i32 = int_literal 1000 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc26_39: i32 = int_literal 32 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc26_32.1: init i32 = call %LeftShift.ref.loc26(%.loc26_33, %.loc26_39) [template = <error>]
-// CHECK:STDOUT:   %.loc26_42: i32 = value_of_initializer %.loc26_32.1 [template = <error>]
-// CHECK:STDOUT:   %.loc26_32.2: i32 = converted %.loc26_32.1, %.loc26_42 [template = <error>]
-// CHECK:STDOUT:   %overflow_2: i32 = bind_name overflow_2, %.loc26_32.2
+// CHECK:STDOUT:   %.loc26_32: init i32 = call %LeftShift.ref.loc26(%.loc26_33, %.loc26_39) [template = <error>]
+// CHECK:STDOUT:   %.loc26_42.1: i32 = value_of_initializer %.loc26_32 [template = <error>]
+// CHECK:STDOUT:   %.loc26_42.2: i32 = converted %.loc26_32, %.loc26_42.1 [template = <error>]
+// CHECK:STDOUT:   %overflow_2: i32 = bind_name overflow_2, %.loc26_42.2
 // CHECK:STDOUT:   %LeftShift.ref.loc29: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc29_36: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc29_39: i32 = int_literal 31 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc29_35.1: init i32 = call %LeftShift.ref.loc29(%.loc29_36, %.loc29_39) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc29_42: i32 = value_of_initializer %.loc29_35.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc29_35.2: i32 = converted %.loc29_35.1, %.loc29_42 [template = constants.%.7]
-// CHECK:STDOUT:   %no_overflow_1: i32 = bind_name no_overflow_1, %.loc29_35.2
+// CHECK:STDOUT:   %.loc29_35: init i32 = call %LeftShift.ref.loc29(%.loc29_36, %.loc29_39) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc29_42.1: i32 = value_of_initializer %.loc29_35 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc29_42.2: i32 = converted %.loc29_35, %.loc29_42.1 [template = constants.%.7]
+// CHECK:STDOUT:   %no_overflow_1: i32 = bind_name no_overflow_1, %.loc29_42.2
 // CHECK:STDOUT:   %LeftShift.ref.loc34: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc34_36: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc34_39: i32 = int_literal 32 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc34_35.1: init i32 = call %LeftShift.ref.loc34(%.loc34_36, %.loc34_39) [template = <error>]
-// CHECK:STDOUT:   %.loc34_42: i32 = value_of_initializer %.loc34_35.1 [template = <error>]
-// CHECK:STDOUT:   %.loc34_35.2: i32 = converted %.loc34_35.1, %.loc34_42 [template = <error>]
-// CHECK:STDOUT:   %no_overflow_2: i32 = bind_name no_overflow_2, %.loc34_35.2
+// CHECK:STDOUT:   %.loc34_35: init i32 = call %LeftShift.ref.loc34(%.loc34_36, %.loc34_39) [template = <error>]
+// CHECK:STDOUT:   %.loc34_42.1: i32 = value_of_initializer %.loc34_35 [template = <error>]
+// CHECK:STDOUT:   %.loc34_42.2: i32 = converted %.loc34_35, %.loc34_42.1 [template = <error>]
+// CHECK:STDOUT:   %no_overflow_2: i32 = bind_name no_overflow_2, %.loc34_42.2
 // CHECK:STDOUT:   %LeftShift.ref.loc40: <function> = name_ref LeftShift, %LeftShift [template = %LeftShift]
 // CHECK:STDOUT:   %.loc40_31: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %Negate.ref: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc40_41: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc40_40.1: init i32 = call %Negate.ref(%.loc40_41) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc40_30.1: i32 = value_of_initializer %.loc40_40.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc40_40.2: i32 = converted %.loc40_40.1, %.loc40_30.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc40_30.2: init i32 = call %LeftShift.ref.loc40(%.loc40_31, %.loc40_40.2) [template = <error>]
-// CHECK:STDOUT:   %.loc40_44: i32 = value_of_initializer %.loc40_30.2 [template = <error>]
-// CHECK:STDOUT:   %.loc40_30.3: i32 = converted %.loc40_30.2, %.loc40_44 [template = <error>]
-// CHECK:STDOUT:   %negative: i32 = bind_name negative, %.loc40_30.3
+// CHECK:STDOUT:   %.loc40_40: init i32 = call %Negate.ref(%.loc40_41) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc40_30.1: i32 = value_of_initializer %.loc40_40 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc40_30.2: i32 = converted %.loc40_40, %.loc40_30.1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc40_30.3: init i32 = call %LeftShift.ref.loc40(%.loc40_31, %.loc40_30.2) [template = <error>]
+// CHECK:STDOUT:   %.loc40_44.1: i32 = value_of_initializer %.loc40_30.3 [template = <error>]
+// CHECK:STDOUT:   %.loc40_44.2: i32 = converted %.loc40_30.3, %.loc40_44.1 [template = <error>]
+// CHECK:STDOUT:   %negative: i32 = bind_name negative, %.loc40_44.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @LeftShift(%a: i32, %b: i32) -> i32 = "int.left_shift";

--- a/toolchain/check/testdata/builtins/int/less.carbon
+++ b/toolchain/check/testdata/builtins/int/less.carbon
@@ -102,10 +102,10 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Less.ref.loc9: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %.loc9_21: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_24: i32 = int_literal 2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_20.1: init bool = call %Less.ref.loc9(%.loc9_21, %.loc9_24) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_20.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_20.2: bool = converted %.loc9_20.1, %.loc9_13.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc9_20.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_20: init bool = call %Less.ref.loc9(%.loc9_21, %.loc9_24) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_20 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_13.2: bool = converted %.loc9_20, %.loc9_13.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc9_13.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -116,15 +116,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_13.2: type = block_arg !if.expr.result.loc9 [template = constants.%True]
+// CHECK:STDOUT:   %.loc9_13.3: type = block_arg !if.expr.result.loc9 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc10: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Less.ref.loc10: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %.loc10_22: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_25: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_21.1: init bool = call %Less.ref.loc10(%.loc10_22, %.loc10_25) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc10_14.1: bool = value_of_initializer %.loc10_21.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc10_21.2: bool = converted %.loc10_21.1, %.loc10_14.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc10_21.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
+// CHECK:STDOUT:   %.loc10_21: init bool = call %Less.ref.loc10(%.loc10_22, %.loc10_25) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc10_14.1: bool = value_of_initializer %.loc10_21 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc10_14.2: bool = converted %.loc10_21, %.loc10_14.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc10_14.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc10:
 // CHECK:STDOUT:   %True.ref.loc10: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -135,15 +135,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc10(%False.ref.loc10)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc10:
-// CHECK:STDOUT:   %.loc10_14.2: type = block_arg !if.expr.result.loc10 [template = constants.%False]
+// CHECK:STDOUT:   %.loc10_14.3: type = block_arg !if.expr.result.loc10 [template = constants.%False]
 // CHECK:STDOUT:   %false_.ref.loc11: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Less.ref.loc11: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %.loc11_22: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_25: i32 = int_literal 0 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_21.1: init bool = call %Less.ref.loc11(%.loc11_22, %.loc11_25) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_21.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_21.2: bool = converted %.loc11_21.1, %.loc11_14.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc11_21.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
+// CHECK:STDOUT:   %.loc11_21: init bool = call %Less.ref.loc11(%.loc11_22, %.loc11_25) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_21 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_21, %.loc11_14.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc11_14.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc11:
 // CHECK:STDOUT:   %True.ref.loc11: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -154,19 +154,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc11(%False.ref.loc11)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc11:
-// CHECK:STDOUT:   %.loc11_14.2: type = block_arg !if.expr.result.loc11 [template = constants.%False]
+// CHECK:STDOUT:   %.loc11_14.3: type = block_arg !if.expr.result.loc11 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc12: True = name_ref true_, %true_
 // CHECK:STDOUT:   %Less.ref.loc12: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc12_28: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_27.1: init i32 = call %Negate.ref.loc12(%.loc12_28) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_27: init i32 = call %Negate.ref.loc12(%.loc12_28) [template = constants.%.9]
 // CHECK:STDOUT:   %.loc12_32: i32 = int_literal 0 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_20.1: i32 = value_of_initializer %.loc12_27.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_27.2: i32 = converted %.loc12_27.1, %.loc12_20.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_20.2: init bool = call %Less.ref.loc12(%.loc12_27.2, %.loc12_32) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_13.1: bool = value_of_initializer %.loc12_20.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_20.3: bool = converted %.loc12_20.2, %.loc12_13.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc12_20.3 br !if.expr.then.loc12 else br !if.expr.else.loc12
+// CHECK:STDOUT:   %.loc12_20.1: i32 = value_of_initializer %.loc12_27 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_20.2: i32 = converted %.loc12_27, %.loc12_20.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_20.3: init bool = call %Less.ref.loc12(%.loc12_20.2, %.loc12_32) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13.1: bool = value_of_initializer %.loc12_20.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13.2: bool = converted %.loc12_20.3, %.loc12_13.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc12_13.2 br !if.expr.then.loc12 else br !if.expr.else.loc12
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc12:
 // CHECK:STDOUT:   %True.ref.loc12: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -177,19 +177,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc12(%False.ref.loc12)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc12:
-// CHECK:STDOUT:   %.loc12_13.2: type = block_arg !if.expr.result.loc12 [template = constants.%True]
+// CHECK:STDOUT:   %.loc12_13.3: type = block_arg !if.expr.result.loc12 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc13: False = name_ref false_, %false_
 // CHECK:STDOUT:   %Less.ref.loc13: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %.loc13_22: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %Negate.ref.loc13: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc13_32: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_31.1: init i32 = call %Negate.ref.loc13(%.loc13_32) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_21.1: i32 = value_of_initializer %.loc13_31.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_31.2: i32 = converted %.loc13_31.1, %.loc13_21.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_21.2: init bool = call %Less.ref.loc13(%.loc13_22, %.loc13_31.2) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc13_14.1: bool = value_of_initializer %.loc13_21.2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc13_21.3: bool = converted %.loc13_21.2, %.loc13_14.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc13_21.3 br !if.expr.then.loc13 else br !if.expr.else.loc13
+// CHECK:STDOUT:   %.loc13_31: init i32 = call %Negate.ref.loc13(%.loc13_32) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_21.1: i32 = value_of_initializer %.loc13_31 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_21.2: i32 = converted %.loc13_31, %.loc13_21.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_21.3: init bool = call %Less.ref.loc13(%.loc13_22, %.loc13_21.2) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc13_14.1: bool = value_of_initializer %.loc13_21.3 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc13_14.2: bool = converted %.loc13_21.3, %.loc13_14.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc13_14.2 br !if.expr.then.loc13 else br !if.expr.else.loc13
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc13:
 // CHECK:STDOUT:   %True.ref.loc13: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -200,7 +200,7 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc13(%False.ref.loc13)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc13:
-// CHECK:STDOUT:   %.loc13_14.2: type = block_arg !if.expr.result.loc13 [template = constants.%False]
+// CHECK:STDOUT:   %.loc13_14.3: type = block_arg !if.expr.result.loc13 [template = constants.%False]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -209,9 +209,9 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Less.ref: <function> = name_ref Less, file.%Less [template = file.%Less]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc17_14.1: init bool = call %Less.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc17_20: bool = value_of_initializer %.loc17_14.1
-// CHECK:STDOUT:   %.loc17_14.2: bool = converted %.loc17_14.1, %.loc17_20
-// CHECK:STDOUT:   return %.loc17_14.2
+// CHECK:STDOUT:   %.loc17_14: init bool = call %Less.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc17_20.1: bool = value_of_initializer %.loc17_14
+// CHECK:STDOUT:   %.loc17_20.2: bool = converted %.loc17_14, %.loc17_20.1
+// CHECK:STDOUT:   return %.loc17_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/less_eq.carbon
+++ b/toolchain/check/testdata/builtins/int/less_eq.carbon
@@ -102,10 +102,10 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %LessEq.ref.loc9: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_26: i32 = int_literal 2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_22.1: init bool = call %LessEq.ref.loc9(%.loc9_23, %.loc9_26) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_22.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_22.2: bool = converted %.loc9_22.1, %.loc9_13.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc9_22.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_22: init bool = call %LessEq.ref.loc9(%.loc9_23, %.loc9_26) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_22 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_13.2: bool = converted %.loc9_22, %.loc9_13.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc9_13.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -116,15 +116,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_13.2: type = block_arg !if.expr.result.loc9 [template = constants.%True]
+// CHECK:STDOUT:   %.loc9_13.3: type = block_arg !if.expr.result.loc9 [template = constants.%True]
 // CHECK:STDOUT:   %true_.ref.loc10: True = name_ref true_, %true_
 // CHECK:STDOUT:   %LessEq.ref.loc10: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %.loc10_23: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_22.1: init bool = call %LessEq.ref.loc10(%.loc10_23, %.loc10_26) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.1: bool = value_of_initializer %.loc10_22.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_22.2: bool = converted %.loc10_22.1, %.loc10_13.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc10_22.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
+// CHECK:STDOUT:   %.loc10_22: init bool = call %LessEq.ref.loc10(%.loc10_23, %.loc10_26) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.1: bool = value_of_initializer %.loc10_22 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: bool = converted %.loc10_22, %.loc10_13.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc10_13.2 br !if.expr.then.loc10 else br !if.expr.else.loc10
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc10:
 // CHECK:STDOUT:   %True.ref.loc10: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -135,15 +135,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc10(%False.ref.loc10)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc10:
-// CHECK:STDOUT:   %.loc10_13.2: type = block_arg !if.expr.result.loc10 [template = constants.%True]
+// CHECK:STDOUT:   %.loc10_13.3: type = block_arg !if.expr.result.loc10 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc11: False = name_ref false_, %false_
 // CHECK:STDOUT:   %LessEq.ref.loc11: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_27: i32 = int_literal 0 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_23.1: init bool = call %LessEq.ref.loc11(%.loc11_24, %.loc11_27) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_23.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_23.2: bool = converted %.loc11_23.1, %.loc11_14.1 [template = constants.%.8]
-// CHECK:STDOUT:   if %.loc11_23.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
+// CHECK:STDOUT:   %.loc11_23: init bool = call %LessEq.ref.loc11(%.loc11_24, %.loc11_27) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_23 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_23, %.loc11_14.1 [template = constants.%.8]
+// CHECK:STDOUT:   if %.loc11_14.2 br !if.expr.then.loc11 else br !if.expr.else.loc11
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc11:
 // CHECK:STDOUT:   %True.ref.loc11: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -154,19 +154,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc11(%False.ref.loc11)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc11:
-// CHECK:STDOUT:   %.loc11_14.2: type = block_arg !if.expr.result.loc11 [template = constants.%False]
+// CHECK:STDOUT:   %.loc11_14.3: type = block_arg !if.expr.result.loc11 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref.loc12: True = name_ref true_, %true_
 // CHECK:STDOUT:   %LessEq.ref.loc12: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc12_30: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_29.1: init i32 = call %Negate.ref.loc12(%.loc12_30) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_29: init i32 = call %Negate.ref.loc12(%.loc12_30) [template = constants.%.9]
 // CHECK:STDOUT:   %.loc12_34: i32 = int_literal 0 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc12_22.1: i32 = value_of_initializer %.loc12_29.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_29.2: i32 = converted %.loc12_29.1, %.loc12_22.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc12_22.2: init bool = call %LessEq.ref.loc12(%.loc12_29.2, %.loc12_34) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_13.1: bool = value_of_initializer %.loc12_22.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_22.3: bool = converted %.loc12_22.2, %.loc12_13.1 [template = constants.%.6]
-// CHECK:STDOUT:   if %.loc12_22.3 br !if.expr.then.loc12 else br !if.expr.else.loc12
+// CHECK:STDOUT:   %.loc12_22.1: i32 = value_of_initializer %.loc12_29 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_22.2: i32 = converted %.loc12_29, %.loc12_22.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_22.3: init bool = call %LessEq.ref.loc12(%.loc12_22.2, %.loc12_34) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13.1: bool = value_of_initializer %.loc12_22.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13.2: bool = converted %.loc12_22.3, %.loc12_13.1 [template = constants.%.6]
+// CHECK:STDOUT:   if %.loc12_13.2 br !if.expr.then.loc12 else br !if.expr.else.loc12
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc12:
 // CHECK:STDOUT:   %True.ref.loc12: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -177,19 +177,19 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc12(%False.ref.loc12)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc12:
-// CHECK:STDOUT:   %.loc12_13.2: type = block_arg !if.expr.result.loc12 [template = constants.%True]
+// CHECK:STDOUT:   %.loc12_13.3: type = block_arg !if.expr.result.loc12 [template = constants.%True]
 // CHECK:STDOUT:   %false_.ref.loc13: False = name_ref false_, %false_
 // CHECK:STDOUT:   %LessEq.ref.loc13: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %.loc13_24: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %Negate.ref.loc13: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %.loc13_34: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_33.1: init i32 = call %Negate.ref.loc13(%.loc13_34) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_23.1: i32 = value_of_initializer %.loc13_33.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_33.2: i32 = converted %.loc13_33.1, %.loc13_23.1 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc13_23.2: init bool = call %LessEq.ref.loc13(%.loc13_24, %.loc13_33.2) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_14.1: bool = value_of_initializer %.loc13_23.2 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_23.3: bool = converted %.loc13_23.2, %.loc13_14.1 [template = constants.%.8]
-// CHECK:STDOUT:   if %.loc13_23.3 br !if.expr.then.loc13 else br !if.expr.else.loc13
+// CHECK:STDOUT:   %.loc13_33: init i32 = call %Negate.ref.loc13(%.loc13_34) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.1: i32 = value_of_initializer %.loc13_33 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.2: i32 = converted %.loc13_33, %.loc13_23.1 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_23.3: init bool = call %LessEq.ref.loc13(%.loc13_24, %.loc13_23.2) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_14.1: bool = value_of_initializer %.loc13_23.3 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_14.2: bool = converted %.loc13_23.3, %.loc13_14.1 [template = constants.%.8]
+// CHECK:STDOUT:   if %.loc13_14.2 br !if.expr.then.loc13 else br !if.expr.else.loc13
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc13:
 // CHECK:STDOUT:   %True.ref.loc13: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -200,7 +200,7 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc13(%False.ref.loc13)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc13:
-// CHECK:STDOUT:   %.loc13_14.2: type = block_arg !if.expr.result.loc13 [template = constants.%False]
+// CHECK:STDOUT:   %.loc13_14.3: type = block_arg !if.expr.result.loc13 [template = constants.%False]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -209,9 +209,9 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %LessEq.ref: <function> = name_ref LessEq, file.%LessEq [template = file.%LessEq]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc17_16.1: init bool = call %LessEq.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc17_22: bool = value_of_initializer %.loc17_16.1
-// CHECK:STDOUT:   %.loc17_16.2: bool = converted %.loc17_16.1, %.loc17_22
-// CHECK:STDOUT:   return %.loc17_16.2
+// CHECK:STDOUT:   %.loc17_16: init bool = call %LessEq.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc17_22.1: bool = value_of_initializer %.loc17_16
+// CHECK:STDOUT:   %.loc17_22.2: bool = converted %.loc17_16, %.loc17_22.1
+// CHECK:STDOUT:   return %.loc17_22.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/make_type_32.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_32.carbon
@@ -48,9 +48,9 @@ var i: Int() = 0;
 // CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+3, loc_11 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
-// CHECK:STDOUT:   %.loc6_11.1: init type = call %Int.ref() [template = i32]
-// CHECK:STDOUT:   %.loc6_12: type = value_of_initializer %.loc6_11.1 [template = i32]
-// CHECK:STDOUT:   %.loc6_11.2: type = converted %.loc6_11.1, %.loc6_12 [template = i32]
+// CHECK:STDOUT:   %.loc6_11: init type = call %Int.ref() [template = i32]
+// CHECK:STDOUT:   %.loc6_12.1: type = value_of_initializer %.loc6_11 [template = i32]
+// CHECK:STDOUT:   %.loc6_12.2: type = converted %.loc6_11, %.loc6_12.1 [template = i32]
 // CHECK:STDOUT:   %i.var: ref i32 = var i
 // CHECK:STDOUT:   %i: ref i32 = bind_name i, %i.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -105,31 +105,31 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Int.ref.loc6_9: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %.loc6_13: i32 = int_literal 64 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc6_12.1: init type = call %Int.ref.loc6_9(%.loc6_13) [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_15: type = value_of_initializer %.loc6_12.1 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_12.2: type = converted %.loc6_12.1, %.loc6_15 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_12: init type = call %Int.ref.loc6_9(%.loc6_13) [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_15.1: type = value_of_initializer %.loc6_12 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_15.2: type = converted %.loc6_12, %.loc6_15.1 [template = constants.%.2]
 // CHECK:STDOUT:     %n.loc6_6.1: i64 = param n
 // CHECK:STDOUT:     @F.%n: i64 = bind_name n, %n.loc6_6.1
 // CHECK:STDOUT:     %Int.ref.loc6_21: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %.loc6_25: i32 = int_literal 64 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc6_24.1: init type = call %Int.ref.loc6_21(%.loc6_25) [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_27: type = value_of_initializer %.loc6_24.1 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_24.2: type = converted %.loc6_24.1, %.loc6_27 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_24: init type = call %Int.ref.loc6_21(%.loc6_25) [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_27.1: type = value_of_initializer %.loc6_24 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_27.2: type = converted %.loc6_24, %.loc6_27.1 [template = constants.%.2]
 // CHECK:STDOUT:     @F.%return: ref i64 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %Int.ref.loc10_9: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %.loc10_13: i32 = int_literal 13 [template = constants.%.3]
-// CHECK:STDOUT:     %.loc10_12.1: init type = call %Int.ref.loc10_9(%.loc10_13) [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_15: type = value_of_initializer %.loc10_12.1 [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_12.2: type = converted %.loc10_12.1, %.loc10_15 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_12: init type = call %Int.ref.loc10_9(%.loc10_13) [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_15.1: type = value_of_initializer %.loc10_12 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_15.2: type = converted %.loc10_12, %.loc10_15.1 [template = constants.%.4]
 // CHECK:STDOUT:     %n.loc10_6.1: i13 = param n
 // CHECK:STDOUT:     @G.%n: i13 = bind_name n, %n.loc10_6.1
 // CHECK:STDOUT:     %Int.ref.loc10_21: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %.loc10_25: i32 = int_literal 13 [template = constants.%.3]
-// CHECK:STDOUT:     %.loc10_24.1: init type = call %Int.ref.loc10_21(%.loc10_25) [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_27: type = value_of_initializer %.loc10_24.1 [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_24.2: type = converted %.loc10_24.1, %.loc10_27 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_24: init type = call %Int.ref.loc10_21(%.loc10_25) [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_27.1: type = value_of_initializer %.loc10_24 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_27.2: type = converted %.loc10_24, %.loc10_27.1 [template = constants.%.4]
 // CHECK:STDOUT:     @G.%return: ref i13 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
@@ -137,16 +137,16 @@ var m: Int(1000000000);
 // CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic]
 // CHECK:STDOUT:     %Int.ref.loc14_25: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %N.ref.loc14_29: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
-// CHECK:STDOUT:     %.loc14_28.1: init type = call %Int.ref.loc14_25(%N.ref.loc14_29) [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_30: type = value_of_initializer %.loc14_28.1 [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_28.2: type = converted %.loc14_28.1, %.loc14_30 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_28: init type = call %Int.ref.loc14_25(%N.ref.loc14_29) [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_30.1: type = value_of_initializer %.loc14_28 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_30.2: type = converted %.loc14_28, %.loc14_30.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %x.loc14_22.1: Core.Int(N) = param x
 // CHECK:STDOUT:     @Symbolic.%x: Core.Int(N) = bind_name x, %x.loc14_22.1
 // CHECK:STDOUT:     %Int.ref.loc14_36: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %N.ref.loc14_40: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
-// CHECK:STDOUT:     %.loc14_39.1: init type = call %Int.ref.loc14_36(%N.ref.loc14_40) [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_41: type = value_of_initializer %.loc14_39.1 [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_39.2: type = converted %.loc14_39.1, %.loc14_41 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_39: init type = call %Int.ref.loc14_36(%N.ref.loc14_40) [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_41.1: type = value_of_initializer %.loc14_39 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_41.2: type = converted %.loc14_39, %.loc14_41.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     @Symbolic.%return: ref Core.Int(N) = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -187,9 +187,9 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_11.1: init type = call %Int.ref(%.loc10_12) [template = <error>]
-// CHECK:STDOUT:   %.loc10_13: type = value_of_initializer %.loc10_11.1 [template = <error>]
-// CHECK:STDOUT:   %.loc10_11.2: type = converted %.loc10_11.1, %.loc10_13 [template = <error>]
+// CHECK:STDOUT:   %.loc10_11: init type = call %Int.ref(%.loc10_12) [template = <error>]
+// CHECK:STDOUT:   %.loc10_13.1: type = value_of_initializer %.loc10_11 [template = <error>]
+// CHECK:STDOUT:   %.loc10_13.2: type = converted %.loc10_11, %.loc10_13.1 [template = <error>]
 // CHECK:STDOUT:   %n.var: ref <error> = var n
 // CHECK:STDOUT:   %n: ref <error> = bind_name n, %n.var
 // CHECK:STDOUT: }
@@ -220,12 +220,12 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %Negate.ref: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc12_19: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_18.1: init i32 = call %Negate.ref(%.loc12_19) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_11.1: i32 = value_of_initializer %.loc12_18.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_18.2: i32 = converted %.loc12_18.1, %.loc12_11.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_11.2: init type = call %Int.ref(%.loc12_18.2) [template = <error>]
-// CHECK:STDOUT:   %.loc12_21: type = value_of_initializer %.loc12_11.2 [template = <error>]
-// CHECK:STDOUT:   %.loc12_11.3: type = converted %.loc12_11.2, %.loc12_21 [template = <error>]
+// CHECK:STDOUT:   %.loc12_18: init i32 = call %Negate.ref(%.loc12_19) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_11.1: i32 = value_of_initializer %.loc12_18 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_11.2: i32 = converted %.loc12_18, %.loc12_11.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_11.3: init type = call %Int.ref(%.loc12_11.2) [template = <error>]
+// CHECK:STDOUT:   %.loc12_21.1: type = value_of_initializer %.loc12_11.3 [template = <error>]
+// CHECK:STDOUT:   %.loc12_21.2: type = converted %.loc12_11.3, %.loc12_21.1 [template = <error>]
 // CHECK:STDOUT:   %n.var: ref <error> = var n
 // CHECK:STDOUT:   %n.loc12: ref <error> = bind_name n, %n.var
 // CHECK:STDOUT: }
@@ -250,9 +250,9 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %.loc9_12: i32 = int_literal 1000000000 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_11.1: init type = call %Int.ref(%.loc9_12) [template = <error>]
-// CHECK:STDOUT:   %.loc9_22: type = value_of_initializer %.loc9_11.1 [template = <error>]
-// CHECK:STDOUT:   %.loc9_11.2: type = converted %.loc9_11.1, %.loc9_22 [template = <error>]
+// CHECK:STDOUT:   %.loc9_11: init type = call %Int.ref(%.loc9_12) [template = <error>]
+// CHECK:STDOUT:   %.loc9_22.1: type = value_of_initializer %.loc9_11 [template = <error>]
+// CHECK:STDOUT:   %.loc9_22.2: type = converted %.loc9_11, %.loc9_22.1 [template = <error>]
 // CHECK:STDOUT:   %m.var: ref <error> = var m
 // CHECK:STDOUT:   %m: ref <error> = bind_name m, %m.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -105,31 +105,31 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %UInt.ref.loc6_9: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %.loc6_14: i32 = int_literal 64 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc6_13.1: init type = call %UInt.ref.loc6_9(%.loc6_14) [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_16: type = value_of_initializer %.loc6_13.1 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_13.2: type = converted %.loc6_13.1, %.loc6_16 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_13: init type = call %UInt.ref.loc6_9(%.loc6_14) [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_16.1: type = value_of_initializer %.loc6_13 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_16.2: type = converted %.loc6_13, %.loc6_16.1 [template = constants.%.2]
 // CHECK:STDOUT:     %n.loc6_6.1: u64 = param n
 // CHECK:STDOUT:     @F.%n: u64 = bind_name n, %n.loc6_6.1
 // CHECK:STDOUT:     %UInt.ref.loc6_22: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %.loc6_27: i32 = int_literal 64 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc6_26.1: init type = call %UInt.ref.loc6_22(%.loc6_27) [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_29: type = value_of_initializer %.loc6_26.1 [template = constants.%.2]
-// CHECK:STDOUT:     %.loc6_26.2: type = converted %.loc6_26.1, %.loc6_29 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_26: init type = call %UInt.ref.loc6_22(%.loc6_27) [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_29.1: type = value_of_initializer %.loc6_26 [template = constants.%.2]
+// CHECK:STDOUT:     %.loc6_29.2: type = converted %.loc6_26, %.loc6_29.1 [template = constants.%.2]
 // CHECK:STDOUT:     @F.%return: ref u64 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %UInt.ref.loc10_9: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %.loc10_14: i32 = int_literal 13 [template = constants.%.3]
-// CHECK:STDOUT:     %.loc10_13.1: init type = call %UInt.ref.loc10_9(%.loc10_14) [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_16: type = value_of_initializer %.loc10_13.1 [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_13.2: type = converted %.loc10_13.1, %.loc10_16 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_13: init type = call %UInt.ref.loc10_9(%.loc10_14) [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_16.1: type = value_of_initializer %.loc10_13 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_16.2: type = converted %.loc10_13, %.loc10_16.1 [template = constants.%.4]
 // CHECK:STDOUT:     %n.loc10_6.1: u13 = param n
 // CHECK:STDOUT:     @G.%n: u13 = bind_name n, %n.loc10_6.1
 // CHECK:STDOUT:     %UInt.ref.loc10_22: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %.loc10_27: i32 = int_literal 13 [template = constants.%.3]
-// CHECK:STDOUT:     %.loc10_26.1: init type = call %UInt.ref.loc10_22(%.loc10_27) [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_29: type = value_of_initializer %.loc10_26.1 [template = constants.%.4]
-// CHECK:STDOUT:     %.loc10_26.2: type = converted %.loc10_26.1, %.loc10_29 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_26: init type = call %UInt.ref.loc10_22(%.loc10_27) [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_29.1: type = value_of_initializer %.loc10_26 [template = constants.%.4]
+// CHECK:STDOUT:     %.loc10_29.2: type = converted %.loc10_26, %.loc10_29.1 [template = constants.%.4]
 // CHECK:STDOUT:     @G.%return: ref u13 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
@@ -137,16 +137,16 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic]
 // CHECK:STDOUT:     %UInt.ref.loc14_25: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %N.ref.loc14_30: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
-// CHECK:STDOUT:     %.loc14_29.1: init type = call %UInt.ref.loc14_25(%N.ref.loc14_30) [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_31: type = value_of_initializer %.loc14_29.1 [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_29.2: type = converted %.loc14_29.1, %.loc14_31 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_29: init type = call %UInt.ref.loc14_25(%N.ref.loc14_30) [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_31.1: type = value_of_initializer %.loc14_29 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_31.2: type = converted %.loc14_29, %.loc14_31.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %x.loc14_22.1: Core.UInt(N) = param x
 // CHECK:STDOUT:     @Symbolic.%x: Core.UInt(N) = bind_name x, %x.loc14_22.1
 // CHECK:STDOUT:     %UInt.ref.loc14_37: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %N.ref.loc14_42: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
-// CHECK:STDOUT:     %.loc14_41.1: init type = call %UInt.ref.loc14_37(%N.ref.loc14_42) [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_43: type = value_of_initializer %.loc14_41.1 [symbolic = constants.%.5]
-// CHECK:STDOUT:     %.loc14_41.2: type = converted %.loc14_41.1, %.loc14_43 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_41: init type = call %UInt.ref.loc14_37(%N.ref.loc14_42) [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_43.1: type = value_of_initializer %.loc14_41 [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc14_43.2: type = converted %.loc14_41, %.loc14_43.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     @Symbolic.%return: ref Core.UInt(N) = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -187,9 +187,9 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %UInt.ref: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:   %.loc10_13: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_12.1: init type = call %UInt.ref(%.loc10_13) [template = <error>]
-// CHECK:STDOUT:   %.loc10_14: type = value_of_initializer %.loc10_12.1 [template = <error>]
-// CHECK:STDOUT:   %.loc10_12.2: type = converted %.loc10_12.1, %.loc10_14 [template = <error>]
+// CHECK:STDOUT:   %.loc10_12: init type = call %UInt.ref(%.loc10_13) [template = <error>]
+// CHECK:STDOUT:   %.loc10_14.1: type = value_of_initializer %.loc10_12 [template = <error>]
+// CHECK:STDOUT:   %.loc10_14.2: type = converted %.loc10_12, %.loc10_14.1 [template = <error>]
 // CHECK:STDOUT:   %n.var: ref <error> = var n
 // CHECK:STDOUT:   %n: ref <error> = bind_name n, %n.var
 // CHECK:STDOUT: }
@@ -220,12 +220,12 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %UInt.ref: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:   %Negate.ref: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc12_20: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_19.1: init i32 = call %Negate.ref(%.loc12_20) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_12.1: i32 = value_of_initializer %.loc12_19.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_19.2: i32 = converted %.loc12_19.1, %.loc12_12.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_12.2: init type = call %UInt.ref(%.loc12_19.2) [template = <error>]
-// CHECK:STDOUT:   %.loc12_22: type = value_of_initializer %.loc12_12.2 [template = <error>]
-// CHECK:STDOUT:   %.loc12_12.3: type = converted %.loc12_12.2, %.loc12_22 [template = <error>]
+// CHECK:STDOUT:   %.loc12_19: init i32 = call %Negate.ref(%.loc12_20) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_12.1: i32 = value_of_initializer %.loc12_19 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_12.2: i32 = converted %.loc12_19, %.loc12_12.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_12.3: init type = call %UInt.ref(%.loc12_12.2) [template = <error>]
+// CHECK:STDOUT:   %.loc12_22.1: type = value_of_initializer %.loc12_12.3 [template = <error>]
+// CHECK:STDOUT:   %.loc12_22.2: type = converted %.loc12_12.3, %.loc12_22.1 [template = <error>]
 // CHECK:STDOUT:   %n.var: ref <error> = var n
 // CHECK:STDOUT:   %n.loc12: ref <error> = bind_name n, %n.var
 // CHECK:STDOUT: }
@@ -250,9 +250,9 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %UInt.ref: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:   %.loc9_13: i32 = int_literal 1000000000 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_12.1: init type = call %UInt.ref(%.loc9_13) [template = <error>]
-// CHECK:STDOUT:   %.loc9_23: type = value_of_initializer %.loc9_12.1 [template = <error>]
-// CHECK:STDOUT:   %.loc9_12.2: type = converted %.loc9_12.1, %.loc9_23 [template = <error>]
+// CHECK:STDOUT:   %.loc9_12: init type = call %UInt.ref(%.loc9_13) [template = <error>]
+// CHECK:STDOUT:   %.loc9_23.1: type = value_of_initializer %.loc9_12 [template = <error>]
+// CHECK:STDOUT:   %.loc9_23.2: type = converted %.loc9_12, %.loc9_23.1 [template = <error>]
 // CHECK:STDOUT:   %m.var: ref <error> = var m
 // CHECK:STDOUT:   %m: ref <error> = bind_name m, %m.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/builtins/int/mod.carbon
+++ b/toolchain/check/testdata/builtins/int/mod.carbon
@@ -110,10 +110,10 @@ let b: i32 = Mod(0, 0);
 // CHECK:STDOUT:   %Mod.ref: <function> = name_ref Mod, file.%Mod [template = file.%Mod]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Mod.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Mod.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -157,54 +157,54 @@ let b: i32 = Mod(0, 0);
 // CHECK:STDOUT:   %Mod.ref.loc9: <function> = name_ref Mod, %Mod [template = %Mod]
 // CHECK:STDOUT:   %Negate.ref.loc9_18: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc9_25: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_24.1: init i32 = call %Negate.ref.loc9_18(%.loc9_25) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_24: init i32 = call %Negate.ref.loc9_18(%.loc9_25) [template = constants.%.2]
 // CHECK:STDOUT:   %Negate.ref.loc9_39: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc9_46: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc9_45.1: init i32 = call %Negate.ref.loc9_39(%.loc9_46) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_17.1: i32 = value_of_initializer %.loc9_24.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc9_24.2: i32 = converted %.loc9_24.1, %.loc9_17.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc9_17.2: i32 = value_of_initializer %.loc9_45.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_45.2: i32 = converted %.loc9_45.1, %.loc9_17.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_17.3: init i32 = call %Mod.ref.loc9(%.loc9_24.2, %.loc9_45.2) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_49: i32 = value_of_initializer %.loc9_17.3 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_17.4: i32 = converted %.loc9_17.3, %.loc9_49 [template = constants.%.5]
-// CHECK:STDOUT:   %a.loc9: i32 = bind_name a, %.loc9_17.4
+// CHECK:STDOUT:   %.loc9_45: init i32 = call %Negate.ref.loc9_39(%.loc9_46) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.1: i32 = value_of_initializer %.loc9_24 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_17.2: i32 = converted %.loc9_24, %.loc9_17.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_17.3: i32 = value_of_initializer %.loc9_45 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.4: i32 = converted %.loc9_45, %.loc9_17.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_17.5: init i32 = call %Mod.ref.loc9(%.loc9_17.2, %.loc9_17.4) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_49.1: i32 = value_of_initializer %.loc9_17.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_49.2: i32 = converted %.loc9_17.5, %.loc9_49.1 [template = constants.%.5]
+// CHECK:STDOUT:   %a.loc9: i32 = bind_name a, %.loc9_49.2
 // CHECK:STDOUT:   %Mod.ref.loc12: <function> = name_ref Mod, %Mod [template = %Mod]
 // CHECK:STDOUT:   %Sub.ref.loc12: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Negate.ref.loc12: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc12_29: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_28.1: init i32 = call %Negate.ref.loc12(%.loc12_29) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_28: init i32 = call %Negate.ref.loc12(%.loc12_29) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc12_43: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_21.1: i32 = value_of_initializer %.loc12_28.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_28.2: i32 = converted %.loc12_28.1, %.loc12_21.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_21.2: init i32 = call %Sub.ref.loc12(%.loc12_28.2, %.loc12_43) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_21.1: i32 = value_of_initializer %.loc12_28 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_21.2: i32 = converted %.loc12_28, %.loc12_21.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_21.3: init i32 = call %Sub.ref.loc12(%.loc12_21.2, %.loc12_43) [template = constants.%.6]
 // CHECK:STDOUT:   %.loc12_47: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_17.1: i32 = value_of_initializer %.loc12_21.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_21.3: i32 = converted %.loc12_21.2, %.loc12_17.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc12_17.2: init i32 = call %Mod.ref.loc12(%.loc12_21.3, %.loc12_47) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_49: i32 = value_of_initializer %.loc12_17.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_17.3: i32 = converted %.loc12_17.2, %.loc12_49 [template = constants.%.5]
-// CHECK:STDOUT:   %b.loc12: i32 = bind_name b, %.loc12_17.3
+// CHECK:STDOUT:   %.loc12_17.1: i32 = value_of_initializer %.loc12_21.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_17.2: i32 = converted %.loc12_21.3, %.loc12_17.1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_17.3: init i32 = call %Mod.ref.loc12(%.loc12_17.2, %.loc12_47) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_49.1: i32 = value_of_initializer %.loc12_17.3 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_49.2: i32 = converted %.loc12_17.3, %.loc12_49.1 [template = constants.%.5]
+// CHECK:STDOUT:   %b.loc12: i32 = bind_name b, %.loc12_49.2
 // CHECK:STDOUT:   %Mod.ref.loc20: <function> = name_ref Mod, %Mod [template = %Mod]
 // CHECK:STDOUT:   %Sub.ref.loc20: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Negate.ref.loc20_22: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc20_29: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc20_28.1: init i32 = call %Negate.ref.loc20_22(%.loc20_29) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc20_28: init i32 = call %Negate.ref.loc20_22(%.loc20_29) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc20_43: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc20_21.1: i32 = value_of_initializer %.loc20_28.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc20_28.2: i32 = converted %.loc20_28.1, %.loc20_21.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc20_21.2: init i32 = call %Sub.ref.loc20(%.loc20_28.2, %.loc20_43) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc20_21.1: i32 = value_of_initializer %.loc20_28 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc20_21.2: i32 = converted %.loc20_28, %.loc20_21.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc20_21.3: init i32 = call %Sub.ref.loc20(%.loc20_21.2, %.loc20_43) [template = constants.%.6]
 // CHECK:STDOUT:   %Negate.ref.loc20_47: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc20_54: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc20_53.1: init i32 = call %Negate.ref.loc20_47(%.loc20_54) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc20_17.1: i32 = value_of_initializer %.loc20_21.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc20_21.3: i32 = converted %.loc20_21.2, %.loc20_17.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc20_17.2: i32 = value_of_initializer %.loc20_53.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc20_53.2: i32 = converted %.loc20_53.1, %.loc20_17.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc20_17.3: init i32 = call %Mod.ref.loc20(%.loc20_21.3, %.loc20_53.2) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc20_57: i32 = value_of_initializer %.loc20_17.3 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc20_17.4: i32 = converted %.loc20_17.3, %.loc20_57 [template = constants.%.5]
-// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc20_17.4
+// CHECK:STDOUT:   %.loc20_53: init i32 = call %Negate.ref.loc20_47(%.loc20_54) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc20_17.1: i32 = value_of_initializer %.loc20_21.3 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc20_17.2: i32 = converted %.loc20_21.3, %.loc20_17.1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc20_17.3: i32 = value_of_initializer %.loc20_53 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc20_17.4: i32 = converted %.loc20_53, %.loc20_17.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc20_17.5: init i32 = call %Mod.ref.loc20(%.loc20_17.2, %.loc20_17.4) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_57.1: i32 = value_of_initializer %.loc20_17.5 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc20_57.2: i32 = converted %.loc20_17.5, %.loc20_57.1 [template = constants.%.5]
+// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc20_57.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Mod(%a: i32, %b: i32) -> i32 = "int.mod";
@@ -236,17 +236,17 @@ let b: i32 = Mod(0, 0);
 // CHECK:STDOUT:   %Mod.ref.loc12: <function> = name_ref Mod, %Mod [template = %Mod]
 // CHECK:STDOUT:   %.loc12_18: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc12_21: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_17.1: init i32 = call %Mod.ref.loc12(%.loc12_18, %.loc12_21) [template = <error>]
-// CHECK:STDOUT:   %.loc12_23: i32 = value_of_initializer %.loc12_17.1 [template = <error>]
-// CHECK:STDOUT:   %.loc12_17.2: i32 = converted %.loc12_17.1, %.loc12_23 [template = <error>]
-// CHECK:STDOUT:   %a.loc12: i32 = bind_name a, %.loc12_17.2
+// CHECK:STDOUT:   %.loc12_17: init i32 = call %Mod.ref.loc12(%.loc12_18, %.loc12_21) [template = <error>]
+// CHECK:STDOUT:   %.loc12_23.1: i32 = value_of_initializer %.loc12_17 [template = <error>]
+// CHECK:STDOUT:   %.loc12_23.2: i32 = converted %.loc12_17, %.loc12_23.1 [template = <error>]
+// CHECK:STDOUT:   %a.loc12: i32 = bind_name a, %.loc12_23.2
 // CHECK:STDOUT:   %Mod.ref.loc17: <function> = name_ref Mod, %Mod [template = %Mod]
 // CHECK:STDOUT:   %.loc17_18: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc17_21: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc17_17.1: init i32 = call %Mod.ref.loc17(%.loc17_18, %.loc17_21) [template = <error>]
-// CHECK:STDOUT:   %.loc17_23: i32 = value_of_initializer %.loc17_17.1 [template = <error>]
-// CHECK:STDOUT:   %.loc17_17.2: i32 = converted %.loc17_17.1, %.loc17_23 [template = <error>]
-// CHECK:STDOUT:   %b.loc17: i32 = bind_name b, %.loc17_17.2
+// CHECK:STDOUT:   %.loc17_17: init i32 = call %Mod.ref.loc17(%.loc17_18, %.loc17_21) [template = <error>]
+// CHECK:STDOUT:   %.loc17_23.1: i32 = value_of_initializer %.loc17_17 [template = <error>]
+// CHECK:STDOUT:   %.loc17_23.2: i32 = converted %.loc17_17, %.loc17_23.1 [template = <error>]
+// CHECK:STDOUT:   %b.loc17: i32 = bind_name b, %.loc17_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Mod(%a: i32, %b: i32) -> i32 = "int.mod";

--- a/toolchain/check/testdata/builtins/int/mul.carbon
+++ b/toolchain/check/testdata/builtins/int/mul.carbon
@@ -81,10 +81,10 @@ let b: i32 = Mul(0x8000, 0x10000);
 // CHECK:STDOUT:   %Mul.ref: <function> = name_ref Mul, file.%Mul [template = file.%Mul]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Mul.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Mul.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -113,17 +113,17 @@ let b: i32 = Mul(0x8000, 0x10000);
 // CHECK:STDOUT:   %Mul.ref.loc6: <function> = name_ref Mul, %Mul [template = %Mul]
 // CHECK:STDOUT:   %.loc6_18: i32 = int_literal 32767 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc6_26: i32 = int_literal 65536 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc6_17.1: init i32 = call %Mul.ref.loc6(%.loc6_18, %.loc6_26) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc6_34: i32 = value_of_initializer %.loc6_17.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc6_17.2: i32 = converted %.loc6_17.1, %.loc6_34 [template = constants.%.3]
-// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_17.2
+// CHECK:STDOUT:   %.loc6_17: init i32 = call %Mul.ref.loc6(%.loc6_18, %.loc6_26) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc6_34.1: i32 = value_of_initializer %.loc6_17 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc6_34.2: i32 = converted %.loc6_17, %.loc6_34.1 [template = constants.%.3]
+// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_34.2
 // CHECK:STDOUT:   %Mul.ref.loc10: <function> = name_ref Mul, %Mul [template = %Mul]
 // CHECK:STDOUT:   %.loc10_18: i32 = int_literal 32768 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 65536 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_17.1: init i32 = call %Mul.ref.loc10(%.loc10_18, %.loc10_26) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_34: i32 = value_of_initializer %.loc10_17.1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_17.2: i32 = converted %.loc10_17.1, %.loc10_34 [template = constants.%.5]
-// CHECK:STDOUT:   %b.loc10: i32 = bind_name b, %.loc10_17.2
+// CHECK:STDOUT:   %.loc10_17: init i32 = call %Mul.ref.loc10(%.loc10_18, %.loc10_26) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_34.1: i32 = value_of_initializer %.loc10_17 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_34.2: i32 = converted %.loc10_17, %.loc10_34.1 [template = constants.%.5]
+// CHECK:STDOUT:   %b.loc10: i32 = bind_name b, %.loc10_34.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Mul(%a: i32, %b: i32) -> i32 = "int.mul";

--- a/toolchain/check/testdata/builtins/int/negate.carbon
+++ b/toolchain/check/testdata/builtins/int/negate.carbon
@@ -139,11 +139,11 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:   %Negate.ref.loc4_16: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %Negate.ref.loc4_23: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc4_30: i32 = int_literal 123 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc4_29.1: init i32 = call %Negate.ref.loc4_23(%.loc4_30) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_22.1: i32 = value_of_initializer %.loc4_29.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_29.2: i32 = converted %.loc4_29.1, %.loc4_22.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_22.2: init i32 = call %Negate.ref.loc4_16(%.loc4_29.2) [template = constants.%.1]
-// CHECK:STDOUT:   %.loc4_35: type = array_type %.loc4_22.2, i32 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc4_29: init i32 = call %Negate.ref.loc4_23(%.loc4_30) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_22.1: i32 = value_of_initializer %.loc4_29 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_22.2: i32 = converted %.loc4_29, %.loc4_22.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_22.3: init i32 = call %Negate.ref.loc4_16(%.loc4_22.2) [template = constants.%.1]
+// CHECK:STDOUT:   %.loc4_35: type = array_type %.loc4_22.3, i32 [template = constants.%.3]
 // CHECK:STDOUT:   %arr.var: ref [i32; 123] = var arr
 // CHECK:STDOUT:   %arr: ref [i32; 123] = bind_name arr, %arr.var
 // CHECK:STDOUT:   %.loc5_18: i32 = int_literal 123 [template = constants.%.1]
@@ -154,10 +154,10 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:   %arr_p: [i32; 123]* = bind_name arr_p, %.loc5_26
 // CHECK:STDOUT:   %Negate.ref.loc7: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc7_21: i32 = int_literal 1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_20.1: init i32 = call %Negate.ref.loc7(%.loc7_21) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_23: i32 = value_of_initializer %.loc7_20.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_20.2: i32 = converted %.loc7_20.1, %.loc7_23 [template = constants.%.6]
-// CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7_20.2
+// CHECK:STDOUT:   %.loc7_20: init i32 = call %Negate.ref.loc7(%.loc7_21) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_23.1: i32 = value_of_initializer %.loc7_20 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_23.2: i32 = converted %.loc7_20, %.loc7_23.1 [template = constants.%.6]
+// CHECK:STDOUT:   %n: i32 = bind_name n, %.loc7_23.2
 // CHECK:STDOUT:   %RuntimeCall: <function> = fn_decl @RuntimeCall [template] {
 // CHECK:STDOUT:     %a.loc9_16.1: i32 = param a
 // CHECK:STDOUT:     @RuntimeCall.%a: i32 = bind_name a, %a.loc9_16.1
@@ -173,10 +173,10 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Negate.ref: <function> = name_ref Negate, file.%Negate [template = file.%Negate]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc10_16.1: init i32 = call %Negate.ref(%a.ref)
-// CHECK:STDOUT:   %.loc10_19: i32 = value_of_initializer %.loc10_16.1
-// CHECK:STDOUT:   %.loc10_16.2: i32 = converted %.loc10_16.1, %.loc10_19
-// CHECK:STDOUT:   return %.loc10_16.2
+// CHECK:STDOUT:   %.loc10_16: init i32 = call %Negate.ref(%a.ref)
+// CHECK:STDOUT:   %.loc10_19.1: i32 = value_of_initializer %.loc10_16
+// CHECK:STDOUT:   %.loc10_19.2: i32 = converted %.loc10_16, %.loc10_19.1
+// CHECK:STDOUT:   return %.loc10_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_bad_decl.carbon
@@ -279,10 +279,10 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %TooFew.ref: <function> = name_ref TooFew, file.%TooFew [template = file.%TooFew]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
-// CHECK:STDOUT:   %.loc54_16.1: init i32 = call %TooFew.ref(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc54_19: i32 = value_of_initializer %.loc54_16.1 [template = <error>]
-// CHECK:STDOUT:   %.loc54_16.2: i32 = converted %.loc54_16.1, %.loc54_19 [template = <error>]
-// CHECK:STDOUT:   return %.loc54_16.2
+// CHECK:STDOUT:   %.loc54_16: init i32 = call %TooFew.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc54_19.1: i32 = value_of_initializer %.loc54_16 [template = <error>]
+// CHECK:STDOUT:   %.loc54_19.2: i32 = converted %.loc54_16, %.loc54_19.1 [template = <error>]
+// CHECK:STDOUT:   return %.loc54_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallTooMany(%a: i32, %b: i32, %c: i32) -> i32 {
@@ -291,10 +291,10 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
 // CHECK:STDOUT:   %c.ref: i32 = name_ref c, %c
-// CHECK:STDOUT:   %.loc65_17.1: init i32 = call %TooMany.ref(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc65_26: i32 = value_of_initializer %.loc65_17.1 [template = <error>]
-// CHECK:STDOUT:   %.loc65_17.2: i32 = converted %.loc65_17.1, %.loc65_26 [template = <error>]
-// CHECK:STDOUT:   return %.loc65_17.2
+// CHECK:STDOUT:   %.loc65_17: init i32 = call %TooMany.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc65_26.1: i32 = value_of_initializer %.loc65_17 [template = <error>]
+// CHECK:STDOUT:   %.loc65_26.2: i32 = converted %.loc65_17, %.loc65_26.1 [template = <error>]
+// CHECK:STDOUT:   return %.loc65_26.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RuntimeCallBadReturnType(%a: i32, %b: i32) -> bool {
@@ -302,10 +302,10 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:   %BadReturnType.ref: <function> = name_ref BadReturnType, file.%BadReturnType [template = file.%BadReturnType]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc76_23.1: init bool = call %BadReturnType.ref(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc76_29: bool = value_of_initializer %.loc76_23.1 [template = <error>]
-// CHECK:STDOUT:   %.loc76_23.2: bool = converted %.loc76_23.1, %.loc76_29 [template = <error>]
-// CHECK:STDOUT:   return %.loc76_23.2
+// CHECK:STDOUT:   %.loc76_23: init bool = call %BadReturnType.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   %.loc76_29.1: bool = value_of_initializer %.loc76_23 [template = <error>]
+// CHECK:STDOUT:   %.loc76_29.2: bool = converted %.loc76_23, %.loc76_29.1 [template = <error>]
+// CHECK:STDOUT:   return %.loc76_29.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -339,28 +339,28 @@ let b: i32 = Negate(Sub(Negate(0x7FFFFFFF), 1));
 // CHECK:STDOUT:   %Negate.ref.loc8_14: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %Negate.ref.loc8_21: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc8_28: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc8_27.1: init i32 = call %Negate.ref.loc8_21(%.loc8_28) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_20.1: i32 = value_of_initializer %.loc8_27.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_27.2: i32 = converted %.loc8_27.1, %.loc8_20.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_20.2: init i32 = call %Negate.ref.loc8_14(%.loc8_27.2) [template = constants.%.1]
-// CHECK:STDOUT:   %.loc8_40: i32 = value_of_initializer %.loc8_20.2 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc8_20.3: i32 = converted %.loc8_20.2, %.loc8_40 [template = constants.%.1]
-// CHECK:STDOUT:   %a.loc8: i32 = bind_name a, %.loc8_20.3
+// CHECK:STDOUT:   %.loc8_27: init i32 = call %Negate.ref.loc8_21(%.loc8_28) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_20.1: i32 = value_of_initializer %.loc8_27 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_20.2: i32 = converted %.loc8_27, %.loc8_20.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_20.3: init i32 = call %Negate.ref.loc8_14(%.loc8_20.2) [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_40.1: i32 = value_of_initializer %.loc8_20.3 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc8_40.2: i32 = converted %.loc8_20.3, %.loc8_40.1 [template = constants.%.1]
+// CHECK:STDOUT:   %a.loc8: i32 = bind_name a, %.loc8_40.2
 // CHECK:STDOUT:   %Negate.ref.loc14_14: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %Sub.ref: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Negate.ref.loc14_25: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc14_32: i32 = int_literal 2147483647 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc14_31.1: init i32 = call %Negate.ref.loc14_25(%.loc14_32) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc14_31: init i32 = call %Negate.ref.loc14_25(%.loc14_32) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc14_45: i32 = int_literal 1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc14_24.1: i32 = value_of_initializer %.loc14_31.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc14_31.2: i32 = converted %.loc14_31.1, %.loc14_24.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc14_24.2: init i32 = call %Sub.ref(%.loc14_31.2, %.loc14_45) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_20.1: i32 = value_of_initializer %.loc14_24.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_24.3: i32 = converted %.loc14_24.2, %.loc14_20.1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_20.2: init i32 = call %Negate.ref.loc14_14(%.loc14_24.3) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_48: i32 = value_of_initializer %.loc14_20.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_20.3: i32 = converted %.loc14_20.2, %.loc14_48 [template = constants.%.4]
-// CHECK:STDOUT:   %b.loc14: i32 = bind_name b, %.loc14_20.3
+// CHECK:STDOUT:   %.loc14_24.1: i32 = value_of_initializer %.loc14_31 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc14_24.2: i32 = converted %.loc14_31, %.loc14_24.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc14_24.3: init i32 = call %Sub.ref(%.loc14_24.2, %.loc14_45) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc14_20.1: i32 = value_of_initializer %.loc14_24.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc14_20.2: i32 = converted %.loc14_24.3, %.loc14_20.1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc14_20.3: init i32 = call %Negate.ref.loc14_14(%.loc14_20.2) [template = constants.%.4]
+// CHECK:STDOUT:   %.loc14_48.1: i32 = value_of_initializer %.loc14_20.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc14_48.2: i32 = converted %.loc14_20.3, %.loc14_48.1 [template = constants.%.4]
+// CHECK:STDOUT:   %b.loc14: i32 = bind_name b, %.loc14_48.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Negate(%a: i32) -> i32 = "int.negate";

--- a/toolchain/check/testdata/builtins/int/neq.carbon
+++ b/toolchain/check/testdata/builtins/int/neq.carbon
@@ -88,10 +88,10 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Neq.ref.loc8: <function> = name_ref Neq, file.%Neq [template = file.%Neq]
 // CHECK:STDOUT:   %.loc8_21: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_24: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_20.1: init bool = call %Neq.ref.loc8(%.loc8_21, %.loc8_24) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_14.1: bool = value_of_initializer %.loc8_20.1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_20.2: bool = converted %.loc8_20.1, %.loc8_14.1 [template = constants.%.5]
-// CHECK:STDOUT:   if %.loc8_20.2 br !if.expr.then.loc8 else br !if.expr.else.loc8
+// CHECK:STDOUT:   %.loc8_20: init bool = call %Neq.ref.loc8(%.loc8_21, %.loc8_24) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_14.1: bool = value_of_initializer %.loc8_20 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_14.2: bool = converted %.loc8_20, %.loc8_14.1 [template = constants.%.5]
+// CHECK:STDOUT:   if %.loc8_14.2 br !if.expr.then.loc8 else br !if.expr.else.loc8
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc8:
 // CHECK:STDOUT:   %True.ref.loc8: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -102,15 +102,15 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc8(%False.ref.loc8)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc8:
-// CHECK:STDOUT:   %.loc8_14.2: type = block_arg !if.expr.result.loc8 [template = constants.%False]
+// CHECK:STDOUT:   %.loc8_14.3: type = block_arg !if.expr.result.loc8 [template = constants.%False]
 // CHECK:STDOUT:   %true_.ref: True = name_ref true_, %true_
 // CHECK:STDOUT:   %Neq.ref.loc9: <function> = name_ref Neq, file.%Neq [template = file.%Neq]
 // CHECK:STDOUT:   %.loc9_20: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_19.1: init bool = call %Neq.ref.loc9(%.loc9_20, %.loc9_23) [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_19.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_19.2: bool = converted %.loc9_19.1, %.loc9_13.1 [template = constants.%.7]
-// CHECK:STDOUT:   if %.loc9_19.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
+// CHECK:STDOUT:   %.loc9_19: init bool = call %Neq.ref.loc9(%.loc9_20, %.loc9_23) [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_13.1: bool = value_of_initializer %.loc9_19 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_13.2: bool = converted %.loc9_19, %.loc9_13.1 [template = constants.%.7]
+// CHECK:STDOUT:   if %.loc9_13.2 br !if.expr.then.loc9 else br !if.expr.else.loc9
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc9:
 // CHECK:STDOUT:   %True.ref.loc9: type = name_ref True, file.%True.decl [template = constants.%True]
@@ -121,7 +121,7 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   br !if.expr.result.loc9(%False.ref.loc9)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
-// CHECK:STDOUT:   %.loc9_13.2: type = block_arg !if.expr.result.loc9 [template = constants.%True]
+// CHECK:STDOUT:   %.loc9_13.3: type = block_arg !if.expr.result.loc9 [template = constants.%True]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -130,9 +130,9 @@ fn RuntimeCall(a: i32, b: i32) -> bool {
 // CHECK:STDOUT:   %Neq.ref: <function> = name_ref Neq, file.%Neq [template = file.%Neq]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc13_13.1: init bool = call %Neq.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc13_19: bool = value_of_initializer %.loc13_13.1
-// CHECK:STDOUT:   %.loc13_13.2: bool = converted %.loc13_13.1, %.loc13_19
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %.loc13_13: init bool = call %Neq.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc13_19.1: bool = value_of_initializer %.loc13_13
+// CHECK:STDOUT:   %.loc13_19.2: bool = converted %.loc13_13, %.loc13_19.1
+// CHECK:STDOUT:   return %.loc13_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/or.carbon
+++ b/toolchain/check/testdata/builtins/int/or.carbon
@@ -69,9 +69,9 @@ fn RuntimeCall(a: i32, b: i32) -> i32 {
 // CHECK:STDOUT:   %Or.ref: <function> = name_ref Or, file.%Or [template = file.%Or]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_12.1: init i32 = call %Or.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_18: i32 = value_of_initializer %.loc8_12.1
-// CHECK:STDOUT:   %.loc8_12.2: i32 = converted %.loc8_12.1, %.loc8_18
-// CHECK:STDOUT:   return %.loc8_12.2
+// CHECK:STDOUT:   %.loc8_12: init i32 = call %Or.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_18.1: i32 = value_of_initializer %.loc8_12
+// CHECK:STDOUT:   %.loc8_18.2: i32 = converted %.loc8_12, %.loc8_18.1
+// CHECK:STDOUT:   return %.loc8_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/builtins/int/right_shift.carbon
+++ b/toolchain/check/testdata/builtins/int/right_shift.carbon
@@ -114,10 +114,10 @@ let negative: i32 = RightShift(1, Negate(1));
 // CHECK:STDOUT:   %RightShift.ref: <function> = name_ref RightShift, file.%RightShift [template = file.%RightShift]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_20.1: init i32 = call %RightShift.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_26: i32 = value_of_initializer %.loc8_20.1
-// CHECK:STDOUT:   %.loc8_20.2: i32 = converted %.loc8_20.1, %.loc8_26
-// CHECK:STDOUT:   return %.loc8_20.2
+// CHECK:STDOUT:   %.loc8_20: init i32 = call %RightShift.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_26.1: i32 = value_of_initializer %.loc8_20
+// CHECK:STDOUT:   %.loc8_26.2: i32 = converted %.loc8_20, %.loc8_26.1
+// CHECK:STDOUT:   return %.loc8_26.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- arith_shift.carbon
@@ -161,15 +161,15 @@ let negative: i32 = RightShift(1, Negate(1));
 // CHECK:STDOUT:   %RightShift.ref.loc10: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %Negate.ref.loc10_35: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc10_42: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_41.1: init i32 = call %Negate.ref.loc10_35(%.loc10_42) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_41: init i32 = call %Negate.ref.loc10_35(%.loc10_42) [template = constants.%.2]
 // CHECK:STDOUT:   %.loc10_46: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_34.1: i32 = value_of_initializer %.loc10_41.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_41.2: i32 = converted %.loc10_41.1, %.loc10_34.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_34.2: init i32 = call %RightShift.ref.loc10(%.loc10_41.2, %.loc10_46) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_23.1: i32 = value_of_initializer %.loc10_34.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_34.3: i32 = converted %.loc10_34.2, %.loc10_23.1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_23.2: init i32 = call %Negate.ref.loc10_17(%.loc10_34.3) [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_49: type = array_type %.loc10_23.2, i32 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_34.1: i32 = value_of_initializer %.loc10_41 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_34.2: i32 = converted %.loc10_41, %.loc10_34.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_34.3: init i32 = call %RightShift.ref.loc10(%.loc10_34.2, %.loc10_46) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_23.1: i32 = value_of_initializer %.loc10_34.3 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_23.2: i32 = converted %.loc10_34.3, %.loc10_23.1 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_23.3: init i32 = call %Negate.ref.loc10_17(%.loc10_23.2) [template = constants.%.1]
+// CHECK:STDOUT:   %.loc10_49: type = array_type %.loc10_23.3, i32 [template = constants.%.3]
 // CHECK:STDOUT:   %arr1.var: ref [i32; 1] = var arr1
 // CHECK:STDOUT:   %arr1: ref [i32; 1] = bind_name arr1, %arr1.var
 // CHECK:STDOUT:   %.loc11_19: i32 = int_literal 1 [template = constants.%.1]
@@ -182,15 +182,15 @@ let negative: i32 = RightShift(1, Negate(1));
 // CHECK:STDOUT:   %RightShift.ref.loc14: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %Negate.ref.loc14_35: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc14_42: i32 = int_literal 10 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc14_41.1: init i32 = call %Negate.ref.loc14_35(%.loc14_42) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_41: init i32 = call %Negate.ref.loc14_35(%.loc14_42) [template = constants.%.6]
 // CHECK:STDOUT:   %.loc14_47: i32 = int_literal 2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc14_34.1: i32 = value_of_initializer %.loc14_41.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_41.2: i32 = converted %.loc14_41.1, %.loc14_34.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_34.2: init i32 = call %RightShift.ref.loc14(%.loc14_41.2, %.loc14_47) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc14_23.1: i32 = value_of_initializer %.loc14_34.2 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc14_34.3: i32 = converted %.loc14_34.2, %.loc14_23.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc14_23.2: init i32 = call %Negate.ref.loc14_17(%.loc14_34.3) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc14_50: type = array_type %.loc14_23.2, i32 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc14_34.1: i32 = value_of_initializer %.loc14_41 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_34.2: i32 = converted %.loc14_41, %.loc14_34.1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_34.3: init i32 = call %RightShift.ref.loc14(%.loc14_34.2, %.loc14_47) [template = constants.%.8]
+// CHECK:STDOUT:   %.loc14_23.1: i32 = value_of_initializer %.loc14_34.3 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc14_23.2: i32 = converted %.loc14_34.3, %.loc14_23.1 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc14_23.3: init i32 = call %Negate.ref.loc14_17(%.loc14_23.2) [template = constants.%.9]
+// CHECK:STDOUT:   %.loc14_50: type = array_type %.loc14_23.3, i32 [template = constants.%.10]
 // CHECK:STDOUT:   %arr2.var: ref [i32; 3] = var arr2
 // CHECK:STDOUT:   %arr2: ref [i32; 3] = bind_name arr2, %arr2.var
 // CHECK:STDOUT:   %.loc15_19: i32 = int_literal 3 [template = constants.%.9]
@@ -238,35 +238,35 @@ let negative: i32 = RightShift(1, Negate(1));
 // CHECK:STDOUT:   %RightShift.ref.loc8: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %.loc8_30: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc8_33: i32 = int_literal 31 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_29.1: init i32 = call %RightShift.ref.loc8(%.loc8_30, %.loc8_33) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_36: i32 = value_of_initializer %.loc8_29.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_29.2: i32 = converted %.loc8_29.1, %.loc8_36 [template = constants.%.3]
-// CHECK:STDOUT:   %size_1: i32 = bind_name size_1, %.loc8_29.2
+// CHECK:STDOUT:   %.loc8_29: init i32 = call %RightShift.ref.loc8(%.loc8_30, %.loc8_33) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_36.1: i32 = value_of_initializer %.loc8_29 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_36.2: i32 = converted %.loc8_29, %.loc8_36.1 [template = constants.%.3]
+// CHECK:STDOUT:   %size_1: i32 = bind_name size_1, %.loc8_36.2
 // CHECK:STDOUT:   %RightShift.ref.loc13: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %.loc13_30: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc13_33: i32 = int_literal 32 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_29.1: init i32 = call %RightShift.ref.loc13(%.loc13_30, %.loc13_33) [template = <error>]
-// CHECK:STDOUT:   %.loc13_36: i32 = value_of_initializer %.loc13_29.1 [template = <error>]
-// CHECK:STDOUT:   %.loc13_29.2: i32 = converted %.loc13_29.1, %.loc13_36 [template = <error>]
-// CHECK:STDOUT:   %size_2: i32 = bind_name size_2, %.loc13_29.2
+// CHECK:STDOUT:   %.loc13_29: init i32 = call %RightShift.ref.loc13(%.loc13_30, %.loc13_33) [template = <error>]
+// CHECK:STDOUT:   %.loc13_36.1: i32 = value_of_initializer %.loc13_29 [template = <error>]
+// CHECK:STDOUT:   %.loc13_36.2: i32 = converted %.loc13_29, %.loc13_36.1 [template = <error>]
+// CHECK:STDOUT:   %size_2: i32 = bind_name size_2, %.loc13_36.2
 // CHECK:STDOUT:   %RightShift.ref.loc18: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %.loc18_30: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc18_33: i32 = int_literal 33 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc18_29.1: init i32 = call %RightShift.ref.loc18(%.loc18_30, %.loc18_33) [template = <error>]
-// CHECK:STDOUT:   %.loc18_36: i32 = value_of_initializer %.loc18_29.1 [template = <error>]
-// CHECK:STDOUT:   %.loc18_29.2: i32 = converted %.loc18_29.1, %.loc18_36 [template = <error>]
-// CHECK:STDOUT:   %size_3: i32 = bind_name size_3, %.loc18_29.2
+// CHECK:STDOUT:   %.loc18_29: init i32 = call %RightShift.ref.loc18(%.loc18_30, %.loc18_33) [template = <error>]
+// CHECK:STDOUT:   %.loc18_36.1: i32 = value_of_initializer %.loc18_29 [template = <error>]
+// CHECK:STDOUT:   %.loc18_36.2: i32 = converted %.loc18_29, %.loc18_36.1 [template = <error>]
+// CHECK:STDOUT:   %size_3: i32 = bind_name size_3, %.loc18_36.2
 // CHECK:STDOUT:   %RightShift.ref.loc24: <function> = name_ref RightShift, %RightShift [template = %RightShift]
 // CHECK:STDOUT:   %.loc24_32: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %Negate.ref: <function> = name_ref Negate, %Negate [template = %Negate]
 // CHECK:STDOUT:   %.loc24_42: i32 = int_literal 1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc24_41.1: init i32 = call %Negate.ref(%.loc24_42) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc24_31.1: i32 = value_of_initializer %.loc24_41.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc24_41.2: i32 = converted %.loc24_41.1, %.loc24_31.1 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc24_31.2: init i32 = call %RightShift.ref.loc24(%.loc24_32, %.loc24_41.2) [template = <error>]
-// CHECK:STDOUT:   %.loc24_45: i32 = value_of_initializer %.loc24_31.2 [template = <error>]
-// CHECK:STDOUT:   %.loc24_31.3: i32 = converted %.loc24_31.2, %.loc24_45 [template = <error>]
-// CHECK:STDOUT:   %negative: i32 = bind_name negative, %.loc24_31.3
+// CHECK:STDOUT:   %.loc24_41: init i32 = call %Negate.ref(%.loc24_42) [template = constants.%.6]
+// CHECK:STDOUT:   %.loc24_31.1: i32 = value_of_initializer %.loc24_41 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc24_31.2: i32 = converted %.loc24_41, %.loc24_31.1 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc24_31.3: init i32 = call %RightShift.ref.loc24(%.loc24_32, %.loc24_31.2) [template = <error>]
+// CHECK:STDOUT:   %.loc24_45.1: i32 = value_of_initializer %.loc24_31.3 [template = <error>]
+// CHECK:STDOUT:   %.loc24_45.2: i32 = converted %.loc24_31.3, %.loc24_45.1 [template = <error>]
+// CHECK:STDOUT:   %negative: i32 = bind_name negative, %.loc24_45.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @RightShift(%a: i32, %b: i32) -> i32 = "int.right_shift";

--- a/toolchain/check/testdata/builtins/int/sub.carbon
+++ b/toolchain/check/testdata/builtins/int/sub.carbon
@@ -82,10 +82,10 @@ let c: i32 = Sub(Sub(0, 0x7FFFFFFF), 2);
 // CHECK:STDOUT:   %Sub.ref: <function> = name_ref Sub, file.%Sub [template = file.%Sub]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Sub.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Sub.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_overflow.carbon
@@ -115,34 +115,34 @@ let c: i32 = Sub(Sub(0, 0x7FFFFFFF), 2);
 // CHECK:STDOUT:   %Sub.ref.loc6: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %.loc6_18: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc6_21: i32 = int_literal 2147483647 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc6_17.1: init i32 = call %Sub.ref.loc6(%.loc6_18, %.loc6_21) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc6_32: i32 = value_of_initializer %.loc6_17.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc6_17.2: i32 = converted %.loc6_17.1, %.loc6_32 [template = constants.%.3]
-// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_17.2
+// CHECK:STDOUT:   %.loc6_17: init i32 = call %Sub.ref.loc6(%.loc6_18, %.loc6_21) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc6_32.1: i32 = value_of_initializer %.loc6_17 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc6_32.2: i32 = converted %.loc6_17, %.loc6_32.1 [template = constants.%.3]
+// CHECK:STDOUT:   %a.loc6: i32 = bind_name a, %.loc6_32.2
 // CHECK:STDOUT:   %Sub.ref.loc7_14: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Sub.ref.loc7_18: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_25: i32 = int_literal 2147483647 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc7_21.1: init i32 = call %Sub.ref.loc7_18(%.loc7_22, %.loc7_25) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_21: init i32 = call %Sub.ref.loc7_18(%.loc7_22, %.loc7_25) [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_38: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_17.1: i32 = value_of_initializer %.loc7_21.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_21.2: i32 = converted %.loc7_21.1, %.loc7_17.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_17.2: init i32 = call %Sub.ref.loc7_14(%.loc7_21.2, %.loc7_38) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_40: i32 = value_of_initializer %.loc7_17.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_17.3: i32 = converted %.loc7_17.2, %.loc7_40 [template = constants.%.5]
-// CHECK:STDOUT:   %b.loc7: i32 = bind_name b, %.loc7_17.3
+// CHECK:STDOUT:   %.loc7_17.1: i32 = value_of_initializer %.loc7_21 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_17.2: i32 = converted %.loc7_21, %.loc7_17.1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_17.3: init i32 = call %Sub.ref.loc7_14(%.loc7_17.2, %.loc7_38) [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_40.1: i32 = value_of_initializer %.loc7_17.3 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_40.2: i32 = converted %.loc7_17.3, %.loc7_40.1 [template = constants.%.5]
+// CHECK:STDOUT:   %b.loc7: i32 = bind_name b, %.loc7_40.2
 // CHECK:STDOUT:   %Sub.ref.loc11_14: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %Sub.ref.loc11_18: <function> = name_ref Sub, %Sub [template = %Sub]
 // CHECK:STDOUT:   %.loc11_22: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_25: i32 = int_literal 2147483647 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc11_21.1: init i32 = call %Sub.ref.loc11_18(%.loc11_22, %.loc11_25) [template = constants.%.3]
+// CHECK:STDOUT:   %.loc11_21: init i32 = call %Sub.ref.loc11_18(%.loc11_22, %.loc11_25) [template = constants.%.3]
 // CHECK:STDOUT:   %.loc11_38: i32 = int_literal 2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc11_17.1: i32 = value_of_initializer %.loc11_21.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc11_21.2: i32 = converted %.loc11_21.1, %.loc11_17.1 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc11_17.2: init i32 = call %Sub.ref.loc11_14(%.loc11_21.2, %.loc11_38) [template = constants.%.2]
-// CHECK:STDOUT:   %.loc11_40: i32 = value_of_initializer %.loc11_17.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc11_17.3: i32 = converted %.loc11_17.2, %.loc11_40 [template = constants.%.2]
-// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc11_17.3
+// CHECK:STDOUT:   %.loc11_17.1: i32 = value_of_initializer %.loc11_21 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc11_17.2: i32 = converted %.loc11_21, %.loc11_17.1 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc11_17.3: init i32 = call %Sub.ref.loc11_14(%.loc11_17.2, %.loc11_38) [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_40.1: i32 = value_of_initializer %.loc11_17.3 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_40.2: i32 = converted %.loc11_17.3, %.loc11_40.1 [template = constants.%.2]
+// CHECK:STDOUT:   %c: i32 = bind_name c, %.loc11_40.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Sub(%a: i32, %b: i32) -> i32 = "int.sub";

--- a/toolchain/check/testdata/builtins/int/xor.carbon
+++ b/toolchain/check/testdata/builtins/int/xor.carbon
@@ -69,9 +69,9 @@ fn RuntimeCall(a: i32, b: i32) -> i32 {
 // CHECK:STDOUT:   %Xor.ref: <function> = name_ref Xor, file.%Xor [template = file.%Xor]
 // CHECK:STDOUT:   %a.ref: i32 = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: i32 = name_ref b, %b
-// CHECK:STDOUT:   %.loc8_13.1: init i32 = call %Xor.ref(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc8_19: i32 = value_of_initializer %.loc8_13.1
-// CHECK:STDOUT:   %.loc8_13.2: i32 = converted %.loc8_13.1, %.loc8_19
-// CHECK:STDOUT:   return %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init i32 = call %Xor.ref(%a.ref, %b.ref)
+// CHECK:STDOUT:   %.loc8_19.1: i32 = value_of_initializer %.loc8_13
+// CHECK:STDOUT:   %.loc8_19.2: i32 = converted %.loc8_13, %.loc8_19.1
+// CHECK:STDOUT:   return %.loc8_19.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -101,12 +101,12 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:   %.loc18_26.2: ref i32 = class_element_access %.loc18_35.2, element0
 // CHECK:STDOUT:   %.loc18_26.3: init i32 = initialize_from %.loc18_25 to %.loc18_26.2 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc18_26.4: init Base = class_init (%.loc18_26.3), %.loc18_35.2 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc18_26.5: init Base = converted %.loc18_26.1, %.loc18_26.4 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc18_35.3: ref i32 = class_element_access %return, element1
-// CHECK:STDOUT:   %.loc18_35.4: init i32 = initialize_from %.loc18_34 to %.loc18_35.3 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc18_35.5: init Derived = class_init (%.loc18_26.5, %.loc18_35.4), %return [template = constants.%.14]
-// CHECK:STDOUT:   %.loc18_35.6: init Derived = converted %.loc18_35.1, %.loc18_35.5 [template = constants.%.14]
-// CHECK:STDOUT:   return %.loc18_35.6
+// CHECK:STDOUT:   %.loc18_35.3: init Base = converted %.loc18_26.1, %.loc18_26.4 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc18_35.4: ref i32 = class_element_access %return, element1
+// CHECK:STDOUT:   %.loc18_35.5: init i32 = initialize_from %.loc18_34 to %.loc18_35.4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc18_35.6: init Derived = class_init (%.loc18_35.3, %.loc18_35.5), %return [template = constants.%.14]
+// CHECK:STDOUT:   %.loc18_36: init Derived = converted %.loc18_35.1, %.loc18_35.6 [template = constants.%.14]
+// CHECK:STDOUT:   return %.loc18_36
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Access(%d: Derived) -> %return: (i32, i32) {
@@ -128,7 +128,7 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:   %.loc22_24.4: ref i32 = tuple_access %return, element1
 // CHECK:STDOUT:   %.loc22_24.5: init i32 = initialize_from %.loc22_22.2 to %.loc22_24.4
 // CHECK:STDOUT:   %.loc22_24.6: init (i32, i32) = tuple_init (%.loc22_24.3, %.loc22_24.5) to %return
-// CHECK:STDOUT:   %.loc22_24.7: init (i32, i32) = converted %.loc22_24.1, %.loc22_24.6
-// CHECK:STDOUT:   return %.loc22_24.7
+// CHECK:STDOUT:   %.loc22_25: init (i32, i32) = converted %.loc22_24.1, %.loc22_24.6
+// CHECK:STDOUT:   return %.loc22_25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_field.carbon
+++ b/toolchain/check/testdata/class/base_field.carbon
@@ -88,12 +88,12 @@ fn Access(p: Derived*) -> i32* {
 // CHECK:STDOUT: fn @Access(%p: Derived*) -> i32* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: Derived* = name_ref p, %p
-// CHECK:STDOUT:   %.loc21_12.1: ref Derived = deref %p.ref
+// CHECK:STDOUT:   %.loc21_12: ref Derived = deref %p.ref
 // CHECK:STDOUT:   %c.ref: <unbound element of class Base> = name_ref c, @Base.%.loc10 [template = @Base.%.loc10]
-// CHECK:STDOUT:   %.loc21_15.1: ref Base = class_element_access %.loc21_12.1, element0
-// CHECK:STDOUT:   %.loc21_12.2: ref Base = converted %.loc21_12.1, %.loc21_15.1
-// CHECK:STDOUT:   %.loc21_15.2: ref i32 = class_element_access %.loc21_12.2, element2
-// CHECK:STDOUT:   %.loc21_10: i32* = addr_of %.loc21_15.2
+// CHECK:STDOUT:   %.loc21_15.1: ref Base = class_element_access %.loc21_12, element0
+// CHECK:STDOUT:   %.loc21_15.2: ref Base = converted %.loc21_12, %.loc21_15.1
+// CHECK:STDOUT:   %.loc21_15.3: ref i32 = class_element_access %.loc21_15.2, element2
+// CHECK:STDOUT:   %.loc21_10: i32* = addr_of %.loc21_15.3
 // CHECK:STDOUT:   return %.loc21_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method.carbon
+++ b/toolchain/check/testdata/class/base_method.carbon
@@ -112,8 +112,8 @@ fn Call(p: Derived*) {
 // CHECK:STDOUT:   %.loc22_9.1: ref Derived = deref %.loc22_4.2
 // CHECK:STDOUT:   %.loc22_9.2: ref Base = class_element_access %.loc22_9.1, element0
 // CHECK:STDOUT:   %.loc22_9.3: Base* = addr_of %.loc22_9.2
-// CHECK:STDOUT:   %.loc22_4.3: Base* = converted %.loc22_4.2, %.loc22_9.3
-// CHECK:STDOUT:   %.loc22_9.4: init () = call %.loc22_7(%.loc22_4.3)
+// CHECK:STDOUT:   %.loc22_9.4: Base* = converted %.loc22_4.2, %.loc22_9.3
+// CHECK:STDOUT:   %.loc22_9.5: init () = call %.loc22_7(%.loc22_9.4)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method_qualified.carbon
+++ b/toolchain/check/testdata/class/base_method_qualified.carbon
@@ -148,12 +148,12 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Base.%F [template = @Base.%F]
 // CHECK:STDOUT:   %.loc22_11: <bound method> = bound_method %a.ref, %F.ref
 // CHECK:STDOUT:   %.loc22_20.1: ref Base = class_element_access %a.ref, element0
-// CHECK:STDOUT:   %.loc22_10.1: ref Base = converted %a.ref, %.loc22_20.1
-// CHECK:STDOUT:   %.loc22_10.2: Base = bind_value %.loc22_10.1
-// CHECK:STDOUT:   %.loc22_20.2: init i32 = call %.loc22_11(%.loc22_10.2)
-// CHECK:STDOUT:   %.loc22_22: i32 = value_of_initializer %.loc22_20.2
-// CHECK:STDOUT:   %.loc22_20.3: i32 = converted %.loc22_20.2, %.loc22_22
-// CHECK:STDOUT:   return %.loc22_20.3
+// CHECK:STDOUT:   %.loc22_20.2: ref Base = converted %a.ref, %.loc22_20.1
+// CHECK:STDOUT:   %.loc22_20.3: Base = bind_value %.loc22_20.2
+// CHECK:STDOUT:   %.loc22_20.4: init i32 = call %.loc22_11(%.loc22_20.3)
+// CHECK:STDOUT:   %.loc22_22.1: i32 = value_of_initializer %.loc22_20.4
+// CHECK:STDOUT:   %.loc22_22.2: i32 = converted %.loc22_20.4, %.loc22_22.1
+// CHECK:STDOUT:   return %.loc22_22.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallIndirect(%p: Derived*) -> i32 {
@@ -164,12 +164,12 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %.loc26_11.1: ref Derived = deref %p.ref
 // CHECK:STDOUT:   %.loc26_11.2: <bound method> = bound_method %.loc26_11.1, %F.ref
 // CHECK:STDOUT:   %.loc26_21.1: ref Base = class_element_access %.loc26_11.1, element0
-// CHECK:STDOUT:   %.loc26_11.3: ref Base = converted %.loc26_11.1, %.loc26_21.1
-// CHECK:STDOUT:   %.loc26_11.4: Base = bind_value %.loc26_11.3
-// CHECK:STDOUT:   %.loc26_21.2: init i32 = call %.loc26_11.2(%.loc26_11.4)
-// CHECK:STDOUT:   %.loc26_23: i32 = value_of_initializer %.loc26_21.2
-// CHECK:STDOUT:   %.loc26_21.3: i32 = converted %.loc26_21.2, %.loc26_23
-// CHECK:STDOUT:   return %.loc26_21.3
+// CHECK:STDOUT:   %.loc26_21.2: ref Base = converted %.loc26_11.1, %.loc26_21.1
+// CHECK:STDOUT:   %.loc26_21.3: Base = bind_value %.loc26_21.2
+// CHECK:STDOUT:   %.loc26_21.4: init i32 = call %.loc26_11.2(%.loc26_21.3)
+// CHECK:STDOUT:   %.loc26_23.1: i32 = value_of_initializer %.loc26_21.4
+// CHECK:STDOUT:   %.loc26_23.2: i32 = converted %.loc26_21.4, %.loc26_23.1
+// CHECK:STDOUT:   return %.loc26_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PassDerivedToBase(%a: Derived) -> i32 {
@@ -178,10 +178,10 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Base.%G [template = @Base.%G]
 // CHECK:STDOUT:   %.loc30_11: <bound method> = bound_method %a.ref, %G.ref
-// CHECK:STDOUT:   %.loc30_20.1: init i32 = call %.loc30_11(%a.ref)
-// CHECK:STDOUT:   %.loc30_22: i32 = value_of_initializer %.loc30_20.1
-// CHECK:STDOUT:   %.loc30_20.2: i32 = converted %.loc30_20.1, %.loc30_22
-// CHECK:STDOUT:   return %.loc30_20.2
+// CHECK:STDOUT:   %.loc30_20: init i32 = call %.loc30_11(%a.ref)
+// CHECK:STDOUT:   %.loc30_22.1: i32 = value_of_initializer %.loc30_20
+// CHECK:STDOUT:   %.loc30_22.2: i32 = converted %.loc30_20, %.loc30_22.1
+// CHECK:STDOUT:   return %.loc30_22.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @PassDerivedToBaseIndirect(%p: Derived*) -> i32 {
@@ -192,9 +192,9 @@ fn PassDerivedToBaseIndirect(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %.loc34_11.1: ref Derived = deref %p.ref
 // CHECK:STDOUT:   %.loc34_11.2: <bound method> = bound_method %.loc34_11.1, %G.ref
 // CHECK:STDOUT:   %.loc34_11.3: Derived = bind_value %.loc34_11.1
-// CHECK:STDOUT:   %.loc34_21.1: init i32 = call %.loc34_11.2(%.loc34_11.3)
-// CHECK:STDOUT:   %.loc34_23: i32 = value_of_initializer %.loc34_21.1
-// CHECK:STDOUT:   %.loc34_21.2: i32 = converted %.loc34_21.1, %.loc34_23
-// CHECK:STDOUT:   return %.loc34_21.2
+// CHECK:STDOUT:   %.loc34_21: init i32 = call %.loc34_11.2(%.loc34_11.3)
+// CHECK:STDOUT:   %.loc34_23.1: i32 = value_of_initializer %.loc34_21
+// CHECK:STDOUT:   %.loc34_23.2: i32 = converted %.loc34_21, %.loc34_23.1
+// CHECK:STDOUT:   return %.loc34_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/base_method_shadow.carbon
+++ b/toolchain/check/testdata/class/base_method_shadow.carbon
@@ -182,8 +182,8 @@ fn Call(a: A*, b: B*, c: C*, d: D*) {
 // CHECK:STDOUT:   %.loc29_9.1: ref D = deref %.loc29_4.2
 // CHECK:STDOUT:   %.loc29_9.2: ref B = class_element_access %.loc29_9.1, element0
 // CHECK:STDOUT:   %.loc29_9.3: B* = addr_of %.loc29_9.2
-// CHECK:STDOUT:   %.loc29_4.3: B* = converted %.loc29_4.2, %.loc29_9.3
-// CHECK:STDOUT:   %.loc29_9.4: init () = call %.loc29_7(%.loc29_4.3)
+// CHECK:STDOUT:   %.loc29_9.4: B* = converted %.loc29_4.2, %.loc29_9.3
+// CHECK:STDOUT:   %.loc29_9.5: init () = call %.loc29_7(%.loc29_9.4)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/basic.carbon
+++ b/toolchain/check/testdata/class/basic.carbon
@@ -86,9 +86,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc22_18: i32 = int_literal 4 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc22_17.1: init i32 = call %F.ref(%.loc22_18)
-// CHECK:STDOUT:   %.loc22_20: i32 = value_of_initializer %.loc22_17.1
-// CHECK:STDOUT:   %.loc22_17.2: i32 = converted %.loc22_17.1, %.loc22_20
-// CHECK:STDOUT:   return %.loc22_17.2
+// CHECK:STDOUT:   %.loc22_17: init i32 = call %F.ref(%.loc22_18)
+// CHECK:STDOUT:   %.loc22_20.1: i32 = value_of_initializer %.loc22_17
+// CHECK:STDOUT:   %.loc22_20.2: i32 = converted %.loc22_17, %.loc22_20.1
+// CHECK:STDOUT:   return %.loc22_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/compound_field.carbon
+++ b/toolchain/check/testdata/class/compound_field.carbon
@@ -136,10 +136,10 @@ fn AccessBaseIndirect(p: Derived*) -> i32* {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
 // CHECK:STDOUT:   %b.ref: <unbound element of class Base> = name_ref b, @Base.%.loc9 [template = @Base.%.loc9]
 // CHECK:STDOUT:   %.loc25_11.1: ref Base = class_element_access %d.ref, element0
-// CHECK:STDOUT:   %.loc25_10: ref Base = converted %d.ref, %.loc25_11.1
-// CHECK:STDOUT:   %.loc25_11.2: ref i32 = class_element_access %.loc25_10, element1
-// CHECK:STDOUT:   %.loc25_11.3: i32 = bind_value %.loc25_11.2
-// CHECK:STDOUT:   return %.loc25_11.3
+// CHECK:STDOUT:   %.loc25_11.2: ref Base = converted %d.ref, %.loc25_11.1
+// CHECK:STDOUT:   %.loc25_11.3: ref i32 = class_element_access %.loc25_11.2, element1
+// CHECK:STDOUT:   %.loc25_11.4: i32 = bind_value %.loc25_11.3
+// CHECK:STDOUT:   return %.loc25_11.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessDerivedIndirect(%p: Derived*) -> i32* {

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -190,8 +190,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc6_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc6_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc6_19.3: init C = converted %.loc6_19.1, %.loc6_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc6_19.3
+// CHECK:STDOUT:   %.loc6_20: init C = converted %.loc6_19.1, %.loc6_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc6_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -268,8 +268,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc17_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc17_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc17_19.3: init C = converted %.loc17_19.1, %.loc17_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc17_19.3
+// CHECK:STDOUT:   %.loc17_20: init C = converted %.loc17_19.1, %.loc17_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc17_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -312,8 +312,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc22_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc22_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc22_19.3: init C = converted %.loc22_19.1, %.loc22_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c.var, %.loc22_19.3
+// CHECK:STDOUT:   %.loc22_20: init C = converted %.loc22_19.1, %.loc22_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c.var, %.loc22_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -167,8 +167,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc21_39.1: ref C = deref %p.ref
 // CHECK:STDOUT:   %.loc21_39.2: ref B = class_element_access %.loc21_39.1, element0
 // CHECK:STDOUT:   %.loc21_39.3: B* = addr_of %.loc21_39.2
-// CHECK:STDOUT:   %.loc21_38: B* = converted %p.ref, %.loc21_39.3
-// CHECK:STDOUT:   return %.loc21_38
+// CHECK:STDOUT:   %.loc21_39.4: B* = converted %p.ref, %.loc21_39.3
+// CHECK:STDOUT:   return %.loc21_39.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertBToA(%p: B*) -> A* {
@@ -177,8 +177,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc22_39.1: ref B = deref %p.ref
 // CHECK:STDOUT:   %.loc22_39.2: ref A = class_element_access %.loc22_39.1, element0
 // CHECK:STDOUT:   %.loc22_39.3: A* = addr_of %.loc22_39.2
-// CHECK:STDOUT:   %.loc22_38: A* = converted %p.ref, %.loc22_39.3
-// CHECK:STDOUT:   return %.loc22_38
+// CHECK:STDOUT:   %.loc22_39.4: A* = converted %p.ref, %.loc22_39.3
+// CHECK:STDOUT:   return %.loc22_39.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertCToA(%p: C*) -> A* {
@@ -188,8 +188,8 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc23_39.2: ref B = class_element_access %.loc23_39.1, element0
 // CHECK:STDOUT:   %.loc23_39.3: ref A = class_element_access %.loc23_39.2, element0
 // CHECK:STDOUT:   %.loc23_39.4: A* = addr_of %.loc23_39.3
-// CHECK:STDOUT:   %.loc23_38: A* = converted %p.ref, %.loc23_39.4
-// CHECK:STDOUT:   return %.loc23_38
+// CHECK:STDOUT:   %.loc23_39.5: A* = converted %p.ref, %.loc23_39.4
+// CHECK:STDOUT:   return %.loc23_39.5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertValue(%c: C) {
@@ -198,21 +198,21 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %c.ref: C = name_ref c, %c
 // CHECK:STDOUT:   %.loc26_15.1: ref B = class_element_access %c.ref, element0
 // CHECK:STDOUT:   %.loc26_15.2: ref A = class_element_access %.loc26_15.1, element0
-// CHECK:STDOUT:   %.loc26_14.1: ref A = converted %c.ref, %.loc26_15.2
-// CHECK:STDOUT:   %.loc26_14.2: A = bind_value %.loc26_14.1
-// CHECK:STDOUT:   %a: A = bind_name a, %.loc26_14.2
+// CHECK:STDOUT:   %.loc26_15.3: ref A = converted %c.ref, %.loc26_15.2
+// CHECK:STDOUT:   %.loc26_15.4: A = bind_value %.loc26_15.3
+// CHECK:STDOUT:   %a: A = bind_name a, %.loc26_15.4
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ConvertRef(%c: C*) -> A* {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %c.ref: C* = name_ref c, %c
-// CHECK:STDOUT:   %.loc30_12.1: ref C = deref %c.ref
+// CHECK:STDOUT:   %.loc30_12: ref C = deref %c.ref
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
-// CHECK:STDOUT:   %.loc30_15.1: ref B = class_element_access %.loc30_12.1, element0
+// CHECK:STDOUT:   %.loc30_15.1: ref B = class_element_access %.loc30_12, element0
 // CHECK:STDOUT:   %.loc30_15.2: ref A = class_element_access %.loc30_15.1, element0
-// CHECK:STDOUT:   %.loc30_12.2: ref A = converted %.loc30_12.1, %.loc30_15.2
-// CHECK:STDOUT:   %.loc30_10: A* = addr_of %.loc30_12.2
+// CHECK:STDOUT:   %.loc30_15.3: ref A = converted %.loc30_12, %.loc30_15.2
+// CHECK:STDOUT:   %.loc30_10: A* = addr_of %.loc30_15.3
 // CHECK:STDOUT:   return %.loc30_10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -232,21 +232,21 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc34_39.2: ref i32 = class_element_access %.loc34_48.2, element0
 // CHECK:STDOUT:   %.loc34_39.3: init i32 = initialize_from %.loc34_38 to %.loc34_39.2 [template = constants.%.19]
 // CHECK:STDOUT:   %.loc34_39.4: init A = class_init (%.loc34_39.3), %.loc34_48.2 [template = constants.%.24]
-// CHECK:STDOUT:   %.loc34_39.5: init A = converted %.loc34_39.1, %.loc34_39.4 [template = constants.%.24]
-// CHECK:STDOUT:   %.loc34_48.3: ref i32 = class_element_access %.loc34_57.3, element1
-// CHECK:STDOUT:   %.loc34_48.4: init i32 = initialize_from %.loc34_47 to %.loc34_48.3 [template = constants.%.20]
-// CHECK:STDOUT:   %.loc34_48.5: init B = class_init (%.loc34_39.5, %.loc34_48.4), %.loc34_57.3 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc34_48.6: init B = converted %.loc34_48.1, %.loc34_48.5 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc34_57.4: ref i32 = class_element_access %.loc34_57.2, element1
-// CHECK:STDOUT:   %.loc34_57.5: init i32 = initialize_from %.loc34_56 to %.loc34_57.4 [template = constants.%.22]
-// CHECK:STDOUT:   %.loc34_57.6: init C = class_init (%.loc34_48.6, %.loc34_57.5), %.loc34_57.2 [template = constants.%.26]
-// CHECK:STDOUT:   %.loc34_57.7: ref C = temporary %.loc34_57.2, %.loc34_57.6
-// CHECK:STDOUT:   %.loc34_57.8: ref C = converted %.loc34_57.1, %.loc34_57.7
-// CHECK:STDOUT:   %.loc34_63.1: ref B = class_element_access %.loc34_57.8, element0
+// CHECK:STDOUT:   %.loc34_48.3: init A = converted %.loc34_39.1, %.loc34_39.4 [template = constants.%.24]
+// CHECK:STDOUT:   %.loc34_48.4: ref i32 = class_element_access %.loc34_57.3, element1
+// CHECK:STDOUT:   %.loc34_48.5: init i32 = initialize_from %.loc34_47 to %.loc34_48.4 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc34_48.6: init B = class_init (%.loc34_48.3, %.loc34_48.5), %.loc34_57.3 [template = constants.%.25]
+// CHECK:STDOUT:   %.loc34_57.4: init B = converted %.loc34_48.1, %.loc34_48.6 [template = constants.%.25]
+// CHECK:STDOUT:   %.loc34_57.5: ref i32 = class_element_access %.loc34_57.2, element1
+// CHECK:STDOUT:   %.loc34_57.6: init i32 = initialize_from %.loc34_56 to %.loc34_57.5 [template = constants.%.22]
+// CHECK:STDOUT:   %.loc34_57.7: init C = class_init (%.loc34_57.4, %.loc34_57.6), %.loc34_57.2 [template = constants.%.26]
+// CHECK:STDOUT:   %.loc34_57.8: ref C = temporary %.loc34_57.2, %.loc34_57.7
+// CHECK:STDOUT:   %.loc34_59: ref C = converted %.loc34_57.1, %.loc34_57.8
+// CHECK:STDOUT:   %.loc34_63.1: ref B = class_element_access %.loc34_59, element0
 // CHECK:STDOUT:   %.loc34_63.2: ref A = class_element_access %.loc34_63.1, element0
-// CHECK:STDOUT:   %.loc34_57.9: ref A = converted %.loc34_57.8, %.loc34_63.2
-// CHECK:STDOUT:   %.loc34_57.10: A = bind_value %.loc34_57.9
-// CHECK:STDOUT:   %a: A = bind_name a, %.loc34_57.10
+// CHECK:STDOUT:   %.loc34_63.3: ref A = converted %.loc34_59, %.loc34_63.2
+// CHECK:STDOUT:   %.loc34_63.4: A = bind_value %.loc34_63.3
+// CHECK:STDOUT:   %a: A = bind_name a, %.loc34_63.4
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_abstract.carbon
+++ b/toolchain/check/testdata/class/fail_abstract.carbon
@@ -121,7 +121,7 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:   %.loc26_24.4: ref i32 = tuple_access %return, element1
 // CHECK:STDOUT:   %.loc26_24.5: init i32 = initialize_from %.loc26_22.2 to %.loc26_24.4
 // CHECK:STDOUT:   %.loc26_24.6: init (i32, i32) = tuple_init (%.loc26_24.3, %.loc26_24.5) to %return
-// CHECK:STDOUT:   %.loc26_24.7: init (i32, i32) = converted %.loc26_24.1, %.loc26_24.6
-// CHECK:STDOUT:   return %.loc26_24.7
+// CHECK:STDOUT:   %.loc26_25: init (i32, i32) = converted %.loc26_24.1, %.loc26_24.6
+// CHECK:STDOUT:   return %.loc26_25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
+++ b/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
@@ -188,8 +188,8 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @MultipleAdapts {
-// CHECK:STDOUT:   %.loc5_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc5_10.2: type = converted %.loc5_10.1, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc5_10: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc5_11: type = converted %.loc5_10, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   adapt_decl ()
 // CHECK:STDOUT:   %.loc13: {} = struct_literal ()
 // CHECK:STDOUT:
@@ -198,8 +198,8 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @MultipleAdaptsSameType {
-// CHECK:STDOUT:   %.loc17_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc17_10.2: type = converted %.loc17_10.1, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc17_10: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc17_11: type = converted %.loc17_10, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   adapt_decl ()
 // CHECK:STDOUT:   %.loc25: () = tuple_literal ()
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_adapt_with_subobjects.carbon
+++ b/toolchain/check/testdata/class/fail_adapt_with_subobjects.carbon
@@ -182,8 +182,8 @@ class AdaptWithBaseAndFields {
 // CHECK:STDOUT:   %Base.ref: type = name_ref Base, file.%Base.decl [template = constants.%Base]
 // CHECK:STDOUT:   %.loc7: <unbound element of class AdaptWithBaseAndFields> = base_decl Base, element0 [template]
 // CHECK:STDOUT:   %.loc8: <unbound element of class AdaptWithBaseAndFields> = field_decl n, element1 [template]
-// CHECK:STDOUT:   %.loc15_10.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc15_10.2: type = converted %.loc15_10.1, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:   %.loc15_10: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc15_11: type = converted %.loc15_10, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   adapt_decl {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/class/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/fail_base_bad_type.carbon
@@ -239,9 +239,9 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:     %p.loc63_26.1: DeriveFromTuple* = param p
 // CHECK:STDOUT:     @ConvertToBadBaseTuple.%p: DeriveFromTuple* = bind_name p, %p.loc63_26.1
 // CHECK:STDOUT:     %Base.ref: type = name_ref Base, %Base.decl [template = constants.%Base]
-// CHECK:STDOUT:     %.loc63_56.1: (type,) = tuple_literal (%Base.ref)
-// CHECK:STDOUT:     %.loc63_56.2: type = converted %.loc63_56.1, constants.%.10 [template = constants.%.10]
-// CHECK:STDOUT:     %.loc63_57: type = ptr_type (Base,) [template = constants.%.15]
+// CHECK:STDOUT:     %.loc63_56: (type,) = tuple_literal (%Base.ref)
+// CHECK:STDOUT:     %.loc63_57.1: type = converted %.loc63_56, constants.%.10 [template = constants.%.10]
+// CHECK:STDOUT:     %.loc63_57.2: type = ptr_type (Base,) [template = constants.%.15]
 // CHECK:STDOUT:     @ConvertToBadBaseTuple.%return: ref (Base,)* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %AccessMemberWithInvalidBaseTuple: <function> = fn_decl @AccessMemberWithInvalidBaseTuple [template] {
@@ -476,20 +476,20 @@ fn AccessMemberWithInvalidBaseFinal_NoMember(p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT:   %.loc117_11.1: ref DeriveFromFinal = deref %p.ref
 // CHECK:STDOUT:   %.loc117_11.2: ref Final = class_element_access %.loc117_11.1, element0
 // CHECK:STDOUT:   %.loc117_11.3: Final* = addr_of %.loc117_11.2
-// CHECK:STDOUT:   %.loc117_10: Final* = converted %p.ref, %.loc117_11.3
-// CHECK:STDOUT:   return %.loc117_10
+// CHECK:STDOUT:   %.loc117_11.4: Final* = converted %p.ref, %.loc117_11.3
+// CHECK:STDOUT:   return %.loc117_11.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_WithMember(%p: DeriveFromFinal*) -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %p.ref: DeriveFromFinal* = name_ref p, %p
-// CHECK:STDOUT:   %.loc121_11.1: ref DeriveFromFinal = deref %p.ref
+// CHECK:STDOUT:   %.loc121_11: ref DeriveFromFinal = deref %p.ref
 // CHECK:STDOUT:   %a.ref: <unbound element of class Final> = name_ref a, @Final.%.loc9 [template = @Final.%.loc9]
-// CHECK:STDOUT:   %.loc121_14.1: ref Final = class_element_access %.loc121_11.1, element0
-// CHECK:STDOUT:   %.loc121_11.2: ref Final = converted %.loc121_11.1, %.loc121_14.1
-// CHECK:STDOUT:   %.loc121_14.2: ref i32 = class_element_access %.loc121_11.2, element0
-// CHECK:STDOUT:   %.loc121_14.3: i32 = bind_value %.loc121_14.2
-// CHECK:STDOUT:   return %.loc121_14.3
+// CHECK:STDOUT:   %.loc121_14.1: ref Final = class_element_access %.loc121_11, element0
+// CHECK:STDOUT:   %.loc121_14.2: ref Final = converted %.loc121_11, %.loc121_14.1
+// CHECK:STDOUT:   %.loc121_14.3: ref i32 = class_element_access %.loc121_14.2, element0
+// CHECK:STDOUT:   %.loc121_14.4: i32 = bind_value %.loc121_14.3
+// CHECK:STDOUT:   return %.loc121_14.4
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @AccessMemberWithInvalidBaseFinal_NoMember(%p: DeriveFromFinal*) -> i32 {

--- a/toolchain/check/testdata/class/fail_init.carbon
+++ b/toolchain/check/testdata/class/fail_init.carbon
@@ -69,7 +69,7 @@ fn F() {
 // CHECK:STDOUT:   %Class.ref.loc17: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %.loc17_10.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc17_10.3: ref Class = temporary %.loc17_10.2, <error>
-// CHECK:STDOUT:   %.loc17_10.4: ref Class = converted %.loc17_10.1, %.loc17_10.3
+// CHECK:STDOUT:   %.loc17_12: ref Class = converted %.loc17_10.1, %.loc17_10.3
 // CHECK:STDOUT:   %.loc22_9: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc22_17: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc22_18.1: {.a: i32, .c: i32} = struct_literal (%.loc22_9, %.loc22_17)
@@ -78,7 +78,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc22_18.3: ref i32 = class_element_access %.loc22_18.2, element0
 // CHECK:STDOUT:   %.loc22_18.4: init i32 = initialize_from %.loc22_9 to %.loc22_18.3 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc22_18.5: ref Class = temporary %.loc22_18.2, <error>
-// CHECK:STDOUT:   %.loc22_18.6: ref Class = converted %.loc22_18.1, %.loc22_18.5
+// CHECK:STDOUT:   %.loc22_20: ref Class = converted %.loc22_18.1, %.loc22_18.5
 // CHECK:STDOUT:   %.loc26_9: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc26_17: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc26_25: i32 = int_literal 3 [template = constants.%.8]
@@ -86,7 +86,7 @@ fn F() {
 // CHECK:STDOUT:   %Class.ref.loc26: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %.loc26_26.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc26_26.3: ref Class = temporary %.loc26_26.2, <error>
-// CHECK:STDOUT:   %.loc26_26.4: ref Class = converted %.loc26_26.1, %.loc26_26.3
+// CHECK:STDOUT:   %.loc26_28: ref Class = converted %.loc26_26.1, %.loc26_26.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -17,7 +17,7 @@ fn F() {
   //
   // CHECK:STDERR: fail_init_as_inplace.carbon:[[@LINE+3]]:18: ERROR: Cannot copy value of type `Class`.
   // CHECK:STDERR:   var c: Class = {.a = 1, .b = 2} as Class;
-  // CHECK:STDERR:                  ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~
   var c: Class = {.a = 1, .b = 2} as Class;
   G(&c);
 }
@@ -82,8 +82,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc21_33.6: init i32 = initialize_from %.loc21_32 to %.loc21_33.5 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc21_33.7: init Class = class_init (%.loc21_33.4, %.loc21_33.6), %.loc21_33.2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc21_33.8: ref Class = temporary %.loc21_33.2, %.loc21_33.7
-// CHECK:STDOUT:   %.loc21_33.9: ref Class = converted %.loc21_33.1, %.loc21_33.8
-// CHECK:STDOUT:   %.loc21_33.10: Class = bind_value %.loc21_33.9
+// CHECK:STDOUT:   %.loc21_35.1: ref Class = converted %.loc21_33.1, %.loc21_33.8
+// CHECK:STDOUT:   %.loc21_35.2: Class = bind_value %.loc21_35.1
 // CHECK:STDOUT:   assign %c.var, <error>
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -197,8 +197,8 @@ fn Run() {
 // CHECK:STDOUT:   %a: ref Empty = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc7_19.2: init Empty = class_init (), %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_19.3: init Empty = converted %.loc7_19.1, %.loc7_19.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %a.var, %.loc7_19.3
+// CHECK:STDOUT:   %.loc7_20: init Empty = converted %.loc7_19.1, %.loc7_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %a.var, %.loc7_20
 // CHECK:STDOUT:   %Field.decl: invalid = class_decl @Field [template = constants.%Field] {}
 // CHECK:STDOUT:   %Field.ref: type = name_ref Field, file.%import_ref.2 [template = constants.%Field]
 // CHECK:STDOUT:   %b.var: ref Field = var b
@@ -208,8 +208,8 @@ fn Run() {
 // CHECK:STDOUT:   %.loc9_25.2: ref i32 = class_element_access %b.var, element0
 // CHECK:STDOUT:   %.loc9_25.3: init i32 = initialize_from %.loc9_24 to %.loc9_25.2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc9_25.4: init Field = class_init (%.loc9_25.3), %b.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_25.5: init Field = converted %.loc9_25.1, %.loc9_25.4 [template = constants.%.8]
-// CHECK:STDOUT:   assign %b.var, %.loc9_25.5
+// CHECK:STDOUT:   %.loc9_26: init Field = converted %.loc9_25.1, %.loc9_25.4 [template = constants.%.8]
+// CHECK:STDOUT:   assign %b.var, %.loc9_26
 // CHECK:STDOUT:   %b.ref: ref Field = name_ref b, %b
 // CHECK:STDOUT:   %x.ref: <unbound element of class Field> = name_ref x, file.%import_ref.7 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_4: ref i32 = class_element_access %b.ref, element0
@@ -221,8 +221,8 @@ fn Run() {
 // CHECK:STDOUT:   %c: ref ForwardDeclared = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc12_29.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_29.2: init ForwardDeclared = class_init (), %c.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc12_29.3: init ForwardDeclared = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%.11]
-// CHECK:STDOUT:   assign %c.var, %.loc12_29.3
+// CHECK:STDOUT:   %.loc12_30: init ForwardDeclared = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%.11]
+// CHECK:STDOUT:   assign %c.var, %.loc12_30
 // CHECK:STDOUT:   %c.ref.loc13: ref ForwardDeclared = name_ref c, %c
 // CHECK:STDOUT:   %ForwardDeclared.decl.2: invalid = class_decl @ForwardDeclared.2 [template = constants.%ForwardDeclared.2] {}
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%import_ref.10 [template = imports.%F]

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -165,24 +165,24 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_47.4: ref i32 = class_element_access %.loc7_48.2, element1
 // CHECK:STDOUT:   %.loc7_47.5: init i32 = initialize_from %.loc7_46 to %.loc7_47.4 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc7_47.6: init Base = class_init (%.loc7_47.3, %.loc7_47.5), %.loc7_48.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_47.7: init Base = converted %.loc7_47.1, %.loc7_47.6 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_48.3: init Child = class_init (%.loc7_47.7), %a.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc7_48.4: init Child = converted %.loc7_48.1, %.loc7_48.3 [template = constants.%.11]
-// CHECK:STDOUT:   assign %a.var, %.loc7_48.4
+// CHECK:STDOUT:   %.loc7_48.3: init Base = converted %.loc7_47.1, %.loc7_47.6 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc7_48.4: init Child = class_init (%.loc7_48.3), %a.var [template = constants.%.11]
+// CHECK:STDOUT:   %.loc7_49: init Child = converted %.loc7_48.1, %.loc7_48.4 [template = constants.%.11]
+// CHECK:STDOUT:   assign %a.var, %.loc7_49
 // CHECK:STDOUT:   %a.ref.loc8: ref Child = name_ref a, %a
 // CHECK:STDOUT:   %x.ref: <unbound element of class Base> = name_ref x, file.%import_ref.5 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_4.1: ref Base = class_element_access %a.ref.loc8, element0
-// CHECK:STDOUT:   %.loc8_3: ref Base = converted %a.ref.loc8, %.loc8_4.1
-// CHECK:STDOUT:   %.loc8_4.2: ref i32 = class_element_access %.loc8_3, element0
+// CHECK:STDOUT:   %.loc8_4.2: ref Base = converted %a.ref.loc8, %.loc8_4.1
+// CHECK:STDOUT:   %.loc8_4.3: ref i32 = class_element_access %.loc8_4.2, element0
 // CHECK:STDOUT:   %.loc8_9: i32 = int_literal 2 [template = constants.%.13]
-// CHECK:STDOUT:   assign %.loc8_4.2, %.loc8_9
+// CHECK:STDOUT:   assign %.loc8_4.3, %.loc8_9
 // CHECK:STDOUT:   %a.ref.loc9: ref Child = name_ref a, %a
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%import_ref.3 [template = imports.%F]
 // CHECK:STDOUT:   %.loc9_4: <bound method> = bound_method %a.ref.loc9, %F.ref
 // CHECK:STDOUT:   %.loc9_6.1: ref Base = class_element_access %a.ref.loc9, element0
-// CHECK:STDOUT:   %.loc9_3.1: ref Base = converted %a.ref.loc9, %.loc9_6.1
-// CHECK:STDOUT:   %.loc9_3.2: Base = bind_value %.loc9_3.1
-// CHECK:STDOUT:   %.loc9_6.2: init () = call %.loc9_4(%.loc9_3.2)
+// CHECK:STDOUT:   %.loc9_6.2: ref Base = converted %a.ref.loc9, %.loc9_6.1
+// CHECK:STDOUT:   %.loc9_6.3: Base = bind_value %.loc9_6.2
+// CHECK:STDOUT:   %.loc9_6.4: init () = call %.loc9_4(%.loc9_6.3)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/import_triangle.carbon
+++ b/toolchain/check/testdata/class/import_triangle.carbon
@@ -98,8 +98,8 @@ var d2: D* = &c2;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_14.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc8_14.2: init C = class_init (), file.%c1.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_14.3: init C = converted %.loc8_14.1, %.loc8_14.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c1.var, %.loc8_14.3
+// CHECK:STDOUT:   %.loc8_15: init C = converted %.loc8_14.1, %.loc8_14.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c1.var, %.loc8_15
 // CHECK:STDOUT:   %c1.ref: ref C = name_ref c1, file.%c1
 // CHECK:STDOUT:   %.loc9: C* = addr_of %c1.ref
 // CHECK:STDOUT:   assign file.%d1.var, %.loc9
@@ -161,8 +161,8 @@ var d2: D* = &c2;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc7_14.2: init C = class_init (), file.%c2.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_14.3: init C = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%c2.var, %.loc7_14.3
+// CHECK:STDOUT:   %.loc7_15: init C = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%c2.var, %.loc7_15
 // CHECK:STDOUT:   %c2.ref: ref C = name_ref c2, file.%c2
 // CHECK:STDOUT:   %.loc11: C* = addr_of %c2.ref
 // CHECK:STDOUT:   assign file.%d2.var, <error>

--- a/toolchain/check/testdata/class/init.carbon
+++ b/toolchain/check/testdata/class/init.carbon
@@ -82,8 +82,8 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:   %.loc13_31.4: ref Class* = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc13_31.5: init Class* = initialize_from %next.ref to %.loc13_31.4
 // CHECK:STDOUT:   %.loc13_31.6: init Class = class_init (%.loc13_31.3, %.loc13_31.5), %return
-// CHECK:STDOUT:   %.loc13_31.7: init Class = converted %.loc13_31.1, %.loc13_31.6
-// CHECK:STDOUT:   return %.loc13_31.7
+// CHECK:STDOUT:   %.loc13_32: init Class = converted %.loc13_31.1, %.loc13_31.6
+// CHECK:STDOUT:   return %.loc13_32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @MakeReorder(%n: i32, %next: Class*) -> %return: Class {
@@ -96,7 +96,7 @@ fn MakeReorder(n: i32, next: Class*) -> Class {
 // CHECK:STDOUT:   %.loc17_31.4: ref Class* = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc17_31.5: init Class* = initialize_from %next.ref to %.loc17_31.4
 // CHECK:STDOUT:   %.loc17_31.6: init Class = class_init (%.loc17_31.3, %.loc17_31.5), %return
-// CHECK:STDOUT:   %.loc17_31.7: init Class = converted %.loc17_31.1, %.loc17_31.6
-// CHECK:STDOUT:   return %.loc17_31.7
+// CHECK:STDOUT:   %.loc17_32: init Class = converted %.loc17_31.1, %.loc17_31.6
+// CHECK:STDOUT:   return %.loc17_32
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/init_adapt.carbon
+++ b/toolchain/check/testdata/class/init_adapt.carbon
@@ -131,9 +131,9 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.loc13_27.6: init i32 = initialize_from %.loc13_26 to %.loc13_27.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc13_27.8: ref C = temporary %.loc13_27.2, %.loc13_27.7
-// CHECK:STDOUT:   %.loc13_27.9: ref C = converted %.loc13_27.1, %.loc13_27.8
-// CHECK:STDOUT:   %.loc13_27.10: C = bind_value %.loc13_27.9
-// CHECK:STDOUT:   %a: C = bind_name a, %.loc13_27.10
+// CHECK:STDOUT:   %.loc13_28.1: ref C = converted %.loc13_27.1, %.loc13_27.8
+// CHECK:STDOUT:   %.loc13_28.2: C = bind_value %.loc13_28.1
+// CHECK:STDOUT:   %a: C = bind_name a, %.loc13_28.2
 // CHECK:STDOUT:   %AdaptC.ref.loc21_8: type = name_ref AdaptC, %AdaptC.decl [template = constants.%AdaptC]
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %AdaptC.ref.loc21_22: type = name_ref AdaptC, %AdaptC.decl [template = constants.%AdaptC]
@@ -233,9 +233,9 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.loc13_27.6: init i32 = initialize_from %.loc13_26 to %.loc13_27.5 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc13_27.8: ref C = temporary %.loc13_27.2, %.loc13_27.7
-// CHECK:STDOUT:   %.loc13_27.9: ref C = converted %.loc13_27.1, %.loc13_27.8
-// CHECK:STDOUT:   %.loc13_27.10: C = bind_value %.loc13_27.9
-// CHECK:STDOUT:   %a: C = bind_name a, %.loc13_27.10
+// CHECK:STDOUT:   %.loc13_28.1: ref C = converted %.loc13_27.1, %.loc13_27.8
+// CHECK:STDOUT:   %.loc13_28.2: C = bind_value %.loc13_28.1
+// CHECK:STDOUT:   %a: C = bind_name a, %.loc13_28.2
 // CHECK:STDOUT:   %AdaptC.ref.loc21: type = name_ref AdaptC, %AdaptC.decl [template = constants.%AdaptC]
 // CHECK:STDOUT:   %a.ref: C = name_ref a, %a
 // CHECK:STDOUT:   %b: AdaptC = bind_name b, <error>

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -61,9 +61,9 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc13_26.6: init i32 = initialize_from %.loc13_25 to %.loc13_26.5 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_26.7: init Class = class_init (%.loc13_26.4, %.loc13_26.6), %.loc13_26.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc13_26.8: ref Class = temporary %.loc13_26.2, %.loc13_26.7
-// CHECK:STDOUT:   %.loc13_26.9: ref Class = converted %.loc13_26.1, %.loc13_26.8
+// CHECK:STDOUT:   %.loc13_28: ref Class = converted %.loc13_26.1, %.loc13_26.8
 // CHECK:STDOUT:   %a.ref: <unbound element of class Class> = name_ref a, @Class.%.loc8 [template = @Class.%.loc8]
-// CHECK:STDOUT:   %.loc13_37.1: ref i32 = class_element_access %.loc13_26.9, element0
+// CHECK:STDOUT:   %.loc13_37.1: ref i32 = class_element_access %.loc13_28, element0
 // CHECK:STDOUT:   %.loc13_37.2: i32 = bind_value %.loc13_37.1
 // CHECK:STDOUT:   return %.loc13_37.2
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/init_nested.carbon
+++ b/toolchain/check/testdata/class/init_nested.carbon
@@ -90,7 +90,7 @@ fn MakeOuter() -> Outer {
 // CHECK:STDOUT:   %.loc20_43: init Inner = call %MakeInner.ref.loc20_34() to %.loc20_45.2
 // CHECK:STDOUT:   %.loc20_45.3: {.c: Inner, .d: Inner} = struct_literal (%.loc20_25, %.loc20_43)
 // CHECK:STDOUT:   %.loc20_45.4: init Outer = class_init (%.loc20_25, %.loc20_43), %return
-// CHECK:STDOUT:   %.loc20_45.5: init Outer = converted %.loc20_45.3, %.loc20_45.4
-// CHECK:STDOUT:   return %.loc20_45.5
+// CHECK:STDOUT:   %.loc20_46: init Outer = converted %.loc20_45.3, %.loc20_45.4
+// CHECK:STDOUT:   return %.loc20_46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -175,10 +175,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %c.ref: Class = name_ref c, %c
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc23_11: <bound method> = bound_method %c.ref, %F.ref
-// CHECK:STDOUT:   %.loc23_13.1: init i32 = call %.loc23_11(%c.ref)
-// CHECK:STDOUT:   %.loc23_15: i32 = value_of_initializer %.loc23_13.1
-// CHECK:STDOUT:   %.loc23_13.2: i32 = converted %.loc23_13.1, %.loc23_15
-// CHECK:STDOUT:   return %.loc23_13.2
+// CHECK:STDOUT:   %.loc23_13: init i32 = call %.loc23_11(%c.ref)
+// CHECK:STDOUT:   %.loc23_15.1: i32 = value_of_initializer %.loc23_13
+// CHECK:STDOUT:   %.loc23_15.2: i32 = converted %.loc23_13, %.loc23_15.1
+// CHECK:STDOUT:   return %.loc23_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallAlias(%c: Class) -> i32 {
@@ -186,10 +186,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %c.ref: Class = name_ref c, %c
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, @Class.%A [template = @Class.%F]
 // CHECK:STDOUT:   %.loc27_11: <bound method> = bound_method %c.ref, %A.ref
-// CHECK:STDOUT:   %.loc27_13.1: init i32 = call %.loc27_11(%c.ref)
-// CHECK:STDOUT:   %.loc27_15: i32 = value_of_initializer %.loc27_13.1
-// CHECK:STDOUT:   %.loc27_13.2: i32 = converted %.loc27_13.1, %.loc27_15
-// CHECK:STDOUT:   return %.loc27_13.2
+// CHECK:STDOUT:   %.loc27_13: init i32 = call %.loc27_11(%c.ref)
+// CHECK:STDOUT:   %.loc27_15.1: i32 = value_of_initializer %.loc27_13
+// CHECK:STDOUT:   %.loc27_15.2: i32 = converted %.loc27_13, %.loc27_15.1
+// CHECK:STDOUT:   return %.loc27_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallOnConstBoundMethod() -> i32 {
@@ -202,14 +202,14 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc31_18.4: init i32 = initialize_from %.loc31_17 to %.loc31_18.3 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc31_18.5: init Class = class_init (%.loc31_18.4), %.loc31_18.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc31_18.6: ref Class = temporary %.loc31_18.2, %.loc31_18.5
-// CHECK:STDOUT:   %.loc31_18.7: ref Class = converted %.loc31_18.1, %.loc31_18.6
+// CHECK:STDOUT:   %.loc31_20.1: ref Class = converted %.loc31_18.1, %.loc31_18.6
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc31_29: <bound method> = bound_method %.loc31_18.7, %F.ref
-// CHECK:STDOUT:   %.loc31_18.8: Class = bind_value %.loc31_18.7
-// CHECK:STDOUT:   %.loc31_31.1: init i32 = call %.loc31_29(%.loc31_18.8)
-// CHECK:STDOUT:   %.loc31_33: i32 = value_of_initializer %.loc31_31.1
-// CHECK:STDOUT:   %.loc31_31.2: i32 = converted %.loc31_31.1, %.loc31_33
-// CHECK:STDOUT:   return %.loc31_31.2
+// CHECK:STDOUT:   %.loc31_29: <bound method> = bound_method %.loc31_20.1, %F.ref
+// CHECK:STDOUT:   %.loc31_20.2: Class = bind_value %.loc31_20.1
+// CHECK:STDOUT:   %.loc31_31: init i32 = call %.loc31_29(%.loc31_20.2)
+// CHECK:STDOUT:   %.loc31_33.1: i32 = value_of_initializer %.loc31_31
+// CHECK:STDOUT:   %.loc31_33.2: i32 = converted %.loc31_31, %.loc31_33.1
+// CHECK:STDOUT:   return %.loc31_33.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallWithAddr() -> i32 {
@@ -221,10 +221,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
 // CHECK:STDOUT:   %.loc36_11: <bound method> = bound_method %c.ref, %G.ref
 // CHECK:STDOUT:   %.loc36_10: Class* = addr_of %c.ref
-// CHECK:STDOUT:   %.loc36_13.1: init i32 = call %.loc36_11(%.loc36_10)
-// CHECK:STDOUT:   %.loc36_15: i32 = value_of_initializer %.loc36_13.1
-// CHECK:STDOUT:   %.loc36_13.2: i32 = converted %.loc36_13.1, %.loc36_15
-// CHECK:STDOUT:   return %.loc36_13.2
+// CHECK:STDOUT:   %.loc36_13: init i32 = call %.loc36_11(%.loc36_10)
+// CHECK:STDOUT:   %.loc36_15.1: i32 = value_of_initializer %.loc36_13
+// CHECK:STDOUT:   %.loc36_15.2: i32 = converted %.loc36_13, %.loc36_15.1
+// CHECK:STDOUT:   return %.loc36_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallFThroughPointer(%p: Class*) -> i32 {
@@ -234,10 +234,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc40_14: <bound method> = bound_method %.loc40_11.1, %F.ref
 // CHECK:STDOUT:   %.loc40_11.2: Class = bind_value %.loc40_11.1
-// CHECK:STDOUT:   %.loc40_16.1: init i32 = call %.loc40_14(%.loc40_11.2)
-// CHECK:STDOUT:   %.loc40_18: i32 = value_of_initializer %.loc40_16.1
-// CHECK:STDOUT:   %.loc40_16.2: i32 = converted %.loc40_16.1, %.loc40_18
-// CHECK:STDOUT:   return %.loc40_16.2
+// CHECK:STDOUT:   %.loc40_16: init i32 = call %.loc40_14(%.loc40_11.2)
+// CHECK:STDOUT:   %.loc40_18.1: i32 = value_of_initializer %.loc40_16
+// CHECK:STDOUT:   %.loc40_18.2: i32 = converted %.loc40_16, %.loc40_18.1
+// CHECK:STDOUT:   return %.loc40_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGThroughPointer(%p: Class*) -> i32 {
@@ -247,10 +247,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
 // CHECK:STDOUT:   %.loc44_14: <bound method> = bound_method %.loc44_11.1, %G.ref
 // CHECK:STDOUT:   %.loc44_11.2: Class* = addr_of %.loc44_11.1
-// CHECK:STDOUT:   %.loc44_16.1: init i32 = call %.loc44_14(%.loc44_11.2)
-// CHECK:STDOUT:   %.loc44_18: i32 = value_of_initializer %.loc44_16.1
-// CHECK:STDOUT:   %.loc44_16.2: i32 = converted %.loc44_16.1, %.loc44_18
-// CHECK:STDOUT:   return %.loc44_16.2
+// CHECK:STDOUT:   %.loc44_16: init i32 = call %.loc44_14(%.loc44_11.2)
+// CHECK:STDOUT:   %.loc44_18.1: i32 = value_of_initializer %.loc44_16
+// CHECK:STDOUT:   %.loc44_18.2: i32 = converted %.loc44_16, %.loc44_18.1
+// CHECK:STDOUT:   return %.loc44_18.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> Class;
@@ -264,10 +264,10 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc50_16: <bound method> = bound_method %.loc50_14.3, %F.ref
 // CHECK:STDOUT:   %.loc50_14.4: Class = bind_value %.loc50_14.3
-// CHECK:STDOUT:   %.loc50_18.1: init i32 = call %.loc50_16(%.loc50_14.4)
-// CHECK:STDOUT:   %.loc50_20: i32 = value_of_initializer %.loc50_18.1
-// CHECK:STDOUT:   %.loc50_18.2: i32 = converted %.loc50_18.1, %.loc50_20
-// CHECK:STDOUT:   return %.loc50_18.2
+// CHECK:STDOUT:   %.loc50_18: init i32 = call %.loc50_16(%.loc50_14.4)
+// CHECK:STDOUT:   %.loc50_20.1: i32 = value_of_initializer %.loc50_18
+// CHECK:STDOUT:   %.loc50_20.2: i32 = converted %.loc50_18, %.loc50_20.1
+// CHECK:STDOUT:   return %.loc50_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallGOnInitializingExpr() -> i32 {
@@ -279,9 +279,9 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, @Class.%G [template = @Class.%G]
 // CHECK:STDOUT:   %.loc54_16: <bound method> = bound_method %.loc54_14.3, %G.ref
 // CHECK:STDOUT:   %.loc54_14.4: Class* = addr_of %.loc54_14.3
-// CHECK:STDOUT:   %.loc54_18.1: init i32 = call %.loc54_16(%.loc54_14.4)
-// CHECK:STDOUT:   %.loc54_20: i32 = value_of_initializer %.loc54_18.1
-// CHECK:STDOUT:   %.loc54_18.2: i32 = converted %.loc54_18.1, %.loc54_20
-// CHECK:STDOUT:   return %.loc54_18.2
+// CHECK:STDOUT:   %.loc54_18: init i32 = call %.loc54_16(%.loc54_14.4)
+// CHECK:STDOUT:   %.loc54_20.1: i32 = value_of_initializer %.loc54_18
+// CHECK:STDOUT:   %.loc54_20.2: i32 = converted %.loc54_18, %.loc54_20.1
+// CHECK:STDOUT:   return %.loc54_20.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/raw_self.carbon
+++ b/toolchain/check/testdata/class/raw_self.carbon
@@ -112,7 +112,7 @@ fn Class.G[self: Self](r#self: i32) -> (i32, i32) {
 // CHECK:STDOUT:   %.loc18_25.4: ref i32 = tuple_access %return, element1
 // CHECK:STDOUT:   %.loc18_25.5: init i32 = initialize_from %self.ref.loc18_19 to %.loc18_25.4
 // CHECK:STDOUT:   %.loc18_25.6: init (i32, i32) = tuple_init (%.loc18_25.3, %.loc18_25.5) to %return
-// CHECK:STDOUT:   %.loc18_25.7: init (i32, i32) = converted %.loc18_25.1, %.loc18_25.6
-// CHECK:STDOUT:   return %.loc18_25.7
+// CHECK:STDOUT:   %.loc18_26: init (i32, i32) = converted %.loc18_25.1, %.loc18_25.6
+// CHECK:STDOUT:   return %.loc18_26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/reenter_scope.carbon
+++ b/toolchain/check/testdata/class/reenter_scope.carbon
@@ -53,10 +53,10 @@ fn Class.F() -> i32 {
 // CHECK:STDOUT:   %G.ref.loc13: <function> = name_ref G, @Class.%G [template = @Class.%G]
 // CHECK:STDOUT:   %.loc13: init i32 = call %G.ref.loc13()
 // CHECK:STDOUT:   %G.ref.loc14: <function> = name_ref G, @Class.%G [template = @Class.%G]
-// CHECK:STDOUT:   %.loc14_11.1: init i32 = call %G.ref.loc14()
-// CHECK:STDOUT:   %.loc14_13: i32 = value_of_initializer %.loc14_11.1
-// CHECK:STDOUT:   %.loc14_11.2: i32 = converted %.loc14_11.1, %.loc14_13
-// CHECK:STDOUT:   return %.loc14_11.2
+// CHECK:STDOUT:   %.loc14_11: init i32 = call %G.ref.loc14()
+// CHECK:STDOUT:   %.loc14_13.1: i32 = value_of_initializer %.loc14_11
+// CHECK:STDOUT:   %.loc14_13.2: i32 = converted %.loc14_11, %.loc14_13.1
+// CHECK:STDOUT:   return %.loc14_13.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> i32;

--- a/toolchain/check/testdata/class/reorder.carbon
+++ b/toolchain/check/testdata/class/reorder.carbon
@@ -49,10 +49,10 @@ class Class {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Class.ref: type = name_ref Class, file.%Class.decl [template = constants.%Class]
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc9_19.1: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc9_21: i32 = value_of_initializer %.loc9_19.1
-// CHECK:STDOUT:   %.loc9_19.2: i32 = converted %.loc9_19.1, %.loc9_21
-// CHECK:STDOUT:   return %.loc9_19.2
+// CHECK:STDOUT:   %.loc9_19: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc9_21.1: i32 = value_of_initializer %.loc9_19
+// CHECK:STDOUT:   %.loc9_21.2: i32 = converted %.loc9_19, %.loc9_21.1
+// CHECK:STDOUT:   return %.loc9_21.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() -> i32 {

--- a/toolchain/check/testdata/class/reorder_qualified.carbon
+++ b/toolchain/check/testdata/class/reorder_qualified.carbon
@@ -145,8 +145,8 @@ class A {
 // CHECK:STDOUT:   %.loc25_25.2: ref i32 = class_element_access %a.var, element0
 // CHECK:STDOUT:   %.loc25_25.3: init i32 = initialize_from %.loc25_24 to %.loc25_25.2 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc25_25.4: init A = class_init (%.loc25_25.3), %a.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc25_25.5: init A = converted %.loc25_25.1, %.loc25_25.4 [template = constants.%.11]
-// CHECK:STDOUT:   assign %a.var, %.loc25_25.5
+// CHECK:STDOUT:   %.loc25_26: init A = converted %.loc25_25.1, %.loc25_25.4 [template = constants.%.11]
+// CHECK:STDOUT:   assign %a.var, %.loc25_26
 // CHECK:STDOUT:   %B.ref: type = name_ref B, @A.%B.decl [template = constants.%B]
 // CHECK:STDOUT:   %b.var: ref B = var b
 // CHECK:STDOUT:   %b: ref B = bind_name b, %b.var
@@ -155,8 +155,8 @@ class A {
 // CHECK:STDOUT:   %.loc26_25.2: ref i32 = class_element_access %b.var, element0
 // CHECK:STDOUT:   %.loc26_25.3: init i32 = initialize_from %.loc26_24 to %.loc26_25.2 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc26_25.4: init B = class_init (%.loc26_25.3), %b.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc26_25.5: init B = converted %.loc26_25.1, %.loc26_25.4 [template = constants.%.14]
-// CHECK:STDOUT:   assign %b.var, %.loc26_25.5
+// CHECK:STDOUT:   %.loc26_26: init B = converted %.loc26_25.1, %.loc26_25.4 [template = constants.%.14]
+// CHECK:STDOUT:   assign %b.var, %.loc26_26
 // CHECK:STDOUT:   %C.ref: type = name_ref C, @B.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
@@ -165,8 +165,8 @@ class A {
 // CHECK:STDOUT:   %.loc27_25.2: ref i32 = class_element_access %c.var, element0
 // CHECK:STDOUT:   %.loc27_25.3: init i32 = initialize_from %.loc27_24 to %.loc27_25.2 [template = constants.%.16]
 // CHECK:STDOUT:   %.loc27_25.4: init C = class_init (%.loc27_25.3), %c.var [template = constants.%.17]
-// CHECK:STDOUT:   %.loc27_25.5: init C = converted %.loc27_25.1, %.loc27_25.4 [template = constants.%.17]
-// CHECK:STDOUT:   assign %c.var, %.loc27_25.5
+// CHECK:STDOUT:   %.loc27_26: init C = converted %.loc27_25.1, %.loc27_25.4 [template = constants.%.17]
+// CHECK:STDOUT:   assign %c.var, %.loc27_26
 // CHECK:STDOUT:   %D.ref: type = name_ref D, @C.%D.decl [template = constants.%D]
 // CHECK:STDOUT:   %d.var: ref D = var d
 // CHECK:STDOUT:   %d: ref D = bind_name d, %d.var
@@ -175,8 +175,8 @@ class A {
 // CHECK:STDOUT:   %.loc28_25.2: ref i32 = class_element_access %d.var, element0
 // CHECK:STDOUT:   %.loc28_25.3: init i32 = initialize_from %.loc28_24 to %.loc28_25.2 [template = constants.%.19]
 // CHECK:STDOUT:   %.loc28_25.4: init D = class_init (%.loc28_25.3), %d.var [template = constants.%.20]
-// CHECK:STDOUT:   %.loc28_25.5: init D = converted %.loc28_25.1, %.loc28_25.4 [template = constants.%.20]
-// CHECK:STDOUT:   assign %d.var, %.loc28_25.5
+// CHECK:STDOUT:   %.loc28_26: init D = converted %.loc28_25.1, %.loc28_25.4 [template = constants.%.20]
+// CHECK:STDOUT:   assign %d.var, %.loc28_26
 // CHECK:STDOUT:   %AF.ref: <function> = name_ref AF, @A.%AF [template = @A.%AF]
 // CHECK:STDOUT:   %.loc31: init () = call %AF.ref()
 // CHECK:STDOUT:   %BF.ref: <function> = name_ref BF, @B.%BF [template = @B.%BF]

--- a/toolchain/check/testdata/class/scope.carbon
+++ b/toolchain/check/testdata/class/scope.carbon
@@ -70,10 +70,10 @@ fn Run() {
 // CHECK:STDOUT: fn @G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc13_13.1: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc13_15: i32 = value_of_initializer %.loc13_13.1
-// CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_13.1, %.loc13_15
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
+// CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1
+// CHECK:STDOUT:   return %.loc13_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.2() -> i32 {

--- a/toolchain/check/testdata/class/self_conversion.carbon
+++ b/toolchain/check/testdata/class/self_conversion.carbon
@@ -141,18 +141,18 @@ fn Call(p: Derived*) -> i32 {
 // CHECK:STDOUT:   %.loc27_20.1: ref Derived = deref %.loc27_4.2
 // CHECK:STDOUT:   %.loc27_20.2: ref Base = class_element_access %.loc27_20.1, element0
 // CHECK:STDOUT:   %.loc27_20.3: Base* = addr_of %.loc27_20.2
-// CHECK:STDOUT:   %.loc27_4.3: Base* = converted %.loc27_4.2, %.loc27_20.3
-// CHECK:STDOUT:   %.loc27_20.4: init () = call %.loc27_7(%.loc27_4.3)
+// CHECK:STDOUT:   %.loc27_20.4: Base* = converted %.loc27_4.2, %.loc27_20.3
+// CHECK:STDOUT:   %.loc27_20.5: init () = call %.loc27_7(%.loc27_20.4)
 // CHECK:STDOUT:   %p.ref.loc28: Derived* = name_ref p, %p
-// CHECK:STDOUT:   %.loc28_11.1: ref Derived = deref %p.ref.loc28
+// CHECK:STDOUT:   %.loc28_11: ref Derived = deref %p.ref.loc28
 // CHECK:STDOUT:   %SelfBase.ref: <function> = name_ref SelfBase, @Derived.%SelfBase [template = @Derived.%SelfBase]
-// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11.1, %SelfBase.ref
-// CHECK:STDOUT:   %.loc28_23.1: ref Base = class_element_access %.loc28_11.1, element0
-// CHECK:STDOUT:   %.loc28_11.2: ref Base = converted %.loc28_11.1, %.loc28_23.1
-// CHECK:STDOUT:   %.loc28_11.3: Base = bind_value %.loc28_11.2
-// CHECK:STDOUT:   %.loc28_23.2: init i32 = call %.loc28_14(%.loc28_11.3)
-// CHECK:STDOUT:   %.loc28_25: i32 = value_of_initializer %.loc28_23.2
-// CHECK:STDOUT:   %.loc28_23.3: i32 = converted %.loc28_23.2, %.loc28_25
-// CHECK:STDOUT:   return %.loc28_23.3
+// CHECK:STDOUT:   %.loc28_14: <bound method> = bound_method %.loc28_11, %SelfBase.ref
+// CHECK:STDOUT:   %.loc28_23.1: ref Base = class_element_access %.loc28_11, element0
+// CHECK:STDOUT:   %.loc28_23.2: ref Base = converted %.loc28_11, %.loc28_23.1
+// CHECK:STDOUT:   %.loc28_23.3: Base = bind_value %.loc28_23.2
+// CHECK:STDOUT:   %.loc28_23.4: init i32 = call %.loc28_14(%.loc28_23.3)
+// CHECK:STDOUT:   %.loc28_25.1: i32 = value_of_initializer %.loc28_23.4
+// CHECK:STDOUT:   %.loc28_25.2: i32 = converted %.loc28_23.4, %.loc28_25.1
+// CHECK:STDOUT:   return %.loc28_25.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/self_type.carbon
+++ b/toolchain/check/testdata/class/self_type.carbon
@@ -75,10 +75,10 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
 // CHECK:STDOUT:   %.loc18_19: <bound method> = bound_method %.loc18_11.1, %F.ref
 // CHECK:STDOUT:   %.loc18_11.2: Class = bind_value %.loc18_11.1
-// CHECK:STDOUT:   %.loc18_21.1: init i32 = call %.loc18_19(%.loc18_11.2)
-// CHECK:STDOUT:   %.loc18_23: i32 = value_of_initializer %.loc18_21.1
-// CHECK:STDOUT:   %.loc18_21.2: i32 = converted %.loc18_21.1, %.loc18_23
-// CHECK:STDOUT:   return %.loc18_21.2
+// CHECK:STDOUT:   %.loc18_21: init i32 = call %.loc18_19(%.loc18_11.2)
+// CHECK:STDOUT:   %.loc18_23.1: i32 = value_of_initializer %.loc18_21
+// CHECK:STDOUT:   %.loc18_23.2: i32 = converted %.loc18_21, %.loc18_23.1
+// CHECK:STDOUT:   return %.loc18_23.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Make() -> @Class.%return.var.loc9: Class {
@@ -92,8 +92,8 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:   %.loc11_17.2: ref Class* = class_element_access %s.ref.loc11_5, element0
 // CHECK:STDOUT:   %.loc11_17.3: init Class* = initialize_from %.loc11_15 to %.loc11_17.2
 // CHECK:STDOUT:   %.loc11_17.4: init Class = class_init (%.loc11_17.3), %s.ref.loc11_5
-// CHECK:STDOUT:   %.loc11_17.5: init Class = converted %.loc11_17.1, %.loc11_17.4
-// CHECK:STDOUT:   assign %s.ref.loc11_5, %.loc11_17.5
+// CHECK:STDOUT:   %.loc11_7: init Class = converted %.loc11_17.1, %.loc11_17.4
+// CHECK:STDOUT:   assign %s.ref.loc11_5, %.loc11_7
 // CHECK:STDOUT:   return %s
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/static_method.carbon
+++ b/toolchain/check/testdata/class/static_method.carbon
@@ -54,9 +54,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %c: ref Class = bind_name c, %c.var
 // CHECK:STDOUT:   %c.ref: ref Class = name_ref c, %c
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]
-// CHECK:STDOUT:   %.loc13_13.1: init i32 = call %F.ref()
-// CHECK:STDOUT:   %.loc13_15: i32 = value_of_initializer %.loc13_13.1
-// CHECK:STDOUT:   %.loc13_13.2: i32 = converted %.loc13_13.1, %.loc13_15
-// CHECK:STDOUT:   return %.loc13_13.2
+// CHECK:STDOUT:   %.loc13_13: init i32 = call %F.ref()
+// CHECK:STDOUT:   %.loc13_15.1: i32 = value_of_initializer %.loc13_13
+// CHECK:STDOUT:   %.loc13_15.2: i32 = converted %.loc13_13, %.loc13_15.1
+// CHECK:STDOUT:   return %.loc13_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/aggregate.carbon
+++ b/toolchain/check/testdata/eval/aggregate.carbon
@@ -83,27 +83,27 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.loc7_35.4: ref i32 = tuple_access file.%tuple_copy.var, element1
 // CHECK:STDOUT:   %.loc7_35.5: init i32 = initialize_from %.loc7_34 to %.loc7_35.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_35.6: init (i32, i32) = tuple_init (%.loc7_35.3, %.loc7_35.5) to file.%tuple_copy.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_35.7: init (i32, i32) = converted %.loc7_35.1, %.loc7_35.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%tuple_copy.var, %.loc7_35.7
+// CHECK:STDOUT:   %.loc7_50: init (i32, i32) = converted %.loc7_35.1, %.loc7_35.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%tuple_copy.var, %.loc7_50
 // CHECK:STDOUT:   %.loc9_54: i32 = int_literal 3 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc9_62: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_70: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_71.1: {.c: i32, .b: i32, .a: i32} = struct_literal (%.loc9_54, %.loc9_62, %.loc9_70)
 // CHECK:STDOUT:   %.loc9_102: type = struct_type {.b: i32, .a: i32, .c: i32} [template = constants.%.11]
 // CHECK:STDOUT:   %.loc9_71.2: {.b: i32, .a: i32, .c: i32} = struct_value (%.loc9_62, %.loc9_70, %.loc9_54) [template = constants.%.13]
-// CHECK:STDOUT:   %.loc9_71.3: {.b: i32, .a: i32, .c: i32} = converted %.loc9_71.1, %.loc9_71.2 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc9_71.4: i32 = struct_access %.loc9_71.3, element1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_71.5: ref i32 = struct_access file.%struct_copy.var, element1
-// CHECK:STDOUT:   %.loc9_71.6: init i32 = initialize_from %.loc9_71.4 to %.loc9_71.5 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_71.7: i32 = struct_access %.loc9_71.3, element0 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_71.8: ref i32 = struct_access file.%struct_copy.var, element0
-// CHECK:STDOUT:   %.loc9_71.9: init i32 = initialize_from %.loc9_71.7 to %.loc9_71.8 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_71.10: i32 = struct_access %.loc9_71.3, element2 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc9_71.11: ref i32 = struct_access file.%struct_copy.var, element2
-// CHECK:STDOUT:   %.loc9_71.12: init i32 = initialize_from %.loc9_71.10 to %.loc9_71.11 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc9_71.13: init {.a: i32, .b: i32, .c: i32} = struct_init (%.loc9_71.6, %.loc9_71.9, %.loc9_71.12) to file.%struct_copy.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc9_71.14: init {.a: i32, .b: i32, .c: i32} = converted %.loc9_71.3, %.loc9_71.13 [template = constants.%.14]
-// CHECK:STDOUT:   assign file.%struct_copy.var, %.loc9_71.14
+// CHECK:STDOUT:   %.loc9_73.1: {.b: i32, .a: i32, .c: i32} = converted %.loc9_71.1, %.loc9_71.2 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc9_73.2: i32 = struct_access %.loc9_73.1, element1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_73.3: ref i32 = struct_access file.%struct_copy.var, element1
+// CHECK:STDOUT:   %.loc9_73.4: init i32 = initialize_from %.loc9_73.2 to %.loc9_73.3 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_73.5: i32 = struct_access %.loc9_73.1, element0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_73.6: ref i32 = struct_access file.%struct_copy.var, element0
+// CHECK:STDOUT:   %.loc9_73.7: init i32 = initialize_from %.loc9_73.5 to %.loc9_73.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_73.8: i32 = struct_access %.loc9_73.1, element2 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc9_73.9: ref i32 = struct_access file.%struct_copy.var, element2
+// CHECK:STDOUT:   %.loc9_73.10: init i32 = initialize_from %.loc9_73.8 to %.loc9_73.9 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc9_73.11: init {.a: i32, .b: i32, .c: i32} = struct_init (%.loc9_73.4, %.loc9_73.7, %.loc9_73.10) to file.%struct_copy.var [template = constants.%.14]
+// CHECK:STDOUT:   %.loc9_103: init {.a: i32, .b: i32, .c: i32} = converted %.loc9_73.1, %.loc9_73.11 [template = constants.%.14]
+// CHECK:STDOUT:   assign file.%struct_copy.var, %.loc9_103
 // CHECK:STDOUT:   %.loc11_30: i32 = int_literal 0 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc11_32.1: (i32,) = tuple_literal (%.loc11_30)
 // CHECK:STDOUT:   %.loc11_44: i32 = int_literal 5 [template = constants.%.19]
@@ -121,8 +121,8 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.loc11_32.3: ref i32 = array_index %.loc11_5, %.loc11_32.2
 // CHECK:STDOUT:   %.loc11_32.4: init i32 = initialize_from %.loc11_30 to %.loc11_32.3 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc11_32.5: init [i32; 1] = array_init (%.loc11_32.4) to %.loc11_5 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc11_32.6: init [i32; 1] = converted %.loc11_32.1, %.loc11_32.5 [template = constants.%.25]
-// CHECK:STDOUT:   assign file.%tuple_index.var, %.loc11_32.6
+// CHECK:STDOUT:   %.loc11_34: init [i32; 1] = converted %.loc11_32.1, %.loc11_32.5 [template = constants.%.25]
+// CHECK:STDOUT:   assign file.%tuple_index.var, %.loc11_34
 // CHECK:STDOUT:   %.loc13_32: i32 = int_literal 0 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc13_34.1: (i32,) = tuple_literal (%.loc13_32)
 // CHECK:STDOUT:   %.loc13_51: i32 = int_literal 3 [template = constants.%.9]
@@ -137,8 +137,8 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.loc13_34.3: ref i32 = array_index %.loc13_5, %.loc13_34.2
 // CHECK:STDOUT:   %.loc13_34.4: init i32 = initialize_from %.loc13_32 to %.loc13_34.3 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc13_34.5: init [i32; 1] = array_init (%.loc13_34.4) to %.loc13_5 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc13_34.6: init [i32; 1] = converted %.loc13_34.1, %.loc13_34.5 [template = constants.%.25]
-// CHECK:STDOUT:   assign file.%struct_access.var, %.loc13_34.6
+// CHECK:STDOUT:   %.loc13_36: init [i32; 1] = converted %.loc13_34.1, %.loc13_34.5 [template = constants.%.25]
+// CHECK:STDOUT:   assign file.%struct_access.var, %.loc13_36
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/fail_aggregate.carbon
+++ b/toolchain/check/testdata/eval/fail_aggregate.carbon
@@ -68,10 +68,10 @@ var array_index: [i32; 1] = (0,) as [i32; ((5, 7, 1, 9) as [i32; 4])[2]];
 // CHECK:STDOUT:   %.loc12_55.13: ref i32 = array_index %.loc12_55.2, %.loc12_55.12
 // CHECK:STDOUT:   %.loc12_55.14: init i32 = initialize_from %.loc12_54 to %.loc12_55.13 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc12_55.15: init [i32; 4] = array_init (%.loc12_55.5, %.loc12_55.8, %.loc12_55.11, %.loc12_55.14) to %.loc12_55.2 [template = constants.%.15]
-// CHECK:STDOUT:   %.loc12_55.16: init [i32; 4] = converted %.loc12_55.1, %.loc12_55.15 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc12_57.1: init [i32; 4] = converted %.loc12_55.1, %.loc12_55.15 [template = constants.%.15]
 // CHECK:STDOUT:   %.loc12_70: i32 = int_literal 2 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc12_55.17: ref [i32; 4] = temporary %.loc12_55.2, %.loc12_55.16
-// CHECK:STDOUT:   %.loc12_71.1: ref i32 = array_index %.loc12_55.17, %.loc12_70
+// CHECK:STDOUT:   %.loc12_57.2: ref [i32; 4] = temporary %.loc12_55.2, %.loc12_57.1
+// CHECK:STDOUT:   %.loc12_71.1: ref i32 = array_index %.loc12_57.2, %.loc12_70
 // CHECK:STDOUT:   %.loc12_71.2: i32 = bind_value %.loc12_71.1
 // CHECK:STDOUT:   assign file.%array_index.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -165,8 +165,8 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   %.loc10_37.9: ref i32 = array_index file.%arr.var, %.loc10_37.8
 // CHECK:STDOUT:   %.loc10_37.10: init i32 = initialize_from %.loc10_34.2 to %.loc10_37.9 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc10_37.11: init [i32; 3] = array_init (%.loc10_37.4, %.loc10_37.7, %.loc10_37.10) to file.%arr.var [template = constants.%.16]
-// CHECK:STDOUT:   %.loc10_37.12: init [i32; 3] = converted %.loc10_37.1, %.loc10_37.11 [template = constants.%.16]
-// CHECK:STDOUT:   assign file.%arr.var, %.loc10_37.12
+// CHECK:STDOUT:   %.loc10_38: init [i32; 3] = converted %.loc10_37.1, %.loc10_37.11 [template = constants.%.16]
+// CHECK:STDOUT:   assign file.%arr.var, %.loc10_38
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/builtin/import.carbon
+++ b/toolchain/check/testdata/function/builtin/import.carbon
@@ -83,8 +83,8 @@ var arr: [i32; Core.Add(1, 2)] = (1, 2, 3);
 // CHECK:STDOUT:   %.loc4_42.9: ref i32 = array_index file.%arr.var, %.loc4_42.8
 // CHECK:STDOUT:   %.loc4_42.10: init i32 = initialize_from %.loc4_41 to %.loc4_42.9 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc4_42.11: init [i32; 3] = array_init (%.loc4_42.4, %.loc4_42.7, %.loc4_42.10) to file.%arr.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc4_42.12: init [i32; 3] = converted %.loc4_42.1, %.loc4_42.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign file.%arr.var, %.loc4_42.12
+// CHECK:STDOUT:   %.loc4_43: init [i32; 3] = converted %.loc4_42.1, %.loc4_42.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign file.%arr.var, %.loc4_43
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/empty_struct.carbon
@@ -50,8 +50,8 @@ fn Main() {
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: {} = struct_value () [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_9.3: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_7: init {} = call %Echo.ref(%.loc12_9.3)
+// CHECK:STDOUT:   %.loc12_7.1: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_7.2: init {} = call %Echo.ref(%.loc12_7.1)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/empty_tuple.carbon
@@ -49,8 +49,8 @@ fn Main() {
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
 // CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_9.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_9.3: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_7: init () = call %Echo.ref(%.loc12_9.3)
+// CHECK:STDOUT:   %.loc12_7.1: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_7.2: init () = call %Echo.ref(%.loc12_7.1)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -54,8 +54,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_22.1: (i32,) = tuple_literal (%.loc10_20)
 // CHECK:STDOUT:   %.loc10_22.2: init (i32,) = tuple_init (%.loc10_20) to %x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_22.3: init (i32,) = converted %.loc10_22.1, %.loc10_22.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %x.var, %.loc10_22.3
+// CHECK:STDOUT:   %.loc10_23: init (i32,) = converted %.loc10_22.1, %.loc10_22.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %x.var, %.loc10_23
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x
 // CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.5]

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -363,9 +363,9 @@ import library "extern_api";
 // CHECK:STDOUT:   %.loc8_23: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc8_25.1: (i32,) = tuple_literal (%.loc8_23)
 // CHECK:STDOUT:   %.loc8_25.2: (i32,) = tuple_value (%.loc8_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_25.3: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_21: init {.c: i32} = call %C.ref(%.loc8_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc8_21
+// CHECK:STDOUT:   %.loc8_21.1: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_21.2: init {.c: i32} = call %C.ref(%.loc8_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc8_21.2
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D]
 // CHECK:STDOUT:   %.loc9: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%d.var, %.loc9
@@ -469,9 +469,9 @@ import library "extern_api";
 // CHECK:STDOUT:   %.loc14_23: i32 = int_literal 1 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc14_25.1: (i32,) = tuple_literal (%.loc14_23)
 // CHECK:STDOUT:   %.loc14_25.2: (i32,) = tuple_value (%.loc14_23) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_25.3: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_21: init {.c: i32} = call %C.ref(%.loc14_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc14_21
+// CHECK:STDOUT:   %.loc14_21.1: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_21.2: init {.c: i32} = call %C.ref(%.loc14_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc14_21.2
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
 // CHECK:STDOUT:   %.loc15: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%d.var, %.loc15
@@ -575,9 +575,9 @@ import library "extern_api";
 // CHECK:STDOUT:   %.loc14_23: i32 = int_literal 1 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc14_25.1: (i32,) = tuple_literal (%.loc14_23)
 // CHECK:STDOUT:   %.loc14_25.2: (i32,) = tuple_value (%.loc14_23) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_25.3: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_21: init {.c: i32} = call %C.ref(%.loc14_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc14_21
+// CHECK:STDOUT:   %.loc14_21.1: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_21.2: init {.c: i32} = call %C.ref(%.loc14_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc14_21.2
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
 // CHECK:STDOUT:   %.loc15: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%d.var, %.loc15
@@ -679,9 +679,9 @@ import library "extern_api";
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_25.1: (i32,) = tuple_literal (%.loc9_23)
 // CHECK:STDOUT:   %.loc9_25.2: (i32,) = tuple_value (%.loc9_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_25.3: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_21: init {.c: i32} = call %C.ref(%.loc9_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc9_21
+// CHECK:STDOUT:   %.loc9_21.1: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_21.2: init {.c: i32} = call %C.ref(%.loc9_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc9_21.2
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D.1]
 // CHECK:STDOUT:   %.loc10: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%d.var, %.loc10
@@ -783,9 +783,9 @@ import library "extern_api";
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_25.1: (i32,) = tuple_literal (%.loc9_23)
 // CHECK:STDOUT:   %.loc9_25.2: (i32,) = tuple_value (%.loc9_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_25.3: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_21: init {.c: i32} = call %C.ref(%.loc9_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc9_21
+// CHECK:STDOUT:   %.loc9_21.1: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_21.2: init {.c: i32} = call %C.ref(%.loc9_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc9_21.2
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D.1]
 // CHECK:STDOUT:   %.loc10: init () = call %D.ref()
 // CHECK:STDOUT:   assign file.%d.var, %.loc10

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -143,8 +143,8 @@ fn D() {}
 // CHECK:STDOUT:   %.loc6_48: i32 = tuple_index %c.ref, %.loc6_47
 // CHECK:STDOUT:   %.loc6_49.1: {.c: i32} = struct_literal (%.loc6_48)
 // CHECK:STDOUT:   %.loc6_49.2: {.c: i32} = struct_value (%.loc6_48)
-// CHECK:STDOUT:   %.loc6_49.3: {.c: i32} = converted %.loc6_49.1, %.loc6_49.2
-// CHECK:STDOUT:   return %.loc6_49.3
+// CHECK:STDOUT:   %.loc6_50: {.c: i32} = converted %.loc6_49.1, %.loc6_49.2
+// CHECK:STDOUT:   return %.loc6_50
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @D();
@@ -218,9 +218,9 @@ fn D() {}
 // CHECK:STDOUT:   %.loc8_23: i32 = int_literal 1 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc8_25.1: (i32,) = tuple_literal (%.loc8_23)
 // CHECK:STDOUT:   %.loc8_25.2: (i32,) = tuple_value (%.loc8_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_25.3: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_21: init {.c: i32} = call %C.ref(%.loc8_25.3)
-// CHECK:STDOUT:   assign file.%c.var, %.loc8_21
+// CHECK:STDOUT:   %.loc8_21.1: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_21.2: init {.c: i32} = call %C.ref(%.loc8_21.1)
+// CHECK:STDOUT:   assign file.%c.var, %.loc8_21.2
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/global/class_obj.carbon
+++ b/toolchain/check/testdata/global/class_obj.carbon
@@ -39,8 +39,8 @@ var a: A = {};
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc8_13.2: init A = class_init (), file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_13.3: init A = converted %.loc8_13.1, %.loc8_13.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%a.var, %.loc8_13.3
+// CHECK:STDOUT:   %.loc8_14: init A = converted %.loc8_13.1, %.loc8_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%a.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/global/class_with_fun.carbon
+++ b/toolchain/check/testdata/global/class_with_fun.carbon
@@ -48,16 +48,16 @@ var a: A = {};
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc9_11.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc9_11.2: init A = class_init (), %return [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_11.3: init A = converted %.loc9_11.1, %.loc9_11.2 [template = constants.%.4]
-// CHECK:STDOUT:   return %.loc9_11.3
+// CHECK:STDOUT:   %.loc9_12: init A = converted %.loc9_11.1, %.loc9_11.2 [template = constants.%.4]
+// CHECK:STDOUT:   return %.loc9_12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc12_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_13.2: init A = class_init (), file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_13.3: init A = converted %.loc12_13.1, %.loc12_13.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%a.var, %.loc12_13.3
+// CHECK:STDOUT:   %.loc12_14: init A = converted %.loc12_13.1, %.loc12_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%a.var, %.loc12_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -49,8 +49,8 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:   %.loc8_24.3: ref i32 = array_index %x.var, %.loc8_24.2
 // CHECK:STDOUT:   %.loc8_24.4: init i32 = initialize_from %.loc8_22 to %.loc8_24.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_24.5: init [i32; 1] = array_init (%.loc8_24.4) to %x.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc8_24.6: init [i32; 1] = converted %.loc8_24.1, %.loc8_24.5 [template = constants.%.6]
-// CHECK:STDOUT:   assign %x.var, %.loc8_24.6
+// CHECK:STDOUT:   %.loc8_25: init [i32; 1] = converted %.loc8_24.1, %.loc8_24.5 [template = constants.%.6]
+// CHECK:STDOUT:   assign %x.var, %.loc8_25
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/if_expr/constant_condition.carbon
+++ b/toolchain/check/testdata/if_expr/constant_condition.carbon
@@ -96,10 +96,10 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc11_33.1: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc11_27: i32 = value_of_initializer %.loc11_33.1
-// CHECK:STDOUT:   %.loc11_33.2: i32 = converted %.loc11_33.1, %.loc11_27
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_33.2)
+// CHECK:STDOUT:   %.loc11_33: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc11_27.1: i32 = value_of_initializer %.loc11_33
+// CHECK:STDOUT:   %.loc11_27.2: i32 = converted %.loc11_33, %.loc11_27.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_27.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_10: i32 = block_arg !if.expr.result
@@ -120,10 +120,10 @@ fn PartiallyConstant(t: type) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc15_34.1: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc15_28: i32 = value_of_initializer %.loc15_34.1
-// CHECK:STDOUT:   %.loc15_34.2: i32 = converted %.loc15_34.1, %.loc15_28
-// CHECK:STDOUT:   br !if.expr.result(%.loc15_34.2)
+// CHECK:STDOUT:   %.loc15_34: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc15_28.1: i32 = value_of_initializer %.loc15_34
+// CHECK:STDOUT:   %.loc15_28.2: i32 = converted %.loc15_34, %.loc15_28.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc15_28.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc15_10: i32 = block_arg !if.expr.result

--- a/toolchain/check/testdata/if_expr/control_flow.carbon
+++ b/toolchain/check/testdata/if_expr/control_flow.carbon
@@ -65,10 +65,10 @@ fn F(b: bool) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc11_30.1: init i32 = call %B.ref()
-// CHECK:STDOUT:   %.loc11_24: i32 = value_of_initializer %.loc11_30.1
-// CHECK:STDOUT:   %.loc11_30.2: i32 = converted %.loc11_30.1, %.loc11_24
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_30.2)
+// CHECK:STDOUT:   %.loc11_30: init i32 = call %B.ref()
+// CHECK:STDOUT:   %.loc11_24.1: i32 = value_of_initializer %.loc11_30
+// CHECK:STDOUT:   %.loc11_24.2: i32 = converted %.loc11_30, %.loc11_24.1
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_24.2)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_10: i32 = block_arg !if.expr.result

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -55,8 +55,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_46.4: ref i32 = struct_access %a.var, element1
 // CHECK:STDOUT:   %.loc10_46.5: init i32 = initialize_from %.loc10_45 to %.loc10_46.4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init (%.loc10_46.3, %.loc10_46.5) to %a.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_46.7: init {.a: i32, .b: i32} = converted %.loc10_46.1, %.loc10_46.6 [template = constants.%.5]
-// CHECK:STDOUT:   assign %a.var, %.loc10_46.7
+// CHECK:STDOUT:   %.loc10_47: init {.a: i32, .b: i32} = converted %.loc10_46.1, %.loc10_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   assign %a.var, %.loc10_47
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %cond.ref: bool = name_ref cond, %cond
 // CHECK:STDOUT:   if %cond.ref br !if.expr.then else br !if.expr.else
@@ -78,8 +78,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc11_25.3: ref i32 = struct_access %a.ref.loc11_25, element1
 // CHECK:STDOUT:   %.loc11_25.4: i32 = bind_value %.loc11_25.3
 // CHECK:STDOUT:   %.loc11_25.5: {.a: i32, .b: i32} = struct_value (%.loc11_25.2, %.loc11_25.4)
-// CHECK:STDOUT:   %.loc11_25.6: {.a: i32, .b: i32} = converted %a.ref.loc11_25, %.loc11_25.5
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_25.6)
+// CHECK:STDOUT:   %.loc11_20: {.a: i32, .b: i32} = converted %a.ref.loc11_25, %.loc11_25.5
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_20)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc11_5: {.a: i32, .b: i32} = block_arg !if.expr.result

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -334,13 +334,13 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.13 [template] {
 // CHECK:STDOUT:     %Self.ref.loc184_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc184_16.1: type = facet_type_access %Self.ref.loc184_12 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_12: type = converted %Self.ref.loc184_12, %.loc184_16.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_16.2: type = ptr_type Self [symbolic = constants.%.9]
+// CHECK:STDOUT:     %.loc184_16.2: type = converted %Self.ref.loc184_12, %.loc184_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_16.3: type = ptr_type Self [symbolic = constants.%.9]
 // CHECK:STDOUT:     %Self.ref.loc184_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc184_24.1: type = facet_type_access %Self.ref.loc184_24 [symbolic = %Self]
 // CHECK:STDOUT:     %.loc184_24.2: type = converted %Self.ref.loc184_24, %.loc184_24.1 [symbolic = %Self]
 // CHECK:STDOUT:     %.loc184_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.10]
-// CHECK:STDOUT:     %.loc184_38.1: (type, type) = tuple_literal (%.loc184_16.2, %.loc184_37)
+// CHECK:STDOUT:     %.loc184_38.1: (type, type) = tuple_literal (%.loc184_16.3, %.loc184_37)
 // CHECK:STDOUT:     %.loc184_38.2: type = converted %.loc184_38.1, constants.%.12 [symbolic = constants.%.12]
 // CHECK:STDOUT:     %x.loc184_8.1: (Self*, {.x: Self, .y: i32}) = param x
 // CHECK:STDOUT:     %x.loc184_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc184_8.1

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -80,8 +80,8 @@ class C {
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc15_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc15_19.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc15_19.3: init C = converted %.loc15_19.1, %.loc15_19.2 [template = constants.%.8]
-// CHECK:STDOUT:   assign %c.var, %.loc15_19.3
+// CHECK:STDOUT:   %.loc15_20: init C = converted %.loc15_19.1, %.loc15_19.2 [template = constants.%.8]
+// CHECK:STDOUT:   assign %c.var, %.loc15_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -104,9 +104,9 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   %F.ref: <associated <function> in I> = name_ref F, @I.%.loc10_28 [template = constants.%.3]
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%F]
 // CHECK:STDOUT:   %.loc20_11: <bound method> = bound_method %c.ref, %.1
-// CHECK:STDOUT:   %.loc20_13.1: init i32 = call %.loc20_11(%c.ref)
-// CHECK:STDOUT:   %.loc20_15: i32 = value_of_initializer %.loc20_13.1
-// CHECK:STDOUT:   %.loc20_13.2: i32 = converted %.loc20_13.1, %.loc20_15
-// CHECK:STDOUT:   return %.loc20_13.2
+// CHECK:STDOUT:   %.loc20_13: init i32 = call %.loc20_11(%c.ref)
+// CHECK:STDOUT:   %.loc20_15.1: i32 = value_of_initializer %.loc20_13
+// CHECK:STDOUT:   %.loc20_15.2: i32 = converted %.loc20_13, %.loc20_15.1
+// CHECK:STDOUT:   return %.loc20_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -126,13 +126,13 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.4 [template] {
 // CHECK:STDOUT:     %Self.ref.loc24_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc24_16.1: type = facet_type_access %Self.ref.loc24_12 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_12: type = converted %Self.ref.loc24_12, %.loc24_16.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_16.2: type = ptr_type Self [symbolic = constants.%.12]
+// CHECK:STDOUT:     %.loc24_16.2: type = converted %Self.ref.loc24_12, %.loc24_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc24_16.3: type = ptr_type Self [symbolic = constants.%.12]
 // CHECK:STDOUT:     %Self.ref.loc24_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc24_24.1: type = facet_type_access %Self.ref.loc24_24 [symbolic = %Self]
 // CHECK:STDOUT:     %.loc24_24.2: type = converted %Self.ref.loc24_24, %.loc24_24.1 [symbolic = %Self]
 // CHECK:STDOUT:     %.loc24_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.13]
-// CHECK:STDOUT:     %.loc24_38.1: (type, type) = tuple_literal (%.loc24_16.2, %.loc24_37)
+// CHECK:STDOUT:     %.loc24_38.1: (type, type) = tuple_literal (%.loc24_16.3, %.loc24_37)
 // CHECK:STDOUT:     %.loc24_38.2: type = converted %.loc24_38.1, constants.%.15 [symbolic = constants.%.15]
 // CHECK:STDOUT:     %x.loc24_8.1: (Self*, {.x: Self, .y: i32}) = param x
 // CHECK:STDOUT:     %x.loc24_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc24_8.1
@@ -233,16 +233,16 @@ impl D as SelfNested {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc16_38.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc16_38.2: init C = class_init (), @impl.1.%return.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc16_38.3: init C = converted %.loc16_38.1, %.loc16_38.2 [template = constants.%.8]
-// CHECK:STDOUT:   return %.loc16_38.3
+// CHECK:STDOUT:   %.loc16_39: init C = converted %.loc16_38.1, %.loc16_38.2 [template = constants.%.8]
+// CHECK:STDOUT:   return %.loc16_39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.3[@impl.2.%self.loc20_8.2: D](@impl.2.%x.loc20_20.2: D) -> @impl.2.%return.var: D {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc20_47.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc20_47.2: init D = class_init (), @impl.2.%return.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc20_47.3: init D = converted %.loc20_47.1, %.loc20_47.2 [template = constants.%.10]
-// CHECK:STDOUT:   return %.loc20_47.3
+// CHECK:STDOUT:   %.loc20_48: init D = converted %.loc20_47.1, %.loc20_47.2 [template = constants.%.10]
+// CHECK:STDOUT:   return %.loc20_48
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.4(@SelfNested.%x.loc24_8.2: (Self*, {.x: Self, .y: i32}));

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -56,8 +56,8 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   %.loc7_26.6: ref i32 = array_index file.%a.var, %.loc7_26.5
 // CHECK:STDOUT:   %.loc7_26.7: init i32 = initialize_from %.loc7_24 to %.loc7_26.6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_26.8: init [i32; 2] = array_init (%.loc7_26.4, %.loc7_26.7) to file.%a.var [template = constants.%.9]
-// CHECK:STDOUT:   %.loc7_26.9: init [i32; 2] = converted %.loc7_26.1, %.loc7_26.8 [template = constants.%.9]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_26.9
+// CHECK:STDOUT:   %.loc7_27: init [i32; 2] = converted %.loc7_26.1, %.loc7_26.8 [template = constants.%.9]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_27
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8
 // CHECK:STDOUT:   %a.ref.loc9: ref [i32; 2] = name_ref a, file.%a

--- a/toolchain/check/testdata/index/expr_category.carbon
+++ b/toolchain/check/testdata/index/expr_category.carbon
@@ -88,8 +88,8 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc10_29.9: ref i32 = array_index %a.var, %.loc10_29.8
 // CHECK:STDOUT:   %.loc10_29.10: init i32 = initialize_from %.loc10_28 to %.loc10_29.9 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_29.11: init [i32; 3] = array_init (%.loc10_29.4, %.loc10_29.7, %.loc10_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc10_29.12: init [i32; 3] = converted %.loc10_29.1, %.loc10_29.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign %a.var, %.loc10_29.12
+// CHECK:STDOUT:   %.loc10_30: init [i32; 3] = converted %.loc10_29.1, %.loc10_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign %a.var, %.loc10_30
 // CHECK:STDOUT:   %.loc13_14: type = ptr_type i32 [template = constants.%.9]
 // CHECK:STDOUT:   %pa.var: ref i32* = var pa
 // CHECK:STDOUT:   %pa: ref i32* = bind_name pa, %pa.var
@@ -126,8 +126,8 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc18_29.9: ref i32 = array_index %a.var, %.loc18_29.8
 // CHECK:STDOUT:   %.loc18_29.10: init i32 = initialize_from %.loc18_28 to %.loc18_29.9 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc18_29.11: init [i32; 3] = array_init (%.loc18_29.4, %.loc18_29.7, %.loc18_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc18_29.12: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11 [template = constants.%.8]
-// CHECK:STDOUT:   assign %a.var, %.loc18_29.12
+// CHECK:STDOUT:   %.loc18_30: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   assign %a.var, %.loc18_30
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, %a
 // CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc22_6: ref i32 = array_index %a.ref, %.loc22_5

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -56,8 +56,8 @@ var c: i32 = a[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref.loc13: ref [i32; 1] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc13_16: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc13_17.1: ref i32 = array_index %a.ref.loc13, %.loc13_16 [template = <error>]

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -46,8 +46,8 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -45,8 +45,8 @@ var b: i32 = a[1];
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_23.6: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_23.6
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_16: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_17.1: ref i32 = array_index %a.ref, %.loc11_16 [template = <error>]

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -52,8 +52,8 @@ var b: i32 = a[-10];
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_27.7: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.7
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc16_17: i32 = int_literal 10 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc16_19: ref <error> = tuple_index %a.ref, <error>

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -51,8 +51,8 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %.loc7_26.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_26.5: init i32 = initialize_from %.loc7_25 to %.loc7_26.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_26.6: init (i32, i32) = tuple_init (%.loc7_26.3, %.loc7_26.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_26.7: init (i32, i32) = converted %.loc7_26.1, %.loc7_26.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_26.7
+// CHECK:STDOUT:   %.loc7_27: init (i32, i32) = converted %.loc7_26.1, %.loc7_26.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_27
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a

--- a/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
+++ b/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
@@ -49,8 +49,8 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.loc7_28.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_28.5: init i32 = initialize_from %.loc7_26 to %.loc7_28.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28.7: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_28.7
+// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_29
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_26: i32 = int_literal 2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_27.1: {.index: i32} = struct_literal (%.loc11_26)

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -46,8 +46,8 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_27.7: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.7
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %oops.ref: <error> = name_ref oops, <error> [template = <error>]
 // CHECK:STDOUT:   %.loc11: ref <error> = tuple_index %a.ref, <error>

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -55,14 +55,14 @@ var d: i32 = b[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_21.3
+// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_22
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %a.ref, element0
 // CHECK:STDOUT:   %.loc8_17.2: i32 = bind_value %.loc8_17.1
 // CHECK:STDOUT:   %.loc8_17.3: init (i32,) = tuple_init (%.loc8_17.2) to file.%b.var
-// CHECK:STDOUT:   %.loc8_17.4: init (i32,) = converted %a.ref, %.loc8_17.3
-// CHECK:STDOUT:   assign file.%b.var, %.loc8_17.4
+// CHECK:STDOUT:   %.loc8_18: init (i32,) = converted %a.ref, %.loc8_17.3
+// CHECK:STDOUT:   assign file.%b.var, %.loc8_18
 // CHECK:STDOUT:   %b.ref.loc13: ref (i32,) = name_ref b, file.%b
 // CHECK:STDOUT:   %.loc13_16: i32 = int_literal 1 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc13_17: ref <error> = tuple_index %b.ref.loc13, <error>

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -47,8 +47,8 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_27.7: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.7
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_16: f64 = real_literal 26e-1 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -47,8 +47,8 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_27.7: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_27.7
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>

--- a/toolchain/check/testdata/index/index_not_literal.carbon
+++ b/toolchain/check/testdata/index/index_not_literal.carbon
@@ -46,8 +46,8 @@ var b: i32 = a[{.index = 1}.index];
 // CHECK:STDOUT:   %.loc7_28.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_28.5: init i32 = initialize_from %.loc7_26 to %.loc7_28.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28.7: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_28.7
+// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_29
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_26: i32 = int_literal 1 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc8_27.1: {.index: i32} = struct_literal (%.loc8_26)

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -43,14 +43,14 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_21.3: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%a.var, %.loc7_21.3
+// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%a.var, %.loc7_22
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %a.ref, element0
 // CHECK:STDOUT:   %.loc8_17.2: i32 = bind_value %.loc8_17.1
 // CHECK:STDOUT:   %.loc8_17.3: init (i32,) = tuple_init (%.loc8_17.2) to file.%b.var
-// CHECK:STDOUT:   %.loc8_17.4: init (i32,) = converted %a.ref, %.loc8_17.3
-// CHECK:STDOUT:   assign file.%b.var, %.loc8_17.4
+// CHECK:STDOUT:   %.loc8_18: init (i32,) = converted %a.ref, %.loc8_17.3
+// CHECK:STDOUT:   assign file.%b.var, %.loc8_18
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, file.%b
 // CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -41,8 +41,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
 // CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_30.3: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
-// CHECK:STDOUT:   return %.loc7_30.3
+// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
+// CHECK:STDOUT:   return %.loc7_31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() -> i32 {

--- a/toolchain/check/testdata/interface/default_fn.carbon
+++ b/toolchain/check/testdata/interface/default_fn.carbon
@@ -81,8 +81,8 @@ class C {
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc12_19.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc12_19.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_19.3: init C = converted %.loc12_19.1, %.loc12_19.2 [template = constants.%.8]
-// CHECK:STDOUT:   assign %c.var, %.loc12_19.3
+// CHECK:STDOUT:   %.loc12_20: init C = converted %.loc12_19.1, %.loc12_19.2 [template = constants.%.8]
+// CHECK:STDOUT:   assign %c.var, %.loc12_20
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %I.ref: type = name_ref I, @C.%I.decl [template = constants.%.1]
 // CHECK:STDOUT:   %F.ref: <associated <function> in I> = name_ref F, @I.%.loc10 [template = constants.%.3]

--- a/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
@@ -40,17 +40,17 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
 // CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
-// CHECK:STDOUT:   %.loc12_35.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc12_35.2: type = converted %.loc12_35.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_35: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc12_36.1: type = converted %.loc12_35, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
-// CHECK:STDOUT:   %.loc12_36: <associated type in I> = assoc_entity element0, %T [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_36.2: <associated type in I> = assoc_entity element0, %T [template = constants.%.5]
 // CHECK:STDOUT:   %.loc16_25: i32 = int_literal 42 [template = constants.%.6]
 // CHECK:STDOUT:   %N: i32 = assoc_const_decl N [template]
 // CHECK:STDOUT:   %.loc16_27: <associated i32 in I> = assoc_entity element1, %N [template = constants.%.8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .T = %.loc12_36
+// CHECK:STDOUT:   .T = %.loc12_36.2
 // CHECK:STDOUT:   .N = %.loc16_27
 // CHECK:STDOUT:   witness = (%T, %N)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/todo_define_not_default.carbon
+++ b/toolchain/check/testdata/interface/todo_define_not_default.carbon
@@ -52,10 +52,10 @@ interface I {
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10: <associated <function> in I> = assoc_entity element1, %G [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_27.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc14_27.2: type = converted %.loc14_27.1, constants.%.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_27: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc14_28.1: type = converted %.loc14_27, constants.%.6 [template = constants.%.6]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
-// CHECK:STDOUT:   %.loc14_28: <associated type in I> = assoc_entity element2, %T [template = constants.%.8]
+// CHECK:STDOUT:   %.loc14_28.2: <associated type in I> = assoc_entity element2, %T [template = constants.%.8]
 // CHECK:STDOUT:   %.loc15_17: i32 = int_literal 42 [template = constants.%.9]
 // CHECK:STDOUT:   %N: i32 = assoc_const_decl N [template]
 // CHECK:STDOUT:   %.loc15_19: <associated i32 in I> = assoc_entity element3, %N [template = constants.%.11]
@@ -64,7 +64,7 @@ interface I {
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .F = %.loc9
 // CHECK:STDOUT:   .G = %.loc10
-// CHECK:STDOUT:   .T = %.loc14_28
+// CHECK:STDOUT:   .T = %.loc14_28.2
 // CHECK:STDOUT:   .N = %.loc15_19
 // CHECK:STDOUT:   witness = (%F, %G, %T, %N)
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -51,8 +51,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.6: ref i32 = tuple_access %v.var, element2
 // CHECK:STDOUT:   %.loc8_36.7: init i32 = initialize_from %.loc8_35 to %.loc8_36.6 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc8_36.8: init (i32, i32, i32) = tuple_init (%.loc8_36.3, %.loc8_36.5, %.loc8_36.7) to %v.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc8_36.9: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8 [template = constants.%.7]
-// CHECK:STDOUT:   assign %v.var, %.loc8_36.9
+// CHECK:STDOUT:   %.loc8_37: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8 [template = constants.%.7]
+// CHECK:STDOUT:   assign %v.var, %.loc8_37
 // CHECK:STDOUT:   %.loc10_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_24.2: type = converted %.loc10_24.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: ref (i32, i32, i32) = name_ref v, %v
@@ -63,8 +63,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_28.5: ref i32 = tuple_access %v.ref, element2
 // CHECK:STDOUT:   %.loc10_28.6: i32 = bind_value %.loc10_28.5
 // CHECK:STDOUT:   %.loc10_28.7: (i32, i32, i32) = tuple_value (%.loc10_28.2, %.loc10_28.4, %.loc10_28.6)
-// CHECK:STDOUT:   %.loc10_28.8: (i32, i32, i32) = converted %v.ref, %.loc10_28.7
-// CHECK:STDOUT:   %w: (i32, i32, i32) = bind_name w, %.loc10_28.8
+// CHECK:STDOUT:   %.loc10_29: (i32, i32, i32) = converted %v.ref, %.loc10_28.7
+// CHECK:STDOUT:   %w: (i32, i32, i32) = bind_name w, %.loc10_29
 // CHECK:STDOUT:   %w.ref: (i32, i32, i32) = name_ref w, %w
 // CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc11_13: i32 = tuple_index %w.ref, %.loc11_12

--- a/toolchain/check/testdata/namespace/alias.carbon
+++ b/toolchain/check/testdata/namespace/alias.carbon
@@ -61,18 +61,18 @@ fn D() -> i32 { return C(); }
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %ns.ref: <namespace> = name_ref ns, file.%ns [template = file.%NS]
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc13_28.1: init i32 = call %A.ref()
-// CHECK:STDOUT:   %.loc13_30: i32 = value_of_initializer %.loc13_28.1
-// CHECK:STDOUT:   %.loc13_28.2: i32 = converted %.loc13_28.1, %.loc13_30
-// CHECK:STDOUT:   return %.loc13_28.2
+// CHECK:STDOUT:   %.loc13_28: init i32 = call %A.ref()
+// CHECK:STDOUT:   %.loc13_30.1: i32 = value_of_initializer %.loc13_28
+// CHECK:STDOUT:   %.loc13_30.2: i32 = converted %.loc13_28, %.loc13_30.1
+// CHECK:STDOUT:   return %.loc13_30.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @D() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%A]
-// CHECK:STDOUT:   %.loc17_25.1: init i32 = call %C.ref()
-// CHECK:STDOUT:   %.loc17_27: i32 = value_of_initializer %.loc17_25.1
-// CHECK:STDOUT:   %.loc17_25.2: i32 = converted %.loc17_25.1, %.loc17_27
-// CHECK:STDOUT:   return %.loc17_25.2
+// CHECK:STDOUT:   %.loc17_25: init i32 = call %C.ref()
+// CHECK:STDOUT:   %.loc17_27.1: i32 = value_of_initializer %.loc17_25
+// CHECK:STDOUT:   %.loc17_27.2: i32 = converted %.loc17_25, %.loc17_27.1
+// CHECK:STDOUT:   return %.loc17_27.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/and.carbon
+++ b/toolchain/check/testdata/operators/builtin/and.carbon
@@ -72,22 +72,22 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT: fn @And() -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11.1
-// CHECK:STDOUT:   %.loc11_11.2: bool = converted %.loc11_11.1, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.2: bool = bool_literal false [template = constants.%.2]
-// CHECK:STDOUT:   if %.loc11_11.2 br !and.rhs else br !and.result(%.loc11_14.2)
+// CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
+// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal false [template = constants.%.2]
+// CHECK:STDOUT:   if %.loc11_14.2 br !and.rhs else br !and.result(%.loc11_14.3)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.rhs:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc11_19.1: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc11_14.3: bool = value_of_initializer %.loc11_19.1
-// CHECK:STDOUT:   %.loc11_19.2: bool = converted %.loc11_19.1, %.loc11_14.3
-// CHECK:STDOUT:   br !and.result(%.loc11_19.2)
+// CHECK:STDOUT:   %.loc11_19: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc11_14.4: bool = value_of_initializer %.loc11_19
+// CHECK:STDOUT:   %.loc11_14.5: bool = converted %.loc11_19, %.loc11_14.4
+// CHECK:STDOUT:   br !and.result(%.loc11_14.5)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !and.result:
-// CHECK:STDOUT:   %.loc11_14.4: bool = block_arg !and.result
-// CHECK:STDOUT:   return %.loc11_14.4
+// CHECK:STDOUT:   %.loc11_14.6: bool = block_arg !and.result
+// CHECK:STDOUT:   return %.loc11_14.6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() {
@@ -108,9 +108,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc15(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc15:
-// CHECK:STDOUT:   %.loc15_43.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_43.2: type = converted %.loc15_43.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_43.2)
+// CHECK:STDOUT:   %.loc15_43: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc15_37: type = converted %.loc15_43, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_37)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc15:
 // CHECK:STDOUT:   %.loc15_10: type = block_arg !if.expr.result.loc15 [template = bool]
@@ -134,9 +134,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc16(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc16:
-// CHECK:STDOUT:   %.loc16_44.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc16_44.2: type = converted %.loc16_44.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_44.2)
+// CHECK:STDOUT:   %.loc16_44: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc16_38: type = converted %.loc16_44, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_38)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc16:
 // CHECK:STDOUT:   %.loc16_10: type = block_arg !if.expr.result.loc16 [template = constants.%.3]
@@ -144,8 +144,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %.loc16_49.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc16_49.2: init () = tuple_init () to %b.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc16_49.3: init () = converted %.loc16_49.1, %.loc16_49.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %b.var, %.loc16_49.3
+// CHECK:STDOUT:   %.loc16_50: init () = converted %.loc16_49.1, %.loc16_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %b.var, %.loc16_50
 // CHECK:STDOUT:   %.loc17_13: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc17_19.1: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   if %.loc17_13 br !and.rhs.loc17 else br !and.result.loc17(%.loc17_19.1)
@@ -162,9 +162,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc17(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc17:
-// CHECK:STDOUT:   %.loc17_44.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc17_44.2: type = converted %.loc17_44.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc17(%.loc17_44.2)
+// CHECK:STDOUT:   %.loc17_44: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc17_38: type = converted %.loc17_44, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc17(%.loc17_38)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc17:
 // CHECK:STDOUT:   %.loc17_10: type = block_arg !if.expr.result.loc17 [template = constants.%.3]
@@ -172,8 +172,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %c: ref () = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc17_49.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc17_49.2: init () = tuple_init () to %c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc17_49.3: init () = converted %.loc17_49.1, %.loc17_49.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %c.var, %.loc17_49.3
+// CHECK:STDOUT:   %.loc17_50: init () = converted %.loc17_49.1, %.loc17_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %c.var, %.loc17_50
 // CHECK:STDOUT:   %.loc18_13: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc18_19.1: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   if %.loc18_13 br !and.rhs.loc18 else br !and.result.loc18(%.loc18_19.1)
@@ -190,9 +190,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc18(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc18:
-// CHECK:STDOUT:   %.loc18_45.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc18_45.2: type = converted %.loc18_45.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc18(%.loc18_45.2)
+// CHECK:STDOUT:   %.loc18_45: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc18_39: type = converted %.loc18_45, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc18(%.loc18_39)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc18:
 // CHECK:STDOUT:   %.loc18_10: type = block_arg !if.expr.result.loc18 [template = constants.%.3]
@@ -200,8 +200,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %d: ref () = bind_name d, %d.var
 // CHECK:STDOUT:   %.loc18_50.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc18_50.2: init () = tuple_init () to %d.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc18_50.3: init () = converted %.loc18_50.1, %.loc18_50.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %d.var, %.loc18_50.3
+// CHECK:STDOUT:   %.loc18_51: init () = converted %.loc18_50.1, %.loc18_50.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %d.var, %.loc18_51
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -223,9 +223,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %.loc22_41.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_41.2: type = converted %.loc22_41.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result(%.loc22_41.2)
+// CHECK:STDOUT:   %.loc22_41: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_35: type = converted %.loc22_41, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result(%.loc22_35)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result [template = constants.%.3]
@@ -233,8 +233,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc22_46.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc22_46.2: init () = tuple_init () to %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc22_46.3: init () = converted %.loc22_46.1, %.loc22_46.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %a.var, %.loc22_46.3
+// CHECK:STDOUT:   %.loc22_47: init () = converted %.loc22_46.1, %.loc22_46.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %a.var, %.loc22_47
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/builtin/assignment.carbon
+++ b/toolchain/check/testdata/operators/builtin/assignment.carbon
@@ -75,8 +75,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_28.4: ref i32 = tuple_access %b.var, element1
 // CHECK:STDOUT:   %.loc11_28.5: init i32 = initialize_from %.loc11_27 to %.loc11_28.4 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_28.6: init (i32, i32) = tuple_init (%.loc11_28.3, %.loc11_28.5) to %b.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_28.7: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6 [template = constants.%.8]
-// CHECK:STDOUT:   assign %b.var, %.loc11_28.7
+// CHECK:STDOUT:   %.loc11_29: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6 [template = constants.%.8]
+// CHECK:STDOUT:   assign %b.var, %.loc11_29
 // CHECK:STDOUT:   %b.ref.loc12: ref (i32, i32) = name_ref b, %b
 // CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc12_6: ref i32 = tuple_index %b.ref.loc12, %.loc12_5
@@ -98,8 +98,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc15_46.4: ref i32 = struct_access %c.var, element1
 // CHECK:STDOUT:   %.loc15_46.5: init i32 = initialize_from %.loc15_45 to %.loc15_46.4 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc15_46.6: init {.a: i32, .b: i32} = struct_init (%.loc15_46.3, %.loc15_46.5) to %c.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc15_46.7: init {.a: i32, .b: i32} = converted %.loc15_46.1, %.loc15_46.6 [template = constants.%.14]
-// CHECK:STDOUT:   assign %c.var, %.loc15_46.7
+// CHECK:STDOUT:   %.loc15_47: init {.a: i32, .b: i32} = converted %.loc15_46.1, %.loc15_46.6 [template = constants.%.14]
+// CHECK:STDOUT:   assign %c.var, %.loc15_47
 // CHECK:STDOUT:   %c.ref.loc16: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc16_4: ref i32 = struct_access %c.ref.loc16, element0
 // CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.10]

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_not_in_function.carbon
@@ -46,9 +46,9 @@ var or_: F(true or true);
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   %.loc38_17: bool = block_arg <unexpected instblockref block14> [template = constants.%.1]
-// CHECK:STDOUT:   %.loc38_11.1: init type = call <unexpected instref inst+28>(%.loc38_17)
-// CHECK:STDOUT:   %.loc38_24: type = value_of_initializer %.loc38_11.1
-// CHECK:STDOUT:   %.loc38_11.2: type = converted %.loc38_11.1, %.loc38_24
+// CHECK:STDOUT:   %.loc38_11: init type = call <unexpected instref inst+28>(%.loc38_17)
+// CHECK:STDOUT:   %.loc38_24.1: type = value_of_initializer %.loc38_11
+// CHECK:STDOUT:   %.loc38_24.2: type = converted %.loc38_11, %.loc38_24.1
 // CHECK:STDOUT:   %or_.var: ref <error> = var or_
 // CHECK:STDOUT:   %or_: ref <error> = bind_name or_, %or_.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/fail_and_or_partial_constant.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_and_or_partial_constant.carbon
@@ -77,9 +77,9 @@ fn KnownValueButNonConstantCondition(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc9(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc9:
-// CHECK:STDOUT:   %.loc9_40.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_40.2: type = converted %.loc9_40.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc9(%.loc9_40.2)
+// CHECK:STDOUT:   %.loc9_40: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc9_34: type = converted %.loc9_40, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc9(%.loc9_34)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc9:
 // CHECK:STDOUT:   %.loc9_10: type = block_arg !if.expr.result.loc9
@@ -102,9 +102,9 @@ fn KnownValueButNonConstantCondition(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc14(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc14:
-// CHECK:STDOUT:   %.loc14_40.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc14_40.2: type = converted %.loc14_40.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc14(%.loc14_40.2)
+// CHECK:STDOUT:   %.loc14_40: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc14_34: type = converted %.loc14_40, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc14(%.loc14_34)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc14:
 // CHECK:STDOUT:   %.loc14_10: type = block_arg !if.expr.result.loc14
@@ -151,9 +151,9 @@ fn KnownValueButNonConstantCondition(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc11(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc11:
-// CHECK:STDOUT:   %.loc11_41.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc11_41.2: type = converted %.loc11_41.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   br !if.expr.result.loc11(%.loc11_41.2)
+// CHECK:STDOUT:   %.loc11_41: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc11_35: type = converted %.loc11_41, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   br !if.expr.result.loc11(%.loc11_35)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc11:
 // CHECK:STDOUT:   %.loc11_10: type = block_arg !if.expr.result.loc11
@@ -176,9 +176,9 @@ fn KnownValueButNonConstantCondition(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc15(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc15:
-// CHECK:STDOUT:   %.loc15_39.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_39.2: type = converted %.loc15_39.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_39.2)
+// CHECK:STDOUT:   %.loc15_39: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc15_33: type = converted %.loc15_39, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_33)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc15:
 // CHECK:STDOUT:   %.loc15_10: type = block_arg !if.expr.result.loc15

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
@@ -108,8 +108,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc24_17.4: i32 = tuple_access %.loc24_8.1, element1
 // CHECK:STDOUT:   %.loc24_17.5: init i32 = initialize_from %.loc24_16 to %.loc24_17.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc24_17.6: init (i32, i32) = tuple_init (%.loc24_17.3, %.loc24_17.5) to %.loc24_8.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc24_17.7: init (i32, i32) = converted %.loc24_17.1, %.loc24_17.6 [template = constants.%.7]
-// CHECK:STDOUT:   assign %.loc24_8.1, %.loc24_17.7
+// CHECK:STDOUT:   %.loc24_10: init (i32, i32) = converted %.loc24_17.1, %.loc24_17.6 [template = constants.%.7]
+// CHECK:STDOUT:   assign %.loc24_8.1, %.loc24_10
 // CHECK:STDOUT:   %.loc24_8.2: (i32, i32) = tuple_value (%.loc24_4, %.loc24_7) [template = constants.%.8]
 // CHECK:STDOUT:   %.loc24_8.3: (i32, i32) = converted %.loc24_8.1, %.loc24_8.2 [template = constants.%.8]
 // CHECK:STDOUT:   %n.var: ref i32 = var n
@@ -127,8 +127,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc30_17.4: i32 = tuple_access %.loc30_8.1, element1
 // CHECK:STDOUT:   %.loc30_17.5: init i32 = initialize_from %.loc30_16 to %.loc30_17.4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc30_17.6: init (i32, i32) = tuple_init (%.loc30_17.3, %.loc30_17.5) to %.loc30_8.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc30_17.7: init (i32, i32) = converted %.loc30_17.1, %.loc30_17.6 [template = constants.%.8]
-// CHECK:STDOUT:   assign %.loc30_8.1, %.loc30_17.7
+// CHECK:STDOUT:   %.loc30_10: init (i32, i32) = converted %.loc30_17.1, %.loc30_17.6 [template = constants.%.8]
+// CHECK:STDOUT:   assign %.loc30_8.1, %.loc30_10
 // CHECK:STDOUT:   %.loc30_4: i32 = bind_value %n.ref.loc30_4
 // CHECK:STDOUT:   %.loc30_7: i32 = bind_value %n.ref.loc30_7
 // CHECK:STDOUT:   %.loc30_8.2: (i32, i32) = tuple_value (%.loc30_4, %.loc30_7)
@@ -146,8 +146,8 @@ fn Main() {
 // CHECK:STDOUT:   %.loc40_37.4: i32 = struct_access %.loc40_18.1, element1
 // CHECK:STDOUT:   %.loc40_37.5: init i32 = initialize_from %.loc40_36 to %.loc40_37.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc40_37.6: init {.x: i32, .y: i32} = struct_init (%.loc40_37.3, %.loc40_37.5) to %.loc40_18.1 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc40_37.7: init {.x: i32, .y: i32} = converted %.loc40_37.1, %.loc40_37.6 [template = constants.%.13]
-// CHECK:STDOUT:   assign %.loc40_18.1, %.loc40_37.7
+// CHECK:STDOUT:   %.loc40_20: init {.x: i32, .y: i32} = converted %.loc40_37.1, %.loc40_37.6 [template = constants.%.13]
+// CHECK:STDOUT:   assign %.loc40_18.1, %.loc40_20
 // CHECK:STDOUT:   %.loc40_18.2: {.x: i32, .y: i32} = struct_value (%.loc40_9, %.loc40_17) [template = constants.%.14]
 // CHECK:STDOUT:   %.loc40_18.3: {.x: i32, .y: i32} = converted %.loc40_18.1, %.loc40_18.2 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.15]

--- a/toolchain/check/testdata/operators/builtin/or.carbon
+++ b/toolchain/check/testdata/operators/builtin/or.carbon
@@ -72,23 +72,23 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT: fn @Or() -> bool {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc11_11.1: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11.1
-// CHECK:STDOUT:   %.loc11_11.2: bool = converted %.loc11_11.1, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.2: bool = not %.loc11_11.2
-// CHECK:STDOUT:   %.loc11_14.3: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   if %.loc11_14.2 br !or.rhs else br !or.result(%.loc11_14.3)
+// CHECK:STDOUT:   %.loc11_11: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc11_14.1: bool = value_of_initializer %.loc11_11
+// CHECK:STDOUT:   %.loc11_14.2: bool = converted %.loc11_11, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.3: bool = not %.loc11_14.2
+// CHECK:STDOUT:   %.loc11_14.4: bool = bool_literal true [template = constants.%.1]
+// CHECK:STDOUT:   if %.loc11_14.3 br !or.rhs else br !or.result(%.loc11_14.4)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.rhs:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc11_18.1: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc11_14.4: bool = value_of_initializer %.loc11_18.1
-// CHECK:STDOUT:   %.loc11_18.2: bool = converted %.loc11_18.1, %.loc11_14.4
-// CHECK:STDOUT:   br !or.result(%.loc11_18.2)
+// CHECK:STDOUT:   %.loc11_18: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc11_14.5: bool = value_of_initializer %.loc11_18
+// CHECK:STDOUT:   %.loc11_14.6: bool = converted %.loc11_18, %.loc11_14.5
+// CHECK:STDOUT:   br !or.result(%.loc11_14.6)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !or.result:
-// CHECK:STDOUT:   %.loc11_14.5: bool = block_arg !or.result
-// CHECK:STDOUT:   return %.loc11_14.5
+// CHECK:STDOUT:   %.loc11_14.7: bool = block_arg !or.result
+// CHECK:STDOUT:   return %.loc11_14.7
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Constant() {
@@ -110,9 +110,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc15(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc15:
-// CHECK:STDOUT:   %.loc15_42.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_42.2: type = converted %.loc15_42.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_42.2)
+// CHECK:STDOUT:   %.loc15_42: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc15_36: type = converted %.loc15_42, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_36)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc15:
 // CHECK:STDOUT:   %.loc15_10: type = block_arg !if.expr.result.loc15 [template = bool]
@@ -137,9 +137,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc16(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc16:
-// CHECK:STDOUT:   %.loc16_43.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc16_43.2: type = converted %.loc16_43.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_43.2)
+// CHECK:STDOUT:   %.loc16_43: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc16_37: type = converted %.loc16_43, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_37)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc16:
 // CHECK:STDOUT:   %.loc16_10: type = block_arg !if.expr.result.loc16 [template = bool]
@@ -164,9 +164,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc17(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc17:
-// CHECK:STDOUT:   %.loc17_43.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc17_43.2: type = converted %.loc17_43.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc17(%.loc17_43.2)
+// CHECK:STDOUT:   %.loc17_43: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc17_37: type = converted %.loc17_43, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc17(%.loc17_37)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc17:
 // CHECK:STDOUT:   %.loc17_10: type = block_arg !if.expr.result.loc17 [template = bool]
@@ -191,9 +191,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result.loc18(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc18:
-// CHECK:STDOUT:   %.loc18_44.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc18_44.2: type = converted %.loc18_44.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc18(%.loc18_44.2)
+// CHECK:STDOUT:   %.loc18_44: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc18_38: type = converted %.loc18_44, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc18(%.loc18_38)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc18:
 // CHECK:STDOUT:   %.loc18_10: type = block_arg !if.expr.result.loc18 [template = constants.%.3]
@@ -201,8 +201,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %d: ref () = bind_name d, %d.var
 // CHECK:STDOUT:   %.loc18_49.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc18_49.2: init () = tuple_init () to %d.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc18_49.3: init () = converted %.loc18_49.1, %.loc18_49.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %d.var, %.loc18_49.3
+// CHECK:STDOUT:   %.loc18_50: init () = converted %.loc18_49.1, %.loc18_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %d.var, %.loc18_50
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -225,9 +225,9 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   br !if.expr.result(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
-// CHECK:STDOUT:   %.loc22_39.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_39.2: type = converted %.loc22_39.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result(%.loc22_39.2)
+// CHECK:STDOUT:   %.loc22_39: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc22_33: type = converted %.loc22_39, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result(%.loc22_33)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc22_10: type = block_arg !if.expr.result [template = bool]

--- a/toolchain/check/testdata/operators/builtin/unary_op.carbon
+++ b/toolchain/check/testdata/operators/builtin/unary_op.carbon
@@ -63,9 +63,9 @@ fn Constant() {
 // CHECK:STDOUT:   br !if.expr.result.loc15(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc15:
-// CHECK:STDOUT:   %.loc15_38.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_38.2: type = converted %.loc15_38.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_38.2)
+// CHECK:STDOUT:   %.loc15_38: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc15_32: type = converted %.loc15_38, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc15(%.loc15_32)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc15:
 // CHECK:STDOUT:   %.loc15_10: type = block_arg !if.expr.result.loc15 [template = constants.%.3]
@@ -73,8 +73,8 @@ fn Constant() {
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc15_43.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc15_43.2: init () = tuple_init () to %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc15_43.3: init () = converted %.loc15_43.1, %.loc15_43.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign %a.var, %.loc15_43.3
+// CHECK:STDOUT:   %.loc15_44: init () = converted %.loc15_43.1, %.loc15_43.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign %a.var, %.loc15_44
 // CHECK:STDOUT:   %.loc16_17: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc16_13: bool = not %.loc16_17 [template = constants.%.1]
 // CHECK:STDOUT:   if %.loc16_13 br !if.expr.then.loc16 else br !if.expr.else.loc16
@@ -83,9 +83,9 @@ fn Constant() {
 // CHECK:STDOUT:   br !if.expr.result.loc16(bool)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else.loc16:
-// CHECK:STDOUT:   %.loc16_39.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc16_39.2: type = converted %.loc16_39.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_39.2)
+// CHECK:STDOUT:   %.loc16_39: () = tuple_literal ()
+// CHECK:STDOUT:   %.loc16_33: type = converted %.loc16_39, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   br !if.expr.result.loc16(%.loc16_33)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc16:
 // CHECK:STDOUT:   %.loc16_10: type = block_arg !if.expr.result.loc16 [template = bool]

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitAndAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -144,8 +144,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self]() -> Self;

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitOrAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitXorAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -52,8 +52,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref: Dec = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_20: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = ptr_type Self [symbolic = constants.%.2]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
 // CHECK:STDOUT:     %.loc5_9: Self* = addr_pattern %self.loc5_14.3
@@ -145,8 +145,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc13_15.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_15.3: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
-// CHECK:STDOUT:   assign %c.var, %.loc13_15.3
+// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
+// CHECK:STDOUT:   assign %c.var, %.loc13_16
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc14_3.1: <bound method> = bound_method %c.ref, %.1

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: DivAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -264,9 +264,9 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Equal]
 // CHECK:STDOUT:   %.loc14_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc14_12.2: init bool = call %.loc14_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc14_16: bool = value_of_initializer %.loc14_12.2
-// CHECK:STDOUT:   %.loc14_12.3: bool = converted %.loc14_12.2, %.loc14_16
-// CHECK:STDOUT:   return %.loc14_12.3
+// CHECK:STDOUT:   %.loc14_16.1: bool = value_of_initializer %.loc14_12.2
+// CHECK:STDOUT:   %.loc14_16.2: bool = converted %.loc14_12.2, %.loc14_16.1
+// CHECK:STDOUT:   return %.loc14_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestNotEqual(%a: C, %b: C) -> bool {
@@ -276,9 +276,9 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element1 [template = @impl.%NotEqual]
 // CHECK:STDOUT:   %.loc18_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc18_12.2: init bool = call %.loc18_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc18_16: bool = value_of_initializer %.loc18_12.2
-// CHECK:STDOUT:   %.loc18_12.3: bool = converted %.loc18_12.2, %.loc18_16
-// CHECK:STDOUT:   return %.loc18_12.3
+// CHECK:STDOUT:   %.loc18_16.1: bool = value_of_initializer %.loc18_12.2
+// CHECK:STDOUT:   %.loc18_16.2: bool = converted %.loc18_12.2, %.loc18_16.1
+// CHECK:STDOUT:   return %.loc18_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_no_impl.carbon
@@ -482,9 +482,9 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Equal]
 // CHECK:STDOUT:   %.loc22_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc22_12.2: init bool = call %.loc22_12.1(<invalid>) [template = <error>]
-// CHECK:STDOUT:   %.loc22_16: bool = value_of_initializer %.loc22_12.2 [template = <error>]
-// CHECK:STDOUT:   %.loc22_12.3: bool = converted %.loc22_12.2, %.loc22_16 [template = <error>]
-// CHECK:STDOUT:   return %.loc22_12.3
+// CHECK:STDOUT:   %.loc22_16.1: bool = value_of_initializer %.loc22_12.2 [template = <error>]
+// CHECK:STDOUT:   %.loc22_16.2: bool = converted %.loc22_12.2, %.loc22_16.1 [template = <error>]
+// CHECK:STDOUT:   return %.loc22_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestLhsBad(%a: D, %b: C) -> bool {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -78,8 +78,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_20: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = ptr_type Self [symbolic = constants.%.2]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
 // CHECK:STDOUT:     %.loc5_9: Self* = addr_pattern %self.loc5_14.3
@@ -97,8 +97,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.6]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.6]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -138,8 +138,8 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %Self.ref.loc11_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc11_24.1: type = facet_type_access %Self.ref.loc11_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_20: type = converted %Self.ref.loc11_20, %.loc11_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_24.2: type = ptr_type Self [symbolic = constants.%.8]
+// CHECK:STDOUT:     %.loc11_24.2: type = converted %Self.ref.loc11_20, %.loc11_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc11_24.3: type = ptr_type Self [symbolic = constants.%.8]
 // CHECK:STDOUT:     %self.loc11_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc11_14.3: Self* = bind_name self, %self.loc11_14.1
 // CHECK:STDOUT:     %.loc11_9: Self* = addr_pattern %self.loc11_14.3
@@ -162,8 +162,8 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.4 [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc14_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc14_20: type = converted %Self.ref, %.loc14_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc14_24.2: type = ptr_type Self [symbolic = constants.%.12]
+// CHECK:STDOUT:     %.loc14_24.2: type = converted %Self.ref, %.loc14_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc14_24.3: type = ptr_type Self [symbolic = constants.%.12]
 // CHECK:STDOUT:     %self.loc14_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: Self* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: Self* = addr_pattern %self.loc14_14.3
@@ -315,8 +315,8 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc25_15.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc25_15.2: init C = class_init (), %a.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc25_15.3: init C = converted %.loc25_15.1, %.loc25_15.2 [template = constants.%.10]
-// CHECK:STDOUT:   assign %a.var, %.loc25_15.3
+// CHECK:STDOUT:   %.loc25_16: init C = converted %.loc25_15.1, %.loc25_15.2 [template = constants.%.10]
+// CHECK:STDOUT:   assign %a.var, %.loc25_16
 // CHECK:STDOUT:   %a.ref.loc30: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: C = name_ref b, %b
 // CHECK:STDOUT:   %AddAssign.decl: invalid = interface_decl @AddAssign [template = constants.%.11] {}

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -105,8 +105,8 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -287,8 +287,8 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc28_15.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc28_15.2: init C = class_init (), %a.var [template = constants.%.12]
-// CHECK:STDOUT:   %.loc28_15.3: init C = converted %.loc28_15.1, %.loc28_15.2 [template = constants.%.12]
-// CHECK:STDOUT:   assign %a.var, %.loc28_15.3
+// CHECK:STDOUT:   %.loc28_16: init C = converted %.loc28_15.1, %.loc28_15.2 [template = constants.%.12]
+// CHECK:STDOUT:   assign %a.var, %.loc28_16
 // CHECK:STDOUT:   %a.ref: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: D = name_ref b, %b
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.2.%.1, element0 [template = @impl.2.%Op]

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -52,8 +52,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_20: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = ptr_type Self [symbolic = constants.%.2]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
 // CHECK:STDOUT:     %.loc5_9: Self* = addr_pattern %self.loc5_14.3
@@ -145,8 +145,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc13_15.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_15.3: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
-// CHECK:STDOUT:   assign %c.var, %.loc13_15.3
+// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
+// CHECK:STDOUT:   assign %c.var, %.loc13_16
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc14_3.1: <bound method> = bound_method %c.ref, %.1

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: LeftShiftAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: ModAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: MulAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -144,8 +144,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self]() -> Self;

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -356,9 +356,9 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Less]
 // CHECK:STDOUT:   %.loc16_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc16_12.2: init bool = call %.loc16_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc16_15: bool = value_of_initializer %.loc16_12.2
-// CHECK:STDOUT:   %.loc16_12.3: bool = converted %.loc16_12.2, %.loc16_15
-// CHECK:STDOUT:   return %.loc16_12.3
+// CHECK:STDOUT:   %.loc16_15.1: bool = value_of_initializer %.loc16_12.2
+// CHECK:STDOUT:   %.loc16_15.2: bool = converted %.loc16_12.2, %.loc16_15.1
+// CHECK:STDOUT:   return %.loc16_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestLessEqual(%a: C, %b: C) -> bool {
@@ -368,9 +368,9 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element1 [template = @impl.%LessOrEquivalent]
 // CHECK:STDOUT:   %.loc20_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc20_12.2: init bool = call %.loc20_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc20_16: bool = value_of_initializer %.loc20_12.2
-// CHECK:STDOUT:   %.loc20_12.3: bool = converted %.loc20_12.2, %.loc20_16
-// CHECK:STDOUT:   return %.loc20_12.3
+// CHECK:STDOUT:   %.loc20_16.1: bool = value_of_initializer %.loc20_12.2
+// CHECK:STDOUT:   %.loc20_16.2: bool = converted %.loc20_12.2, %.loc20_16.1
+// CHECK:STDOUT:   return %.loc20_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestGreater(%a: C, %b: C) -> bool {
@@ -380,9 +380,9 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element2 [template = @impl.%Greater]
 // CHECK:STDOUT:   %.loc24_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc24_12.2: init bool = call %.loc24_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc24_15: bool = value_of_initializer %.loc24_12.2
-// CHECK:STDOUT:   %.loc24_12.3: bool = converted %.loc24_12.2, %.loc24_15
-// CHECK:STDOUT:   return %.loc24_12.3
+// CHECK:STDOUT:   %.loc24_15.1: bool = value_of_initializer %.loc24_12.2
+// CHECK:STDOUT:   %.loc24_15.2: bool = converted %.loc24_12.2, %.loc24_15.1
+// CHECK:STDOUT:   return %.loc24_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @TestGreaterEqual(%a: C, %b: C) -> bool {
@@ -392,9 +392,9 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element3 [template = @impl.%GreaterOrEquivalent]
 // CHECK:STDOUT:   %.loc28_12.1: <bound method> = bound_method %a.ref, %.1
 // CHECK:STDOUT:   %.loc28_12.2: init bool = call %.loc28_12.1(%a.ref, %b.ref)
-// CHECK:STDOUT:   %.loc28_16: bool = value_of_initializer %.loc28_12.2
-// CHECK:STDOUT:   %.loc28_12.3: bool = converted %.loc28_12.2, %.loc28_16
-// CHECK:STDOUT:   return %.loc28_12.3
+// CHECK:STDOUT:   %.loc28_16.1: bool = value_of_initializer %.loc28_12.2
+// CHECK:STDOUT:   %.loc28_16.2: bool = converted %.loc28_12.2, %.loc28_16.1
+// CHECK:STDOUT:   return %.loc28_16.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_no_impl.carbon

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: RightShiftAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -94,8 +94,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: SubAssign = name_ref Self, %Self [symbolic = %Self]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_20: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = ptr_type Self [symbolic = constants.%.5]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
@@ -250,8 +250,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_13.3: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc10_13.3
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc10_14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.2[%self: Self](%other: Self) -> Self;

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -54,8 +54,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc8_46.4: ref i32 = struct_access %s.var, element1
 // CHECK:STDOUT:   %.loc8_46.5: init i32 = initialize_from %.loc8_45 to %.loc8_46.4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_46.6: init {.a: i32, .b: i32} = struct_init (%.loc8_46.3, %.loc8_46.5) to %s.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_46.7: init {.a: i32, .b: i32} = converted %.loc8_46.1, %.loc8_46.6 [template = constants.%.5]
-// CHECK:STDOUT:   assign %s.var, %.loc8_46.7
+// CHECK:STDOUT:   %.loc8_47: init {.a: i32, .b: i32} = converted %.loc8_46.1, %.loc8_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   assign %s.var, %.loc8_47
 // CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_28: type = ptr_type {.a: i32, .b: i32} [template = constants.%.2]
 // CHECK:STDOUT:   %p.var: ref {.a: i32, .b: i32}* = var p
@@ -89,8 +89,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc14_28.4: ref i32 = tuple_access %t.var, element1
 // CHECK:STDOUT:   %.loc14_28.5: init i32 = initialize_from %.loc14_27 to %.loc14_28.4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc14_28.6: init (i32, i32) = tuple_init (%.loc14_28.3, %.loc14_28.5) to %t.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc14_28.7: init (i32, i32) = converted %.loc14_28.1, %.loc14_28.6 [template = constants.%.10]
-// CHECK:STDOUT:   assign %t.var, %.loc14_28.7
+// CHECK:STDOUT:   %.loc14_29: init (i32, i32) = converted %.loc14_28.1, %.loc14_28.6 [template = constants.%.10]
+// CHECK:STDOUT:   assign %t.var, %.loc14_29
 // CHECK:STDOUT:   %.loc15_14: type = ptr_type i32 [template = constants.%.6]
 // CHECK:STDOUT:   %t0.var: ref i32* = var t0
 // CHECK:STDOUT:   %t0: ref i32* = bind_name t0, %t0.var

--- a/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
+++ b/toolchain/check/testdata/pointer/fail_type_mismatch.carbon
@@ -28,15 +28,15 @@ fn ConstMismatch(p: const {}*) -> const ({}*) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %ConstMismatch: <function> = fn_decl @ConstMismatch [template] {
-// CHECK:STDOUT:     %.loc7_28.1: {} = struct_literal ()
-// CHECK:STDOUT:     %.loc7_28.2: type = converted %.loc7_28.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc7_21: type = const_type {} [template = constants.%.2]
+// CHECK:STDOUT:     %.loc7_28: {} = struct_literal ()
+// CHECK:STDOUT:     %.loc7_21.1: type = converted %.loc7_28, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc7_21.2: type = const_type {} [template = constants.%.2]
 // CHECK:STDOUT:     %.loc7_29: type = ptr_type const {} [template = constants.%.3]
 // CHECK:STDOUT:     %p.loc7_18.1: const {}* = param p
 // CHECK:STDOUT:     @ConstMismatch.%p: const {}* = bind_name p, %p.loc7_18.1
-// CHECK:STDOUT:     %.loc7_43.1: {} = struct_literal ()
-// CHECK:STDOUT:     %.loc7_43.2: type = converted %.loc7_43.1, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:     %.loc7_44: type = ptr_type {} [template = constants.%.4]
+// CHECK:STDOUT:     %.loc7_43: {} = struct_literal ()
+// CHECK:STDOUT:     %.loc7_44.1: type = converted %.loc7_43, constants.%.1 [template = constants.%.1]
+// CHECK:STDOUT:     %.loc7_44.2: type = ptr_type {} [template = constants.%.4]
 // CHECK:STDOUT:     %.loc7_35: type = const_type {}* [template = constants.%.5]
 // CHECK:STDOUT:     @ConstMismatch.%return: ref const ({}*) = var <return slot>
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/return/fail_call_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_call_in_type.carbon
@@ -30,9 +30,9 @@ fn Six() -> ReturnType() { return 6; }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Six: <function> = fn_decl @Six [template] {
 // CHECK:STDOUT:     %ReturnType.ref: <function> = name_ref ReturnType, %ReturnType [template = %ReturnType]
-// CHECK:STDOUT:     %.loc13_23.1: init type = call %ReturnType.ref()
-// CHECK:STDOUT:     %.loc13_24: type = value_of_initializer %.loc13_23.1
-// CHECK:STDOUT:     %.loc13_23.2: type = converted %.loc13_23.1, %.loc13_24
+// CHECK:STDOUT:     %.loc13_23: init type = call %ReturnType.ref()
+// CHECK:STDOUT:     %.loc13_24.1: type = value_of_initializer %.loc13_23
+// CHECK:STDOUT:     %.loc13_24.2: type = converted %.loc13_23, %.loc13_24.1
 // CHECK:STDOUT:     @Six.%return: ref <error> = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -91,8 +91,8 @@ fn G() -> C {
 // CHECK:STDOUT:   %.loc21_38.4: ref i32 = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc21_38.5: init i32 = initialize_from %.loc21_37 to %.loc21_38.4 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc21_38.6: init C = class_init (%.loc21_38.3, %.loc21_38.5), %return [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_38.7: init C = converted %.loc21_38.1, %.loc21_38.6 [template = constants.%.7]
-// CHECK:STDOUT:   assign %return, %.loc21_38.7
+// CHECK:STDOUT:   %.loc21_39: init C = converted %.loc21_38.1, %.loc21_38.6 [template = constants.%.7]
+// CHECK:STDOUT:   assign %return, %.loc21_39
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -72,8 +72,8 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc13_43.4: ref i32 = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc13_43.5: init i32 = initialize_from %.loc13_42 to %.loc13_43.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc13_43.6: init C = class_init (%.loc13_43.3, %.loc13_43.5), %return [template = constants.%.6]
-// CHECK:STDOUT:   %.loc13_43.7: init C = converted %.loc13_43.1, %.loc13_43.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign %return, %.loc13_43.7
+// CHECK:STDOUT:   %.loc13_44: init C = converted %.loc13_43.1, %.loc13_43.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign %return, %.loc13_44
 // CHECK:STDOUT:   return %result
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -33,7 +33,7 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc8_17.1: {.a: i32} = struct_literal (%.loc8_16)
 // CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_17.3: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.3]
-// CHECK:STDOUT:   return %.loc8_17.3
+// CHECK:STDOUT:   %.loc8_18: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.3]
+// CHECK:STDOUT:   return %.loc8_18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -43,7 +43,7 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT:   %.loc9_17.4: ref i32 = tuple_access %return, element1
 // CHECK:STDOUT:   %.loc9_17.5: init i32 = initialize_from %.loc9_15 to %.loc9_17.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_17.6: init (i32, i32) = tuple_init (%.loc9_17.3, %.loc9_17.5) to %return [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_17.7: init (i32, i32) = converted %.loc9_17.1, %.loc9_17.6 [template = constants.%.6]
-// CHECK:STDOUT:   return %.loc9_17.7
+// CHECK:STDOUT:   %.loc9_18: init (i32, i32) = converted %.loc9_17.1, %.loc9_17.6 [template = constants.%.6]
+// CHECK:STDOUT:   return %.loc9_18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/empty.carbon
+++ b/toolchain/check/testdata/struct/empty.carbon
@@ -36,12 +36,12 @@ var y: {} = x;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc7_14.2: init {} = struct_init () to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_14.3: init {} = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_14.3
+// CHECK:STDOUT:   %.loc7_15: init {} = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_15
 // CHECK:STDOUT:   %x.ref: ref {} = name_ref x, file.%x
-// CHECK:STDOUT:   %.loc8_13.1: init {} = struct_init () to file.%y.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_13.2: init {} = converted %x.ref, %.loc8_13.1 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%y.var, %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init {} = struct_init () to file.%y.var [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_14: init {} = converted %x.ref, %.loc8_13 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%y.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -37,8 +37,8 @@ var y: i32 = x.b;
 // CHECK:STDOUT:   %.loc7_26: f64 = real_literal 40e-1 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_29.1: {.a: f64} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_29.2: init {.a: f64} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_29.3: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_29.3
+// CHECK:STDOUT:   %.loc7_30: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_30
 // CHECK:STDOUT:   %x.ref: ref {.a: f64} = name_ref x, file.%x
 // CHECK:STDOUT:   assign file.%y.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -37,8 +37,8 @@ var y: i32 = x.b;
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_27.3
+// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   assign file.%y.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -60,8 +60,8 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %.loc4_30: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc4_31.1: {.a: i32} = struct_literal (%.loc4_30)
 // CHECK:STDOUT:   %.loc4_31.2: init {.a: i32} = struct_init (%.loc4_30) to file.%a_ref.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc4_31.3: init {.a: i32} = converted %.loc4_31.1, %.loc4_31.2 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_31.3
+// CHECK:STDOUT:   %.loc4_32: init {.a: i32} = converted %.loc4_31.1, %.loc4_31.2 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_32
 // CHECK:STDOUT:   %.loc6_17: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc6_26: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc6_28.1: (i32,) = tuple_literal (%.loc6_26)
@@ -73,15 +73,15 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %.loc6_29.3: init i32 = initialize_from %.loc6_17 to %.loc6_29.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc6_29.4: ref (i32,) = struct_access %.loc6_38.2, element1
 // CHECK:STDOUT:   %.loc6_28.2: init (i32,) = tuple_init (%.loc6_26) to %.loc6_29.4 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_28.3: init (i32,) = converted %.loc6_28.1, %.loc6_28.2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_29.5: init (i32,) = initialize_from %.loc6_28.3 to %.loc6_29.4 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_29.6: init {.b: i32, .c: (i32,)} = struct_init (%.loc6_29.3, %.loc6_29.5) to %.loc6_38.2 [template = constants.%.12]
-// CHECK:STDOUT:   %.loc6_29.7: init {.b: i32, .c: (i32,)} = converted %.loc6_29.1, %.loc6_29.6 [template = constants.%.12]
-// CHECK:STDOUT:   %.loc6_38.3: ref i32 = struct_access file.%b_ref.var, element1
-// CHECK:STDOUT:   %.loc6_38.4: init i32 = initialize_from %.loc6_37 to %.loc6_38.3 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc6_38.5: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_init (%.loc6_29.7, %.loc6_38.4) to file.%b_ref.var [template = constants.%.13]
-// CHECK:STDOUT:   %.loc6_38.6: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %.loc6_38.1, %.loc6_38.5 [template = constants.%.13]
-// CHECK:STDOUT:   assign file.%b_ref.var, %.loc6_38.6
+// CHECK:STDOUT:   %.loc6_29.5: init (i32,) = converted %.loc6_28.1, %.loc6_28.2 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc6_29.6: init (i32,) = initialize_from %.loc6_29.5 to %.loc6_29.4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc6_29.7: init {.b: i32, .c: (i32,)} = struct_init (%.loc6_29.3, %.loc6_29.6) to %.loc6_38.2 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc6_38.3: init {.b: i32, .c: (i32,)} = converted %.loc6_29.1, %.loc6_29.7 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc6_38.4: ref i32 = struct_access file.%b_ref.var, element1
+// CHECK:STDOUT:   %.loc6_38.5: init i32 = initialize_from %.loc6_37 to %.loc6_38.4 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc6_38.6: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_init (%.loc6_38.3, %.loc6_38.5) to file.%b_ref.var [template = constants.%.13]
+// CHECK:STDOUT:   %.loc6_39: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %.loc6_38.1, %.loc6_38.6 [template = constants.%.13]
+// CHECK:STDOUT:   assign file.%b_ref.var, %.loc6_39
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -126,8 +126,8 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %.loc4_20.1: ref i32 = struct_access %a_ref.ref, element0
 // CHECK:STDOUT:   %.loc4_20.2: i32 = bind_value %.loc4_20.1
 // CHECK:STDOUT:   %.loc4_20.3: init {.a: i32} = struct_init (%.loc4_20.2) to file.%a.var
-// CHECK:STDOUT:   %.loc4_20.4: init {.a: i32} = converted %a_ref.ref, %.loc4_20.3
-// CHECK:STDOUT:   assign file.%a.var, %.loc4_20.4
+// CHECK:STDOUT:   %.loc4_25: init {.a: i32} = converted %a_ref.ref, %.loc4_20.3
+// CHECK:STDOUT:   assign file.%a.var, %.loc4_25
 // CHECK:STDOUT:   %b_ref.ref: ref {.a: {.b: i32, .c: (i32,)}, .d: i32} = name_ref b_ref, file.%import_ref.2
 // CHECK:STDOUT:   %.loc5_47.1: ref {.b: i32, .c: (i32,)} = struct_access %b_ref.ref, element0
 // CHECK:STDOUT:   %.loc5_47.2: ref i32 = struct_access %.loc5_47.1, element0
@@ -149,8 +149,8 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %.loc5_47.18: ref i32 = struct_access file.%b.var, element1
 // CHECK:STDOUT:   %.loc5_47.19: init i32 = initialize_from %.loc5_47.17 to %.loc5_47.18
 // CHECK:STDOUT:   %.loc5_47.20: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_init (%.loc5_47.15, %.loc5_47.19) to file.%b.var
-// CHECK:STDOUT:   %.loc5_47.21: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %b_ref.ref, %.loc5_47.20
-// CHECK:STDOUT:   assign file.%b.var, %.loc5_47.21
+// CHECK:STDOUT:   %.loc5_52: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %b_ref.ref, %.loc5_47.20
+// CHECK:STDOUT:   assign file.%b.var, %.loc5_52
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -56,10 +56,10 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_25.8: ref i32 = struct_access %.loc10_25.3, element2
 // CHECK:STDOUT:   %.loc10_25.9: i32 = bind_value %.loc10_25.8
 // CHECK:STDOUT:   %.loc10_25.10: {.x: i32, .y: i32, .z: i32} = struct_value (%.loc10_25.5, %.loc10_25.7, %.loc10_25.9)
-// CHECK:STDOUT:   %.loc10_25.11: {.x: i32, .y: i32, .z: i32} = converted %.loc10_25.2, %.loc10_25.10
-// CHECK:STDOUT:   %.loc10_35.2: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value (%.loc10_16, %.loc10_25.11, %.loc10_34)
-// CHECK:STDOUT:   %.loc10_35.3: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = converted %.loc10_35.1, %.loc10_35.2
-// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.3, element1
+// CHECK:STDOUT:   %.loc10_35.2: {.x: i32, .y: i32, .z: i32} = converted %.loc10_25.2, %.loc10_25.10
+// CHECK:STDOUT:   %.loc10_35.3: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value (%.loc10_16, %.loc10_35.2, %.loc10_34)
+// CHECK:STDOUT:   %.loc10_35.4: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = converted %.loc10_35.1, %.loc10_35.3
+// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.4, element1
 // CHECK:STDOUT:   %.loc10_38: i32 = struct_access %.loc10_36, element1
 // CHECK:STDOUT:   return %.loc10_38
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -45,8 +45,8 @@ var z: i32 = y;
 // CHECK:STDOUT:   %.loc7_46.4: ref i32 = struct_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc7_46.5: init i32 = initialize_from %.loc7_45 to %.loc7_46.4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_46.6: init {.a: f64, .b: i32} = struct_init (%.loc7_46.3, %.loc7_46.5) to file.%x.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_46.7: init {.a: f64, .b: i32} = converted %.loc7_46.1, %.loc7_46.6 [template = constants.%.5]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_46.7
+// CHECK:STDOUT:   %.loc7_47: init {.a: f64, .b: i32} = converted %.loc7_46.1, %.loc7_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_47
 // CHECK:STDOUT:   %x.ref: ref {.a: f64, .b: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_15.1: ref i32 = struct_access %x.ref, element1
 // CHECK:STDOUT:   %.loc8_15.2: i32 = bind_value %.loc8_15.1

--- a/toolchain/check/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/check/testdata/struct/nested_struct_in_place.carbon
@@ -55,8 +55,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_72: init (i32, i32, i32) = call %F.ref.loc10_71() to %.loc10_74.2
 // CHECK:STDOUT:   %.loc10_74.3: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = struct_literal (%.loc10_62, %.loc10_72)
 // CHECK:STDOUT:   %.loc10_74.4: init {.a: (i32, i32, i32), .b: (i32, i32, i32)} = struct_init (%.loc10_62, %.loc10_72) to %v.var
-// CHECK:STDOUT:   %.loc10_74.5: init {.a: (i32, i32, i32), .b: (i32, i32, i32)} = converted %.loc10_74.3, %.loc10_74.4
-// CHECK:STDOUT:   assign %v.var, %.loc10_74.5
+// CHECK:STDOUT:   %.loc10_75: init {.a: (i32, i32, i32), .b: (i32, i32, i32)} = converted %.loc10_74.3, %.loc10_74.4
+// CHECK:STDOUT:   assign %v.var, %.loc10_75
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -35,14 +35,14 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
 // CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.3: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_27.3
+// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_20.1: ref i32 = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc8_20.2: i32 = bind_value %.loc8_20.1
 // CHECK:STDOUT:   %.loc8_20.3: init {.a: i32} = struct_init (%.loc8_20.2) to file.%y.var
-// CHECK:STDOUT:   %.loc8_20.4: init {.a: i32} = converted %x.ref, %.loc8_20.3
-// CHECK:STDOUT:   assign file.%y.var, %.loc8_20.4
+// CHECK:STDOUT:   %.loc8_21: init {.a: i32} = converted %x.ref, %.loc8_20.3
+// CHECK:STDOUT:   assign file.%y.var, %.loc8_21
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -50,24 +50,24 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc11_27: type = struct_type {.a: i32, .b: f64} [template = constants.%.1]
 // CHECK:STDOUT:   %MakeF64.ref: <function> = name_ref MakeF64, file.%MakeF64 [template = file.%MakeF64]
-// CHECK:STDOUT:   %.loc11_44.1: init f64 = call %MakeF64.ref()
+// CHECK:STDOUT:   %.loc11_44: init f64 = call %MakeF64.ref()
 // CHECK:STDOUT:   %MakeI32.ref: <function> = name_ref MakeI32, file.%MakeI32 [template = file.%MakeI32]
-// CHECK:STDOUT:   %.loc11_60.1: init i32 = call %MakeI32.ref()
-// CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44.1, %.loc11_60.1)
-// CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60.1
-// CHECK:STDOUT:   %.loc11_60.2: i32 = converted %.loc11_60.1, %.loc11_62.2
-// CHECK:STDOUT:   %.loc11_62.3: f64 = value_of_initializer %.loc11_44.1
-// CHECK:STDOUT:   %.loc11_44.2: f64 = converted %.loc11_44.1, %.loc11_62.3
-// CHECK:STDOUT:   %.loc11_62.4: {.a: i32, .b: f64} = struct_value (%.loc11_60.2, %.loc11_44.2)
-// CHECK:STDOUT:   %.loc11_62.5: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.4
-// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_62.5
+// CHECK:STDOUT:   %.loc11_60: init i32 = call %MakeI32.ref()
+// CHECK:STDOUT:   %.loc11_62.1: {.b: f64, .a: i32} = struct_literal (%.loc11_44, %.loc11_60)
+// CHECK:STDOUT:   %.loc11_62.2: i32 = value_of_initializer %.loc11_60
+// CHECK:STDOUT:   %.loc11_62.3: i32 = converted %.loc11_60, %.loc11_62.2
+// CHECK:STDOUT:   %.loc11_62.4: f64 = value_of_initializer %.loc11_44
+// CHECK:STDOUT:   %.loc11_62.5: f64 = converted %.loc11_44, %.loc11_62.4
+// CHECK:STDOUT:   %.loc11_62.6: {.a: i32, .b: f64} = struct_value (%.loc11_62.3, %.loc11_62.5)
+// CHECK:STDOUT:   %.loc11_63: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.6
+// CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_63
 // CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32} [template = constants.%.3]
 // CHECK:STDOUT:   %x.ref: {.a: i32, .b: f64} = name_ref x, %x
 // CHECK:STDOUT:   %.loc12_31.1: f64 = struct_access %x.ref, element1
 // CHECK:STDOUT:   %.loc12_31.2: i32 = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc12_31.3: {.b: f64, .a: i32} = struct_value (%.loc12_31.1, %.loc12_31.2)
-// CHECK:STDOUT:   %.loc12_31.4: {.b: f64, .a: i32} = converted %x.ref, %.loc12_31.3
-// CHECK:STDOUT:   %y: {.b: f64, .a: i32} = bind_name y, %.loc12_31.4
+// CHECK:STDOUT:   %.loc12_32: {.b: f64, .a: i32} = converted %x.ref, %.loc12_31.3
+// CHECK:STDOUT:   %y: {.b: f64, .a: i32} = bind_name y, %.loc12_32
 // CHECK:STDOUT:   %y.ref: {.b: f64, .a: i32} = name_ref y, %y
 // CHECK:STDOUT:   %.loc13_10.1: i32 = struct_access %y.ref, element1
 // CHECK:STDOUT:   %.loc13_10.2: ref i32 = struct_access %return, element1
@@ -76,7 +76,7 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT:   %.loc13_10.5: ref f64 = struct_access %return, element0
 // CHECK:STDOUT:   %.loc13_10.6: init f64 = initialize_from %.loc13_10.4 to %.loc13_10.5
 // CHECK:STDOUT:   %.loc13_10.7: init {.a: i32, .b: f64} = struct_init (%.loc13_10.3, %.loc13_10.6) to %return
-// CHECK:STDOUT:   %.loc13_10.8: init {.a: i32, .b: f64} = converted %y.ref, %.loc13_10.7
-// CHECK:STDOUT:   return %.loc13_10.8
+// CHECK:STDOUT:   %.loc13_11: init {.a: i32, .b: f64} = converted %y.ref, %.loc13_10.7
+// CHECK:STDOUT:   return %.loc13_11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -49,11 +49,11 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc7_50.3: init i32 = initialize_from %.loc7_38 to %.loc7_50.2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_50.4: ref (i32,) = struct_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc7_49.2: init (i32,) = tuple_init (%.loc7_47) to %.loc7_50.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_49.3: init (i32,) = converted %.loc7_49.1, %.loc7_49.2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_50.5: init (i32,) = initialize_from %.loc7_49.3 to %.loc7_50.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_50.6: init {.a: i32, .b: (i32,)} = struct_init (%.loc7_50.3, %.loc7_50.5) to file.%x.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.6 [template = constants.%.8]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_50.7
+// CHECK:STDOUT:   %.loc7_50.5: init (i32,) = converted %.loc7_49.1, %.loc7_49.2 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_50.6: init (i32,) = initialize_from %.loc7_50.5 to %.loc7_50.4 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = struct_init (%.loc7_50.3, %.loc7_50.6) to file.%x.var [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_51: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.7 [template = constants.%.8]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_51
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: (i32,)} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_32.1: ref i32 = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc8_32.2: i32 = bind_value %.loc8_32.1
@@ -67,8 +67,8 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc8_32.10: init (i32,) = converted %.loc8_32.5, %.loc8_32.9
 // CHECK:STDOUT:   %.loc8_32.11: init (i32,) = initialize_from %.loc8_32.10 to %.loc8_32.8
 // CHECK:STDOUT:   %.loc8_32.12: init {.a: i32, .b: (i32,)} = struct_init (%.loc8_32.4, %.loc8_32.11) to file.%y.var
-// CHECK:STDOUT:   %.loc8_32.13: init {.a: i32, .b: (i32,)} = converted %x.ref, %.loc8_32.12
-// CHECK:STDOUT:   assign file.%y.var, %.loc8_32.13
+// CHECK:STDOUT:   %.loc8_33: init {.a: i32, .b: (i32,)} = converted %x.ref, %.loc8_32.12
+// CHECK:STDOUT:   assign file.%y.var, %.loc8_33
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -32,8 +32,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_44.1: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
 // CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_44.3: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.5]
-// CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_44.3
+// CHECK:STDOUT:   %.loc7_45: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.5]
+// CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_45
 // CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v
 // CHECK:STDOUT:   %w: {.a: i32, .b: i32} = bind_name w, %v.ref
@@ -55,8 +55,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc10_44.4: ref i32 = struct_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc10_44.5: init i32 = initialize_from %.loc10_43 to %.loc10_44.4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_44.6: init {.a: i32, .b: i32} = struct_init (%.loc10_44.3, %.loc10_44.5) to file.%x.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_44.7: init {.a: i32, .b: i32} = converted %.loc10_44.1, %.loc10_44.6 [template = constants.%.5]
-// CHECK:STDOUT:   assign file.%x.var, %.loc10_44.7
+// CHECK:STDOUT:   %.loc10_45: init {.a: i32, .b: i32} = converted %.loc10_44.1, %.loc10_44.6 [template = constants.%.5]
+// CHECK:STDOUT:   assign file.%x.var, %.loc10_45
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc11_29.1: ref i32 = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc11_29.2: i32 = bind_value %.loc11_29.1
@@ -67,8 +67,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc11_29.7: ref i32 = struct_access file.%y.var, element1
 // CHECK:STDOUT:   %.loc11_29.8: init i32 = initialize_from %.loc11_29.6 to %.loc11_29.7
 // CHECK:STDOUT:   %.loc11_29.9: init {.a: i32, .b: i32} = struct_init (%.loc11_29.4, %.loc11_29.8) to file.%y.var
-// CHECK:STDOUT:   %.loc11_29.10: init {.a: i32, .b: i32} = converted %x.ref, %.loc11_29.9
-// CHECK:STDOUT:   assign file.%y.var, %.loc11_29.10
+// CHECK:STDOUT:   %.loc11_30: init {.a: i32, .b: i32} = converted %x.ref, %.loc11_29.9
+// CHECK:STDOUT:   assign file.%y.var, %.loc11_30
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/empty.carbon
+++ b/toolchain/check/testdata/tuples/empty.carbon
@@ -35,12 +35,12 @@ var y: () = x;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_14.2: init () = tuple_init () to file.%x.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc7_14.3: init () = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.2]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_14.3
+// CHECK:STDOUT:   %.loc7_15: init () = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.2]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_15
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, file.%x
-// CHECK:STDOUT:   %.loc8_13.1: init () = tuple_init () to file.%y.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_13.2: init () = converted %x.ref, %.loc8_13.1 [template = constants.%.2]
-// CHECK:STDOUT:   assign file.%y.var, %.loc8_13.2
+// CHECK:STDOUT:   %.loc8_13: init () = tuple_init () to file.%y.var [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_14: init () = converted %x.ref, %.loc8_13 [template = constants.%.2]
+// CHECK:STDOUT:   assign file.%y.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/fail_assign_nested.carbon
+++ b/toolchain/check/testdata/tuples/fail_assign_nested.carbon
@@ -35,12 +35,12 @@ var x: ((i32, i32), (i32, i32)) = ((1, 2, 3), (4, 5, 6));
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc10_18.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_30.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18.1, %.loc10_30.1)
-// CHECK:STDOUT:   %.loc10_18.2: type = converted %.loc10_18.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc10_30.2: type = converted %.loc10_30.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_31.1, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_18: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_30: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc10_31.1: ((type, type), (type, type)) = tuple_literal (%.loc10_18, %.loc10_30)
+// CHECK:STDOUT:   %.loc10_31.2: type = converted %.loc10_18, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_31.3: type = converted %.loc10_30, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc10_31.4: type = converted %.loc10_31.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), (i32, i32)) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), (i32, i32)) = bind_name x, %x.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/import.carbon
+++ b/toolchain/check/testdata/tuples/import.carbon
@@ -54,14 +54,14 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc4_17.2: type = converted %.loc4_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a_ref.var: ref (i32,) = var a_ref
 // CHECK:STDOUT:   %a_ref: ref (i32,) = bind_name a_ref, %a_ref.var
-// CHECK:STDOUT:   %.loc5_19.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc5_25.1: ((type,), type) = tuple_literal (%.loc5_19.1, i32)
-// CHECK:STDOUT:   %.loc5_37.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc5_38.1: (((type,), type), (type, type)) = tuple_literal (%.loc5_25.1, %.loc5_37.1)
-// CHECK:STDOUT:   %.loc5_19.2: type = converted %.loc5_19.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc5_25.2: type = converted %.loc5_25.1, constants.%.8 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc5_37.2: type = converted %.loc5_37.1, constants.%.9 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc5_38.2: type = converted %.loc5_38.1, constants.%.10 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc5_19: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc5_25: ((type,), type) = tuple_literal (%.loc5_19, i32)
+// CHECK:STDOUT:   %.loc5_37: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc5_38.1: (((type,), type), (type, type)) = tuple_literal (%.loc5_25, %.loc5_37)
+// CHECK:STDOUT:   %.loc5_38.2: type = converted %.loc5_19, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc5_38.3: type = converted %.loc5_25, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc5_38.4: type = converted %.loc5_37, constants.%.9 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc5_38.5: type = converted %.loc5_38.1, constants.%.10 [template = constants.%.10]
 // CHECK:STDOUT:   %b_ref.var: ref (((i32,), i32), (i32, i32)) = var b_ref
 // CHECK:STDOUT:   %b_ref: ref (((i32,), i32), (i32, i32)) = bind_name b_ref, %b_ref.var
 // CHECK:STDOUT: }
@@ -71,8 +71,8 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc4_22: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc4_24.1: (i32,) = tuple_literal (%.loc4_22)
 // CHECK:STDOUT:   %.loc4_24.2: init (i32,) = tuple_init (%.loc4_22) to file.%a_ref.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc4_24.3: init (i32,) = converted %.loc4_24.1, %.loc4_24.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_24.3
+// CHECK:STDOUT:   %.loc4_25: init (i32,) = converted %.loc4_24.1, %.loc4_24.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_25
 // CHECK:STDOUT:   %.loc5_45: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc5_47.1: (i32,) = tuple_literal (%.loc5_45)
 // CHECK:STDOUT:   %.loc5_50: i32 = int_literal 1 [template = constants.%.15]
@@ -84,22 +84,22 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc5_60.2: ref ((i32,), i32) = tuple_access file.%b_ref.var, element0
 // CHECK:STDOUT:   %.loc5_51.2: ref (i32,) = tuple_access %.loc5_60.2, element0
 // CHECK:STDOUT:   %.loc5_47.2: init (i32,) = tuple_init (%.loc5_45) to %.loc5_51.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_47.3: init (i32,) = converted %.loc5_47.1, %.loc5_47.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_51.3: init (i32,) = initialize_from %.loc5_47.3 to %.loc5_51.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_51.4: ref i32 = tuple_access %.loc5_60.2, element1
-// CHECK:STDOUT:   %.loc5_51.5: init i32 = initialize_from %.loc5_50 to %.loc5_51.4 [template = constants.%.15]
-// CHECK:STDOUT:   %.loc5_51.6: init ((i32,), i32) = tuple_init (%.loc5_51.3, %.loc5_51.5) to %.loc5_60.2 [template = constants.%.18]
-// CHECK:STDOUT:   %.loc5_51.7: init ((i32,), i32) = converted %.loc5_51.1, %.loc5_51.6 [template = constants.%.18]
-// CHECK:STDOUT:   %.loc5_60.3: ref (i32, i32) = tuple_access file.%b_ref.var, element1
-// CHECK:STDOUT:   %.loc5_59.2: ref i32 = tuple_access %.loc5_60.3, element0
+// CHECK:STDOUT:   %.loc5_51.3: init (i32,) = converted %.loc5_47.1, %.loc5_47.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc5_51.4: init (i32,) = initialize_from %.loc5_51.3 to %.loc5_51.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc5_51.5: ref i32 = tuple_access %.loc5_60.2, element1
+// CHECK:STDOUT:   %.loc5_51.6: init i32 = initialize_from %.loc5_50 to %.loc5_51.5 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc5_51.7: init ((i32,), i32) = tuple_init (%.loc5_51.4, %.loc5_51.6) to %.loc5_60.2 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc5_60.3: init ((i32,), i32) = converted %.loc5_51.1, %.loc5_51.7 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc5_60.4: ref (i32, i32) = tuple_access file.%b_ref.var, element1
+// CHECK:STDOUT:   %.loc5_59.2: ref i32 = tuple_access %.loc5_60.4, element0
 // CHECK:STDOUT:   %.loc5_59.3: init i32 = initialize_from %.loc5_55 to %.loc5_59.2 [template = constants.%.16]
-// CHECK:STDOUT:   %.loc5_59.4: ref i32 = tuple_access %.loc5_60.3, element1
+// CHECK:STDOUT:   %.loc5_59.4: ref i32 = tuple_access %.loc5_60.4, element1
 // CHECK:STDOUT:   %.loc5_59.5: init i32 = initialize_from %.loc5_58 to %.loc5_59.4 [template = constants.%.17]
-// CHECK:STDOUT:   %.loc5_59.6: init (i32, i32) = tuple_init (%.loc5_59.3, %.loc5_59.5) to %.loc5_60.3 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc5_59.7: init (i32, i32) = converted %.loc5_59.1, %.loc5_59.6 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc5_60.4: init (((i32,), i32), (i32, i32)) = tuple_init (%.loc5_51.7, %.loc5_59.7) to file.%b_ref.var [template = constants.%.20]
-// CHECK:STDOUT:   %.loc5_60.5: init (((i32,), i32), (i32, i32)) = converted %.loc5_60.1, %.loc5_60.4 [template = constants.%.20]
-// CHECK:STDOUT:   assign file.%b_ref.var, %.loc5_60.5
+// CHECK:STDOUT:   %.loc5_59.6: init (i32, i32) = tuple_init (%.loc5_59.3, %.loc5_59.5) to %.loc5_60.4 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc5_60.5: init (i32, i32) = converted %.loc5_59.1, %.loc5_59.6 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc5_60.6: init (((i32,), i32), (i32, i32)) = tuple_init (%.loc5_60.3, %.loc5_60.5) to file.%b_ref.var [template = constants.%.20]
+// CHECK:STDOUT:   %.loc5_61: init (((i32,), i32), (i32, i32)) = converted %.loc5_60.1, %.loc5_60.6 [template = constants.%.20]
+// CHECK:STDOUT:   assign file.%b_ref.var, %.loc5_61
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -135,14 +135,14 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc4_13.2: type = converted %.loc4_13.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref (i32,) = var a
 // CHECK:STDOUT:   %a: ref (i32,) = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc5_15.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc5_21.1: ((type,), type) = tuple_literal (%.loc5_15.1, i32)
-// CHECK:STDOUT:   %.loc5_33.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc5_34.1: (((type,), type), (type, type)) = tuple_literal (%.loc5_21.1, %.loc5_33.1)
-// CHECK:STDOUT:   %.loc5_15.2: type = converted %.loc5_15.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc5_21.2: type = converted %.loc5_21.1, constants.%.6 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc5_33.2: type = converted %.loc5_33.1, constants.%.7 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc5_34.2: type = converted %.loc5_34.1, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc5_15: (type,) = tuple_literal (i32)
+// CHECK:STDOUT:   %.loc5_21: ((type,), type) = tuple_literal (%.loc5_15, i32)
+// CHECK:STDOUT:   %.loc5_33: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc5_34.1: (((type,), type), (type, type)) = tuple_literal (%.loc5_21, %.loc5_33)
+// CHECK:STDOUT:   %.loc5_34.2: type = converted %.loc5_15, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc5_34.3: type = converted %.loc5_21, constants.%.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc5_34.4: type = converted %.loc5_33, constants.%.7 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc5_34.5: type = converted %.loc5_34.1, constants.%.8 [template = constants.%.8]
 // CHECK:STDOUT:   %b.var: ref (((i32,), i32), (i32, i32)) = var b
 // CHECK:STDOUT:   %b: ref (((i32,), i32), (i32, i32)) = bind_name b, %b.var
 // CHECK:STDOUT: }
@@ -153,8 +153,8 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc4_17.1: ref i32 = tuple_access %a_ref.ref, element0
 // CHECK:STDOUT:   %.loc4_17.2: i32 = bind_value %.loc4_17.1
 // CHECK:STDOUT:   %.loc4_17.3: init (i32,) = tuple_init (%.loc4_17.2) to file.%a.var
-// CHECK:STDOUT:   %.loc4_17.4: init (i32,) = converted %a_ref.ref, %.loc4_17.3
-// CHECK:STDOUT:   assign file.%a.var, %.loc4_17.4
+// CHECK:STDOUT:   %.loc4_22: init (i32,) = converted %a_ref.ref, %.loc4_17.3
+// CHECK:STDOUT:   assign file.%a.var, %.loc4_22
 // CHECK:STDOUT:   %b_ref.ref: ref (((i32,), i32), (i32, i32)) = name_ref b_ref, file.%import_ref.2
 // CHECK:STDOUT:   %.loc5_38.1: ref ((i32,), i32) = tuple_access %b_ref.ref, element0
 // CHECK:STDOUT:   %.loc5_38.2: ref (i32,) = tuple_access %.loc5_38.1, element0
@@ -184,8 +184,8 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc5_38.26: init (i32, i32) = tuple_init (%.loc5_38.21, %.loc5_38.25) to %.loc5_38.19
 // CHECK:STDOUT:   %.loc5_38.27: init (i32, i32) = converted %.loc5_38.16, %.loc5_38.26
 // CHECK:STDOUT:   %.loc5_38.28: init (((i32,), i32), (i32, i32)) = tuple_init (%.loc5_38.15, %.loc5_38.27) to file.%b.var
-// CHECK:STDOUT:   %.loc5_38.29: init (((i32,), i32), (i32, i32)) = converted %b_ref.ref, %.loc5_38.28
-// CHECK:STDOUT:   assign file.%b.var, %.loc5_38.29
+// CHECK:STDOUT:   %.loc5_43: init (((i32,), i32), (i32, i32)) = converted %b_ref.ref, %.loc5_38.28
+// CHECK:STDOUT:   assign file.%b.var, %.loc5_43
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -29,10 +29,10 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:     .x = %x
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %.loc7_18.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18.1, i32)
-// CHECK:STDOUT:   %.loc7_18.2: type = converted %.loc7_18.1, constants.%.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_24.1, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_18: (type, type) = tuple_literal (i32, i32)
+// CHECK:STDOUT:   %.loc7_24.1: ((type, type), type) = tuple_literal (%.loc7_18, i32)
+// CHECK:STDOUT:   %.loc7_24.2: type = converted %.loc7_18, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_24.3: type = converted %.loc7_24.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %x.var: ref ((i32, i32), i32) = var x
 // CHECK:STDOUT:   %x: ref ((i32, i32), i32) = bind_name x, %x.var
 // CHECK:STDOUT: }
@@ -50,12 +50,12 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:   %.loc7_36.4: ref i32 = tuple_access %.loc7_40.2, element1
 // CHECK:STDOUT:   %.loc7_36.5: init i32 = initialize_from %.loc7_34 to %.loc7_36.4 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc7_36.6: init (i32, i32) = tuple_init (%.loc7_36.3, %.loc7_36.5) to %.loc7_40.2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc7_36.7: init (i32, i32) = converted %.loc7_36.1, %.loc7_36.6 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc7_40.3: ref i32 = tuple_access file.%x.var, element1
-// CHECK:STDOUT:   %.loc7_40.4: init i32 = initialize_from %.loc7_39 to %.loc7_40.3 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_40.5: init ((i32, i32), i32) = tuple_init (%.loc7_36.7, %.loc7_40.4) to file.%x.var [template = constants.%.12]
-// CHECK:STDOUT:   %.loc7_40.6: init ((i32, i32), i32) = converted %.loc7_40.1, %.loc7_40.5 [template = constants.%.12]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_40.6
+// CHECK:STDOUT:   %.loc7_40.3: init (i32, i32) = converted %.loc7_36.1, %.loc7_36.6 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc7_40.4: ref i32 = tuple_access file.%x.var, element1
+// CHECK:STDOUT:   %.loc7_40.5: init i32 = initialize_from %.loc7_39 to %.loc7_40.4 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc7_40.6: init ((i32, i32), i32) = tuple_init (%.loc7_40.3, %.loc7_40.5) to file.%x.var [template = constants.%.12]
+// CHECK:STDOUT:   %.loc7_41: init ((i32, i32), i32) = converted %.loc7_40.1, %.loc7_40.6 [template = constants.%.12]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_41
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple_in_place.carbon
@@ -53,12 +53,12 @@ fn H() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_25.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_42.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc10_43.1: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25.1, %.loc10_42.1)
-// CHECK:STDOUT:   %.loc10_25.2: type = converted %.loc10_25.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_42.2: type = converted %.loc10_42.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_43.1, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_25: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_42: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc10_43.1: ((type, type, type), (type, type, type)) = tuple_literal (%.loc10_25, %.loc10_42)
+// CHECK:STDOUT:   %.loc10_43.2: type = converted %.loc10_25, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_43.3: type = converted %.loc10_42, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_43.4: type = converted %.loc10_43.1, constants.%.4 [template = constants.%.4]
 // CHECK:STDOUT:   %v.var: ref ((i32, i32, i32), (i32, i32, i32)) = var v
 // CHECK:STDOUT:   %v: ref ((i32, i32, i32), (i32, i32, i32)) = bind_name v, %v.var
 // CHECK:STDOUT:   %F.ref.loc10_48: <function> = name_ref F, file.%F [template = file.%F]
@@ -69,17 +69,17 @@ fn H() {
 // CHECK:STDOUT:   %.loc10_54: init (i32, i32, i32) = call %F.ref.loc10_53() to %.loc10_56.2
 // CHECK:STDOUT:   %.loc10_56.3: ((i32, i32, i32), (i32, i32, i32)) = tuple_literal (%.loc10_49, %.loc10_54)
 // CHECK:STDOUT:   %.loc10_56.4: init ((i32, i32, i32), (i32, i32, i32)) = tuple_init (%.loc10_49, %.loc10_54) to %v.var
-// CHECK:STDOUT:   %.loc10_56.5: init ((i32, i32, i32), (i32, i32, i32)) = converted %.loc10_56.3, %.loc10_56.4
-// CHECK:STDOUT:   assign %v.var, %.loc10_56.5
+// CHECK:STDOUT:   %.loc10_57: init ((i32, i32, i32), (i32, i32, i32)) = converted %.loc10_56.3, %.loc10_56.4
+// CHECK:STDOUT:   assign %v.var, %.loc10_57
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @H() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc14_30.1: (type, type, type) = tuple_literal (i32, i32, i32)
-// CHECK:STDOUT:   %.loc14_36.1: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30.1, i32)
-// CHECK:STDOUT:   %.loc14_30.2: type = converted %.loc14_30.1, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_36.1, constants.%.9 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc14_30: (type, type, type) = tuple_literal (i32, i32, i32)
+// CHECK:STDOUT:   %.loc14_36.1: (type, (type, type, type), type) = tuple_literal (i32, %.loc14_30, i32)
+// CHECK:STDOUT:   %.loc14_36.2: type = converted %.loc14_30, constants.%.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc14_36.3: type = converted %.loc14_36.1, constants.%.9 [template = constants.%.9]
 // CHECK:STDOUT:   %v.var: ref (i32, (i32, i32, i32), i32) = var v
 // CHECK:STDOUT:   %v: ref (i32, (i32, i32, i32), i32) = bind_name v, %v.var
 // CHECK:STDOUT:   %.loc14_41: i32 = int_literal 1 [template = constants.%.12]
@@ -93,8 +93,8 @@ fn H() {
 // CHECK:STDOUT:   %.loc14_50.5: ref i32 = tuple_access %v.var, element2
 // CHECK:STDOUT:   %.loc14_50.6: init i32 = initialize_from %.loc14_49 to %.loc14_50.5 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc14_50.7: init (i32, (i32, i32, i32), i32) = tuple_init (%.loc14_50.4, %.loc14_45, %.loc14_50.6) to %v.var
-// CHECK:STDOUT:   %.loc14_50.8: init (i32, (i32, i32, i32), i32) = converted %.loc14_50.2, %.loc14_50.7
-// CHECK:STDOUT:   assign %v.var, %.loc14_50.8
+// CHECK:STDOUT:   %.loc14_51: init (i32, (i32, i32, i32), i32) = converted %.loc14_50.2, %.loc14_50.7
+// CHECK:STDOUT:   assign %v.var, %.loc14_51
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -38,14 +38,14 @@ var y: (i32,) = x;
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_20.1: (i32,) = tuple_literal (%.loc7_18)
 // CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to file.%x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_20.3: init (i32,) = converted %.loc7_20.1, %.loc7_20.2 [template = constants.%.4]
-// CHECK:STDOUT:   assign file.%x.var, %.loc7_20.3
+// CHECK:STDOUT:   %.loc7_21: init (i32,) = converted %.loc7_20.1, %.loc7_20.2 [template = constants.%.4]
+// CHECK:STDOUT:   assign file.%x.var, %.loc7_21
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %x.ref, element0
 // CHECK:STDOUT:   %.loc8_17.2: i32 = bind_value %.loc8_17.1
 // CHECK:STDOUT:   %.loc8_17.3: init (i32,) = tuple_init (%.loc8_17.2) to file.%y.var
-// CHECK:STDOUT:   %.loc8_17.4: init (i32,) = converted %x.ref, %.loc8_17.3
-// CHECK:STDOUT:   assign file.%y.var, %.loc8_17.4
+// CHECK:STDOUT:   %.loc8_18: init (i32,) = converted %x.ref, %.loc8_17.3
+// CHECK:STDOUT:   assign file.%y.var, %.loc8_18
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -34,8 +34,8 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
 // CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28.3: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
-// CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_28.3
+// CHECK:STDOUT:   %.loc7_29: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
+// CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_29
 // CHECK:STDOUT:   %.loc8_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %v.ref: (i32, i32) = name_ref v, %v
@@ -60,8 +60,8 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc10_28.4: ref i32 = tuple_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc10_28.5: init i32 = initialize_from %.loc10_25 to %.loc10_28.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc10_28.6: init (i32, i32) = tuple_init (%.loc10_28.3, %.loc10_28.5) to file.%x.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_28.7: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6 [template = constants.%.6]
-// CHECK:STDOUT:   assign file.%x.var, %.loc10_28.7
+// CHECK:STDOUT:   %.loc10_29: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   assign file.%x.var, %.loc10_29
 // CHECK:STDOUT:   %x.ref: ref (i32, i32) = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc11_21.1: ref i32 = tuple_access %x.ref, element0
 // CHECK:STDOUT:   %.loc11_21.2: i32 = bind_value %.loc11_21.1
@@ -72,8 +72,8 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc11_21.7: ref i32 = tuple_access file.%y.var, element1
 // CHECK:STDOUT:   %.loc11_21.8: init i32 = initialize_from %.loc11_21.6 to %.loc11_21.7
 // CHECK:STDOUT:   %.loc11_21.9: init (i32, i32) = tuple_init (%.loc11_21.4, %.loc11_21.8) to file.%y.var
-// CHECK:STDOUT:   %.loc11_21.10: init (i32, i32) = converted %x.ref, %.loc11_21.9
-// CHECK:STDOUT:   assign file.%y.var, %.loc11_21.10
+// CHECK:STDOUT:   %.loc11_22: init (i32, i32) = converted %x.ref, %.loc11_21.9
+// CHECK:STDOUT:   assign file.%y.var, %.loc11_22
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/while/break_continue.carbon
+++ b/toolchain/check/testdata/while/break_continue.carbon
@@ -91,27 +91,27 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc17:
 // CHECK:STDOUT:   %A.ref: <function> = name_ref A, file.%A [template = file.%A]
-// CHECK:STDOUT:   %.loc17_11.1: init bool = call %A.ref()
-// CHECK:STDOUT:   %.loc17_13: bool = value_of_initializer %.loc17_11.1
-// CHECK:STDOUT:   %.loc17_11.2: bool = converted %.loc17_11.1, %.loc17_13
-// CHECK:STDOUT:   if %.loc17_11.2 br !while.body.loc17 else br !while.done.loc17
+// CHECK:STDOUT:   %.loc17_11: init bool = call %A.ref()
+// CHECK:STDOUT:   %.loc17_13.1: bool = value_of_initializer %.loc17_11
+// CHECK:STDOUT:   %.loc17_13.2: bool = converted %.loc17_11, %.loc17_13.1
+// CHECK:STDOUT:   if %.loc17_13.2 br !while.body.loc17 else br !while.done.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc17:
 // CHECK:STDOUT:   %B.ref: <function> = name_ref B, file.%B [template = file.%B]
-// CHECK:STDOUT:   %.loc18_10.1: init bool = call %B.ref()
-// CHECK:STDOUT:   %.loc18_12: bool = value_of_initializer %.loc18_10.1
-// CHECK:STDOUT:   %.loc18_10.2: bool = converted %.loc18_10.1, %.loc18_12
-// CHECK:STDOUT:   if %.loc18_10.2 br !if.then.loc18 else br !if.else.loc18
+// CHECK:STDOUT:   %.loc18_10: init bool = call %B.ref()
+// CHECK:STDOUT:   %.loc18_12.1: bool = value_of_initializer %.loc18_10
+// CHECK:STDOUT:   %.loc18_12.2: bool = converted %.loc18_10, %.loc18_12.1
+// CHECK:STDOUT:   if %.loc18_12.2 br !if.then.loc18 else br !if.else.loc18
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc18:
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc18:
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
-// CHECK:STDOUT:   %.loc19_10.1: init bool = call %C.ref()
-// CHECK:STDOUT:   %.loc19_12: bool = value_of_initializer %.loc19_10.1
-// CHECK:STDOUT:   %.loc19_10.2: bool = converted %.loc19_10.1, %.loc19_12
-// CHECK:STDOUT:   if %.loc19_10.2 br !if.then.loc19 else br !if.else.loc19
+// CHECK:STDOUT:   %.loc19_10: init bool = call %C.ref()
+// CHECK:STDOUT:   %.loc19_12.1: bool = value_of_initializer %.loc19_10
+// CHECK:STDOUT:   %.loc19_12.2: bool = converted %.loc19_10, %.loc19_12.1
+// CHECK:STDOUT:   if %.loc19_12.2 br !if.then.loc19 else br !if.else.loc19
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc19:
 // CHECK:STDOUT:   br !while.done.loc17
@@ -121,27 +121,27 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond.loc20:
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
-// CHECK:STDOUT:   %.loc20_13.1: init bool = call %D.ref()
-// CHECK:STDOUT:   %.loc20_15: bool = value_of_initializer %.loc20_13.1
-// CHECK:STDOUT:   %.loc20_13.2: bool = converted %.loc20_13.1, %.loc20_15
-// CHECK:STDOUT:   if %.loc20_13.2 br !while.body.loc20 else br !while.done.loc20
+// CHECK:STDOUT:   %.loc20_13: init bool = call %D.ref()
+// CHECK:STDOUT:   %.loc20_15.1: bool = value_of_initializer %.loc20_13
+// CHECK:STDOUT:   %.loc20_15.2: bool = converted %.loc20_13, %.loc20_15.1
+// CHECK:STDOUT:   if %.loc20_15.2 br !while.body.loc20 else br !while.done.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body.loc20:
 // CHECK:STDOUT:   %E.ref: <function> = name_ref E, file.%E [template = file.%E]
-// CHECK:STDOUT:   %.loc21_12.1: init bool = call %E.ref()
-// CHECK:STDOUT:   %.loc21_14: bool = value_of_initializer %.loc21_12.1
-// CHECK:STDOUT:   %.loc21_12.2: bool = converted %.loc21_12.1, %.loc21_14
-// CHECK:STDOUT:   if %.loc21_12.2 br !if.then.loc21 else br !if.else.loc21
+// CHECK:STDOUT:   %.loc21_12: init bool = call %E.ref()
+// CHECK:STDOUT:   %.loc21_14.1: bool = value_of_initializer %.loc21_12
+// CHECK:STDOUT:   %.loc21_14.2: bool = converted %.loc21_12, %.loc21_14.1
+// CHECK:STDOUT:   if %.loc21_14.2 br !if.then.loc21 else br !if.else.loc21
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc21:
 // CHECK:STDOUT:   br !while.cond.loc20
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc21:
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
-// CHECK:STDOUT:   %.loc22_12.1: init bool = call %F.ref()
-// CHECK:STDOUT:   %.loc22_14: bool = value_of_initializer %.loc22_12.1
-// CHECK:STDOUT:   %.loc22_12.2: bool = converted %.loc22_12.1, %.loc22_14
-// CHECK:STDOUT:   if %.loc22_12.2 br !if.then.loc22 else br !if.else.loc22
+// CHECK:STDOUT:   %.loc22_12: init bool = call %F.ref()
+// CHECK:STDOUT:   %.loc22_14.1: bool = value_of_initializer %.loc22_12
+// CHECK:STDOUT:   %.loc22_14.2: bool = converted %.loc22_12, %.loc22_14.1
+// CHECK:STDOUT:   if %.loc22_14.2 br !if.then.loc22 else br !if.else.loc22
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc22:
 // CHECK:STDOUT:   br !while.done.loc20
@@ -151,20 +151,20 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.done.loc20:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
-// CHECK:STDOUT:   %.loc24_10.1: init bool = call %G.ref()
-// CHECK:STDOUT:   %.loc24_12: bool = value_of_initializer %.loc24_10.1
-// CHECK:STDOUT:   %.loc24_10.2: bool = converted %.loc24_10.1, %.loc24_12
-// CHECK:STDOUT:   if %.loc24_10.2 br !if.then.loc24 else br !if.else.loc24
+// CHECK:STDOUT:   %.loc24_10: init bool = call %G.ref()
+// CHECK:STDOUT:   %.loc24_12.1: bool = value_of_initializer %.loc24_10
+// CHECK:STDOUT:   %.loc24_12.2: bool = converted %.loc24_10, %.loc24_12.1
+// CHECK:STDOUT:   if %.loc24_12.2 br !if.then.loc24 else br !if.else.loc24
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc24:
 // CHECK:STDOUT:   br !while.cond.loc17
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.else.loc24:
 // CHECK:STDOUT:   %H.ref: <function> = name_ref H, file.%H [template = file.%H]
-// CHECK:STDOUT:   %.loc25_10.1: init bool = call %H.ref()
-// CHECK:STDOUT:   %.loc25_12: bool = value_of_initializer %.loc25_10.1
-// CHECK:STDOUT:   %.loc25_10.2: bool = converted %.loc25_10.1, %.loc25_12
-// CHECK:STDOUT:   if %.loc25_10.2 br !if.then.loc25 else br !if.else.loc25
+// CHECK:STDOUT:   %.loc25_10: init bool = call %H.ref()
+// CHECK:STDOUT:   %.loc25_12.1: bool = value_of_initializer %.loc25_10
+// CHECK:STDOUT:   %.loc25_12.2: bool = converted %.loc25_10, %.loc25_12.1
+// CHECK:STDOUT:   if %.loc25_12.2 br !if.then.loc25 else br !if.else.loc25
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then.loc25:
 // CHECK:STDOUT:   br !while.done.loc17

--- a/toolchain/check/testdata/while/unreachable_end.carbon
+++ b/toolchain/check/testdata/while/unreachable_end.carbon
@@ -60,10 +60,10 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
 // CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
-// CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
-// CHECK:STDOUT:   %.loc15_16: bool = value_of_initializer %.loc15_14.1
-// CHECK:STDOUT:   %.loc15_14.2: bool = converted %.loc15_14.1, %.loc15_16
-// CHECK:STDOUT:   if %.loc15_14.2 br !while.body else br !while.done
+// CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
+// CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
+// CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
+// CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]

--- a/toolchain/check/testdata/while/while.carbon
+++ b/toolchain/check/testdata/while/while.carbon
@@ -59,10 +59,10 @@ fn While() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.cond:
 // CHECK:STDOUT:   %Cond.ref: <function> = name_ref Cond, file.%Cond [template = file.%Cond]
-// CHECK:STDOUT:   %.loc15_14.1: init bool = call %Cond.ref()
-// CHECK:STDOUT:   %.loc15_16: bool = value_of_initializer %.loc15_14.1
-// CHECK:STDOUT:   %.loc15_14.2: bool = converted %.loc15_14.1, %.loc15_16
-// CHECK:STDOUT:   if %.loc15_14.2 br !while.body else br !while.done
+// CHECK:STDOUT:   %.loc15_14: init bool = call %Cond.ref()
+// CHECK:STDOUT:   %.loc15_16.1: bool = value_of_initializer %.loc15_14
+// CHECK:STDOUT:   %.loc15_16.2: bool = converted %.loc15_14, %.loc15_16.1
+// CHECK:STDOUT:   if %.loc15_16.2 br !while.body else br !while.done
 // CHECK:STDOUT:
 // CHECK:STDOUT: !while.body:
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]


### PR DESCRIPTION
Use the complete location of the `as` conversion rather than the location of the first operand, so diagnostics referring to the result point at the whole thing.