### PR TITLE
Handle an invalid loc_id in SemIRLoc

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -86,30 +86,32 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLoc> {
     }
 
     while (true) {
-      // If the parse node is valid, use it for the location.
-      if (auto loc_id = cursor_ir->insts().GetLocId(cursor_inst_id);
-          loc_id.is_valid()) {
-        if (auto diag_loc = handle_loc(loc_id)) {
-          return *diag_loc;
-        }
-        continue;
-      }
-
-      // If the parse node was invalid, recurse through import references when
-      // possible.
-      if (auto import_ref = cursor_ir->insts().TryGetAs<SemIR::AnyImportRef>(
-              cursor_inst_id)) {
-        follow_import_ref(import_ref->import_ir_inst_id);
-        continue;
-      }
-
-      // If a namespace has an instruction for an import, switch to looking at
-      // it.
-      if (auto ns =
-              cursor_ir->insts().TryGetAs<SemIR::Namespace>(cursor_inst_id)) {
-        if (ns->import_id.is_valid()) {
-          cursor_inst_id = ns->import_id;
+      if (cursor_inst_id.is_valid()) {
+        // If the parse node is valid, use it for the location.
+        if (auto loc_id = cursor_ir->insts().GetLocId(cursor_inst_id);
+            loc_id.is_valid()) {
+          if (auto diag_loc = handle_loc(loc_id)) {
+            return *diag_loc;
+          }
           continue;
+        }
+
+        // If the parse node was invalid, recurse through import references when
+        // possible.
+        if (auto import_ref = cursor_ir->insts().TryGetAs<SemIR::AnyImportRef>(
+                cursor_inst_id)) {
+          follow_import_ref(import_ref->import_ir_inst_id);
+          continue;
+        }
+
+        // If a namespace has an instruction for an import, switch to looking at
+        // it.
+        if (auto ns =
+                cursor_ir->insts().TryGetAs<SemIR::Namespace>(cursor_inst_id)) {
+          if (ns->import_id.is_valid()) {
+            cursor_inst_id = ns->import_id;
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION
This is mainly to prevent a crash. We should typically have a valid location, but in cases of bugs I think this is better than a simple check-failure (namely, provides the diagnostic to give better context of why the diagnostic location looks bad). I also think we might have more invalid locations in the future.

Note I ran into this because we weren't setting the definition_id for a class in import_ref; I think this made it much easier to examine.