### PR TITLE
Start adding tracking of the complete list of IRs under check.

### DIFF
--- a/toolchain/check/context.cpp
+++ b/toolchain/check/context.cpp
@@ -153,24 +153,6 @@ auto Context::ReplaceInstBeforeConstantUse(SemIR::InstId inst_id,
   constant_values().Set(inst_id, const_id);
 }
 
-auto Context::AddImportRef(SemIR::ImportIRInst import_ir_inst)
-    -> SemIR::InstId {
-  auto import_ir_inst_id = import_ir_insts().Add(import_ir_inst);
-  auto import_ref_id = AddPlaceholderInstInNoBlock(
-      {import_ir_inst_id, SemIR::ImportRefUnloaded{import_ir_inst_id}});
-
-  // We can't insert this instruction into whatever block we happen to be in,
-  // because this function is typically called by name lookup in the middle of
-  // an otherwise unknown checking step. But we need to add the instruction
-  // somewhere, because it's referenced by other instructions and needs to be
-  // visible in textual IR. Adding it to the file block is arbitrary but is the
-  // best place we have right now.
-  //
-  // TODO: Consider adding a dedicated block for import_refs.
-  inst_block_stack().AddInstIdToFileBlock(import_ref_id);
-  return import_ref_id;
-}
-
 auto Context::DiagnoseDuplicateName(SemIRLoc dup_def, SemIRLoc prev_def)
     -> void {
   CARBON_DIAGNOSTIC(NameDeclDuplicate, Error,
@@ -342,7 +324,7 @@ static auto LookupInImportIRScopes(Context& context, SemIRLoc loc,
       continue;
     }
     auto import_inst_id =
-        context.AddImportRef({.ir_id = import_ir_id, .inst_id = it->second});
+        AddImportRef(context, {.ir_id = import_ir_id, .inst_id = it->second});
     if (result_id.is_valid()) {
       MergeImportRef(context, import_inst_id, result_id);
     } else {

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -82,10 +82,6 @@ class Context {
   auto ReplaceInstBeforeConstantUse(SemIR::InstId inst_id, SemIR::Inst inst)
       -> void;
 
-  // Adds an import_ref instruction for the specified instruction in the
-  // specified IR. The import_ref is initially marked as unused.
-  auto AddImportRef(SemIR::ImportIRInst import_ir_inst) -> SemIR::InstId;
-
   // Sets only the parse node of an instruction. This is only used when setting
   // the parse node of an imported namespace. Versus
   // ReplaceInstBeforeConstantUse, it is safe to use after the namespace is used
@@ -315,6 +311,10 @@ class Context {
     return scope_stack().break_continue_stack();
   }
 
+  auto check_ir_map() -> llvm::SmallVector<SemIR::ImportIRId>& {
+    return check_ir_map_;
+  }
+
   auto import_ir_constant_values()
       -> llvm::SmallVector<SemIR::ConstantValueStore, 0>& {
     return import_ir_constant_values_;
@@ -433,6 +433,9 @@ class Context {
 
   // The list which will form NodeBlockId::Exports.
   llvm::SmallVector<SemIR::InstId> exports_;
+
+  // Maps CheckIRId to ImportIRId.
+  llvm::SmallVector<SemIR::ImportIRId> check_ir_map_;
 
   // Per-import constant values. These refer to the main IR and mainly serve as
   // a lookup table for quick access.

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -7,6 +7,7 @@
 #include "common/check.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
+#include "toolchain/check/import_ref.h"
 #include "toolchain/check/merge.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/file.h"
@@ -212,18 +213,9 @@ static auto CopyEnclosingNameScopesFromImportIR(
 auto ImportLibraryFromCurrentPackage(Context& context,
                                      SemIR::TypeId namespace_type_id,
                                      Parse::ImportDirectiveId node_id,
-                                     bool is_api_for_impl,
                                      const SemIR::File& import_sem_ir) -> void {
-  auto ir_id = SemIR::ImportIRId::Invalid;
-  if (is_api_for_impl) {
-    ir_id = SemIR::ImportIRId::ApiForImpl;
-    auto& import_ir = context.import_irs().Get(ir_id);
-    CARBON_CHECK(import_ir.sem_ir == nullptr) << "ApiForImpl is only set once";
-    import_ir = {.node_id = node_id, .sem_ir = &import_sem_ir};
-  } else {
-    ir_id = context.import_irs().Add(
-        {.node_id = node_id, .sem_ir = &import_sem_ir});
-  }
+  auto ir_id =
+      AddImportIR(context, {.node_id = node_id, .sem_ir = &import_sem_ir});
 
   context.import_ir_constant_values()[ir_id.index].Set(
       SemIR::InstId::PackageNamespace,
@@ -256,7 +248,7 @@ auto ImportLibraryFromCurrentPackage(Context& context,
     } else {
       // Leave a placeholder that the inst comes from the other IR.
       auto target_id =
-          context.AddImportRef({.ir_id = ir_id, .inst_id = import_inst_id});
+          AddImportRef(context, {.ir_id = ir_id, .inst_id = import_inst_id});
       auto [it, success] = context.name_scopes()
                                .Get(enclosing_scope_id)
                                .names.insert({name_id, target_id});
@@ -285,7 +277,7 @@ auto ImportLibrariesFromOtherPackage(Context& context,
   auto& scope = context.name_scopes().Get(namespace_scope_id);
   scope.is_closed_import = !is_duplicate;
   for (auto import_ir : import_irs) {
-    auto ir_id = context.import_irs().Add(import_ir);
+    auto ir_id = AddImportIR(context, import_ir);
     scope.import_ir_scopes.push_back({ir_id, SemIR::NameScopeId::Package});
     context.import_ir_constant_values()[ir_id.index].Set(
         SemIR::InstId::PackageNamespace, namespace_const_id);

--- a/toolchain/check/import.h
+++ b/toolchain/check/import.h
@@ -17,7 +17,6 @@ namespace Carbon::Check {
 auto ImportLibraryFromCurrentPackage(Context& context,
                                      SemIR::TypeId namespace_type_id,
                                      Parse::ImportDirectiveId node_id,
-                                     bool is_api_for_impl,
                                      const SemIR::File& import_sem_ir) -> void;
 
 // Adds another package's imports to name lookup, with all libraries together.

--- a/toolchain/check/import_ref.h
+++ b/toolchain/check/import_ref.h
@@ -7,8 +7,22 @@
 
 #include "toolchain/check/context.h"
 #include "toolchain/sem_ir/file.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::Check {
+
+// Sets the IR for ImportIRId::ApiForImpl. Should be called before AddImportIR
+// in order to ensure the correct ID is assigned.
+auto SetApiImportIR(Context& context, SemIR::ImportIR import_ir) -> void;
+
+// Adds an ImportIR, returning the ID. May use an existing ID if already added.
+auto AddImportIR(Context& context, SemIR::ImportIR import_ir)
+    -> SemIR::ImportIRId;
+
+// Adds an import_ref instruction for the specified instruction in the
+// specified IR. The import_ref is initially marked as unused.
+auto AddImportRef(Context& context, SemIR::ImportIRInst import_ir_inst)
+    -> SemIR::InstId;
 
 // If the passed in instruction ID is an ImportRefUnloaded, loads it for use.
 // The result will be an ImportRefUsed.

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -62,18 +62,15 @@ auto TypeInfo::Print(llvm::raw_ostream& out) const -> void {
   out << "{constant: " << constant_id << ", value_rep: " << value_repr << "}";
 }
 
-File::File(SharedValueStores& value_stores, std::string filename)
-    : value_stores_(&value_stores),
+File::File(CheckIRId check_ir_id, SharedValueStores& value_stores,
+           std::string filename)
+    : check_ir_id_(check_ir_id),
+      value_stores_(&value_stores),
       filename_(std::move(filename)),
       type_blocks_(allocator_),
       constant_values_(ConstantId::NotConstant),
       inst_blocks_(allocator_),
       constants_(*this, allocator_) {
-  auto api_placeholder_id =
-      import_irs_.Add({.node_id = Parse::NodeId::Invalid, .sem_ir = nullptr});
-  CARBON_CHECK(api_placeholder_id == ImportIRId::ApiForImpl)
-      << "ApiForImpl must be the first IR";
-
   insts_.Reserve(BuiltinKind::ValidCount);
 // Error uses a self-referential type so that it's not accidentally treated as
 // a normal type. Every other builtin is a type, including the

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -47,7 +47,8 @@ class File;
 class File : public Printable<File> {
  public:
   // Starts a new file for Check::CheckParseTree.
-  explicit File(SharedValueStores& value_stores, std::string filename);
+  explicit File(CheckIRId check_ir_id, SharedValueStores& value_stores,
+                std::string filename);
 
   File(const File&) = delete;
   auto operator=(const File&) -> File& = delete;
@@ -97,6 +98,8 @@ class File : public Printable<File> {
   // Same as `StringifyType`, but starting with an instruction representing a
   // type expression rather than a canonical type.
   auto StringifyTypeExpr(InstId outer_inst_id) const -> std::string;
+
+  auto check_ir_id() const -> CheckIRId { return check_ir_id_; }
 
   // Directly expose SharedValueStores members.
   auto identifiers() -> StringStoreWrapper<IdentifierId>& {
@@ -191,6 +194,8 @@ class File : public Printable<File> {
 
  private:
   bool has_errors_ = false;
+
+  CheckIRId check_ir_id_;
 
   // Shared, compile-scoped values.
   SharedValueStores* value_stores_;

--- a/toolchain/sem_ir/ids.h
+++ b/toolchain/sem_ir/ids.h
@@ -220,6 +220,16 @@ struct FunctionId : public IdBase, public Printable<FunctionId> {
 
 constexpr FunctionId FunctionId::Invalid = FunctionId(InvalidIndex);
 
+// The ID of an IR within the set of all IRs being evaluated in the current
+// check execution.
+struct CheckIRId : public IdBase, public Printable<CheckIRId> {
+  using IdBase::IdBase;
+  auto Print(llvm::raw_ostream& out) const -> void {
+    out << "check_ir";
+    IdBase::Print(out);
+  }
+};
+
 // The ID of a class.
 struct ClassId : public IdBase, public Printable<ClassId> {
   using ValueType = Class;
@@ -268,7 +278,7 @@ struct ImplId : public IdBase, public Printable<ImplId> {
 
 constexpr ImplId ImplId::Invalid = ImplId(InvalidIndex);
 
-// The ID of an imported IR.
+// The ID of an IR within the set of imported IRs, both direct and indirect.
 struct ImportIRId : public IdBase, public Printable<ImportIRId> {
   using ValueType = ImportIR;
 


### PR DESCRIPTION
As we talk about how imports should work, we want to start having indirectly imported IRs in `import_irs`, where it's currently only directly imported IRs. The tracking of `CheckIRId` is set up to be able to determine whether an IR being indirectly imported is actually already tracked (and may be a direct import). Changes here to how ApiForImpl is handled start using the logic.

Note that indirect imports may be added while processing even the first import from the current library. As a consequence, it's necessary to prepare this map before starting imports, in particular, setting ApiForImpl before any indirect imports may encounter the same import. Also, prior validation that `num_irs` matches the final size are no longer relevant.

check_ir_id is tracked on SemIR because I want to be able to figure it out given an ImportIR, but the mapping is ephemeral after checking and so I store that in Context.

I'm putting relevant logic into import_ref.cpp because the primary alternative is import.cpp, and as more logic is added, ImportRefResolver will be adding import IRs.