### PR TITLE
Remove explicit instruction names for floating-point arithmetic.

### DIFF
--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -372,32 +372,32 @@ static auto HandleBuiltinCall(FunctionContext& context, SemIR::InstId inst_id,
       return;
     }
     case SemIR::BuiltinFunctionKind::FloatNegate: {
-      context.SetLocal(inst_id, context.builder().CreateFNeg(
-                                    context.GetValue(arg_ids[0]), "fneg"));
+      context.SetLocal(
+          inst_id, context.builder().CreateFNeg(context.GetValue(arg_ids[0])));
       return;
     }
     case SemIR::BuiltinFunctionKind::FloatAdd: {
-      context.SetLocal(inst_id, context.builder().CreateFAdd(
-                                    context.GetValue(arg_ids[0]),
-                                    context.GetValue(arg_ids[1]), "fadd"));
+      context.SetLocal(
+          inst_id, context.builder().CreateFAdd(context.GetValue(arg_ids[0]),
+                                                context.GetValue(arg_ids[1])));
       return;
     }
     case SemIR::BuiltinFunctionKind::FloatSub: {
-      context.SetLocal(inst_id, context.builder().CreateFSub(
-                                    context.GetValue(arg_ids[0]),
-                                    context.GetValue(arg_ids[1]), "fsub"));
+      context.SetLocal(
+          inst_id, context.builder().CreateFSub(context.GetValue(arg_ids[0]),
+                                                context.GetValue(arg_ids[1])));
       return;
     }
     case SemIR::BuiltinFunctionKind::FloatMul: {
-      context.SetLocal(inst_id, context.builder().CreateFMul(
-                                    context.GetValue(arg_ids[0]),
-                                    context.GetValue(arg_ids[1]), "fmul"));
+      context.SetLocal(
+          inst_id, context.builder().CreateFMul(context.GetValue(arg_ids[0]),
+                                                context.GetValue(arg_ids[1])));
       return;
     }
     case SemIR::BuiltinFunctionKind::FloatDiv: {
-      context.SetLocal(inst_id, context.builder().CreateFDiv(
-                                    context.GetValue(arg_ids[0]),
-                                    context.GetValue(arg_ids[1]), "fdiv"));
+      context.SetLocal(
+          inst_id, context.builder().CreateFDiv(context.GetValue(arg_ids[0]),
+                                                context.GetValue(arg_ids[1])));
       return;
     }
   }

--- a/toolchain/lower/testdata/builtins/float.carbon
+++ b/toolchain/lower/testdata/builtins/float.carbon
@@ -24,30 +24,30 @@ fn TestDiv(a: f64, b: f64) -> f64 { return Div(a, b); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @TestNegate(double %a) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %float.negate.fneg = fneg double %a
-// CHECK:STDOUT:   ret double %float.negate.fneg
+// CHECK:STDOUT:   %float.negate = fneg double %a
+// CHECK:STDOUT:   ret double %float.negate
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @TestAdd(double %a, double %b) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %float.add.fadd = fadd double %a, %b
-// CHECK:STDOUT:   ret double %float.add.fadd
+// CHECK:STDOUT:   %float.add = fadd double %a, %b
+// CHECK:STDOUT:   ret double %float.add
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @TestSub(double %a, double %b) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %float.sub.fsub = fsub double %a, %b
-// CHECK:STDOUT:   ret double %float.sub.fsub
+// CHECK:STDOUT:   %float.sub = fsub double %a, %b
+// CHECK:STDOUT:   ret double %float.sub
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @TestMul(double %a, double %b) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %float.mul.fmul = fmul double %a, %b
-// CHECK:STDOUT:   ret double %float.mul.fmul
+// CHECK:STDOUT:   %float.mul = fmul double %a, %b
+// CHECK:STDOUT:   ret double %float.mul
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @TestDiv(double %a, double %b) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %float.div.fdiv = fdiv double %a, %b
-// CHECK:STDOUT:   ret double %float.div.fdiv
+// CHECK:STDOUT:   %float.div = fdiv double %a, %b
+// CHECK:STDOUT:   ret double %float.div
 // CHECK:STDOUT: }


### PR DESCRIPTION
These are no longer necessary after #3898.