### PR TITLE
Fix prelude finding for direct driver execution.

### DIFF
--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -60,7 +60,7 @@ class FileTestBase : public testing::Test {
     bool success;
 
     // Per-file success results. May be empty.
-    llvm::SmallVector<std::pair<llvm::StringRef, bool>> per_file_success;
+    llvm::SmallVector<std::pair<std::string, bool>> per_file_success;
   };
 
   explicit FileTestBase(llvm::StringRef test_name) : test_name_(test_name) {}

--- a/toolchain/check/check_fuzzer.cpp
+++ b/toolchain/check/check_fuzzer.cpp
@@ -27,7 +27,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data,
                                        /*RequiresNullTerminator=*/false)));
 
   llvm::raw_null_ostream null_ostream;
-  Driver driver(fs, null_ostream, null_ostream);
+  Driver driver(fs, "", null_ostream, null_ostream);
 
   // TODO: Get checking to a point where it can handle invalid parse trees
   // without crashing.

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -643,7 +643,7 @@ class Driver::CompilationUnit {
   Driver* driver_;
   SharedValueStores value_stores_;
   const CompileOptions& options_;
-  llvm::StringRef input_filename_;
+  std::string input_filename_;
 
   // Copied from driver_ for CARBON_VLOG.
   llvm::raw_pwrite_stream* vlog_stream_;
@@ -713,7 +713,7 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
     for (const auto& unit : units) {
       result.success &= unit->success();
       result.per_file_success.push_back(
-          {unit->input_filename(), unit->success()});
+          {unit->input_filename().str(), unit->success()});
     }
     return result;
   };

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -677,8 +677,11 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
   // TODO: Should expand this into a more rich system to search for the core
   // package source code.
   if (options.prelude_import) {
+    llvm::SmallString<256> prelude_file(data_dir_);
+    llvm::sys::path::append(prelude_file, llvm::sys::path::Style::posix,
+                            "core/prelude.carbon");
     units.push_back(std::make_unique<CompilationUnit>(
-        this, options, &stream_consumer, "core/prelude.carbon"));
+        this, options, &stream_consumer, prelude_file));
   }
 
   // Add the input source files.

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -32,9 +32,13 @@ class Driver {
 
   // Constructs a driver with any error or informational output directed to a
   // specified stream.
-  Driver(llvm::vfs::FileSystem& fs, llvm::raw_pwrite_stream& output_stream,
+  Driver(llvm::vfs::FileSystem& fs, llvm::StringRef data_dir,
+         llvm::raw_pwrite_stream& output_stream,
          llvm::raw_pwrite_stream& error_stream)
-      : fs_(fs), output_stream_(output_stream), error_stream_(error_stream) {}
+      : fs_(fs),
+        data_dir_(data_dir),
+        output_stream_(output_stream),
+        error_stream_(error_stream) {}
 
   // Parses the given arguments into both a subcommand to select the operation
   // to perform and any arguments to that subcommand.
@@ -61,9 +65,18 @@ class Driver {
   // Implements the compile subcommand of the driver.
   auto Compile(const CompileOptions& options) -> RunResult;
 
+  // The filesystem for source code.
   llvm::vfs::FileSystem& fs_;
+
+  // The path within fs for data files.
+  llvm::StringRef data_dir_;
+
+  // Standard output; stdout.
   llvm::raw_pwrite_stream& output_stream_;
+  // Error output; stderr.
   llvm::raw_pwrite_stream& error_stream_;
+
+  // For CARBON_VLOG.
   llvm::raw_pwrite_stream* vlog_stream_ = nullptr;
 };
 

--- a/toolchain/driver/driver.h
+++ b/toolchain/driver/driver.h
@@ -27,7 +27,7 @@ class Driver {
 
     // Per-file success results. May be empty if files aren't individually
     // processed.
-    llvm::SmallVector<std::pair<llvm::StringRef, bool>> per_file_success;
+    llvm::SmallVector<std::pair<std::string, bool>> per_file_success;
   };
 
   // Constructs a driver with any error or informational output directed to a
@@ -69,7 +69,7 @@ class Driver {
   llvm::vfs::FileSystem& fs_;
 
   // The path within fs for data files.
-  llvm::StringRef data_dir_;
+  std::string data_dir_;
 
   // Standard output; stdout.
   llvm::raw_pwrite_stream& output_stream_;

--- a/toolchain/driver/driver_fuzzer.cpp
+++ b/toolchain/driver/driver_fuzzer.cpp
@@ -68,7 +68,7 @@ extern "C" auto LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
   llvm::vfs::InMemoryFileSystem fs;
   TestRawOstream error_stream;
   llvm::raw_null_ostream dest;
-  Driver d(fs, dest, error_stream);
+  Driver d(fs, "", dest, error_stream);
   if (!d.RunCommand(args).success) {
     if (error_stream.TakeStr().find("ERROR:") == std::string::npos) {
       llvm::errs() << "No error message on a failure!\n";

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -40,7 +40,7 @@ static auto ReadFile(std::filesystem::path path) -> std::string {
 
 class DriverTest : public testing::Test {
  protected:
-  DriverTest() : driver_(fs_, test_output_stream_, test_error_stream_) {
+  DriverTest() : driver_(fs_, "", test_output_stream_, test_error_stream_) {
     char* tmpdir_env = getenv("TEST_TMPDIR");
     CARBON_CHECK(tmpdir_env != nullptr);
     test_tmpdir_ = tmpdir_env;

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -35,7 +35,7 @@ TEST(SemIRTest, YAML) {
       "test.carbon", /*ModificationTime=*/0,
       llvm::MemoryBuffer::getMemBuffer("fn F() { var x: () = (); return; }")));
   TestRawOstream print_stream;
-  Driver d(fs, print_stream, llvm::errs());
+  Driver d(fs, "", print_stream, llvm::errs());
   auto run_result =
       d.RunCommand({"compile", "--no-prelude-import", "--phase=check",
                     "--dump-raw-sem-ir", "test.carbon"});

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -31,7 +31,7 @@ class ToolchainFileTest : public FileTestBase {
            llvm::raw_pwrite_stream& stderr) -> ErrorOr<RunResult> override {
     CARBON_RETURN_IF_ERROR(AddFile(fs, "core/prelude.carbon"));
 
-    Driver driver(fs, stdout, stderr);
+    Driver driver(fs, "", stdout, stderr);
     auto driver_result = driver.RunCommand(test_args);
 
     RunResult result{


### PR DESCRIPTION
This is just to be able to directly run the driver (e.g., `bazel run //toolchain/driver:carbon compile foo.carbon`); it shouldn't affect anything else.