### PR TITLE
Use `CARBON_KIND_SWITCH` in type lowering.

### DIFF
--- a/toolchain/lower/BUILD
+++ b/toolchain/lower/BUILD
@@ -42,6 +42,7 @@ cc_library(
     deps = [
         "//common:check",
         "//common:vlog",
+        "//toolchain/base:kind_switch",
         "//toolchain/sem_ir:entry_point",
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:inst",


### PR DESCRIPTION
Clean up type lowering using `CARBON_KIND` for cases.