### PR TITLE
Remove the builtin IR, and instead define builtin types locally.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -736,11 +736,10 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
 static auto CheckParseTree(
     llvm::DenseMap<const SemIR::File*, Parse::NodeLocConverter*>*
         node_converters,
-    const SemIR::File& builtin_ir, UnitInfo& unit_info,
-    llvm::raw_ostream* vlog_stream) -> void {
+    UnitInfo& unit_info, llvm::raw_ostream* vlog_stream) -> void {
   unit_info.unit->sem_ir->emplace(
       *unit_info.unit->value_stores,
-      unit_info.unit->tokens->source().filename().str(), &builtin_ir);
+      unit_info.unit->tokens->source().filename().str());
 
   // For ease-of-access.
   SemIR::File& sem_ir = **unit_info.unit->sem_ir;
@@ -1041,8 +1040,7 @@ static auto BuildApiMapAndDiagnosePackaging(
   return api_map;
 }
 
-auto CheckParseTrees(const SemIR::File& builtin_ir,
-                     llvm::MutableArrayRef<Unit> units, bool prelude_import,
+auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
                      llvm::raw_ostream* vlog_stream) -> void {
   // Prepare diagnostic emitters in case we run into issues during package
   // checking.
@@ -1103,7 +1101,7 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
   for (int check_index = 0;
        check_index < static_cast<int>(ready_to_check.size()); ++check_index) {
     auto* unit_info = ready_to_check[check_index];
-    CheckParseTree(&node_converters, builtin_ir, *unit_info, vlog_stream);
+    CheckParseTree(&node_converters, *unit_info, vlog_stream);
     for (auto* incoming_import : unit_info->incoming_imports) {
       --incoming_import->imports_remaining;
       if (incoming_import->imports_remaining == 0) {
@@ -1153,7 +1151,7 @@ auto CheckParseTrees(const SemIR::File& builtin_ir,
     // incomplete imports.
     for (auto& unit_info : unit_infos) {
       if (unit_info.imports_remaining > 0) {
-        CheckParseTree(&node_converters, builtin_ir, unit_info, vlog_stream);
+        CheckParseTree(&node_converters, unit_info, vlog_stream);
       }
     }
   }

--- a/toolchain/check/check.h
+++ b/toolchain/check/check.h
@@ -14,12 +14,6 @@
 
 namespace Carbon::Check {
 
-// Constructs builtins. A single instance should be reused with CheckParseTree
-// calls associated with a given compilation.
-inline auto MakeBuiltins(SharedValueStores& value_stores) -> SemIR::File {
-  return SemIR::File(value_stores);
-}
-
 // Checking information that's tracked per file.
 struct Unit {
   SharedValueStores* value_stores;
@@ -32,8 +26,7 @@ struct Unit {
 
 // Checks a group of parse trees. This will use imports to decide the order of
 // checking.
-auto CheckParseTrees(const SemIR::File& builtin_ir,
-                     llvm::MutableArrayRef<Unit> units, bool prelude_import,
+auto CheckParseTrees(llvm::MutableArrayRef<Unit> units, bool prelude_import,
                      llvm::raw_ostream* vlog_stream) -> void;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/testdata/alias/import.carbon
+++ b/toolchain/check/testdata/alias/import.carbon
@@ -111,12 +111,12 @@ var c: i32 = a_alias_alias;
 // CHECK:STDOUT:     .c_alias_alias = %c_alias_alias
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+6, loc_12 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+6, loc_12 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+11, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %c_alias.ref.loc6: type = name_ref c_alias, %import_ref.2 [template = constants.%C]
 // CHECK:STDOUT:   %c_alias_alias: type = bind_alias c_alias_alias, %import_ref.2 [template = constants.%C]
 // CHECK:STDOUT:   %c_alias.ref.loc8: type = name_ref c_alias, %import_ref.2 [template = constants.%C]
@@ -145,11 +145,11 @@ var c: i32 = a_alias_alias;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+10, loc_11 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+10, loc_11 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+15, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+8, unloaded
 // CHECK:STDOUT:   %c_alias_alias.ref: type = name_ref c_alias_alias, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %.loc6: type = ptr_type C [template = constants.%.2]
 // CHECK:STDOUT:   %c.var: ref C* = var c
@@ -197,8 +197,8 @@ var c: i32 = a_alias_alias;
 // CHECK:STDOUT:     .a_alias_alias = %a_alias_alias
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir2, inst+8, loc_12
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir1, inst+8, loc_12
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a_alias.ref: ref i32 = name_ref a_alias, %import_ref.2
 // CHECK:STDOUT:   %a_alias_alias: ref i32 = bind_alias a_alias_alias, %import_ref.2
@@ -223,8 +223,8 @@ var c: i32 = a_alias_alias;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: ref i32 = import_ref ir2, inst+5, loc_14 [template = <error>]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.1: ref i32 = import_ref ir1, inst+5, loc_14 [template = <error>]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %c.var: ref i32 = var c
 // CHECK:STDOUT:   %c: ref i32 = bind_name c, %c.var

--- a/toolchain/check/testdata/alias/import_order.carbon
+++ b/toolchain/check/testdata/alias/import_order.carbon
@@ -87,15 +87,15 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:     .b_val = %b_val
 // CHECK:STDOUT:     .a_val = %a_val
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+10, loc_51 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+12, loc_37 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref ir2, inst+14, loc_23 [template = constants.%C]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+16, loc_11 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+10, loc_51 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+12, loc_37 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref ir1, inst+14, loc_23 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir1, inst+16, loc_11 [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.6: <unbound element of class C> = import_ref ir2, inst+5, loc_31 [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.6: <unbound element of class C> = import_ref ir1, inst+5, loc_31 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %d.ref: type = name_ref d, %import_ref.5 [template = constants.%C]
 // CHECK:STDOUT:   %d_val.var: ref C = var d_val
 // CHECK:STDOUT:   %d_val: ref C = bind_name d_val, %d_val.var

--- a/toolchain/check/testdata/basics/builtin_insts.carbon
+++ b/toolchain/check/testdata/basics/builtin_insts.carbon
@@ -9,7 +9,7 @@
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        builtin_insts.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -19,16 +19,16 @@
 // CHECK:STDOUT:     type0:           {constant: template instNamespaceType, value_rep: {kind: copy, type: type0}}
 // CHECK:STDOUT:   type_blocks:     {}
 // CHECK:STDOUT:   insts:
-// CHECK:STDOUT:     instTypeType:    {kind: ImportRefLoaded, arg0: 0, type: typeTypeType}
-// CHECK:STDOUT:     instError:       {kind: ImportRefLoaded, arg0: 1, type: typeError}
-// CHECK:STDOUT:     instBoolType:    {kind: ImportRefLoaded, arg0: 2, type: typeTypeType}
-// CHECK:STDOUT:     instIntType:     {kind: ImportRefLoaded, arg0: 3, type: typeTypeType}
-// CHECK:STDOUT:     instFloatType:   {kind: ImportRefLoaded, arg0: 4, type: typeTypeType}
-// CHECK:STDOUT:     instStringType:  {kind: ImportRefLoaded, arg0: 5, type: typeTypeType}
-// CHECK:STDOUT:     instFunctionType: {kind: ImportRefLoaded, arg0: 6, type: typeTypeType}
-// CHECK:STDOUT:     instBoundMethodType: {kind: ImportRefLoaded, arg0: 7, type: typeTypeType}
-// CHECK:STDOUT:     instNamespaceType: {kind: ImportRefLoaded, arg0: 8, type: typeTypeType}
-// CHECK:STDOUT:     instWitnessType: {kind: ImportRefLoaded, arg0: 9, type: typeTypeType}
+// CHECK:STDOUT:     instTypeType:    {kind: Builtin, arg0: TypeType, type: typeTypeType}
+// CHECK:STDOUT:     instError:       {kind: Builtin, arg0: Error, type: typeError}
+// CHECK:STDOUT:     instBoolType:    {kind: Builtin, arg0: BoolType, type: typeTypeType}
+// CHECK:STDOUT:     instIntType:     {kind: Builtin, arg0: IntType, type: typeTypeType}
+// CHECK:STDOUT:     instFloatType:   {kind: Builtin, arg0: FloatType, type: typeTypeType}
+// CHECK:STDOUT:     instStringType:  {kind: Builtin, arg0: StringType, type: typeTypeType}
+// CHECK:STDOUT:     instFunctionType: {kind: Builtin, arg0: FunctionType, type: typeTypeType}
+// CHECK:STDOUT:     instBoundMethodType: {kind: Builtin, arg0: BoundMethodType, type: typeTypeType}
+// CHECK:STDOUT:     instNamespaceType: {kind: Builtin, arg0: NamespaceType, type: typeTypeType}
+// CHECK:STDOUT:     instWitnessType: {kind: Builtin, arg0: WitnessType, type: typeTypeType}
 // CHECK:STDOUT:     inst+0:          {kind: Namespace, arg0: name_scope0, arg1: inst<invalid>, type: type0}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     instTypeType:    template instTypeType

--- a/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_and_textual_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -68,7 +68,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/multifile_raw_ir.carbon
+++ b/toolchain/check/testdata/basics/multifile_raw_ir.carbon
@@ -21,7 +21,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        a.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}
@@ -53,7 +53,7 @@ fn B() {}
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        b.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+1}}
 // CHECK:STDOUT:   bind_names:      {}

--- a/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_and_textual_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_and_textual_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/basics/raw_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_ir.carbon
@@ -15,7 +15,7 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT: ---
 // CHECK:STDOUT: filename:        raw_ir.carbon
 // CHECK:STDOUT: sem_ir:
-// CHECK:STDOUT:   import_irs_size: 2
+// CHECK:STDOUT:   import_irs_size: 1
 // CHECK:STDOUT:   name_scopes:
 // CHECK:STDOUT:     name_scope0:     {inst: inst+0, enclosing_scope: name_scope<invalid>, has_error: false, extended_scopes: [], names: {name0: inst+14}}
 // CHECK:STDOUT:   bind_names:

--- a/toolchain/check/testdata/builtins/bool/make_type.carbon
+++ b/toolchain/check/testdata/builtins/bool/make_type.carbon
@@ -45,7 +45,7 @@ var b: Bool() = false;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+3, loc_11 [template = imports.%Bool]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+3, loc_11 [template = imports.%Bool]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Bool.ref: <function> = name_ref Bool, %import_ref [template = imports.%Bool]
 // CHECK:STDOUT:   %bool.make_type: init type = call %Bool.ref() [template = bool]

--- a/toolchain/check/testdata/builtins/float/make_type.carbon
+++ b/toolchain/check/testdata/builtins/float/make_type.carbon
@@ -71,7 +71,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:     .f = %f
 // CHECK:STDOUT:     .GetFloat = %GetFloat
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%Float]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%Float]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Float.ref: <function> = name_ref Float, %import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %.loc6_14: i32 = int_literal 64 [template = constants.%.1]
@@ -121,7 +121,7 @@ var dyn: Float(dyn_size);
 // CHECK:STDOUT:     .dyn_size = %dyn_size
 // CHECK:STDOUT:     .dyn = %dyn
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%Float]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%Float]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Float.ref.loc10: <function> = name_ref Float, %import_ref [template = imports.%Float]
 // CHECK:STDOUT:   %.loc10_26: i32 = int_literal 32 [template = constants.%.1]

--- a/toolchain/check/testdata/builtins/int/make_type_32.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_32.carbon
@@ -45,7 +45,7 @@ var i: Int() = 0;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .i = %i
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+3, loc_11 [template = imports.%Int]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+3, loc_11 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %int.make_type_32: init type = call %Int.ref() [template = i32]

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -100,7 +100,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:     .G = %G
 // CHECK:STDOUT:     .Symbolic = %Symbolic
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_13 [template = imports.%Int]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_13 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %Int.ref.loc6_9: <function> = name_ref Int, %import_ref [template = imports.%Int]
@@ -183,7 +183,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .n = %n
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%Int]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %.loc10_12: i32 = int_literal 0 [template = constants.%.1]
@@ -210,7 +210,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:     .Negate = %Negate
 // CHECK:STDOUT:     .n = %n.loc12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_23 [template = imports.%Int]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_23 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Negate: <function> = fn_decl @Negate [template] {
 // CHECK:STDOUT:     %n.loc6_11.1: i32 = param n
@@ -246,7 +246,7 @@ var m: Int(1000000000);
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .m = %m
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%Int]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%Int]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Int.ref: <function> = name_ref Int, %import_ref [template = imports.%Int]
 // CHECK:STDOUT:   %.loc9_12: i32 = int_literal 1000000000 [template = constants.%.1]

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -100,7 +100,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:     .G = %G
 // CHECK:STDOUT:     .Symbolic = %Symbolic
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_13 [template = imports.%UInt]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_13 [template = imports.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {
 // CHECK:STDOUT:     %UInt.ref.loc6_9: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
@@ -183,7 +183,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .n = %n
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%UInt]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %UInt.ref: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:   %.loc10_13: i32 = int_literal 0 [template = constants.%.1]
@@ -210,7 +210,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:     .Negate = %Negate
 // CHECK:STDOUT:     .n = %n.loc12
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_23 [template = imports.%UInt]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_23 [template = imports.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Negate: <function> = fn_decl @Negate [template] {
 // CHECK:STDOUT:     %n.loc6_11.1: i32 = param n
@@ -246,7 +246,7 @@ var m: UInt(1000000000);
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .m = %m
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+5, loc_11 [template = imports.%UInt]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+5, loc_11 [template = imports.%UInt]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %UInt.ref: <function> = name_ref UInt, %import_ref [template = imports.%UInt]
 // CHECK:STDOUT:   %.loc9_13: i32 = int_literal 1000000000 [template = constants.%.1]

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -158,9 +158,9 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+2, loc_14 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_14 [template = constants.%C]
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
@@ -197,7 +197,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref: type = import_ref ir3, inst+3, loc_14 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir2, inst+3, loc_14 [template = constants.%.1]
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref [template = constants.%.1]
 // CHECK:STDOUT:   %c.var: ref extern C = var c
@@ -234,10 +234,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+2, loc_19 [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_19 [template = constants.%C.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir4, inst+3, loaded [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir3, inst+3, loaded [template = constants.%.2]
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C.1]
 // CHECK:STDOUT:   %c.var: ref C = var c
@@ -279,10 +279,10 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other.ref: <namespace> = name_ref Other, %Other [template = %Other]
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_19 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_19 [template = constants.%C]
 // CHECK:STDOUT:   %C.decl: type = class_decl @C.2 [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+2, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+2, loaded [template = imports.%C]
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var

--- a/toolchain/check/testdata/class/extern.carbon
+++ b/toolchain/check/testdata/class/extern.carbon
@@ -452,8 +452,8 @@ extern class C;
 // CHECK:STDOUT:     .C = %import_ref.2
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+3, loaded [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+2, loaded [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+3, loaded [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+2, loaded [template = constants.%C.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -476,8 +476,8 @@ extern class C;
 // CHECK:STDOUT:     .C = %import_ref.1
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loaded [template = constants.%C.2]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+3, loaded [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+3, loaded [template = constants.%.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -501,10 +501,10 @@ extern class C;
 // CHECK:STDOUT:     .C = %import_ref.2
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+3, loaded [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+2, loaded [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+3, loaded [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+2, loaded [template = constants.%C.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
@@ -534,13 +534,13 @@ extern class C;
 // CHECK:STDOUT:     .C = %import_ref.2
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+3, loaded [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+2, loaded [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+3, loaded [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+2, loaded [template = constants.%C.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir4, inst+2, loaded [template = constants.%C.3]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir3, inst+2, loaded [template = constants.%C.3]
 // CHECK:STDOUT:   %C.decl.3: type = class_decl @C.3 [template = constants.%C.3] {}
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir4, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir3, inst+3, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -570,8 +570,8 @@ extern class C;
 // CHECK:STDOUT:     .C = %import_ref.1
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+3, loaded [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+3, loaded [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+3, loaded [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+3, loaded [template = constants.%.1]
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
@@ -593,7 +593,7 @@ extern class C;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir2, inst+3, loaded [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+3, loaded [template = constants.%.1]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl.loc6: type = class_decl @C [template = constants.%C] {
 // CHECK:STDOUT:     %C.decl.1: type = class_decl @C [template = constants.%C] {}
@@ -615,7 +615,7 @@ extern class C;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir2, inst+2, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl.loc6: type = class_decl @C [template = constants.%C] {
 // CHECK:STDOUT:     %C.decl.1: type = class_decl @C [template = constants.%C] {}
@@ -638,9 +638,9 @@ extern class C;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %C.decl.loc6: type = class_decl @C [template = constants.%C] {
 // CHECK:STDOUT:     %C.decl.1: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   }
@@ -665,9 +665,9 @@ extern class C;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .C = %C.decl.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loaded [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %C.decl.loc6: type = class_decl @C [template = constants.%C] {
 // CHECK:STDOUT:     %C.decl.1: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -84,10 +84,10 @@ var a: Incomplete;
 // CHECK:STDOUT:     .Empty = %Empty.decl.loc16
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loaded [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+5, loc_15 [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loaded [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+5, loc_15 [template = constants.%Incomplete]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %Empty.decl.loc16: type = class_decl @Empty [template = constants.%Empty] {
 // CHECK:STDOUT:     %Empty.decl.1: type = class_decl @Empty [template = constants.%Empty] {}
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -145,21 +145,21 @@ fn Run() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_16 [template = constants.%Empty]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+5, loc_24 [template = constants.%Field]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+12, loc_42 [template = constants.%ForwardDeclared.1]
-// CHECK:STDOUT:   %import_ref.4: type = import_ref ir2, inst+26, loc_71 [template = constants.%Incomplete]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_16 [template = constants.%Empty]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+5, loc_24 [template = constants.%Field]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+12, loc_42 [template = constants.%ForwardDeclared.1]
+// CHECK:STDOUT:   %import_ref.4: type = import_ref ir1, inst+26, loc_71 [template = constants.%Incomplete]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.7: <unbound element of class Field> = import_ref ir2, inst+8, loc_36 [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+25, loc_56 [template = imports.%G]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+18, loc_50 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+25, unloaded
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.7: <unbound element of class Field> = import_ref ir1, inst+8, loc_36 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir1, inst+25, loc_56 [template = imports.%G]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir1, inst+18, loc_50 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir1, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir1, inst+18, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Empty {

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -119,17 +119,17 @@ fn Run() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+20, loc_16 [template = constants.%Child]
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+20, loc_16 [template = constants.%Child]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+7, loc_44 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.5: <unbound element of class Base> = import_ref ir2, inst+13, loc_38 [template = imports.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+11, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+16, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+25, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+7, loc_44 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.5: <unbound element of class Base> = import_ref ir1, inst+13, loc_38 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+11, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+16, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+25, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Child {

--- a/toolchain/check/testdata/class/import_forward_decl.carbon
+++ b/toolchain/check/testdata/class/import_forward_decl.carbon
@@ -46,7 +46,7 @@ class ForwardDecl {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .ForwardDecl = %ForwardDecl.decl.loc4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loaded [template = constants.%ForwardDecl]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir0, inst+2, loaded [template = constants.%ForwardDecl]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %ForwardDecl.decl.loc4: type = class_decl @ForwardDecl [template = constants.%ForwardDecl] {
 // CHECK:STDOUT:     %ForwardDecl.decl.1: type = class_decl @ForwardDecl [template = constants.%ForwardDecl] {}

--- a/toolchain/check/testdata/class/import_member_cycle.carbon
+++ b/toolchain/check/testdata/class/import_member_cycle.carbon
@@ -64,11 +64,11 @@ fn Run() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_16 [template = constants.%Cycle]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_16 [template = constants.%Cycle]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Cycle {

--- a/toolchain/check/testdata/class/import_struct_cyle.carbon
+++ b/toolchain/check/testdata/class/import_struct_cyle.carbon
@@ -82,12 +82,12 @@ fn Run() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref {.b: Cycle*} = import_ref ir2, inst+12, loc_14
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref {.b: Cycle*} = import_ref ir1, inst+12, loc_14
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <unbound element of class Cycle> = import_ref ir2, inst+19, loc_24 [template = imports.%.1]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <unbound element of class Cycle> = import_ref ir1, inst+19, loc_24 [template = imports.%.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @Cycle {

--- a/toolchain/check/testdata/class/import_triangle.carbon
+++ b/toolchain/check/testdata/class/import_triangle.carbon
@@ -74,10 +74,10 @@ var d2: D* = &c2;
 // CHECK:STDOUT:     .c1 = %c1
 // CHECK:STDOUT:     .d1 = %d1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_12 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_12 [template = constants.%C]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %C.ref.loc6: type = name_ref C, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %D: type = bind_alias D, %import_ref.1 [template = constants.%C]
 // CHECK:STDOUT:   %C.ref.loc8: type = name_ref C, %import_ref.1 [template = constants.%C]
@@ -129,18 +129,18 @@ var d2: D* = &c2;
 // CHECK:STDOUT:     .c2 = %c2
 // CHECK:STDOUT:     .d2 = %d2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_15 [template = constants.%C.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir3, inst+8, loc_23 [template = constants.%C.2]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+13, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir3, inst+23, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_15 [template = constants.%C.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+8, loc_23 [template = constants.%C.2]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+23, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl.1: type = class_decl @C.1 [template = constants.%C.1] {}
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %C.ref: type = name_ref C, %import_ref.1 [template = constants.%C.1]
 // CHECK:STDOUT:   %c2.var: ref C = var c2
 // CHECK:STDOUT:   %c2: ref C = bind_name c2, %c2.var
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+6, unloaded
 // CHECK:STDOUT:   %D.ref: type = name_ref D, %import_ref.2 [template = constants.%C.2]
 // CHECK:STDOUT:   %.loc11: type = ptr_type C [template = constants.%.5]
 // CHECK:STDOUT:   %d2.var: ref C* = var d2

--- a/toolchain/check/testdata/const/import.carbon
+++ b/toolchain/check/testdata/const/import.carbon
@@ -79,9 +79,9 @@ var a_ptr: const i32* = a_ptr_ref;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .a_ptr = %a_ptr
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref const i32 = import_ref ir1, inst+8, loc_12
-// CHECK:STDOUT:   %import_ref.3: ref const i32* = import_ref ir1, inst+16, loc_22
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir0, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref const i32 = import_ref ir0, inst+8, loc_12
+// CHECK:STDOUT:   %import_ref.3: ref const i32* = import_ref ir0, inst+16, loc_22
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_8: type = const_type i32 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc6_17: type = ptr_type const i32 [template = constants.%.2]

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -94,10 +94,10 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:     .arr = %arr
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_9 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_36 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_10 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_9 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_36 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_10 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.1] {}
@@ -105,15 +105,15 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 2 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_36 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_36 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc10_18: <bound method> = bound_method %.loc10_16, %.1 [template = constants.%.7]
 // CHECK:STDOUT:   %int.sadd: init i32 = call %.loc10_18(%.loc10_16, %.loc10_20) [template = constants.%.8]
 // CHECK:STDOUT:   %.loc10_21: type = array_type %int.sadd, i32 [template = constants.%.9]
 // CHECK:STDOUT:   %arr.var: ref [i32; 3] = var arr
 // CHECK:STDOUT:   %arr: ref [i32; 3] = bind_name arr, %arr.var
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir3, inst+1, loc_47 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_47 [template = constants.%.1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/function/builtin/import.carbon
+++ b/toolchain/check/testdata/function/builtin/import.carbon
@@ -55,7 +55,7 @@ var arr: [i32; Core.Add(1, 2)] = (1, 2, 3);
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir3, inst+6, loc_11 [template = imports.%Add]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+6, loc_11 [template = imports.%Add]
 // CHECK:STDOUT:   %Add.ref: <function> = name_ref Add, %import_ref [template = imports.%Add]
 // CHECK:STDOUT:   %.loc4_25: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc4_28: i32 = int_literal 2 [template = constants.%.2]

--- a/toolchain/check/testdata/function/declaration/fail_import_incomplete_return.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_import_incomplete_return.carbon
@@ -159,16 +159,16 @@ fn CallFAndGIncomplete() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .CallFAndGIncomplete = %CallFAndGIncomplete
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+8, loc_14 [template = imports.%ReturnCUnused]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+11, loc_18 [template = imports.%ReturnCUsed]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir2, inst+14, loc_22 [template = imports.%ReturnDUnused]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+17, loc_26 [template = imports.%ReturnDUsed]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+8, loc_14 [template = imports.%ReturnCUnused]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+11, loc_18 [template = imports.%ReturnCUsed]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir1, inst+14, loc_22 [template = imports.%ReturnDUnused]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+17, loc_26 [template = imports.%ReturnDUsed]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir1, inst+18, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %CallFAndGIncomplete: <function> = fn_decl @CallFAndGIncomplete [template] {}
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+5, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: class @C;

--- a/toolchain/check/testdata/function/declaration/implicit_import.carbon
+++ b/toolchain/check/testdata/function/declaration/implicit_import.carbon
@@ -79,7 +79,7 @@ extern fn A();
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -106,7 +106,7 @@ extern fn A();
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -133,7 +133,7 @@ extern fn A();
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -311,15 +311,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loc_24 [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loc_39 [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_53 [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loc_24 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loc_39 [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loc_53 [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loc_65 [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loc_65 [template = imports.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
@@ -401,15 +401,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loaded [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loaded [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %E
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loaded [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loaded [template = imports.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
@@ -507,15 +507,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loaded [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loaded [template = imports.%D]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loaded [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %E
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loaded [template = imports.%E]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loaded [template = imports.%E]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
@@ -612,20 +612,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_19 [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loc_28 [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loc_43 [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_57 [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_19 [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loc_28 [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loc_43 [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loc_57 [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loc_69 [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+2, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+6, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+18, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+19, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+21, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loc_69 [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+2, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+6, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+18, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+19, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+21, loaded [template = imports.%E.2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.3 [template = constants.%.3]
@@ -716,20 +716,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loaded [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loaded [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_57 [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loaded [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loaded [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loc_57 [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = imports.%E.2
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loaded [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+2, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+6, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+18, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+19, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+21, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loaded [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+2, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+6, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+18, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+19, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+21, loaded [template = imports.%E.2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc7_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_9.2: type = converted %.loc7_9.1, constants.%.3 [template = constants.%.3]
@@ -812,15 +812,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+21, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
@@ -855,15 +855,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+21, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
@@ -902,15 +902,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+21, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
@@ -940,15 +940,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+21, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -963,15 +963,15 @@ import library "extern_api";
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+6, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+6, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+21, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -991,20 +991,20 @@ import library "extern_api";
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%A.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+6, loaded [template = imports.%B.1]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+18, loaded [template = imports.%C.1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loaded [template = imports.%D.1]
-// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir2, inst+20, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%A.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+6, loaded [template = imports.%B.1]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+18, loaded [template = imports.%C.1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loaded [template = imports.%D.1]
+// CHECK:STDOUT:   %import_ref.5: <namespace> = import_ref ir1, inst+20, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.5, [template] {
 // CHECK:STDOUT:     .E = %import_ref.6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+21, loaded [template = imports.%E.1]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+2, loaded [template = imports.%A.2]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+6, loaded [template = imports.%B.2]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+18, loaded [template = imports.%C.2]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+19, loaded [template = imports.%D.2]
-// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir3, inst+21, loaded [template = imports.%E.2]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir1, inst+21, loaded [template = imports.%E.1]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+2, loaded [template = imports.%A.2]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+6, loaded [template = imports.%B.2]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+18, loaded [template = imports.%C.2]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+19, loaded [template = imports.%D.2]
+// CHECK:STDOUT:   %import_ref.11: <function> = import_ref ir2, inst+21, loaded [template = imports.%E.2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/definition/implicit_import.carbon
+++ b/toolchain/check/testdata/function/definition/implicit_import.carbon
@@ -117,7 +117,7 @@ fn A() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -147,7 +147,7 @@ fn A() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -177,7 +177,7 @@ fn A() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -210,7 +210,7 @@ fn A() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }
@@ -240,7 +240,7 @@ fn A() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -183,10 +183,10 @@ fn D() {}
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_15 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+7, loc_24 [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+21, loc_39 [template = imports.%C]
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+31, unloaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loc_15 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+7, loc_24 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+21, loc_39 [template = imports.%C]
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+31, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]
@@ -234,10 +234,10 @@ fn D() {}
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+7, loaded [template = imports.%B]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+31, unloaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+7, loaded [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+31, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %B: <function> = fn_decl @B [template] {
@@ -261,7 +261,7 @@ fn D() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .A = %A.loc6
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+2, loaded [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %A.loc6: <function> = fn_decl @A [template] {}
 // CHECK:STDOUT:   %A.loc7: <function> = fn_decl @A [template] {}
@@ -282,10 +282,10 @@ fn D() {}
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .D = %D.loc13
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+21, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+31, loaded [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+21, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+31, loaded [template = imports.%D]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %D.loc6: <function> = fn_decl @D [template] {}
 // CHECK:STDOUT:   %D.loc13: <function> = fn_decl @D [template] {}

--- a/toolchain/check/testdata/impl/lookup/import.carbon
+++ b/toolchain/check/testdata/impl/lookup/import.carbon
@@ -106,21 +106,21 @@ fn G(c: Impl.C) {
 // CHECK:STDOUT:   %Impl: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+10, unloaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+10, unloaded
 // CHECK:STDOUT:   %HasF.decl: type = interface_decl @HasF [template = constants.%.2] {}
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in HasF> = import_ref ir2, inst+7, loc_20 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+4, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+5, unloaded
-// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir2, inst+16, loc_22 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: type = import_ref ir2, inst+9, loc_10 [template = constants.%C]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in HasF> = import_ref ir1, inst+7, loc_20 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir1, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.5: <witness> = import_ref ir1, inst+16, loc_22 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: type = import_ref ir1, inst+9, loc_10 [template = constants.%C]
 // CHECK:STDOUT:   %G: <function> = fn_decl @G [template] {
 // CHECK:STDOUT:     %Impl.ref: <namespace> = name_ref Impl, %Impl [template = %Impl]
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %import_ref.6 [template = constants.%C]
 // CHECK:STDOUT:     %c.loc4_6.1: C = param c
 // CHECK:STDOUT:     @G.%c: C = bind_name c, %c.loc4_6.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+2, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+5, unloaded
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir1, inst+2, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir1, inst+5, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @HasF {

--- a/toolchain/check/testdata/interface/import.carbon
+++ b/toolchain/check/testdata/interface/import.carbon
@@ -157,34 +157,34 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     .UseForwardDeclaredF = %UseForwardDeclaredF
 // CHECK:STDOUT:     .f = %f.loc16
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+2, loc_13 [template = constants.%.1]
-// CHECK:STDOUT:   %import_ref.2: type = import_ref ir2, inst+5, loc_22 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.3: type = import_ref ir2, inst+16, loc_31 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir2, inst+37, loc_70
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+2, loc_13 [template = constants.%.1]
+// CHECK:STDOUT:   %import_ref.2: type = import_ref ir1, inst+5, loc_22 [template = constants.%.3]
+// CHECK:STDOUT:   %import_ref.3: type = import_ref ir1, inst+16, loc_31 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.4: ref {.f: ForwardDeclared} = import_ref ir1, inst+37, loc_70
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+4, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir1, inst+4, unloaded
 // CHECK:STDOUT:   %UseEmpty: <function> = fn_decl @UseEmpty [template] {
 // CHECK:STDOUT:     %Empty.decl: type = interface_decl @Empty [template = constants.%.1] {}
 // CHECK:STDOUT:     %Empty.ref: type = name_ref Empty, %import_ref.1 [template = constants.%.1]
 // CHECK:STDOUT:     %e.loc6_13.1: Empty = param e
 // CHECK:STDOUT:     @UseEmpty.%e: Empty = bind_name e, %e.loc6_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+7, unloaded
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir2, inst+14, loc_48 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir2, inst+10, loc_41 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+8, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir1, inst+7, unloaded
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Basic> = import_ref ir1, inst+14, loc_48 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.8: <associated type in Basic> = import_ref ir1, inst+10, loc_41 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir1, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %UseBasic: <function> = fn_decl @UseBasic [template] {
 // CHECK:STDOUT:     %Basic.decl: type = interface_decl @Basic [template = constants.%.3] {}
 // CHECK:STDOUT:     %Basic.ref.loc7: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
 // CHECK:STDOUT:     %e.loc7_13.1: Basic = param e
 // CHECK:STDOUT:     @UseBasic.%e: Basic = bind_name e, %e.loc7_13.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+19, unloaded
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir2, inst+26, loc_62 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir2, inst+22, loc_55 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+20, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir1, inst+19, unloaded
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in ForwardDeclared> = import_ref ir1, inst+26, loc_62 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.13: <associated type in ForwardDeclared> = import_ref ir1, inst+22, loc_55 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir1, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir1, inst+24, unloaded
 // CHECK:STDOUT:   %UseForwardDeclared: <function> = fn_decl @UseForwardDeclared [template] {
 // CHECK:STDOUT:     %ForwardDeclared.decl: type = interface_decl @ForwardDeclared [template = constants.%.4] {}
 // CHECK:STDOUT:     %ForwardDeclared.ref.loc8: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
@@ -192,19 +192,19 @@ var f: ForwardDeclared* = &f_ref.f;
 // CHECK:STDOUT:     @UseForwardDeclared.%f: ForwardDeclared = bind_name f, %f.loc8_23.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Basic.ref.loc10: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+8, unloaded
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir1, inst+8, unloaded
 // CHECK:STDOUT:   %T.ref.loc10: <associated type in Basic> = name_ref T, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %UseBasicT: <associated type in Basic> = bind_alias UseBasicT, %import_ref.8 [template = constants.%.6]
 // CHECK:STDOUT:   %Basic.ref.loc11: type = name_ref Basic, %import_ref.2 [template = constants.%.3]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir1, inst+12, unloaded
 // CHECK:STDOUT:   %F.ref.loc11: <associated <function> in Basic> = name_ref F, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %UseBasicF: <associated <function> in Basic> = bind_alias UseBasicF, %import_ref.7 [template = constants.%.8]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc13: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+20, unloaded
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir1, inst+20, unloaded
 // CHECK:STDOUT:   %T.ref.loc13: <associated type in ForwardDeclared> = name_ref T, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %UseForwardDeclaredT: <associated type in ForwardDeclared> = bind_alias UseForwardDeclaredT, %import_ref.13 [template = constants.%.10]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc14: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir1, inst+24, unloaded
 // CHECK:STDOUT:   %F.ref.loc14: <associated <function> in ForwardDeclared> = name_ref F, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %UseForwardDeclaredF: <associated <function> in ForwardDeclared> = bind_alias UseForwardDeclaredF, %import_ref.12 [template = constants.%.12]
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, %import_ref.3 [template = constants.%.4]

--- a/toolchain/check/testdata/let/fail_generic_import.carbon
+++ b/toolchain/check/testdata/let/fail_generic_import.carbon
@@ -41,7 +41,7 @@ let a: T = 0;
 // CHECK:STDOUT:     .T = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir0, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %T.ref: type = name_ref T, %import_ref [symbolic = <unexpected instref inst+3>]
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.1]

--- a/toolchain/check/testdata/let/generic_import.carbon
+++ b/toolchain/check/testdata/let/generic_import.carbon
@@ -40,7 +40,7 @@ var b: T = *a;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: type = import_ref ir1, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
+// CHECK:STDOUT:   %import_ref: type = import_ref ir0, inst+2, loc_7 [symbolic = <unexpected instref inst+3>]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %T.ref.loc4: type = name_ref T, %import_ref [symbolic = <unexpected instref inst+3>]
 // CHECK:STDOUT:   %.loc4: type = ptr_type T [symbolic = constants.%.1]

--- a/toolchain/check/testdata/let/import.carbon
+++ b/toolchain/check/testdata/let/import.carbon
@@ -38,7 +38,7 @@ let b:! bool = a;
 // CHECK:STDOUT:     .a = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: bool = import_ref ir1, inst+2, loc_10 [symbolic = <unexpected instref inst+4>]
+// CHECK:STDOUT:   %import_ref: bool = import_ref ir0, inst+2, loc_10 [symbolic = <unexpected instref inst+4>]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a.ref: bool = name_ref a, %import_ref [symbolic = <unexpected instref inst+4>]
 // CHECK:STDOUT:   %b: bool = bind_symbolic_name b, %a.ref [symbolic]

--- a/toolchain/check/testdata/namespace/add_to_import.carbon
+++ b/toolchain/check/testdata/namespace/add_to_import.carbon
@@ -41,7 +41,7 @@ var a: i32 = NS.A();
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+2, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir0, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_after_merge.carbon
@@ -59,7 +59,7 @@ fn NS();
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc8: <namespace> = namespace [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_first.carbon
@@ -47,7 +47,7 @@ fn NS.Foo();
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .Foo = %Foo
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -56,7 +56,7 @@ fn NS.Foo();
 // CHECK:STDOUT:     .NS = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+2, loaded [template = imports.%NS]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loaded [template = imports.%NS]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc16: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc24: <function> = fn_decl @.1 [template] {}

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_first.carbon
@@ -80,13 +80,13 @@ fn NS.Bar() {}
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.2
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+2, loaded [template = imports.%NS]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir1, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+2, loaded [template = imports.%NS]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_in_imports_namespace_second.carbon
@@ -80,13 +80,13 @@ fn NS.Bar() {}
 // CHECK:STDOUT:     .NS = %NS
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir2, inst+2, unloaded
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir3, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .Foo = %import_ref.3
 // CHECK:STDOUT:     .Bar = %Bar
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Bar: <function> = fn_decl @Bar [template] {}
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/namespace/imported.carbon
+++ b/toolchain/check/testdata/namespace/imported.carbon
@@ -62,17 +62,17 @@ var package_b: () = package.NS.ChildNS.B();
 // CHECK:STDOUT:     .package_a = %package_a
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir0, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .ChildNS = %ChildNS
 // CHECK:STDOUT:     .A = %import_ref.3
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir0, inst+3, loaded
 // CHECK:STDOUT:   %ChildNS: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .B = %import_ref.4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir1, inst+4, loc_13 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+5, loc_27 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir0, inst+4, loc_13 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir0, inst+5, loc_27 [template = imports.%B]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.1 [template = constants.%.1]

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -56,7 +56,7 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
@@ -71,11 +71,11 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
@@ -90,15 +90,15 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:     .A = %A
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir2, inst+6, loaded
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+6, loaded
 // CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %D
 // CHECK:STDOUT:   }
@@ -123,19 +123,19 @@ var e: () = A.B.C.D();
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .e = %e
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %A: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .B = %B
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir2, inst+4, loaded
+// CHECK:STDOUT:   %import_ref.2: <namespace> = import_ref ir1, inst+4, loaded
 // CHECK:STDOUT:   %B: <namespace> = namespace %import_ref.2, [template] {
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir2, inst+6, loaded
+// CHECK:STDOUT:   %import_ref.3: <namespace> = import_ref ir1, inst+6, loaded
 // CHECK:STDOUT:   %C: <namespace> = namespace %import_ref.3, [template] {
 // CHECK:STDOUT:     .D = %import_ref.4
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+8, loc_23 [template = imports.%D]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+8, loc_23 [template = imports.%D]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc5_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc5_9.2: type = converted %.loc5_9.1, constants.%.1 [template = constants.%.1]

--- a/toolchain/check/testdata/namespace/merging.carbon
+++ b/toolchain/check/testdata/namespace/merging.carbon
@@ -100,16 +100,16 @@ fn Run() {
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .Run = %Run
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %NS: <namespace> = namespace %import_ref.1, [template] {
 // CHECK:STDOUT:     .A = %import_ref.2
 // CHECK:STDOUT:     .B1 = %import_ref.3
 // CHECK:STDOUT:     .B2 = %import_ref.4
 // CHECK:STDOUT:     .C = %C
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+3, loc_33 [template = imports.%A]
-// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir3, inst+3, loc_39 [template = imports.%B1]
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+6, loc_45 [template = imports.%B2]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir1, inst+3, loc_33 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref.3: <function> = import_ref ir2, inst+3, loc_39 [template = imports.%B1]
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+6, loc_45 [template = imports.%B2]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc7: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C: <function> = fn_decl @C [template] {}

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitAnd.decl: type = interface_decl @BitAnd [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitAnd.ref: type = name_ref BitAnd, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitAnd {

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -92,10 +92,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir3, inst+15, loc_50 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir2, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -109,8 +109,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_50 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitComplement {

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitOr.decl: type = interface_decl @BitOr [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitOr.ref: type = name_ref BitOr, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitOr {

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %BitXor.decl: type = interface_decl @BitXor [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitXor.ref: type = name_ref BitXor, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @BitXor {

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -92,10 +92,10 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir3, inst+14, loc_47 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir2, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -103,8 +103,8 @@ fn TestOp() {
 // CHECK:STDOUT:     %Dec.ref: type = name_ref Dec, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_47 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Dec {

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Div.decl: type = interface_decl @Div [template = constants.%.2] {}
 // CHECK:STDOUT:     %Div.ref: type = name_ref Div, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Div {

--- a/toolchain/check/testdata/operators/overloaded/eq.carbon
+++ b/toolchain/check/testdata/operators/overloaded/eq.carbon
@@ -173,12 +173,12 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_68 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_88 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+15, loc_19 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+30, loc_19 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir2, inst+17, loc_68 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_88 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir2, inst+15, loc_19 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+30, loc_19 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -194,8 +194,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestEqual.%b: C = bind_name b, %b.loc13_20.1
 // CHECK:STDOUT:     @TestEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir3, inst+1, loc_68 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_68 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc17_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc17_17.1: C = param a
@@ -205,8 +205,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%b: C = bind_name b, %b.loc17_23.1
 // CHECK:STDOUT:     @TestNotEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_88 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_88 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -312,13 +312,13 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestEqual.%b: D = bind_name b, %b.loc8_20.1
 // CHECK:STDOUT:     @TestEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_30 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_30 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir2, inst+17, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestNotEqual: <function> = fn_decl @TestNotEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_20: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_17.1: D = param a
@@ -328,8 +328,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestNotEqual.%b: D = bind_name b, %b.loc16_23.1
 // CHECK:STDOUT:     @TestNotEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.8: type = import_ref ir3, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.8: type = import_ref ir2, inst+1, loc_50 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {
@@ -386,12 +386,12 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_23 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir3, inst+17, loc_73 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir3, inst+31, loc_93 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir3, inst+15, loc_24 [template = imports.%Equal]
-// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir3, inst+30, loc_24 [template = imports.%NotEqual]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_23 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.3: <associated <function> in Eq> = import_ref ir2, inst+17, loc_73 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Eq> = import_ref ir2, inst+31, loc_93 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <function> = import_ref ir2, inst+15, loc_24 [template = imports.%Equal]
+// CHECK:STDOUT:   %import_ref.6: <function> = import_ref ir2, inst+30, loc_24 [template = imports.%NotEqual]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -407,8 +407,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestRhsBad.%b: D = bind_name b, %b.loc14_21.1
 // CHECK:STDOUT:     @TestRhsBad.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.7: type = import_ref ir3, inst+1, loc_73 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.7: type = import_ref ir2, inst+1, loc_73 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLhsBad: <function> = fn_decl @TestLhsBad [template] {
 // CHECK:STDOUT:     %D.ref.loc25: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc25_15.1: D = param a
@@ -418,8 +418,8 @@ fn TestLhsBad(a: D, b: C) -> bool {
 // CHECK:STDOUT:     @TestLhsBad.%b: C = bind_name b, %b.loc25_21.1
 // CHECK:STDOUT:     @TestLhsBad.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_93 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_93 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Eq {

--- a/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_assign_non_ref.carbon
@@ -149,20 +149,20 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+14, loc_65 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+14, loc_65 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Inc.decl: type = interface_decl @Inc [template = constants.%.2] {}
 // CHECK:STDOUT:     %Inc.ref: type = name_ref Inc, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+16, loc_38 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+34, loc_82 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+18, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+32, loc_39 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+16, loc_38 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+34, loc_82 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+32, loc_39 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc11: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc11: <namespace> = name_ref Core, %Core [template = %Core]
@@ -174,8 +174,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %a.loc15_18.1: C = param a
 // CHECK:STDOUT:     @TestIncNonRef.%a: C = bind_name a, %a.loc15_18.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_65 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_65 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT:   %TestAddAssignNonRef: <function> = fn_decl @TestAddAssignNonRef [template] {
 // CHECK:STDOUT:     %C.ref.loc26_27: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc26_24.1: C = param a
@@ -184,8 +184,8 @@ fn TestAddAssignNonRef(a: C, b: C) {
 // CHECK:STDOUT:     %b.loc26_30.1: C = param b
 // CHECK:STDOUT:     @TestAddAssignNonRef.%b: C = bind_name b, %b.loc26_30.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+16, loc_82 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+32, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+16, loc_82 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+32, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -223,11 +223,11 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %C.ref.loc8_23: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestUnary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_25 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+11, loc_25 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4 = import_ref ir3, inst+9, unloaded
-// CHECK:STDOUT:   %import_ref.5 = import_ref ir3, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_25 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+11, loc_25 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4 = import_ref ir2, inst+9, unloaded
+// CHECK:STDOUT:   %import_ref.5 = import_ref ir2, inst+9, unloaded
 // CHECK:STDOUT:   %TestBinary: <function> = fn_decl @TestBinary [template] {
 // CHECK:STDOUT:     %C.ref.loc16_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc16_15.1: C = param a
@@ -238,26 +238,26 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %C.ref.loc16_30: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestBinary.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.6: type = import_ref ir3, inst+13, loc_45 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir3, inst+32, loc_45 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.6: type = import_ref ir2, inst+13, loc_45 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.7: <associated <function> in Add> = import_ref ir2, inst+32, loc_45 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestRef: <function> = fn_decl @TestRef [template] {
 // CHECK:STDOUT:     %C.ref.loc24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc24_12.1: C = param b
 // CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc24_12.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+34, loc_66 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir3, inst+52, loc_66 [template = constants.%.13]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+36, unloaded
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+50, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir3, inst+54, loc_69 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir3, inst+67, loc_69 [template = constants.%.16]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+56, unloaded
-// CHECK:STDOUT:   %import_ref.19 = import_ref ir3, inst+65, unloaded
-// CHECK:STDOUT:   %import_ref.20 = import_ref ir3, inst+65, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+34, loc_66 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir2, inst+52, loc_66 [template = constants.%.13]
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+36, unloaded
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+50, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+54, loc_69 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir2, inst+67, loc_69 [template = constants.%.16]
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+56, unloaded
+// CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+65, unloaded
+// CHECK:STDOUT:   %import_ref.20 = import_ref ir2, inst+65, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -160,20 +160,20 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_23 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir3, inst+20, loc_81 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_24 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_23 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+20, loc_81 [template = constants.%.11]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_24 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc9: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir3, inst+40, loc_102 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+40, loc_102 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc12: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc12: <namespace> = name_ref Core, %Core [template = %Core]
@@ -190,15 +190,15 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %C.ref.loc16_24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @Test.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_81 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_81 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %D.ref.loc27: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %b.loc27_15.1: D = param b
 // CHECK:STDOUT:     @TestAssign.%b: D = bind_name b, %b.loc27_15.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_102 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_102 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Add {

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -92,10 +92,10 @@ fn TestOp() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir3, inst+14, loc_47 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+12, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+14, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+12, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -103,8 +103,8 @@ fn TestOp() {
 // CHECK:STDOUT:     %Inc.ref: type = name_ref Inc, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {}
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_47 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+12, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_47 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+12, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Inc {

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %LeftShift.decl: type = interface_decl @LeftShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %LeftShift.ref: type = name_ref LeftShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @LeftShift {

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mod.decl: type = interface_decl @Mod [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mod.ref: type = name_ref Mod, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mod {

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Mul.decl: type = interface_decl @Mul [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mul.ref: type = name_ref Mul, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Mul {

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -92,10 +92,10 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir3, inst+15, loc_50 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+13, loc_19 [template = imports.%Op]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+15, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -109,8 +109,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+1, loc_50 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.6 = import_ref ir3, inst+13, unloaded
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+1, loc_50 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+13, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Negate {

--- a/toolchain/check/testdata/operators/overloaded/ordered.carbon
+++ b/toolchain/check/testdata/operators/overloaded/ordered.carbon
@@ -209,16 +209,16 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+59, loc_158 [template = constants.%.10]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+45, loc_138 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+17, loc_98 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+31, loc_118 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir3, inst+15, loc_19 [template = imports.%Less]
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+30, loc_19 [template = imports.%LessOrEquivalent]
-// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir3, inst+44, loc_19 [template = imports.%Greater]
-// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir3, inst+58, loc_19 [template = imports.%GreaterOrEquivalent]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir2, inst+59, loc_158 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir2, inst+45, loc_138 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir2, inst+17, loc_98 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir2, inst+31, loc_118 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.7: <function> = import_ref ir2, inst+15, loc_19 [template = imports.%Less]
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+30, loc_19 [template = imports.%LessOrEquivalent]
+// CHECK:STDOUT:   %import_ref.9: <function> = import_ref ir2, inst+44, loc_19 [template = imports.%Greater]
+// CHECK:STDOUT:   %import_ref.10: <function> = import_ref ir2, inst+58, loc_19 [template = imports.%GreaterOrEquivalent]
 // CHECK:STDOUT:   impl_decl @impl {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, %Core [template = %Core]
@@ -234,8 +234,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%b: C = bind_name b, %b.loc15_19.1
 // CHECK:STDOUT:     @TestLess.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+1, loc_98 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+1, loc_98 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc19_21: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc19_18.1: C = param a
@@ -245,8 +245,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%b: C = bind_name b, %b.loc19_24.1
 // CHECK:STDOUT:     @TestLessEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.13: type = import_ref ir3, inst+1, loc_118 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.14 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.13: type = import_ref ir2, inst+1, loc_118 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %C.ref.loc23_19: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc23_16.1: C = param a
@@ -256,8 +256,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%b: C = bind_name b, %b.loc23_22.1
 // CHECK:STDOUT:     @TestGreater.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.15: type = import_ref ir3, inst+1, loc_138 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.16 = import_ref ir3, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.15: type = import_ref ir2, inst+1, loc_138 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.16 = import_ref ir2, inst+44, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %C.ref.loc27_24: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %a.loc27_21.1: C = param a
@@ -267,8 +267,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%b: C = bind_name b, %b.loc27_27.1
 // CHECK:STDOUT:     @TestGreaterEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.17: type = import_ref ir3, inst+1, loc_158 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.18 = import_ref ir3, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.17: type = import_ref ir2, inst+1, loc_158 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+58, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {
@@ -432,17 +432,17 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLess.%b: D = bind_name b, %b.loc8_19.1
 // CHECK:STDOUT:     @TestLess.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_30 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir3, inst+59, loc_90 [template = constants.%.9]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir3, inst+45, loc_70 [template = constants.%.8]
-// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir3, inst+17, loc_30 [template = constants.%.6]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir3, inst+31, loc_50 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+15, unloaded
-// CHECK:STDOUT:   %import_ref.8 = import_ref ir3, inst+30, unloaded
-// CHECK:STDOUT:   %import_ref.9 = import_ref ir3, inst+44, unloaded
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+58, unloaded
-// CHECK:STDOUT:   %import_ref.11 = import_ref ir3, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_30 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Ordered> = import_ref ir2, inst+59, loc_90 [template = constants.%.9]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <associated <function> in Ordered> = import_ref ir2, inst+45, loc_70 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.5: <associated <function> in Ordered> = import_ref ir2, inst+17, loc_30 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in Ordered> = import_ref ir2, inst+31, loc_50 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+15, unloaded
+// CHECK:STDOUT:   %import_ref.8 = import_ref ir2, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.9 = import_ref ir2, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.11 = import_ref ir2, inst+15, unloaded
 // CHECK:STDOUT:   %TestLessEqual: <function> = fn_decl @TestLessEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc16_21: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc16_18.1: D = param a
@@ -452,8 +452,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestLessEqual.%b: D = bind_name b, %b.loc16_24.1
 // CHECK:STDOUT:     @TestLessEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.12: type = import_ref ir3, inst+1, loc_50 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.13 = import_ref ir3, inst+30, unloaded
+// CHECK:STDOUT:   %import_ref.12: type = import_ref ir2, inst+1, loc_50 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+30, unloaded
 // CHECK:STDOUT:   %TestGreater: <function> = fn_decl @TestGreater [template] {
 // CHECK:STDOUT:     %D.ref.loc24_19: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc24_16.1: D = param a
@@ -463,8 +463,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreater.%b: D = bind_name b, %b.loc24_22.1
 // CHECK:STDOUT:     @TestGreater.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.14: type = import_ref ir3, inst+1, loc_70 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.15 = import_ref ir3, inst+44, unloaded
+// CHECK:STDOUT:   %import_ref.14: type = import_ref ir2, inst+1, loc_70 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+44, unloaded
 // CHECK:STDOUT:   %TestGreaterEqual: <function> = fn_decl @TestGreaterEqual [template] {
 // CHECK:STDOUT:     %D.ref.loc32_24: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %a.loc32_21.1: D = param a
@@ -474,8 +474,8 @@ fn TestGreaterEqual(a: D, b: D) -> bool {
 // CHECK:STDOUT:     @TestGreaterEqual.%b: D = bind_name b, %b.loc32_27.1
 // CHECK:STDOUT:     @TestGreaterEqual.%return: ref bool = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir3, inst+1, loc_90 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.17 = import_ref ir3, inst+58, unloaded
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+1, loc_90 [template = constants.%.4]
+// CHECK:STDOUT:   %import_ref.17 = import_ref ir2, inst+58, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Ordered {

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %RightShift.decl: type = interface_decl @RightShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %RightShift.ref: type = name_ref RightShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @RightShift {

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -146,20 +146,20 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
-// CHECK:STDOUT:   %import_ref.1: type = import_ref ir3, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir3, inst+20, loc_82 [template = constants.%.12]
-// CHECK:STDOUT:   %import_ref.3 = import_ref ir3, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir3, inst+18, loc_19 [template = imports.%Op.1]
+// CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir2, inst+20, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+18, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
 // CHECK:STDOUT:     %C.ref.loc8: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc8: <namespace> = name_ref Core, %Core [template = %Core]
 // CHECK:STDOUT:     %Sub.decl: type = interface_decl @Sub [template = constants.%.2] {}
 // CHECK:STDOUT:     %Sub.ref: type = name_ref Sub, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir3, inst+22, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir3, inst+40, loc_101 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.7 = import_ref ir3, inst+24, unloaded
-// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir3, inst+38, loc_47 [template = imports.%Op.2]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+22, loc_46 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir2, inst+40, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+24, unloaded
+// CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+38, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
@@ -176,8 +176,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %C.ref.loc17_26: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     @TestOp.%return: ref C = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.9: type = import_ref ir3, inst+1, loc_82 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.10 = import_ref ir3, inst+18, unloaded
+// CHECK:STDOUT:   %import_ref.9: type = import_ref ir2, inst+1, loc_82 [template = constants.%.2]
+// CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+18, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
@@ -187,8 +187,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir3, inst+22, loc_101 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.12 = import_ref ir3, inst+38, unloaded
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+22, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @Sub {

--- a/toolchain/check/testdata/packages/cross_package_import.carbon
+++ b/toolchain/check/testdata/packages/cross_package_import.carbon
@@ -250,8 +250,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir3, inst+2, loc_22 [template = imports.%F]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir4, inst+2, loc_28 [template = imports.%F2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_22 [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+2, loc_28 [template = imports.%F2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -284,8 +284,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir3, inst+2, loc_22 [template = imports.%F.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir4, inst+2, loaded [template = imports.%F.2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_22 [template = imports.%F.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+2, loaded [template = imports.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -326,8 +326,8 @@ fn Other.G() {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Other: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %Run: <function> = fn_decl @Run [template] {}
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir3, inst+2, loc_22 [template = imports.%F.1]
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir4, inst+4, loaded [template = imports.%F.2]
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loc_22 [template = imports.%F.1]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+4, loaded [template = imports.%F.2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
@@ -349,10 +349,10 @@ fn Other.G() {}
 // CHECK:STDOUT:     .Other = %Other
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir2, inst+2, loaded
+// CHECK:STDOUT:   %import_ref.1: <namespace> = import_ref ir1, inst+2, loaded
 // CHECK:STDOUT:   %Other: <namespace> = namespace %import_ref.1, [template] {}
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
-// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir3, inst+2, loaded [template = imports.%F]
+// CHECK:STDOUT:   %import_ref.2: <function> = import_ref ir2, inst+2, loaded [template = imports.%F]
 // CHECK:STDOUT:   %F: <function> = fn_decl @F [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
+++ b/toolchain/check/testdata/packages/fail_conflict_no_namespaces.carbon
@@ -67,8 +67,8 @@ import library "var";
 // CHECK:STDOUT:     .Foo = %import_ref.1
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir2, inst+2, loaded [template = imports.%Foo]
-// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir3, inst+3, loaded
+// CHECK:STDOUT:   %import_ref.1: <function> = import_ref ir1, inst+2, loaded [template = imports.%Foo]
+// CHECK:STDOUT:   %import_ref.2: ref i32 = import_ref ir2, inst+3, loaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/packages/fail_import_type_error.carbon
+++ b/toolchain/check/testdata/packages/fail_import_type_error.carbon
@@ -81,10 +81,10 @@ var d: i32 = d_ref;
 // CHECK:STDOUT:     .c = %c
 // CHECK:STDOUT:     .d = %d
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: ref <error> = import_ref ir1, inst+4, loc_10
-// CHECK:STDOUT:   %import_ref.2: ref <error> = import_ref ir1, inst+9, loc_17
-// CHECK:STDOUT:   %import_ref.3: ref <error> = import_ref ir1, inst+13, loc_24
-// CHECK:STDOUT:   %import_ref.4: ref <error> = import_ref ir1, inst+17, loc_31
+// CHECK:STDOUT:   %import_ref.1: ref <error> = import_ref ir0, inst+4, loc_10
+// CHECK:STDOUT:   %import_ref.2: ref <error> = import_ref ir0, inst+9, loc_17
+// CHECK:STDOUT:   %import_ref.3: ref <error> = import_ref ir0, inst+13, loc_24
+// CHECK:STDOUT:   %import_ref.4: ref <error> = import_ref ir0, inst+17, loc_31
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var

--- a/toolchain/check/testdata/packages/loaded_global.carbon
+++ b/toolchain/check/testdata/packages/loaded_global.carbon
@@ -60,7 +60,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .package_a = %package_a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loc_11 [template = imports.%A]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir0, inst+2, loc_11 [template = imports.%A]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc4_9.2: type = converted %.loc4_9.1, constants.%.1 [template = constants.%.1]
@@ -112,7 +112,7 @@ var package_b: () = package.B();
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:     .package_b = %package_b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: <function> = import_ref ir2, inst+2, loc_17 [template = imports.%B]
+// CHECK:STDOUT:   %import_ref: <function> = import_ref ir1, inst+2, loc_17 [template = imports.%B]
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc6_9.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc6_9.2: type = converted %.loc6_9.1, constants.%.1 [template = constants.%.1]

--- a/toolchain/check/testdata/packages/unused_lazy_import.carbon
+++ b/toolchain/check/testdata/packages/unused_lazy_import.carbon
@@ -34,7 +34,7 @@ package Implicit impl;
 // CHECK:STDOUT:     .A = %import_ref
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref = import_ref ir1, inst+2, unloaded
+// CHECK:STDOUT:   %import_ref = import_ref ir0, inst+2, unloaded
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/import.carbon
+++ b/toolchain/check/testdata/pointer/import.carbon
@@ -61,8 +61,8 @@ var a: i32* = a_ref;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1 = import_ref ir1, inst+3, unloaded
-// CHECK:STDOUT:   %import_ref.2: ref i32* = import_ref ir1, inst+10, loc_11
+// CHECK:STDOUT:   %import_ref.1 = import_ref ir0, inst+3, unloaded
+// CHECK:STDOUT:   %import_ref.2: ref i32* = import_ref ir0, inst+10, loc_11
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4: type = ptr_type i32 [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref i32* = var a

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -106,8 +106,8 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: ref {.a: i32} = import_ref ir1, inst+7, loc_15
-// CHECK:STDOUT:   %import_ref.2: ref {.a: {.b: i32, .c: (i32,)}, .d: i32} = import_ref ir1, inst+38, loc_45
+// CHECK:STDOUT:   %import_ref.1: ref {.a: i32} = import_ref ir0, inst+7, loc_15
+// CHECK:STDOUT:   %import_ref.2: ref {.a: {.b: i32, .c: (i32,)}, .d: i32} = import_ref ir0, inst+38, loc_45
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4: type = struct_type {.a: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %a.var: ref {.a: i32} = var a

--- a/toolchain/check/testdata/tuples/import.carbon
+++ b/toolchain/check/testdata/tuples/import.carbon
@@ -128,8 +128,8 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:     .b = %b
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.1: ref (i32,) = import_ref ir1, inst+7, loc_13
-// CHECK:STDOUT:   %import_ref.2: ref (((i32,), i32), (i32, i32)) = import_ref ir1, inst+35, loc_35
+// CHECK:STDOUT:   %import_ref.1: ref (i32,) = import_ref ir0, inst+7, loc_13
+// CHECK:STDOUT:   %import_ref.2: ref (((i32,), i32), (i32, i32)) = import_ref ir0, inst+35, loc_35
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %.loc4_13.1: (type,) = tuple_literal (i32)
 // CHECK:STDOUT:   %.loc4_13.2: type = converted %.loc4_13.1, constants.%.2 [template = constants.%.2]

--- a/toolchain/check/testdata/var/import.carbon
+++ b/toolchain/check/testdata/var/import.carbon
@@ -47,7 +47,7 @@ var a: i32 = a_ref;
 // CHECK:STDOUT:     .Core = %Core
 // CHECK:STDOUT:     .a = %a
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref: ref i32 = import_ref ir1, inst+3, loc_10
+// CHECK:STDOUT:   %import_ref: ref i32 = import_ref ir0, inst+3, loc_10
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -787,7 +787,6 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
 
   // Check.
   SharedValueStores builtin_value_stores;
-  auto builtins = Check::MakeBuiltins(builtin_value_stores);
   llvm::SmallVector<Check::Unit> check_units;
   for (auto& unit : units) {
     if (unit->has_source()) {
@@ -795,7 +794,7 @@ auto Driver::Compile(const CompileOptions& options) -> RunResult {
     }
   }
   CARBON_VLOG() << "*** Check::CheckParseTrees ***\n";
-  Check::CheckParseTrees(builtins, llvm::MutableArrayRef(check_units),
+  Check::CheckParseTrees(llvm::MutableArrayRef(check_units),
                          options.prelude_import, vlog_stream_);
   CARBON_VLOG() << "*** Check::CheckParseTrees done ***\n";
   for (auto& unit : units) {

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -72,7 +72,7 @@ File::File(SharedValueStores& value_stores, std::string filename)
   auto api_placeholder_id =
       import_irs_.Add({.node_id = Parse::NodeId::Invalid, .sem_ir = nullptr});
   CARBON_CHECK(api_placeholder_id == ImportIRId::ApiForImpl)
-      << "ApiForImpl must be the second IR";
+      << "ApiForImpl must be the first IR";
 
   insts_.Reserve(BuiltinKind::ValidCount);
 // Error uses a self-referential type so that it's not accidentally treated as

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -44,12 +44,8 @@ class File;
 // Provides semantic analysis on a Parse::Tree.
 class File : public Printable<File> {
  public:
-  // Produces a file for the builtins.
-  explicit File(SharedValueStores& value_stores);
-
-  // Starts a new file for Check::CheckParseTree. Builtins are required.
-  explicit File(SharedValueStores& value_stores, std::string filename,
-                const File* builtins);
+  // Starts a new file for Check::CheckParseTree.
+  explicit File(SharedValueStores& value_stores, std::string filename);
 
   File(const File&) = delete;
   auto operator=(const File&) -> File& = delete;
@@ -192,10 +188,6 @@ class File : public Printable<File> {
   auto filename() const -> llvm::StringRef { return filename_; }
 
  private:
-  // Common File initialization.
-  explicit File(SharedValueStores& value_stores, std::string filename,
-                const File* builtins, llvm::function_ref<void()> init_builtins);
-
   bool has_errors_ = false;
 
   // Shared, compile-scoped values.
@@ -237,8 +229,8 @@ class File : public Printable<File> {
   // the data is provided by allocator_.
   BlockValueStore<TypeBlockId> type_blocks_;
 
-  // All instructions. The first entries will always be ImportRefs to builtins,
-  // at indices matching BuiltinKind ordering.
+  // All instructions. The first entries will always be Builtin insts, at
+  // indices matching BuiltinKind ordering.
   InstStore insts_;
 
   // Constant values for instructions.

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -256,9 +256,6 @@ struct ImportIRId : public IdBase, public Printable<ImportIRId> {
   // An explicitly invalid ID.
   static const ImportIRId Invalid;
 
-  // The builtin IR's import location.
-  static const ImportIRId Builtins;
-
   // The implicit `api` import, for an `impl` file. A null entry is added if
   // there is none, as in an `api`, in which case this ID should not show up in
   // instructions.
@@ -272,8 +269,7 @@ struct ImportIRId : public IdBase, public Printable<ImportIRId> {
 };
 
 constexpr ImportIRId ImportIRId::Invalid = ImportIRId(InvalidIndex);
-constexpr ImportIRId ImportIRId::Builtins = ImportIRId(0);
-constexpr ImportIRId ImportIRId::ApiForImpl = ImportIRId(1);
+constexpr ImportIRId ImportIRId::ApiForImpl = ImportIRId(0);
 
 // A boolean value.
 struct BoolValue : public IdBase, public Printable<BoolValue> {

--- a/toolchain/sem_ir/yaml_test.cpp
+++ b/toolchain/sem_ir/yaml_test.cpp
@@ -54,7 +54,7 @@ TEST(SemIRTest, YAML) {
                                          Pair("value_rep", Yaml::Mapping(_)))));
 
   auto file = Yaml::Mapping(ElementsAre(
-      Pair("import_irs_size", "2"),
+      Pair("import_irs_size", "1"),
       Pair("name_scopes", Yaml::Mapping(SizeIs(1))),
       Pair("bind_names", Yaml::Mapping(SizeIs(1))),
       Pair("functions", Yaml::Mapping(SizeIs(1))),


### PR DESCRIPTION
We don't need it any more, and removing it simplifies a few things:

- One fewer predefined `File` and reserved ID.
- We now have simply `Builtin` instructions for builtins, instead of having an `ImportRef` that indirectly references a `Builtin`.
- `ConstantId`s now always refer directly to a local constant, instead of sometimes referring to an `ImportRef` for a constant in the builtins IR.
