### PR TITLE
When using --dump_output with file_test, dump stderr directly.

### DIFF
--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -145,6 +145,10 @@ class FileTestBase : public testing::Test {
     // Whether checks are a subset, generated from SET-CHECK-SUBSET.
     bool check_subset = false;
 
+    // Output is typically captured for tests and autoupdate, but not when
+    // dumping to console.
+    bool capture_output = true;
+
     // stdout and stderr based on CHECK lines in the file.
     llvm::SmallVector<testing::Matcher<std::string>> expected_stdout;
     llvm::SmallVector<testing::Matcher<std::string>> expected_stderr;


### PR DESCRIPTION
Right now, debugging a crash means errs never flushes: it's buffered in the string. As a consequence, -v doesn't print anything. By stopping the output capture in --dump_output, it prints directly for debugging.