### PR TITLE
Switch ImportRefs to provide a LocId.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -96,14 +96,6 @@ class SemIRDiagnosticConverter : public DiagnosticConverter<SemIRLoc> {
           continue;
         }
 
-        // If the parse node was invalid, recurse through import references when
-        // possible.
-        if (auto import_ref = cursor_ir->insts().TryGetAs<SemIR::AnyImportRef>(
-                cursor_inst_id)) {
-          follow_import_ref(import_ref->import_ir_inst_id);
-          continue;
-        }
-
         // If a namespace has an instruction for an import, switch to looking at
         // it.
         if (auto ns =

--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -155,8 +155,9 @@ auto Context::ReplaceInstBeforeConstantUse(SemIR::InstId inst_id,
 
 auto Context::AddImportRef(SemIR::ImportIRInst import_ir_inst)
     -> SemIR::InstId {
+  auto import_ir_inst_id = import_ir_insts().Add(import_ir_inst);
   auto import_ref_id = AddPlaceholderInstInNoBlock(
-      SemIR::ImportRefUnloaded{import_ir_insts().Add(import_ir_inst)});
+      {import_ir_inst_id, SemIR::ImportRefUnloaded{import_ir_inst_id}});
 
   // We can't insert this instruction into whatever block we happen to be in,
   // because this function is typically called by name lookup in the middle of

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -11,6 +11,7 @@
 #include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/impl.h"
+#include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -124,8 +125,8 @@ static auto BuildInterfaceWitness(
   }
 
   auto table_id = context.inst_blocks().Add(table);
-  return context.AddInst(SemIR::InterfaceWitness{
-      context.GetBuiltinType(SemIR::BuiltinKind::WitnessType), table_id});
+  return context.AddInst(SemIR::LocIdAndInst::NoLoc(SemIR::InterfaceWitness{
+      context.GetBuiltinType(SemIR::BuiltinKind::WitnessType), table_id}));
 }
 
 auto BuildImplWitness(Context& context, SemIR::ImplId impl_id)

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -140,8 +140,10 @@ static auto CopySingleNameScopeFromImportIR(
   auto make_import_id = [&]() {
     auto import_ir_inst_id = context.import_ir_insts().Add(
         {.ir_id = ir_id, .inst_id = import_inst_id});
-    return context.AddInst(SemIR::ImportRefLoaded{
-        .type_id = namespace_type_id, .import_ir_inst_id = import_ir_inst_id});
+    return context.AddInst(
+        {import_ir_inst_id,
+         SemIR::ImportRefLoaded{.type_id = namespace_type_id,
+                                .import_ir_inst_id = import_ir_inst_id}});
   };
   auto [namespace_scope_id, namespace_const_id, _] =
       AddNamespace(context, namespace_type_id, Parse::NodeId::Invalid, name_id,

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -6,6 +6,7 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -196,8 +196,9 @@ static auto PerformImplLookup(Context& context, Parse::NodeId node_id,
   auto subst_type_id =
       SubstType(context, assoc_type.entity_type_id, substitutions);
 
-  return context.AddInst(SemIR::InterfaceWitnessAccess{
-      subst_type_id, witness_id, assoc_entity->index});
+  return context.AddInst(
+      SemIR::LocIdAndInst::NoLoc(SemIR::InterfaceWitnessAccess{
+          subst_type_id, witness_id, assoc_entity->index}));
 }
 
 // Performs a member name lookup into the specified scope, including performing

--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -42,8 +42,8 @@ auto ConstantStore::GetOrAdd(Inst inst, bool is_symbolic) -> ConstantId {
   }
 
   // Create the new inst and insert the new node.
-  auto inst_id = constants_.getContext()->insts().AddInNoBlock(
-      LocIdAndInst::Untyped(Parse::NodeId::Invalid, inst));
+  auto inst_id =
+      constants_.getContext()->insts().AddInNoBlock(LocIdAndInst::NoLoc(inst));
   auto constant_id = is_symbolic
                          ? SemIR::ConstantId::ForSymbolicConstant(inst_id)
                          : SemIR::ConstantId::ForTemplateConstant(inst_id);

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -78,11 +78,11 @@ File::File(SharedValueStores& value_stores, std::string filename)
 // Error uses a self-referential type so that it's not accidentally treated as
 // a normal type. Every other builtin is a type, including the
 // self-referential TypeType.
-#define CARBON_SEM_IR_BUILTIN_KIND(Name, ...)                              \
-  insts_.AddInNoBlock(                                                     \
-      {Builtin{BuiltinKind::Name == BuiltinKind::Error ? TypeId::Error     \
-                                                       : TypeId::TypeType, \
-               BuiltinKind::Name}});
+#define CARBON_SEM_IR_BUILTIN_KIND(Name, ...)                             \
+  insts_.AddInNoBlock(LocIdAndInst::NoLoc(                                \
+      Builtin{BuiltinKind::Name == BuiltinKind::Error ? TypeId::Error     \
+                                                      : TypeId::TypeType, \
+              BuiltinKind::Name}));
 #include "toolchain/sem_ir/builtin_kind.def"
   CARBON_CHECK(insts_.size() == BuiltinKind::ValidCount)
       << "Builtins should produce " << BuiltinKind::ValidCount

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -291,42 +291,41 @@ inline auto operator<<(llvm::raw_ostream& out, TypedInst inst)
 // Associates a LocId and Inst in order to provide type-checking that the
 // TypedNodeId corresponds to the InstT.
 struct LocIdAndInst {
-  // In cases where the NodeId is untyped, an inst_id, or the InstT is unknown,
-  // the NodeId check can't be done at compile time.
-  // TODO: Consider runtime validation that InstT::Kind::TypedNodeId
-  // corresponds.
-  static auto Untyped(LocId loc_id, Inst inst) -> LocIdAndInst {
-    return LocIdAndInst(loc_id, inst, /*is_untyped=*/true);
+  // For cases with no location.
+  template <typename InstT>
+    requires(!Internal::HasNodeId<InstT>)
+  static auto NoLoc(InstT inst) -> LocIdAndInst {
+    return LocIdAndInst(LocId::Invalid, inst, /*is_untyped=*/true);
   }
 
   // For the common case, support construction as:
   //   context.AddInst({node_id, SemIR::MyInst{...}});
   template <typename InstT>
     requires(Internal::HasNodeId<InstT>)
-  // NOLINTNEXTLINE(google-explicit-constructor)
   LocIdAndInst(decltype(InstT::Kind)::TypedNodeId node_id, InstT inst)
       : loc_id(node_id), inst(inst) {}
 
-  // For cases with no parse node, support construction as:
-  //   context.AddInst({SemIR::MyInst{...}});
-  template <typename InstT>
-    requires(!Internal::HasNodeId<InstT>)
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  LocIdAndInst(InstT inst) : loc_id(Parse::NodeId::Invalid), inst(inst) {}
-
-  // If TypedNodeId is Parse::NodeId, allow construction with a LocId
-  // rather than requiring Untyped.
+  // If TypedNodeId is Parse::NodeId, allow construction with a LocId.
   // TODO: This is somewhat historical due to fetching the NodeId from insts()
-  // for things like Temporary; should we require Untyped in these cases?
+  // for things like Temporary; should we require an explicit call in these
+  // cases?
   template <typename InstT>
     requires(std::same_as<typename decltype(InstT::Kind)::TypedNodeId,
                           Parse::NodeId>)
   LocIdAndInst(LocId loc_id, InstT inst) : loc_id(loc_id), inst(inst) {}
 
+  // Imports can pass an ImportIRInstId instead of another location.
+  template <typename InstT>
+  LocIdAndInst(ImportIRInstId import_ir_inst_id, InstT inst)
+      : loc_id(import_ir_inst_id), inst(inst) {}
+
   LocId loc_id;
   Inst inst;
 
  private:
+  // Expose the internal constructor for GetWithLocId.
+  friend class InstStore;
+
   explicit LocIdAndInst(LocId loc_id, Inst inst, bool /*is_untyped*/)
       : loc_id(loc_id), inst(inst) {}
 };
@@ -349,7 +348,7 @@ class InstStore {
 
   // Returns the requested instruction and its location ID.
   auto GetWithLocId(InstId inst_id) const -> LocIdAndInst {
-    return LocIdAndInst::Untyped(GetLocId(inst_id), Get(inst_id));
+    return LocIdAndInst(GetLocId(inst_id), Get(inst_id), /*is_untyped=*/true);
   }
 
   // Returns whether the requested instruction is the specified type.


### PR DESCRIPTION
This allows ImportRefs to point at a potentially distant instruction, while still providing a LocId that can be used for diagnostics. I think this'll be used if we're trying to point ImportRefs at canonical instructions in distant IRs. It conveniently eliminates a special-case in check.cpp.

Restructures LocIdAndInst::Untyped because I think it's not really needed after this change (the key non-import use was GetWithLocId, which I just give friend access for). Adding NoLoc for things that don't provide _any_ location because it turns out Inst can easily be passed in this way which was not what I had intended, but is used.