### PR TITLE
More explicitly disable ui events.

### DIFF
--- a/explorer/autoupdate_testdata.sh
+++ b/explorer/autoupdate_testdata.sh
@@ -5,6 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 bazel run -c opt --experimental_convenience_symlinks=ignore \
-  --ui_event_filters=-info,-stdout,-stderr,-finish \
+  --ui_event_filters= \
   --test_sharding_strategy=disabled \
   //explorer:file_test -- --autoupdate

--- a/testing/file_test/autoupdate_testdata.sh
+++ b/testing/file_test/autoupdate_testdata.sh
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 bazel run -c opt --experimental_convenience_symlinks=ignore \
-  --ui_event_filters=-info,-stdout,-stderr,-finish \
+  --ui_event_filters= \
   //testing/file_test:file_test_base_test -- --autoupdate "$@"

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -20,7 +20,7 @@ def main() -> None:
         "-c",
         "opt",
         "--experimental_convenience_symlinks=ignore",
-        "--ui_event_filters=-info,-stdout,-stderr,-finish",
+        "--ui_event_filters=",
         "//toolchain/testing:file_test",
         "--",
         "--autoupdate",


### PR DESCRIPTION
Rather than individually disabling single events, resulting in no events being printed, clear all events.