### PR TITLE
Allocate de Bruijn levels to symbolic bindings.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -1035,11 +1035,12 @@ auto TryEvalInst(Context& context, SemIR::InstId inst_id, SemIR::Inst inst)
     case SemIR::ValueAsRef::Kind:
       break;
 
-    case SemIR::BindSymbolicName::Kind:
-      // TODO: Consider forming a constant value here using a de Bruijn index or
-      // similar, so that corresponding symbolic parameters in redeclarations
-      // are treated as the same value.
-      return SemIR::ConstantId::ForSymbolicConstant(inst_id);
+    case CARBON_KIND(SemIR::BindSymbolicName bind): {
+      // The constant form of a symbolic binding is an idealized form of the
+      // original, with no equivalent value.
+      bind.value_id = SemIR::InstId::Invalid;
+      return MakeConstantResult(context, bind, Phase::Symbolic);
+    }
 
     // These semantic wrappers don't change the constant value.
     case CARBON_KIND(SemIR::AsCompatible inst): {

--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -39,7 +39,8 @@ auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
 
   auto bind_name_id = context.bind_names().Add(
       {.name_id = name_context.name_id_for_new_inst(),
-       .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst()});
+       .enclosing_scope_id = name_context.enclosing_scope_id_for_new_inst(),
+       .bind_index = SemIR::CompileTimeBindIndex::Invalid});
 
   auto alias_id = SemIR::InstId::Invalid;
   if (expr_id.is_builtin()) {

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/return.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
 
@@ -25,7 +26,12 @@ auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
     // scopes, but right now we don't support qualified names here.
     auto bind_name_id = context.bind_names().Add(
         {.name_id = name_id,
-         .enclosing_scope_id = context.scope_stack().PeekNameScopeId()});
+         .enclosing_scope_id = context.scope_stack().PeekNameScopeId(),
+         // TODO: Don't allocate a compile-time binding index for an associated
+         // constant declaration.
+         .bind_index = is_generic
+                           ? context.scope_stack().AddCompileTimeBinding()
+                           : SemIR::CompileTimeBindIndex::Invalid});
     if (is_generic) {
       // TODO: Create a `BindTemplateName` instead inside a `template` pattern.
       return {name_node,

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -144,7 +144,8 @@ auto HandleInterfaceDefinitionStart(Context& context,
     // the `value_id` on the `BindSymbolicName`.
     auto bind_name_id = context.bind_names().Add(
         {.name_id = SemIR::NameId::SelfType,
-         .enclosing_scope_id = interface_info.scope_id});
+         .enclosing_scope_id = interface_info.scope_id,
+         .bind_index = context.scope_stack().AddCompileTimeBinding()});
     interface_info.self_param_id =
         context.AddInst({Parse::NodeId::Invalid,
                          SemIR::BindSymbolicName{self_type_id, bind_name_id,

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -81,8 +81,10 @@ static auto BuildInterfaceWitness(
   table.reserve(assoc_entities.size());
 
   // Substitute `Self` with the impl's self type when associated functions.
+  auto self_bind =
+      context.insts().GetAs<SemIR::BindSymbolicName>(interface.self_param_id);
   Substitution substitutions[1] = {
-      {.bind_id = interface.self_param_id,
+      {.bind_id = context.bind_names().Get(self_bind.bind_name_id).bind_index,
        .replacement_id = context.types().GetConstantId(impl.self_id)}};
 
   for (auto decl_id : assoc_entities) {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -251,7 +251,8 @@ class ImportRefResolver {
           case SemIR::BindName::Kind: {
             auto bind_name_id = context_.bind_names().Add(
                 {.name_id = name_id,
-                 .enclosing_scope_id = SemIR::NameScopeId::Invalid});
+                 .enclosing_scope_id = SemIR::NameScopeId::Invalid,
+                 .bind_index = SemIR::CompileTimeBindIndex::Invalid});
             new_param_id = context_.AddInstInNoBlock(
                 {AddImportIRInst(bind_id),
                  SemIR::BindName{type_id, bind_name_id, new_param_id}});
@@ -524,11 +525,13 @@ class ImportRefResolver {
       return ResolveResult::Retry();
     }
 
-    auto name_id =
-        GetLocalNameId(import_ir_.bind_names().Get(inst.bind_name_id).name_id);
+    const auto& import_bind_info =
+        import_ir_.bind_names().Get(inst.bind_name_id);
+    auto name_id = GetLocalNameId(import_bind_info.name_id);
     auto bind_name_id = context_.bind_names().Add(
         {.name_id = name_id,
-         .enclosing_scope_id = SemIR::NameScopeId::Invalid});
+         .enclosing_scope_id = SemIR::NameScopeId::Invalid,
+         .bind_index = import_bind_info.bind_index});
     auto new_bind_id = context_.AddInstInNoBlock(
         {AddImportIRInst(import_inst_id),
          SemIR::BindSymbolicName{context_.GetTypeIdForTypeConstant(type_id),

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -188,8 +188,11 @@ static auto PerformImplLookup(Context& context, Parse::NodeId node_id,
   }
 
   // Substitute into the type declared in the interface.
+  auto self_param =
+      context.insts().GetAs<SemIR::BindSymbolicName>(interface.self_param_id);
   Substitution substitutions[1] = {
-      {.bind_id = interface.self_param_id, .replacement_id = type_const_id}};
+      {.bind_id = context.bind_names().Get(self_param.bind_name_id).bind_index,
+       .replacement_id = type_const_id}};
   auto subst_type_id =
       SubstType(context, assoc_type.entity_type_id, substitutions);
 

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -19,6 +19,10 @@ auto ScopeStack::Push(SemIR::InstId scope_inst_id, SemIR::NameScopeId scope_id,
       {.index = next_scope_index_,
        .scope_inst_id = scope_inst_id,
        .scope_id = scope_id,
+       .next_compile_time_bind_index =
+           scope_stack_.empty()
+               ? SemIR::CompileTimeBindIndex(0)
+               : scope_stack_.back().next_compile_time_bind_index,
        .lexical_lookup_has_load_error =
            LexicalLookupHasLoadError() || lexical_lookup_has_load_error});
   if (scope_id.is_valid()) {

--- a/toolchain/check/scope_stack.h
+++ b/toolchain/check/scope_stack.h
@@ -115,6 +115,13 @@ class ScopeStack {
   auto LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id)
       -> SemIR::InstId;
 
+  // Adds a compile-time binding in the current scope, and returns its index.
+  auto AddCompileTimeBinding() -> SemIR::CompileTimeBindIndex {
+    auto index = scope_stack_.back().next_compile_time_bind_index;
+    ++scope_stack_.back().next_compile_time_bind_index.index;
+    return index;
+  }
+
   // Temporarily removes the top of the stack and its lexical lookup results.
   auto Suspend() -> SuspendedScope;
 
@@ -149,6 +156,9 @@ class ScopeStack {
     // The name scope associated with this entry, if any.
     SemIR::NameScopeId scope_id;
 
+    // The next compile-time binding index to allocate in this scope.
+    SemIR::CompileTimeBindIndex next_compile_time_bind_index;
+
     // Whether lexical_lookup_ has load errors from this scope or an enclosing
     // scope.
     bool lexical_lookup_has_load_error;
@@ -159,7 +169,7 @@ class ScopeStack {
 
     // Names which are registered with lexical_lookup_, and will need to be
     // unregistered when the scope ends.
-    llvm::DenseSet<SemIR::NameId> names;
+    llvm::DenseSet<SemIR::NameId> names = {};
 
     // TODO: This likely needs to track things which need to be destructed.
   };

--- a/toolchain/check/subst.cpp
+++ b/toolchain/check/subst.cpp
@@ -198,13 +198,15 @@ auto SubstConstant(Context& context, SemIR::ConstantId const_id,
       continue;
     }
 
-    if (context.insts().Is<SemIR::BindSymbolicName>(item.inst_id)) {
+    if (auto bind =
+            context.insts().TryGetAs<SemIR::BindSymbolicName>(item.inst_id)) {
       // This is a symbolic binding. Check if we're substituting it.
 
       // TODO: Consider building a hash map for substitutions. We might have a
       // lot of them.
-      for (auto [bind_id, replacement_id] : substitutions) {
-        if (item.inst_id == bind_id) {
+      for (auto [bind_index, replacement_id] : substitutions) {
+        if (context.bind_names().Get(bind->bind_name_id).bind_index ==
+            bind_index) {
           // This is the binding we're replacing. Perform substitution.
           item.inst_id = replacement_id.inst_id();
           break;

--- a/toolchain/check/subst.h
+++ b/toolchain/check/subst.h
@@ -12,8 +12,8 @@ namespace Carbon::Check {
 
 // A substitution that is being performed.
 struct Substitution {
-  // The ID of a `BindSymbolicName` instruction that is being replaced.
-  SemIR::InstId bind_id;
+  // The index of a `BindSymbolicName` instruction that is being replaced.
+  SemIR::CompileTimeBindIndex bind_id;
   // The replacement constant value to substitute.
   SemIR::ConstantId replacement_id;
 };

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -19,7 +19,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>}
+// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -19,7 +19,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:
-// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>}
+// CHECK:STDOUT:     bindName0:       {name: name1, enclosing_scope: name_scope<invalid>, index: compTimeBind<invalid>}
 // CHECK:STDOUT:   functions:
 // CHECK:STDOUT:     function0:       {name: name0, enclosing_scope: name_scope0, param_refs: block3, return_type: type2, return_storage: inst+13, return_slot: present, body: [block6]}
 // CHECK:STDOUT:   classes:         {}

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -89,7 +89,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %.2: type = int_type signed, %.1 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 13 [template]
 // CHECK:STDOUT:   %.4: type = int_type signed, %.3 [template]
-// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = int_type signed, %N [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -135,7 +135,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
 // CHECK:STDOUT:     %N.loc14_13.1: i32 = param N
-// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic = constants.%N]
+// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N 0, %N.loc14_13.1 [symbolic = constants.%N]
 // CHECK:STDOUT:     %Int.ref.loc14_25: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:     %N.ref.loc14_29: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_signed.loc14_28: init type = call %Int.ref.loc14_25(%N.ref.loc14_29) [symbolic = constants.%.5]

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -89,7 +89,8 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   %.2: type = int_type signed, %.1 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 13 [template]
 // CHECK:STDOUT:   %.4: type = int_type signed, %.3 [template]
-// CHECK:STDOUT:   %.5: type = int_type signed, @Symbolic.%N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %.5: type = int_type signed, %N [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -134,16 +135,16 @@ var m: Int(1000000000);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
 // CHECK:STDOUT:     %N.loc14_13.1: i32 = param N
-// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic]
+// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic = constants.%N]
 // CHECK:STDOUT:     %Int.ref.loc14_25: <function> = name_ref Int, %import_ref [template = imports.%Int]
-// CHECK:STDOUT:     %N.ref.loc14_29: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
+// CHECK:STDOUT:     %N.ref.loc14_29: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_signed.loc14_28: init type = call %Int.ref.loc14_25(%N.ref.loc14_29) [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_30.1: type = value_of_initializer %int.make_type_signed.loc14_28 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_30.2: type = converted %int.make_type_signed.loc14_28, %.loc14_30.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %x.loc14_22.1: Core.Int(N) = param x
 // CHECK:STDOUT:     @Symbolic.%x: Core.Int(N) = bind_name x, %x.loc14_22.1
 // CHECK:STDOUT:     %Int.ref.loc14_36: <function> = name_ref Int, %import_ref [template = imports.%Int]
-// CHECK:STDOUT:     %N.ref.loc14_40: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
+// CHECK:STDOUT:     %N.ref.loc14_40: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_signed.loc14_39: init type = call %Int.ref.loc14_36(%N.ref.loc14_40) [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_41.1: type = value_of_initializer %int.make_type_signed.loc14_39 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_41.2: type = converted %int.make_type_signed.loc14_39, %.loc14_41.1 [symbolic = constants.%.5]

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -89,7 +89,8 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %.2: type = int_type unsigned, %.1 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 13 [template]
 // CHECK:STDOUT:   %.4: type = int_type unsigned, %.3 [template]
-// CHECK:STDOUT:   %.5: type = int_type unsigned, @Symbolic.%N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %.5: type = int_type unsigned, %N [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -134,16 +135,16 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
 // CHECK:STDOUT:     %N.loc14_13.1: i32 = param N
-// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic]
+// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic = constants.%N]
 // CHECK:STDOUT:     %UInt.ref.loc14_25: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
-// CHECK:STDOUT:     %N.ref.loc14_30: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
+// CHECK:STDOUT:     %N.ref.loc14_30: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_unsigned.loc14_29: init type = call %UInt.ref.loc14_25(%N.ref.loc14_30) [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_31.1: type = value_of_initializer %int.make_type_unsigned.loc14_29 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_31.2: type = converted %int.make_type_unsigned.loc14_29, %.loc14_31.1 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %x.loc14_22.1: Core.UInt(N) = param x
 // CHECK:STDOUT:     @Symbolic.%x: Core.UInt(N) = bind_name x, %x.loc14_22.1
 // CHECK:STDOUT:     %UInt.ref.loc14_37: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
-// CHECK:STDOUT:     %N.ref.loc14_42: i32 = name_ref N, @Symbolic.%N [symbolic = @Symbolic.%N]
+// CHECK:STDOUT:     %N.ref.loc14_42: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_unsigned.loc14_41: init type = call %UInt.ref.loc14_37(%N.ref.loc14_42) [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_43.1: type = value_of_initializer %int.make_type_unsigned.loc14_41 [symbolic = constants.%.5]
 // CHECK:STDOUT:     %.loc14_43.2: type = converted %int.make_type_unsigned.loc14_41, %.loc14_43.1 [symbolic = constants.%.5]

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -89,7 +89,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   %.2: type = int_type unsigned, %.1 [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 13 [template]
 // CHECK:STDOUT:   %.4: type = int_type unsigned, %.3 [template]
-// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = int_type unsigned, %N [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -135,7 +135,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Symbolic: <function> = fn_decl @Symbolic [template] {
 // CHECK:STDOUT:     %N.loc14_13.1: i32 = param N
-// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N, %N.loc14_13.1 [symbolic = constants.%N]
+// CHECK:STDOUT:     @Symbolic.%N: i32 = bind_symbolic_name N 0, %N.loc14_13.1 [symbolic = constants.%N]
 // CHECK:STDOUT:     %UInt.ref.loc14_25: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:     %N.ref.loc14_30: i32 = name_ref N, @Symbolic.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %int.make_type_unsigned.loc14_29: init type = call %UInt.ref.loc14_25(%N.ref.loc14_30) [symbolic = constants.%.5]

--- a/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
+++ b/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
@@ -212,10 +212,10 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @I.1 [template]
-// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.3: type = interface_type @I.2 [template]
-// CHECK:STDOUT:   %Self.2: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -231,7 +231,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.1 {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %.loc15: {} = struct_literal ()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -240,7 +240,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.2 {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %.loc23: {} = struct_literal ()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
+++ b/toolchain/check/testdata/class/fail_adapt_bad_decl.carbon
@@ -212,8 +212,10 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @I.1 [template]
+// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.3: type = interface_type @I.2 [template]
+// CHECK:STDOUT:   %Self.2: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -229,7 +231,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.1 {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %.loc15: {} = struct_literal ()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -238,7 +240,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I.2 {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %.loc23: {} = struct_literal ()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/class/fail_todo_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_todo_generic_method.carbon
@@ -28,6 +28,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT: --- fail_todo_generic_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = unbound_element_type Class, T [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {.a: T} [symbolic]
@@ -41,22 +42,22 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {
 // CHECK:STDOUT:     %T.loc11_13.1: type = param T
-// CHECK:STDOUT:     %T.loc11_13.2: type = bind_symbolic_name T, %T.loc11_13.1 [symbolic]
+// CHECK:STDOUT:     %T.loc11_13.2: type = bind_symbolic_name T, %T.loc11_13.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc26: <function> = fn_decl @.1 [template] {
 // CHECK:STDOUT:     %T.loc26_10.1: type = param T
-// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T, %T.loc26_10.1 [symbolic]
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T, %T.loc26_10.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Class {
-// CHECK:STDOUT:   %T.ref.loc12: type = name_ref T, file.%T.loc11_13.2 [symbolic = file.%T.loc11_13.2]
+// CHECK:STDOUT:   %T.ref.loc12: type = name_ref T, file.%T.loc11_13.2 [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc12: <unbound element of class Class> = field_decl a, element0 [template]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%Class [template = constants.%Class]
 // CHECK:STDOUT:     %self.loc13_8.1: Class = param self
 // CHECK:STDOUT:     %self.loc13_8.2: Class = bind_name self, %self.loc13_8.1
-// CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, file.%T.loc11_13.2 [symbolic = file.%T.loc11_13.2]
+// CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, file.%T.loc11_13.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %n.loc13_20.1: T = param n
 // CHECK:STDOUT:     %n.loc13_20.2: T = bind_name n, %n.loc13_20.1
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/fail_todo_generic_method.carbon
+++ b/toolchain/check/testdata/class/fail_todo_generic_method.carbon
@@ -28,7 +28,7 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT: --- fail_todo_generic_method.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %.1: type = unbound_element_type Class, T [symbolic]
 // CHECK:STDOUT:   %.2: type = struct_type {.a: T} [symbolic]
@@ -42,11 +42,11 @@ fn Class(T:! type).F[self: Self](n: T) {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Class.decl: type = class_decl @Class [template = constants.%Class] {
 // CHECK:STDOUT:     %T.loc11_13.1: type = param T
-// CHECK:STDOUT:     %T.loc11_13.2: type = bind_symbolic_name T, %T.loc11_13.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.loc11_13.2: type = bind_symbolic_name T 0, %T.loc11_13.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc26: <function> = fn_decl @.1 [template] {
 // CHECK:STDOUT:     %T.loc26_10.1: type = param T
-// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T, %T.loc26_10.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T 0, %T.loc26_10.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/fail_symbolic.carbon
+++ b/toolchain/check/testdata/eval/fail_symbolic.carbon
@@ -14,6 +14,10 @@ fn G(N:! i32) {
 
 // CHECK:STDOUT: --- fail_symbolic.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
@@ -22,13 +26,13 @@ fn G(N:! i32) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %N.loc8_6.1: i32 = param N
-// CHECK:STDOUT:     @G.%N: i32 = bind_symbolic_name N, %N.loc8_6.1 [symbolic]
+// CHECK:STDOUT:     @G.%N: i32 = bind_symbolic_name N, %N.loc8_6.1 [symbolic = constants.%N]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G(%N: i32) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %N.ref: i32 = name_ref N, %N [symbolic = %N]
+// CHECK:STDOUT:   %N.ref: i32 = name_ref N, %N [symbolic = constants.%N]
 // CHECK:STDOUT:   %.loc12: type = array_type %N.ref, i32 [template = <error>]
 // CHECK:STDOUT:   %k.var: ref <error> = var k
 // CHECK:STDOUT:   %k: ref <error> = bind_name k, %k.var

--- a/toolchain/check/testdata/eval/fail_symbolic.carbon
+++ b/toolchain/check/testdata/eval/fail_symbolic.carbon
@@ -15,7 +15,7 @@ fn G(N:! i32) {
 // CHECK:STDOUT: --- fail_symbolic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -26,7 +26,7 @@ fn G(N:! i32) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %N.loc8_6.1: i32 = param N
-// CHECK:STDOUT:     @G.%N: i32 = bind_symbolic_name N, %N.loc8_6.1 [symbolic = constants.%N]
+// CHECK:STDOUT:     @G.%N: i32 = bind_symbolic_name N 0, %N.loc8_6.1 [symbolic = constants.%N]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -14,7 +14,7 @@ fn F(T:! type) {
 // CHECK:STDOUT: --- symbolic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT:   %.2: type = const_type T [symbolic]
 // CHECK:STDOUT:   %.3: type = tuple_type (type, type) [template]
@@ -35,7 +35,7 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc8_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc8_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc8_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/symbolic.carbon
+++ b/toolchain/check/testdata/eval/symbolic.carbon
@@ -14,6 +14,7 @@ fn F(T:! type) {
 // CHECK:STDOUT: --- symbolic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT:   %.2: type = const_type T [symbolic]
 // CHECK:STDOUT:   %.3: type = tuple_type (type, type) [template]
@@ -34,25 +35,25 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc8_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc8_6.1 [symbolic]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc8_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref.loc9_11: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc9_11: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc9_12: type = ptr_type T [symbolic = constants.%.1]
-// CHECK:STDOUT:   %T.ref.loc9_21: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc9_21: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc9_15: type = const_type T [symbolic = constants.%.2]
 // CHECK:STDOUT:   %.loc9_22.1: (type, type) = tuple_literal (%.loc9_12, %.loc9_15)
 // CHECK:STDOUT:   %.loc9_22.2: type = converted %.loc9_22.1, constants.%.4 [symbolic = constants.%.4]
 // CHECK:STDOUT:   %u.var: ref (T*, const T) = var u
 // CHECK:STDOUT:   %u: ref (T*, const T) = bind_name u, %u.var
-// CHECK:STDOUT:   %T.ref.loc10: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc10: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc10: type = struct_type {.a: T} [symbolic = constants.%.7]
 // CHECK:STDOUT:   %v.var: ref {.a: T} = var v
 // CHECK:STDOUT:   %v: ref {.a: T} = bind_name v, %v.var
-// CHECK:STDOUT:   %T.ref.loc11: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc11: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc11_14: i32 = int_literal 5 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc11_15: type = array_type %.loc11_14, T [symbolic = constants.%.9]
 // CHECK:STDOUT:   %w.var: ref [T; 5] = var w

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -28,6 +28,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT: }
@@ -40,21 +41,21 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Add> = assoc_entity element0, %Op [template = constants.%.3]
@@ -71,6 +72,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
@@ -95,9 +97,9 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_9 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_36 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+21, loc_36 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_10 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_10 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.1] {}
@@ -106,7 +108,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_36 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc10_18: <bound method> = bound_method %.loc10_16, %.1 [template = constants.%.7]
 // CHECK:STDOUT:   %int.sadd: init i32 = call %.loc10_18(%.loc10_16, %.loc10_20) [template = constants.%.8]

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -28,7 +28,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT: }
@@ -41,7 +41,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
@@ -72,7 +72,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]

--- a/toolchain/check/testdata/function/builtin/method.carbon
+++ b/toolchain/check/testdata/function/builtin/method.carbon
@@ -18,7 +18,7 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -54,7 +54,7 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_14: I = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self]

--- a/toolchain/check/testdata/function/builtin/method.carbon
+++ b/toolchain/check/testdata/function/builtin/method.carbon
@@ -18,6 +18,7 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -53,21 +54,21 @@ var arr: [i32; 1.(I.F)(2)];
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_14: I = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_14: I = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc8_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_8.2: Self = bind_name self, %self.loc8_8.1
-// CHECK:STDOUT:     %Self.ref.loc8_27: I = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_27.1: type = facet_type_access %Self.ref.loc8_27 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_27.2: type = converted %Self.ref.loc8_27, %.loc8_27.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_27: I = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_27.1: type = facet_type_access %Self.ref.loc8_27 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_27.2: type = converted %Self.ref.loc8_27, %.loc8_27.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc8_20.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_20.2: Self = bind_name other, %other.loc8_20.1
-// CHECK:STDOUT:     %Self.ref.loc8_36: I = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_36.1: type = facet_type_access %Self.ref.loc8_36 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_36.2: type = converted %Self.ref.loc8_36, %.loc8_36.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_36: I = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_36.1: type = facet_type_access %Self.ref.loc8_36 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_36.2: type = converted %Self.ref.loc8_36, %.loc8_36.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_40: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]

--- a/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
+++ b/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
@@ -12,7 +12,7 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT: --- fail_todo_param_in_type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -23,7 +23,7 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %N.loc10_6.1: i32 = param N
-// CHECK:STDOUT:     @F.%N: i32 = bind_symbolic_name N, %N.loc10_6.1 [symbolic = constants.%N]
+// CHECK:STDOUT:     @F.%N: i32 = bind_symbolic_name N 0, %N.loc10_6.1 [symbolic = constants.%N]
 // CHECK:STDOUT:     %N.ref: i32 = name_ref N, @F.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %.loc10_25: type = array_type %N.ref, i32 [template = <error>]
 // CHECK:STDOUT:     %.loc10_26: type = ptr_type <error> [template = <error>]

--- a/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
+++ b/toolchain/check/testdata/function/generic/fail_todo_param_in_type.carbon
@@ -11,6 +11,10 @@ fn F(N:! i32, a: [i32; N]*);
 
 // CHECK:STDOUT: --- fail_todo_param_in_type.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %N: i32 = bind_symbolic_name N [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
@@ -19,8 +23,8 @@ fn F(N:! i32, a: [i32; N]*);
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %N.loc10_6.1: i32 = param N
-// CHECK:STDOUT:     @F.%N: i32 = bind_symbolic_name N, %N.loc10_6.1 [symbolic]
-// CHECK:STDOUT:     %N.ref: i32 = name_ref N, @F.%N [symbolic = @F.%N]
+// CHECK:STDOUT:     @F.%N: i32 = bind_symbolic_name N, %N.loc10_6.1 [symbolic = constants.%N]
+// CHECK:STDOUT:     %N.ref: i32 = name_ref N, @F.%N [symbolic = constants.%N]
 // CHECK:STDOUT:     %.loc10_25: type = array_type %N.ref, i32 [template = <error>]
 // CHECK:STDOUT:     %.loc10_26: type = ptr_type <error> [template = <error>]
 // CHECK:STDOUT:     %a.loc10_15.1: <error> = param a

--- a/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
@@ -15,6 +15,8 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT: --- fail_type_param_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -26,19 +28,19 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %U.loc7_16.1: type = param U
-// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U, %U.loc7_16.1 [symbolic]
+// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U, %U.loc7_16.1 [symbolic = constants.%U]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type, %U: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc8: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %U.ref: type = name_ref U, %U [symbolic = %U]
+// CHECK:STDOUT:   %U.ref: type = name_ref U, %U [symbolic = constants.%U]
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc12_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc12_14: ref T = deref %.loc12_15

--- a/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/generic/fail_type_param_mismatch.carbon
@@ -15,8 +15,8 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT: --- fail_type_param_mismatch.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
-// CHECK:STDOUT:   %U: type = bind_symbolic_name U [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U 1 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -28,9 +28,9 @@ fn F(T:! type, U:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %U.loc7_16.1: type = param U
-// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U, %U.loc7_16.1 [symbolic = constants.%U]
+// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U 1, %U.loc7_16.1 [symbolic = constants.%U]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -13,7 +13,7 @@ fn F(T:! type) -> T* {
 // CHECK:STDOUT: --- redeclare.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -25,14 +25,14 @@ fn F(T:! type) -> T* {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F.loc7: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     %T.loc7_6.2: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.loc7_6.2: type = bind_symbolic_name T 0, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref.loc7: type = name_ref T, %T.loc7_6.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %.loc7: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:     %return.var.loc7: ref T* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.loc9: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc9_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc9_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc9_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref.loc9: type = name_ref T, @F.%T [symbolic = constants.%T]
 // CHECK:STDOUT:     %.loc9: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:     @F.%return: ref T* = var <return slot>

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -1,0 +1,51 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// AUTOUPDATE
+
+fn F(T:! type) -> T*;
+
+fn F(T:! type) -> T* {
+  return F(T);
+}
+
+// CHECK:STDOUT: --- redeclare.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = %Core
+// CHECK:STDOUT:     .F = %F.loc7
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %F.loc7: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc7_6.1: type = param T
+// CHECK:STDOUT:     %T.loc7_6.2: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref.loc7: type = name_ref T, %T.loc7_6.2 [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc7: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     %return.var.loc7: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %F.loc9: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc9_6.1: type = param T
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc9_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref.loc9: type = name_ref T, @F.%T [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc9: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     @F.%return: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%T: type) -> T* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F.loc7 [template = file.%F.loc7]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
+// CHECK:STDOUT:   %F.call: init T* = call %F.ref(%T.ref)
+// CHECK:STDOUT:   %.loc10_14.1: T* = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc10_14.2: T* = converted %F.call, %.loc10_14.1
+// CHECK:STDOUT:   return %.loc10_14.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/redeclare.carbon
+++ b/toolchain/check/testdata/function/generic/redeclare.carbon
@@ -4,9 +4,96 @@
 //
 // AUTOUPDATE
 
+// --- redeclare.carbon
+
+library "redeclare" api;
+
 fn F(T:! type) -> T*;
 
 fn F(T:! type) -> T* {
+  return F(T);
+}
+
+// --- fail_different_return_type.carbon
+
+library "fail_different_return_type" api;
+
+fn F(T:! type, U:! type) -> T*;
+
+// CHECK:STDERR: fail_different_return_type.carbon:[[@LINE+7]]:1: ERROR: Function redeclaration differs because return type is `U*`.
+// CHECK:STDERR: fn F(T:! type, U:! type) -> U* {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_different_return_type.carbon:[[@LINE-5]]:1: Previously declared with return type `T*`.
+// CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(T:! type, U:! type) -> U* {
+  // CHECK:STDERR: fail_different_return_type.carbon:[[@LINE+11]]:3: ERROR: Cannot implicitly convert from `T*` to `U*`.
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_different_return_type.carbon:[[@LINE+7]]:10: ERROR: 1 argument(s) passed to function expecting 2 argument(s).
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:          ^~
+  // CHECK:STDERR: fail_different_return_type.carbon:[[@LINE-17]]:1: Calling function declared here.
+  // CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  return F(T);
+}
+
+// --- fail_reorder.carbon
+
+library "fail_reorder" api;
+
+fn F(T:! type, U:! type) -> T*;
+
+// CHECK:STDERR: fail_reorder.carbon:[[@LINE+7]]:6: ERROR: Function redeclaration differs at parameter 1.
+// CHECK:STDERR: fn F(U:! type, T:! type) -> T* {
+// CHECK:STDERR:      ^
+// CHECK:STDERR: fail_reorder.carbon:[[@LINE-5]]:6: Previous declaration's corresponding parameter here.
+// CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+// CHECK:STDERR:      ^
+// CHECK:STDERR:
+fn F(U:! type, T:! type) -> T* {
+  // CHECK:STDERR: fail_reorder.carbon:[[@LINE+11]]:3: ERROR: Cannot implicitly convert from `T*` to `T*`.
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_reorder.carbon:[[@LINE+7]]:10: ERROR: 1 argument(s) passed to function expecting 2 argument(s).
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:          ^~
+  // CHECK:STDERR: fail_reorder.carbon:[[@LINE-17]]:1: Calling function declared here.
+  // CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  return F(T);
+}
+
+// --- fail_rename.carbon
+
+library "fail_rename" api;
+
+fn F(T:! type, U:! type) -> T*;
+
+// CHECK:STDERR: fail_rename.carbon:[[@LINE+7]]:6: ERROR: Function redeclaration differs at parameter 1.
+// CHECK:STDERR: fn F(U:! type, T:! type) -> U* {
+// CHECK:STDERR:      ^
+// CHECK:STDERR: fail_rename.carbon:[[@LINE-5]]:6: Previous declaration's corresponding parameter here.
+// CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+// CHECK:STDERR:      ^
+// CHECK:STDERR:
+fn F(U:! type, T:! type) -> U* {
+  // CHECK:STDERR: fail_rename.carbon:[[@LINE+10]]:3: ERROR: Cannot implicitly convert from `T*` to `U*`.
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_rename.carbon:[[@LINE+6]]:10: ERROR: 1 argument(s) passed to function expecting 2 argument(s).
+  // CHECK:STDERR:   return F(T);
+  // CHECK:STDERR:          ^~
+  // CHECK:STDERR: fail_rename.carbon:[[@LINE-17]]:1: Calling function declared here.
+  // CHECK:STDERR: fn F(T:! type, U:! type) -> T*;
+  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   return F(T);
 }
 
@@ -20,32 +107,171 @@ fn F(T:! type) -> T* {
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
-// CHECK:STDOUT:     .F = %F.loc7
+// CHECK:STDOUT:     .F = %F.loc4
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %F.loc7: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     %T.loc7_6.2: type = bind_symbolic_name T 0, %T.loc7_6.1 [symbolic = constants.%T]
-// CHECK:STDOUT:     %T.ref.loc7: type = name_ref T, %T.loc7_6.2 [symbolic = constants.%T]
-// CHECK:STDOUT:     %.loc7: type = ptr_type T [symbolic = constants.%.1]
-// CHECK:STDOUT:     %return.var.loc7: ref T* = var <return slot>
+// CHECK:STDOUT:   %F.loc4: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc4_6.1: type = param T
+// CHECK:STDOUT:     %T.loc4_6.2: type = bind_symbolic_name T 0, %T.loc4_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref.loc4: type = name_ref T, %T.loc4_6.2 [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc4: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     %return.var.loc4: ref T* = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %F.loc9: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %T.loc9_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc9_6.1 [symbolic = constants.%T]
-// CHECK:STDOUT:     %T.ref.loc9: type = name_ref T, @F.%T [symbolic = constants.%T]
-// CHECK:STDOUT:     %.loc9: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:   %F.loc6: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc6_6.1: type = param T
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc6_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref.loc6: type = name_ref T, @F.%T [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc6: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:     @F.%return: ref T* = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type) -> T* {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F.loc7 [template = file.%F.loc7]
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F.loc4 [template = file.%F.loc4]
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %F.call: init T* = call %F.ref(%T.ref)
-// CHECK:STDOUT:   %.loc10_14.1: T* = value_of_initializer %F.call
-// CHECK:STDOUT:   %.loc10_14.2: T* = converted %F.call, %.loc10_14.1
-// CHECK:STDOUT:   return %.loc10_14.2
+// CHECK:STDOUT:   %.loc7_14.1: T* = value_of_initializer %F.call
+// CHECK:STDOUT:   %.loc7_14.2: T* = converted %F.call, %.loc7_14.1
+// CHECK:STDOUT:   return %.loc7_14.2
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_different_return_type.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U 1 [symbolic]
+// CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
+// CHECK:STDOUT:   %.2: type = ptr_type U [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = %Core
+// CHECK:STDOUT:     .F = %F
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc4_6.1: type = param T
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc4_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %U.loc4_16.1: type = param U
+// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U 1, %U.loc4_16.1 [symbolic = constants.%U]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, @F.%T [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc4: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     @F.%return: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc13_32: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %T.loc13_6.1: type = param T
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T 0, %T.loc13_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %U.loc13_16.1: type = param U
+// CHECK:STDOUT:     @.1.%U: type = bind_symbolic_name U 1, %U.loc13_16.1 [symbolic = constants.%U]
+// CHECK:STDOUT:     %U.ref: type = name_ref U, @.1.%U [symbolic = constants.%U]
+// CHECK:STDOUT:     %.loc13_30: type = ptr_type U [symbolic = constants.%.2]
+// CHECK:STDOUT:     @.1.%return: ref U* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%T: type, %U: type) -> T*;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @.1(%T: type, %U: type) -> U* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
+// CHECK:STDOUT:   %F.call: init T* = call %F.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_reorder.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T.1: type = bind_symbolic_name T 0 [symbolic]
+// CHECK:STDOUT:   %U.1: type = bind_symbolic_name U 1 [symbolic]
+// CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
+// CHECK:STDOUT:   %U.2: type = bind_symbolic_name U 0 [symbolic]
+// CHECK:STDOUT:   %T.2: type = bind_symbolic_name T 1 [symbolic]
+// CHECK:STDOUT:   %.2: type = ptr_type T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = %Core
+// CHECK:STDOUT:     .F = %F
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc4_6.1: type = param T
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc4_6.1 [symbolic = constants.%T.1]
+// CHECK:STDOUT:     %U.loc4_16.1: type = param U
+// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U 1, %U.loc4_16.1 [symbolic = constants.%U.1]
+// CHECK:STDOUT:     %T.ref.loc4: type = name_ref T, @F.%T [symbolic = constants.%T.1]
+// CHECK:STDOUT:     %.loc4: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     @F.%return: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc13_32: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %U.loc13_6.1: type = param U
+// CHECK:STDOUT:     @.1.%U: type = bind_symbolic_name U 0, %U.loc13_6.1 [symbolic = constants.%U.2]
+// CHECK:STDOUT:     %T.loc13_16.1: type = param T
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T 1, %T.loc13_16.1 [symbolic = constants.%T.2]
+// CHECK:STDOUT:     %T.ref.loc13: type = name_ref T, @.1.%T [symbolic = constants.%T.2]
+// CHECK:STDOUT:     %.loc13_30: type = ptr_type T [symbolic = constants.%.2]
+// CHECK:STDOUT:     @.1.%return: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%T: type, %U: type) -> T*;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @.1(%U: type, %T: type) -> T* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T.2]
+// CHECK:STDOUT:   %F.call: init T* = call %F.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   return <error>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- fail_rename.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T.1: type = bind_symbolic_name T 0 [symbolic]
+// CHECK:STDOUT:   %U.1: type = bind_symbolic_name U 1 [symbolic]
+// CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
+// CHECK:STDOUT:   %U.2: type = bind_symbolic_name U 0 [symbolic]
+// CHECK:STDOUT:   %T.2: type = bind_symbolic_name T 1 [symbolic]
+// CHECK:STDOUT:   %.2: type = ptr_type U [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [template] {
+// CHECK:STDOUT:     .Core = %Core
+// CHECK:STDOUT:     .F = %F
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
+// CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
+// CHECK:STDOUT:     %T.loc4_6.1: type = param T
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc4_6.1 [symbolic = constants.%T.1]
+// CHECK:STDOUT:     %U.loc4_16.1: type = param U
+// CHECK:STDOUT:     @F.%U: type = bind_symbolic_name U 1, %U.loc4_16.1 [symbolic = constants.%U.1]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, @F.%T [symbolic = constants.%T.1]
+// CHECK:STDOUT:     %.loc4: type = ptr_type T [symbolic = constants.%.1]
+// CHECK:STDOUT:     @F.%return: ref T* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.loc13_32: <function> = fn_decl @.1 [template] {
+// CHECK:STDOUT:     %U.loc13_6.1: type = param U
+// CHECK:STDOUT:     @.1.%U: type = bind_symbolic_name U 0, %U.loc13_6.1 [symbolic = constants.%U.2]
+// CHECK:STDOUT:     %T.loc13_16.1: type = param T
+// CHECK:STDOUT:     @.1.%T: type = bind_symbolic_name T 1, %T.loc13_16.1 [symbolic = constants.%T.2]
+// CHECK:STDOUT:     %U.ref: type = name_ref U, @.1.%U [symbolic = constants.%U.2]
+// CHECK:STDOUT:     %.loc13_30: type = ptr_type U [symbolic = constants.%.2]
+// CHECK:STDOUT:     @.1.%return: ref U* = var <return slot>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F(%T: type, %U: type) -> T*;
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @.1(%U: type, %T: type) -> U* {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T.2]
+// CHECK:STDOUT:   %F.call: init T* = call %F.ref(<invalid>) [template = <error>]
+// CHECK:STDOUT:   return <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/type_param.carbon
@@ -12,6 +12,7 @@ fn F(T:! type) {
 // CHECK:STDOUT: --- type_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -23,17 +24,17 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc8: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc8: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p
 // CHECK:STDOUT:   %.loc9_15: T* = bind_value %p.ref
 // CHECK:STDOUT:   %.loc9_14.1: ref T = deref %.loc9_15

--- a/toolchain/check/testdata/function/generic/type_param.carbon
+++ b/toolchain/check/testdata/function/generic/type_param.carbon
@@ -12,7 +12,7 @@ fn F(T:! type) {
 // CHECK:STDOUT: --- type_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -24,7 +24,7 @@ fn F(T:! type) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/generic/type_param_scope.carbon
+++ b/toolchain/check/testdata/function/generic/type_param_scope.carbon
@@ -12,7 +12,7 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT: --- type_param_scope.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -23,7 +23,7 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T 0, %T.loc7_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref.loc7_19: type = name_ref T, @F.%T [symbolic = constants.%T]
 // CHECK:STDOUT:     %n.loc7_16.1: T = param n
 // CHECK:STDOUT:     @F.%n: T = bind_name n, %n.loc7_16.1

--- a/toolchain/check/testdata/function/generic/type_param_scope.carbon
+++ b/toolchain/check/testdata/function/generic/type_param_scope.carbon
@@ -11,6 +11,10 @@ fn F(T:! type, n: T) -> T {
 
 // CHECK:STDOUT: --- type_param_scope.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
@@ -19,18 +23,18 @@ fn F(T:! type, n: T) -> T {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %T.loc7_6.1: type = param T
-// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic]
-// CHECK:STDOUT:     %T.ref.loc7_19: type = name_ref T, @F.%T [symbolic = @F.%T]
+// CHECK:STDOUT:     @F.%T: type = bind_symbolic_name T, %T.loc7_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref.loc7_19: type = name_ref T, @F.%T [symbolic = constants.%T]
 // CHECK:STDOUT:     %n.loc7_16.1: T = param n
 // CHECK:STDOUT:     @F.%n: T = bind_name n, %n.loc7_16.1
-// CHECK:STDOUT:     %T.ref.loc7_25: type = name_ref T, @F.%T [symbolic = @F.%T]
+// CHECK:STDOUT:     %T.ref.loc7_25: type = name_ref T, @F.%T [symbolic = constants.%T]
 // CHECK:STDOUT:     @F.%return: ref T = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: type, %n: T) -> T {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %n.ref: T = name_ref n, %n
 // CHECK:STDOUT:   %m: T = bind_name m, %n.ref
 // CHECK:STDOUT:   %m.ref: T = name_ref m, %m

--- a/toolchain/check/testdata/impl/basic.carbon
+++ b/toolchain/check/testdata/impl/basic.carbon
@@ -16,7 +16,7 @@ impl i32 as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -35,7 +35,7 @@ impl i32 as Simple {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/basic.carbon
+++ b/toolchain/check/testdata/impl/basic.carbon
@@ -16,6 +16,7 @@ impl i32 as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -34,7 +35,7 @@ impl i32 as Simple {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/compound.carbon
+++ b/toolchain/check/testdata/impl/compound.carbon
@@ -34,7 +34,7 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Simple> = assoc_entity element1, @Simple.%G [template]
@@ -78,7 +78,7 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G.1 [template] {

--- a/toolchain/check/testdata/impl/compound.carbon
+++ b/toolchain/check/testdata/impl/compound.carbon
@@ -34,6 +34,7 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Simple> = assoc_entity element1, @Simple.%G [template]
@@ -77,13 +78,13 @@ fn InstanceCallIndirect(p: i32*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G.1 [template] {
-// CHECK:STDOUT:     %Self.ref: Simple = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_14.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_14.2: type = converted %Self.ref, %.loc9_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Simple = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_14.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_14.2: type = converted %Self.ref, %.loc9_14.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc9_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc9_8.2: Self = bind_name self, %self.loc9_8.1
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/impl/declaration.carbon
+++ b/toolchain/check/testdata/impl/declaration.carbon
@@ -12,6 +12,7 @@ impl i32 as I;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -27,7 +28,7 @@ impl i32 as I;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/declaration.carbon
+++ b/toolchain/check/testdata/impl/declaration.carbon
@@ -12,7 +12,7 @@ impl i32 as I;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,7 +28,7 @@ impl i32 as I;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/empty.carbon
+++ b/toolchain/check/testdata/impl/empty.carbon
@@ -14,7 +14,7 @@ impl i32 as Empty {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -31,7 +31,7 @@ impl i32 as Empty {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/empty.carbon
+++ b/toolchain/check/testdata/impl/empty.carbon
@@ -14,6 +14,7 @@ impl i32 as Empty {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -30,7 +31,7 @@ impl i32 as Empty {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/extend_impl.carbon
+++ b/toolchain/check/testdata/impl/extend_impl.carbon
@@ -23,6 +23,7 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -50,7 +51,7 @@ fn G(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/extend_impl.carbon
+++ b/toolchain/check/testdata/impl/extend_impl.carbon
@@ -23,7 +23,7 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -51,7 +51,7 @@ fn G(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_call_invalid.carbon
+++ b/toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -23,6 +23,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%G [template]
 // CHECK:STDOUT: }
@@ -45,11 +46,11 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G.1 [template] {
-// CHECK:STDOUT:     %Self.ref: Simple = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref, %.loc8_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Simple = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref, %.loc8_14.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc8_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_8.2: Self = bind_name self, %self.loc8_8.1
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/impl/fail_call_invalid.carbon
+++ b/toolchain/check/testdata/impl/fail_call_invalid.carbon
@@ -23,7 +23,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%G [template]
 // CHECK:STDOUT: }
@@ -46,7 +46,7 @@ fn InstanceCall(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G.1 [template] {
 // CHECK:STDOUT:     %Self.ref: Simple = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -32,7 +32,9 @@ class C {
 // CHECK:STDOUT: --- fail_extend_impl_forall.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: type = interface_type @GenericInterface [template]
+// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @GenericInterface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in GenericInterface> = assoc_entity element0, @GenericInterface.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -48,15 +50,15 @@ class C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %GenericInterface.decl: type = interface_decl @GenericInterface [template = constants.%.1] {
 // CHECK:STDOUT:     %T.loc11_28.1: type = param T
-// CHECK:STDOUT:     %T.loc11_28.2: type = bind_symbolic_name T, %T.loc11_28.1 [symbolic]
+// CHECK:STDOUT:     %T.loc11_28.2: type = bind_symbolic_name T, %T.loc11_28.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @GenericInterface {
-// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, file.%T.loc11_28.2 [symbolic = file.%T.loc11_28.2]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, file.%T.loc11_28.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %x.loc12_8.1: T = param x
 // CHECK:STDOUT:     %x.loc12_8.2: T = bind_name x, %x.loc12_8.1
 // CHECK:STDOUT:   }
@@ -70,7 +72,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: C as <error> {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {
-// CHECK:STDOUT:     %T.ref: type = name_ref T, @C.%T.loc27_23.2 [symbolic = @C.%T.loc27_23.2]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, @C.%T.loc27_23.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %x.loc28_10.1: T = param x
 // CHECK:STDOUT:     %x.loc28_10.2: T = bind_name x, %x.loc28_10.1
 // CHECK:STDOUT:   }
@@ -83,9 +85,9 @@ class C {
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %T.loc27_23.1: type = param T
-// CHECK:STDOUT:     %T.loc27_23.2: type = bind_symbolic_name T, %T.loc27_23.1 [symbolic]
+// CHECK:STDOUT:     %T.loc27_23.2: type = bind_symbolic_name T, %T.loc27_23.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %GenericInterface.ref: type = name_ref GenericInterface, file.%GenericInterface.decl [template = constants.%.1]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc27_23.2 [symbolic = %T.loc27_23.2]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc27_23.2 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_forall.carbon
@@ -32,9 +32,9 @@ class C {
 // CHECK:STDOUT: --- fail_extend_impl_forall.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = interface_type @GenericInterface [template]
-// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @GenericInterface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in GenericInterface> = assoc_entity element0, @GenericInterface.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -50,13 +50,13 @@ class C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %GenericInterface.decl: type = interface_decl @GenericInterface [template = constants.%.1] {
 // CHECK:STDOUT:     %T.loc11_28.1: type = param T
-// CHECK:STDOUT:     %T.loc11_28.2: type = bind_symbolic_name T, %T.loc11_28.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.loc11_28.2: type = bind_symbolic_name T 0, %T.loc11_28.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @GenericInterface {
-// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: GenericInterface = bind_symbolic_name Self 1 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, file.%T.loc11_28.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %x.loc12_8.1: T = param x
@@ -85,7 +85,7 @@ class C {
 // CHECK:STDOUT: class @C {
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %T.loc27_23.1: type = param T
-// CHECK:STDOUT:     %T.loc27_23.2: type = bind_symbolic_name T, %T.loc27_23.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.loc27_23.2: type = bind_symbolic_name T 0, %T.loc27_23.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %GenericInterface.ref: type = name_ref GenericInterface, file.%GenericInterface.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc27_23.2 [symbolic = constants.%T]
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/impl/fail_extend_impl_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_scope.carbon
@@ -15,6 +15,7 @@ extend impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -31,7 +32,7 @@ extend impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_extend_impl_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_scope.carbon
@@ -15,7 +15,7 @@ extend impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -32,7 +32,7 @@ extend impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
@@ -39,7 +39,7 @@ class E {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT:   %.3: type = struct_type {} [template]
@@ -63,7 +63,7 @@ class E {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_impl_type_as.carbon
@@ -39,6 +39,7 @@ class E {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT:   %.3: type = struct_type {} [template]
@@ -62,7 +63,7 @@ class E {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -20,7 +20,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
@@ -35,7 +35,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_partially_defined_interface.carbon
@@ -20,6 +20,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT: }
@@ -34,7 +35,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
@@ -19,7 +19,7 @@ impl as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -38,7 +38,7 @@ impl as Simple {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_as_scope.carbon
@@ -19,6 +19,7 @@ impl as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -37,7 +38,7 @@ impl as Simple {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
@@ -15,6 +15,7 @@ impl bool as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT: }
@@ -32,7 +33,7 @@ impl bool as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_const.carbon
@@ -15,7 +15,7 @@ impl bool as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT: }
@@ -33,7 +33,7 @@ impl bool as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -213,6 +213,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %NoF: type = class_type @NoF [template]
@@ -224,6 +225,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %FExtraImplicitParam: type = class_type @FExtraImplicitParam [template]
 // CHECK:STDOUT:   %FExtraReturnType: type = class_type @FExtraReturnType [template]
 // CHECK:STDOUT:   %.5: type = interface_type @J [template]
+// CHECK:STDOUT:   %Self.2: J = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @J, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in J> = assoc_entity element0, @J.%F [template]
 // CHECK:STDOUT:   %FMissingParam: type = class_type @FMissingParam [template]
@@ -234,6 +236,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %FDifferentReturnType: type = class_type @FDifferentReturnType [template]
 // CHECK:STDOUT:   %FDifferentParamName: type = class_type @FDifferentParamName [template]
 // CHECK:STDOUT:   %.8: type = interface_type @SelfNested [template]
+// CHECK:STDOUT:   %Self.3: SelfNested = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: type = struct_type {.x: Self, .y: i32} [symbolic]
 // CHECK:STDOUT:   %.11: type = tuple_type (type, type) [template]
@@ -302,7 +305,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc7: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
@@ -313,7 +316,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @J {
-// CHECK:STDOUT:   %Self: J = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: J = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.5 [template] {
 // CHECK:STDOUT:     %self.loc89_20.1: bool = param self
 // CHECK:STDOUT:     %self.loc89_20.2: bool = bind_name self, %self.loc89_20.1
@@ -330,24 +333,24 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SelfNested {
-// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.13 [template] {
-// CHECK:STDOUT:     %Self.ref.loc184_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_16.1: type = facet_type_access %Self.ref.loc184_12 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_16.2: type = converted %Self.ref.loc184_12, %.loc184_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc184_12: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc184_16.1: type = facet_type_access %Self.ref.loc184_12 [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc184_16.2: type = converted %Self.ref.loc184_12, %.loc184_16.1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc184_16.3: type = ptr_type Self [symbolic = constants.%.9]
-// CHECK:STDOUT:     %Self.ref.loc184_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_24.1: type = facet_type_access %Self.ref.loc184_24 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_24.2: type = converted %Self.ref.loc184_24, %.loc184_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc184_24: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc184_24.1: type = facet_type_access %Self.ref.loc184_24 [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc184_24.2: type = converted %Self.ref.loc184_24, %.loc184_24.1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc184_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.10]
 // CHECK:STDOUT:     %.loc184_38.1: (type, type) = tuple_literal (%.loc184_16.3, %.loc184_37)
 // CHECK:STDOUT:     %.loc184_38.2: type = converted %.loc184_38.1, constants.%.12 [symbolic = constants.%.12]
 // CHECK:STDOUT:     %x.loc184_8.1: (Self*, {.x: Self, .y: i32}) = param x
 // CHECK:STDOUT:     %x.loc184_8.2: (Self*, {.x: Self, .y: i32}) = bind_name x, %x.loc184_8.1
-// CHECK:STDOUT:     %Self.ref.loc184_45: SelfNested = name_ref Self, %Self [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc184_45: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc184_51: i32 = int_literal 4 [template = constants.%.13]
-// CHECK:STDOUT:     %.loc184_45.1: type = facet_type_access %Self.ref.loc184_45 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc184_45.2: type = converted %Self.ref.loc184_45, %.loc184_45.1 [symbolic = %Self]
+// CHECK:STDOUT:     %.loc184_45.1: type = facet_type_access %Self.ref.loc184_45 [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc184_45.2: type = converted %Self.ref.loc184_45, %.loc184_45.1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc184_52: type = array_type %.loc184_51, Self [symbolic = constants.%.14]
 // CHECK:STDOUT:     %return.var: ref [Self; 4] = var <return slot>
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -213,7 +213,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %NoF: type = class_type @NoF [template]
@@ -225,7 +225,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %FExtraImplicitParam: type = class_type @FExtraImplicitParam [template]
 // CHECK:STDOUT:   %FExtraReturnType: type = class_type @FExtraReturnType [template]
 // CHECK:STDOUT:   %.5: type = interface_type @J [template]
-// CHECK:STDOUT:   %Self.2: J = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: J = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @J, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in J> = assoc_entity element0, @J.%F [template]
 // CHECK:STDOUT:   %FMissingParam: type = class_type @FMissingParam [template]
@@ -236,7 +236,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT:   %FDifferentReturnType: type = class_type @FDifferentReturnType [template]
 // CHECK:STDOUT:   %FDifferentParamName: type = class_type @FDifferentParamName [template]
 // CHECK:STDOUT:   %.8: type = interface_type @SelfNested [template]
-// CHECK:STDOUT:   %Self.3: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: SelfNested = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: type = struct_type {.x: Self, .y: i32} [symbolic]
 // CHECK:STDOUT:   %.11: type = tuple_type (type, type) [template]
@@ -305,7 +305,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc7: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
@@ -316,7 +316,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @J {
-// CHECK:STDOUT:   %Self: J = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: J = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.5 [template] {
 // CHECK:STDOUT:     %self.loc89_20.1: bool = param self
 // CHECK:STDOUT:     %self.loc89_20.2: bool = bind_name self, %self.loc89_20.1
@@ -333,7 +333,7 @@ class SelfNestedBadReturnType {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SelfNested {
-// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self 0 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.13 [template] {
 // CHECK:STDOUT:     %Self.ref.loc184_12: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc184_16.1: type = facet_type_access %Self.ref.loc184_12 [symbolic = constants.%Self.3]

--- a/toolchain/check/testdata/impl/fail_impl_bad_type.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_type.carbon
@@ -15,6 +15,7 @@ impl true as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: bool = bool_literal true [template]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
@@ -33,7 +34,7 @@ impl true as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_impl_bad_type.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_type.carbon
@@ -15,7 +15,7 @@ impl true as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: bool = bool_literal true [template]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
@@ -34,7 +34,7 @@ impl true as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_redefinition.carbon
+++ b/toolchain/check/testdata/impl/fail_redefinition.carbon
@@ -20,6 +20,7 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -39,7 +40,7 @@ impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -48,6 +49,6 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @impl: i32 as I {
 // CHECK:STDOUT: !members:
-// CHECK:STDOUT:   witness = <unexpected instref inst+7>
+// CHECK:STDOUT:   witness = <unexpected instref inst+8>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_redefinition.carbon
+++ b/toolchain/check/testdata/impl/fail_redefinition.carbon
@@ -20,7 +20,7 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: <witness> = interface_witness () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -40,7 +40,7 @@ impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
@@ -15,6 +15,7 @@ impl bool as I where .T = bool {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT: }
@@ -32,7 +33,7 @@ impl bool as I where .T = bool {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
+++ b/toolchain/check/testdata/impl/fail_todo_impl_assoc_const.carbon
@@ -15,7 +15,7 @@ impl bool as I where .T = bool {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT: }
@@ -33,7 +33,7 @@ impl bool as I where .T = bool {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc7: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -21,6 +21,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -43,7 +44,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -21,7 +21,7 @@ class C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -44,7 +44,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -16,8 +16,10 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -30,14 +32,14 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   %Simple.decl: type = interface_decl @Simple [template = constants.%.1] {}
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %T.loc11_14.1: type = param T
-// CHECK:STDOUT:     %T.loc11_14.2: type = bind_symbolic_name T, %T.loc11_14.1 [symbolic]
-// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_14.2 [symbolic = %T.loc11_14.2]
+// CHECK:STDOUT:     %T.loc11_14.2: type = bind_symbolic_name T, %T.loc11_14.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_14.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %Simple.ref: type = name_ref Simple, %Simple.decl [template = constants.%.1]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/impl_forall.carbon
+++ b/toolchain/check/testdata/impl/impl_forall.carbon
@@ -16,10 +16,10 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Simple [template]
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Simple, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Simple> = assoc_entity element0, @Simple.%F [template]
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -32,14 +32,14 @@ impl forall [T:! type] T as Simple {
 // CHECK:STDOUT:   %Simple.decl: type = interface_decl @Simple [template = constants.%.1] {}
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %T.loc11_14.1: type = param T
-// CHECK:STDOUT:     %T.loc11_14.2: type = bind_symbolic_name T, %T.loc11_14.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.loc11_14.2: type = bind_symbolic_name T 0, %T.loc11_14.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc11_14.2 [symbolic = constants.%T]
 // CHECK:STDOUT:     %Simple.ref: type = name_ref Simple, %Simple.decl [template = constants.%.1]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Simple {
-// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Simple = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Simple> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/alias.carbon
+++ b/toolchain/check/testdata/impl/lookup/alias.carbon
@@ -25,7 +25,7 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -57,7 +57,7 @@ fn G(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/alias.carbon
+++ b/toolchain/check/testdata/impl/lookup/alias.carbon
@@ -25,6 +25,7 @@ fn G(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -56,7 +57,7 @@ fn G(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -28,6 +28,7 @@ fn F(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -54,7 +55,7 @@ fn F(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_alias_impl_not_found.carbon
@@ -28,7 +28,7 @@ fn F(c: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -55,7 +55,7 @@ fn F(c: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
@@ -28,6 +28,7 @@ impl C as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -55,7 +56,7 @@ impl C as I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
+++ b/toolchain/check/testdata/impl/lookup/fail_todo_undefined_impl.carbon
@@ -28,7 +28,7 @@ impl C as I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -56,7 +56,7 @@ impl C as I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -30,6 +30,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -53,7 +54,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc5: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
@@ -90,11 +91,12 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @HasF [template]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT:   %.4: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in HasF> = assoc_entity element0, file.%import_ref.8 [template]
-// CHECK:STDOUT:   %.7: <witness> = interface_witness (<unexpected instref inst+32>) [template]
+// CHECK:STDOUT:   %.7: <witness> = interface_witness (<unexpected instref inst+33>) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -106,13 +108,13 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %Impl: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+11, unloaded
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%.2] {}
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in HasF> = import_ref ir2, inst+7, loc_20 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in HasF> = import_ref ir2, inst+8, loc_20 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir2, inst+16, loc_22 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: type = import_ref ir2, inst+9, loc_10 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir2, inst+17, loc_22 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: type = import_ref ir2, inst+10, loc_10 [template = constants.%C]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %Impl.ref: <namespace> = name_ref Impl, %Impl [template = %Impl]
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %import_ref.6 [template = constants.%C]
@@ -120,7 +122,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:     @G.%c: C = bind_name c, %c.loc4_6.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+2, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+6, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
@@ -143,7 +145,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %Impl.ref: <namespace> = name_ref Impl, file.%Impl [template = file.%Impl]
 // CHECK:STDOUT:   %HasF.ref: type = name_ref HasF, file.%import_ref.7 [template = constants.%.2]
 // CHECK:STDOUT:   %F.ref: <associated <function> in HasF> = name_ref F, file.%import_ref.2 [template = constants.%.6]
-// CHECK:STDOUT:   %.1: <function> = interface_witness_access file.%import_ref.5, element0 [template = <unexpected instref inst+32>]
+// CHECK:STDOUT:   %.1: <function> = interface_witness_access file.%import_ref.5, element0 [template = <unexpected instref inst+33>]
 // CHECK:STDOUT:   %F.call: init () = call %.1()
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -30,7 +30,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @HasF [template]
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @HasF, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in HasF> = assoc_entity element0, @HasF.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -54,7 +54,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc5: <associated <function> in HasF> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
@@ -91,7 +91,7 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @HasF [template]
-// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: HasF = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT:   %.4: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @HasF, <function> [template]

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -25,7 +25,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -54,7 +54,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
 // CHECK:STDOUT:     %Self.ref: I = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc10_14.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]

--- a/toolchain/check/testdata/impl/lookup/instance_method.carbon
+++ b/toolchain/check/testdata/impl/lookup/instance_method.carbon
@@ -25,6 +25,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -53,11 +54,11 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %Self.ref: I = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_14.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_14.2: type = converted %Self.ref, %.loc10_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: I = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_14.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_14.2: type = converted %Self.ref, %.loc10_14.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc10_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc10_8.2: Self = bind_name self, %self.loc10_8.1
 // CHECK:STDOUT:     %return.var: ref i32 = var <return slot>

--- a/toolchain/check/testdata/impl/redeclaration.carbon
+++ b/toolchain/check/testdata/impl/redeclaration.carbon
@@ -18,7 +18,7 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %X: type = class_type @X [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness () [template]
@@ -42,7 +42,7 @@ impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/redeclaration.carbon
+++ b/toolchain/check/testdata/impl/redeclaration.carbon
@@ -18,6 +18,7 @@ impl i32 as I {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %X: type = class_type @X [template]
 // CHECK:STDOUT:   %.2: type = struct_type {} [template]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness () [template]
@@ -41,7 +42,7 @@ impl i32 as I {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/impl/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/self_in_class.carbon
@@ -20,7 +20,7 @@ class A {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @DefaultConstructible [template]
-// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @DefaultConstructible, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in DefaultConstructible> = assoc_entity element0, @DefaultConstructible.%Make [template]
 // CHECK:STDOUT:   %A: type = class_type @A [template]
@@ -41,7 +41,7 @@ class A {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @DefaultConstructible {
-// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make.1 [template] {
 // CHECK:STDOUT:     %Self.ref: DefaultConstructible = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc8_16.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]

--- a/toolchain/check/testdata/impl/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/self_in_class.carbon
@@ -20,6 +20,7 @@ class A {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @DefaultConstructible [template]
+// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @DefaultConstructible, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in DefaultConstructible> = assoc_entity element0, @DefaultConstructible.%Make [template]
 // CHECK:STDOUT:   %A: type = class_type @A [template]
@@ -40,11 +41,11 @@ class A {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @DefaultConstructible {
-// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: DefaultConstructible = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Make: <function> = fn_decl @Make.1 [template] {
-// CHECK:STDOUT:     %Self.ref: DefaultConstructible = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_16.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_16.2: type = converted %Self.ref, %.loc8_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: DefaultConstructible = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_16.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_16.2: type = converted %Self.ref, %.loc8_16.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_20: <associated <function> in DefaultConstructible> = assoc_entity element0, %Make [template = constants.%.3]

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -36,7 +36,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
-// CHECK:STDOUT:   %Self.1: UseSelf = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: UseSelf = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @UseSelf, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in UseSelf> = assoc_entity element0, @UseSelf.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -49,7 +49,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%F) [template]
 // CHECK:STDOUT:   %.10: D = struct_value () [template]
 // CHECK:STDOUT:   %.11: type = interface_type @SelfNested [template]
-// CHECK:STDOUT:   %Self.2: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: SelfNested = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.12: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.13: type = struct_type {.x: Self, .y: i32} [symbolic]
 // CHECK:STDOUT:   %.14: type = tuple_type (type, type) [template]
@@ -98,7 +98,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @UseSelf {
-// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self.1]
@@ -124,7 +124,7 @@ impl D as SelfNested {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SelfNested {
-// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.4 [template] {
 // CHECK:STDOUT:     %Self.ref.loc24_12: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_16.1: type = facet_type_access %Self.ref.loc24_12 [symbolic = constants.%Self.2]

--- a/toolchain/check/testdata/impl/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/self_in_signature.carbon
@@ -36,6 +36,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
+// CHECK:STDOUT:   %Self.1: UseSelf = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @UseSelf, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in UseSelf> = assoc_entity element0, @UseSelf.%F [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
@@ -48,6 +49,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%F) [template]
 // CHECK:STDOUT:   %.10: D = struct_value () [template]
 // CHECK:STDOUT:   %.11: type = interface_type @SelfNested [template]
+// CHECK:STDOUT:   %Self.2: SelfNested = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.12: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.13: type = struct_type {.x: Self, .y: i32} [symbolic]
 // CHECK:STDOUT:   %.14: type = tuple_type (type, type) [template]
@@ -96,21 +98,21 @@ impl D as SelfNested {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @UseSelf {
-// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc8_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_8.2: Self = bind_name self, %self.loc8_8.1
-// CHECK:STDOUT:     %Self.ref.loc8_23: UseSelf = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_23.1: type = facet_type_access %Self.ref.loc8_23 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_23.2: type = converted %Self.ref.loc8_23, %.loc8_23.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_23: UseSelf = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_23.1: type = facet_type_access %Self.ref.loc8_23 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_23.2: type = converted %Self.ref.loc8_23, %.loc8_23.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %x.loc8_20.1: Self = param x
 // CHECK:STDOUT:     %x.loc8_20.2: Self = bind_name x, %x.loc8_20.1
-// CHECK:STDOUT:     %Self.ref.loc8_32: UseSelf = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_32.1: type = facet_type_access %Self.ref.loc8_32 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_32.2: type = converted %Self.ref.loc8_32, %.loc8_32.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_32: UseSelf = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_32.1: type = facet_type_access %Self.ref.loc8_32 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc8_32.2: type = converted %Self.ref.loc8_32, %.loc8_32.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_36: <associated <function> in UseSelf> = assoc_entity element0, %F [template = constants.%.3]
@@ -122,15 +124,15 @@ impl D as SelfNested {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SelfNested {
-// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: SelfNested = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.4 [template] {
-// CHECK:STDOUT:     %Self.ref.loc24_12: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_16.1: type = facet_type_access %Self.ref.loc24_12 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_16.2: type = converted %Self.ref.loc24_12, %.loc24_16.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc24_12: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc24_16.1: type = facet_type_access %Self.ref.loc24_12 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc24_16.2: type = converted %Self.ref.loc24_12, %.loc24_16.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_16.3: type = ptr_type Self [symbolic = constants.%.12]
-// CHECK:STDOUT:     %Self.ref.loc24_24: SelfNested = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_24.1: type = facet_type_access %Self.ref.loc24_24 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc24_24.2: type = converted %Self.ref.loc24_24, %.loc24_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc24_24: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc24_24.1: type = facet_type_access %Self.ref.loc24_24 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc24_24.2: type = converted %Self.ref.loc24_24, %.loc24_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_37: type = struct_type {.x: Self, .y: i32} [symbolic = constants.%.13]
 // CHECK:STDOUT:     %.loc24_38.1: (type, type) = tuple_literal (%.loc24_16.3, %.loc24_37)
 // CHECK:STDOUT:     %.loc24_38.2: type = converted %.loc24_38.1, constants.%.15 [symbolic = constants.%.15]

--- a/toolchain/check/testdata/interface/as_type.carbon
+++ b/toolchain/check/testdata/interface/as_type.carbon
@@ -12,7 +12,7 @@ fn F(e: Empty) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -32,7 +32,7 @@ fn F(e: Empty) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/as_type.carbon
+++ b/toolchain/check/testdata/interface/as_type.carbon
@@ -12,6 +12,7 @@ fn F(e: Empty) {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -31,7 +32,7 @@ fn F(e: Empty) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/as_type_of_type.carbon
+++ b/toolchain/check/testdata/interface/as_type_of_type.carbon
@@ -14,8 +14,8 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
-// CHECK:STDOUT:   %T: Empty = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic]
+// CHECK:STDOUT:   %T: Empty = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -30,12 +30,12 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, %Empty.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc9_6.1: Empty = param T
-// CHECK:STDOUT:     @F.%T: Empty = bind_symbolic_name T, %T.loc9_6.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @F.%T: Empty = bind_symbolic_name T 0, %T.loc9_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/as_type_of_type.carbon
+++ b/toolchain/check/testdata/interface/as_type_of_type.carbon
@@ -14,6 +14,8 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %T: Empty = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -28,12 +30,12 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, %Empty.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc9_6.1: Empty = param T
-// CHECK:STDOUT:     @F.%T: Empty = bind_symbolic_name T, %T.loc9_6.1 [symbolic]
+// CHECK:STDOUT:     @F.%T: Empty = bind_symbolic_name T, %T.loc9_6.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -42,9 +44,9 @@ fn F(T:! Empty) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%T: Empty) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: Empty = name_ref T, %T [symbolic = %T]
-// CHECK:STDOUT:   %.loc10_10.1: type = facet_type_access %T.ref [symbolic = %T]
-// CHECK:STDOUT:   %.loc10_10.2: type = converted %T.ref, %.loc10_10.1 [symbolic = %T]
+// CHECK:STDOUT:   %T.ref: Empty = name_ref T, %T [symbolic = constants.%T]
+// CHECK:STDOUT:   %.loc10_10.1: type = facet_type_access %T.ref [symbolic = constants.%T]
+// CHECK:STDOUT:   %.loc10_10.2: type = converted %T.ref, %.loc10_10.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   %x.var: ref T = var x
 // CHECK:STDOUT:   %x: ref T = bind_name x, %x.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/interface/assoc_const.carbon
+++ b/toolchain/check/testdata/interface/assoc_const.carbon
@@ -13,6 +13,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @I, i32 [template]
@@ -29,7 +30,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc8: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:   %N: i32 = assoc_const_decl N [template]

--- a/toolchain/check/testdata/interface/assoc_const.carbon
+++ b/toolchain/check/testdata/interface/assoc_const.carbon
@@ -13,7 +13,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.3: <associated type in I> = assoc_entity element0, @I.%T [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @I, i32 [template]
@@ -30,7 +30,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc8: <associated type in I> = assoc_entity element0, %T [template = constants.%.3]
 // CHECK:STDOUT:   %N: i32 = assoc_const_decl N [template]

--- a/toolchain/check/testdata/interface/basic.carbon
+++ b/toolchain/check/testdata/interface/basic.carbon
@@ -17,7 +17,9 @@ interface ForwardDeclared {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @ForwardDeclared [template]
+// CHECK:STDOUT:   %Self.2: ForwardDeclared = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @ForwardDeclared, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in ForwardDeclared> = assoc_entity element0, @ForwardDeclared.%F [template]
 // CHECK:STDOUT: }
@@ -35,7 +37,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -43,7 +45,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
-// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc13: <associated <function> in ForwardDeclared> = assoc_entity element0, %F [template = constants.%.4]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/basic.carbon
+++ b/toolchain/check/testdata/interface/basic.carbon
@@ -17,9 +17,9 @@ interface ForwardDeclared {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @ForwardDeclared [template]
-// CHECK:STDOUT:   %Self.2: ForwardDeclared = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: ForwardDeclared = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @ForwardDeclared, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in ForwardDeclared> = assoc_entity element0, @ForwardDeclared.%F [template]
 // CHECK:STDOUT: }
@@ -37,7 +37,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -45,7 +45,7 @@ interface ForwardDeclared {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
-// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc13: <associated <function> in ForwardDeclared> = assoc_entity element0, %F [template = constants.%.4]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/default_fn.carbon
+++ b/toolchain/check/testdata/interface/default_fn.carbon
@@ -24,7 +24,7 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -44,7 +44,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc10: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/default_fn.carbon
+++ b/toolchain/check/testdata/interface/default_fn.carbon
@@ -24,6 +24,7 @@ class C {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <witness> = interface_witness (@impl.%F) [template]
@@ -43,7 +44,7 @@ class C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc10: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
+++ b/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
@@ -31,11 +31,11 @@ interface Outer {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Outer [template]
-// CHECK:STDOUT:   %Self.2: Outer = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Outer = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = interface_type @Inner [template]
-// CHECK:STDOUT:   %Self.3: Inner = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: Inner = bind_symbolic_name Self 1 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -51,7 +51,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -60,7 +60,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Outer {
-// CHECK:STDOUT:   %Self: Outer = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: Outer = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Inner.decl: type = interface_decl @Inner [template = constants.%.3] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
 // CHECK:STDOUT:
@@ -71,7 +71,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inner {
-// CHECK:STDOUT:   %Self: Inner = bind_symbolic_name Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:   %Self: Inner = bind_symbolic_name Self 1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
+++ b/toolchain/check/testdata/interface/fail_add_member_outside_definition.carbon
@@ -31,8 +31,11 @@ interface Outer {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Outer [template]
+// CHECK:STDOUT:   %Self.2: Outer = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = interface_type @Inner [template]
+// CHECK:STDOUT:   %Self.3: Inner = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,7 +51,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -57,7 +60,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Outer {
-// CHECK:STDOUT:   %Self: Outer = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Outer = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Inner.decl: type = interface_decl @Inner [template = constants.%.3] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
 // CHECK:STDOUT:
@@ -68,7 +71,7 @@ interface Outer {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inner {
-// CHECK:STDOUT:   %Self: Inner = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inner = bind_symbolic_name Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %.loc22: <function> = fn_decl @.1 [template] {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/interface/fail_assoc_const_bad_default.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_bad_default.carbon
@@ -15,7 +15,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: i32 = int_literal 42 [template]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.4: <associated type in I> = assoc_entity element0, @I.%T [template]
@@ -31,7 +31,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %.loc11_18: i32 = int_literal 42 [template = constants.%.2]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc11_20: <associated type in I> = assoc_entity element0, %T [template = constants.%.4]

--- a/toolchain/check/testdata/interface/fail_assoc_const_bad_default.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_bad_default.carbon
@@ -15,6 +15,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: i32 = int_literal 42 [template]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @I, type [template]
 // CHECK:STDOUT:   %.4: <associated type in I> = assoc_entity element0, @I.%T [template]
@@ -30,7 +31,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %.loc11_18: i32 = int_literal 42 [template = constants.%.2]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc11_20: <associated type in I> = assoc_entity element0, %T [template = constants.%.4]

--- a/toolchain/check/testdata/interface/fail_assoc_const_not_binding.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_not_binding.carbon
@@ -15,6 +15,9 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/interface/fail_assoc_const_not_binding.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_not_binding.carbon
@@ -15,9 +15,9 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
-// CHECK:STDOUT:   %U: type = bind_symbolic_name U [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 1 [symbolic]
+// CHECK:STDOUT:   %U: type = bind_symbolic_name U 2 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
@@ -21,6 +21,7 @@ alias UseOther = I.other;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -41,7 +42,7 @@ alias UseOther = I.other;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_not_constant.carbon
@@ -21,7 +21,7 @@ alias UseOther = I.other;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -42,7 +42,7 @@ alias UseOther = I.other;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_assoc_const_template.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_template.carbon
@@ -15,7 +15,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/interface/fail_assoc_const_template.carbon
+++ b/toolchain/check/testdata/interface/fail_assoc_const_template.carbon
@@ -15,6 +15,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -42,9 +42,11 @@ interface Class { }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @.1 [template]
 // CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %.3: type = interface_type @.2 [template]
+// CHECK:STDOUT:   %Self.2: <invalid> = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -75,7 +77,7 @@ interface Class { }
 // CHECK:STDOUT: interface @.1;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @.2 {
-// CHECK:STDOUT:   %Self: <invalid> = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: <invalid> = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_duplicate.carbon
+++ b/toolchain/check/testdata/interface/fail_duplicate.carbon
@@ -42,11 +42,11 @@ interface Class { }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @.1 [template]
 // CHECK:STDOUT:   %Class: type = class_type @Class [template]
 // CHECK:STDOUT:   %.3: type = interface_type @.2 [template]
-// CHECK:STDOUT:   %Self.2: <invalid> = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: <invalid> = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -77,7 +77,7 @@ interface Class { }
 // CHECK:STDOUT: interface @.1;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @.2 {
-// CHECK:STDOUT:   %Self: <invalid> = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: <invalid> = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
@@ -50,6 +50,7 @@ interface BeingDefined {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Undefined [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BeingDefined [template]
+// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @BeingDefined, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in BeingDefined> = assoc_entity element0, @BeingDefined.%H [template]
 // CHECK:STDOUT: }
@@ -71,7 +72,7 @@ interface BeingDefined {
 // CHECK:STDOUT: interface @Undefined;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BeingDefined {
-// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {
 // CHECK:STDOUT:     %BeingDefined.ref: type = name_ref BeingDefined, file.%BeingDefined.decl [template = constants.%.2]
 // CHECK:STDOUT:     %T.ref: <error> = name_ref T, <error> [template = <error>]

--- a/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
@@ -50,7 +50,7 @@ interface BeingDefined {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Undefined [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BeingDefined [template]
-// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @BeingDefined, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in BeingDefined> = assoc_entity element0, @BeingDefined.%H [template]
 // CHECK:STDOUT: }
@@ -72,7 +72,7 @@ interface BeingDefined {
 // CHECK:STDOUT: interface @Undefined;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BeingDefined {
-// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: BeingDefined = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %H: <function> = fn_decl @H [template] {
 // CHECK:STDOUT:     %BeingDefined.ref: type = name_ref BeingDefined, file.%BeingDefined.decl [template = constants.%.2]
 // CHECK:STDOUT:     %T.ref: <error> = name_ref T, <error> [template = <error>]

--- a/toolchain/check/testdata/interface/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_member_lookup.carbon
@@ -27,6 +27,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @Interface, type [template]
@@ -45,7 +46,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]

--- a/toolchain/check/testdata/interface/fail_member_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_member_lookup.carbon
@@ -27,7 +27,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @Interface, type [template]
@@ -46,7 +46,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]

--- a/toolchain/check/testdata/interface/fail_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_modifiers.carbon
@@ -33,8 +33,10 @@ protected interface Protected;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Abstract [template]
+// CHECK:STDOUT:   %Self.1: Abstract = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Default [template]
 // CHECK:STDOUT:   %.3: type = interface_type @Virtual [template]
+// CHECK:STDOUT:   %Self.2: Virtual = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.4: type = interface_type @Protected [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -54,7 +56,7 @@ protected interface Protected;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Abstract {
-// CHECK:STDOUT:   %Self: Abstract = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Abstract = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -64,7 +66,7 @@ protected interface Protected;
 // CHECK:STDOUT: interface @Default;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Virtual {
-// CHECK:STDOUT:   %Self: Virtual = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Virtual = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_modifiers.carbon
@@ -33,10 +33,10 @@ protected interface Protected;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Abstract [template]
-// CHECK:STDOUT:   %Self.1: Abstract = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Abstract = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Default [template]
 // CHECK:STDOUT:   %.3: type = interface_type @Virtual [template]
-// CHECK:STDOUT:   %Self.2: Virtual = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Virtual = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.4: type = interface_type @Protected [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -56,7 +56,7 @@ protected interface Protected;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Abstract {
-// CHECK:STDOUT:   %Self: Abstract = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Abstract = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -66,7 +66,7 @@ protected interface Protected;
 // CHECK:STDOUT: interface @Default;
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Virtual {
-// CHECK:STDOUT:   %Self: Virtual = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: Virtual = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_redeclare_member.carbon
+++ b/toolchain/check/testdata/interface/fail_redeclare_member.carbon
@@ -19,6 +19,7 @@ interface Interface {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT: }
@@ -33,7 +34,7 @@ interface Interface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template] {}

--- a/toolchain/check/testdata/interface/fail_redeclare_member.carbon
+++ b/toolchain/check/testdata/interface/fail_redeclare_member.carbon
@@ -19,7 +19,7 @@ interface Interface {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT: }
@@ -34,7 +34,7 @@ interface Interface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc8: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %.loc15: <function> = fn_decl @.1 [template] {}

--- a/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
@@ -20,6 +20,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type (type, type) [template]
 // CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @I, type [template]
@@ -39,7 +40,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %.loc12_35: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc12_36.1: type = converted %.loc12_35, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]

--- a/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_assoc_const_default.carbon
@@ -20,7 +20,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type (type, type) [template]
 // CHECK:STDOUT:   %.3: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: type = assoc_entity_type @I, type [template]
@@ -40,7 +40,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %.loc12_35: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc12_36.1: type = converted %.loc12_35, constants.%.3 [template = constants.%.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
@@ -21,7 +21,7 @@ interface Interface {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Interface> = assoc_entity element1, @Interface.%G [template]
@@ -37,7 +37,7 @@ interface Interface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_inline.carbon
@@ -21,6 +21,7 @@ interface Interface {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Interface> = assoc_entity element1, @Interface.%G [template]
@@ -36,7 +37,7 @@ interface Interface {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -39,6 +39,7 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Interface> = assoc_entity element1, @Interface.%G [template]
@@ -62,7 +63,7 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_define_default_fn_out_of_line.carbon
@@ -39,7 +39,7 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Interface> = assoc_entity element1, @Interface.%G [template]
@@ -63,7 +63,7 @@ fn Interface.G(a: i32, b: i32) -> i32 = "int.sadd";
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
@@ -25,10 +25,10 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
-// CHECK:STDOUT:   %T: Interface = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: Interface = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -44,12 +44,12 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:   %CallStatic: <function> = fn_decl @CallStatic [template] {
 // CHECK:STDOUT:     %Interface.ref.loc9: type = name_ref Interface, %Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc9_15.1: Interface = param T
-// CHECK:STDOUT:     @CallStatic.%T: Interface = bind_symbolic_name T, %T.loc9_15.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @CallStatic.%T: Interface = bind_symbolic_name T 0, %T.loc9_15.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallFacet: <function> = fn_decl @CallFacet [template] {
 // CHECK:STDOUT:     %Interface.ref.loc17: type = name_ref Interface, %Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc17_14.1: Interface = param T
-// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T, %T.loc17_14.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T 0, %T.loc17_14.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %T.ref: Interface = name_ref T, @CallFacet.%T [symbolic = constants.%T]
 // CHECK:STDOUT:     %.loc17_32.1: type = facet_type_access %T.ref [symbolic = constants.%T]
 // CHECK:STDOUT:     %.loc17_32.2: type = converted %T.ref, %.loc17_32.1 [symbolic = constants.%T]
@@ -59,7 +59,7 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc7: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_facet_lookup.carbon
@@ -25,8 +25,10 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Interface [template]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Interface, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Interface> = assoc_entity element0, @Interface.%F [template]
+// CHECK:STDOUT:   %T: Interface = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -42,22 +44,22 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:   %CallStatic: <function> = fn_decl @CallStatic [template] {
 // CHECK:STDOUT:     %Interface.ref.loc9: type = name_ref Interface, %Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc9_15.1: Interface = param T
-// CHECK:STDOUT:     @CallStatic.%T: Interface = bind_symbolic_name T, %T.loc9_15.1 [symbolic]
+// CHECK:STDOUT:     @CallStatic.%T: Interface = bind_symbolic_name T, %T.loc9_15.1 [symbolic = constants.%T]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallFacet: <function> = fn_decl @CallFacet [template] {
 // CHECK:STDOUT:     %Interface.ref.loc17: type = name_ref Interface, %Interface.decl [template = constants.%.1]
 // CHECK:STDOUT:     %T.loc17_14.1: Interface = param T
-// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T, %T.loc17_14.1 [symbolic]
-// CHECK:STDOUT:     %T.ref: Interface = name_ref T, @CallFacet.%T [symbolic = @CallFacet.%T]
-// CHECK:STDOUT:     %.loc17_32.1: type = facet_type_access %T.ref [symbolic = @CallFacet.%T]
-// CHECK:STDOUT:     %.loc17_32.2: type = converted %T.ref, %.loc17_32.1 [symbolic = @CallFacet.%T]
+// CHECK:STDOUT:     @CallFacet.%T: Interface = bind_symbolic_name T, %T.loc17_14.1 [symbolic = constants.%T]
+// CHECK:STDOUT:     %T.ref: Interface = name_ref T, @CallFacet.%T [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc17_32.1: type = facet_type_access %T.ref [symbolic = constants.%T]
+// CHECK:STDOUT:     %.loc17_32.2: type = converted %T.ref, %.loc17_32.1 [symbolic = constants.%T]
 // CHECK:STDOUT:     %x.loc17_29.1: T = param x
 // CHECK:STDOUT:     @CallFacet.%x: T = bind_name x, %x.loc17_29.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Interface {
-// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Interface = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc7: <associated <function> in Interface> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:
@@ -71,7 +73,7 @@ fn CallFacet(T:! Interface, x: T) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @CallStatic(%T: Interface) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T.ref: Interface = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref: Interface = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %F.ref: <associated <function> in Interface> = name_ref F, @Interface.%.loc7 [template = constants.%.3]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
@@ -27,10 +27,12 @@ private interface Private {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Modifiers [template]
+// CHECK:STDOUT:   %Self.1: Modifiers = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Modifiers, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Modifiers> = assoc_entity element0, @Modifiers.%Final [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Modifiers> = assoc_entity element1, @Modifiers.%Default [template]
 // CHECK:STDOUT:   %.5: type = interface_type @Private [template]
+// CHECK:STDOUT:   %Self.2: Private = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,7 +47,7 @@ private interface Private {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Modifiers {
-// CHECK:STDOUT:   %Self: Modifiers = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Modifiers = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Modifiers> = assoc_entity element0, %Final [template = constants.%.3]
 // CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template] {}
@@ -59,7 +61,7 @@ private interface Private {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Private {
-// CHECK:STDOUT:   %Self: Private = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Private = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
+++ b/toolchain/check/testdata/interface/fail_todo_modifiers.carbon
@@ -27,12 +27,12 @@ private interface Private {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Modifiers [template]
-// CHECK:STDOUT:   %Self.1: Modifiers = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Modifiers = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Modifiers, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Modifiers> = assoc_entity element0, @Modifiers.%Final [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Modifiers> = assoc_entity element1, @Modifiers.%Default [template]
 // CHECK:STDOUT:   %.5: type = interface_type @Private [template]
-// CHECK:STDOUT:   %Self.2: Private = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Private = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,7 +47,7 @@ private interface Private {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Modifiers {
-// CHECK:STDOUT:   %Self: Modifiers = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Modifiers = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Final: <function> = fn_decl @Final [template] {}
 // CHECK:STDOUT:   %.loc12: <associated <function> in Modifiers> = assoc_entity element0, %Final [template = constants.%.3]
 // CHECK:STDOUT:   %Default: <function> = fn_decl @Default [template] {}
@@ -61,7 +61,7 @@ private interface Private {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Private {
-// CHECK:STDOUT:   %Self: Private = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: Private = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self

--- a/toolchain/check/testdata/interface/import.carbon
+++ b/toolchain/check/testdata/interface/import.carbon
@@ -47,15 +47,15 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Basic [template]
-// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Basic, type [template]
 // CHECK:STDOUT:   %.4: <associated type in Basic> = assoc_entity element0, @Basic.%T [template]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Basic, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Basic> = assoc_entity element1, @Basic.%F [template]
 // CHECK:STDOUT:   %.7: type = interface_type @ForwardDeclared [template]
-// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = assoc_entity_type @ForwardDeclared, type [template]
 // CHECK:STDOUT:   %.9: <associated type in ForwardDeclared> = assoc_entity element0, @ForwardDeclared.%T [template]
 // CHECK:STDOUT:   %.10: type = assoc_entity_type @ForwardDeclared, <function> [template]
@@ -85,7 +85,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -93,7 +93,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Basic {
-// CHECK:STDOUT:   %Self: Basic = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: Basic = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc8: <associated type in Basic> = assoc_entity element0, %T [template = constants.%.4]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
@@ -107,7 +107,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
-// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self 0 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc15: <associated type in ForwardDeclared> = assoc_entity element0, %T [template = constants.%.9]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
@@ -128,12 +128,12 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
-// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = interface_type @Basic [template]
-// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.4: type = interface_type @ForwardDeclared [template]
-// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Basic, type [template]
 // CHECK:STDOUT:   %.6: <associated type in Basic> = assoc_entity element0, file.%import_ref.16 [template]
 // CHECK:STDOUT:   %.7: type = assoc_entity_type @Basic, <function> [template]

--- a/toolchain/check/testdata/interface/import.carbon
+++ b/toolchain/check/testdata/interface/import.carbon
@@ -47,12 +47,15 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = interface_type @Basic [template]
+// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Basic, type [template]
 // CHECK:STDOUT:   %.4: <associated type in Basic> = assoc_entity element0, @Basic.%T [template]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Basic, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Basic> = assoc_entity element1, @Basic.%F [template]
 // CHECK:STDOUT:   %.7: type = interface_type @ForwardDeclared [template]
+// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = assoc_entity_type @ForwardDeclared, type [template]
 // CHECK:STDOUT:   %.9: <associated type in ForwardDeclared> = assoc_entity element0, @ForwardDeclared.%T [template]
 // CHECK:STDOUT:   %.10: type = assoc_entity_type @ForwardDeclared, <function> [template]
@@ -82,7 +85,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Empty {
-// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Empty = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -90,7 +93,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Basic {
-// CHECK:STDOUT:   %Self: Basic = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Basic = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc8: <associated type in Basic> = assoc_entity element0, %T [template = constants.%.4]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.1 [template] {}
@@ -104,7 +107,7 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ForwardDeclared {
-// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: ForwardDeclared = bind_symbolic_name Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %T: type = assoc_const_decl T [template]
 // CHECK:STDOUT:   %.loc15: <associated type in ForwardDeclared> = assoc_entity element0, %T [template = constants.%.9]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.2 [template] {}
@@ -125,9 +128,12 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Empty [template]
+// CHECK:STDOUT:   %Self.1: Empty = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = interface_type @Basic [template]
+// CHECK:STDOUT:   %Self.2: Basic = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.4: type = interface_type @ForwardDeclared [template]
+// CHECK:STDOUT:   %Self.3: ForwardDeclared = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Basic, type [template]
 // CHECK:STDOUT:   %.6: <associated type in Basic> = assoc_entity element0, file.%import_ref.16 [template]
 // CHECK:STDOUT:   %.7: type = assoc_entity_type @Basic, <function> [template]
@@ -158,9 +164,9 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     .f = %f.loc16
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_13 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+5, loc_22 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+16, loc_31 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir2, inst+37, loc_70
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+6, loc_22 [template = constants.%.3]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+18, loc_31 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir2, inst+40, loc_70
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+4, unloaded
 // CHECK:STDOUT:   %UseEmpty: <function> = fn_decl @UseEmpty [template] {
@@ -169,22 +175,22 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     %e.loc6_13.1: Empty = param e
 // CHECK:STDOUT:     @UseEmpty.%e: Empty = bind_name e, %e.loc6_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir2, inst+14, loc_48 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir2, inst+10, loc_41 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir2, inst+16, loc_48 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir2, inst+12, loc_41 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+14, unloaded
 // CHECK:STDOUT:   %UseBasic: <function> = fn_decl @UseBasic [template] {
 // CHECK:STDOUT:     %Basic.decl: type = interface_decl @Basic [template = constants.%.3] {}
 // CHECK:STDOUT:     %Basic.ref.loc7: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
 // CHECK:STDOUT:     %e.loc7_13.1: Basic = param e
 // CHECK:STDOUT:     @UseBasic.%e: Basic = bind_name e, %e.loc7_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir2, inst+26, loc_62 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir2, inst+22, loc_55 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir2, inst+29, loc_62 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir2, inst+25, loc_55 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+23, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+27, unloaded
 // CHECK:STDOUT:   %UseForwardDeclared: <function> = fn_decl @UseForwardDeclared [template] {
 // CHECK:STDOUT:     %ForwardDeclared.decl: type = interface_decl @ForwardDeclared [template = constants.%.4] {}
 // CHECK:STDOUT:     %ForwardDeclared.ref.loc8: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
@@ -192,19 +198,19 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     @UseForwardDeclared.%f: ForwardDeclared = bind_name f, %f.loc8_23.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Basic.ref.loc10: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+10, unloaded
 // CHECK:STDOUT:   %T.ref.loc10: <associated type in Basic> = name_ref T, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %UseBasicT: <associated type in Basic> = bind_alias UseBasicT, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %Basic.ref.loc11: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+14, unloaded
 // CHECK:STDOUT:   %F.ref.loc11: <associated <function> in Basic> = name_ref F, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %UseBasicF: <associated <function> in Basic> = bind_alias UseBasicF, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc13: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+23, unloaded
 // CHECK:STDOUT:   %T.ref.loc13: <associated type in ForwardDeclared> = name_ref T, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %UseForwardDeclaredT: <associated type in ForwardDeclared> = bind_alias UseForwardDeclaredT, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc14: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+27, unloaded
 // CHECK:STDOUT:   %F.ref.loc14: <associated <function> in ForwardDeclared> = name_ref F, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %UseForwardDeclaredF: <associated <function> in ForwardDeclared> = bind_alias UseForwardDeclaredF, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]

--- a/toolchain/check/testdata/interface/self.carbon
+++ b/toolchain/check/testdata/interface/self.carbon
@@ -12,6 +12,7 @@ interface UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @UseSelf, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in UseSelf> = assoc_entity element0, @UseSelf.%F [template]
 // CHECK:STDOUT: }
@@ -26,16 +27,16 @@ interface UseSelf {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @UseSelf {
-// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_14.2: type = converted %Self.ref.loc8_14, %.loc8_14.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc8_8.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_8.2: Self = bind_name self, %self.loc8_8.1
-// CHECK:STDOUT:     %Self.ref.loc8_25: UseSelf = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_25.1: type = facet_type_access %Self.ref.loc8_25 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_25.2: type = converted %Self.ref.loc8_25, %.loc8_25.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_25: UseSelf = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_25.1: type = facet_type_access %Self.ref.loc8_25 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_25.2: type = converted %Self.ref.loc8_25, %.loc8_25.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_29: <associated <function> in UseSelf> = assoc_entity element0, %F [template = constants.%.3]

--- a/toolchain/check/testdata/interface/self.carbon
+++ b/toolchain/check/testdata/interface/self.carbon
@@ -12,7 +12,7 @@ interface UseSelf {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @UseSelf [template]
-// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @UseSelf, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in UseSelf> = assoc_entity element0, @UseSelf.%F [template]
 // CHECK:STDOUT: }
@@ -27,7 +27,7 @@ interface UseSelf {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @UseSelf {
-// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: UseSelf = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_14: UseSelf = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc8_14.1: type = facet_type_access %Self.ref.loc8_14 [symbolic = constants.%Self]

--- a/toolchain/check/testdata/interface/todo_define_not_default.carbon
+++ b/toolchain/check/testdata/interface/todo_define_not_default.carbon
@@ -19,7 +19,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in I> = assoc_entity element1, @I.%G [template]
@@ -42,7 +42,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc9: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/interface/todo_define_not_default.carbon
+++ b/toolchain/check/testdata/interface/todo_define_not_default.carbon
@@ -19,6 +19,7 @@ interface I {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @I [template]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @I, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in I> = assoc_entity element0, @I.%F [template]
 // CHECK:STDOUT:   %.4: <associated <function> in I> = assoc_entity element1, @I.%G [template]
@@ -41,7 +42,7 @@ interface I {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
-// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: I = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT:   %.loc9: <associated <function> in I> = assoc_entity element0, %F [template = constants.%.3]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -21,6 +21,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 5 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -39,8 +40,8 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc14: i32 = int_literal 5 [template = constants.%.1]
 // CHECK:STDOUT:   %x: T = bind_name x, <error>
 // CHECK:STDOUT:   %x.ref: T = name_ref x, %x

--- a/toolchain/check/testdata/let/fail_generic.carbon
+++ b/toolchain/check/testdata/let/fail_generic.carbon
@@ -21,7 +21,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 5 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -40,7 +40,7 @@ fn F(a: i32) -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F(%a: i32) -> i32 {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, i32 [symbolic = constants.%T]
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc14: i32 = int_literal 5 [template = constants.%.1]
 // CHECK:STDOUT:   %x: T = bind_name x, <error>

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -23,7 +23,7 @@ let a: T = 0;
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,13 +31,13 @@ let a: T = 0;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, i32 [symbolic = constants.%T]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -22,17 +22,22 @@ let a: T = 0;
 
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- fail_implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -41,9 +46,9 @@ let a: T = 0;
 // CHECK:STDOUT:     .T = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = constants.%T]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T.ref: type = name_ref T, %import_ref [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %T.ref: type = name_ref T, %import_ref [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   %a: T = bind_name a, <error>
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/generic.carbon
+++ b/toolchain/check/testdata/let/generic.carbon
@@ -13,7 +13,7 @@ fn F() {
 // CHECK:STDOUT: --- generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -28,7 +28,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, i32 [symbolic = constants.%T]
 // CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc9: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:   %p.var: ref T* = var p

--- a/toolchain/check/testdata/let/generic.carbon
+++ b/toolchain/check/testdata/let/generic.carbon
@@ -13,6 +13,7 @@ fn F() {
 // CHECK:STDOUT: --- generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -27,12 +28,12 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
-// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T.ref.loc9: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc9: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:   %p.var: ref T* = var p
 // CHECK:STDOUT:   %p: ref T* = bind_name p, %p.var
-// CHECK:STDOUT:   %T.ref.loc10: type = name_ref T, %T [symbolic = %T]
+// CHECK:STDOUT:   %T.ref.loc10: type = name_ref T, %T [symbolic = constants.%T]
 // CHECK:STDOUT:   %a.var: ref T = var a
 // CHECK:STDOUT:   %a: ref T = bind_name a, %a.var
 // CHECK:STDOUT:   %p.ref: ref T* = name_ref p, %p

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -19,17 +19,22 @@ var b: T = *a;
 
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -40,13 +45,13 @@ var b: T = *a;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = constants.%T]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T.ref.loc4: type = name_ref T, %import_ref [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %T.ref.loc4: type = name_ref T, %import_ref [symbolic = constants.%T]
 // CHECK:STDOUT:   %.loc4: type = ptr_type T [symbolic = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref T* = var a
 // CHECK:STDOUT:   %a: ref T* = bind_name a, %a.var
-// CHECK:STDOUT:   %T.ref.loc5: type = name_ref T, %import_ref [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %T.ref.loc5: type = name_ref T, %import_ref [symbolic = constants.%T]
 // CHECK:STDOUT:   %b.var: ref T = var b
 // CHECK:STDOUT:   %b: ref T = bind_name b, %b.var
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -20,7 +20,7 @@ var b: T = *a;
 // CHECK:STDOUT: --- implicit.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,13 +28,13 @@ var b: T = *a;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T, i32 [symbolic = constants.%T]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0, i32 [symbolic = constants.%T]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %T: type = bind_symbolic_name T [symbolic]
+// CHECK:STDOUT:   %T: type = bind_symbolic_name T 0 [symbolic]
 // CHECK:STDOUT:   %.1: type = ptr_type T [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/import.carbon
+++ b/toolchain/check/testdata/let/import.carbon
@@ -20,7 +20,7 @@ let b:! bool = a;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: bool = bool_literal true [template]
-// CHECK:STDOUT:   %a: bool = bind_symbolic_name a [symbolic]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -29,14 +29,14 @@ let b:! bool = a;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   %a: bool = bind_symbolic_name a, %.loc4 [symbolic = constants.%a]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a 0, %.loc4 [symbolic = constants.%a]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %a: bool = bind_symbolic_name a [symbolic]
-// CHECK:STDOUT:   %b: bool = bind_symbolic_name b [symbolic]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a 0 [symbolic]
+// CHECK:STDOUT:   %b: bool = bind_symbolic_name b 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,6 +47,6 @@ let b:! bool = a;
 // CHECK:STDOUT:   %import_ref: bool = import_ref ir1, inst+2, loc_10 [symbolic = constants.%a]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a.ref: bool = name_ref a, %import_ref [symbolic = constants.%a]
-// CHECK:STDOUT:   %b: bool = bind_symbolic_name b, %a.ref [symbolic = constants.%b]
+// CHECK:STDOUT:   %b: bool = bind_symbolic_name b 0, %a.ref [symbolic = constants.%b]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/let/import.carbon
+++ b/toolchain/check/testdata/let/import.carbon
@@ -20,6 +20,7 @@ let b:! bool = a;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: bool = bool_literal true [template]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -28,19 +29,24 @@ let b:! bool = a;
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4: bool = bool_literal true [template = constants.%.1]
-// CHECK:STDOUT:   %a: bool = bind_symbolic_name a, %.loc4 [symbolic]
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a, %.loc4 [symbolic = constants.%a]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit.impl.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %a: bool = bind_symbolic_name a [symbolic]
+// CHECK:STDOUT:   %b: bool = bind_symbolic_name b [symbolic]
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   package: <namespace> = namespace [template] {
 // CHECK:STDOUT:     .a = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: bool = import_ref ir1, inst+2, loc_10 [symbolic = <unexpected instref inst+4>]
+// CHECK:STDOUT:   %import_ref: bool = import_ref ir1, inst+2, loc_10 [symbolic = constants.%a]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %a.ref: bool = name_ref a, %import_ref [symbolic = <unexpected instref inst+4>]
-// CHECK:STDOUT:   %b: bool = bind_symbolic_name b, %a.ref [symbolic]
+// CHECK:STDOUT:   %a.ref: bool = name_ref a, %import_ref [symbolic = constants.%a]
+// CHECK:STDOUT:   %b: bool = bind_symbolic_name b, %a.ref [symbolic = constants.%b]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Add> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitAnd [template]
-// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitAnd, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitAnd> = assoc_entity element0, @BitAnd.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitAndAssign [template]
-// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitAndAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitAndAssign> = assoc_entity element0, @BitAndAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAnd {
-// CHECK:STDOUT:   %Self: BitAnd = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: BitAnd = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: BitAnd = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAndAssign {
-// CHECK:STDOUT:   %Self: BitAndAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: BitAndAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitAndAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitAnd [template]
-// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitAndAssign [template]
-// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitAnd [template]
+// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitAnd, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitAnd> = assoc_entity element0, @BitAnd.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitAndAssign [template]
+// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitAndAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitAndAssign> = assoc_entity element0, @BitAndAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAnd {
-// CHECK:STDOUT:   %Self: BitAnd = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitAnd = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: BitAnd = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: BitAnd = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: BitAnd = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: BitAnd = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: BitAnd = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: BitAnd = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in BitAnd> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAndAssign {
-// CHECK:STDOUT:   %Self: BitAndAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitAndAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: BitAndAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: BitAndAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: BitAndAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: BitAndAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitAnd [template]
+// CHECK:STDOUT:   %Self.1: BitAnd = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitAndAssign [template]
+// CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitAnd.decl: type = interface_decl @BitAnd [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitAnd.ref: type = name_ref BitAnd, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAnd {

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -36,7 +36,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitComplement [template]
-// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitComplement, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitComplement> = assoc_entity element0, @BitComplement.%Op [template]
 // CHECK:STDOUT: }
@@ -49,7 +49,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitComplement {
-// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: BitComplement = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
@@ -77,7 +77,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitComplement [template]
-// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -36,6 +36,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitComplement [template]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitComplement, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitComplement> = assoc_entity element0, @BitComplement.%Op [template]
 // CHECK:STDOUT: }
@@ -48,16 +49,16 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitComplement {
-// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: BitComplement = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: BitComplement = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_26: BitComplement = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_26.1: type = facet_type_access %Self.ref.loc5_26 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_26.2: type = converted %Self.ref.loc5_26, %.loc5_26.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_26: BitComplement = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_26.1: type = facet_type_access %Self.ref.loc5_26 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_26.2: type = converted %Self.ref.loc5_26, %.loc5_26.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_30: <associated <function> in BitComplement> = assoc_entity element0, %Op [template = constants.%.3]
@@ -76,6 +77,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitComplement [template]
+// CHECK:STDOUT:   %Self: BitComplement = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -93,9 +95,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir3, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir3, inst+16, loc_50 [template = constants.%.8]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+14, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -110,7 +112,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+14, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitComplement {

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitOr [template]
+// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitOr, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitOr> = assoc_entity element0, @BitOr.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitOrAssign [template]
+// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitOrAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitOrAssign> = assoc_entity element0, @BitOrAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOr {
-// CHECK:STDOUT:   %Self: BitOr = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitOr = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: BitOr = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: BitOr = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: BitOr = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: BitOr = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: BitOr = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: BitOr = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in BitOr> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOrAssign {
-// CHECK:STDOUT:   %Self: BitOrAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitOrAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: BitOrAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: BitOrAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: BitOrAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: BitOrAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitOr [template]
+// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitOrAssign [template]
+// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitOr.decl: type = interface_decl @BitOr [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitOr.ref: type = name_ref BitOr, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOr {

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitOr [template]
-// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitOr, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitOr> = assoc_entity element0, @BitOr.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitOrAssign [template]
-// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitOrAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitOrAssign> = assoc_entity element0, @BitOrAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOr {
-// CHECK:STDOUT:   %Self: BitOr = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: BitOr = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: BitOr = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOrAssign {
-// CHECK:STDOUT:   %Self: BitOrAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: BitOrAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitOrAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitOr [template]
-// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitOr = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitOrAssign [template]
-// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitXor [template]
-// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitXor, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitXor> = assoc_entity element0, @BitXor.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitXorAssign [template]
-// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitXorAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitXorAssign> = assoc_entity element0, @BitXorAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXor {
-// CHECK:STDOUT:   %Self: BitXor = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: BitXor = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: BitXor = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXorAssign {
-// CHECK:STDOUT:   %Self: BitXorAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: BitXorAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: BitXorAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitXor [template]
-// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitXorAssign [template]
-// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @BitXor [template]
+// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @BitXor, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in BitXor> = assoc_entity element0, @BitXor.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @BitXorAssign [template]
+// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @BitXorAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in BitXorAssign> = assoc_entity element0, @BitXorAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXor {
-// CHECK:STDOUT:   %Self: BitXor = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitXor = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: BitXor = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: BitXor = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: BitXor = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: BitXor = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: BitXor = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: BitXor = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in BitXor> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXorAssign {
-// CHECK:STDOUT:   %Self: BitXorAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: BitXorAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: BitXorAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: BitXorAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: BitXorAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: BitXorAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @BitXor [template]
+// CHECK:STDOUT:   %Self.1: BitXor = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @BitXorAssign [template]
+// CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitXor.decl: type = interface_decl @BitXor [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitXor.ref: type = name_ref BitXor, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXor {

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -35,6 +35,7 @@ fn TestOp() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Dec [template]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Dec, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Dec> = assoc_entity element0, @Dec.%Op [template]
@@ -48,11 +49,11 @@ fn TestOp() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Dec {
-// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
-// CHECK:STDOUT:     %Self.ref: Dec = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Dec = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
@@ -74,6 +75,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Dec [template]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]
@@ -93,9 +95,9 @@ fn TestOp() {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir3, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir3, inst+15, loc_47 [template = constants.%.10]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -104,7 +106,7 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Dec {

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -35,7 +35,7 @@ fn TestOp() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Dec [template]
-// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Dec, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Dec> = assoc_entity element0, @Dec.%Op [template]
@@ -49,7 +49,7 @@ fn TestOp() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Dec {
-// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref: Dec = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
@@ -75,7 +75,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Dec [template]
-// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Dec = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Div [template]
+// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Div, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Div> = assoc_entity element0, @Div.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @DivAssign [template]
+// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @DivAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in DivAssign> = assoc_entity element0, @DivAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Div {
-// CHECK:STDOUT:   %Self: Div = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Div = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Div = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Div = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Div = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Div = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Div = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Div = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Div> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @DivAssign {
-// CHECK:STDOUT:   %Self: DivAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: DivAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: DivAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: DivAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: DivAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: DivAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Div [template]
+// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @DivAssign [template]
+// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Div.decl: type = interface_decl @Div [template = constants.%.2] {}
 // CHECK:STDOUT:     %Div.ref: type = name_ref Div, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Div {

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Div [template]
-// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Div, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Div> = assoc_entity element0, @Div.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @DivAssign [template]
-// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @DivAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in DivAssign> = assoc_entity element0, @DivAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Div {
-// CHECK:STDOUT:   %Self: Div = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Div = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Div = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @DivAssign {
-// CHECK:STDOUT:   %Self: DivAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: DivAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: DivAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Div [template]
-// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Div = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @DivAssign [template]
-// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -96,7 +96,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Eq [template]
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Eq, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Eq> = assoc_entity element0, @Eq.%Equal [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Eq> = assoc_entity element1, @Eq.%NotEqual [template]
@@ -110,7 +110,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Equal: <function> = fn_decl @Equal [template] {
 // CHECK:STDOUT:     %Self.ref.loc7_18: Eq = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc7_18.1: type = facet_type_access %Self.ref.loc7_18 [symbolic = constants.%Self]
@@ -157,7 +157,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Eq [template]
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Equal, @impl.%NotEqual) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -291,7 +291,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Eq [template]
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Eq, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Eq> = assoc_entity element0, file.%import_ref.7 [template]
 // CHECK:STDOUT:   %.7: <associated <function> in Eq> = assoc_entity element1, file.%import_ref.9 [template]
@@ -370,7 +370,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Eq [template]
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Equal, @impl.%NotEqual) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -96,6 +96,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Eq [template]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Eq, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Eq> = assoc_entity element0, @Eq.%Equal [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Eq> = assoc_entity element1, @Eq.%NotEqual [template]
@@ -109,30 +110,30 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
-// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Equal: <function> = fn_decl @Equal [template] {
-// CHECK:STDOUT:     %Self.ref.loc7_18: Eq = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc7_18.1: type = facet_type_access %Self.ref.loc7_18 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc7_18.2: type = converted %Self.ref.loc7_18, %.loc7_18.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc7_18: Eq = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc7_18.1: type = facet_type_access %Self.ref.loc7_18 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc7_18.2: type = converted %Self.ref.loc7_18, %.loc7_18.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc7_12.1: Self = param self
 // CHECK:STDOUT:     %self.loc7_12.2: Self = bind_name self, %self.loc7_12.1
-// CHECK:STDOUT:     %Self.ref.loc7_31: Eq = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc7_31.1: type = facet_type_access %Self.ref.loc7_31 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc7_31.2: type = converted %Self.ref.loc7_31, %.loc7_31.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc7_31: Eq = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc7_31.1: type = facet_type_access %Self.ref.loc7_31 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc7_31.2: type = converted %Self.ref.loc7_31, %.loc7_31.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc7_24.1: Self = param other
 // CHECK:STDOUT:     %other.loc7_24.2: Self = bind_name other, %other.loc7_24.1
 // CHECK:STDOUT:     %return.var.loc7: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc7_44: <associated <function> in Eq> = assoc_entity element0, %Equal [template = constants.%.3]
 // CHECK:STDOUT:   %NotEqual: <function> = fn_decl @NotEqual [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_21: Eq = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_21.1: type = facet_type_access %Self.ref.loc8_21 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_21.2: type = converted %Self.ref.loc8_21, %.loc8_21.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_21: Eq = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_21.1: type = facet_type_access %Self.ref.loc8_21 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_21.2: type = converted %Self.ref.loc8_21, %.loc8_21.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc8_15.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_15.2: Self = bind_name self, %self.loc8_15.1
-// CHECK:STDOUT:     %Self.ref.loc8_34: Eq = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: Eq = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:     %return.var.loc8: ref bool = var <return slot>
@@ -156,6 +157,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Eq [template]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Equal, @impl.%NotEqual) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -175,10 +177,10 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_68 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_88 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+15, loc_19 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+30, loc_19 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+18, loc_68 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+32, loc_88 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+16, loc_19 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+31, loc_19 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -195,7 +197,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.7: type = import_ref ir3, inst+1, loc_68 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+16, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc17_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc17_17.1: C = param a
@@ -206,7 +208,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_88 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+31, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -289,6 +291,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Eq [template]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Eq, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Eq> = assoc_entity element0, file.%import_ref.7 [template]
 // CHECK:STDOUT:   %.7: <associated <function> in Eq> = assoc_entity element1, file.%import_ref.9 [template]
@@ -314,11 +317,11 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_30 [template = constants.%.4]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+18, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+32, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+31, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+16, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_20: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_17.1: D = param a
@@ -329,7 +332,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.8: type = import_ref ir3, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+31, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -367,6 +370,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Eq [template]
+// CHECK:STDOUT:   %Self: Eq = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Equal, @impl.%NotEqual) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -388,10 +392,10 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_23 [template = constants.%.2]
 // CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_73 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_93 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+15, loc_24 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+30, loc_24 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+18, loc_73 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+32, loc_93 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+16, loc_24 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+31, loc_24 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -408,7 +412,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestRhsBad.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.7: type = import_ref ir3, inst+1, loc_73 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+16, unloaded
 // CHECK:STDOUT:   %TestLhsBad: <function> = fn_decl @TestLhsBad [template] {
 // CHECK:STDOUT:     %D.ref.loc25: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc25_15.1: D = param a
@@ -419,7 +423,7 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestLhsBad.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_93 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+31, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -55,12 +55,12 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
 // CHECK:STDOUT:   %.5: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.6: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.7: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.8: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -76,7 +76,7 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.1]
@@ -95,7 +95,7 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -128,12 +128,12 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.6: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.7: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.2.%Op) [template]
 // CHECK:STDOUT:   %.9: type = tuple_type () [template]

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -55,10 +55,12 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
 // CHECK:STDOUT:   %.5: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.6: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.7: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.8: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -74,11 +76,11 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
@@ -93,18 +95,18 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.6]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -126,10 +128,12 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self.1: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.6: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.7: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.2.%Op) [template]
 // CHECK:STDOUT:   %.9: type = tuple_type () [template]
@@ -150,19 +154,19 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+14, loc_65 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+15, loc_65 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Inc.decl: type = interface_decl @Inc [template = constants.%.2] {}
 // CHECK:STDOUT:     %Inc.ref: type = name_ref Inc, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+16, loc_38 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+34, loc_82 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+32, loc_39 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+17, loc_38 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+36, loc_82 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+34, loc_39 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc11: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc11: <namespace> = name_ref Core, %Core [template = %Core]
@@ -175,7 +179,7 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     @TestIncNonRef.%a: C = bind_name a, %a.loc15_18.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_65 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+13, unloaded
 // CHECK:STDOUT:   %TestAddAssignNonRef: <function> = fn_decl @TestAddAssignNonRef [template] {
 // CHECK:STDOUT:     %C.ref.loc26_27: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc26_24.1: C = param a
@@ -184,8 +188,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %b.loc26_30.1: C = param b
 // CHECK:STDOUT:     @TestAddAssignNonRef.%b: C = bind_name b, %b.loc26_30.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+16, loc_82 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+32, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+17, loc_82 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+34, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -62,20 +62,20 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Negate [template]
-// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Negate> = assoc_entity element0, @Negate.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.7: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.9: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.10: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
 // CHECK:STDOUT:   %.11: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.12: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.13: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.14: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
@@ -95,7 +95,7 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref: Negate = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.1]
@@ -112,7 +112,7 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_15: Add = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_15.1: type = facet_type_access %Self.ref.loc8_15 [symbolic = constants.%Self.2]
@@ -138,7 +138,7 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %Self.ref.loc11_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc11_24.1: type = facet_type_access %Self.ref.loc11_20 [symbolic = constants.%Self.3]
@@ -162,7 +162,7 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self.4]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self 0 [symbolic = constants.%Self.4]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.4 [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self.4]
 // CHECK:STDOUT:     %.loc14_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.4]
@@ -196,20 +196,20 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Negate [template]
-// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Negate> = assoc_entity element0, file.%import_ref.5 [template]
 // CHECK:STDOUT:   %.7: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.9: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
 // CHECK:STDOUT:   %.10: C = struct_value () [template]
 // CHECK:STDOUT:   %.11: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.12: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.13: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.15 [template]
 // CHECK:STDOUT:   %.14: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.15: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.16: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.20 [template]
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -62,16 +62,20 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Negate [template]
+// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Negate> = assoc_entity element0, @Negate.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.7: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.9: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.10: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
 // CHECK:STDOUT:   %.11: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.12: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.13: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.14: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
@@ -91,11 +95,11 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref: Negate = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Negate = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
 // CHECK:STDOUT:   }
@@ -108,21 +112,21 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_15: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_15.1: type = facet_type_access %Self.ref.loc8_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_15.2: type = converted %Self.ref.loc8_15, %.loc8_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_15: Add = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_15.1: type = facet_type_access %Self.ref.loc8_15 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_15.2: type = converted %Self.ref.loc8_15, %.loc8_15.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %self.loc8_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_9.2: Self = bind_name self, %self.loc8_9.1
-// CHECK:STDOUT:     %Self.ref.loc8_28: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_28.1: type = facet_type_access %Self.ref.loc8_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_28.2: type = converted %Self.ref.loc8_28, %.loc8_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_28: Add = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_28.1: type = facet_type_access %Self.ref.loc8_28 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_28.2: type = converted %Self.ref.loc8_28, %.loc8_28.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_21.2: Self = bind_name other, %other.loc8_21.1
-// CHECK:STDOUT:     %Self.ref.loc8_37: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_37.1: type = facet_type_access %Self.ref.loc8_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_37.2: type = converted %Self.ref.loc8_37, %.loc8_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_37: Add = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_37.1: type = facet_type_access %Self.ref.loc8_37 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_37.2: type = converted %Self.ref.loc8_37, %.loc8_37.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_41: <associated <function> in Add> = assoc_entity element0, %Op [template = constants.%.6]
@@ -134,18 +138,18 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.3]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
-// CHECK:STDOUT:     %Self.ref.loc11_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_24.1: type = facet_type_access %Self.ref.loc11_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_24.2: type = converted %Self.ref.loc11_20, %.loc11_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc11_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc11_24.1: type = facet_type_access %Self.ref.loc11_20 [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc11_24.2: type = converted %Self.ref.loc11_20, %.loc11_24.1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %.loc11_24.3: type = ptr_type Self [symbolic = constants.%.8]
 // CHECK:STDOUT:     %self.loc11_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc11_14.3: Self* = bind_name self, %self.loc11_14.1
 // CHECK:STDOUT:     %.loc11_9: Self* = addr_pattern %self.loc11_14.3
-// CHECK:STDOUT:     %Self.ref.loc11_34: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_34.1: type = facet_type_access %Self.ref.loc11_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_34.2: type = converted %Self.ref.loc11_34, %.loc11_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc11_34: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc11_34.1: type = facet_type_access %Self.ref.loc11_34 [symbolic = constants.%Self.3]
+// CHECK:STDOUT:     %.loc11_34.2: type = converted %Self.ref.loc11_34, %.loc11_34.1 [symbolic = constants.%Self.3]
 // CHECK:STDOUT:     %other.loc11_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc11_27.2: Self = bind_name other, %other.loc11_27.1
 // CHECK:STDOUT:   }
@@ -158,11 +162,11 @@ fn TestRef(b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self.4]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.4 [template] {
-// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc14_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc14_24.2: type = converted %Self.ref, %.loc14_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self.4]
+// CHECK:STDOUT:     %.loc14_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self.4]
+// CHECK:STDOUT:     %.loc14_24.2: type = converted %Self.ref, %.loc14_24.1 [symbolic = constants.%Self.4]
 // CHECK:STDOUT:     %.loc14_24.3: type = ptr_type Self [symbolic = constants.%.12]
 // CHECK:STDOUT:     %self.loc14_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: Self* = bind_name self, %self.loc14_14.1
@@ -192,16 +196,20 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Negate [template]
+// CHECK:STDOUT:   %Self.1: Negate = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Negate> = assoc_entity element0, file.%import_ref.5 [template]
 // CHECK:STDOUT:   %.7: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.9: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
 // CHECK:STDOUT:   %.10: C = struct_value () [template]
 // CHECK:STDOUT:   %.11: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.12: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.13: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.15 [template]
 // CHECK:STDOUT:   %.14: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.15: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.16: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.20 [template]
 // CHECK:STDOUT: }
@@ -224,10 +232,10 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     @TestUnary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_25 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+11, loc_25 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+12, loc_25 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir3, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir3, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+10, unloaded
 // CHECK:STDOUT:   %TestBinary: <function> = fn_decl @TestBinary [template] {
 // CHECK:STDOUT:     %C.ref.loc16_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc16_15.1: C = param a
@@ -238,26 +246,26 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %C.ref.loc16_30: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestBinary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: type = import_ref ir3, inst+13, loc_45 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir3, inst+32, loc_45 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref ir3, inst+14, loc_45 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir3, inst+34, loc_45 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+32, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+32, unloaded
 // CHECK:STDOUT:   %TestRef: <function> = fn_decl @TestRef [template] {
 // CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc24_12.1: C = param b
 // CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc24_12.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+34, loc_66 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir3, inst+52, loc_66 [template = constants.%.13]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir3, inst+54, loc_69 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir3, inst+67, loc_69 [template = constants.%.16]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+56, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir3, inst+65, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref ir3, inst+65, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+36, loc_66 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir3, inst+55, loc_66 [template = constants.%.13]
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+53, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+53, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir3, inst+57, loc_69 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir3, inst+71, loc_69 [template = constants.%.16]
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+59, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir3, inst+69, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref ir3, inst+69, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -57,11 +57,11 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -77,7 +77,7 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -103,7 +103,7 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -137,10 +137,10 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Add [template]
-// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
-// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type C [template]
 // CHECK:STDOUT:   %.6: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.7: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -57,9 +57,11 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Add> = assoc_entity element0, @Add.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @AddAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in AddAssign> = assoc_entity element0, @AddAssign.%Op [template]
@@ -75,21 +77,21 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {
-// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Add = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Add> = assoc_entity element0, %Op [template = constants.%.3]
@@ -101,18 +103,18 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @AddAssign {
-// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: AddAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: AddAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -135,8 +137,10 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Add [template]
+// CHECK:STDOUT:   %Self.1: Add = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type C [template]
 // CHECK:STDOUT:   %.6: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.7: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -161,19 +165,19 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_23 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_81 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+21, loc_81 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_24 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_24 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc9: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+40, loc_102 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+42, loc_102 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc12: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc12: <namespace> = name_ref Core, %Core [template = %Core]
@@ -191,14 +195,14 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     @Test.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_81 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %D.ref.loc27: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %b.loc27_15.1: D = param b
 // CHECK:STDOUT:     @TestAssign.%b: D = bind_name b, %b.loc27_15.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_102 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_102 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -35,6 +35,7 @@ fn TestOp() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
@@ -48,11 +49,11 @@ fn TestOp() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
-// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_24.2: type = converted %Self.ref, %.loc5_24.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_24.3: type = ptr_type Self [symbolic = constants.%.2]
 // CHECK:STDOUT:     %self.loc5_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc5_14.3: Self* = bind_name self, %self.loc5_14.1
@@ -74,6 +75,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]
@@ -93,9 +95,9 @@ fn TestOp() {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+15, loc_47 [template = constants.%.10]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -104,7 +106,7 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -35,7 +35,7 @@ fn TestOp() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.3: type = assoc_entity_type @Inc, <function> [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Inc> = assoc_entity element0, @Inc.%Op [template]
@@ -49,7 +49,7 @@ fn TestOp() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref: Inc = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_24.1: type = facet_type_access %Self.ref [symbolic = constants.%Self]
@@ -75,7 +75,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Inc [template]
-// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Inc = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: type = ptr_type C [template]
 // CHECK:STDOUT:   %.4: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @LeftShift [template]
-// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @LeftShift, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in LeftShift> = assoc_entity element0, @LeftShift.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @LeftShiftAssign [template]
-// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @LeftShiftAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in LeftShiftAssign> = assoc_entity element0, @LeftShiftAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShift {
-// CHECK:STDOUT:   %Self: LeftShift = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: LeftShift = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: LeftShift = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShiftAssign {
-// CHECK:STDOUT:   %Self: LeftShiftAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: LeftShiftAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: LeftShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @LeftShift [template]
-// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @LeftShiftAssign [template]
-// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @LeftShift [template]
+// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @LeftShift, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in LeftShift> = assoc_entity element0, @LeftShift.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @LeftShiftAssign [template]
+// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @LeftShiftAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in LeftShiftAssign> = assoc_entity element0, @LeftShiftAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShift {
-// CHECK:STDOUT:   %Self: LeftShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: LeftShift = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: LeftShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: LeftShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: LeftShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: LeftShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: LeftShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: LeftShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in LeftShift> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShiftAssign {
-// CHECK:STDOUT:   %Self: LeftShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: LeftShiftAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: LeftShiftAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: LeftShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: LeftShiftAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: LeftShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @LeftShift [template]
+// CHECK:STDOUT:   %Self.1: LeftShift = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @LeftShiftAssign [template]
+// CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %LeftShift.decl: type = interface_decl @LeftShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %LeftShift.ref: type = name_ref LeftShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShift {

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Mod [template]
-// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Mod, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Mod> = assoc_entity element0, @Mod.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @ModAssign [template]
-// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @ModAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in ModAssign> = assoc_entity element0, @ModAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mod {
-// CHECK:STDOUT:   %Self: Mod = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Mod = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Mod = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ModAssign {
-// CHECK:STDOUT:   %Self: ModAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: ModAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: ModAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Mod [template]
-// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @ModAssign [template]
-// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Mod [template]
+// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Mod, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Mod> = assoc_entity element0, @Mod.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @ModAssign [template]
+// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @ModAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in ModAssign> = assoc_entity element0, @ModAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mod {
-// CHECK:STDOUT:   %Self: Mod = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Mod = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Mod = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Mod = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Mod = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Mod = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Mod = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Mod = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Mod> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @ModAssign {
-// CHECK:STDOUT:   %Self: ModAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: ModAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: ModAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: ModAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: ModAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: ModAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Mod [template]
+// CHECK:STDOUT:   %Self.1: Mod = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @ModAssign [template]
+// CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mod.decl: type = interface_decl @Mod [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mod.ref: type = name_ref Mod, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mod {

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Mul [template]
+// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Mul, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Mul> = assoc_entity element0, @Mul.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @MulAssign [template]
+// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @MulAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in MulAssign> = assoc_entity element0, @MulAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mul {
-// CHECK:STDOUT:   %Self: Mul = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Mul = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Mul = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Mul = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Mul = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Mul = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Mul = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Mul = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Mul> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @MulAssign {
-// CHECK:STDOUT:   %Self: MulAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: MulAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: MulAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: MulAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: MulAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: MulAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Mul [template]
+// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @MulAssign [template]
+// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mul.decl: type = interface_decl @Mul [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mul.ref: type = name_ref Mul, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mul {

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Mul [template]
-// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Mul, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Mul> = assoc_entity element0, @Mul.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @MulAssign [template]
-// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @MulAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in MulAssign> = assoc_entity element0, @MulAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mul {
-// CHECK:STDOUT:   %Self: Mul = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Mul = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Mul = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @MulAssign {
-// CHECK:STDOUT:   %Self: MulAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: MulAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: MulAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Mul [template]
-// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Mul = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @MulAssign [template]
-// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -36,6 +36,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Negate [template]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Negate> = assoc_entity element0, @Negate.%Op [template]
 // CHECK:STDOUT: }
@@ -48,16 +49,16 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Negate = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Negate = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_26: Negate = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_26.1: type = facet_type_access %Self.ref.loc5_26 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_26.2: type = converted %Self.ref.loc5_26, %.loc5_26.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_26: Negate = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_26.1: type = facet_type_access %Self.ref.loc5_26 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc5_26.2: type = converted %Self.ref.loc5_26, %.loc5_26.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_30: <associated <function> in Negate> = assoc_entity element0, %Op [template = constants.%.3]
@@ -76,6 +77,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Negate [template]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -93,9 +95,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+16, loc_50 [template = constants.%.8]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+14, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -110,7 +112,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+14, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -36,7 +36,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Negate [template]
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Negate, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Negate> = assoc_entity element0, @Negate.%Op [template]
 // CHECK:STDOUT: }
@@ -49,7 +49,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Negate = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self]
@@ -77,7 +77,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Negate [template]
-// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Negate = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -92,6 +92,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Ordered [template]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Ordered, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Ordered> = assoc_entity element0, @Ordered.%Less [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Ordered> = assoc_entity element1, @Ordered.%LessOrEquivalent [template]
@@ -107,58 +108,58 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
-// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Less: <function> = fn_decl @Less [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_17: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_17.1: type = facet_type_access %Self.ref.loc8_17 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_17.2: type = converted %Self.ref.loc8_17, %.loc8_17.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_17: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_17.1: type = facet_type_access %Self.ref.loc8_17 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_17.2: type = converted %Self.ref.loc8_17, %.loc8_17.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc8_11.1: Self = param self
 // CHECK:STDOUT:     %self.loc8_11.2: Self = bind_name self, %self.loc8_11.1
-// CHECK:STDOUT:     %Self.ref.loc8_30: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_30.1: type = facet_type_access %Self.ref.loc8_30 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_30.2: type = converted %Self.ref.loc8_30, %.loc8_30.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_30: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_30.1: type = facet_type_access %Self.ref.loc8_30 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc8_30.2: type = converted %Self.ref.loc8_30, %.loc8_30.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc8_23.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_23.2: Self = bind_name other, %other.loc8_23.1
 // CHECK:STDOUT:     %return.var.loc8: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc8_43: <associated <function> in Ordered> = assoc_entity element0, %Less [template = constants.%.3]
 // CHECK:STDOUT:   %LessOrEquivalent: <function> = fn_decl @LessOrEquivalent [template] {
-// CHECK:STDOUT:     %Self.ref.loc9_29: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_29.1: type = facet_type_access %Self.ref.loc9_29 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_29.2: type = converted %Self.ref.loc9_29, %.loc9_29.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc9_29: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_29.1: type = facet_type_access %Self.ref.loc9_29 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_29.2: type = converted %Self.ref.loc9_29, %.loc9_29.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc9_23.1: Self = param self
 // CHECK:STDOUT:     %self.loc9_23.2: Self = bind_name self, %self.loc9_23.1
-// CHECK:STDOUT:     %Self.ref.loc9_42: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_42.1: type = facet_type_access %Self.ref.loc9_42 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc9_42.2: type = converted %Self.ref.loc9_42, %.loc9_42.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc9_42: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_42.1: type = facet_type_access %Self.ref.loc9_42 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc9_42.2: type = converted %Self.ref.loc9_42, %.loc9_42.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc9_35.1: Self = param other
 // CHECK:STDOUT:     %other.loc9_35.2: Self = bind_name other, %other.loc9_35.1
 // CHECK:STDOUT:     %return.var.loc9: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc9_55: <associated <function> in Ordered> = assoc_entity element1, %LessOrEquivalent [template = constants.%.4]
 // CHECK:STDOUT:   %Greater: <function> = fn_decl @Greater [template] {
-// CHECK:STDOUT:     %Self.ref.loc10_20: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_20.1: type = facet_type_access %Self.ref.loc10_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_20.2: type = converted %Self.ref.loc10_20, %.loc10_20.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc10_20: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_20.1: type = facet_type_access %Self.ref.loc10_20 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_20.2: type = converted %Self.ref.loc10_20, %.loc10_20.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc10_14.1: Self = param self
 // CHECK:STDOUT:     %self.loc10_14.2: Self = bind_name self, %self.loc10_14.1
-// CHECK:STDOUT:     %Self.ref.loc10_33: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_33.1: type = facet_type_access %Self.ref.loc10_33 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc10_33.2: type = converted %Self.ref.loc10_33, %.loc10_33.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc10_33: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_33.1: type = facet_type_access %Self.ref.loc10_33 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc10_33.2: type = converted %Self.ref.loc10_33, %.loc10_33.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc10_26.1: Self = param other
 // CHECK:STDOUT:     %other.loc10_26.2: Self = bind_name other, %other.loc10_26.1
 // CHECK:STDOUT:     %return.var.loc10: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_46: <associated <function> in Ordered> = assoc_entity element2, %Greater [template = constants.%.5]
 // CHECK:STDOUT:   %GreaterOrEquivalent: <function> = fn_decl @GreaterOrEquivalent [template] {
-// CHECK:STDOUT:     %Self.ref.loc11_32: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_32.1: type = facet_type_access %Self.ref.loc11_32 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_32.2: type = converted %Self.ref.loc11_32, %.loc11_32.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc11_32: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc11_32.1: type = facet_type_access %Self.ref.loc11_32 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc11_32.2: type = converted %Self.ref.loc11_32, %.loc11_32.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %self.loc11_26.1: Self = param self
 // CHECK:STDOUT:     %self.loc11_26.2: Self = bind_name self, %self.loc11_26.1
-// CHECK:STDOUT:     %Self.ref.loc11_45: Ordered = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_45.1: type = facet_type_access %Self.ref.loc11_45 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc11_45.2: type = converted %Self.ref.loc11_45, %.loc11_45.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc11_45: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc11_45.1: type = facet_type_access %Self.ref.loc11_45 [symbolic = constants.%Self]
+// CHECK:STDOUT:     %.loc11_45.2: type = converted %Self.ref.loc11_45, %.loc11_45.1 [symbolic = constants.%Self]
 // CHECK:STDOUT:     %other.loc11_38.1: Self = param other
 // CHECK:STDOUT:     %other.loc11_38.2: Self = bind_name other, %other.loc11_38.1
 // CHECK:STDOUT:     %return.var.loc11: ref bool = var <return slot>
@@ -188,6 +189,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Ordered [template]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Less, @impl.%LessOrEquivalent, @impl.%Greater, @impl.%GreaterOrEquivalent) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -210,15 +212,15 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+59, loc_158 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+60, loc_158 [template = constants.%.10]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+45, loc_138 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+17, loc_98 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+31, loc_118 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+15, loc_19 [template = imports.%Less]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+30, loc_19 [template = imports.%LessOrEquivalent]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+44, loc_19 [template = imports.%Greater]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+58, loc_19 [template = imports.%GreaterOrEquivalent]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+46, loc_138 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+18, loc_98 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+32, loc_118 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+16, loc_19 [template = imports.%Less]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+31, loc_19 [template = imports.%LessOrEquivalent]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+45, loc_19 [template = imports.%Greater]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+59, loc_19 [template = imports.%GreaterOrEquivalent]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -235,7 +237,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+1, loc_98 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+16, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc19_21: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc19_18.1: C = param a
@@ -246,7 +248,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.13: type = import_ref ir3, inst+1, loc_118 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+31, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %C.ref.loc23_19: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc23_16.1: C = param a
@@ -257,7 +259,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.15: type = import_ref ir3, inst+1, loc_138 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir3, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir3, inst+45, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc27_24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc27_21.1: C = param a
@@ -268,7 +270,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.17: type = import_ref ir3, inst+1, loc_158 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+59, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
@@ -405,6 +407,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Ordered [template]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Ordered, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Ordered> = assoc_entity element0, file.%import_ref.11 [template]
 // CHECK:STDOUT:   %.7: <associated <function> in Ordered> = assoc_entity element1, file.%import_ref.13 [template]
@@ -433,16 +436,16 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_30 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+59, loc_90 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+60, loc_90 [template = constants.%.9]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+45, loc_70 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+44, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+58, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+46, loc_70 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+18, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+32, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+31, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+45, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+59, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir3, inst+16, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_21: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_18.1: D = param a
@@ -453,7 +456,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.12: type = import_ref ir3, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+31, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %D.ref.loc24_19: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc24_16.1: D = param a
@@ -464,7 +467,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.14: type = import_ref ir3, inst+1, loc_70 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+45, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc32_24: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc32_21.1: D = param a
@@ -475,7 +478,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.16: type = import_ref ir3, inst+1, loc_90 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir3, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir3, inst+59, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -92,7 +92,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Ordered [template]
-// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Ordered, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Ordered> = assoc_entity element0, @Ordered.%Less [template]
 // CHECK:STDOUT:   %.4: <associated <function> in Ordered> = assoc_entity element1, @Ordered.%LessOrEquivalent [template]
@@ -108,7 +108,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
-// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic = constants.%Self]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self 0 [symbolic = constants.%Self]
 // CHECK:STDOUT:   %Less: <function> = fn_decl @Less [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_17: Ordered = name_ref Self, %Self [symbolic = constants.%Self]
 // CHECK:STDOUT:     %.loc8_17.1: type = facet_type_access %Self.ref.loc8_17 [symbolic = constants.%Self]
@@ -189,7 +189,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Ordered [template]
-// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Less, @impl.%LessOrEquivalent, @impl.%Greater, @impl.%GreaterOrEquivalent) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
@@ -407,7 +407,7 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.4: type = interface_type @Ordered [template]
-// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Ordered = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = assoc_entity_type @Ordered, <function> [template]
 // CHECK:STDOUT:   %.6: <associated <function> in Ordered> = assoc_entity element0, file.%import_ref.11 [template]
 // CHECK:STDOUT:   %.7: <associated <function> in Ordered> = assoc_entity element1, file.%import_ref.13 [template]

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @RightShift [template]
+// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @RightShift, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in RightShift> = assoc_entity element0, @RightShift.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @RightShiftAssign [template]
+// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @RightShiftAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in RightShiftAssign> = assoc_entity element0, @RightShiftAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShift {
-// CHECK:STDOUT:   %Self: RightShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: RightShift = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: RightShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: RightShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: RightShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: RightShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: RightShift = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: RightShift = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in RightShift> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShiftAssign {
-// CHECK:STDOUT:   %Self: RightShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: RightShiftAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: RightShiftAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: RightShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: RightShiftAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: RightShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @RightShift [template]
+// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @RightShiftAssign [template]
+// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %RightShift.decl: type = interface_decl @RightShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %RightShift.ref: type = name_ref RightShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShift {

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @RightShift [template]
-// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @RightShift, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in RightShift> = assoc_entity element0, @RightShift.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @RightShiftAssign [template]
-// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @RightShiftAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in RightShiftAssign> = assoc_entity element0, @RightShiftAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShift {
-// CHECK:STDOUT:   %Self: RightShift = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: RightShift = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: RightShift = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShiftAssign {
-// CHECK:STDOUT:   %Self: RightShiftAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: RightShiftAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: RightShiftAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @RightShift [template]
-// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: RightShift = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @RightShiftAssign [template]
-// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -46,9 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Sub [template]
+// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Sub, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Sub> = assoc_entity element0, @Sub.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @SubAssign [template]
+// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @SubAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in SubAssign> = assoc_entity element0, @SubAssign.%Op [template]
@@ -64,21 +66,21 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Sub {
-// CHECK:STDOUT:   %Self: Sub = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: Sub = bind_symbolic_name Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
-// CHECK:STDOUT:     %Self.ref.loc5_15: Sub = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_15: Sub = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_15.2: type = converted %Self.ref.loc5_15, %.loc5_15.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %self.loc5_9.1: Self = param self
 // CHECK:STDOUT:     %self.loc5_9.2: Self = bind_name self, %self.loc5_9.1
-// CHECK:STDOUT:     %Self.ref.loc5_28: Sub = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_28: Sub = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.1: type = facet_type_access %Self.ref.loc5_28 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_28.2: type = converted %Self.ref.loc5_28, %.loc5_28.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %other.loc5_21.1: Self = param other
 // CHECK:STDOUT:     %other.loc5_21.2: Self = bind_name other, %other.loc5_21.1
-// CHECK:STDOUT:     %Self.ref.loc5_37: Sub = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc5_37: Sub = name_ref Self, %Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.1: type = facet_type_access %Self.ref.loc5_37 [symbolic = constants.%Self.1]
+// CHECK:STDOUT:     %.loc5_37.2: type = converted %Self.ref.loc5_37, %.loc5_37.1 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %return.var: ref Self = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc5_41: <associated <function> in Sub> = assoc_entity element0, %Op [template = constants.%.3]
@@ -90,18 +92,18 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SubAssign {
-// CHECK:STDOUT:   %Self: SubAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self: SubAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
-// CHECK:STDOUT:     %Self.ref.loc8_20: SubAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_20: SubAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_24.2: type = converted %Self.ref.loc8_20, %.loc8_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.3: type = ptr_type Self [symbolic = constants.%.5]
 // CHECK:STDOUT:     %self.loc8_14.1: Self* = param self
 // CHECK:STDOUT:     %self.loc8_14.3: Self* = bind_name self, %self.loc8_14.1
 // CHECK:STDOUT:     %.loc8_9: Self* = addr_pattern %self.loc8_14.3
-// CHECK:STDOUT:     %Self.ref.loc8_34: SubAssign = name_ref Self, %Self [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = %Self]
-// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = %Self]
+// CHECK:STDOUT:     %Self.ref.loc8_34: SubAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.1: type = facet_type_access %Self.ref.loc8_34 [symbolic = constants.%Self.2]
+// CHECK:STDOUT:     %.loc8_34.2: type = converted %Self.ref.loc8_34, %.loc8_34.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %other.loc8_27.1: Self = param other
 // CHECK:STDOUT:     %other.loc8_27.2: Self = bind_name other, %other.loc8_27.1
 // CHECK:STDOUT:   }
@@ -123,11 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Sub [template]
+// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @SubAssign [template]
+// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
@@ -147,19 +151,19 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir3, inst+21, loc_82 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Sub.decl: type = interface_decl @Sub [template = constants.%.2] {}
 // CHECK:STDOUT:     %Sub.ref: type = name_ref Sub, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+23, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir3, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -177,7 +181,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +191,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Sub {

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -46,11 +46,11 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = interface_type @Sub [template]
-// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.2: type = assoc_entity_type @Sub, <function> [template]
 // CHECK:STDOUT:   %.3: <associated <function> in Sub> = assoc_entity element0, @Sub.%Op [template]
 // CHECK:STDOUT:   %.4: type = interface_type @SubAssign [template]
-// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.5: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.6: type = assoc_entity_type @SubAssign, <function> [template]
 // CHECK:STDOUT:   %.7: <associated <function> in SubAssign> = assoc_entity element0, @SubAssign.%Op [template]
@@ -66,7 +66,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Sub {
-// CHECK:STDOUT:   %Self: Sub = bind_symbolic_name Self [symbolic = constants.%Self.1]
+// CHECK:STDOUT:   %Self: Sub = bind_symbolic_name Self 0 [symbolic = constants.%Self.1]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.1 [template] {
 // CHECK:STDOUT:     %Self.ref.loc5_15: Sub = name_ref Self, %Self [symbolic = constants.%Self.1]
 // CHECK:STDOUT:     %.loc5_15.1: type = facet_type_access %Self.ref.loc5_15 [symbolic = constants.%Self.1]
@@ -92,7 +92,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @SubAssign {
-// CHECK:STDOUT:   %Self: SubAssign = bind_symbolic_name Self [symbolic = constants.%Self.2]
+// CHECK:STDOUT:   %Self: SubAssign = bind_symbolic_name Self 0 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.2 [template] {
 // CHECK:STDOUT:     %Self.ref.loc8_20: SubAssign = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc8_24.1: type = facet_type_access %Self.ref.loc8_20 [symbolic = constants.%Self.2]
@@ -125,13 +125,13 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = interface_type @Sub [template]
-// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.1: Sub = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.6: C = struct_value () [template]
 // CHECK:STDOUT:   %.7: type = interface_type @SubAssign [template]
-// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self [symbolic]
+// CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = ptr_type C [template]
 // CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
 // CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -30,6 +30,7 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %y: type = bind_symbolic_name y [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/return/fail_let_in_type.carbon
+++ b/toolchain/check/testdata/return/fail_let_in_type.carbon
@@ -30,7 +30,7 @@ fn FirstPerfectNumber() -> z { return 6; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %y: type = bind_symbolic_name y [symbolic]
+// CHECK:STDOUT:   %y: type = bind_symbolic_name y 0 [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/var/fail_generic.carbon
+++ b/toolchain/check/testdata/var/fail_generic.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x [symbolic]
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x 0 [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -30,7 +30,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
-// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var [symbolic = constants.%x]
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x 0, %x.var [symbolic = constants.%x]
 // CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc11
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/var/fail_generic.carbon
+++ b/toolchain/check/testdata/var/fail_generic.carbon
@@ -14,6 +14,7 @@ fn Main() {
 // CHECK:STDOUT: --- fail_generic.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x [symbolic]
 // CHECK:STDOUT:   %.1: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -29,7 +30,7 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.var: ref i32 = var x
-// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var [symbolic]
+// CHECK:STDOUT:   %x: i32 = bind_symbolic_name x, %x.var [symbolic = constants.%x]
 // CHECK:STDOUT:   %.loc11: i32 = int_literal 0 [template = constants.%.1]
 // CHECK:STDOUT:   assign %x.var, %.loc11
 // CHECK:STDOUT:   return

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -30,13 +30,15 @@ namespace Carbon::SemIR {
 struct BindNameInfo : public Printable<BindNameInfo> {
   auto Print(llvm::raw_ostream& out) const -> void {
     out << "{name: " << name_id << ", enclosing_scope: " << enclosing_scope_id
-        << "}";
+        << ", index: " << bind_index << "}";
   }
 
   // The name.
   NameId name_id;
   // The enclosing scope.
   NameScopeId enclosing_scope_id;
+  // The index for a compile-time binding. Invalid for a runtime binding.
+  CompileTimeBindIndex bind_index;
 };
 
 class File;

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -670,7 +670,11 @@ class Formatter {
   auto FormatArg(BuiltinKind kind) -> void { out_ << kind.label(); }
 
   auto FormatArg(BindNameId id) -> void {
-    FormatName(sem_ir_.bind_names().Get(id).name_id);
+    const auto& info = sem_ir_.bind_names().Get(id);
+    FormatName(info.name_id);
+    if (info.bind_index.is_valid()) {
+      out_ << " " << info.bind_index.index;
+    }
   }
 
   auto FormatArg(FunctionId id) -> void { FormatFunctionName(id); }

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -120,9 +120,10 @@ using IdKind = TypeEnum<
     // From base/value_store.h.
     IntId, RealId, FloatId, StringLiteralValueId,
     // From sem_ir/id.h.
-    InstId, ConstantId, BindNameId, FunctionId, ClassId, InterfaceId, ImplId,
-    ImportIRId, ImportIRInstId, LocId, BoolValue, IntKind, NameId, NameScopeId,
-    InstBlockId, TypeId, TypeBlockId, ElementIndex, FloatKind>;
+    InstId, ConstantId, BindNameId, CompileTimeBindIndex, FunctionId, ClassId,
+    InterfaceId, ImplId, ImportIRId, ImportIRInstId, LocId, BoolValue, IntKind,
+    NameId, NameScopeId, InstBlockId, TypeId, TypeBlockId, ElementIndex,
+    FloatKind>;
 
 }  // namespace Carbon::SemIR
 

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -185,6 +185,25 @@ struct BindNameId : public IdBase, public Printable<BindNameId> {
 
 constexpr BindNameId BindNameId::Invalid = BindNameId(InvalidIndex);
 
+// The index of a compile-time binding. This is the de Bruijn level for the
+// binding -- that is, this is the number of other compile time bindings whose
+// scope encloses this binding.
+struct CompileTimeBindIndex : public IndexBase,
+                              public Printable<CompileTimeBindIndex> {
+  // An explicitly invalid index.
+  static const CompileTimeBindIndex Invalid;
+
+  using IndexBase::IndexBase;
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "compTimeBind";
+    IndexBase::Print(out);
+  }
+};
+
+constexpr CompileTimeBindIndex CompileTimeBindIndex::Invalid =
+    CompileTimeBindIndex(InvalidIndex);
+
 // The ID of a function.
 struct FunctionId : public IdBase, public Printable<FunctionId> {
   using ValueType = Function;

--- a/toolchain/sem_ir/inst_profile.cpp
+++ b/toolchain/sem_ir/inst_profile.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/sem_ir/inst_profile.h"
 
 #include "toolchain/sem_ir/file.h"
+#include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
 
 namespace Carbon::SemIR {
@@ -65,6 +66,17 @@ static auto RealProfileArgFunction(llvm::FoldingSetNodeID& id,
   id.AddBoolean(real.is_decimal);
 }
 
+// Profiling for BindNameInfo.
+static auto BindNameIdProfileArgFunction(llvm::FoldingSetNodeID& id,
+                                         const File& sem_ir, int32_t arg)
+    -> void {
+  const auto& [name_id, enclosing_scope_id, bind_index] =
+      sem_ir.bind_names().Get(BindNameId(arg));
+  id.AddInteger(name_id.index);
+  id.AddInteger(enclosing_scope_id.index);
+  id.AddInteger(bind_index.index);
+}
+
 // Profiles the given instruction argument, which is of the specified kind.
 static auto ProfileArg(llvm::FoldingSetNodeID& id, const File& sem_ir,
                        IdKind arg_kind, int32_t arg) -> void {
@@ -77,6 +89,7 @@ static auto ProfileArg(llvm::FoldingSetNodeID& id, const File& sem_ir,
         array[IdKind::For<TypeBlockId>.ToIndex()] = TypeBlockProfileArgFunction;
         array[IdKind::For<IntId>.ToIndex()] = IntProfileArgFunction;
         array[IdKind::For<RealId>.ToIndex()] = RealProfileArgFunction;
+        array[IdKind::For<BindNameId>.ToIndex()] = BindNameIdProfileArgFunction;
         return array;
       }();
   ProfileFunctions[arg_kind.ToIndex()](id, sem_ir, arg);


### PR DESCRIPTION
Use a level comparison during substitution to determine whether we're substituting a particular binding. Evaluate symbolic bindings with the same name and the same level to the same symbolic constant, for example across redeclarations of a generic function.