### PR TITLE
Move instruction names for struct and tuple values from lower to `InstNamer`.

### DIFF
--- a/toolchain/check/testdata/alias/no_prelude/alias_of_alias.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/alias_of_alias.carbon
@@ -17,7 +17,7 @@ let d: c = {};
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,7 +37,7 @@ let d: c = {};
 // CHECK:STDOUT:   %c.ref: type = name_ref c, %c [template = constants.%C]
 // CHECK:STDOUT:   %.loc11_13.1: {} = struct_literal ()
 // CHECK:STDOUT:   %.loc11_13.2: ref C = temporary_storage
-// CHECK:STDOUT:   %.loc11_13.3: init C = class_init (), %.loc11_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_13.3: init C = class_init (), %.loc11_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc11_13.4: ref C = temporary %.loc11_13.2, %.loc11_13.3
 // CHECK:STDOUT:   %.loc11_14.1: ref C = converted %.loc11_13.1, %.loc11_13.4
 // CHECK:STDOUT:   %.loc11_14.2: C = bind_value %.loc11_14.1

--- a/toolchain/check/testdata/alias/no_prelude/fail_aliased_name_in_diag.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_aliased_name_in_diag.carbon
@@ -23,7 +23,7 @@ let c_var: c = d;
 // CHECK:STDOUT:   %D: type = class_type @D [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: D = struct_value () [template]
+// CHECK:STDOUT:   %struct: D = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -58,8 +58,8 @@ let c_var: c = d;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc11_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc11_13.2: init D = class_init (), file.%d.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc11_14: init D = converted %.loc11_13.1, %.loc11_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_13.2: init D = class_init (), file.%d.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc11_14: init D = converted %.loc11_13.1, %.loc11_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%d.var, %.loc11_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/no_prelude/fail_name_conflict.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_name_conflict.carbon
@@ -32,7 +32,7 @@ alias b = C;
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -62,12 +62,12 @@ alias b = C;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc17_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc17_13.2: init C = class_init (), file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc17_14: init C = converted %.loc17_13.1, %.loc17_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17_13.2: init C = class_init (), file.%a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc17_14: init C = converted %.loc17_13.1, %.loc17_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%a.var, %.loc17_14
 // CHECK:STDOUT:   %.loc19_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc19_13.2: init C = class_init (), file.%b.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc19_14: init C = converted %.loc19_13.1, %.loc19_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc19_13.2: init C = class_init (), file.%b.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc19_14: init C = converted %.loc19_13.1, %.loc19_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%b.var, %.loc19_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/no_prelude/fail_not_constant.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_not_constant.carbon
@@ -17,8 +17,8 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
-// CHECK:STDOUT:   %.3: type = ptr_type () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.2: type = ptr_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,12 +35,12 @@ fn F() {
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc8_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %a.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %a.var, %.loc8_17
 // CHECK:STDOUT:   %.loc9_11: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_12.1: type = converted %.loc9_11, constants.%.1 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_12.2: type = ptr_type () [template = constants.%.3]
+// CHECK:STDOUT:   %.loc9_12.2: type = ptr_type () [template = constants.%.2]
 // CHECK:STDOUT:   %b.var: ref ()* = var b
 // CHECK:STDOUT:   %b: ref ()* = bind_name b, %b.var
 // CHECK:STDOUT:   %a.ref: ref () = name_ref a, %a

--- a/toolchain/check/testdata/alias/no_prelude/import.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import.carbon
@@ -159,7 +159,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -178,8 +178,8 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc4_14.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_14.2: init () = tuple_init () to file.%a.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_15: init () = converted %.loc4_14.1, %.loc4_14.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_14.2: init () = tuple_init () to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc4_15: init () = converted %.loc4_14.1, %.loc4_14.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc4_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -188,7 +188,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -211,8 +211,8 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a_alias.ref: ref () = name_ref a_alias, file.%import_ref.2
-// CHECK:STDOUT:   %.loc8_13: init () = tuple_init () to file.%b.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_20: init () = converted %a_alias.ref, %.loc8_13 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_13: init () = tuple_init () to file.%b.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_20: init () = converted %a_alias.ref, %.loc8_13 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -221,7 +221,7 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -241,8 +241,8 @@ var c: () = a_alias_alias;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a_alias_alias.ref: ref () = name_ref a_alias_alias, file.%import_ref.1 [template = <error>]
-// CHECK:STDOUT:   %.loc12_13: init () = tuple_init () to file.%c.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_26: init () = converted %a_alias_alias.ref, %.loc12_13 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_13: init () = tuple_init () to file.%c.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc12_26: init () = converted %a_alias_alias.ref, %.loc12_13 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%c.var, %.loc12_26
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/no_prelude/import_order.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/import_order.carbon
@@ -71,9 +71,9 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.v: ()} [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {.v: ()} [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
-// CHECK:STDOUT:   %.5: C = struct_value (%.4) [template]
-// CHECK:STDOUT:   %.6: type = unbound_element_type C, () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%tuple) [template]
+// CHECK:STDOUT:   %.4: type = unbound_element_type C, () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -121,40 +121,40 @@ var a_val: a = {.v = b_val.v};
 // CHECK:STDOUT:   %.loc7_23.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_24.1: {.v: ()} = struct_literal (%.loc7_23.1)
 // CHECK:STDOUT:   %.loc7_24.2: ref () = class_element_access file.%d_val.var, element0
-// CHECK:STDOUT:   %.loc7_23.2: init () = tuple_init () to %.loc7_24.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_24.3: init () = converted %.loc7_23.1, %.loc7_23.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_24.4: init C = class_init (%.loc7_24.3), file.%d_val.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_25: init C = converted %.loc7_24.1, %.loc7_24.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_23.2: init () = tuple_init () to %.loc7_24.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_24.3: init () = converted %.loc7_23.1, %.loc7_23.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_24.4: init C = class_init (%.loc7_24.3), file.%d_val.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_25: init C = converted %.loc7_24.1, %.loc7_24.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%d_val.var, %.loc7_25
 // CHECK:STDOUT:   %d_val.ref: ref C = name_ref d_val, file.%d_val
 // CHECK:STDOUT:   %v.ref.loc8: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_27.1: ref () = class_element_access %d_val.ref, element0
 // CHECK:STDOUT:   %.loc8_29.1: {.v: ()} = struct_literal (%.loc8_27.1)
 // CHECK:STDOUT:   %.loc8_29.2: ref () = class_element_access file.%c_val.var, element0
-// CHECK:STDOUT:   %.loc8_27.2: init () = tuple_init () to %.loc8_29.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_29.3: init () = converted %.loc8_27.1, %.loc8_27.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_29.4: init C = class_init (%.loc8_29.3), file.%c_val.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_30: init C = converted %.loc8_29.1, %.loc8_29.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_27.2: init () = tuple_init () to %.loc8_29.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_29.3: init () = converted %.loc8_27.1, %.loc8_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_29.4: init C = class_init (%.loc8_29.3), file.%c_val.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_30: init C = converted %.loc8_29.1, %.loc8_29.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c_val.var, %.loc8_30
 // CHECK:STDOUT:   %c_val.ref: ref C = name_ref c_val, file.%c_val
 // CHECK:STDOUT:   %v.ref.loc9: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc9_27.1: ref () = class_element_access %c_val.ref, element0
 // CHECK:STDOUT:   %.loc9_29.1: {.v: ()} = struct_literal (%.loc9_27.1)
 // CHECK:STDOUT:   %.loc9_29.2: ref () = class_element_access file.%b_val.var, element0
-// CHECK:STDOUT:   %.loc9_27.2: init () = tuple_init () to %.loc9_29.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_29.3: init () = converted %.loc9_27.1, %.loc9_27.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_29.4: init C = class_init (%.loc9_29.3), file.%b_val.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_30: init C = converted %.loc9_29.1, %.loc9_29.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_27.2: init () = tuple_init () to %.loc9_29.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_29.3: init () = converted %.loc9_27.1, %.loc9_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_29.4: init C = class_init (%.loc9_29.3), file.%b_val.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc9_30: init C = converted %.loc9_29.1, %.loc9_29.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%b_val.var, %.loc9_30
 // CHECK:STDOUT:   %b_val.ref: ref C = name_ref b_val, file.%b_val
 // CHECK:STDOUT:   %v.ref.loc10: <unbound element of class C> = name_ref v, file.%import_ref.6 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_27.1: ref () = class_element_access %b_val.ref, element0
 // CHECK:STDOUT:   %.loc10_29.1: {.v: ()} = struct_literal (%.loc10_27.1)
 // CHECK:STDOUT:   %.loc10_29.2: ref () = class_element_access file.%a_val.var, element0
-// CHECK:STDOUT:   %.loc10_27.2: init () = tuple_init () to %.loc10_29.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_29.3: init () = converted %.loc10_27.1, %.loc10_27.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_29.4: init C = class_init (%.loc10_29.3), file.%a_val.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_30: init C = converted %.loc10_29.1, %.loc10_29.4 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_27.2: init () = tuple_init () to %.loc10_29.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_29.3: init () = converted %.loc10_27.1, %.loc10_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_29.4: init C = class_init (%.loc10_29.3), file.%a_val.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_30: init C = converted %.loc10_29.1, %.loc10_29.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%a_val.var, %.loc10_30
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/alias/no_prelude/in_namespace.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/in_namespace.carbon
@@ -23,8 +23,8 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   %.2: type = unbound_element_type C, () [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.v: ()} [template]
 // CHECK:STDOUT:   %.4: type = ptr_type {.v: ()} [template]
-// CHECK:STDOUT:   %.5: () = tuple_value () [template]
-// CHECK:STDOUT:   %.6: C = struct_value (%.5) [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,9 +45,9 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   %.loc12_23.1: {.v: ()} = struct_literal (%.loc12_22.1)
 // CHECK:STDOUT:   %.loc12_23.2: ref C = temporary_storage
 // CHECK:STDOUT:   %.loc12_23.3: ref () = class_element_access %.loc12_23.2, element0
-// CHECK:STDOUT:   %.loc12_22.2: init () = tuple_init () to %.loc12_23.3 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_23.4: init () = converted %.loc12_22.1, %.loc12_22.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_23.5: init C = class_init (%.loc12_23.4), %.loc12_23.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_22.2: init () = tuple_init () to %.loc12_23.3 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc12_23.4: init () = converted %.loc12_22.1, %.loc12_22.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc12_23.5: init C = class_init (%.loc12_23.4), %.loc12_23.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc12_23.6: ref C = temporary %.loc12_23.2, %.loc12_23.5
 // CHECK:STDOUT:   %.loc12_24.1: ref C = converted %.loc12_23.1, %.loc12_23.6
 // CHECK:STDOUT:   %.loc12_24.2: C = bind_value %.loc12_24.1
@@ -74,10 +74,10 @@ fn F() -> NS.a {
 // CHECK:STDOUT:   %.loc15_17.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc15_18.1: {.v: ()} = struct_literal (%.loc15_17.1)
 // CHECK:STDOUT:   %.loc15_18.2: ref () = class_element_access %return, element0
-// CHECK:STDOUT:   %.loc15_17.2: init () = tuple_init () to %.loc15_18.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc15_18.3: init () = converted %.loc15_17.1, %.loc15_17.2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc15_18.4: init C = class_init (%.loc15_18.3), %return [template = constants.%.6]
-// CHECK:STDOUT:   %.loc15_19: init C = converted %.loc15_18.1, %.loc15_18.4 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc15_17.2: init () = tuple_init () to %.loc15_18.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_18.3: init () = converted %.loc15_17.1, %.loc15_17.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_18.4: init C = class_init (%.loc15_18.3), %return [template = constants.%struct]
+// CHECK:STDOUT:   %.loc15_19: init C = converted %.loc15_18.1, %.loc15_18.4 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc15_19 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/alias/no_prelude/local.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/local.carbon
@@ -14,7 +14,7 @@ fn F() -> () {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -35,14 +35,14 @@ fn F() -> () {
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc8_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %a.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %a.var, %.loc8_17
 // CHECK:STDOUT:   %a.ref: ref () = name_ref a, %a
 // CHECK:STDOUT:   %b: ref () = bind_alias b, %a
 // CHECK:STDOUT:   %b.ref: ref () = name_ref b, %b
-// CHECK:STDOUT:   %.loc10_10: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_11: () = converted %b.ref, %.loc10_10 [template = constants.%.2]
-// CHECK:STDOUT:   return %.loc10_11
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10: () = converted %b.ref, %tuple [template = constants.%tuple]
+// CHECK:STDOUT:   return %.loc10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/array/array_vs_tuple.carbon
+++ b/toolchain/check/testdata/array/array_vs_tuple.carbon
@@ -20,10 +20,10 @@ fn G() {
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
-// CHECK:STDOUT:   %.9: type = tuple_type (type, type, type) [template]
-// CHECK:STDOUT:   %.10: type = ptr_type (i32, i32, i32) [template]
-// CHECK:STDOUT:   %.11: (i32, i32, i32) = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %.8: type = tuple_type (type, type, type) [template]
+// CHECK:STDOUT:   %.9: type = ptr_type (i32, i32, i32) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32, i32) = tuple_value (%.4, %.5, %.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,8 +54,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc9_29.8: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_29.9: ref i32 = array_index %a.var, %.loc9_29.8
 // CHECK:STDOUT:   %.loc9_29.10: init i32 = initialize_from %.loc9_28 to %.loc9_29.9 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc9_29.11: init [i32; 3] = array_init (%.loc9_29.4, %.loc9_29.7, %.loc9_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_30: init [i32; 3] = converted %.loc9_29.1, %.loc9_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc9_29.11: init [i32; 3] = array_init (%.loc9_29.4, %.loc9_29.7, %.loc9_29.10) to %a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc9_30: init [i32; 3] = converted %.loc9_29.1, %.loc9_29.11 [template = constants.%array]
 // CHECK:STDOUT:   assign %a.var, %.loc9_30
 // CHECK:STDOUT:   %.loc10_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_24.2: type = converted %.loc10_24.1, constants.%.6 [template = constants.%.6]
@@ -71,8 +71,8 @@ fn G() {
 // CHECK:STDOUT:   %.loc10_36.5: init i32 = initialize_from %.loc10_32 to %.loc10_36.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc10_36.6: ref i32 = tuple_access %b.var, element2
 // CHECK:STDOUT:   %.loc10_36.7: init i32 = initialize_from %.loc10_35 to %.loc10_36.6 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_36.8: init (i32, i32, i32) = tuple_init (%.loc10_36.3, %.loc10_36.5, %.loc10_36.7) to %b.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc10_37: init (i32, i32, i32) = converted %.loc10_36.1, %.loc10_36.8 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc10_36.8: init (i32, i32, i32) = tuple_init (%.loc10_36.3, %.loc10_36.5, %.loc10_36.7) to %b.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_37: init (i32, i32, i32) = converted %.loc10_36.1, %.loc10_36.8 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %b.var, %.loc10_37
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/assign_return_value.carbon
+++ b/toolchain/check/testdata/array/assign_return_value.carbon
@@ -16,10 +16,10 @@ fn Run() {
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.6: type = array_type %.5, i32 [template]
-// CHECK:STDOUT:   %.7: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: type = array_type %.4, i32 [template]
+// CHECK:STDOUT:   %.6: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -40,16 +40,16 @@ fn Run() {
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_literal (%.loc7_28)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc7_28) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc7_31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Run() {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_16: i32 = int_literal 1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_17: type = array_type %.loc10_16, i32 [template = constants.%.5]
 // CHECK:STDOUT:   %t.var: ref [i32; 1] = var t
 // CHECK:STDOUT:   %t: ref [i32; 1] = bind_name t, %t.var
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%F [template = file.%F]

--- a/toolchain/check/testdata/array/assign_var.carbon
+++ b/toolchain/check/testdata/array/assign_var.carbon
@@ -16,10 +16,10 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.7: (i32, i32, i32) = tuple_value (%.4, %.5, %.6) [template]
-// CHECK:STDOUT:   %.8: type = array_type %.6, i32 [template]
-// CHECK:STDOUT:   %.9: type = ptr_type [i32; 3] [template]
-// CHECK:STDOUT:   %.10: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32, i32) = tuple_value (%.4, %.5, %.6) [template]
+// CHECK:STDOUT:   %.7: type = array_type %.6, i32 [template]
+// CHECK:STDOUT:   %.8: type = ptr_type [i32; 3] [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -34,7 +34,7 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %a.var: ref (i32, i32, i32) = var a
 // CHECK:STDOUT:   %a: ref (i32, i32, i32) = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc8_14: i32 = int_literal 3 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, i32 [template = constants.%.7]
 // CHECK:STDOUT:   %b.var: ref [i32; 3] = var b
 // CHECK:STDOUT:   %b: ref [i32; 3] = bind_name b, %b.var
 // CHECK:STDOUT: }
@@ -51,13 +51,13 @@ var b: [i32; 3] = a;
 // CHECK:STDOUT:   %.loc7_34.5: init i32 = initialize_from %.loc7_30 to %.loc7_34.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_34.6: ref i32 = tuple_access file.%a.var, element2
 // CHECK:STDOUT:   %.loc7_34.7: init i32 = initialize_from %.loc7_33 to %.loc7_34.6 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_35: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_34.8: init (i32, i32, i32) = tuple_init (%.loc7_34.3, %.loc7_34.5, %.loc7_34.7) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_35: init (i32, i32, i32) = converted %.loc7_34.1, %.loc7_34.8 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_35
 // CHECK:STDOUT:   %a.ref: ref (i32, i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_19.1: ref i32 = tuple_access %a.ref, element0
 // CHECK:STDOUT:   %.loc8_19.2: i32 = bind_value %.loc8_19.1
-// CHECK:STDOUT:   %.loc8_19.3: i32 = int_literal 0 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc8_19.3: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc8_19.4: ref i32 = array_index file.%b.var, %.loc8_19.3
 // CHECK:STDOUT:   %.loc8_19.5: init i32 = initialize_from %.loc8_19.2 to %.loc8_19.4
 // CHECK:STDOUT:   %.loc8_19.6: ref i32 = tuple_access %a.ref, element1

--- a/toolchain/check/testdata/array/base.carbon
+++ b/toolchain/check/testdata/array/base.carbon
@@ -16,23 +16,23 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT:   %.4: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.6: [i32; 1] = tuple_value (%.1) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.8: type = array_type %.7, f64 [template]
-// CHECK:STDOUT:   %.9: type = ptr_type [f64; 2] [template]
-// CHECK:STDOUT:   %.10: f64 = float_literal 11.100000000000001 [template]
-// CHECK:STDOUT:   %.11: f64 = float_literal 2.2000000000000002 [template]
-// CHECK:STDOUT:   %.12: type = tuple_type (f64, f64) [template]
-// CHECK:STDOUT:   %.13: [f64; 2] = tuple_value (%.10, %.11) [template]
-// CHECK:STDOUT:   %.14: type = tuple_type () [template]
-// CHECK:STDOUT:   %.15: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.16: type = array_type %.15, () [template]
-// CHECK:STDOUT:   %.17: type = ptr_type [(); 5] [template]
-// CHECK:STDOUT:   %.18: type = tuple_type ((), (), (), (), ()) [template]
-// CHECK:STDOUT:   %.19: () = tuple_value () [template]
-// CHECK:STDOUT:   %.20: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.21: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.22: [(); 5] = tuple_value (%.19, %.19, %.19, %.19, %.19) [template]
+// CHECK:STDOUT:   %array.1: [i32; 1] = tuple_value (%.1) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.7: type = array_type %.6, f64 [template]
+// CHECK:STDOUT:   %.8: type = ptr_type [f64; 2] [template]
+// CHECK:STDOUT:   %.9: f64 = float_literal 11.100000000000001 [template]
+// CHECK:STDOUT:   %.10: f64 = float_literal 2.2000000000000002 [template]
+// CHECK:STDOUT:   %.11: type = tuple_type (f64, f64) [template]
+// CHECK:STDOUT:   %array.2: [f64; 2] = tuple_value (%.9, %.10) [template]
+// CHECK:STDOUT:   %.12: type = tuple_type () [template]
+// CHECK:STDOUT:   %.13: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.14: type = array_type %.13, () [template]
+// CHECK:STDOUT:   %.15: type = ptr_type [(); 5] [template]
+// CHECK:STDOUT:   %.16: type = tuple_type ((), (), (), (), ()) [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.18: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %array.3: [(); 5] = tuple_value (%tuple, %tuple, %tuple, %tuple, %tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,14 +47,14 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc7_15: type = array_type %.loc7_14, i32 [template = constants.%.2]
 // CHECK:STDOUT:   %a.var: ref [i32; 1] = var a
 // CHECK:STDOUT:   %a: ref [i32; 1] = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc8_14: i32 = int_literal 2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc8_15: type = array_type %.loc8_14, f64 [template = constants.%.7]
 // CHECK:STDOUT:   %b.var: ref [f64; 2] = var b
 // CHECK:STDOUT:   %b: ref [f64; 2] = bind_name b, %b.var
 // CHECK:STDOUT:   %.loc9_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.15]
-// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.14 [template = constants.%.14]
-// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.16]
+// CHECK:STDOUT:   %.loc9_13: i32 = int_literal 5 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc9_10.2: type = converted %.loc9_10.1, constants.%.12 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc9_14: type = array_type %.loc9_13, () [template = constants.%.14]
 // CHECK:STDOUT:   %c.var: ref [(); 5] = var c
 // CHECK:STDOUT:   %c: ref [(); 5] = bind_name c, %c.var
 // CHECK:STDOUT: }
@@ -66,20 +66,20 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc7_22.2: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_22.3: ref i32 = array_index file.%a.var, %.loc7_22.2
 // CHECK:STDOUT:   %.loc7_22.4: init i32 = initialize_from %.loc7_20 to %.loc7_22.3 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init (%.loc7_22.4) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_23: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_22.5: init [i32; 1] = array_init (%.loc7_22.4) to file.%a.var [template = constants.%array.1]
+// CHECK:STDOUT:   %.loc7_23: init [i32; 1] = converted %.loc7_22.1, %.loc7_22.5 [template = constants.%array.1]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_23
-// CHECK:STDOUT:   %.loc8_20: f64 = float_literal 11.100000000000001 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc8_26: f64 = float_literal 2.2000000000000002 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc8_20: f64 = float_literal 11.100000000000001 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc8_26: f64 = float_literal 2.2000000000000002 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc8_30.1: (f64, f64) = tuple_literal (%.loc8_20, %.loc8_26)
 // CHECK:STDOUT:   %.loc8_30.2: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc8_30.3: ref f64 = array_index file.%b.var, %.loc8_30.2
-// CHECK:STDOUT:   %.loc8_30.4: init f64 = initialize_from %.loc8_20 to %.loc8_30.3 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc8_30.4: init f64 = initialize_from %.loc8_20 to %.loc8_30.3 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc8_30.5: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc8_30.6: ref f64 = array_index file.%b.var, %.loc8_30.5
-// CHECK:STDOUT:   %.loc8_30.7: init f64 = initialize_from %.loc8_26 to %.loc8_30.6 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init (%.loc8_30.4, %.loc8_30.7) to file.%b.var [template = constants.%.13]
-// CHECK:STDOUT:   %.loc8_31: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc8_30.7: init f64 = initialize_from %.loc8_26 to %.loc8_30.6 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc8_30.8: init [f64; 2] = array_init (%.loc8_30.4, %.loc8_30.7) to file.%b.var [template = constants.%array.2]
+// CHECK:STDOUT:   %.loc8_31: init [f64; 2] = converted %.loc8_30.1, %.loc8_30.8 [template = constants.%array.2]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_31
 // CHECK:STDOUT:   %.loc9_20.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc9_24.1: () = tuple_literal ()
@@ -89,26 +89,26 @@ var c: [(); 5] = ((), (), (), (), (),);
 // CHECK:STDOUT:   %.loc9_38.1: ((), (), (), (), ()) = tuple_literal (%.loc9_20.1, %.loc9_24.1, %.loc9_28.1, %.loc9_32.1, %.loc9_36.1)
 // CHECK:STDOUT:   %.loc9_38.2: i32 = int_literal 0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_38.3: ref () = array_index file.%c.var, %.loc9_38.2
-// CHECK:STDOUT:   %.loc9_20.2: init () = tuple_init () to %.loc9_38.3 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.4: init () = converted %.loc9_20.1, %.loc9_20.2 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc9_20.2: init () = tuple_init () to %.loc9_38.3 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.4: init () = converted %.loc9_20.1, %.loc9_20.2 [template = constants.%tuple]
 // CHECK:STDOUT:   %.loc9_38.5: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc9_38.6: ref () = array_index file.%c.var, %.loc9_38.5
-// CHECK:STDOUT:   %.loc9_24.2: init () = tuple_init () to %.loc9_38.6 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.7: init () = converted %.loc9_24.1, %.loc9_24.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.8: i32 = int_literal 2 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_24.2: init () = tuple_init () to %.loc9_38.6 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.7: init () = converted %.loc9_24.1, %.loc9_24.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.8: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc9_38.9: ref () = array_index file.%c.var, %.loc9_38.8
-// CHECK:STDOUT:   %.loc9_28.2: init () = tuple_init () to %.loc9_38.9 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.10: init () = converted %.loc9_28.1, %.loc9_28.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.11: i32 = int_literal 3 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc9_28.2: init () = tuple_init () to %.loc9_38.9 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.10: init () = converted %.loc9_28.1, %.loc9_28.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.11: i32 = int_literal 3 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc9_38.12: ref () = array_index file.%c.var, %.loc9_38.11
-// CHECK:STDOUT:   %.loc9_32.2: init () = tuple_init () to %.loc9_38.12 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.13: init () = converted %.loc9_32.1, %.loc9_32.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.14: i32 = int_literal 4 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc9_32.2: init () = tuple_init () to %.loc9_38.12 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.13: init () = converted %.loc9_32.1, %.loc9_32.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.14: i32 = int_literal 4 [template = constants.%.18]
 // CHECK:STDOUT:   %.loc9_38.15: ref () = array_index file.%c.var, %.loc9_38.14
-// CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init () to %.loc9_38.15 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.16: init () = converted %.loc9_36.1, %.loc9_36.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc9_38.17: init [(); 5] = array_init (%.loc9_38.4, %.loc9_38.7, %.loc9_38.10, %.loc9_38.13, %.loc9_38.16) to file.%c.var [template = constants.%.22]
-// CHECK:STDOUT:   %.loc9_39: init [(); 5] = converted %.loc9_38.1, %.loc9_38.17 [template = constants.%.22]
+// CHECK:STDOUT:   %.loc9_36.2: init () = tuple_init () to %.loc9_38.15 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.16: init () = converted %.loc9_36.1, %.loc9_36.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_38.17: init [(); 5] = array_init (%.loc9_38.4, %.loc9_38.7, %.loc9_38.10, %.loc9_38.13, %.loc9_38.16) to file.%c.var [template = constants.%array.3]
+// CHECK:STDOUT:   %.loc9_39: init [(); 5] = converted %.loc9_38.1, %.loc9_38.17 [template = constants.%array.3]
 // CHECK:STDOUT:   assign file.%c.var, %.loc9_39
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/canonicalize_index.carbon
+++ b/toolchain/check/testdata/array/canonicalize_index.carbon
@@ -19,7 +19,7 @@ let b: [i32; 3]* = &a;
 // CHECK:STDOUT:   %.5: type = ptr_type [i32; 3] [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.1, %.2, %.3) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.1, %.2, %.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -68,8 +68,8 @@ let b: [i32; 3]* = &a;
 // CHECK:STDOUT:   %.loc9_35.8: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc9_35.9: ref i32 = array_index file.%a.var, %.loc9_35.8
 // CHECK:STDOUT:   %.loc9_35.10: init i32 = initialize_from %.loc9_34 to %.loc9_35.9 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc9_35.11: init [i32; 3] = array_init (%.loc9_35.4, %.loc9_35.7, %.loc9_35.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_36: init [i32; 3] = converted %.loc9_35.1, %.loc9_35.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc9_35.11: init [i32; 3] = array_init (%.loc9_35.4, %.loc9_35.7, %.loc9_35.10) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc9_36: init [i32; 3] = converted %.loc9_35.1, %.loc9_35.11 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc9_36
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/array/fail_out_of_bound_non_literal.carbon
+++ b/toolchain/check/testdata/array/fail_out_of_bound_non_literal.carbon
@@ -20,9 +20,9 @@ var b: i32 = a[{.index = 3}.index];
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
-// CHECK:STDOUT:   %.9: type = struct_type {.index: i32} [template]
-// CHECK:STDOUT:   %.10: {.index: i32} = struct_value (%.1) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.index: i32} [template]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -55,15 +55,15 @@ var b: i32 = a[{.index = 3}.index];
 // CHECK:STDOUT:   %.loc7_27.8: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.9: ref i32 = array_index file.%a.var, %.loc7_27.8
 // CHECK:STDOUT:   %.loc7_27.10: init i32 = initialize_from %.loc7_26 to %.loc7_27.9 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_26: i32 = int_literal 3 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_27.1: {.index: i32} = struct_literal (%.loc11_26)
-// CHECK:STDOUT:   %.loc11_27.2: {.index: i32} = struct_value (%.loc11_26) [template = constants.%.10]
-// CHECK:STDOUT:   %.loc11_27.3: {.index: i32} = converted %.loc11_27.1, %.loc11_27.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc11_28: i32 = struct_access %.loc11_27.3, element0 [template = constants.%.1]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.loc11_26) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc11_27.2: {.index: i32} = converted %.loc11_27.1, %struct [template = constants.%struct]
+// CHECK:STDOUT:   %.loc11_28: i32 = struct_access %.loc11_27.2, element0 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc11_34.1: ref i32 = array_index %a.ref, %.loc11_28 [template = <error>]
 // CHECK:STDOUT:   %.loc11_34.2: i32 = bind_value %.loc11_34.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc11_34.2

--- a/toolchain/check/testdata/array/function_param.carbon
+++ b/toolchain/check/testdata/array/function_param.carbon
@@ -22,7 +22,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -74,8 +74,8 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc12_20.9: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_20.10: ref i32 = array_index %.loc12_20.2, %.loc12_20.9
 // CHECK:STDOUT:   %.loc12_20.11: init i32 = initialize_from %.loc12_19 to %.loc12_20.10 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc12_20.12: init [i32; 3] = array_init (%.loc12_20.5, %.loc12_20.8, %.loc12_20.11) to %.loc12_20.2 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_11.1: init [i32; 3] = converted %.loc12_20.1, %.loc12_20.12 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc12_20.12: init [i32; 3] = array_init (%.loc12_20.5, %.loc12_20.8, %.loc12_20.11) to %.loc12_20.2 [template = constants.%array]
+// CHECK:STDOUT:   %.loc12_11.1: init [i32; 3] = converted %.loc12_20.1, %.loc12_20.12 [template = constants.%array]
 // CHECK:STDOUT:   %.loc12_11.2: ref [i32; 3] = temporary %.loc12_20.2, %.loc12_11.1
 // CHECK:STDOUT:   %.loc12_11.3: [i32; 3] = bind_value %.loc12_11.2
 // CHECK:STDOUT:   %F.call: init i32 = call %F.ref(%.loc12_11.3, %.loc12_23)

--- a/toolchain/check/testdata/array/index_not_literal.carbon
+++ b/toolchain/check/testdata/array/index_not_literal.carbon
@@ -17,9 +17,9 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
-// CHECK:STDOUT:   %.9: type = struct_type {.index: i32} [template]
-// CHECK:STDOUT:   %.10: {.index: i32} = struct_value (%.5) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.index: i32} [template]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -52,15 +52,15 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.loc7_27.8: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_27.9: ref i32 = array_index file.%a.var, %.loc7_27.8
 // CHECK:STDOUT:   %.loc7_27.10: init i32 = initialize_from %.loc7_26 to %.loc7_27.9 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_27.11: init [i32; 3] = array_init (%.loc7_27.4, %.loc7_27.7, %.loc7_27.10) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_28: init [i32; 3] = converted %.loc7_27.1, %.loc7_27.11 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_26: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc8_27.1: {.index: i32} = struct_literal (%.loc8_26)
-// CHECK:STDOUT:   %.loc8_27.2: {.index: i32} = struct_value (%.loc8_26) [template = constants.%.10]
-// CHECK:STDOUT:   %.loc8_27.3: {.index: i32} = converted %.loc8_27.1, %.loc8_27.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc8_28: i32 = struct_access %.loc8_27.3, element0 [template = constants.%.5]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.loc8_26) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_27.2: {.index: i32} = converted %.loc8_27.1, %struct [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_28: i32 = struct_access %.loc8_27.2, element0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc8_34.1: ref i32 = array_index %a.ref, %.loc8_28
 // CHECK:STDOUT:   %.loc8_34.2: i32 = bind_value %.loc8_34.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_34.2

--- a/toolchain/check/testdata/array/nine_elements.carbon
+++ b/toolchain/check/testdata/array/nine_elements.carbon
@@ -22,7 +22,7 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.11: i32 = int_literal 8 [template]
 // CHECK:STDOUT:   %.12: type = tuple_type (i32, i32, i32, i32, i32, i32, i32, i32, i32) [template]
 // CHECK:STDOUT:   %.13: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.14: [i32; 9] = tuple_value (%.4, %.5, %.6, %.7, %.8, %.9, %.10, %.11, %.1) [template]
+// CHECK:STDOUT:   %array: [i32; 9] = tuple_value (%.4, %.5, %.6, %.7, %.8, %.9, %.10, %.11, %.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -76,8 +76,8 @@ var a: [i32; 9] = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 // CHECK:STDOUT:   %.loc7_45.26: i32 = int_literal 8 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc7_45.27: ref i32 = array_index file.%a.var, %.loc7_45.26
 // CHECK:STDOUT:   %.loc7_45.28: init i32 = initialize_from %.loc7_44 to %.loc7_45.27 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc7_45.29: init [i32; 9] = array_init (%.loc7_45.4, %.loc7_45.7, %.loc7_45.10, %.loc7_45.13, %.loc7_45.16, %.loc7_45.19, %.loc7_45.22, %.loc7_45.25, %.loc7_45.28) to file.%a.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc7_46: init [i32; 9] = converted %.loc7_45.1, %.loc7_45.29 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc7_45.29: init [i32; 9] = array_init (%.loc7_45.4, %.loc7_45.7, %.loc7_45.10, %.loc7_45.13, %.loc7_45.16, %.loc7_45.19, %.loc7_45.22, %.loc7_45.25, %.loc7_45.28) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_46: init [i32; 9] = converted %.loc7_45.1, %.loc7_45.29 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_46
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/as/adapter_conversion.carbon
+++ b/toolchain/check/testdata/as/adapter_conversion.carbon
@@ -107,9 +107,9 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.3: type = ptr_type {.x: i32, .y: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: A = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %struct: A = struct_value (%.4, %.5) [template]
 // CHECK:STDOUT:   %B: type = class_type @B [template]
-// CHECK:STDOUT:   %.7: type = ptr_type B [template]
+// CHECK:STDOUT:   %.6: type = ptr_type B [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -137,7 +137,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.loc21_22.2: B = converted %a_val.ref, %.loc21_22.1
 // CHECK:STDOUT:   %b_val: B = bind_name b_val, %.loc21_22.2
 // CHECK:STDOUT:   %B.ref.loc22_12: type = name_ref B, %B.decl [template = constants.%B]
-// CHECK:STDOUT:   %.loc22_13: type = ptr_type B [template = constants.%.7]
+// CHECK:STDOUT:   %.loc22_13: type = ptr_type B [template = constants.%.6]
 // CHECK:STDOUT:   %a_ref.ref.loc22: ref A = name_ref a_ref, %a_ref
 // CHECK:STDOUT:   %B.ref.loc22_28: type = name_ref B, %B.decl [template = constants.%B]
 // CHECK:STDOUT:   %.loc22_25.1: ref B = as_compatible %a_ref.ref.loc22
@@ -181,8 +181,8 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.loc9_27.3: init i32 = initialize_from %.loc9_18 to %.loc9_27.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_27.4: ref i32 = class_element_access @A.%return.var, element1
 // CHECK:STDOUT:   %.loc9_27.5: init i32 = initialize_from %.loc9_26 to %.loc9_27.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_27.6: init A = class_init (%.loc9_27.3, %.loc9_27.5), @A.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_28: init A = converted %.loc9_27.1, %.loc9_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_27.6: init A = class_init (%.loc9_27.3, %.loc9_27.5), @A.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc9_28: init A = converted %.loc9_27.1, %.loc9_27.6 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc9_28 to @A.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -195,8 +195,8 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.loc17_31.3: init i32 = initialize_from %.loc17_22 to %.loc17_31.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc17_31.4: ref i32 = class_element_access file.%a_ref.var, element1
 // CHECK:STDOUT:   %.loc17_31.5: init i32 = initialize_from %.loc17_30 to %.loc17_31.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc17_31.6: init A = class_init (%.loc17_31.3, %.loc17_31.5), file.%a_ref.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc17_32: init A = converted %.loc17_31.1, %.loc17_31.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc17_31.6: init A = class_init (%.loc17_31.3, %.loc17_31.5), file.%a_ref.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc17_32: init A = converted %.loc17_31.1, %.loc17_31.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%a_ref.var, %.loc17_32
 // CHECK:STDOUT:   %A.ref: type = name_ref A, file.%A.decl [template = constants.%A]
 // CHECK:STDOUT:   %Make.ref: <function> = name_ref Make, @A.%Make [template = @A.%Make]
@@ -251,7 +251,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %B: type = class_type @B [template]
 // CHECK:STDOUT:   %C: type = class_type @C [template]
 // CHECK:STDOUT:   %D: type = class_type @D [template]
-// CHECK:STDOUT:   %.3: {} = struct_value () [template]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -268,11 +268,11 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %D.decl: type = class_decl @D [template = constants.%D] {}
 // CHECK:STDOUT:   %D.ref.loc9_8: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:   %.loc9_13.1: {} = struct_literal ()
+// CHECK:STDOUT:   %.loc9_13: {} = struct_literal ()
 // CHECK:STDOUT:   %D.ref.loc9_18: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:   %.loc9_13.2: {} = struct_value () [template = constants.%.3]
-// CHECK:STDOUT:   %.loc9_15.1: D = as_compatible %.loc9_13.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc9_15.2: D = converted %.loc9_13.1, %.loc9_15.1 [template = constants.%.3]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template = constants.%struct]
+// CHECK:STDOUT:   %.loc9_15.1: D = as_compatible %struct [template = constants.%struct]
+// CHECK:STDOUT:   %.loc9_15.2: D = converted %.loc9_13, %.loc9_15.1 [template = constants.%struct]
 // CHECK:STDOUT:   %d: D = bind_name d, %.loc9_15.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -319,7 +319,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.3: type = ptr_type {.x: i32, .y: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: A = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %struct: A = struct_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -342,7 +342,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.loc13_34.4: init i32 = initialize_from %.loc13_25 to %.loc13_34.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_34.5: ref i32 = class_element_access %.loc13_34.2, element1
 // CHECK:STDOUT:   %.loc13_34.6: init i32 = initialize_from %.loc13_33 to %.loc13_34.5 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc13_34.7: init A = class_init (%.loc13_34.4, %.loc13_34.6), %.loc13_34.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc13_34.7: init A = class_init (%.loc13_34.4, %.loc13_34.6), %.loc13_34.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc13_34.8: ref A = temporary %.loc13_34.2, %.loc13_34.7
 // CHECK:STDOUT:   %.loc13_36: ref A = converted %.loc13_34.1, %.loc13_34.8
 // CHECK:STDOUT:   %B.ref.loc13_45: type = name_ref B, %B.decl [template = constants.%B]
@@ -384,7 +384,7 @@ var b: B = {.x = 1} as B;
 // CHECK:STDOUT:   %.loc24_33.4: init i32 = initialize_from %.loc24_24 to %.loc24_33.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc24_33.5: ref i32 = class_element_access %.loc24_33.2, element1
 // CHECK:STDOUT:   %.loc24_33.6: init i32 = initialize_from %.loc24_32 to %.loc24_33.5 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc24_33.7: init A = class_init (%.loc24_33.4, %.loc24_33.6), %.loc24_33.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc24_33.7: init A = class_init (%.loc24_33.4, %.loc24_33.6), %.loc24_33.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc24_33.8: ref A = temporary %.loc24_33.2, %.loc24_33.7
 // CHECK:STDOUT:   %.loc24_35: ref A = converted %.loc24_33.1, %.loc24_33.8
 // CHECK:STDOUT:   %B.ref: type = name_ref B, file.%B.decl [template = constants.%B]

--- a/toolchain/check/testdata/as/no_prelude/tuple.carbon
+++ b/toolchain/check/testdata/as/no_prelude/tuple.carbon
@@ -68,7 +68,7 @@ fn Var() {
 // CHECK:STDOUT:   %Make.ref.loc15_28: <function> = name_ref Make, file.%Make [template = file.%Make]
 // CHECK:STDOUT:   %.loc15_32.1: ref X = temporary_storage
 // CHECK:STDOUT:   %Make.call.loc15_32: init X = call %Make.ref.loc15_28() to %.loc15_32.1
-// CHECK:STDOUT:   %.loc15_34.1: (X, X) = tuple_literal (%Make.call.loc15_24, %Make.call.loc15_32)
+// CHECK:STDOUT:   %.loc15_34: (X, X) = tuple_literal (%Make.call.loc15_24, %Make.call.loc15_32)
 // CHECK:STDOUT:   %X.ref.loc15_40: type = name_ref X, file.%X.decl [template = constants.%X]
 // CHECK:STDOUT:   %X.ref.loc15_43: type = name_ref X, file.%X.decl [template = constants.%X]
 // CHECK:STDOUT:   %.loc15_44.1: (type, type) = tuple_literal (%X.ref.loc15_40, %X.ref.loc15_43)
@@ -77,8 +77,8 @@ fn Var() {
 // CHECK:STDOUT:   %.loc15_24.3: X = bind_value %.loc15_24.2
 // CHECK:STDOUT:   %.loc15_32.2: ref X = temporary %.loc15_32.1, %Make.call.loc15_32
 // CHECK:STDOUT:   %.loc15_32.3: X = bind_value %.loc15_32.2
-// CHECK:STDOUT:   %.loc15_34.2: (X, X) = tuple_value (%.loc15_24.3, %.loc15_32.3)
-// CHECK:STDOUT:   %.loc15_45: (X, X) = converted %.loc15_34.1, %.loc15_34.2
+// CHECK:STDOUT:   %tuple: (X, X) = tuple_value (%.loc15_24.3, %.loc15_32.3)
+// CHECK:STDOUT:   %.loc15_45: (X, X) = converted %.loc15_34, %tuple
 // CHECK:STDOUT:   %a: (X, X) = bind_name a, %.loc15_45
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/raw_and_textual_ir.carbon
@@ -154,8 +154,8 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = tuple_type ((), ()) [template]
 // CHECK:STDOUT:   %.3: type = ptr_type ((), ()) [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
-// CHECK:STDOUT:   %.5: ((), ()) = tuple_value (%.4, %.4) [template]
+// CHECK:STDOUT:   %tuple.1: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple.2: ((), ()) = tuple_value (%tuple.1, %tuple.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -183,13 +183,13 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.loc12_15.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_16.1: ((), ()) = tuple_literal (%n.ref, %.loc12_15.1)
 // CHECK:STDOUT:   %.loc12_16.2: ref () = tuple_access %return, element0
-// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%tuple.1]
 // CHECK:STDOUT:   %.loc12_16.4: ref () = tuple_access %return, element1
-// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%tuple.2]
 // CHECK:STDOUT:   return %.loc12_17 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/no_prelude/textual_ir.carbon
+++ b/toolchain/check/testdata/basics/no_prelude/textual_ir.carbon
@@ -18,8 +18,8 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = tuple_type ((), ()) [template]
 // CHECK:STDOUT:   %.3: type = ptr_type ((), ()) [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
-// CHECK:STDOUT:   %.5: ((), ()) = tuple_value (%.4, %.4) [template]
+// CHECK:STDOUT:   %tuple.1: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple.2: ((), ()) = tuple_value (%tuple.1, %tuple.1) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,13 +47,13 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   %.loc12_15.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc12_16.1: ((), ()) = tuple_literal (%n.ref, %.loc12_15.1)
 // CHECK:STDOUT:   %.loc12_16.2: ref () = tuple_access %return, element0
-// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_11: init () = tuple_init () to %.loc12_16.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.3: init () = converted %n.ref, %.loc12_11 [template = constants.%tuple.1]
 // CHECK:STDOUT:   %.loc12_16.4: ref () = tuple_access %return, element1
-// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%.5]
-// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_15.2: init () = tuple_init () to %.loc12_16.4 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.5: init () = converted %.loc12_15.1, %.loc12_15.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc12_16.6: init ((), ()) = tuple_init (%.loc12_16.3, %.loc12_16.5) to %return [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc12_17: init ((), ()) = converted %.loc12_16.1, %.loc12_16.6 [template = constants.%tuple.2]
 // CHECK:STDOUT:   return %.loc12_17 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/basics/numeric_literals.carbon
+++ b/toolchain/check/testdata/basics/numeric_literals.carbon
@@ -41,17 +41,17 @@ fn F() {
 // CHECK:STDOUT:   %.11: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.12: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.13: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.14: [i32; 6] = tuple_value (%.4, %.5, %.4, %.4, %.6, %.6) [template]
-// CHECK:STDOUT:   %.15: type = array_type %.1, f64 [template]
-// CHECK:STDOUT:   %.16: type = ptr_type [f64; 6] [template]
-// CHECK:STDOUT:   %.17: f64 = float_literal 0.90000000000000002 [template]
-// CHECK:STDOUT:   %.18: f64 = float_literal 8 [template]
-// CHECK:STDOUT:   %.19: f64 = float_literal 80 [template]
-// CHECK:STDOUT:   %.20: f64 = float_literal 1.0E+7 [template]
-// CHECK:STDOUT:   %.21: f64 = float_literal 1.0E+8 [template]
-// CHECK:STDOUT:   %.22: f64 = float_literal 1.0E-8 [template]
-// CHECK:STDOUT:   %.23: type = tuple_type (f64, f64, f64, f64, f64, f64) [template]
-// CHECK:STDOUT:   %.24: [f64; 6] = tuple_value (%.17, %.18, %.19, %.20, %.21, %.22) [template]
+// CHECK:STDOUT:   %array.1: [i32; 6] = tuple_value (%.4, %.5, %.4, %.4, %.6, %.6) [template]
+// CHECK:STDOUT:   %.14: type = array_type %.1, f64 [template]
+// CHECK:STDOUT:   %.15: type = ptr_type [f64; 6] [template]
+// CHECK:STDOUT:   %.16: f64 = float_literal 0.90000000000000002 [template]
+// CHECK:STDOUT:   %.17: f64 = float_literal 8 [template]
+// CHECK:STDOUT:   %.18: f64 = float_literal 80 [template]
+// CHECK:STDOUT:   %.19: f64 = float_literal 1.0E+7 [template]
+// CHECK:STDOUT:   %.20: f64 = float_literal 1.0E+8 [template]
+// CHECK:STDOUT:   %.21: f64 = float_literal 1.0E-8 [template]
+// CHECK:STDOUT:   %.22: type = tuple_type (f64, f64, f64, f64, f64, f64) [template]
+// CHECK:STDOUT:   %array.2: [f64; 6] = tuple_value (%.16, %.17, %.18, %.19, %.20, %.21) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -94,40 +94,40 @@ fn F() {
 // CHECK:STDOUT:   %.loc17_3.17: i32 = int_literal 5 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc17_3.18: ref i32 = array_index %ints.var, %.loc17_3.17
 // CHECK:STDOUT:   %.loc17_3.19: init i32 = initialize_from %.loc16 to %.loc17_3.18 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc17_3.20: init [i32; 6] = array_init (%.loc17_3.4, %.loc17_3.7, %.loc17_3.10, %.loc17_3.13, %.loc17_3.16, %.loc17_3.19) to %ints.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc17_4: init [i32; 6] = converted %.loc17_3.1, %.loc17_3.20 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc17_3.20: init [i32; 6] = array_init (%.loc17_3.4, %.loc17_3.7, %.loc17_3.10, %.loc17_3.13, %.loc17_3.16, %.loc17_3.19) to %ints.var [template = constants.%array.1]
+// CHECK:STDOUT:   %.loc17_4: init [i32; 6] = converted %.loc17_3.1, %.loc17_3.20 [template = constants.%array.1]
 // CHECK:STDOUT:   assign %ints.var, %.loc17_4
 // CHECK:STDOUT:   %.loc18_21: i32 = int_literal 6 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc18_22: type = array_type %.loc18_21, f64 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc18_22: type = array_type %.loc18_21, f64 [template = constants.%.14]
 // CHECK:STDOUT:   %floats.var: ref [f64; 6] = var floats
 // CHECK:STDOUT:   %floats: ref [f64; 6] = bind_name floats, %floats.var
-// CHECK:STDOUT:   %.loc19: f64 = float_literal 0.90000000000000002 [template = constants.%.17]
-// CHECK:STDOUT:   %.loc20: f64 = float_literal 8 [template = constants.%.18]
-// CHECK:STDOUT:   %.loc21: f64 = float_literal 80 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc22: f64 = float_literal 1.0E+7 [template = constants.%.20]
-// CHECK:STDOUT:   %.loc23: f64 = float_literal 1.0E+8 [template = constants.%.21]
-// CHECK:STDOUT:   %.loc24: f64 = float_literal 1.0E-8 [template = constants.%.22]
+// CHECK:STDOUT:   %.loc19: f64 = float_literal 0.90000000000000002 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc20: f64 = float_literal 8 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc21: f64 = float_literal 80 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc22: f64 = float_literal 1.0E+7 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc23: f64 = float_literal 1.0E+8 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc24: f64 = float_literal 1.0E-8 [template = constants.%.21]
 // CHECK:STDOUT:   %.loc25_3.1: (f64, f64, f64, f64, f64, f64) = tuple_literal (%.loc19, %.loc20, %.loc21, %.loc22, %.loc23, %.loc24)
 // CHECK:STDOUT:   %.loc25_3.2: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc25_3.3: ref f64 = array_index %floats.var, %.loc25_3.2
-// CHECK:STDOUT:   %.loc25_3.4: init f64 = initialize_from %.loc19 to %.loc25_3.3 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc25_3.4: init f64 = initialize_from %.loc19 to %.loc25_3.3 [template = constants.%.16]
 // CHECK:STDOUT:   %.loc25_3.5: i32 = int_literal 1 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc25_3.6: ref f64 = array_index %floats.var, %.loc25_3.5
-// CHECK:STDOUT:   %.loc25_3.7: init f64 = initialize_from %.loc20 to %.loc25_3.6 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc25_3.7: init f64 = initialize_from %.loc20 to %.loc25_3.6 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc25_3.8: i32 = int_literal 2 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc25_3.9: ref f64 = array_index %floats.var, %.loc25_3.8
-// CHECK:STDOUT:   %.loc25_3.10: init f64 = initialize_from %.loc21 to %.loc25_3.9 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc25_3.10: init f64 = initialize_from %.loc21 to %.loc25_3.9 [template = constants.%.18]
 // CHECK:STDOUT:   %.loc25_3.11: i32 = int_literal 3 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc25_3.12: ref f64 = array_index %floats.var, %.loc25_3.11
-// CHECK:STDOUT:   %.loc25_3.13: init f64 = initialize_from %.loc22 to %.loc25_3.12 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc25_3.13: init f64 = initialize_from %.loc22 to %.loc25_3.12 [template = constants.%.19]
 // CHECK:STDOUT:   %.loc25_3.14: i32 = int_literal 4 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc25_3.15: ref f64 = array_index %floats.var, %.loc25_3.14
-// CHECK:STDOUT:   %.loc25_3.16: init f64 = initialize_from %.loc23 to %.loc25_3.15 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc25_3.16: init f64 = initialize_from %.loc23 to %.loc25_3.15 [template = constants.%.20]
 // CHECK:STDOUT:   %.loc25_3.17: i32 = int_literal 5 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc25_3.18: ref f64 = array_index %floats.var, %.loc25_3.17
-// CHECK:STDOUT:   %.loc25_3.19: init f64 = initialize_from %.loc24 to %.loc25_3.18 [template = constants.%.22]
-// CHECK:STDOUT:   %.loc25_3.20: init [f64; 6] = array_init (%.loc25_3.4, %.loc25_3.7, %.loc25_3.10, %.loc25_3.13, %.loc25_3.16, %.loc25_3.19) to %floats.var [template = constants.%.24]
-// CHECK:STDOUT:   %.loc25_4: init [f64; 6] = converted %.loc25_3.1, %.loc25_3.20 [template = constants.%.24]
+// CHECK:STDOUT:   %.loc25_3.19: init f64 = initialize_from %.loc24 to %.loc25_3.18 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc25_3.20: init [f64; 6] = array_init (%.loc25_3.4, %.loc25_3.7, %.loc25_3.10, %.loc25_3.13, %.loc25_3.16, %.loc25_3.19) to %floats.var [template = constants.%array.2]
+// CHECK:STDOUT:   %.loc25_4: init [f64; 6] = converted %.loc25_3.1, %.loc25_3.20 [template = constants.%array.2]
 // CHECK:STDOUT:   assign %floats.var, %.loc25_4
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/base.carbon
+++ b/toolchain/check/testdata/class/base.carbon
@@ -39,11 +39,11 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:   %.10: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.11: i32 = int_literal 7 [template]
 // CHECK:STDOUT:   %.12: type = struct_type {.base: {.b: i32}, .d: i32} [template]
-// CHECK:STDOUT:   %.13: Base = struct_value (%.10) [template]
-// CHECK:STDOUT:   %.14: Derived = struct_value (%.13, %.11) [template]
-// CHECK:STDOUT:   %.15: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.16: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.17: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %struct.1: Base = struct_value (%.10) [template]
+// CHECK:STDOUT:   %struct.2: Derived = struct_value (%struct.1, %.11) [template]
+// CHECK:STDOUT:   %.13: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.14: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.15: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -66,7 +66,7 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:     %d.loc21_11.1: Derived = param d
 // CHECK:STDOUT:     @Access.%d: Derived = bind_name d, %d.loc21_11.1
 // CHECK:STDOUT:     %.loc21_35.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:     %.loc21_35.2: type = converted %.loc21_35.1, constants.%.16 [template = constants.%.16]
+// CHECK:STDOUT:     %.loc21_35.2: type = converted %.loc21_35.1, constants.%.14 [template = constants.%.14]
 // CHECK:STDOUT:     @Access.%return: ref (i32, i32) = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -100,12 +100,12 @@ fn Access(d: Derived) -> (i32, i32) {
 // CHECK:STDOUT:   %.loc18_35.2: ref Base = class_element_access %return, element0
 // CHECK:STDOUT:   %.loc18_26.2: ref i32 = class_element_access %.loc18_35.2, element0
 // CHECK:STDOUT:   %.loc18_26.3: init i32 = initialize_from %.loc18_25 to %.loc18_26.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc18_26.4: init Base = class_init (%.loc18_26.3), %.loc18_35.2 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc18_35.3: init Base = converted %.loc18_26.1, %.loc18_26.4 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc18_26.4: init Base = class_init (%.loc18_26.3), %.loc18_35.2 [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc18_35.3: init Base = converted %.loc18_26.1, %.loc18_26.4 [template = constants.%struct.1]
 // CHECK:STDOUT:   %.loc18_35.4: ref i32 = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc18_35.5: init i32 = initialize_from %.loc18_34 to %.loc18_35.4 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc18_35.6: init Derived = class_init (%.loc18_35.3, %.loc18_35.5), %return [template = constants.%.14]
-// CHECK:STDOUT:   %.loc18_36: init Derived = converted %.loc18_35.1, %.loc18_35.6 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc18_35.6: init Derived = class_init (%.loc18_35.3, %.loc18_35.5), %return [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc18_36: init Derived = converted %.loc18_35.1, %.loc18_35.6 [template = constants.%struct.2]
 // CHECK:STDOUT:   return %.loc18_36 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -166,7 +166,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -194,8 +194,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc6_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc6_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc6_20: init C = converted %.loc6_19.1, %.loc6_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc6_19.2: init C = class_init (), file.%c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc6_20: init C = converted %.loc6_19.1, %.loc6_19.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c.var, %.loc6_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -240,7 +240,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %C.2: type = class_type @C.2 [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -272,8 +272,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc23_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc23_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc23_20: init C = converted %.loc23_19.1, %.loc23_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc23_19.2: init C = class_init (), file.%c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc23_20: init C = converted %.loc23_19.1, %.loc23_19.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c.var, %.loc23_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -285,7 +285,7 @@ var c: Other.C = {};
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -316,8 +316,8 @@ var c: Other.C = {};
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc22_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc22_19.2: init C = class_init (), file.%c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc22_20: init C = converted %.loc22_19.1, %.loc22_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc22_19.2: init C = class_init (), file.%c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc22_20: init C = converted %.loc22_19.1, %.loc22_19.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c.var, %.loc22_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/class/derived_to_base.carbon
+++ b/toolchain/check/testdata/class/derived_to_base.carbon
@@ -63,9 +63,9 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.21: type = struct_type {.base: {.a: i32}, .b: i32} [template]
 // CHECK:STDOUT:   %.22: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.23: type = struct_type {.base: {.base: {.a: i32}, .b: i32}, .c: i32} [template]
-// CHECK:STDOUT:   %.24: A = struct_value (%.19) [template]
-// CHECK:STDOUT:   %.25: B = struct_value (%.24, %.20) [template]
-// CHECK:STDOUT:   %.26: C = struct_value (%.25, %.22) [template]
+// CHECK:STDOUT:   %struct.1: A = struct_value (%.19) [template]
+// CHECK:STDOUT:   %struct.2: B = struct_value (%struct.1, %.20) [template]
+// CHECK:STDOUT:   %struct.3: C = struct_value (%struct.2, %.22) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -231,15 +231,15 @@ fn ConvertInit() {
 // CHECK:STDOUT:   %.loc34_48.2: ref A = class_element_access %.loc34_57.3, element0
 // CHECK:STDOUT:   %.loc34_39.2: ref i32 = class_element_access %.loc34_48.2, element0
 // CHECK:STDOUT:   %.loc34_39.3: init i32 = initialize_from %.loc34_38 to %.loc34_39.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc34_39.4: init A = class_init (%.loc34_39.3), %.loc34_48.2 [template = constants.%.24]
-// CHECK:STDOUT:   %.loc34_48.3: init A = converted %.loc34_39.1, %.loc34_39.4 [template = constants.%.24]
+// CHECK:STDOUT:   %.loc34_39.4: init A = class_init (%.loc34_39.3), %.loc34_48.2 [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc34_48.3: init A = converted %.loc34_39.1, %.loc34_39.4 [template = constants.%struct.1]
 // CHECK:STDOUT:   %.loc34_48.4: ref i32 = class_element_access %.loc34_57.3, element1
 // CHECK:STDOUT:   %.loc34_48.5: init i32 = initialize_from %.loc34_47 to %.loc34_48.4 [template = constants.%.20]
-// CHECK:STDOUT:   %.loc34_48.6: init B = class_init (%.loc34_48.3, %.loc34_48.5), %.loc34_57.3 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc34_57.4: init B = converted %.loc34_48.1, %.loc34_48.6 [template = constants.%.25]
+// CHECK:STDOUT:   %.loc34_48.6: init B = class_init (%.loc34_48.3, %.loc34_48.5), %.loc34_57.3 [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc34_57.4: init B = converted %.loc34_48.1, %.loc34_48.6 [template = constants.%struct.2]
 // CHECK:STDOUT:   %.loc34_57.5: ref i32 = class_element_access %.loc34_57.2, element1
 // CHECK:STDOUT:   %.loc34_57.6: init i32 = initialize_from %.loc34_56 to %.loc34_57.5 [template = constants.%.22]
-// CHECK:STDOUT:   %.loc34_57.7: init C = class_init (%.loc34_57.4, %.loc34_57.6), %.loc34_57.2 [template = constants.%.26]
+// CHECK:STDOUT:   %.loc34_57.7: init C = class_init (%.loc34_57.4, %.loc34_57.6), %.loc34_57.2 [template = constants.%struct.3]
 // CHECK:STDOUT:   %.loc34_57.8: ref C = temporary %.loc34_57.2, %.loc34_57.7
 // CHECK:STDOUT:   %.loc34_59: ref C = converted %.loc34_57.1, %.loc34_57.8
 // CHECK:STDOUT:   %.loc34_63.1: ref B = class_element_access %.loc34_59, element0

--- a/toolchain/check/testdata/class/fail_init_as_inplace.carbon
+++ b/toolchain/check/testdata/class/fail_init_as_inplace.carbon
@@ -32,8 +32,8 @@ fn F() {
 // CHECK:STDOUT:   %.4: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.7: Class = struct_value (%.5, %.6) [template]
-// CHECK:STDOUT:   %.8: type = tuple_type () [template]
+// CHECK:STDOUT:   %struct: Class = struct_value (%.5, %.6) [template]
+// CHECK:STDOUT:   %.7: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -80,7 +80,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc21_33.4: init i32 = initialize_from %.loc21_24 to %.loc21_33.3 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc21_33.5: ref i32 = class_element_access %.loc21_33.2, element1
 // CHECK:STDOUT:   %.loc21_33.6: init i32 = initialize_from %.loc21_32 to %.loc21_33.5 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc21_33.7: init Class = class_init (%.loc21_33.4, %.loc21_33.6), %.loc21_33.2 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_33.7: init Class = class_init (%.loc21_33.4, %.loc21_33.6), %.loc21_33.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc21_33.8: ref Class = temporary %.loc21_33.2, %.loc21_33.7
 // CHECK:STDOUT:   %.loc21_35.1: ref Class = converted %.loc21_33.1, %.loc21_33.8
 // CHECK:STDOUT:   %.loc21_35.2: Class = bind_value %.loc21_35.1

--- a/toolchain/check/testdata/class/fail_self_type_member.carbon
+++ b/toolchain/check/testdata/class/fail_self_type_member.carbon
@@ -29,7 +29,7 @@ fn F() -> bool {
 // CHECK:STDOUT:   %.2: type = struct_type {.b: bool} [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {.b: bool} [template]
 // CHECK:STDOUT:   %.4: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.5: Class = struct_value (%.4) [template]
+// CHECK:STDOUT:   %struct: Class = struct_value (%.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {}

--- a/toolchain/check/testdata/class/import.carbon
+++ b/toolchain/check/testdata/class/import.carbon
@@ -120,20 +120,20 @@ fn Run() {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: Empty = struct_value () [template]
+// CHECK:STDOUT:   %struct.1: Empty = struct_value () [template]
 // CHECK:STDOUT:   %Field: type = class_type @Field [template]
-// CHECK:STDOUT:   %.5: type = struct_type {.x: i32} [template]
-// CHECK:STDOUT:   %.6: type = ptr_type {.x: i32} [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.8: Field = struct_value (%.7) [template]
-// CHECK:STDOUT:   %.9: type = unbound_element_type Field, i32 [template]
-// CHECK:STDOUT:   %.10: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.4: type = struct_type {.x: i32} [template]
+// CHECK:STDOUT:   %.5: type = ptr_type {.x: i32} [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %struct.2: Field = struct_value (%.6) [template]
+// CHECK:STDOUT:   %.7: type = unbound_element_type Field, i32 [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %ForwardDeclared.1: type = class_type @ForwardDeclared.1 [template]
-// CHECK:STDOUT:   %.11: ForwardDeclared = struct_value () [template]
+// CHECK:STDOUT:   %struct.3: ForwardDeclared = struct_value () [template]
 // CHECK:STDOUT:   %ForwardDeclared.2: type = class_type @ForwardDeclared.2 [template]
-// CHECK:STDOUT:   %.12: type = ptr_type ForwardDeclared [template]
+// CHECK:STDOUT:   %.9: type = ptr_type ForwardDeclared [template]
 // CHECK:STDOUT:   %Incomplete: type = class_type @Incomplete [template]
-// CHECK:STDOUT:   %.13: type = ptr_type Incomplete [template]
+// CHECK:STDOUT:   %.10: type = ptr_type Incomplete [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -196,32 +196,32 @@ fn Run() {
 // CHECK:STDOUT:   %a.var: ref Empty = var a
 // CHECK:STDOUT:   %a: ref Empty = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc7_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_19.2: init Empty = class_init (), %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_20: init Empty = converted %.loc7_19.1, %.loc7_19.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_19.2: init Empty = class_init (), %a.var [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc7_20: init Empty = converted %.loc7_19.1, %.loc7_19.2 [template = constants.%struct.1]
 // CHECK:STDOUT:   assign %a.var, %.loc7_20
 // CHECK:STDOUT:   %Field.decl: type = class_decl @Field [template = constants.%Field] {}
 // CHECK:STDOUT:   %Field.ref: type = name_ref Field, file.%import_ref.2 [template = constants.%Field]
 // CHECK:STDOUT:   %b.var: ref Field = var b
 // CHECK:STDOUT:   %b: ref Field = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc9_24: i32 = int_literal 1 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9_24: i32 = int_literal 1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc9_25.1: {.x: i32} = struct_literal (%.loc9_24)
 // CHECK:STDOUT:   %.loc9_25.2: ref i32 = class_element_access %b.var, element0
-// CHECK:STDOUT:   %.loc9_25.3: init i32 = initialize_from %.loc9_24 to %.loc9_25.2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc9_25.4: init Field = class_init (%.loc9_25.3), %b.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc9_26: init Field = converted %.loc9_25.1, %.loc9_25.4 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc9_25.3: init i32 = initialize_from %.loc9_24 to %.loc9_25.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_25.4: init Field = class_init (%.loc9_25.3), %b.var [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc9_26: init Field = converted %.loc9_25.1, %.loc9_25.4 [template = constants.%struct.2]
 // CHECK:STDOUT:   assign %b.var, %.loc9_26
 // CHECK:STDOUT:   %b.ref: ref Field = name_ref b, %b
 // CHECK:STDOUT:   %x.ref: <unbound element of class Field> = name_ref x, file.%import_ref.7 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc10_4: ref i32 = class_element_access %b.ref, element0
-// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 2 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc10_9: i32 = int_literal 2 [template = constants.%.8]
 // CHECK:STDOUT:   assign %.loc10_4, %.loc10_9
 // CHECK:STDOUT:   %ForwardDeclared.decl.1: type = class_decl @ForwardDeclared.1 [template = constants.%ForwardDeclared.1] {}
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc12: type = name_ref ForwardDeclared, file.%import_ref.3 [template = constants.%ForwardDeclared.1]
 // CHECK:STDOUT:   %c.var: ref ForwardDeclared = var c
 // CHECK:STDOUT:   %c: ref ForwardDeclared = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc12_29.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_29.2: init ForwardDeclared = class_init (), %c.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc12_30: init ForwardDeclared = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc12_29.2: init ForwardDeclared = class_init (), %c.var [template = constants.%struct.3]
+// CHECK:STDOUT:   %.loc12_30: init ForwardDeclared = converted %.loc12_29.1, %.loc12_29.2 [template = constants.%struct.3]
 // CHECK:STDOUT:   assign %c.var, %.loc12_30
 // CHECK:STDOUT:   %c.ref.loc13: ref ForwardDeclared = name_ref c, %c
 // CHECK:STDOUT:   %ForwardDeclared.decl.2: type = class_decl @ForwardDeclared.2 [template = constants.%ForwardDeclared.2] {}
@@ -235,7 +235,7 @@ fn Run() {
 // CHECK:STDOUT:   %.loc14_3: ForwardDeclared* = addr_of %c.ref.loc14
 // CHECK:STDOUT:   %.loc14_6: init () = call %.loc14_4(%.loc14_3)
 // CHECK:STDOUT:   %ForwardDeclared.ref.loc16: type = name_ref ForwardDeclared, file.%import_ref.3 [template = constants.%ForwardDeclared.1]
-// CHECK:STDOUT:   %.loc16_25: type = ptr_type ForwardDeclared [template = constants.%.12]
+// CHECK:STDOUT:   %.loc16_25: type = ptr_type ForwardDeclared [template = constants.%.9]
 // CHECK:STDOUT:   %d.var: ref ForwardDeclared* = var d
 // CHECK:STDOUT:   %d: ref ForwardDeclared* = bind_name d, %d.var
 // CHECK:STDOUT:   %c.ref.loc16: ref ForwardDeclared = name_ref c, %c
@@ -243,7 +243,7 @@ fn Run() {
 // CHECK:STDOUT:   assign %d.var, %.loc16_29
 // CHECK:STDOUT:   %Incomplete.decl: type = class_decl @Incomplete [template = constants.%Incomplete] {}
 // CHECK:STDOUT:   %Incomplete.ref: type = name_ref Incomplete, file.%import_ref.4 [template = constants.%Incomplete]
-// CHECK:STDOUT:   %.loc18: type = ptr_type Incomplete [template = constants.%.13]
+// CHECK:STDOUT:   %.loc18: type = ptr_type Incomplete [template = constants.%.10]
 // CHECK:STDOUT:   %e.var: ref Incomplete* = var e
 // CHECK:STDOUT:   %e: ref Incomplete* = bind_name e, %e.var
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/class/import_base.carbon
+++ b/toolchain/check/testdata/class/import_base.carbon
@@ -105,11 +105,11 @@ fn Run() {
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.9: type = struct_type {.base: {.x: i32, .unused: i32}} [template]
-// CHECK:STDOUT:   %.10: Base = struct_value (%.7, %.8) [template]
-// CHECK:STDOUT:   %.11: Child = struct_value (%.10) [template]
-// CHECK:STDOUT:   %.12: type = unbound_element_type Base, i32 [template]
-// CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.14: type = tuple_type () [template]
+// CHECK:STDOUT:   %struct.1: Base = struct_value (%.7, %.8) [template]
+// CHECK:STDOUT:   %struct.2: Child = struct_value (%struct.1) [template]
+// CHECK:STDOUT:   %.10: type = unbound_element_type Base, i32 [template]
+// CHECK:STDOUT:   %.11: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.12: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -164,17 +164,17 @@ fn Run() {
 // CHECK:STDOUT:   %.loc7_47.3: init i32 = initialize_from %.loc7_33 to %.loc7_47.2 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc7_47.4: ref i32 = class_element_access %.loc7_48.2, element1
 // CHECK:STDOUT:   %.loc7_47.5: init i32 = initialize_from %.loc7_46 to %.loc7_47.4 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_47.6: init Base = class_init (%.loc7_47.3, %.loc7_47.5), %.loc7_48.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_48.3: init Base = converted %.loc7_47.1, %.loc7_47.6 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_48.4: init Child = class_init (%.loc7_48.3), %a.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc7_49: init Child = converted %.loc7_48.1, %.loc7_48.4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc7_47.6: init Base = class_init (%.loc7_47.3, %.loc7_47.5), %.loc7_48.2 [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc7_48.3: init Base = converted %.loc7_47.1, %.loc7_47.6 [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc7_48.4: init Child = class_init (%.loc7_48.3), %a.var [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc7_49: init Child = converted %.loc7_48.1, %.loc7_48.4 [template = constants.%struct.2]
 // CHECK:STDOUT:   assign %a.var, %.loc7_49
 // CHECK:STDOUT:   %a.ref.loc8: ref Child = name_ref a, %a
 // CHECK:STDOUT:   %x.ref: <unbound element of class Base> = name_ref x, file.%import_ref.5 [template = imports.%.1]
 // CHECK:STDOUT:   %.loc8_4.1: ref Base = class_element_access %a.ref.loc8, element0
 // CHECK:STDOUT:   %.loc8_4.2: ref Base = converted %a.ref.loc8, %.loc8_4.1
 // CHECK:STDOUT:   %.loc8_4.3: ref i32 = class_element_access %.loc8_4.2, element0
-// CHECK:STDOUT:   %.loc8_9: i32 = int_literal 2 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc8_9: i32 = int_literal 2 [template = constants.%.11]
 // CHECK:STDOUT:   assign %.loc8_4.3, %.loc8_9
 // CHECK:STDOUT:   %a.ref.loc9: ref Child = name_ref a, %a
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, file.%import_ref.3 [template = imports.%F]

--- a/toolchain/check/testdata/class/import_triangle.carbon
+++ b/toolchain/check/testdata/class/import_triangle.carbon
@@ -62,8 +62,8 @@ var d2: D* = &c2;
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
-// CHECK:STDOUT:   %.5: type = ptr_type C [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.4: type = ptr_type C [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -84,7 +84,7 @@ var d2: D* = &c2;
 // CHECK:STDOUT:   %c1.var: ref C = var c1
 // CHECK:STDOUT:   %c1: ref C = bind_name c1, %c1.var
 // CHECK:STDOUT:   %D.ref: type = name_ref D, %D [template = constants.%C]
-// CHECK:STDOUT:   %.loc9: type = ptr_type C [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9: type = ptr_type C [template = constants.%.4]
 // CHECK:STDOUT:   %d1.var: ref C* = var d1
 // CHECK:STDOUT:   %d1: ref C* = bind_name d1, %d1.var
 // CHECK:STDOUT: }
@@ -97,8 +97,8 @@ var d2: D* = &c2;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_14.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc8_14.2: init C = class_init (), file.%c1.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_15: init C = converted %.loc8_14.1, %.loc8_14.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc8_14.2: init C = class_init (), file.%c1.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_15: init C = converted %.loc8_14.1, %.loc8_14.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c1.var, %.loc8_15
 // CHECK:STDOUT:   %c1.ref: ref C = name_ref c1, file.%c1
 // CHECK:STDOUT:   %.loc9: C* = addr_of %c1.ref
@@ -113,10 +113,10 @@ var d2: D* = &c2;
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT:   %C.2: type = class_type @C.2 [template]
+// CHECK:STDOUT:   %.4: type = ptr_type C [template]
 // CHECK:STDOUT:   %.5: type = ptr_type C [template]
-// CHECK:STDOUT:   %.6: type = ptr_type C [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -142,7 +142,7 @@ var d2: D* = &c2;
 // CHECK:STDOUT:   %C.decl.2: type = class_decl @C.2 [template = constants.%C.2] {}
 // CHECK:STDOUT:   %import_ref.6 = import_ref ir2, inst+6, unloaded
 // CHECK:STDOUT:   %D.ref: type = name_ref D, %import_ref.2 [template = constants.%C.2]
-// CHECK:STDOUT:   %.loc11: type = ptr_type C [template = constants.%.5]
+// CHECK:STDOUT:   %.loc11: type = ptr_type C [template = constants.%.4]
 // CHECK:STDOUT:   %d2.var: ref C* = var d2
 // CHECK:STDOUT:   %d2: ref C* = bind_name d2, %d2.var
 // CHECK:STDOUT: }
@@ -160,8 +160,8 @@ var d2: D* = &c2;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_14.2: init C = class_init (), file.%c2.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_15: init C = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_14.2: init C = class_init (), file.%c2.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_15: init C = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c2.var, %.loc7_15
 // CHECK:STDOUT:   %c2.ref: ref C = name_ref c2, file.%c2
 // CHECK:STDOUT:   %.loc11: C* = addr_of %c2.ref

--- a/toolchain/check/testdata/class/init_adapt.carbon
+++ b/toolchain/check/testdata/class/init_adapt.carbon
@@ -85,7 +85,7 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.3: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: C = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -110,7 +110,7 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.loc13_27.4: init i32 = initialize_from %.loc13_18 to %.loc13_27.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_27.5: ref i32 = class_element_access %.loc13_27.2, element1
 // CHECK:STDOUT:   %.loc13_27.6: init i32 = initialize_from %.loc13_26 to %.loc13_27.5 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc13_27.8: ref C = temporary %.loc13_27.2, %.loc13_27.7
 // CHECK:STDOUT:   %.loc13_28.1: ref C = converted %.loc13_27.1, %.loc13_27.8
 // CHECK:STDOUT:   %.loc13_28.2: C = bind_value %.loc13_28.1
@@ -194,7 +194,7 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.3: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: C = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -219,7 +219,7 @@ var e: C = MakeAdaptC();
 // CHECK:STDOUT:   %.loc13_27.4: init i32 = initialize_from %.loc13_18 to %.loc13_27.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_27.5: ref i32 = class_element_access %.loc13_27.2, element1
 // CHECK:STDOUT:   %.loc13_27.6: init i32 = initialize_from %.loc13_26 to %.loc13_27.5 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc13_27.7: init C = class_init (%.loc13_27.4, %.loc13_27.6), %.loc13_27.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc13_27.8: ref C = temporary %.loc13_27.2, %.loc13_27.7
 // CHECK:STDOUT:   %.loc13_28.1: ref C = converted %.loc13_27.1, %.loc13_27.8
 // CHECK:STDOUT:   %.loc13_28.2: C = bind_value %.loc13_28.1

--- a/toolchain/check/testdata/class/init_as.carbon
+++ b/toolchain/check/testdata/class/init_as.carbon
@@ -22,7 +22,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.6: Class = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %struct: Class = struct_value (%.3, %.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -59,7 +59,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc13_26.4: init i32 = initialize_from %.loc13_17 to %.loc13_26.3 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc13_26.5: ref i32 = class_element_access %.loc13_26.2, element1
 // CHECK:STDOUT:   %.loc13_26.6: init i32 = initialize_from %.loc13_25 to %.loc13_26.5 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_26.7: init Class = class_init (%.loc13_26.4, %.loc13_26.6), %.loc13_26.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc13_26.7: init Class = class_init (%.loc13_26.4, %.loc13_26.6), %.loc13_26.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc13_26.8: ref Class = temporary %.loc13_26.2, %.loc13_26.7
 // CHECK:STDOUT:   %.loc13_28: ref Class = converted %.loc13_26.1, %.loc13_26.8
 // CHECK:STDOUT:   %a.ref: <unbound element of class Class> = name_ref a, @Class.%.loc8 [template = @Class.%.loc8]

--- a/toolchain/check/testdata/class/method.carbon
+++ b/toolchain/check/testdata/class/method.carbon
@@ -63,7 +63,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.3: type = struct_type {.k: i32} [template]
 // CHECK:STDOUT:   %.4: type = ptr_type {.k: i32} [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.6: Class = struct_value (%.5) [template]
+// CHECK:STDOUT:   %struct: Class = struct_value (%.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -200,7 +200,7 @@ fn CallGOnInitializingExpr() -> i32 {
 // CHECK:STDOUT:   %.loc31_18.2: ref Class = temporary_storage
 // CHECK:STDOUT:   %.loc31_18.3: ref i32 = class_element_access %.loc31_18.2, element0
 // CHECK:STDOUT:   %.loc31_18.4: init i32 = initialize_from %.loc31_17 to %.loc31_18.3 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc31_18.5: init Class = class_init (%.loc31_18.4), %.loc31_18.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc31_18.5: init Class = class_init (%.loc31_18.4), %.loc31_18.2 [template = constants.%struct]
 // CHECK:STDOUT:   %.loc31_18.6: ref Class = temporary %.loc31_18.2, %.loc31_18.5
 // CHECK:STDOUT:   %.loc31_20.1: ref Class = converted %.loc31_18.1, %.loc31_18.6
 // CHECK:STDOUT:   %F.ref: <function> = name_ref F, @Class.%F [template = @Class.%F]

--- a/toolchain/check/testdata/class/reorder_qualified.carbon
+++ b/toolchain/check/testdata/class/reorder_qualified.carbon
@@ -59,17 +59,17 @@ class A {
 // CHECK:STDOUT:   %.8: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %.9: type = ptr_type {.a: i32} [template]
 // CHECK:STDOUT:   %.10: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.11: A = struct_value (%.10) [template]
-// CHECK:STDOUT:   %.12: type = ptr_type {.b: i32} [template]
-// CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.14: B = struct_value (%.13) [template]
-// CHECK:STDOUT:   %.15: type = ptr_type {.c: i32} [template]
-// CHECK:STDOUT:   %.16: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.17: C = struct_value (%.16) [template]
-// CHECK:STDOUT:   %.18: type = ptr_type {.d: i32} [template]
-// CHECK:STDOUT:   %.19: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.20: D = struct_value (%.19) [template]
-// CHECK:STDOUT:   %.21: type = tuple_type () [template]
+// CHECK:STDOUT:   %struct.1: A = struct_value (%.10) [template]
+// CHECK:STDOUT:   %.11: type = ptr_type {.b: i32} [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %struct.2: B = struct_value (%.12) [template]
+// CHECK:STDOUT:   %.13: type = ptr_type {.c: i32} [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %struct.3: C = struct_value (%.14) [template]
+// CHECK:STDOUT:   %.15: type = ptr_type {.d: i32} [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %struct.4: D = struct_value (%.16) [template]
+// CHECK:STDOUT:   %.17: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -144,38 +144,38 @@ class A {
 // CHECK:STDOUT:   %.loc25_25.1: {.a: i32} = struct_literal (%.loc25_24)
 // CHECK:STDOUT:   %.loc25_25.2: ref i32 = class_element_access %a.var, element0
 // CHECK:STDOUT:   %.loc25_25.3: init i32 = initialize_from %.loc25_24 to %.loc25_25.2 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc25_25.4: init A = class_init (%.loc25_25.3), %a.var [template = constants.%.11]
-// CHECK:STDOUT:   %.loc25_26: init A = converted %.loc25_25.1, %.loc25_25.4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc25_25.4: init A = class_init (%.loc25_25.3), %a.var [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc25_26: init A = converted %.loc25_25.1, %.loc25_25.4 [template = constants.%struct.1]
 // CHECK:STDOUT:   assign %a.var, %.loc25_26
 // CHECK:STDOUT:   %B.ref: type = name_ref B, @A.%B.decl [template = constants.%B]
 // CHECK:STDOUT:   %b.var: ref B = var b
 // CHECK:STDOUT:   %b: ref B = bind_name b, %b.var
-// CHECK:STDOUT:   %.loc26_24: i32 = int_literal 2 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc26_24: i32 = int_literal 2 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc26_25.1: {.b: i32} = struct_literal (%.loc26_24)
 // CHECK:STDOUT:   %.loc26_25.2: ref i32 = class_element_access %b.var, element0
-// CHECK:STDOUT:   %.loc26_25.3: init i32 = initialize_from %.loc26_24 to %.loc26_25.2 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc26_25.4: init B = class_init (%.loc26_25.3), %b.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc26_26: init B = converted %.loc26_25.1, %.loc26_25.4 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc26_25.3: init i32 = initialize_from %.loc26_24 to %.loc26_25.2 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc26_25.4: init B = class_init (%.loc26_25.3), %b.var [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc26_26: init B = converted %.loc26_25.1, %.loc26_25.4 [template = constants.%struct.2]
 // CHECK:STDOUT:   assign %b.var, %.loc26_26
 // CHECK:STDOUT:   %C.ref: type = name_ref C, @B.%C.decl [template = constants.%C]
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
-// CHECK:STDOUT:   %.loc27_24: i32 = int_literal 3 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc27_24: i32 = int_literal 3 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc27_25.1: {.c: i32} = struct_literal (%.loc27_24)
 // CHECK:STDOUT:   %.loc27_25.2: ref i32 = class_element_access %c.var, element0
-// CHECK:STDOUT:   %.loc27_25.3: init i32 = initialize_from %.loc27_24 to %.loc27_25.2 [template = constants.%.16]
-// CHECK:STDOUT:   %.loc27_25.4: init C = class_init (%.loc27_25.3), %c.var [template = constants.%.17]
-// CHECK:STDOUT:   %.loc27_26: init C = converted %.loc27_25.1, %.loc27_25.4 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc27_25.3: init i32 = initialize_from %.loc27_24 to %.loc27_25.2 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc27_25.4: init C = class_init (%.loc27_25.3), %c.var [template = constants.%struct.3]
+// CHECK:STDOUT:   %.loc27_26: init C = converted %.loc27_25.1, %.loc27_25.4 [template = constants.%struct.3]
 // CHECK:STDOUT:   assign %c.var, %.loc27_26
 // CHECK:STDOUT:   %D.ref: type = name_ref D, @C.%D.decl [template = constants.%D]
 // CHECK:STDOUT:   %d.var: ref D = var d
 // CHECK:STDOUT:   %d: ref D = bind_name d, %d.var
-// CHECK:STDOUT:   %.loc28_24: i32 = int_literal 4 [template = constants.%.19]
+// CHECK:STDOUT:   %.loc28_24: i32 = int_literal 4 [template = constants.%.16]
 // CHECK:STDOUT:   %.loc28_25.1: {.d: i32} = struct_literal (%.loc28_24)
 // CHECK:STDOUT:   %.loc28_25.2: ref i32 = class_element_access %d.var, element0
-// CHECK:STDOUT:   %.loc28_25.3: init i32 = initialize_from %.loc28_24 to %.loc28_25.2 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc28_25.4: init D = class_init (%.loc28_25.3), %d.var [template = constants.%.20]
-// CHECK:STDOUT:   %.loc28_26: init D = converted %.loc28_25.1, %.loc28_25.4 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc28_25.3: init i32 = initialize_from %.loc28_24 to %.loc28_25.2 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc28_25.4: init D = class_init (%.loc28_25.3), %d.var [template = constants.%struct.4]
+// CHECK:STDOUT:   %.loc28_26: init D = converted %.loc28_25.1, %.loc28_25.4 [template = constants.%struct.4]
 // CHECK:STDOUT:   assign %d.var, %.loc28_26
 // CHECK:STDOUT:   %AF.ref: <function> = name_ref AF, @A.%AF [template = @A.%AF]
 // CHECK:STDOUT:   %AF.call: init () = call %AF.ref()

--- a/toolchain/check/testdata/eval/aggregate.carbon
+++ b/toolchain/check/testdata/eval/aggregate.carbon
@@ -20,29 +20,29 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.8: type = ptr_type {.a: i32, .b: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.9: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.10: type = struct_type {.c: i32, .b: i32, .a: i32} [template]
-// CHECK:STDOUT:   %.11: type = struct_type {.b: i32, .a: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.12: type = ptr_type {.b: i32, .a: i32, .c: i32} [template]
-// CHECK:STDOUT:   %.13: {.b: i32, .a: i32, .c: i32} = struct_value (%.5, %.4, %.9) [template]
-// CHECK:STDOUT:   %.14: {.a: i32, .b: i32, .c: i32} = struct_value (%.4, %.5, %.9) [template]
-// CHECK:STDOUT:   %.15: type = array_type %.4, i32 [template]
-// CHECK:STDOUT:   %.16: type = ptr_type [i32; 1] [template]
-// CHECK:STDOUT:   %.17: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.18: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.19: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.20: i32 = int_literal 7 [template]
-// CHECK:STDOUT:   %.21: i32 = int_literal 9 [template]
-// CHECK:STDOUT:   %.22: type = tuple_type (i32, i32, i32, i32) [template]
-// CHECK:STDOUT:   %.23: type = ptr_type (i32, i32, i32, i32) [template]
-// CHECK:STDOUT:   %.24: (i32, i32, i32, i32) = tuple_value (%.19, %.20, %.4, %.21) [template]
-// CHECK:STDOUT:   %.25: [i32; 1] = tuple_value (%.17) [template]
-// CHECK:STDOUT:   %.26: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.27: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.28: {.a: i32, .b: i32} = struct_value (%.9, %.4) [template]
+// CHECK:STDOUT:   %tuple.1: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type {.a: i32, .b: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.9: type = struct_type {.c: i32, .b: i32, .a: i32} [template]
+// CHECK:STDOUT:   %.10: type = struct_type {.b: i32, .a: i32, .c: i32} [template]
+// CHECK:STDOUT:   %.11: type = ptr_type {.b: i32, .a: i32, .c: i32} [template]
+// CHECK:STDOUT:   %struct.1: {.b: i32, .a: i32, .c: i32} = struct_value (%.5, %.4, %.8) [template]
+// CHECK:STDOUT:   %struct.2: {.a: i32, .b: i32, .c: i32} = struct_value (%.4, %.5, %.8) [template]
+// CHECK:STDOUT:   %.12: type = array_type %.4, i32 [template]
+// CHECK:STDOUT:   %.13: type = ptr_type [i32; 1] [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.15: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.17: i32 = int_literal 7 [template]
+// CHECK:STDOUT:   %.18: i32 = int_literal 9 [template]
+// CHECK:STDOUT:   %.19: type = tuple_type (i32, i32, i32, i32) [template]
+// CHECK:STDOUT:   %.20: type = ptr_type (i32, i32, i32, i32) [template]
+// CHECK:STDOUT:   %tuple.2: (i32, i32, i32, i32) = tuple_value (%.16, %.17, %.4, %.18) [template]
+// CHECK:STDOUT:   %array: [i32; 1] = tuple_value (%.14) [template]
+// CHECK:STDOUT:   %.21: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.22: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %struct.3: {.a: i32, .b: i32} = struct_value (%.8, %.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -58,15 +58,15 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.loc7_26.2: type = converted %.loc7_26.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %tuple_copy.var: ref (i32, i32) = var tuple_copy
 // CHECK:STDOUT:   %tuple_copy: ref (i32, i32) = bind_name tuple_copy, %tuple_copy.var
-// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32, .b: i32, .c: i32} [template = constants.%.7]
+// CHECK:STDOUT:   %.loc9: type = struct_type {.a: i32, .b: i32, .c: i32} [template = constants.%.6]
 // CHECK:STDOUT:   %struct_copy.var: ref {.a: i32, .b: i32, .c: i32} = var struct_copy
 // CHECK:STDOUT:   %struct_copy: ref {.a: i32, .b: i32, .c: i32} = bind_name struct_copy, %struct_copy.var
 // CHECK:STDOUT:   %.loc11_24: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc11_25: type = array_type %.loc11_24, i32 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc11_25: type = array_type %.loc11_24, i32 [template = constants.%.12]
 // CHECK:STDOUT:   %tuple_index.var: ref [i32; 1] = var tuple_index
 // CHECK:STDOUT:   %tuple_index: ref [i32; 1] = bind_name tuple_index, %tuple_index.var
 // CHECK:STDOUT:   %.loc13_26: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_27: type = array_type %.loc13_26, i32 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc13_27: type = array_type %.loc13_26, i32 [template = constants.%.12]
 // CHECK:STDOUT:   %struct_access.var: ref [i32; 1] = var struct_access
 // CHECK:STDOUT:   %struct_access: ref [i32; 1] = bind_name struct_access, %struct_access.var
 // CHECK:STDOUT: }
@@ -82,62 +82,62 @@ var struct_access: [i32; 1] = (0,) as [i32; {.a = 3, .b = 1}.b];
 // CHECK:STDOUT:   %.loc7_35.3: init i32 = initialize_from %.loc7_31 to %.loc7_35.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_35.4: ref i32 = tuple_access file.%tuple_copy.var, element1
 // CHECK:STDOUT:   %.loc7_35.5: init i32 = initialize_from %.loc7_34 to %.loc7_35.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_35.6: init (i32, i32) = tuple_init (%.loc7_35.3, %.loc7_35.5) to file.%tuple_copy.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_50: init (i32, i32) = converted %.loc7_35.1, %.loc7_35.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_35.6: init (i32, i32) = tuple_init (%.loc7_35.3, %.loc7_35.5) to file.%tuple_copy.var [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc7_50: init (i32, i32) = converted %.loc7_35.1, %.loc7_35.6 [template = constants.%tuple.1]
 // CHECK:STDOUT:   assign file.%tuple_copy.var, %.loc7_50
-// CHECK:STDOUT:   %.loc9_54: i32 = int_literal 3 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc9_54: i32 = int_literal 3 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc9_62: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_70: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_71.1: {.c: i32, .b: i32, .a: i32} = struct_literal (%.loc9_54, %.loc9_62, %.loc9_70)
-// CHECK:STDOUT:   %.loc9_102: type = struct_type {.b: i32, .a: i32, .c: i32} [template = constants.%.11]
-// CHECK:STDOUT:   %.loc9_71.2: {.b: i32, .a: i32, .c: i32} = struct_value (%.loc9_62, %.loc9_70, %.loc9_54) [template = constants.%.13]
-// CHECK:STDOUT:   %.loc9_73.1: {.b: i32, .a: i32, .c: i32} = converted %.loc9_71.1, %.loc9_71.2 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc9_71: {.c: i32, .b: i32, .a: i32} = struct_literal (%.loc9_54, %.loc9_62, %.loc9_70)
+// CHECK:STDOUT:   %.loc9_102: type = struct_type {.b: i32, .a: i32, .c: i32} [template = constants.%.10]
+// CHECK:STDOUT:   %struct.loc9: {.b: i32, .a: i32, .c: i32} = struct_value (%.loc9_62, %.loc9_70, %.loc9_54) [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc9_73.1: {.b: i32, .a: i32, .c: i32} = converted %.loc9_71, %struct.loc9 [template = constants.%struct.1]
 // CHECK:STDOUT:   %.loc9_73.2: i32 = struct_access %.loc9_73.1, element1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_73.3: ref i32 = struct_access file.%struct_copy.var, element1
 // CHECK:STDOUT:   %.loc9_73.4: init i32 = initialize_from %.loc9_73.2 to %.loc9_73.3 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_73.5: i32 = struct_access %.loc9_73.1, element0 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc9_73.6: ref i32 = struct_access file.%struct_copy.var, element0
 // CHECK:STDOUT:   %.loc9_73.7: init i32 = initialize_from %.loc9_73.5 to %.loc9_73.6 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_73.8: i32 = struct_access %.loc9_73.1, element2 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc9_73.8: i32 = struct_access %.loc9_73.1, element2 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc9_73.9: ref i32 = struct_access file.%struct_copy.var, element2
-// CHECK:STDOUT:   %.loc9_73.10: init i32 = initialize_from %.loc9_73.8 to %.loc9_73.9 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc9_73.11: init {.a: i32, .b: i32, .c: i32} = struct_init (%.loc9_73.4, %.loc9_73.7, %.loc9_73.10) to file.%struct_copy.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc9_103: init {.a: i32, .b: i32, .c: i32} = converted %.loc9_73.1, %.loc9_73.11 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc9_73.10: init i32 = initialize_from %.loc9_73.8 to %.loc9_73.9 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc9_73.11: init {.a: i32, .b: i32, .c: i32} = struct_init (%.loc9_73.4, %.loc9_73.7, %.loc9_73.10) to file.%struct_copy.var [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc9_103: init {.a: i32, .b: i32, .c: i32} = converted %.loc9_73.1, %.loc9_73.11 [template = constants.%struct.2]
 // CHECK:STDOUT:   assign file.%struct_copy.var, %.loc9_103
-// CHECK:STDOUT:   %.loc11_30: i32 = int_literal 0 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc11_30: i32 = int_literal 0 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc11_32.1: (i32,) = tuple_literal (%.loc11_30)
-// CHECK:STDOUT:   %.loc11_44: i32 = int_literal 5 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc11_47: i32 = int_literal 7 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc11_44: i32 = int_literal 5 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc11_47: i32 = int_literal 7 [template = constants.%.17]
 // CHECK:STDOUT:   %.loc11_50: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc11_53: i32 = int_literal 9 [template = constants.%.21]
+// CHECK:STDOUT:   %.loc11_53: i32 = int_literal 9 [template = constants.%.18]
 // CHECK:STDOUT:   %.loc11_54.1: (i32, i32, i32, i32) = tuple_literal (%.loc11_44, %.loc11_47, %.loc11_50, %.loc11_53)
 // CHECK:STDOUT:   %.loc11_56: i32 = int_literal 2 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc11_54.2: (i32, i32, i32, i32) = tuple_value (%.loc11_44, %.loc11_47, %.loc11_50, %.loc11_53) [template = constants.%.24]
-// CHECK:STDOUT:   %.loc11_54.3: (i32, i32, i32, i32) = converted %.loc11_54.1, %.loc11_54.2 [template = constants.%.24]
-// CHECK:STDOUT:   %.loc11_57: i32 = tuple_index %.loc11_54.3, %.loc11_56 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc11_58: type = array_type %.loc11_57, i32 [template = constants.%.15]
+// CHECK:STDOUT:   %tuple: (i32, i32, i32, i32) = tuple_value (%.loc11_44, %.loc11_47, %.loc11_50, %.loc11_53) [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc11_54.2: (i32, i32, i32, i32) = converted %.loc11_54.1, %tuple [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc11_57: i32 = tuple_index %.loc11_54.2, %.loc11_56 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc11_58: type = array_type %.loc11_57, i32 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc11_5: ref [i32; 1] = splice_block file.%tuple_index.var {}
-// CHECK:STDOUT:   %.loc11_32.2: i32 = int_literal 0 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc11_32.2: i32 = int_literal 0 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc11_32.3: ref i32 = array_index %.loc11_5, %.loc11_32.2
-// CHECK:STDOUT:   %.loc11_32.4: init i32 = initialize_from %.loc11_30 to %.loc11_32.3 [template = constants.%.17]
-// CHECK:STDOUT:   %.loc11_32.5: init [i32; 1] = array_init (%.loc11_32.4) to %.loc11_5 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc11_34: init [i32; 1] = converted %.loc11_32.1, %.loc11_32.5 [template = constants.%.25]
+// CHECK:STDOUT:   %.loc11_32.4: init i32 = initialize_from %.loc11_30 to %.loc11_32.3 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc11_32.5: init [i32; 1] = array_init (%.loc11_32.4) to %.loc11_5 [template = constants.%array]
+// CHECK:STDOUT:   %.loc11_34: init [i32; 1] = converted %.loc11_32.1, %.loc11_32.5 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%tuple_index.var, %.loc11_34
-// CHECK:STDOUT:   %.loc13_32: i32 = int_literal 0 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc13_32: i32 = int_literal 0 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc13_34.1: (i32,) = tuple_literal (%.loc13_32)
-// CHECK:STDOUT:   %.loc13_51: i32 = int_literal 3 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_51: i32 = int_literal 3 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc13_59: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_60.1: {.a: i32, .b: i32} = struct_literal (%.loc13_51, %.loc13_59)
-// CHECK:STDOUT:   %.loc13_60.2: {.a: i32, .b: i32} = struct_value (%.loc13_51, %.loc13_59) [template = constants.%.28]
-// CHECK:STDOUT:   %.loc13_60.3: {.a: i32, .b: i32} = converted %.loc13_60.1, %.loc13_60.2 [template = constants.%.28]
-// CHECK:STDOUT:   %.loc13_61: i32 = struct_access %.loc13_60.3, element1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc13_63: type = array_type %.loc13_61, i32 [template = constants.%.15]
+// CHECK:STDOUT:   %struct.loc13: {.a: i32, .b: i32} = struct_value (%.loc13_51, %.loc13_59) [template = constants.%struct.3]
+// CHECK:STDOUT:   %.loc13_60.2: {.a: i32, .b: i32} = converted %.loc13_60.1, %struct.loc13 [template = constants.%struct.3]
+// CHECK:STDOUT:   %.loc13_61: i32 = struct_access %.loc13_60.2, element1 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc13_63: type = array_type %.loc13_61, i32 [template = constants.%.12]
 // CHECK:STDOUT:   %.loc13_5: ref [i32; 1] = splice_block file.%struct_access.var {}
-// CHECK:STDOUT:   %.loc13_34.2: i32 = int_literal 0 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc13_34.2: i32 = int_literal 0 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc13_34.3: ref i32 = array_index %.loc13_5, %.loc13_34.2
-// CHECK:STDOUT:   %.loc13_34.4: init i32 = initialize_from %.loc13_32 to %.loc13_34.3 [template = constants.%.17]
-// CHECK:STDOUT:   %.loc13_34.5: init [i32; 1] = array_init (%.loc13_34.4) to %.loc13_5 [template = constants.%.25]
-// CHECK:STDOUT:   %.loc13_36: init [i32; 1] = converted %.loc13_34.1, %.loc13_34.5 [template = constants.%.25]
+// CHECK:STDOUT:   %.loc13_34.4: init i32 = initialize_from %.loc13_32 to %.loc13_34.3 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc13_34.5: init [i32; 1] = array_init (%.loc13_34.4) to %.loc13_5 [template = constants.%array]
+// CHECK:STDOUT:   %.loc13_36: init [i32; 1] = converted %.loc13_34.1, %.loc13_34.5 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%struct_access.var, %.loc13_36
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/eval/fail_aggregate.carbon
+++ b/toolchain/check/testdata/eval/fail_aggregate.carbon
@@ -28,7 +28,7 @@ var array_index: [i32; 1] = (0,) as [i32; ((5, 7, 1, 9) as [i32; 4])[2]];
 // CHECK:STDOUT:   %.12: type = ptr_type [i32; 4] [template]
 // CHECK:STDOUT:   %.13: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.14: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.15: [i32; 4] = tuple_value (%.6, %.7, %.1, %.8) [template]
+// CHECK:STDOUT:   %array: [i32; 4] = tuple_value (%.6, %.7, %.1, %.8) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -67,8 +67,8 @@ var array_index: [i32; 1] = (0,) as [i32; ((5, 7, 1, 9) as [i32; 4])[2]];
 // CHECK:STDOUT:   %.loc12_55.12: i32 = int_literal 3 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc12_55.13: ref i32 = array_index %.loc12_55.2, %.loc12_55.12
 // CHECK:STDOUT:   %.loc12_55.14: init i32 = initialize_from %.loc12_54 to %.loc12_55.13 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_55.15: init [i32; 4] = array_init (%.loc12_55.5, %.loc12_55.8, %.loc12_55.11, %.loc12_55.14) to %.loc12_55.2 [template = constants.%.15]
-// CHECK:STDOUT:   %.loc12_57.1: init [i32; 4] = converted %.loc12_55.1, %.loc12_55.15 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc12_55.15: init [i32; 4] = array_init (%.loc12_55.5, %.loc12_55.8, %.loc12_55.11, %.loc12_55.14) to %.loc12_55.2 [template = constants.%array]
+// CHECK:STDOUT:   %.loc12_57.1: init [i32; 4] = converted %.loc12_55.1, %.loc12_55.15 [template = constants.%array]
 // CHECK:STDOUT:   %.loc12_70: i32 = int_literal 2 [template = constants.%.13]
 // CHECK:STDOUT:   %.loc12_57.2: ref [i32; 4] = temporary %.loc12_55.2, %.loc12_57.1
 // CHECK:STDOUT:   %.loc12_71.1: ref i32 = array_index %.loc12_57.2, %.loc12_70

--- a/toolchain/check/testdata/function/builtin/call_from_operator.carbon
+++ b/toolchain/check/testdata/function/builtin/call_from_operator.carbon
@@ -87,7 +87,7 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   %.13: i32 = int_literal 7 [template]
 // CHECK:STDOUT:   %.14: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.15: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.16: [i32; 3] = tuple_value (%.8, %.11, %.13) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.8, %.11, %.13) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -166,8 +166,8 @@ var arr: [i32; 1 + 2] = (3, 4, 3 + 4);
 // CHECK:STDOUT:   %.loc10_37.8: i32 = int_literal 2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_37.9: ref i32 = array_index file.%arr.var, %.loc10_37.8
 // CHECK:STDOUT:   %.loc10_37.10: init i32 = initialize_from %int.sadd to %.loc10_37.9 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc10_37.11: init [i32; 3] = array_init (%.loc10_37.4, %.loc10_37.7, %.loc10_37.10) to file.%arr.var [template = constants.%.16]
-// CHECK:STDOUT:   %.loc10_38: init [i32; 3] = converted %.loc10_37.1, %.loc10_37.11 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc10_37.11: init [i32; 3] = array_init (%.loc10_37.4, %.loc10_37.7, %.loc10_37.10) to file.%arr.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc10_38: init [i32; 3] = converted %.loc10_37.1, %.loc10_37.11 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%arr.var, %.loc10_38
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/builtin/import.carbon
+++ b/toolchain/check/testdata/function/builtin/import.carbon
@@ -45,7 +45,7 @@ var arr: [i32; Core.Add(1, 2)] = (1, 2, 3);
 // CHECK:STDOUT:   %.5: type = ptr_type [i32; 3] [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.1, %.2, %.3) [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.1, %.2, %.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -82,8 +82,8 @@ var arr: [i32; Core.Add(1, 2)] = (1, 2, 3);
 // CHECK:STDOUT:   %.loc4_42.8: i32 = int_literal 2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc4_42.9: ref i32 = array_index file.%arr.var, %.loc4_42.8
 // CHECK:STDOUT:   %.loc4_42.10: init i32 = initialize_from %.loc4_41 to %.loc4_42.9 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc4_42.11: init [i32; 3] = array_init (%.loc4_42.4, %.loc4_42.7, %.loc4_42.10) to file.%arr.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc4_43: init [i32; 3] = converted %.loc4_42.1, %.loc4_42.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc4_42.11: init [i32; 3] = array_init (%.loc4_42.4, %.loc4_42.7, %.loc4_42.10) to file.%arr.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc4_43: init [i32; 3] = converted %.loc4_42.1, %.loc4_42.11 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%arr.var, %.loc4_43
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/more_param_ir.carbon
+++ b/toolchain/check/testdata/function/call/more_param_ir.carbon
@@ -18,10 +18,10 @@ fn Main() {
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.6: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.7: type = tuple_type () [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -53,14 +53,14 @@ fn Main() {
 // CHECK:STDOUT:   %x: ref (i32,) = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc10_20: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_22.1: (i32,) = tuple_literal (%.loc10_20)
-// CHECK:STDOUT:   %.loc10_22.2: init (i32,) = tuple_init (%.loc10_20) to %x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_23: init (i32,) = converted %.loc10_22.1, %.loc10_22.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_22.2: init (i32,) = tuple_init (%.loc10_20) to %x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_23: init (i32,) = converted %.loc10_22.1, %.loc10_22.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var, %.loc10_23
 // CHECK:STDOUT:   %Foo.ref: <function> = name_ref Foo, file.%Foo [template = file.%Foo]
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, %x
-// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc12_9: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc12_10.1: ref i32 = tuple_index %x.ref, %.loc12_9
-// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13: i32 = int_literal 6 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc12_10.2: i32 = bind_value %.loc12_10.1
 // CHECK:STDOUT:   %Foo.call: init () = call %Foo.ref(%.loc12_10.2, %.loc12_13)
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/call/no_prelude/alias.carbon
+++ b/toolchain/check/testdata/function/call/no_prelude/alias.carbon
@@ -16,7 +16,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,9 +37,9 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @A() -> () {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_24.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_24.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc7_25: () = converted %.loc7_24.1, %.loc7_24.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_24: () = tuple_literal ()
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_25: () = converted %.loc7_24, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc7_25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/function/call/no_prelude/empty_struct.carbon
+++ b/toolchain/check/testdata/function/call/no_prelude/empty_struct.carbon
@@ -17,7 +17,7 @@ fn Main() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.3: {} = struct_value () [template]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -46,9 +46,9 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
-// CHECK:STDOUT:   %.loc12_9.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: {} = struct_value () [template = constants.%.3]
-// CHECK:STDOUT:   %.loc12_7: {} = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc12_9: {} = struct_literal ()
+// CHECK:STDOUT:   %struct: {} = struct_value () [template = constants.%struct]
+// CHECK:STDOUT:   %.loc12_7: {} = converted %.loc12_9, %struct [template = constants.%struct]
 // CHECK:STDOUT:   %Echo.call: init {} = call %Echo.ref(%.loc12_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/call/no_prelude/empty_tuple.carbon
+++ b/toolchain/check/testdata/function/call/no_prelude/empty_tuple.carbon
@@ -16,7 +16,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,9 +45,9 @@ fn Main() {
 // CHECK:STDOUT: fn @Main() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Echo.ref: <function> = name_ref Echo, file.%Echo [template = file.%Echo]
-// CHECK:STDOUT:   %.loc12_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc12_9.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc12_7: () = converted %.loc12_9.1, %.loc12_9.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc12_9: () = tuple_literal ()
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc12_7: () = converted %.loc12_9, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %Echo.call: init () = call %Echo.ref(%.loc12_7)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/function/declaration/import.carbon
+++ b/toolchain/check/testdata/function/declaration/import.carbon
@@ -294,7 +294,7 @@ import library "extern_api";
 // CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.4: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.5: (i32,) = tuple_value (%.2) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -361,9 +361,9 @@ import library "extern_api";
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%import_ref.3 [template = imports.%C]
 // CHECK:STDOUT:   %.loc8_23: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_25.1: (i32,) = tuple_literal (%.loc8_23)
-// CHECK:STDOUT:   %.loc8_25.2: (i32,) = tuple_value (%.loc8_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_21: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_25: (i32,) = tuple_literal (%.loc8_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc8_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_21: (i32,) = converted %.loc8_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc8_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D]
@@ -384,7 +384,7 @@ import library "extern_api";
 // CHECK:STDOUT:   %.3: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.6: (i32,) = tuple_value (%.5) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -467,9 +467,9 @@ import library "extern_api";
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc14_23: i32 = int_literal 1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc14_25.1: (i32,) = tuple_literal (%.loc14_23)
-// CHECK:STDOUT:   %.loc14_25.2: (i32,) = tuple_value (%.loc14_23) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_21: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_25: (i32,) = tuple_literal (%.loc14_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc14_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc14_21: (i32,) = converted %.loc14_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc14_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
@@ -490,7 +490,7 @@ import library "extern_api";
 // CHECK:STDOUT:   %.3: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.6: (i32,) = tuple_value (%.5) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -573,9 +573,9 @@ import library "extern_api";
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%C [template = file.%C]
 // CHECK:STDOUT:   %.loc14_23: i32 = int_literal 1 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc14_25.1: (i32,) = tuple_literal (%.loc14_23)
-// CHECK:STDOUT:   %.loc14_25.2: (i32,) = tuple_value (%.loc14_23) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc14_21: (i32,) = converted %.loc14_25.1, %.loc14_25.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc14_25: (i32,) = tuple_literal (%.loc14_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc14_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc14_21: (i32,) = converted %.loc14_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc14_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%D [template = file.%D]
@@ -595,7 +595,7 @@ import library "extern_api";
 // CHECK:STDOUT:   %.2: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.5: (i32,) = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -677,9 +677,9 @@ import library "extern_api";
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%import_ref.3 [template = imports.%C.1]
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_25.1: (i32,) = tuple_literal (%.loc9_23)
-// CHECK:STDOUT:   %.loc9_25.2: (i32,) = tuple_value (%.loc9_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_21: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_25: (i32,) = tuple_literal (%.loc9_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc9_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_21: (i32,) = converted %.loc9_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc9_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D.1]
@@ -699,7 +699,7 @@ import library "extern_api";
 // CHECK:STDOUT:   %.2: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.5: (i32,) = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -781,9 +781,9 @@ import library "extern_api";
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, imports.%C.2 [template = imports.%C.2]
 // CHECK:STDOUT:   %.loc9_23: i32 = int_literal 1 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_25.1: (i32,) = tuple_literal (%.loc9_23)
-// CHECK:STDOUT:   %.loc9_25.2: (i32,) = tuple_value (%.loc9_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_21: (i32,) = converted %.loc9_25.1, %.loc9_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_25: (i32,) = tuple_literal (%.loc9_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc9_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_21: (i32,) = converted %.loc9_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc9_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   %D.ref: <function> = name_ref D, file.%import_ref.4 [template = imports.%D.1]

--- a/toolchain/check/testdata/function/definition/import.carbon
+++ b/toolchain/check/testdata/function/definition/import.carbon
@@ -141,9 +141,9 @@ fn D() {}
 // CHECK:STDOUT:   %c.ref: (i32,) = name_ref c, %c
 // CHECK:STDOUT:   %.loc6_47: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc6_48: i32 = tuple_index %c.ref, %.loc6_47
-// CHECK:STDOUT:   %.loc6_49.1: {.c: i32} = struct_literal (%.loc6_48)
-// CHECK:STDOUT:   %.loc6_49.2: {.c: i32} = struct_value (%.loc6_48)
-// CHECK:STDOUT:   %.loc6_50: {.c: i32} = converted %.loc6_49.1, %.loc6_49.2
+// CHECK:STDOUT:   %.loc6_49: {.c: i32} = struct_literal (%.loc6_48)
+// CHECK:STDOUT:   %struct: {.c: i32} = struct_value (%.loc6_48)
+// CHECK:STDOUT:   %.loc6_50: {.c: i32} = converted %.loc6_49, %struct
 // CHECK:STDOUT:   return %.loc6_50
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -169,7 +169,7 @@ fn D() {}
 // CHECK:STDOUT:   %.2: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.3: type = struct_type {.c: i32} [template]
 // CHECK:STDOUT:   %.4: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.5: (i32,) = tuple_value (%.2) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -216,9 +216,9 @@ fn D() {}
 // CHECK:STDOUT:   assign file.%b.var, %B.call
 // CHECK:STDOUT:   %C.ref: <function> = name_ref C, file.%import_ref.3 [template = imports.%C]
 // CHECK:STDOUT:   %.loc8_23: i32 = int_literal 1 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_25.1: (i32,) = tuple_literal (%.loc8_23)
-// CHECK:STDOUT:   %.loc8_25.2: (i32,) = tuple_value (%.loc8_23) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_21: (i32,) = converted %.loc8_25.1, %.loc8_25.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_25: (i32,) = tuple_literal (%.loc8_23)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc8_23) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_21: (i32,) = converted %.loc8_25, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %C.call: init {.c: i32} = call %C.ref(%.loc8_21)
 // CHECK:STDOUT:   assign file.%c.var, %C.call
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/function/definition/no_prelude/fail_decl_param_mismatch.carbon
+++ b/toolchain/check/testdata/function/definition/no_prelude/fail_decl_param_mismatch.carbon
@@ -67,9 +67,9 @@ fn K() -> {} { return {}; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
-// CHECK:STDOUT:   %.3: type = struct_type {} [template]
-// CHECK:STDOUT:   %.4: {} = struct_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -124,7 +124,7 @@ fn K() -> {} { return {}; }
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %.loc64_14: <function> = fn_decl @.6 [template] {
 // CHECK:STDOUT:     %.loc64_12.1: {} = struct_literal ()
-// CHECK:STDOUT:     %.loc64_12.2: type = converted %.loc64_12.1, constants.%.3 [template = constants.%.3]
+// CHECK:STDOUT:     %.loc64_12.2: type = converted %.loc64_12.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:     @.6.%return: ref {} = var <return slot>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -154,9 +154,9 @@ fn K() -> {} { return {}; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.4() -> () {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc45_24.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc45_24.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc45_25: () = converted %.loc45_24.1, %.loc45_24.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc45_24: () = tuple_literal ()
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc45_25: () = converted %.loc45_24, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc45_25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -171,9 +171,9 @@ fn K() -> {} { return {}; }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @.6() -> {} {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc64_24.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc64_24.2: {} = struct_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc64_25: {} = converted %.loc64_24.1, %.loc64_24.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc64_24: {} = struct_literal ()
+// CHECK:STDOUT:   %struct: {} = struct_value () [template = constants.%struct]
+// CHECK:STDOUT:   %.loc64_25: {} = converted %.loc64_24, %struct [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc64_25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/global/class_obj.carbon
+++ b/toolchain/check/testdata/global/class_obj.carbon
@@ -14,7 +14,7 @@ var a: A = {};
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: A = struct_value () [template]
+// CHECK:STDOUT:   %struct: A = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -38,8 +38,8 @@ var a: A = {};
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc8_13.2: init A = class_init (), file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_14: init A = converted %.loc8_13.1, %.loc8_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc8_13.2: init A = class_init (), file.%a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_14: init A = converted %.loc8_13.1, %.loc8_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%a.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/global/class_with_fun.carbon
+++ b/toolchain/check/testdata/global/class_with_fun.carbon
@@ -18,7 +18,7 @@ var a: A = {};
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
 // CHECK:STDOUT:   %.3: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.4: A = struct_value () [template]
+// CHECK:STDOUT:   %struct: A = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -47,16 +47,16 @@ var a: A = {};
 // CHECK:STDOUT: fn @ret_a() -> %return: A {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc9_11.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc9_11.2: init A = class_init (), %return [template = constants.%.4]
-// CHECK:STDOUT:   %.loc9_12: init A = converted %.loc9_11.1, %.loc9_11.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc9_11.2: init A = class_init (), %return [template = constants.%struct]
+// CHECK:STDOUT:   %.loc9_12: init A = converted %.loc9_11.1, %.loc9_11.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc9_12 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc12_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_13.2: init A = class_init (), file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc12_14: init A = converted %.loc12_13.1, %.loc12_13.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc12_13.2: init A = class_init (), file.%a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc12_14: init A = converted %.loc12_13.1, %.loc12_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%a.var, %.loc12_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/if_expr/basic.carbon
+++ b/toolchain/check/testdata/if_expr/basic.carbon
@@ -17,7 +17,7 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:   %.3: type = ptr_type [i32; 1] [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.6: [i32; 1] = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %array: [i32; 1] = tuple_value (%.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,8 +48,8 @@ fn F(b: bool, n: i32, m: i32) -> i32 {
 // CHECK:STDOUT:   %.loc8_24.2: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc8_24.3: ref i32 = array_index %x.var, %.loc8_24.2
 // CHECK:STDOUT:   %.loc8_24.4: init i32 = initialize_from %.loc8_22 to %.loc8_24.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_24.5: init [i32; 1] = array_init (%.loc8_24.4) to %x.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc8_25: init [i32; 1] = converted %.loc8_24.1, %.loc8_24.5 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc8_24.5: init [i32; 1] = array_init (%.loc8_24.4) to %x.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc8_25: init [i32; 1] = converted %.loc8_24.1, %.loc8_24.5 [template = constants.%array]
 // CHECK:STDOUT:   assign %x.var, %.loc8_25
 // CHECK:STDOUT:   %b.ref: bool = name_ref b, %b
 // CHECK:STDOUT:   if %b.ref br !if.expr.then else br !if.expr.else

--- a/toolchain/check/testdata/if_expr/struct.carbon
+++ b/toolchain/check/testdata/if_expr/struct.carbon
@@ -18,8 +18,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.5: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
-// CHECK:STDOUT:   %.6: type = tuple_type () [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %.5: type = tuple_type () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,8 +54,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc10_46.3: init i32 = initialize_from %.loc10_37 to %.loc10_46.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_46.4: ref i32 = struct_access %a.var, element1
 // CHECK:STDOUT:   %.loc10_46.5: init i32 = initialize_from %.loc10_45 to %.loc10_46.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init (%.loc10_46.3, %.loc10_46.5) to %a.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_47: init {.a: i32, .b: i32} = converted %.loc10_46.1, %.loc10_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_46.6: init {.a: i32, .b: i32} = struct_init (%.loc10_46.3, %.loc10_46.5) to %a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_47: init {.a: i32, .b: i32} = converted %.loc10_46.1, %.loc10_46.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign %a.var, %.loc10_47
 // CHECK:STDOUT:   %G.ref: <function> = name_ref G, file.%G [template = file.%G]
 // CHECK:STDOUT:   %cond.ref: bool = name_ref cond, %cond
@@ -67,9 +67,9 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc11_18.2: i32 = bind_value %.loc11_18.1
 // CHECK:STDOUT:   %.loc11_18.3: ref i32 = struct_access %a.ref.loc11_18, element1
 // CHECK:STDOUT:   %.loc11_18.4: i32 = bind_value %.loc11_18.3
-// CHECK:STDOUT:   %.loc11_18.5: {.a: i32, .b: i32} = struct_value (%.loc11_18.2, %.loc11_18.4)
-// CHECK:STDOUT:   %.loc11_18.6: {.a: i32, .b: i32} = converted %a.ref.loc11_18, %.loc11_18.5
-// CHECK:STDOUT:   br !if.expr.result(%.loc11_18.6)
+// CHECK:STDOUT:   %struct.loc11_18: {.a: i32, .b: i32} = struct_value (%.loc11_18.2, %.loc11_18.4)
+// CHECK:STDOUT:   %.loc11_18.5: {.a: i32, .b: i32} = converted %a.ref.loc11_18, %struct.loc11_18
+// CHECK:STDOUT:   br !if.expr.result(%.loc11_18.5)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.else:
 // CHECK:STDOUT:   %a.ref.loc11_25: ref {.a: i32, .b: i32} = name_ref a, %a
@@ -77,8 +77,8 @@ fn F(cond: bool) {
 // CHECK:STDOUT:   %.loc11_25.2: i32 = bind_value %.loc11_25.1
 // CHECK:STDOUT:   %.loc11_25.3: ref i32 = struct_access %a.ref.loc11_25, element1
 // CHECK:STDOUT:   %.loc11_25.4: i32 = bind_value %.loc11_25.3
-// CHECK:STDOUT:   %.loc11_25.5: {.a: i32, .b: i32} = struct_value (%.loc11_25.2, %.loc11_25.4)
-// CHECK:STDOUT:   %.loc11_20: {.a: i32, .b: i32} = converted %a.ref.loc11_25, %.loc11_25.5
+// CHECK:STDOUT:   %struct.loc11_25: {.a: i32, .b: i32} = struct_value (%.loc11_25.2, %.loc11_25.4)
+// CHECK:STDOUT:   %.loc11_20: {.a: i32, .b: i32} = converted %a.ref.loc11_25, %struct.loc11_25
 // CHECK:STDOUT:   br !if.expr.result(%.loc11_20)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result:

--- a/toolchain/check/testdata/impl/impl_as.carbon
+++ b/toolchain/check/testdata/impl/impl_as.carbon
@@ -29,7 +29,7 @@ class C {
 // CHECK:STDOUT:   %.5: type = struct_type {} [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -80,8 +80,8 @@ class C {
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc15_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc15_19.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc15_20: init C = converted %.loc15_19.1, %.loc15_19.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc15_19.2: init C = class_init (), %c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc15_20: init C = converted %.loc15_19.1, %.loc15_19.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %c.var, %.loc15_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/no_prelude/import_self.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/import_self.carbon
@@ -77,9 +77,9 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:   %.2: type = interface_type @Add [template]
 // CHECK:STDOUT:   %Self: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
-// CHECK:STDOUT:   %.5: type = assoc_entity_type @Add, <function> [template]
-// CHECK:STDOUT:   %.6: <associated <function> in Add> = assoc_entity element0, file.%import_ref.5 [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.4: type = assoc_entity_type @Add, <function> [template]
+// CHECK:STDOUT:   %.5: <associated <function> in Add> = assoc_entity element0, file.%import_ref.5 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -88,7 +88,7 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:     .F = %F
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir1, inst+1, loc_13 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir1, inst+21, loc_58 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir1, inst+21, loc_58 [template = constants.%.5]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir1, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir1, inst+19, loc_14 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
@@ -140,9 +140,9 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Op.1[@impl.%self.loc7_9.2: ()](@impl.%other.loc7_21.2: ()) -> () {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %.loc7_52.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_52.2: () = tuple_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_53: () = converted %.loc7_52.1, %.loc7_52.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_52: () = tuple_literal ()
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_53: () = converted %.loc7_52, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc7_53
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -152,15 +152,15 @@ fn F(x: (), y: ()) -> () {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %x.ref: () = name_ref x, %x
 // CHECK:STDOUT:   %Add.ref: type = name_ref Add, file.%import_ref.1 [template = constants.%.2]
-// CHECK:STDOUT:   %Op.ref: <associated <function> in Add> = name_ref Op, file.%import_ref.2 [template = constants.%.6]
+// CHECK:STDOUT:   %Op.ref: <associated <function> in Add> = name_ref Op, file.%import_ref.2 [template = constants.%.5]
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]
 // CHECK:STDOUT:   %.loc11_11: <bound method> = bound_method %x.ref, %.1
 // CHECK:STDOUT:   %y.ref: () = name_ref y, %y
 // CHECK:STDOUT:   %.loc11_20.1: init () = call %.loc11_11(%x.ref, %y.ref)
 // CHECK:STDOUT:   %.loc11_20.2: ref () = temporary_storage
 // CHECK:STDOUT:   %.loc11_20.3: ref () = temporary %.loc11_20.2, %.loc11_20.1
-// CHECK:STDOUT:   %.loc11_20.4: () = tuple_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc11_23: () = converted %.loc11_20.1, %.loc11_20.4 [template = constants.%.4]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc11_23: () = converted %.loc11_20.1, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc11_23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_class.carbon
@@ -31,7 +31,7 @@ class A {
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Make) [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -93,8 +93,8 @@ class A {
 // CHECK:STDOUT: fn @Make.2() -> @impl.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc17_33.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc17_33.2: init C = class_init (), @impl.%return.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc17_34: init C = converted %.loc17_33.1, %.loc17_33.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc17_33.2: init C = class_init (), @impl.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc17_34: init C = converted %.loc17_33.1, %.loc17_33.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc17_34 to @impl.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
+++ b/toolchain/check/testdata/impl/no_prelude/self_in_signature.carbon
@@ -45,25 +45,25 @@ impl D as SelfNested {
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.1.%F) [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
-// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%F) [template]
-// CHECK:STDOUT:   %.10: D = struct_value () [template]
-// CHECK:STDOUT:   %.11: type = interface_type @SelfNested [template]
+// CHECK:STDOUT:   %struct.1: C = struct_value () [template]
+// CHECK:STDOUT:   %.8: <witness> = interface_witness (@impl.2.%F) [template]
+// CHECK:STDOUT:   %struct.2: D = struct_value () [template]
+// CHECK:STDOUT:   %.9: type = interface_type @SelfNested [template]
 // CHECK:STDOUT:   %Self.2: SelfNested = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.12: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.13: type = struct_type {.x: Self, .y: ()} [symbolic]
-// CHECK:STDOUT:   %.14: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.15: type = tuple_type (Self*, {.x: Self, .y: ()}) [symbolic]
-// CHECK:STDOUT:   %.16: type = assoc_entity_type @SelfNested, <function> [template]
-// CHECK:STDOUT:   %.17: <associated <function> in SelfNested> = assoc_entity element0, @SelfNested.%F [template]
-// CHECK:STDOUT:   %.18: type = ptr_type C [template]
-// CHECK:STDOUT:   %.19: type = struct_type {.x: C, .y: ()} [template]
-// CHECK:STDOUT:   %.20: type = tuple_type (C*, {.x: C, .y: ()}) [template]
-// CHECK:STDOUT:   %.21: <witness> = interface_witness (@impl.3.%F) [template]
-// CHECK:STDOUT:   %.22: type = ptr_type D [template]
-// CHECK:STDOUT:   %.23: type = struct_type {.x: D, .y: ()} [template]
-// CHECK:STDOUT:   %.24: type = tuple_type (D*, {.x: D, .y: ()}) [template]
-// CHECK:STDOUT:   %.25: <witness> = interface_witness (@impl.4.%F) [template]
+// CHECK:STDOUT:   %.10: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.11: type = struct_type {.x: Self, .y: ()} [symbolic]
+// CHECK:STDOUT:   %.12: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.13: type = tuple_type (Self*, {.x: Self, .y: ()}) [symbolic]
+// CHECK:STDOUT:   %.14: type = assoc_entity_type @SelfNested, <function> [template]
+// CHECK:STDOUT:   %.15: <associated <function> in SelfNested> = assoc_entity element0, @SelfNested.%F [template]
+// CHECK:STDOUT:   %.16: type = ptr_type C [template]
+// CHECK:STDOUT:   %.17: type = struct_type {.x: C, .y: ()} [template]
+// CHECK:STDOUT:   %.18: type = tuple_type (C*, {.x: C, .y: ()}) [template]
+// CHECK:STDOUT:   %.19: <witness> = interface_witness (@impl.3.%F) [template]
+// CHECK:STDOUT:   %.20: type = ptr_type D [template]
+// CHECK:STDOUT:   %.21: type = struct_type {.x: D, .y: ()} [template]
+// CHECK:STDOUT:   %.22: type = tuple_type (D*, {.x: D, .y: ()}) [template]
+// CHECK:STDOUT:   %.23: <witness> = interface_witness (@impl.4.%F) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -84,14 +84,14 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %D.ref.loc19: type = name_ref D, %D.decl [template = constants.%D]
 // CHECK:STDOUT:     %UseSelf.ref.loc19: type = name_ref UseSelf, %UseSelf.decl [template = constants.%.1]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %SelfNested.decl: type = interface_decl @SelfNested [template = constants.%.11] {}
+// CHECK:STDOUT:   %SelfNested.decl: type = interface_decl @SelfNested [template = constants.%.9] {}
 // CHECK:STDOUT:   impl_decl @impl.3 {
 // CHECK:STDOUT:     %C.ref.loc27: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %SelfNested.ref.loc27: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.11]
+// CHECK:STDOUT:     %SelfNested.ref.loc27: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   impl_decl @impl.4 {
 // CHECK:STDOUT:     %D.ref.loc31: type = name_ref D, %D.decl [template = constants.%D]
-// CHECK:STDOUT:     %SelfNested.ref.loc31: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.11]
+// CHECK:STDOUT:     %SelfNested.ref.loc31: type = name_ref SelfNested, %SelfNested.decl [template = constants.%.9]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -127,19 +127,19 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %Self.ref.loc24_12: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_16.1: type = facet_type_access %Self.ref.loc24_12 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_16.2: type = converted %Self.ref.loc24_12, %.loc24_16.1 [symbolic = constants.%Self.2]
-// CHECK:STDOUT:     %.loc24_16.3: type = ptr_type Self [symbolic = constants.%.12]
+// CHECK:STDOUT:     %.loc24_16.3: type = ptr_type Self [symbolic = constants.%.10]
 // CHECK:STDOUT:     %Self.ref.loc24_24: SelfNested = name_ref Self, %Self [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_24.1: type = facet_type_access %Self.ref.loc24_24 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_24.2: type = converted %Self.ref.loc24_24, %.loc24_24.1 [symbolic = constants.%Self.2]
 // CHECK:STDOUT:     %.loc24_35.1: () = tuple_literal ()
 // CHECK:STDOUT:     %.loc24_35.2: type = converted %.loc24_35.1, constants.%.6 [template = constants.%.6]
-// CHECK:STDOUT:     %.loc24_36: type = struct_type {.x: Self, .y: ()} [symbolic = constants.%.13]
+// CHECK:STDOUT:     %.loc24_36: type = struct_type {.x: Self, .y: ()} [symbolic = constants.%.11]
 // CHECK:STDOUT:     %.loc24_37.1: (type, type) = tuple_literal (%.loc24_16.3, %.loc24_36)
-// CHECK:STDOUT:     %.loc24_37.2: type = converted %.loc24_37.1, constants.%.15 [symbolic = constants.%.15]
+// CHECK:STDOUT:     %.loc24_37.2: type = converted %.loc24_37.1, constants.%.13 [symbolic = constants.%.13]
 // CHECK:STDOUT:     %x.loc24_8.1: (Self*, {.x: Self, .y: ()}) = param x
 // CHECK:STDOUT:     %x.loc24_8.2: (Self*, {.x: Self, .y: ()}) = bind_name x, %x.loc24_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc24_39: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.17]
+// CHECK:STDOUT:   %.loc24_39: <associated <function> in SelfNested> = assoc_entity element0, %F [template = constants.%.15]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
@@ -176,7 +176,7 @@ impl D as SelfNested {
 // CHECK:STDOUT:     %Self.ref.loc20_32: type = name_ref Self, constants.%D [template = constants.%D]
 // CHECK:STDOUT:     %return.var: ref D = var <return slot>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.9]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.8]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -186,17 +186,17 @@ impl D as SelfNested {
 // CHECK:STDOUT: impl @impl.3: C as SelfNested {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.5 [template] {
 // CHECK:STDOUT:     %C.ref.loc28_12: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc28_13: type = ptr_type C [template = constants.%.18]
+// CHECK:STDOUT:     %.loc28_13: type = ptr_type C [template = constants.%.16]
 // CHECK:STDOUT:     %C.ref.loc28_21: type = name_ref C, file.%C.decl [template = constants.%C]
 // CHECK:STDOUT:     %.loc28_29.1: () = tuple_literal ()
 // CHECK:STDOUT:     %.loc28_29.2: type = converted %.loc28_29.1, constants.%.6 [template = constants.%.6]
-// CHECK:STDOUT:     %.loc28_30: type = struct_type {.x: C, .y: ()} [template = constants.%.19]
+// CHECK:STDOUT:     %.loc28_30: type = struct_type {.x: C, .y: ()} [template = constants.%.17]
 // CHECK:STDOUT:     %.loc28_31.1: (type, type) = tuple_literal (%.loc28_13, %.loc28_30)
-// CHECK:STDOUT:     %.loc28_31.2: type = converted %.loc28_31.1, constants.%.20 [template = constants.%.20]
+// CHECK:STDOUT:     %.loc28_31.2: type = converted %.loc28_31.1, constants.%.18 [template = constants.%.18]
 // CHECK:STDOUT:     %x.loc28_8.1: (C*, {.x: C, .y: ()}) = param x
 // CHECK:STDOUT:     %x.loc28_8.2: (C*, {.x: C, .y: ()}) = bind_name x, %x.loc28_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.21]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.19]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -206,17 +206,17 @@ impl D as SelfNested {
 // CHECK:STDOUT: impl @impl.4: D as SelfNested {
 // CHECK:STDOUT:   %F: <function> = fn_decl @F.6 [template] {
 // CHECK:STDOUT:     %Self.ref.loc32_12: type = name_ref Self, constants.%D [template = constants.%D]
-// CHECK:STDOUT:     %.loc32_16: type = ptr_type D [template = constants.%.22]
+// CHECK:STDOUT:     %.loc32_16: type = ptr_type D [template = constants.%.20]
 // CHECK:STDOUT:     %Self.ref.loc32_24: type = name_ref Self, constants.%D [template = constants.%D]
 // CHECK:STDOUT:     %.loc32_35.1: () = tuple_literal ()
 // CHECK:STDOUT:     %.loc32_35.2: type = converted %.loc32_35.1, constants.%.6 [template = constants.%.6]
-// CHECK:STDOUT:     %.loc32_36: type = struct_type {.x: D, .y: ()} [template = constants.%.23]
+// CHECK:STDOUT:     %.loc32_36: type = struct_type {.x: D, .y: ()} [template = constants.%.21]
 // CHECK:STDOUT:     %.loc32_37.1: (type, type) = tuple_literal (%.loc32_16, %.loc32_36)
-// CHECK:STDOUT:     %.loc32_37.2: type = converted %.loc32_37.1, constants.%.24 [template = constants.%.24]
+// CHECK:STDOUT:     %.loc32_37.2: type = converted %.loc32_37.1, constants.%.22 [template = constants.%.22]
 // CHECK:STDOUT:     %x.loc32_8.1: (D*, {.x: D, .y: ()}) = param x
 // CHECK:STDOUT:     %x.loc32_8.2: (D*, {.x: D, .y: ()}) = bind_name x, %x.loc32_8.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.25]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%F) [template = constants.%.23]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .F = %F
@@ -238,16 +238,16 @@ impl D as SelfNested {
 // CHECK:STDOUT: fn @F.2[@impl.1.%self.loc16_8.2: C](@impl.1.%x.loc16_17.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc16_38.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc16_38.2: init C = class_init (), @impl.1.%return.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc16_39: init C = converted %.loc16_38.1, %.loc16_38.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc16_38.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc16_39: init C = converted %.loc16_38.1, %.loc16_38.2 [template = constants.%struct.1]
 // CHECK:STDOUT:   return %.loc16_39 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F.3[@impl.2.%self.loc20_8.2: D](@impl.2.%x.loc20_20.2: D) -> @impl.2.%return.var: D {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc20_47.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc20_47.2: init D = class_init (), @impl.2.%return.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc20_48: init D = converted %.loc20_47.1, %.loc20_47.2 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc20_47.2: init D = class_init (), @impl.2.%return.var [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc20_48: init D = converted %.loc20_47.1, %.loc20_47.2 [template = constants.%struct.2]
 // CHECK:STDOUT:   return %.loc20_48 to @impl.2.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/index/array_element_access.carbon
+++ b/toolchain/check/testdata/index/array_element_access.carbon
@@ -20,7 +20,7 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
 // CHECK:STDOUT:   %.8: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.9: [i32; 2] = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %array: [i32; 2] = tuple_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -55,8 +55,8 @@ var d: i32 = a[b];
 // CHECK:STDOUT:   %.loc7_26.5: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc7_26.6: ref i32 = array_index file.%a.var, %.loc7_26.5
 // CHECK:STDOUT:   %.loc7_26.7: init i32 = initialize_from %.loc7_24 to %.loc7_26.6 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_26.8: init [i32; 2] = array_init (%.loc7_26.4, %.loc7_26.7) to file.%a.var [template = constants.%.9]
-// CHECK:STDOUT:   %.loc7_27: init [i32; 2] = converted %.loc7_26.1, %.loc7_26.8 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc7_26.8: init [i32; 2] = array_init (%.loc7_26.4, %.loc7_26.7) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_27: init [i32; 2] = converted %.loc7_26.1, %.loc7_26.8 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_27
 // CHECK:STDOUT:   %.loc8: i32 = int_literal 1 [template = constants.%.8]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8

--- a/toolchain/check/testdata/index/expr_category.carbon
+++ b/toolchain/check/testdata/index/expr_category.carbon
@@ -34,9 +34,9 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: type = tuple_type (i32, i32, i32) [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.8: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
-// CHECK:STDOUT:   %.9: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %.10: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %array: [i32; 3] = tuple_value (%.4, %.5, %.1) [template]
+// CHECK:STDOUT:   %.8: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 4 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -87,10 +87,10 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc10_29.8: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc10_29.9: ref i32 = array_index %a.var, %.loc10_29.8
 // CHECK:STDOUT:   %.loc10_29.10: init i32 = initialize_from %.loc10_28 to %.loc10_29.9 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc10_29.11: init [i32; 3] = array_init (%.loc10_29.4, %.loc10_29.7, %.loc10_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc10_30: init [i32; 3] = converted %.loc10_29.1, %.loc10_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc10_29.11: init [i32; 3] = array_init (%.loc10_29.4, %.loc10_29.7, %.loc10_29.10) to %a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc10_30: init [i32; 3] = converted %.loc10_29.1, %.loc10_29.11 [template = constants.%array]
 // CHECK:STDOUT:   assign %a.var, %.loc10_30
-// CHECK:STDOUT:   %.loc13_14: type = ptr_type i32 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc13_14: type = ptr_type i32 [template = constants.%.8]
 // CHECK:STDOUT:   %pa.var: ref i32* = var pa
 // CHECK:STDOUT:   %pa: ref i32* = bind_name pa, %pa.var
 // CHECK:STDOUT:   %a.ref.loc13: ref [i32; 3] = name_ref a, %a
@@ -101,7 +101,7 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %a.ref.loc14: ref [i32; 3] = name_ref a, %a
 // CHECK:STDOUT:   %.loc14_5: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc14_6: ref i32 = array_index %a.ref.loc14, %.loc14_5
-// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc14_10: i32 = int_literal 4 [template = constants.%.9]
 // CHECK:STDOUT:   assign %.loc14_6, %.loc14_10
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -125,8 +125,8 @@ fn ValueBinding(b: [i32; 3]) {
 // CHECK:STDOUT:   %.loc18_29.8: i32 = int_literal 2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc18_29.9: ref i32 = array_index %a.var, %.loc18_29.8
 // CHECK:STDOUT:   %.loc18_29.10: init i32 = initialize_from %.loc18_28 to %.loc18_29.9 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc18_29.11: init [i32; 3] = array_init (%.loc18_29.4, %.loc18_29.7, %.loc18_29.10) to %a.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc18_30: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc18_29.11: init [i32; 3] = array_init (%.loc18_29.4, %.loc18_29.7, %.loc18_29.10) to %a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc18_30: init [i32; 3] = converted %.loc18_29.1, %.loc18_29.11 [template = constants.%array]
 // CHECK:STDOUT:   assign %a.var, %.loc18_30
 // CHECK:STDOUT:   %a.ref: ref [i32; 3] = name_ref a, %a
 // CHECK:STDOUT:   %.loc22_5: i32 = int_literal 0 [template = constants.%.7]

--- a/toolchain/check/testdata/index/fail_array_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_array_large_index.carbon
@@ -26,8 +26,8 @@ var c: i32 = a[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.7: [i32; 1] = tuple_value (%.4) [template]
-// CHECK:STDOUT:   %.8: i32 = int_literal 2147483647 [template]
+// CHECK:STDOUT:   %array: [i32; 1] = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 2147483647 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -55,8 +55,8 @@ var c: i32 = a[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref.loc13: ref [i32; 1] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc13_16: i32 = int_literal 1 [template = constants.%.1]
@@ -64,7 +64,7 @@ var c: i32 = a[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.loc13_17.2: i32 = bind_value %.loc13_17.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc13_17.2
 // CHECK:STDOUT:   %a.ref.loc18: ref [i32; 1] = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 2147483647 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc18_16: i32 = int_literal 2147483647 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc18_27.1: ref i32 = array_index %a.ref.loc18, %.loc18_16 [template = <error>]
 // CHECK:STDOUT:   %.loc18_27.2: i32 = bind_value %.loc18_27.1
 // CHECK:STDOUT:   assign file.%c.var, %.loc18_27.2

--- a/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_array_non_int_indexing.carbon
@@ -19,8 +19,8 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.7: [i32; 1] = tuple_value (%.4) [template]
-// CHECK:STDOUT:   %.8: f64 = float_literal 2.6000000000000001 [template]
+// CHECK:STDOUT:   %array: [i32; 1] = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %.7: f64 = float_literal 2.6000000000000001 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,11 +45,11 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc11_16: f64 = float_literal 2.6000000000000001 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_16: f64 = float_literal 2.6000000000000001 [template = constants.%.7]
 // CHECK:STDOUT:   %.loc11_19.1: ref i32 = array_index %a.ref, <error>
 // CHECK:STDOUT:   %.loc11_19.2: i32 = bind_value %.loc11_19.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc11_19.2

--- a/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_array_out_of_bound_access.carbon
@@ -19,7 +19,7 @@ var b: i32 = a[1];
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.7: [i32; 1] = tuple_value (%.4) [template]
+// CHECK:STDOUT:   %array: [i32; 1] = tuple_value (%.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -44,8 +44,8 @@ var b: i32 = a[1];
 // CHECK:STDOUT:   %.loc7_23.2: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc7_23.3: ref i32 = array_index file.%a.var, %.loc7_23.2
 // CHECK:STDOUT:   %.loc7_23.4: init i32 = initialize_from %.loc7_20 to %.loc7_23.3 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc7_23.5: init [i32; 1] = array_init (%.loc7_23.4) to file.%a.var [template = constants.%array]
+// CHECK:STDOUT:   %.loc7_24: init [i32; 1] = converted %.loc7_23.1, %.loc7_23.5 [template = constants.%array]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_24
 // CHECK:STDOUT:   %a.ref: ref [i32; 1] = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc11_16: i32 = int_literal 1 [template = constants.%.1]

--- a/toolchain/check/testdata/index/fail_invalid_base.carbon
+++ b/toolchain/check/testdata/index/fail_invalid_base.carbon
@@ -37,7 +37,7 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %.3: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.4: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.6: {.a: i32, .b: i32} = struct_value (%.2, %.3) [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.2, %.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -77,8 +77,8 @@ var d: i32 = {.a: i32, .b: i32}[0];
 // CHECK:STDOUT:   %.loc25_28: i32 = int_literal 2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc25_29.1: {.a: i32, .b: i32} = struct_literal (%.loc25_20, %.loc25_28)
 // CHECK:STDOUT:   %.loc25_31: i32 = int_literal 0 [template = constants.%.1]
-// CHECK:STDOUT:   %.loc25_29.2: {.a: i32, .b: i32} = struct_value (%.loc25_20, %.loc25_28) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc25_29.3: {.a: i32, .b: i32} = converted %.loc25_29.1, %.loc25_29.2 [template = constants.%.6]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.loc25_20, %.loc25_28) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc25_29.2: {.a: i32, .b: i32} = converted %.loc25_29.1, %struct [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   %.loc30_31: type = struct_type {.a: i32, .b: i32} [template = constants.%.4]
 // CHECK:STDOUT:   %.loc30_33: i32 = int_literal 0 [template = constants.%.1]

--- a/toolchain/check/testdata/index/fail_negative_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_negative_indexing.carbon
@@ -23,8 +23,8 @@ var b: i32 = a[-10];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -51,11 +51,11 @@ var b: i32 = a[-10];
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc16_17: i32 = int_literal 10 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc16_17: i32 = int_literal 10 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc16_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
+++ b/toolchain/check/testdata/index/fail_non_deterministic_type.carbon
@@ -19,8 +19,8 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,10 +50,10 @@ var c: i32 = a[b];
 // CHECK:STDOUT:   %.loc7_26.3: init i32 = initialize_from %.loc7_22 to %.loc7_26.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_26.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_26.5: init i32 = initialize_from %.loc7_25 to %.loc7_26.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_26.6: init (i32, i32) = tuple_init (%.loc7_26.3, %.loc7_26.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_27: init (i32, i32) = converted %.loc7_26.1, %.loc7_26.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_26.6: init (i32, i32) = tuple_init (%.loc7_26.3, %.loc7_26.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27: init (i32, i32) = converted %.loc7_26.1, %.loc7_26.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_27
-// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc8: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   assign file.%b.var, %.loc8
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %b.ref: ref i32 = name_ref b, file.%b

--- a/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
+++ b/toolchain/check/testdata/index/fail_out_of_bound_not_literal.carbon
@@ -18,10 +18,10 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 34 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.8: type = struct_type {.index: i32} [template]
-// CHECK:STDOUT:   %.9: {.index: i32} = struct_value (%.7) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.index: i32} [template]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,15 +48,15 @@ var b: i32 = a[{.index = 2}.index];
 // CHECK:STDOUT:   %.loc7_28.3: init i32 = initialize_from %.loc7_22 to %.loc7_28.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_28.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_28.5: init i32 = initialize_from %.loc7_26 to %.loc7_28.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_29
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc11_26: i32 = int_literal 2 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_26: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_27.1: {.index: i32} = struct_literal (%.loc11_26)
-// CHECK:STDOUT:   %.loc11_27.2: {.index: i32} = struct_value (%.loc11_26) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc11_27.3: {.index: i32} = converted %.loc11_27.1, %.loc11_27.2 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc11_28: i32 = struct_access %.loc11_27.3, element0 [template = constants.%.7]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.loc11_26) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc11_27.2: {.index: i32} = converted %.loc11_27.1, %struct [template = constants.%struct]
+// CHECK:STDOUT:   %.loc11_28: i32 = struct_access %.loc11_27.2, element0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_34: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/fail_tuple_index_error.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_index_error.carbon
@@ -18,7 +18,7 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,8 +45,8 @@ var b: i32 = a[oops];
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
 // CHECK:STDOUT:   %oops.ref: <error> = name_ref oops, <error> [template = <error>]

--- a/toolchain/check/testdata/index/fail_tuple_large_index.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_large_index.carbon
@@ -22,9 +22,9 @@ var d: i32 = b[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.6: i32 = int_literal 2147483647 [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.5: i32 = int_literal 2147483647 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -54,8 +54,8 @@ var d: i32 = b[0x7FFF_FFFF];
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
-// CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_22
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %a.ref, element0
@@ -64,11 +64,11 @@ var d: i32 = b[0x7FFF_FFFF];
 // CHECK:STDOUT:   %.loc8_18: init (i32,) = converted %a.ref, %.loc8_17.3
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_18
 // CHECK:STDOUT:   %b.ref.loc13: ref (i32,) = name_ref b, file.%b
-// CHECK:STDOUT:   %.loc13_16: i32 = int_literal 1 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc13_16: i32 = int_literal 1 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_17: ref <error> = tuple_index %b.ref.loc13, <error>
 // CHECK:STDOUT:   assign file.%c.var, <error>
 // CHECK:STDOUT:   %b.ref.loc17: ref (i32,) = name_ref b, file.%b
-// CHECK:STDOUT:   %.loc17_16: i32 = int_literal 2147483647 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc17_16: i32 = int_literal 2147483647 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc17_27: ref <error> = tuple_index %b.ref.loc17, <error>
 // CHECK:STDOUT:   assign file.%d.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_non_int_indexing.carbon
@@ -18,8 +18,8 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: f64 = float_literal 2.6000000000000001 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: f64 = float_literal 2.6000000000000001 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -46,11 +46,11 @@ var b: i32 = a[2.6];
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc11_16: f64 = float_literal 2.6000000000000001 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_16: f64 = float_literal 2.6000000000000001 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_19: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
+++ b/toolchain/check/testdata/index/fail_tuple_out_of_bound_access.carbon
@@ -18,8 +18,8 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -46,11 +46,11 @@ var b: i32 = a[2];
 // CHECK:STDOUT:   %.loc7_27.3: init i32 = initialize_from %.loc7_22 to %.loc7_27.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_27.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_27.5: init i32 = initialize_from %.loc7_26 to %.loc7_27.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_27.6: init (i32, i32) = tuple_init (%.loc7_27.3, %.loc7_27.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_28: init (i32, i32) = converted %.loc7_27.1, %.loc7_27.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_28
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc11_16: i32 = int_literal 2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_17: ref <error> = tuple_index %a.ref, <error>
 // CHECK:STDOUT:   assign file.%b.var, <error>
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/index/index_not_literal.carbon
+++ b/toolchain/check/testdata/index/index_not_literal.carbon
@@ -15,10 +15,10 @@ var b: i32 = a[{.index = 1}.index];
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 34 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.8: type = struct_type {.index: i32} [template]
-// CHECK:STDOUT:   %.9: {.index: i32} = struct_value (%.7) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.7: type = struct_type {.index: i32} [template]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -45,15 +45,15 @@ var b: i32 = a[{.index = 1}.index];
 // CHECK:STDOUT:   %.loc7_28.3: init i32 = initialize_from %.loc7_22 to %.loc7_28.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_28.4: ref i32 = tuple_access file.%a.var, element1
 // CHECK:STDOUT:   %.loc7_28.5: init i32 = initialize_from %.loc7_26 to %.loc7_28.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_28.6: init (i32, i32) = tuple_init (%.loc7_28.3, %.loc7_28.5) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_29: init (i32, i32) = converted %.loc7_28.1, %.loc7_28.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_29
 // CHECK:STDOUT:   %a.ref: ref (i32, i32) = name_ref a, file.%a
-// CHECK:STDOUT:   %.loc8_26: i32 = int_literal 1 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc8_26: i32 = int_literal 1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc8_27.1: {.index: i32} = struct_literal (%.loc8_26)
-// CHECK:STDOUT:   %.loc8_27.2: {.index: i32} = struct_value (%.loc8_26) [template = constants.%.9]
-// CHECK:STDOUT:   %.loc8_27.3: {.index: i32} = converted %.loc8_27.1, %.loc8_27.2 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc8_28: i32 = struct_access %.loc8_27.3, element0 [template = constants.%.7]
+// CHECK:STDOUT:   %struct: {.index: i32} = struct_value (%.loc8_26) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_27.2: {.index: i32} = converted %.loc8_27.1, %struct [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_28: i32 = struct_access %.loc8_27.2, element0 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc8_34.1: ref i32 = tuple_index %a.ref, %.loc8_28
 // CHECK:STDOUT:   %.loc8_34.2: i32 = bind_value %.loc8_34.1
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_34.2

--- a/toolchain/check/testdata/index/tuple_element_access.carbon
+++ b/toolchain/check/testdata/index/tuple_element_access.carbon
@@ -14,8 +14,8 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 12 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
-// CHECK:STDOUT:   %.5: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.4: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -42,8 +42,8 @@ var c: i32 = b[0];
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 12 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_21.1: (i32,) = tuple_literal (%.loc7_18)
-// CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_21.2: init (i32,) = tuple_init (%.loc7_18) to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_22: init (i32,) = converted %.loc7_21.1, %.loc7_21.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc7_22
 // CHECK:STDOUT:   %a.ref: ref (i32,) = name_ref a, file.%a
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %a.ref, element0
@@ -52,7 +52,7 @@ var c: i32 = b[0];
 // CHECK:STDOUT:   %.loc8_18: init (i32,) = converted %a.ref, %.loc8_17.3
 // CHECK:STDOUT:   assign file.%b.var, %.loc8_18
 // CHECK:STDOUT:   %b.ref: ref (i32,) = name_ref b, file.%b
-// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc9_16: i32 = int_literal 0 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_17.1: ref i32 = tuple_index %b.ref, %.loc9_16
 // CHECK:STDOUT:   %.loc9_17.2: i32 = bind_value %.loc9_17.1
 // CHECK:STDOUT:   assign file.%c.var, %.loc9_17.2

--- a/toolchain/check/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/check/testdata/index/tuple_return_value_access.carbon
@@ -16,7 +16,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -39,9 +39,9 @@ fn Run() -> i32 {
 // CHECK:STDOUT: fn @F() -> (i32,) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_28: i32 = int_literal 0 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_30.1: (i32,) = tuple_literal (%.loc7_28)
-// CHECK:STDOUT:   %.loc7_30.2: (i32,) = tuple_value (%.loc7_28) [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30.1, %.loc7_30.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_30: (i32,) = tuple_literal (%.loc7_28)
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.loc7_28) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_31: (i32,) = converted %.loc7_30, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc7_31
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
+++ b/toolchain/check/testdata/interface/no_prelude/default_fn.carbon
@@ -31,7 +31,7 @@ class C {
 // CHECK:STDOUT:   %.5: type = struct_type {} [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -79,8 +79,8 @@ class C {
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc12_19.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc12_19.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc12_20: init C = converted %.loc12_19.1, %.loc12_19.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc12_19.2: init C = class_init (), %c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc12_20: init C = converted %.loc12_19.1, %.loc12_19.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %c.var, %.loc12_20
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %I.ref: type = name_ref I, @C.%I.decl [template = constants.%.1]

--- a/toolchain/check/testdata/let/convert.carbon
+++ b/toolchain/check/testdata/let/convert.carbon
@@ -20,7 +20,7 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.7: (i32, i32, i32) = tuple_value (%.4, %.5, %.6) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32, i32) = tuple_value (%.4, %.5, %.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -50,8 +50,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.5: init i32 = initialize_from %.loc8_32 to %.loc8_36.4 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc8_36.6: ref i32 = tuple_access %v.var, element2
 // CHECK:STDOUT:   %.loc8_36.7: init i32 = initialize_from %.loc8_35 to %.loc8_36.6 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc8_36.8: init (i32, i32, i32) = tuple_init (%.loc8_36.3, %.loc8_36.5, %.loc8_36.7) to %v.var [template = constants.%.7]
-// CHECK:STDOUT:   %.loc8_37: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc8_36.8: init (i32, i32, i32) = tuple_init (%.loc8_36.3, %.loc8_36.5, %.loc8_36.7) to %v.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_37: init (i32, i32, i32) = converted %.loc8_36.1, %.loc8_36.8 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %v.var, %.loc8_37
 // CHECK:STDOUT:   %.loc10_24.1: (type, type, type) = tuple_literal (i32, i32, i32)
 // CHECK:STDOUT:   %.loc10_24.2: type = converted %.loc10_24.1, constants.%.2 [template = constants.%.2]
@@ -62,8 +62,8 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_28.4: i32 = bind_value %.loc10_28.3
 // CHECK:STDOUT:   %.loc10_28.5: ref i32 = tuple_access %v.ref, element2
 // CHECK:STDOUT:   %.loc10_28.6: i32 = bind_value %.loc10_28.5
-// CHECK:STDOUT:   %.loc10_28.7: (i32, i32, i32) = tuple_value (%.loc10_28.2, %.loc10_28.4, %.loc10_28.6)
-// CHECK:STDOUT:   %.loc10_29: (i32, i32, i32) = converted %v.ref, %.loc10_28.7
+// CHECK:STDOUT:   %tuple: (i32, i32, i32) = tuple_value (%.loc10_28.2, %.loc10_28.4, %.loc10_28.6)
+// CHECK:STDOUT:   %.loc10_29: (i32, i32, i32) = converted %v.ref, %tuple
 // CHECK:STDOUT:   %w: (i32, i32, i32) = bind_name w, %.loc10_29
 // CHECK:STDOUT:   %w.ref: (i32, i32, i32) = name_ref w, %w
 // CHECK:STDOUT:   %.loc11_12: i32 = int_literal 1 [template = constants.%.4]

--- a/toolchain/check/testdata/operators/builtin/and.carbon
+++ b/toolchain/check/testdata/operators/builtin/and.carbon
@@ -28,7 +28,7 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %.1: bool = bool_literal true [template]
 // CHECK:STDOUT:   %.2: bool = bool_literal false [template]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -143,8 +143,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %b.var: ref () = var b
 // CHECK:STDOUT:   %b: ref () = bind_name b, %b.var
 // CHECK:STDOUT:   %.loc16_49.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc16_49.2: init () = tuple_init () to %b.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc16_50: init () = converted %.loc16_49.1, %.loc16_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc16_49.2: init () = tuple_init () to %b.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc16_50: init () = converted %.loc16_49.1, %.loc16_49.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %b.var, %.loc16_50
 // CHECK:STDOUT:   %.loc17_13: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc17_19.1: bool = bool_literal false [template = constants.%.2]
@@ -171,8 +171,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %c.var: ref () = var c
 // CHECK:STDOUT:   %c: ref () = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc17_49.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc17_49.2: init () = tuple_init () to %c.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc17_50: init () = converted %.loc17_49.1, %.loc17_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc17_49.2: init () = tuple_init () to %c.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc17_50: init () = converted %.loc17_49.1, %.loc17_49.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %c.var, %.loc17_50
 // CHECK:STDOUT:   %.loc18_13: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc18_19.1: bool = bool_literal false [template = constants.%.2]
@@ -199,8 +199,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %d.var: ref () = var d
 // CHECK:STDOUT:   %d: ref () = bind_name d, %d.var
 // CHECK:STDOUT:   %.loc18_50.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc18_50.2: init () = tuple_init () to %d.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc18_51: init () = converted %.loc18_50.1, %.loc18_50.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc18_50.2: init () = tuple_init () to %d.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc18_51: init () = converted %.loc18_50.1, %.loc18_50.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %d.var, %.loc18_51
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -232,8 +232,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc22_46.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_46.2: init () = tuple_init () to %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc22_47: init () = converted %.loc22_46.1, %.loc22_46.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc22_46.2: init () = tuple_init () to %a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc22_47: init () = converted %.loc22_46.1, %.loc22_46.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %a.var, %.loc22_47
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/assignment.carbon
+++ b/toolchain/check/testdata/operators/builtin/assignment.carbon
@@ -32,17 +32,17 @@ fn Main() {
 // CHECK:STDOUT:   %.5: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.7: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.8: (i32, i32) = tuple_value (%.6, %.7) [template]
-// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.10: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.11: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.12: type = struct_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.13: type = ptr_type {.a: i32, .b: i32} [template]
-// CHECK:STDOUT:   %.14: {.a: i32, .b: i32} = struct_value (%.6, %.7) [template]
-// CHECK:STDOUT:   %.15: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %.16: i32 = int_literal 5 [template]
-// CHECK:STDOUT:   %.17: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.18: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.6, %.7) [template]
+// CHECK:STDOUT:   %.8: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %.10: i32 = int_literal 4 [template]
+// CHECK:STDOUT:   %.11: type = struct_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %.12: type = ptr_type {.a: i32, .b: i32} [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.6, %.7) [template]
+// CHECK:STDOUT:   %.13: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 5 [template]
+// CHECK:STDOUT:   %.15: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -74,20 +74,20 @@ fn Main() {
 // CHECK:STDOUT:   %.loc11_28.3: init i32 = initialize_from %.loc11_24 to %.loc11_28.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc11_28.4: ref i32 = tuple_access %b.var, element1
 // CHECK:STDOUT:   %.loc11_28.5: init i32 = initialize_from %.loc11_27 to %.loc11_28.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc11_28.6: init (i32, i32) = tuple_init (%.loc11_28.3, %.loc11_28.5) to %b.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc11_29: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc11_28.6: init (i32, i32) = tuple_init (%.loc11_28.3, %.loc11_28.5) to %b.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc11_29: init (i32, i32) = converted %.loc11_28.1, %.loc11_28.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %b.var, %.loc11_29
 // CHECK:STDOUT:   %b.ref.loc12: ref (i32, i32) = name_ref b, %b
-// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc12_5: i32 = int_literal 0 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc12_6: ref i32 = tuple_index %b.ref.loc12, %.loc12_5
-// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc12_10: i32 = int_literal 3 [template = constants.%.9]
 // CHECK:STDOUT:   assign %.loc12_6, %.loc12_10
 // CHECK:STDOUT:   %b.ref.loc13: ref (i32, i32) = name_ref b, %b
 // CHECK:STDOUT:   %.loc13_5: i32 = int_literal 1 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc13_6: ref i32 = tuple_index %b.ref.loc13, %.loc13_5
-// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc13_10: i32 = int_literal 4 [template = constants.%.10]
 // CHECK:STDOUT:   assign %.loc13_6, %.loc13_10
-// CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32} [template = constants.%.12]
+// CHECK:STDOUT:   %.loc15_27: type = struct_type {.a: i32, .b: i32} [template = constants.%.11]
 // CHECK:STDOUT:   %c.var: ref {.a: i32, .b: i32} = var c
 // CHECK:STDOUT:   %c: ref {.a: i32, .b: i32} = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc15_37: i32 = int_literal 1 [template = constants.%.6]
@@ -97,18 +97,18 @@ fn Main() {
 // CHECK:STDOUT:   %.loc15_46.3: init i32 = initialize_from %.loc15_37 to %.loc15_46.2 [template = constants.%.6]
 // CHECK:STDOUT:   %.loc15_46.4: ref i32 = struct_access %c.var, element1
 // CHECK:STDOUT:   %.loc15_46.5: init i32 = initialize_from %.loc15_45 to %.loc15_46.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc15_46.6: init {.a: i32, .b: i32} = struct_init (%.loc15_46.3, %.loc15_46.5) to %c.var [template = constants.%.14]
-// CHECK:STDOUT:   %.loc15_47: init {.a: i32, .b: i32} = converted %.loc15_46.1, %.loc15_46.6 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc15_46.6: init {.a: i32, .b: i32} = struct_init (%.loc15_46.3, %.loc15_46.5) to %c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc15_47: init {.a: i32, .b: i32} = converted %.loc15_46.1, %.loc15_46.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign %c.var, %.loc15_47
 // CHECK:STDOUT:   %c.ref.loc16: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc16_4: ref i32 = struct_access %c.ref.loc16, element0
-// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc16_9: i32 = int_literal 3 [template = constants.%.9]
 // CHECK:STDOUT:   assign %.loc16_4, %.loc16_9
 // CHECK:STDOUT:   %c.ref.loc17: ref {.a: i32, .b: i32} = name_ref c, %c
 // CHECK:STDOUT:   %.loc17_4: ref i32 = struct_access %c.ref.loc17, element1
-// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc17_9: i32 = int_literal 4 [template = constants.%.10]
 // CHECK:STDOUT:   assign %.loc17_4, %.loc17_9
-// CHECK:STDOUT:   %.loc19_13: type = ptr_type i32 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc19_13: type = ptr_type i32 [template = constants.%.13]
 // CHECK:STDOUT:   %p.var: ref i32* = var p
 // CHECK:STDOUT:   %p: ref i32* = bind_name p, %p.var
 // CHECK:STDOUT:   %a.ref.loc19: ref i32 = name_ref a, %a
@@ -117,9 +117,9 @@ fn Main() {
 // CHECK:STDOUT:   %p.ref.loc20: ref i32* = name_ref p, %p
 // CHECK:STDOUT:   %.loc20_4: i32* = bind_value %p.ref.loc20
 // CHECK:STDOUT:   %.loc20_3: ref i32 = deref %.loc20_4
-// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc20_8: i32 = int_literal 5 [template = constants.%.14]
 // CHECK:STDOUT:   assign %.loc20_3, %.loc20_8
-// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template = constants.%.17]
+// CHECK:STDOUT:   %.loc22_8: bool = bool_literal true [template = constants.%.15]
 // CHECK:STDOUT:   if %.loc22_8 br !if.expr.then else br !if.expr.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then:
@@ -135,7 +135,7 @@ fn Main() {
 // CHECK:STDOUT: !if.expr.result:
 // CHECK:STDOUT:   %.loc22_5: i32* = block_arg !if.expr.result
 // CHECK:STDOUT:   %.loc22_3: ref i32 = deref %.loc22_5
-// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc22_31: i32 = int_literal 10 [template = constants.%.16]
 // CHECK:STDOUT:   assign %.loc22_3, %.loc22_31
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
+++ b/toolchain/check/testdata/operators/builtin/fail_assignment_to_non_assignable.carbon
@@ -61,16 +61,16 @@ fn Main() {
 // CHECK:STDOUT:   %.4: i32 = int_literal 3 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.6: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.7: (i32, i32) = tuple_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.8: (i32, i32) = tuple_value (%.1, %.2) [template]
-// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.10: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %.11: type = struct_type {.x: i32, .y: i32} [template]
-// CHECK:STDOUT:   %.12: type = ptr_type {.x: i32, .y: i32} [template]
-// CHECK:STDOUT:   %.13: {.x: i32, .y: i32} = struct_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.14: {.x: i32, .y: i32} = struct_value (%.1, %.2) [template]
-// CHECK:STDOUT:   %.15: bool = bool_literal true [template]
-// CHECK:STDOUT:   %.16: i32 = int_literal 10 [template]
+// CHECK:STDOUT:   %tuple.1: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %tuple.2: (i32, i32) = tuple_value (%.1, %.2) [template]
+// CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %.8: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.9: type = struct_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %.10: type = ptr_type {.x: i32, .y: i32} [template]
+// CHECK:STDOUT:   %struct.1: {.x: i32, .y: i32} = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %struct.2: {.x: i32, .y: i32} = struct_value (%.1, %.2) [template]
+// CHECK:STDOUT:   %.11: bool = bool_literal true [template]
+// CHECK:STDOUT:   %.12: i32 = int_literal 10 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -107,14 +107,14 @@ fn Main() {
 // CHECK:STDOUT:   %.loc24_17.3: init i32 = initialize_from %.loc24_13 to %.loc24_17.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc24_17.4: i32 = tuple_access %.loc24_8.1, element1
 // CHECK:STDOUT:   %.loc24_17.5: init i32 = initialize_from %.loc24_16 to %.loc24_17.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc24_17.6: init (i32, i32) = tuple_init (%.loc24_17.3, %.loc24_17.5) to %.loc24_8.1 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc24_10: init (i32, i32) = converted %.loc24_17.1, %.loc24_17.6 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc24_17.6: init (i32, i32) = tuple_init (%.loc24_17.3, %.loc24_17.5) to %.loc24_8.1 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc24_10: init (i32, i32) = converted %.loc24_17.1, %.loc24_17.6 [template = constants.%tuple.1]
 // CHECK:STDOUT:   assign %.loc24_8.1, %.loc24_10
-// CHECK:STDOUT:   %.loc24_8.2: (i32, i32) = tuple_value (%.loc24_4, %.loc24_7) [template = constants.%.8]
-// CHECK:STDOUT:   %.loc24_8.3: (i32, i32) = converted %.loc24_8.1, %.loc24_8.2 [template = constants.%.8]
+// CHECK:STDOUT:   %tuple.loc24: (i32, i32) = tuple_value (%.loc24_4, %.loc24_7) [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc24_8.2: (i32, i32) = converted %.loc24_8.1, %tuple.loc24 [template = constants.%tuple.2]
 // CHECK:STDOUT:   %n.var: ref i32 = var n
 // CHECK:STDOUT:   %n: ref i32 = bind_name n, %n.var
-// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template = constants.%.9]
+// CHECK:STDOUT:   %.loc25: i32 = int_literal 0 [template = constants.%.7]
 // CHECK:STDOUT:   assign %n.var, %.loc25
 // CHECK:STDOUT:   %n.ref.loc30_4: ref i32 = name_ref n, %n
 // CHECK:STDOUT:   %n.ref.loc30_7: ref i32 = name_ref n, %n
@@ -126,14 +126,14 @@ fn Main() {
 // CHECK:STDOUT:   %.loc30_17.3: init i32 = initialize_from %.loc30_13 to %.loc30_17.2 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc30_17.4: i32 = tuple_access %.loc30_8.1, element1
 // CHECK:STDOUT:   %.loc30_17.5: init i32 = initialize_from %.loc30_16 to %.loc30_17.4 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc30_17.6: init (i32, i32) = tuple_init (%.loc30_17.3, %.loc30_17.5) to %.loc30_8.1 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc30_10: init (i32, i32) = converted %.loc30_17.1, %.loc30_17.6 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc30_17.6: init (i32, i32) = tuple_init (%.loc30_17.3, %.loc30_17.5) to %.loc30_8.1 [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc30_10: init (i32, i32) = converted %.loc30_17.1, %.loc30_17.6 [template = constants.%tuple.2]
 // CHECK:STDOUT:   assign %.loc30_8.1, %.loc30_10
 // CHECK:STDOUT:   %.loc30_4: i32 = bind_value %n.ref.loc30_4
 // CHECK:STDOUT:   %.loc30_7: i32 = bind_value %n.ref.loc30_7
-// CHECK:STDOUT:   %.loc30_8.2: (i32, i32) = tuple_value (%.loc30_4, %.loc30_7)
-// CHECK:STDOUT:   %.loc30_8.3: (i32, i32) = converted %.loc30_8.1, %.loc30_8.2
-// CHECK:STDOUT:   %.loc35: type = ptr_type i32 [template = constants.%.10]
+// CHECK:STDOUT:   %tuple.loc30: (i32, i32) = tuple_value (%.loc30_4, %.loc30_7)
+// CHECK:STDOUT:   %.loc30_8.2: (i32, i32) = converted %.loc30_8.1, %tuple.loc30
+// CHECK:STDOUT:   %.loc35: type = ptr_type i32 [template = constants.%.8]
 // CHECK:STDOUT:   assign i32, %.loc35
 // CHECK:STDOUT:   %.loc40_9: i32 = int_literal 1 [template = constants.%.1]
 // CHECK:STDOUT:   %.loc40_17: i32 = int_literal 2 [template = constants.%.2]
@@ -145,12 +145,12 @@ fn Main() {
 // CHECK:STDOUT:   %.loc40_37.3: init i32 = initialize_from %.loc40_28 to %.loc40_37.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc40_37.4: i32 = struct_access %.loc40_18.1, element1
 // CHECK:STDOUT:   %.loc40_37.5: init i32 = initialize_from %.loc40_36 to %.loc40_37.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc40_37.6: init {.x: i32, .y: i32} = struct_init (%.loc40_37.3, %.loc40_37.5) to %.loc40_18.1 [template = constants.%.13]
-// CHECK:STDOUT:   %.loc40_20: init {.x: i32, .y: i32} = converted %.loc40_37.1, %.loc40_37.6 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc40_37.6: init {.x: i32, .y: i32} = struct_init (%.loc40_37.3, %.loc40_37.5) to %.loc40_18.1 [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc40_20: init {.x: i32, .y: i32} = converted %.loc40_37.1, %.loc40_37.6 [template = constants.%struct.1]
 // CHECK:STDOUT:   assign %.loc40_18.1, %.loc40_20
-// CHECK:STDOUT:   %.loc40_18.2: {.x: i32, .y: i32} = struct_value (%.loc40_9, %.loc40_17) [template = constants.%.14]
-// CHECK:STDOUT:   %.loc40_18.3: {.x: i32, .y: i32} = converted %.loc40_18.1, %.loc40_18.2 [template = constants.%.14]
-// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.15]
+// CHECK:STDOUT:   %struct: {.x: i32, .y: i32} = struct_value (%.loc40_9, %.loc40_17) [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc40_18.2: {.x: i32, .y: i32} = converted %.loc40_18.1, %struct [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc45_7: bool = bool_literal true [template = constants.%.11]
 // CHECK:STDOUT:   if %.loc45_7 br !if.expr.then.loc45 else br !if.expr.else.loc45
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc45:
@@ -167,7 +167,7 @@ fn Main() {
 // CHECK:STDOUT:   assign %.loc45_4, %.loc45_29
 // CHECK:STDOUT:   %a.var: ref i32 = var a
 // CHECK:STDOUT:   %a: ref i32 = bind_name a, %a.var
-// CHECK:STDOUT:   %.loc52_7: bool = bool_literal true [template = constants.%.15]
+// CHECK:STDOUT:   %.loc52_7: bool = bool_literal true [template = constants.%.11]
 // CHECK:STDOUT:   if %.loc52_7 br !if.expr.then.loc52 else br !if.expr.else.loc52
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.then.loc52:
@@ -182,7 +182,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.expr.result.loc52:
 // CHECK:STDOUT:   %.loc52_4: i32 = block_arg !if.expr.result.loc52
-// CHECK:STDOUT:   %.loc52_29: i32 = int_literal 10 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc52_29: i32 = int_literal 10 [template = constants.%.12]
 // CHECK:STDOUT:   assign %.loc52_4, %.loc52_29
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/or.carbon
+++ b/toolchain/check/testdata/operators/builtin/or.carbon
@@ -28,7 +28,7 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %.1: bool = bool_literal true [template]
 // CHECK:STDOUT:   %.2: bool = bool_literal false [template]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -200,8 +200,8 @@ fn PartialConstant(x: bool) {
 // CHECK:STDOUT:   %d.var: ref () = var d
 // CHECK:STDOUT:   %d: ref () = bind_name d, %d.var
 // CHECK:STDOUT:   %.loc18_49.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc18_49.2: init () = tuple_init () to %d.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc18_50: init () = converted %.loc18_49.1, %.loc18_49.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc18_49.2: init () = tuple_init () to %d.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc18_50: init () = converted %.loc18_49.1, %.loc18_49.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %d.var, %.loc18_50
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/operators/builtin/unary_op.carbon
+++ b/toolchain/check/testdata/operators/builtin/unary_op.carbon
@@ -22,7 +22,7 @@ fn Constant() {
 // CHECK:STDOUT:   %.1: bool = bool_literal true [template]
 // CHECK:STDOUT:   %.2: bool = bool_literal false [template]
 // CHECK:STDOUT:   %.3: type = tuple_type () [template]
-// CHECK:STDOUT:   %.4: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -72,8 +72,8 @@ fn Constant() {
 // CHECK:STDOUT:   %a.var: ref () = var a
 // CHECK:STDOUT:   %a: ref () = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc15_43.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_43.2: init () = tuple_init () to %a.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc15_44: init () = converted %.loc15_43.1, %.loc15_43.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc15_43.2: init () = tuple_init () to %a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_44: init () = converted %.loc15_43.1, %.loc15_43.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %a.var, %.loc15_44
 // CHECK:STDOUT:   %.loc16_17: bool = bool_literal false [template = constants.%.2]
 // CHECK:STDOUT:   %.loc16_13: bool = not %.loc16_17 [template = constants.%.1]

--- a/toolchain/check/testdata/operators/overloaded/add.carbon
+++ b/toolchain/check/testdata/operators/overloaded/add.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @AddAssign [template]
 // CHECK:STDOUT:   %Self.2: AddAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @Add, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @AddAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @Add, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @AddAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Add> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %Add.decl: type = interface_decl @Add [template = constants.%.2] {}
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %AddAssign.decl: type = interface_decl @AddAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %AddAssign.ref: type = name_ref AddAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %AddAssign.decl: type = interface_decl @AddAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %AddAssign.ref: type = name_ref AddAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as AddAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/bit_and.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_and.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @BitAndAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @BitAndAssign [template]
 // CHECK:STDOUT:   %Self.2: BitAndAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @BitAnd, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in BitAnd> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @BitAndAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in BitAndAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @BitAnd, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in BitAnd> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @BitAndAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in BitAndAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitAnd> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %BitAnd.decl: type = interface_decl @BitAnd [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitAnd.ref: type = name_ref BitAnd, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitAndAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %BitAndAssign.decl: type = interface_decl @BitAndAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %BitAndAssign.ref: type = name_ref BitAndAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %BitAndAssign.decl: type = interface_decl @BitAndAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %BitAndAssign.ref: type = name_ref BitAndAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as BitAndAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_complement.carbon
@@ -81,9 +81,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = assoc_entity_type @BitComplement, <function> [template]
-// CHECK:STDOUT:   %.8: <associated <function> in BitComplement> = assoc_entity element0, file.%import_ref.6 [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = assoc_entity_type @BitComplement, <function> [template]
+// CHECK:STDOUT:   %.7: <associated <function> in BitComplement> = assoc_entity element0, file.%import_ref.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -95,7 +95,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir2, inst+16, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitComplement> = import_ref ir2, inst+16, loc_50 [template = constants.%.7]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+14, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
@@ -145,8 +145,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: fn @Op.1[@impl.%self.loc9_9.2: C]() -> @impl.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/bit_or.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_or.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @BitOrAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @BitOrAssign [template]
 // CHECK:STDOUT:   %Self.2: BitOrAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @BitOr, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in BitOr> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @BitOrAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in BitOrAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @BitOr, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in BitOr> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @BitOrAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in BitOrAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitOr> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %BitOr.decl: type = interface_decl @BitOr [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitOr.ref: type = name_ref BitOr, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitOrAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %BitOrAssign.decl: type = interface_decl @BitOrAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %BitOrAssign.ref: type = name_ref BitOrAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %BitOrAssign.decl: type = interface_decl @BitOrAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %BitOrAssign.ref: type = name_ref BitOrAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as BitOrAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
+++ b/toolchain/check/testdata/operators/overloaded/bit_xor.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @BitXorAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @BitXorAssign [template]
 // CHECK:STDOUT:   %Self.2: BitXorAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @BitXor, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in BitXor> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @BitXorAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in BitXorAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @BitXor, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in BitXor> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @BitXorAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in BitXorAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in BitXor> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %BitXor.decl: type = interface_decl @BitXor [template = constants.%.2] {}
 // CHECK:STDOUT:     %BitXor.ref: type = name_ref BitXor, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in BitXorAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %BitXorAssign.decl: type = interface_decl @BitXorAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %BitXorAssign.ref: type = name_ref BitXorAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %BitXorAssign.decl: type = interface_decl @BitXorAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %BitXorAssign.ref: type = name_ref BitXorAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as BitXorAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/dec.carbon
+++ b/toolchain/check/testdata/operators/overloaded/dec.carbon
@@ -81,9 +81,9 @@ fn TestOp() {
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
-// CHECK:STDOUT:   %.9: type = assoc_entity_type @Dec, <function> [template]
-// CHECK:STDOUT:   %.10: <associated <function> in Dec> = assoc_entity element0, file.%import_ref.6 [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.8: type = assoc_entity_type @Dec, <function> [template]
+// CHECK:STDOUT:   %.9: <associated <function> in Dec> = assoc_entity element0, file.%import_ref.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -95,7 +95,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir2, inst+15, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Dec> = import_ref ir2, inst+15, loc_47 [template = constants.%.9]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
@@ -146,8 +146,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc13_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %c.var, %.loc13_16
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]

--- a/toolchain/check/testdata/operators/overloaded/div.carbon
+++ b/toolchain/check/testdata/operators/overloaded/div.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @DivAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @DivAssign [template]
 // CHECK:STDOUT:   %Self.2: DivAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @Div, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in Div> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @DivAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in DivAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @Div, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in Div> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @DivAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in DivAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Div> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %Div.decl: type = interface_decl @Div [template = constants.%.2] {}
 // CHECK:STDOUT:     %Div.ref: type = name_ref Div, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in DivAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %DivAssign.decl: type = interface_decl @DivAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %DivAssign.ref: type = name_ref DivAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %DivAssign.decl: type = interface_decl @DivAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %DivAssign.ref: type = name_ref DivAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as DivAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl.carbon
@@ -203,15 +203,15 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %Self.2: Add = bind_symbolic_name Self 0 [symbolic]
 // CHECK:STDOUT:   %.8: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.9: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.10: C = struct_value () [template]
-// CHECK:STDOUT:   %.11: type = interface_type @AddAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.10: type = interface_type @AddAssign [template]
 // CHECK:STDOUT:   %Self.3: AddAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.12: type = assoc_entity_type @AddAssign, <function> [template]
-// CHECK:STDOUT:   %.13: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.15 [template]
-// CHECK:STDOUT:   %.14: type = interface_type @Inc [template]
+// CHECK:STDOUT:   %.11: type = assoc_entity_type @AddAssign, <function> [template]
+// CHECK:STDOUT:   %.12: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.15 [template]
+// CHECK:STDOUT:   %.13: type = interface_type @Inc [template]
 // CHECK:STDOUT:   %Self.4: Inc = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.15: type = assoc_entity_type @Inc, <function> [template]
-// CHECK:STDOUT:   %.16: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.20 [template]
+// CHECK:STDOUT:   %.14: type = assoc_entity_type @Inc, <function> [template]
+// CHECK:STDOUT:   %.15: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.20 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -256,13 +256,13 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:     %b.loc24_12.1: C = param b
 // CHECK:STDOUT:     @TestRef.%b: C = bind_name b, %b.loc24_12.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+36, loc_66 [template = constants.%.11]
-// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir2, inst+55, loc_66 [template = constants.%.13]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+36, loc_66 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.12: <associated <function> in AddAssign> = import_ref ir2, inst+55, loc_66 [template = constants.%.12]
 // CHECK:STDOUT:   %import_ref.13 = import_ref ir2, inst+38, unloaded
 // CHECK:STDOUT:   %import_ref.14 = import_ref ir2, inst+53, unloaded
 // CHECK:STDOUT:   %import_ref.15 = import_ref ir2, inst+53, unloaded
-// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+57, loc_69 [template = constants.%.14]
-// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir2, inst+71, loc_69 [template = constants.%.16]
+// CHECK:STDOUT:   %import_ref.16: type = import_ref ir2, inst+57, loc_69 [template = constants.%.13]
+// CHECK:STDOUT:   %import_ref.17: <associated <function> in Inc> = import_ref ir2, inst+71, loc_69 [template = constants.%.15]
 // CHECK:STDOUT:   %import_ref.18 = import_ref ir2, inst+59, unloaded
 // CHECK:STDOUT:   %import_ref.19 = import_ref ir2, inst+69, unloaded
 // CHECK:STDOUT:   %import_ref.20 = import_ref ir2, inst+69, unloaded
@@ -322,14 +322,14 @@ fn TestRef(b: C) {
 // CHECK:STDOUT:   %a.var: ref C = var a
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc25_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc25_15.2: init C = class_init (), %a.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc25_16: init C = converted %.loc25_15.1, %.loc25_15.2 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc25_15.2: init C = class_init (), %a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc25_16: init C = converted %.loc25_15.1, %.loc25_15.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %a.var, %.loc25_16
 // CHECK:STDOUT:   %a.ref.loc30: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: C = name_ref b, %b
-// CHECK:STDOUT:   %AddAssign.decl: type = interface_decl @AddAssign [template = constants.%.11] {}
+// CHECK:STDOUT:   %AddAssign.decl: type = interface_decl @AddAssign [template = constants.%.10] {}
 // CHECK:STDOUT:   %a.ref.loc34: ref C = name_ref a, %a
-// CHECK:STDOUT:   %Inc.decl: type = interface_decl @Inc [template = constants.%.14] {}
+// CHECK:STDOUT:   %Inc.decl: type = interface_decl @Inc [template = constants.%.13] {}
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
+++ b/toolchain/check/testdata/operators/overloaded/fail_no_impl_for_arg.carbon
@@ -148,9 +148,9 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %.9: type = ptr_type {} [template]
 // CHECK:STDOUT:   %.10: type = assoc_entity_type @Add, <function> [template]
 // CHECK:STDOUT:   %.11: <associated <function> in Add> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.12: C = struct_value () [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @AddAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @AddAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in AddAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -175,7 +175,7 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:     %Add.ref: type = name_ref Add, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.4]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+42, loc_102 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in AddAssign> = import_ref ir2, inst+42, loc_102 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
@@ -290,8 +290,8 @@ fn TestAssign(b: D) {
 // CHECK:STDOUT:   %a.var: ref C = var a
 // CHECK:STDOUT:   %a: ref C = bind_name a, %a.var
 // CHECK:STDOUT:   %.loc28_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc28_15.2: init C = class_init (), %a.var [template = constants.%.12]
-// CHECK:STDOUT:   %.loc28_16: init C = converted %.loc28_15.1, %.loc28_15.2 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc28_15.2: init C = class_init (), %a.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc28_16: init C = converted %.loc28_15.1, %.loc28_15.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %a.var, %.loc28_16
 // CHECK:STDOUT:   %a.ref: ref C = name_ref a, %a
 // CHECK:STDOUT:   %b.ref: D = name_ref b, %b

--- a/toolchain/check/testdata/operators/overloaded/inc.carbon
+++ b/toolchain/check/testdata/operators/overloaded/inc.carbon
@@ -81,9 +81,9 @@ fn TestOp() {
 // CHECK:STDOUT:   %.5: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.6: type = tuple_type () [template]
 // CHECK:STDOUT:   %.7: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.8: C = struct_value () [template]
-// CHECK:STDOUT:   %.9: type = assoc_entity_type @Inc, <function> [template]
-// CHECK:STDOUT:   %.10: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.6 [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.8: type = assoc_entity_type @Inc, <function> [template]
+// CHECK:STDOUT:   %.9: <associated <function> in Inc> = assoc_entity element0, file.%import_ref.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -95,7 +95,7 @@ fn TestOp() {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+15, loc_47 [template = constants.%.10]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Inc> = import_ref ir2, inst+15, loc_47 [template = constants.%.9]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+13, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
@@ -146,8 +146,8 @@ fn TestOp() {
 // CHECK:STDOUT:   %c.var: ref C = var c
 // CHECK:STDOUT:   %c: ref C = bind_name c, %c.var
 // CHECK:STDOUT:   %.loc13_15.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc13_15.2: init C = class_init (), %c.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc13_16: init C = converted %.loc13_15.1, %.loc13_15.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign %c.var, %.loc13_16
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   %.1: <function> = interface_witness_access @impl.%.1, element0 [template = @impl.%Op]

--- a/toolchain/check/testdata/operators/overloaded/left_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/left_shift.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @LeftShiftAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @LeftShiftAssign [template]
 // CHECK:STDOUT:   %Self.2: LeftShiftAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @LeftShift, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in LeftShift> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @LeftShiftAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in LeftShiftAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @LeftShift, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in LeftShift> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @LeftShiftAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in LeftShiftAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in LeftShift> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %LeftShift.decl: type = interface_decl @LeftShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %LeftShift.ref: type = name_ref LeftShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in LeftShiftAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %LeftShiftAssign.decl: type = interface_decl @LeftShiftAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %LeftShiftAssign.ref: type = name_ref LeftShiftAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %LeftShiftAssign.decl: type = interface_decl @LeftShiftAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %LeftShiftAssign.ref: type = name_ref LeftShiftAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as LeftShiftAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/mod.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mod.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @ModAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @ModAssign [template]
 // CHECK:STDOUT:   %Self.2: ModAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @Mod, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in Mod> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @ModAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in ModAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @Mod, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in Mod> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @ModAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in ModAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mod> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %Mod.decl: type = interface_decl @Mod [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mod.ref: type = name_ref Mod, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in ModAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %ModAssign.decl: type = interface_decl @ModAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %ModAssign.ref: type = name_ref ModAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %ModAssign.decl: type = interface_decl @ModAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %ModAssign.ref: type = name_ref ModAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as ModAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/mul.carbon
+++ b/toolchain/check/testdata/operators/overloaded/mul.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @MulAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @MulAssign [template]
 // CHECK:STDOUT:   %Self.2: MulAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @Mul, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in Mul> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @MulAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in MulAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @Mul, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in Mul> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @MulAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in MulAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Mul> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %Mul.decl: type = interface_decl @Mul [template = constants.%.2] {}
 // CHECK:STDOUT:     %Mul.ref: type = name_ref Mul, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in MulAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %MulAssign.decl: type = interface_decl @MulAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %MulAssign.ref: type = name_ref MulAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %MulAssign.decl: type = interface_decl @MulAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %MulAssign.ref: type = name_ref MulAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as MulAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/negate.carbon
+++ b/toolchain/check/testdata/operators/overloaded/negate.carbon
@@ -81,9 +81,9 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = assoc_entity_type @Negate, <function> [template]
-// CHECK:STDOUT:   %.8: <associated <function> in Negate> = assoc_entity element0, file.%import_ref.6 [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = assoc_entity_type @Negate, <function> [template]
+// CHECK:STDOUT:   %.7: <associated <function> in Negate> = assoc_entity element0, file.%import_ref.6 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -95,7 +95,7 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+16, loc_50 [template = constants.%.8]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Negate> = import_ref ir2, inst+16, loc_50 [template = constants.%.7]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+14, loc_19 [template = imports.%Op]
 // CHECK:STDOUT:   impl_decl @impl {
@@ -145,8 +145,8 @@ fn TestOp(a: C) -> C {
 // CHECK:STDOUT: fn @Op.1[@impl.%self.loc9_9.2: C]() -> @impl.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/right_shift.carbon
+++ b/toolchain/check/testdata/operators/overloaded/right_shift.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @RightShiftAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @RightShiftAssign [template]
 // CHECK:STDOUT:   %Self.2: RightShiftAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @RightShift, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in RightShift> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @RightShiftAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in RightShiftAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @RightShift, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in RightShift> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @RightShiftAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in RightShiftAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in RightShift> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %RightShift.decl: type = interface_decl @RightShift [template = constants.%.2] {}
 // CHECK:STDOUT:     %RightShift.ref: type = name_ref RightShift, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in RightShiftAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %RightShiftAssign.decl: type = interface_decl @RightShiftAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %RightShiftAssign.ref: type = name_ref RightShiftAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %RightShiftAssign.decl: type = interface_decl @RightShiftAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %RightShiftAssign.ref: type = name_ref RightShiftAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as RightShiftAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/operators/overloaded/sub.carbon
+++ b/toolchain/check/testdata/operators/overloaded/sub.carbon
@@ -129,16 +129,16 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %.3: <witness> = interface_witness (@impl.1.%Op) [template]
 // CHECK:STDOUT:   %.4: type = tuple_type () [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {} [template]
-// CHECK:STDOUT:   %.6: C = struct_value () [template]
-// CHECK:STDOUT:   %.7: type = interface_type @SubAssign [template]
+// CHECK:STDOUT:   %struct: C = struct_value () [template]
+// CHECK:STDOUT:   %.6: type = interface_type @SubAssign [template]
 // CHECK:STDOUT:   %Self.2: SubAssign = bind_symbolic_name Self 0 [symbolic]
-// CHECK:STDOUT:   %.8: type = ptr_type C [template]
-// CHECK:STDOUT:   %.9: type = ptr_type Self [symbolic]
-// CHECK:STDOUT:   %.10: <witness> = interface_witness (@impl.2.%Op) [template]
-// CHECK:STDOUT:   %.11: type = assoc_entity_type @Sub, <function> [template]
-// CHECK:STDOUT:   %.12: <associated <function> in Sub> = assoc_entity element0, file.%import_ref.10 [template]
-// CHECK:STDOUT:   %.13: type = assoc_entity_type @SubAssign, <function> [template]
-// CHECK:STDOUT:   %.14: <associated <function> in SubAssign> = assoc_entity element0, file.%import_ref.12 [template]
+// CHECK:STDOUT:   %.7: type = ptr_type C [template]
+// CHECK:STDOUT:   %.8: type = ptr_type Self [symbolic]
+// CHECK:STDOUT:   %.9: <witness> = interface_witness (@impl.2.%Op) [template]
+// CHECK:STDOUT:   %.10: type = assoc_entity_type @Sub, <function> [template]
+// CHECK:STDOUT:   %.11: <associated <function> in Sub> = assoc_entity element0, file.%import_ref.10 [template]
+// CHECK:STDOUT:   %.12: type = assoc_entity_type @SubAssign, <function> [template]
+// CHECK:STDOUT:   %.13: <associated <function> in SubAssign> = assoc_entity element0, file.%import_ref.12 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -151,7 +151,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %Core: <namespace> = namespace [template] {}
 // CHECK:STDOUT:   %C.decl: type = class_decl @C [template = constants.%C] {}
 // CHECK:STDOUT:   %import_ref.1: type = import_ref ir2, inst+1, loc_18 [template = constants.%.2]
-// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir2, inst+21, loc_82 [template = constants.%.12]
+// CHECK:STDOUT:   %import_ref.2: <associated <function> in Sub> = import_ref ir2, inst+21, loc_82 [template = constants.%.11]
 // CHECK:STDOUT:   %import_ref.3 = import_ref ir2, inst+3, unloaded
 // CHECK:STDOUT:   %import_ref.4: <function> = import_ref ir2, inst+19, loc_19 [template = imports.%Op.1]
 // CHECK:STDOUT:   impl_decl @impl.1 {
@@ -160,15 +160,15 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %Sub.decl: type = interface_decl @Sub [template = constants.%.2] {}
 // CHECK:STDOUT:     %Sub.ref: type = name_ref Sub, %import_ref.1 [template = constants.%.2]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.7]
-// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.14]
+// CHECK:STDOUT:   %import_ref.5: type = import_ref ir2, inst+23, loc_46 [template = constants.%.6]
+// CHECK:STDOUT:   %import_ref.6: <associated <function> in SubAssign> = import_ref ir2, inst+42, loc_101 [template = constants.%.13]
 // CHECK:STDOUT:   %import_ref.7 = import_ref ir2, inst+25, unloaded
 // CHECK:STDOUT:   %import_ref.8: <function> = import_ref ir2, inst+40, loc_47 [template = imports.%Op.2]
 // CHECK:STDOUT:   impl_decl @impl.2 {
 // CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %Core.ref.loc13: <namespace> = name_ref Core, %Core [template = %Core]
-// CHECK:STDOUT:     %SubAssign.decl: type = interface_decl @SubAssign [template = constants.%.7] {}
-// CHECK:STDOUT:     %SubAssign.ref: type = name_ref SubAssign, %import_ref.5 [template = constants.%.7]
+// CHECK:STDOUT:     %SubAssign.decl: type = interface_decl @SubAssign [template = constants.%.6] {}
+// CHECK:STDOUT:     %SubAssign.ref: type = name_ref SubAssign, %import_ref.5 [template = constants.%.6]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %TestOp: <function> = fn_decl @TestOp [template] {
 // CHECK:STDOUT:     %C.ref.loc17_14: type = name_ref C, %C.decl [template = constants.%C]
@@ -184,14 +184,14 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:   %import_ref.10 = import_ref ir2, inst+19, unloaded
 // CHECK:STDOUT:   %TestAssign: <function> = fn_decl @TestAssign [template] {
 // CHECK:STDOUT:     %C.ref.loc21_18: type = name_ref C, %C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %a.loc21_15.1: C* = param a
 // CHECK:STDOUT:     @TestAssign.%a: C* = bind_name a, %a.loc21_15.1
 // CHECK:STDOUT:     %C.ref.loc21_25: type = name_ref C, %C.decl [template = constants.%C]
 // CHECK:STDOUT:     %b.loc21_22.1: C = param b
 // CHECK:STDOUT:     @TestAssign.%b: C = bind_name b, %b.loc21_22.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.7]
+// CHECK:STDOUT:   %import_ref.11: type = import_ref ir2, inst+23, loc_101 [template = constants.%.6]
 // CHECK:STDOUT:   %import_ref.12 = import_ref ir2, inst+40, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -230,7 +230,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: impl @impl.2: C as SubAssign {
 // CHECK:STDOUT:   %Op: <function> = fn_decl @Op.3 [template] {
 // CHECK:STDOUT:     %C.ref.loc14_20: type = name_ref C, file.%C.decl [template = constants.%C]
-// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.8]
+// CHECK:STDOUT:     %.loc14_21: type = ptr_type C [template = constants.%.7]
 // CHECK:STDOUT:     %self.loc14_14.1: C* = param self
 // CHECK:STDOUT:     %self.loc14_14.3: C* = bind_name self, %self.loc14_14.1
 // CHECK:STDOUT:     %.loc14_9: C* = addr_pattern %self.loc14_14.3
@@ -238,7 +238,7 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT:     %other.loc14_24.1: C = param other
 // CHECK:STDOUT:     %other.loc14_24.2: C = bind_name other, %other.loc14_24.1
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.10]
+// CHECK:STDOUT:   %.1: <witness> = interface_witness (%Op) [template = constants.%.9]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Op = %Op
@@ -253,8 +253,8 @@ fn TestAssign(a: C*, b: C) {
 // CHECK:STDOUT: fn @Op.1[@impl.1.%self.loc9_9.2: C](@impl.1.%other.loc9_18.2: C) -> @impl.1.%return.var: C {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc10_13.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_13.2: init C = class_init (), @impl.1.%return.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_14: init C = converted %.loc10_13.1, %.loc10_13.2 [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc10_14 to @impl.1.%return.var
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/pointer/address_of_lvalue.carbon
+++ b/toolchain/check/testdata/pointer/address_of_lvalue.carbon
@@ -23,13 +23,13 @@ fn F() {
 // CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.5: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
-// CHECK:STDOUT:   %.6: type = ptr_type i32 [template]
-// CHECK:STDOUT:   %.7: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.8: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.9: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.10: (i32, i32) = tuple_value (%.3, %.4) [template]
-// CHECK:STDOUT:   %.11: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %.5: type = ptr_type i32 [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.7: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.8: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %.9: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -53,8 +53,8 @@ fn F() {
 // CHECK:STDOUT:   %.loc8_46.3: init i32 = initialize_from %.loc8_37 to %.loc8_46.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc8_46.4: ref i32 = struct_access %s.var, element1
 // CHECK:STDOUT:   %.loc8_46.5: init i32 = initialize_from %.loc8_45 to %.loc8_46.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_46.6: init {.a: i32, .b: i32} = struct_init (%.loc8_46.3, %.loc8_46.5) to %s.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc8_47: init {.a: i32, .b: i32} = converted %.loc8_46.1, %.loc8_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc8_46.6: init {.a: i32, .b: i32} = struct_init (%.loc8_46.3, %.loc8_46.5) to %s.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_47: init {.a: i32, .b: i32} = converted %.loc8_46.1, %.loc8_46.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign %s.var, %.loc8_47
 // CHECK:STDOUT:   %.loc10_27: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %.loc10_28: type = ptr_type {.a: i32, .b: i32} [template = constants.%.2]
@@ -63,14 +63,14 @@ fn F() {
 // CHECK:STDOUT:   %s.ref.loc10: ref {.a: i32, .b: i32} = name_ref s, %s
 // CHECK:STDOUT:   %.loc10_32: {.a: i32, .b: i32}* = addr_of %s.ref.loc10
 // CHECK:STDOUT:   assign %p.var, %.loc10_32
-// CHECK:STDOUT:   %.loc11_13: type = ptr_type i32 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc11_13: type = ptr_type i32 [template = constants.%.5]
 // CHECK:STDOUT:   %q.var: ref i32* = var q
 // CHECK:STDOUT:   %q: ref i32* = bind_name q, %q.var
 // CHECK:STDOUT:   %s.ref.loc11: ref {.a: i32, .b: i32} = name_ref s, %s
 // CHECK:STDOUT:   %.loc11_19: ref i32 = struct_access %s.ref.loc11, element0
 // CHECK:STDOUT:   %.loc11_17: i32* = addr_of %.loc11_19
 // CHECK:STDOUT:   assign %q.var, %.loc11_17
-// CHECK:STDOUT:   %.loc12_13: type = ptr_type i32 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc12_13: type = ptr_type i32 [template = constants.%.5]
 // CHECK:STDOUT:   %r.var: ref i32* = var r
 // CHECK:STDOUT:   %r: ref i32* = bind_name r, %r.var
 // CHECK:STDOUT:   %s.ref.loc12: ref {.a: i32, .b: i32} = name_ref s, %s
@@ -78,7 +78,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_17: i32* = addr_of %.loc12_19
 // CHECK:STDOUT:   assign %r.var, %.loc12_17
 // CHECK:STDOUT:   %.loc14_19.1: (type, type) = tuple_literal (i32, i32)
-// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc14_19.2: type = converted %.loc14_19.1, constants.%.7 [template = constants.%.7]
 // CHECK:STDOUT:   %t.var: ref (i32, i32) = var t
 // CHECK:STDOUT:   %t: ref (i32, i32) = bind_name t, %t.var
 // CHECK:STDOUT:   %.loc14_24: i32 = int_literal 1 [template = constants.%.3]
@@ -88,18 +88,18 @@ fn F() {
 // CHECK:STDOUT:   %.loc14_28.3: init i32 = initialize_from %.loc14_24 to %.loc14_28.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc14_28.4: ref i32 = tuple_access %t.var, element1
 // CHECK:STDOUT:   %.loc14_28.5: init i32 = initialize_from %.loc14_27 to %.loc14_28.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc14_28.6: init (i32, i32) = tuple_init (%.loc14_28.3, %.loc14_28.5) to %t.var [template = constants.%.10]
-// CHECK:STDOUT:   %.loc14_29: init (i32, i32) = converted %.loc14_28.1, %.loc14_28.6 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc14_28.6: init (i32, i32) = tuple_init (%.loc14_28.3, %.loc14_28.5) to %t.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc14_29: init (i32, i32) = converted %.loc14_28.1, %.loc14_28.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %t.var, %.loc14_29
-// CHECK:STDOUT:   %.loc15_14: type = ptr_type i32 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc15_14: type = ptr_type i32 [template = constants.%.5]
 // CHECK:STDOUT:   %t0.var: ref i32* = var t0
 // CHECK:STDOUT:   %t0: ref i32* = bind_name t0, %t0.var
 // CHECK:STDOUT:   %t.ref.loc15: ref (i32, i32) = name_ref t, %t
-// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc15_21: i32 = int_literal 0 [template = constants.%.9]
 // CHECK:STDOUT:   %.loc15_22: ref i32 = tuple_index %t.ref.loc15, %.loc15_21
 // CHECK:STDOUT:   %.loc15_18: i32* = addr_of %.loc15_22
 // CHECK:STDOUT:   assign %t0.var, %.loc15_18
-// CHECK:STDOUT:   %.loc16_14: type = ptr_type i32 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc16_14: type = ptr_type i32 [template = constants.%.5]
 // CHECK:STDOUT:   %t1.var: ref i32* = var t1
 // CHECK:STDOUT:   %t1: ref i32* = bind_name t1, %t1.var
 // CHECK:STDOUT:   %t.ref.loc16: ref (i32, i32) = name_ref t, %t

--- a/toolchain/check/testdata/pointer/fail_address_of_value.carbon
+++ b/toolchain/check/testdata/pointer/fail_address_of_value.carbon
@@ -117,7 +117,7 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %.17: type = ptr_type type [template]
 // CHECK:STDOUT:   %.18: type = const_type i32 [template]
 // CHECK:STDOUT:   %.19: type = ptr_type const i32 [template]
-// CHECK:STDOUT:   %.20: (i32, i32) = tuple_value (%.10, %.11) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.10, %.11) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -223,9 +223,9 @@ fn AddressOfParam(param: i32) {
 // CHECK:STDOUT:   %.loc88_9: i32 = int_literal 2 [template = constants.%.11]
 // CHECK:STDOUT:   %.loc88_10.1: (i32, i32) = tuple_literal (%.loc88_6, %.loc88_9)
 // CHECK:STDOUT:   %.loc88_12: i32 = int_literal 0 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc88_10.2: (i32, i32) = tuple_value (%.loc88_6, %.loc88_9) [template = constants.%.20]
-// CHECK:STDOUT:   %.loc88_10.3: (i32, i32) = converted %.loc88_10.1, %.loc88_10.2 [template = constants.%.20]
-// CHECK:STDOUT:   %.loc88_13: i32 = tuple_index %.loc88_10.3, %.loc88_12 [template = constants.%.10]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.loc88_6, %.loc88_9) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc88_10.2: (i32, i32) = converted %.loc88_10.1, %tuple [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc88_13: i32 = tuple_index %.loc88_10.2, %.loc88_12 [template = constants.%.10]
 // CHECK:STDOUT:   %.loc88_3: i32* = addr_of <error> [template = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
+++ b/toolchain/check/testdata/pointer/fail_deref_not_pointer.carbon
@@ -40,9 +40,9 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
-// CHECK:STDOUT:   %.3: type = struct_type {} [template]
-// CHECK:STDOUT:   %.4: {} = struct_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.2: type = struct_type {} [template]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -64,21 +64,21 @@ fn Deref(n: i32) {
 // CHECK:STDOUT:   %n.ref.loc17: i32 = name_ref n, %n
 // CHECK:STDOUT:   %.loc17: ref <error> = deref %n.ref.loc17
 // CHECK:STDOUT:   %.loc22_5.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc22_5.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc22_5.3: () = converted %.loc22_5.1, %.loc22_5.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc22_3: ref <error> = deref %.loc22_5.3
+// CHECK:STDOUT:   %tuple.loc22: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc22_5.2: () = converted %.loc22_5.1, %tuple.loc22 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc22_3: ref <error> = deref %.loc22_5.2
 // CHECK:STDOUT:   %.loc27_4.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc27_4.2: () = tuple_value () [template = constants.%.2]
-// CHECK:STDOUT:   %.loc27_4.3: () = converted %.loc27_4.1, %.loc27_4.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc27_5: ref <error> = deref %.loc27_4.3
+// CHECK:STDOUT:   %tuple.loc27: () = tuple_value () [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc27_4.2: () = converted %.loc27_4.1, %tuple.loc27 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc27_5: ref <error> = deref %.loc27_4.2
 // CHECK:STDOUT:   %.loc32_5.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc32_5.2: {} = struct_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc32_5.3: {} = converted %.loc32_5.1, %.loc32_5.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc32_3: ref <error> = deref %.loc32_5.3
+// CHECK:STDOUT:   %struct.loc32: {} = struct_value () [template = constants.%struct]
+// CHECK:STDOUT:   %.loc32_5.2: {} = converted %.loc32_5.1, %struct.loc32 [template = constants.%struct]
+// CHECK:STDOUT:   %.loc32_3: ref <error> = deref %.loc32_5.2
 // CHECK:STDOUT:   %.loc36_4.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc36_4.2: {} = struct_value () [template = constants.%.4]
-// CHECK:STDOUT:   %.loc36_4.3: {} = converted %.loc36_4.1, %.loc36_4.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc36_5: ref <error> = deref %.loc36_4.3
+// CHECK:STDOUT:   %struct.loc36: {} = struct_value () [template = constants.%struct]
+// CHECK:STDOUT:   %.loc36_4.2: {} = converted %.loc36_4.1, %struct.loc36 [template = constants.%struct]
+// CHECK:STDOUT:   %.loc36_5: ref <error> = deref %.loc36_4.2
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
+++ b/toolchain/check/testdata/return/fail_return_with_returned_var.carbon
@@ -38,7 +38,7 @@ fn G() -> C {
 // CHECK:STDOUT:   %.4: type = struct_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.5: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.7: C = struct_value (%.2, %.6) [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%.2, %.6) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -90,8 +90,8 @@ fn G() -> C {
 // CHECK:STDOUT:   %.loc21_38.3: init i32 = initialize_from %.loc21_29 to %.loc21_38.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc21_38.4: ref i32 = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc21_38.5: init i32 = initialize_from %.loc21_37 to %.loc21_38.4 [template = constants.%.6]
-// CHECK:STDOUT:   %.loc21_38.6: init C = class_init (%.loc21_38.3, %.loc21_38.5), %return [template = constants.%.7]
-// CHECK:STDOUT:   %.loc21_39: init C = converted %.loc21_38.1, %.loc21_38.6 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc21_38.6: init C = class_init (%.loc21_38.3, %.loc21_38.5), %return [template = constants.%struct]
+// CHECK:STDOUT:   %.loc21_39: init C = converted %.loc21_38.1, %.loc21_38.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign %return, %.loc21_39
 // CHECK:STDOUT:   %c.ref: ref C = name_ref c, %c
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -28,8 +28,8 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.3: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.6: C = struct_value (%.4, %.5) [template]
-// CHECK:STDOUT:   %.7: i32 = int_literal 0 [template]
+// CHECK:STDOUT:   %struct: C = struct_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %.6: i32 = int_literal 0 [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -71,8 +71,8 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc13_43.3: init i32 = initialize_from %.loc13_34 to %.loc13_43.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc13_43.4: ref i32 = class_element_access %return, element1
 // CHECK:STDOUT:   %.loc13_43.5: init i32 = initialize_from %.loc13_42 to %.loc13_43.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc13_43.6: init C = class_init (%.loc13_43.3, %.loc13_43.5), %return [template = constants.%.6]
-// CHECK:STDOUT:   %.loc13_44: init C = converted %.loc13_43.1, %.loc13_43.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc13_43.6: init C = class_init (%.loc13_43.3, %.loc13_43.5), %return [template = constants.%struct]
+// CHECK:STDOUT:   %.loc13_44: init C = converted %.loc13_43.1, %.loc13_43.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign %return, %.loc13_44
 // CHECK:STDOUT:   return %result to %return
 // CHECK:STDOUT: }
@@ -81,7 +81,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %result.var: ref i32 = var result
 // CHECK:STDOUT:   %result: ref i32 = bind_name result, %result.var
-// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc18_30: i32 = int_literal 0 [template = constants.%.6]
 // CHECK:STDOUT:   assign %result.var, %.loc18_30
 // CHECK:STDOUT:   %.loc18_16: i32 = bind_value %result
 // CHECK:STDOUT:   return %.loc18_16

--- a/toolchain/check/testdata/return/struct.carbon
+++ b/toolchain/check/testdata/return/struct.carbon
@@ -13,7 +13,7 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.3: {.a: i32} = struct_value (%.2) [template]
+// CHECK:STDOUT:   %struct: {.a: i32} = struct_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,9 +31,9 @@ fn Main() -> {.a: i32} {
 // CHECK:STDOUT: fn @Main() -> {.a: i32} {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc8_16: i32 = int_literal 3 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_17.1: {.a: i32} = struct_literal (%.loc8_16)
-// CHECK:STDOUT:   %.loc8_17.2: {.a: i32} = struct_value (%.loc8_16) [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_18: {.a: i32} = converted %.loc8_17.1, %.loc8_17.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_17: {.a: i32} = struct_literal (%.loc8_16)
+// CHECK:STDOUT:   %struct: {.a: i32} = struct_value (%.loc8_16) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_18: {.a: i32} = converted %.loc8_17, %struct [template = constants.%struct]
 // CHECK:STDOUT:   return %.loc8_18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/tuple.carbon
+++ b/toolchain/check/testdata/return/tuple.carbon
@@ -17,7 +17,7 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 15 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 35 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -42,8 +42,8 @@ fn Main() -> (i32, i32) {
 // CHECK:STDOUT:   %.loc9_17.3: init i32 = initialize_from %.loc9_11 to %.loc9_17.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc9_17.4: ref i32 = tuple_access %return, element1
 // CHECK:STDOUT:   %.loc9_17.5: init i32 = initialize_from %.loc9_15 to %.loc9_17.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc9_17.6: init (i32, i32) = tuple_init (%.loc9_17.3, %.loc9_17.5) to %return [template = constants.%.6]
-// CHECK:STDOUT:   %.loc9_18: init (i32, i32) = converted %.loc9_17.1, %.loc9_17.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc9_17.6: init (i32, i32) = tuple_init (%.loc9_17.3, %.loc9_17.5) to %return [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_18: init (i32, i32) = converted %.loc9_17.1, %.loc9_17.6 [template = constants.%tuple]
 // CHECK:STDOUT:   return %.loc9_18 to %return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/struct/fail_member_access_type.carbon
+++ b/toolchain/check/testdata/struct/fail_member_access_type.carbon
@@ -15,7 +15,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {.a: f64} [template]
 // CHECK:STDOUT:   %.2: f64 = float_literal 4 [template]
-// CHECK:STDOUT:   %.3: {.a: f64} = struct_value (%.2) [template]
+// CHECK:STDOUT:   %struct: {.a: f64} = struct_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -36,8 +36,8 @@ var y: i32 = x.b;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_26: f64 = float_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_29.1: {.a: f64} = struct_literal (%.loc7_26)
-// CHECK:STDOUT:   %.loc7_29.2: init {.a: f64} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_30: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_29.2: init {.a: f64} = struct_init (%.loc7_26) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_30: init {.a: f64} = converted %.loc7_29.1, %.loc7_29.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_30
 // CHECK:STDOUT:   %x.ref: ref {.a: f64} = name_ref x, file.%x
 // CHECK:STDOUT:   assign file.%y.var, <error>

--- a/toolchain/check/testdata/struct/fail_non_member_access.carbon
+++ b/toolchain/check/testdata/struct/fail_non_member_access.carbon
@@ -15,7 +15,7 @@ var y: i32 = x.b;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.3: {.a: i32} = struct_value (%.2) [template]
+// CHECK:STDOUT:   %struct: {.a: i32} = struct_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -36,8 +36,8 @@ var y: i32 = x.b;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
-// CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   assign file.%y.var, <error>

--- a/toolchain/check/testdata/struct/import.carbon
+++ b/toolchain/check/testdata/struct/import.carbon
@@ -24,17 +24,17 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.3: {.a: i32} = struct_value (%.2) [template]
-// CHECK:STDOUT:   %.4: type = tuple_type (type) [template]
-// CHECK:STDOUT:   %.5: type = tuple_type (i32) [template]
-// CHECK:STDOUT:   %.6: type = struct_type {.b: i32, .c: (i32,)} [template]
-// CHECK:STDOUT:   %.7: type = struct_type {.a: {.b: i32, .c: (i32,)}, .d: i32} [template]
-// CHECK:STDOUT:   %.8: type = ptr_type {.b: i32, .c: (i32,)} [template]
-// CHECK:STDOUT:   %.9: type = struct_type {.a: {.b: i32, .c: (i32,)}*, .d: i32} [template]
-// CHECK:STDOUT:   %.10: type = ptr_type {.a: {.b: i32, .c: (i32,)}*, .d: i32} [template]
-// CHECK:STDOUT:   %.11: (i32,) = tuple_value (%.2) [template]
-// CHECK:STDOUT:   %.12: {.b: i32, .c: (i32,)} = struct_value (%.2, %.11) [template]
-// CHECK:STDOUT:   %.13: {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_value (%.12, %.2) [template]
+// CHECK:STDOUT:   %struct.1: {.a: i32} = struct_value (%.2) [template]
+// CHECK:STDOUT:   %.3: type = tuple_type (type) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type (i32) [template]
+// CHECK:STDOUT:   %.5: type = struct_type {.b: i32, .c: (i32,)} [template]
+// CHECK:STDOUT:   %.6: type = struct_type {.a: {.b: i32, .c: (i32,)}, .d: i32} [template]
+// CHECK:STDOUT:   %.7: type = ptr_type {.b: i32, .c: (i32,)} [template]
+// CHECK:STDOUT:   %.8: type = struct_type {.a: {.b: i32, .c: (i32,)}*, .d: i32} [template]
+// CHECK:STDOUT:   %.9: type = ptr_type {.a: {.b: i32, .c: (i32,)}*, .d: i32} [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.2) [template]
+// CHECK:STDOUT:   %struct.2: {.b: i32, .c: (i32,)} = struct_value (%.2, %tuple) [template]
+// CHECK:STDOUT:   %struct.3: {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_value (%struct.2, %.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,9 +48,9 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %a_ref.var: ref {.a: i32} = var a_ref
 // CHECK:STDOUT:   %a_ref: ref {.a: i32} = bind_name a_ref, %a_ref.var
 // CHECK:STDOUT:   %.loc5_36.1: (type,) = tuple_literal (i32)
-// CHECK:STDOUT:   %.loc5_36.2: type = converted %.loc5_36.1, constants.%.5 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc5_37: type = struct_type {.b: i32, .c: (i32,)} [template = constants.%.6]
-// CHECK:STDOUT:   %.loc5_47: type = struct_type {.a: {.b: i32, .c: (i32,)}, .d: i32} [template = constants.%.7]
+// CHECK:STDOUT:   %.loc5_36.2: type = converted %.loc5_36.1, constants.%.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc5_37: type = struct_type {.b: i32, .c: (i32,)} [template = constants.%.5]
+// CHECK:STDOUT:   %.loc5_47: type = struct_type {.a: {.b: i32, .c: (i32,)}, .d: i32} [template = constants.%.6]
 // CHECK:STDOUT:   %b_ref.var: ref {.a: {.b: i32, .c: (i32,)}, .d: i32} = var b_ref
 // CHECK:STDOUT:   %b_ref: ref {.a: {.b: i32, .c: (i32,)}, .d: i32} = bind_name b_ref, %b_ref.var
 // CHECK:STDOUT: }
@@ -59,8 +59,8 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc4_30: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc4_31.1: {.a: i32} = struct_literal (%.loc4_30)
-// CHECK:STDOUT:   %.loc4_31.2: init {.a: i32} = struct_init (%.loc4_30) to file.%a_ref.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc4_32: init {.a: i32} = converted %.loc4_31.1, %.loc4_31.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc4_31.2: init {.a: i32} = struct_init (%.loc4_30) to file.%a_ref.var [template = constants.%struct.1]
+// CHECK:STDOUT:   %.loc4_32: init {.a: i32} = converted %.loc4_31.1, %.loc4_31.2 [template = constants.%struct.1]
 // CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_32
 // CHECK:STDOUT:   %.loc6_17: i32 = int_literal 0 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc6_26: i32 = int_literal 0 [template = constants.%.2]
@@ -72,15 +72,15 @@ var b: {.a: {.b: i32, .c: (i32,)}, .d: i32} = b_ref;
 // CHECK:STDOUT:   %.loc6_29.2: ref i32 = struct_access %.loc6_38.2, element0
 // CHECK:STDOUT:   %.loc6_29.3: init i32 = initialize_from %.loc6_17 to %.loc6_29.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc6_29.4: ref (i32,) = struct_access %.loc6_38.2, element1
-// CHECK:STDOUT:   %.loc6_28.2: init (i32,) = tuple_init (%.loc6_26) to %.loc6_29.4 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_29.5: init (i32,) = converted %.loc6_28.1, %.loc6_28.2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_29.6: init (i32,) = initialize_from %.loc6_29.5 to %.loc6_29.4 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc6_29.7: init {.b: i32, .c: (i32,)} = struct_init (%.loc6_29.3, %.loc6_29.6) to %.loc6_38.2 [template = constants.%.12]
-// CHECK:STDOUT:   %.loc6_38.3: init {.b: i32, .c: (i32,)} = converted %.loc6_29.1, %.loc6_29.7 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc6_28.2: init (i32,) = tuple_init (%.loc6_26) to %.loc6_29.4 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc6_29.5: init (i32,) = converted %.loc6_28.1, %.loc6_28.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc6_29.6: init (i32,) = initialize_from %.loc6_29.5 to %.loc6_29.4 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc6_29.7: init {.b: i32, .c: (i32,)} = struct_init (%.loc6_29.3, %.loc6_29.6) to %.loc6_38.2 [template = constants.%struct.2]
+// CHECK:STDOUT:   %.loc6_38.3: init {.b: i32, .c: (i32,)} = converted %.loc6_29.1, %.loc6_29.7 [template = constants.%struct.2]
 // CHECK:STDOUT:   %.loc6_38.4: ref i32 = struct_access file.%b_ref.var, element1
 // CHECK:STDOUT:   %.loc6_38.5: init i32 = initialize_from %.loc6_37 to %.loc6_38.4 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc6_38.6: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_init (%.loc6_38.3, %.loc6_38.5) to file.%b_ref.var [template = constants.%.13]
-// CHECK:STDOUT:   %.loc6_39: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %.loc6_38.1, %.loc6_38.6 [template = constants.%.13]
+// CHECK:STDOUT:   %.loc6_38.6: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = struct_init (%.loc6_38.3, %.loc6_38.5) to file.%b_ref.var [template = constants.%struct.3]
+// CHECK:STDOUT:   %.loc6_39: init {.a: {.b: i32, .c: (i32,)}, .d: i32} = converted %.loc6_38.1, %.loc6_38.6 [template = constants.%struct.3]
 // CHECK:STDOUT:   assign file.%b_ref.var, %.loc6_39
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/literal_member_access.carbon
+++ b/toolchain/check/testdata/struct/literal_member_access.carbon
@@ -55,11 +55,11 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc10_25.6: i32 = bind_value %.loc10_25.5
 // CHECK:STDOUT:   %.loc10_25.7: ref i32 = struct_access %.loc10_25.2, element2
 // CHECK:STDOUT:   %.loc10_25.8: i32 = bind_value %.loc10_25.7
-// CHECK:STDOUT:   %.loc10_25.9: {.x: i32, .y: i32, .z: i32} = struct_value (%.loc10_25.4, %.loc10_25.6, %.loc10_25.8)
-// CHECK:STDOUT:   %.loc10_35.2: {.x: i32, .y: i32, .z: i32} = converted %G.call, %.loc10_25.9
-// CHECK:STDOUT:   %.loc10_35.3: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value (%.loc10_16, %.loc10_35.2, %.loc10_34)
-// CHECK:STDOUT:   %.loc10_35.4: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = converted %.loc10_35.1, %.loc10_35.3
-// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.4, element1
+// CHECK:STDOUT:   %struct.loc10_25: {.x: i32, .y: i32, .z: i32} = struct_value (%.loc10_25.4, %.loc10_25.6, %.loc10_25.8)
+// CHECK:STDOUT:   %.loc10_35.2: {.x: i32, .y: i32, .z: i32} = converted %G.call, %struct.loc10_25
+// CHECK:STDOUT:   %struct.loc10_35: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = struct_value (%.loc10_16, %.loc10_35.2, %.loc10_34)
+// CHECK:STDOUT:   %.loc10_35.3: {.a: i32, .b: {.x: i32, .y: i32, .z: i32}, .c: i32} = converted %.loc10_35.1, %struct.loc10_35
+// CHECK:STDOUT:   %.loc10_36: {.x: i32, .y: i32, .z: i32} = struct_access %.loc10_35.3, element1
 // CHECK:STDOUT:   %.loc10_38: i32 = struct_access %.loc10_36, element1
 // CHECK:STDOUT:   return %.loc10_38
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/member_access.carbon
+++ b/toolchain/check/testdata/struct/member_access.carbon
@@ -15,7 +15,7 @@ var z: i32 = y;
 // CHECK:STDOUT:   %.2: type = ptr_type {.a: f64, .b: i32} [template]
 // CHECK:STDOUT:   %.3: f64 = float_literal 0 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.5: {.a: f64, .b: i32} = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %struct: {.a: f64, .b: i32} = struct_value (%.3, %.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -44,8 +44,8 @@ var z: i32 = y;
 // CHECK:STDOUT:   %.loc7_46.3: init f64 = initialize_from %.loc7_35 to %.loc7_46.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_46.4: ref i32 = struct_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc7_46.5: init i32 = initialize_from %.loc7_45 to %.loc7_46.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_46.6: init {.a: f64, .b: i32} = struct_init (%.loc7_46.3, %.loc7_46.5) to file.%x.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_47: init {.a: f64, .b: i32} = converted %.loc7_46.1, %.loc7_46.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_46.6: init {.a: f64, .b: i32} = struct_init (%.loc7_46.3, %.loc7_46.5) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_47: init {.a: f64, .b: i32} = converted %.loc7_46.1, %.loc7_46.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_47
 // CHECK:STDOUT:   %x.ref: ref {.a: f64, .b: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_15.1: ref i32 = struct_access %x.ref, element1

--- a/toolchain/check/testdata/struct/no_prelude/empty.carbon
+++ b/toolchain/check/testdata/struct/no_prelude/empty.carbon
@@ -12,7 +12,7 @@ var y: {} = x;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {} [template]
 // CHECK:STDOUT:   %.2: type = tuple_type () [template]
-// CHECK:STDOUT:   %.3: {} = struct_value () [template]
+// CHECK:STDOUT:   %struct: {} = struct_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,12 +33,12 @@ var y: {} = x;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc7_14.2: init {} = struct_init () to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_15: init {} = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_14.2: init {} = struct_init () to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_15: init {} = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_15
 // CHECK:STDOUT:   %x.ref: ref {} = name_ref x, file.%x
-// CHECK:STDOUT:   %.loc8_13: init {} = struct_init () to file.%y.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_14: init {} = converted %x.ref, %.loc8_13 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc8_13: init {} = struct_init () to file.%y.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_14: init {} = converted %x.ref, %.loc8_13 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%y.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/struct/one_entry.carbon
+++ b/toolchain/check/testdata/struct/one_entry.carbon
@@ -12,7 +12,7 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = struct_type {.a: i32} [template]
 // CHECK:STDOUT:   %.2: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.3: {.a: i32} = struct_value (%.2) [template]
+// CHECK:STDOUT:   %struct: {.a: i32} = struct_value (%.2) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -34,8 +34,8 @@ var y: {.a: i32} = x;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_26: i32 = int_literal 4 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_27.1: {.a: i32} = struct_literal (%.loc7_26)
-// CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%.3]
+// CHECK:STDOUT:   %.loc7_27.2: init {.a: i32} = struct_init (%.loc7_26) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_28: init {.a: i32} = converted %.loc7_27.1, %.loc7_27.2 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   %x.ref: ref {.a: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_20.1: ref i32 = struct_access %x.ref, element0

--- a/toolchain/check/testdata/struct/reorder_fields.carbon
+++ b/toolchain/check/testdata/struct/reorder_fields.carbon
@@ -58,15 +58,15 @@ fn F() -> {.a: i32, .b: f64} {
 // CHECK:STDOUT:   %.loc11_62.3: i32 = converted %MakeI32.call, %.loc11_62.2
 // CHECK:STDOUT:   %.loc11_62.4: f64 = value_of_initializer %MakeF64.call
 // CHECK:STDOUT:   %.loc11_62.5: f64 = converted %MakeF64.call, %.loc11_62.4
-// CHECK:STDOUT:   %.loc11_62.6: {.a: i32, .b: f64} = struct_value (%.loc11_62.3, %.loc11_62.5)
-// CHECK:STDOUT:   %.loc11_63: {.a: i32, .b: f64} = converted %.loc11_62.1, %.loc11_62.6
+// CHECK:STDOUT:   %struct.loc11: {.a: i32, .b: f64} = struct_value (%.loc11_62.3, %.loc11_62.5)
+// CHECK:STDOUT:   %.loc11_63: {.a: i32, .b: f64} = converted %.loc11_62.1, %struct.loc11
 // CHECK:STDOUT:   %x: {.a: i32, .b: f64} = bind_name x, %.loc11_63
 // CHECK:STDOUT:   %.loc12_27: type = struct_type {.b: f64, .a: i32} [template = constants.%.3]
 // CHECK:STDOUT:   %x.ref: {.a: i32, .b: f64} = name_ref x, %x
 // CHECK:STDOUT:   %.loc12_31.1: f64 = struct_access %x.ref, element1
 // CHECK:STDOUT:   %.loc12_31.2: i32 = struct_access %x.ref, element0
-// CHECK:STDOUT:   %.loc12_31.3: {.b: f64, .a: i32} = struct_value (%.loc12_31.1, %.loc12_31.2)
-// CHECK:STDOUT:   %.loc12_32: {.b: f64, .a: i32} = converted %x.ref, %.loc12_31.3
+// CHECK:STDOUT:   %struct.loc12: {.b: f64, .a: i32} = struct_value (%.loc12_31.1, %.loc12_31.2)
+// CHECK:STDOUT:   %.loc12_32: {.b: f64, .a: i32} = converted %x.ref, %struct.loc12
 // CHECK:STDOUT:   %y: {.b: f64, .a: i32} = bind_name y, %.loc12_32
 // CHECK:STDOUT:   %y.ref: {.b: f64, .a: i32} = name_ref y, %y
 // CHECK:STDOUT:   %.loc13_10.1: i32 = struct_access %y.ref, element1

--- a/toolchain/check/testdata/struct/tuple_as_element.carbon
+++ b/toolchain/check/testdata/struct/tuple_as_element.carbon
@@ -16,8 +16,8 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.4: type = ptr_type {.a: i32, .b: (i32,)} [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.6: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.7: (i32,) = tuple_value (%.6) [template]
-// CHECK:STDOUT:   %.8: {.a: i32, .b: (i32,)} = struct_value (%.5, %.7) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.6) [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: (i32,)} = struct_value (%.5, %tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,11 +48,11 @@ var y: {.a: i32, .b: (i32,)} = x;
 // CHECK:STDOUT:   %.loc7_50.2: ref i32 = struct_access file.%x.var, element0
 // CHECK:STDOUT:   %.loc7_50.3: init i32 = initialize_from %.loc7_38 to %.loc7_50.2 [template = constants.%.5]
 // CHECK:STDOUT:   %.loc7_50.4: ref (i32,) = struct_access file.%x.var, element1
-// CHECK:STDOUT:   %.loc7_49.2: init (i32,) = tuple_init (%.loc7_47) to %.loc7_50.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_50.5: init (i32,) = converted %.loc7_49.1, %.loc7_49.2 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_50.6: init (i32,) = initialize_from %.loc7_50.5 to %.loc7_50.4 [template = constants.%.7]
-// CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = struct_init (%.loc7_50.3, %.loc7_50.6) to file.%x.var [template = constants.%.8]
-// CHECK:STDOUT:   %.loc7_51: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.7 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc7_49.2: init (i32,) = tuple_init (%.loc7_47) to %.loc7_50.4 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_50.5: init (i32,) = converted %.loc7_49.1, %.loc7_49.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_50.6: init (i32,) = initialize_from %.loc7_50.5 to %.loc7_50.4 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_50.7: init {.a: i32, .b: (i32,)} = struct_init (%.loc7_50.3, %.loc7_50.6) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_51: init {.a: i32, .b: (i32,)} = converted %.loc7_50.1, %.loc7_50.7 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_51
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: (i32,)} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_32.1: ref i32 = struct_access %x.ref, element0

--- a/toolchain/check/testdata/struct/two_entries.carbon
+++ b/toolchain/check/testdata/struct/two_entries.carbon
@@ -17,7 +17,7 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.2: type = ptr_type {.a: i32, .b: i32} [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 1 [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.5: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.3, %.4) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,9 +30,9 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc7_25: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %.loc7_35: i32 = int_literal 1 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_43: i32 = int_literal 2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_44.1: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
-// CHECK:STDOUT:   %.loc7_44.2: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_45: {.a: i32, .b: i32} = converted %.loc7_44.1, %.loc7_44.2 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc7_44: {.a: i32, .b: i32} = struct_literal (%.loc7_35, %.loc7_43)
+// CHECK:STDOUT:   %struct: {.a: i32, .b: i32} = struct_value (%.loc7_35, %.loc7_43) [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_45: {.a: i32, .b: i32} = converted %.loc7_44, %struct [template = constants.%struct]
 // CHECK:STDOUT:   %v: {.a: i32, .b: i32} = bind_name v, %.loc7_45
 // CHECK:STDOUT:   %.loc8: type = struct_type {.a: i32, .b: i32} [template = constants.%.1]
 // CHECK:STDOUT:   %v.ref: {.a: i32, .b: i32} = name_ref v, %v
@@ -54,8 +54,8 @@ var y: {.a: i32, .b: i32} = x;
 // CHECK:STDOUT:   %.loc10_44.3: init i32 = initialize_from %.loc10_35 to %.loc10_44.2 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc10_44.4: ref i32 = struct_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc10_44.5: init i32 = initialize_from %.loc10_43 to %.loc10_44.4 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_44.6: init {.a: i32, .b: i32} = struct_init (%.loc10_44.3, %.loc10_44.5) to file.%x.var [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_45: init {.a: i32, .b: i32} = converted %.loc10_44.1, %.loc10_44.6 [template = constants.%.5]
+// CHECK:STDOUT:   %.loc10_44.6: init {.a: i32, .b: i32} = struct_init (%.loc10_44.3, %.loc10_44.5) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_45: init {.a: i32, .b: i32} = converted %.loc10_44.1, %.loc10_44.6 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc10_45
 // CHECK:STDOUT:   %x.ref: ref {.a: i32, .b: i32} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc11_29.1: ref i32 = struct_access %x.ref, element0

--- a/toolchain/check/testdata/tuples/import.carbon
+++ b/toolchain/check/testdata/tuples/import.carbon
@@ -24,23 +24,23 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 0 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
-// CHECK:STDOUT:   %.5: type = tuple_type ((type,), type) [template]
-// CHECK:STDOUT:   %.6: type = tuple_type (type, type) [template]
-// CHECK:STDOUT:   %.7: type = tuple_type (((type,), type), (type, type)) [template]
-// CHECK:STDOUT:   %.8: type = tuple_type ((i32,), i32) [template]
-// CHECK:STDOUT:   %.9: type = tuple_type (i32, i32) [template]
-// CHECK:STDOUT:   %.10: type = tuple_type (((i32,), i32), (i32, i32)) [template]
-// CHECK:STDOUT:   %.11: type = ptr_type (i32, i32) [template]
-// CHECK:STDOUT:   %.12: type = ptr_type ((i32,), i32) [template]
-// CHECK:STDOUT:   %.13: type = tuple_type (((i32,), i32)*, (i32, i32)*) [template]
-// CHECK:STDOUT:   %.14: type = ptr_type (((i32,), i32)*, (i32, i32)*) [template]
-// CHECK:STDOUT:   %.15: i32 = int_literal 1 [template]
-// CHECK:STDOUT:   %.16: i32 = int_literal 2 [template]
-// CHECK:STDOUT:   %.17: i32 = int_literal 3 [template]
-// CHECK:STDOUT:   %.18: ((i32,), i32) = tuple_value (%.4, %.15) [template]
-// CHECK:STDOUT:   %.19: (i32, i32) = tuple_value (%.16, %.17) [template]
-// CHECK:STDOUT:   %.20: (((i32,), i32), (i32, i32)) = tuple_value (%.18, %.19) [template]
+// CHECK:STDOUT:   %tuple.1: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %.4: type = tuple_type ((type,), type) [template]
+// CHECK:STDOUT:   %.5: type = tuple_type (type, type) [template]
+// CHECK:STDOUT:   %.6: type = tuple_type (((type,), type), (type, type)) [template]
+// CHECK:STDOUT:   %.7: type = tuple_type ((i32,), i32) [template]
+// CHECK:STDOUT:   %.8: type = tuple_type (i32, i32) [template]
+// CHECK:STDOUT:   %.9: type = tuple_type (((i32,), i32), (i32, i32)) [template]
+// CHECK:STDOUT:   %.10: type = ptr_type (i32, i32) [template]
+// CHECK:STDOUT:   %.11: type = ptr_type ((i32,), i32) [template]
+// CHECK:STDOUT:   %.12: type = tuple_type (((i32,), i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.13: type = ptr_type (((i32,), i32)*, (i32, i32)*) [template]
+// CHECK:STDOUT:   %.14: i32 = int_literal 1 [template]
+// CHECK:STDOUT:   %.15: i32 = int_literal 2 [template]
+// CHECK:STDOUT:   %.16: i32 = int_literal 3 [template]
+// CHECK:STDOUT:   %tuple.2: ((i32,), i32) = tuple_value (%tuple.1, %.14) [template]
+// CHECK:STDOUT:   %tuple.3: (i32, i32) = tuple_value (%.15, %.16) [template]
+// CHECK:STDOUT:   %tuple.4: (((i32,), i32), (i32, i32)) = tuple_value (%tuple.2, %tuple.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -59,9 +59,9 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT:   %.loc5_37: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc5_38.1: (((type,), type), (type, type)) = tuple_literal (%.loc5_25, %.loc5_37)
 // CHECK:STDOUT:   %.loc5_38.2: type = converted %.loc5_19, constants.%.2 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc5_38.3: type = converted %.loc5_25, constants.%.8 [template = constants.%.8]
-// CHECK:STDOUT:   %.loc5_38.4: type = converted %.loc5_37, constants.%.9 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc5_38.5: type = converted %.loc5_38.1, constants.%.10 [template = constants.%.10]
+// CHECK:STDOUT:   %.loc5_38.3: type = converted %.loc5_25, constants.%.7 [template = constants.%.7]
+// CHECK:STDOUT:   %.loc5_38.4: type = converted %.loc5_37, constants.%.8 [template = constants.%.8]
+// CHECK:STDOUT:   %.loc5_38.5: type = converted %.loc5_38.1, constants.%.9 [template = constants.%.9]
 // CHECK:STDOUT:   %b_ref.var: ref (((i32,), i32), (i32, i32)) = var b_ref
 // CHECK:STDOUT:   %b_ref: ref (((i32,), i32), (i32, i32)) = bind_name b_ref, %b_ref.var
 // CHECK:STDOUT: }
@@ -70,35 +70,35 @@ var b: (((i32,), i32), (i32, i32)) = b_ref;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc4_22: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc4_24.1: (i32,) = tuple_literal (%.loc4_22)
-// CHECK:STDOUT:   %.loc4_24.2: init (i32,) = tuple_init (%.loc4_22) to file.%a_ref.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc4_25: init (i32,) = converted %.loc4_24.1, %.loc4_24.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc4_24.2: init (i32,) = tuple_init (%.loc4_22) to file.%a_ref.var [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc4_25: init (i32,) = converted %.loc4_24.1, %.loc4_24.2 [template = constants.%tuple.1]
 // CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_25
 // CHECK:STDOUT:   %.loc5_45: i32 = int_literal 0 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc5_47.1: (i32,) = tuple_literal (%.loc5_45)
-// CHECK:STDOUT:   %.loc5_50: i32 = int_literal 1 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc5_50: i32 = int_literal 1 [template = constants.%.14]
 // CHECK:STDOUT:   %.loc5_51.1: ((i32,), i32) = tuple_literal (%.loc5_47.1, %.loc5_50)
-// CHECK:STDOUT:   %.loc5_55: i32 = int_literal 2 [template = constants.%.16]
-// CHECK:STDOUT:   %.loc5_58: i32 = int_literal 3 [template = constants.%.17]
+// CHECK:STDOUT:   %.loc5_55: i32 = int_literal 2 [template = constants.%.15]
+// CHECK:STDOUT:   %.loc5_58: i32 = int_literal 3 [template = constants.%.16]
 // CHECK:STDOUT:   %.loc5_59.1: (i32, i32) = tuple_literal (%.loc5_55, %.loc5_58)
 // CHECK:STDOUT:   %.loc5_60.1: (((i32,), i32), (i32, i32)) = tuple_literal (%.loc5_51.1, %.loc5_59.1)
 // CHECK:STDOUT:   %.loc5_60.2: ref ((i32,), i32) = tuple_access file.%b_ref.var, element0
 // CHECK:STDOUT:   %.loc5_51.2: ref (i32,) = tuple_access %.loc5_60.2, element0
-// CHECK:STDOUT:   %.loc5_47.2: init (i32,) = tuple_init (%.loc5_45) to %.loc5_51.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_51.3: init (i32,) = converted %.loc5_47.1, %.loc5_47.2 [template = constants.%.4]
-// CHECK:STDOUT:   %.loc5_51.4: init (i32,) = initialize_from %.loc5_51.3 to %.loc5_51.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc5_47.2: init (i32,) = tuple_init (%.loc5_45) to %.loc5_51.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc5_51.3: init (i32,) = converted %.loc5_47.1, %.loc5_47.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc5_51.4: init (i32,) = initialize_from %.loc5_51.3 to %.loc5_51.2 [template = constants.%tuple.1]
 // CHECK:STDOUT:   %.loc5_51.5: ref i32 = tuple_access %.loc5_60.2, element1
-// CHECK:STDOUT:   %.loc5_51.6: init i32 = initialize_from %.loc5_50 to %.loc5_51.5 [template = constants.%.15]
-// CHECK:STDOUT:   %.loc5_51.7: init ((i32,), i32) = tuple_init (%.loc5_51.4, %.loc5_51.6) to %.loc5_60.2 [template = constants.%.18]
-// CHECK:STDOUT:   %.loc5_60.3: init ((i32,), i32) = converted %.loc5_51.1, %.loc5_51.7 [template = constants.%.18]
+// CHECK:STDOUT:   %.loc5_51.6: init i32 = initialize_from %.loc5_50 to %.loc5_51.5 [template = constants.%.14]
+// CHECK:STDOUT:   %.loc5_51.7: init ((i32,), i32) = tuple_init (%.loc5_51.4, %.loc5_51.6) to %.loc5_60.2 [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc5_60.3: init ((i32,), i32) = converted %.loc5_51.1, %.loc5_51.7 [template = constants.%tuple.2]
 // CHECK:STDOUT:   %.loc5_60.4: ref (i32, i32) = tuple_access file.%b_ref.var, element1
 // CHECK:STDOUT:   %.loc5_59.2: ref i32 = tuple_access %.loc5_60.4, element0
-// CHECK:STDOUT:   %.loc5_59.3: init i32 = initialize_from %.loc5_55 to %.loc5_59.2 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc5_59.3: init i32 = initialize_from %.loc5_55 to %.loc5_59.2 [template = constants.%.15]
 // CHECK:STDOUT:   %.loc5_59.4: ref i32 = tuple_access %.loc5_60.4, element1
-// CHECK:STDOUT:   %.loc5_59.5: init i32 = initialize_from %.loc5_58 to %.loc5_59.4 [template = constants.%.17]
-// CHECK:STDOUT:   %.loc5_59.6: init (i32, i32) = tuple_init (%.loc5_59.3, %.loc5_59.5) to %.loc5_60.4 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc5_60.5: init (i32, i32) = converted %.loc5_59.1, %.loc5_59.6 [template = constants.%.19]
-// CHECK:STDOUT:   %.loc5_60.6: init (((i32,), i32), (i32, i32)) = tuple_init (%.loc5_60.3, %.loc5_60.5) to file.%b_ref.var [template = constants.%.20]
-// CHECK:STDOUT:   %.loc5_61: init (((i32,), i32), (i32, i32)) = converted %.loc5_60.1, %.loc5_60.6 [template = constants.%.20]
+// CHECK:STDOUT:   %.loc5_59.5: init i32 = initialize_from %.loc5_58 to %.loc5_59.4 [template = constants.%.16]
+// CHECK:STDOUT:   %.loc5_59.6: init (i32, i32) = tuple_init (%.loc5_59.3, %.loc5_59.5) to %.loc5_60.4 [template = constants.%tuple.3]
+// CHECK:STDOUT:   %.loc5_60.5: init (i32, i32) = converted %.loc5_59.1, %.loc5_59.6 [template = constants.%tuple.3]
+// CHECK:STDOUT:   %.loc5_60.6: init (((i32,), i32), (i32, i32)) = tuple_init (%.loc5_60.3, %.loc5_60.5) to file.%b_ref.var [template = constants.%tuple.4]
+// CHECK:STDOUT:   %.loc5_61: init (((i32,), i32), (i32, i32)) = converted %.loc5_60.1, %.loc5_60.6 [template = constants.%tuple.4]
 // CHECK:STDOUT:   assign file.%b_ref.var, %.loc5_61
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/nested_tuple.carbon
+++ b/toolchain/check/testdata/tuples/nested_tuple.carbon
@@ -19,8 +19,8 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:   %.8: i32 = int_literal 12 [template]
 // CHECK:STDOUT:   %.9: i32 = int_literal 76 [template]
 // CHECK:STDOUT:   %.10: i32 = int_literal 6 [template]
-// CHECK:STDOUT:   %.11: (i32, i32) = tuple_value (%.8, %.9) [template]
-// CHECK:STDOUT:   %.12: ((i32, i32), i32) = tuple_value (%.11, %.10) [template]
+// CHECK:STDOUT:   %tuple.1: (i32, i32) = tuple_value (%.8, %.9) [template]
+// CHECK:STDOUT:   %tuple.2: ((i32, i32), i32) = tuple_value (%tuple.1, %.10) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -49,12 +49,12 @@ var x: ((i32, i32), i32) = ((12, 76), 6);
 // CHECK:STDOUT:   %.loc7_36.3: init i32 = initialize_from %.loc7_30 to %.loc7_36.2 [template = constants.%.8]
 // CHECK:STDOUT:   %.loc7_36.4: ref i32 = tuple_access %.loc7_40.2, element1
 // CHECK:STDOUT:   %.loc7_36.5: init i32 = initialize_from %.loc7_34 to %.loc7_36.4 [template = constants.%.9]
-// CHECK:STDOUT:   %.loc7_36.6: init (i32, i32) = tuple_init (%.loc7_36.3, %.loc7_36.5) to %.loc7_40.2 [template = constants.%.11]
-// CHECK:STDOUT:   %.loc7_40.3: init (i32, i32) = converted %.loc7_36.1, %.loc7_36.6 [template = constants.%.11]
+// CHECK:STDOUT:   %.loc7_36.6: init (i32, i32) = tuple_init (%.loc7_36.3, %.loc7_36.5) to %.loc7_40.2 [template = constants.%tuple.1]
+// CHECK:STDOUT:   %.loc7_40.3: init (i32, i32) = converted %.loc7_36.1, %.loc7_36.6 [template = constants.%tuple.1]
 // CHECK:STDOUT:   %.loc7_40.4: ref i32 = tuple_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc7_40.5: init i32 = initialize_from %.loc7_39 to %.loc7_40.4 [template = constants.%.10]
-// CHECK:STDOUT:   %.loc7_40.6: init ((i32, i32), i32) = tuple_init (%.loc7_40.3, %.loc7_40.5) to file.%x.var [template = constants.%.12]
-// CHECK:STDOUT:   %.loc7_41: init ((i32, i32), i32) = converted %.loc7_40.1, %.loc7_40.6 [template = constants.%.12]
+// CHECK:STDOUT:   %.loc7_40.6: init ((i32, i32), i32) = tuple_init (%.loc7_40.3, %.loc7_40.5) to file.%x.var [template = constants.%tuple.2]
+// CHECK:STDOUT:   %.loc7_41: init ((i32, i32), i32) = converted %.loc7_40.1, %.loc7_40.6 [template = constants.%tuple.2]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_41
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/no_prelude/empty.carbon
+++ b/toolchain/check/testdata/tuples/no_prelude/empty.carbon
@@ -11,7 +11,7 @@ var y: () = x;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,12 +32,12 @@ var y: () = x;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_14.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc7_14.2: init () = tuple_init () to file.%x.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc7_15: init () = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc7_14.2: init () = tuple_init () to file.%x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_15: init () = converted %.loc7_14.1, %.loc7_14.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_15
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, file.%x
-// CHECK:STDOUT:   %.loc8_13: init () = tuple_init () to file.%y.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_14: init () = converted %x.ref, %.loc8_13 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_13: init () = tuple_init () to file.%y.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_14: init () = converted %x.ref, %.loc8_13 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%y.var, %.loc8_14
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/tuples/one_element.carbon
+++ b/toolchain/check/testdata/tuples/one_element.carbon
@@ -13,7 +13,7 @@ var y: (i32,) = x;
 // CHECK:STDOUT:   %.1: type = tuple_type (type) [template]
 // CHECK:STDOUT:   %.2: type = tuple_type (i32) [template]
 // CHECK:STDOUT:   %.3: i32 = int_literal 4 [template]
-// CHECK:STDOUT:   %.4: (i32,) = tuple_value (%.3) [template]
+// CHECK:STDOUT:   %tuple: (i32,) = tuple_value (%.3) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,8 +37,8 @@ var y: (i32,) = x;
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc7_18: i32 = int_literal 4 [template = constants.%.3]
 // CHECK:STDOUT:   %.loc7_20.1: (i32,) = tuple_literal (%.loc7_18)
-// CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to file.%x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_21: init (i32,) = converted %.loc7_20.1, %.loc7_20.2 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_20.2: init (i32,) = tuple_init (%.loc7_18) to file.%x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_21: init (i32,) = converted %.loc7_20.1, %.loc7_20.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_21
 // CHECK:STDOUT:   %x.ref: ref (i32,) = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_17.1: ref i32 = tuple_access %x.ref, element0

--- a/toolchain/check/testdata/tuples/two_elements.carbon
+++ b/toolchain/check/testdata/tuples/two_elements.carbon
@@ -18,7 +18,7 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.3: type = ptr_type (i32, i32) [template]
 // CHECK:STDOUT:   %.4: i32 = int_literal 4 [template]
 // CHECK:STDOUT:   %.5: i32 = int_literal 102 [template]
-// CHECK:STDOUT:   %.6: (i32, i32) = tuple_value (%.4, %.5) [template]
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.4, %.5) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -32,9 +32,9 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc7_17.2: type = converted %.loc7_17.1, constants.%.2 [template = constants.%.2]
 // CHECK:STDOUT:   %.loc7_22: i32 = int_literal 4 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc7_25: i32 = int_literal 102 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc7_28.1: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
-// CHECK:STDOUT:   %.loc7_28.2: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%.6]
-// CHECK:STDOUT:   %.loc7_29: (i32, i32) = converted %.loc7_28.1, %.loc7_28.2 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc7_28: (i32, i32) = tuple_literal (%.loc7_22, %.loc7_25)
+// CHECK:STDOUT:   %tuple: (i32, i32) = tuple_value (%.loc7_22, %.loc7_25) [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_29: (i32, i32) = converted %.loc7_28, %tuple [template = constants.%tuple]
 // CHECK:STDOUT:   %v: (i32, i32) = bind_name v, %.loc7_29
 // CHECK:STDOUT:   %.loc8_17.1: (type, type) = tuple_literal (i32, i32)
 // CHECK:STDOUT:   %.loc8_17.2: type = converted %.loc8_17.1, constants.%.2 [template = constants.%.2]
@@ -59,8 +59,8 @@ var y: (i32, i32) = x;
 // CHECK:STDOUT:   %.loc10_28.3: init i32 = initialize_from %.loc10_22 to %.loc10_28.2 [template = constants.%.4]
 // CHECK:STDOUT:   %.loc10_28.4: ref i32 = tuple_access file.%x.var, element1
 // CHECK:STDOUT:   %.loc10_28.5: init i32 = initialize_from %.loc10_25 to %.loc10_28.4 [template = constants.%.5]
-// CHECK:STDOUT:   %.loc10_28.6: init (i32, i32) = tuple_init (%.loc10_28.3, %.loc10_28.5) to file.%x.var [template = constants.%.6]
-// CHECK:STDOUT:   %.loc10_29: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6 [template = constants.%.6]
+// CHECK:STDOUT:   %.loc10_28.6: init (i32, i32) = tuple_init (%.loc10_28.3, %.loc10_28.5) to file.%x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_29: init (i32, i32) = converted %.loc10_28.1, %.loc10_28.6 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%x.var, %.loc10_29
 // CHECK:STDOUT:   %x.ref: ref (i32, i32) = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc11_21.1: ref i32 = tuple_access %x.ref, element0

--- a/toolchain/check/testdata/var/no_prelude/decl_with_init.carbon
+++ b/toolchain/check/testdata/var/no_prelude/decl_with_init.carbon
@@ -12,7 +12,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -29,8 +29,8 @@ fn Main() {
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc8_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %x.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var, %.loc8_17
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/fail_duplicate_decl.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_duplicate_decl.carbon
@@ -20,7 +20,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -37,16 +37,16 @@ fn Main() {
 // CHECK:STDOUT:   %x.var.loc9: ref () = var x
 // CHECK:STDOUT:   %x.loc9: ref () = bind_name x, %x.var.loc9
 // CHECK:STDOUT:   %.loc9_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc9_16.2: init () = tuple_init () to %x.var.loc9 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc9_17: init () = converted %.loc9_16.1, %.loc9_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc9_16.2: init () = tuple_init () to %x.var.loc9 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc9_17: init () = converted %.loc9_16.1, %.loc9_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var.loc9, %.loc9_17
 // CHECK:STDOUT:   %.loc16_11.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc16_11.2: type = converted %.loc16_11.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var.loc16: ref () = var x
 // CHECK:STDOUT:   %x.loc16: ref () = bind_name x, %x.var.loc16
 // CHECK:STDOUT:   %.loc16_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc16_16.2: init () = tuple_init () to %x.var.loc16 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc16_17: init () = converted %.loc16_16.1, %.loc16_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc16_16.2: init () = tuple_init () to %x.var.loc16 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc16_17: init () = converted %.loc16_16.1, %.loc16_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var.loc16, %.loc16_17
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/fail_generic.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_generic.carbon
@@ -16,7 +16,7 @@ fn Main() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %x: () = bind_symbolic_name x 0 [symbolic]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -33,8 +33,8 @@ fn Main() {
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: () = bind_symbolic_name x 0, %x.var [symbolic = constants.%x]
 // CHECK:STDOUT:   %.loc11_17.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc11_17.2: init () = tuple_init () to %x.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc11_18: init () = converted %.loc11_17.1, %.loc11_17.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_17.2: init () = tuple_init () to %x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc11_18: init () = converted %.loc11_17.1, %.loc11_17.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var, %.loc11_18
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/fail_namespace_conflict.carbon
+++ b/toolchain/check/testdata/var/no_prelude/fail_namespace_conflict.carbon
@@ -27,7 +27,7 @@ var A: () = ();
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -48,8 +48,8 @@ var A: () = ();
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc24_14.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc24_14.2: init () = tuple_init () to file.%A.var.loc24 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc24_15: init () = converted %.loc24_14.1, %.loc24_14.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc24_14.2: init () = tuple_init () to file.%A.var.loc24 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc24_15: init () = converted %.loc24_14.1, %.loc24_14.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%A.var.loc24, %.loc24_15
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/global_decl_with_init.carbon
+++ b/toolchain/check/testdata/var/no_prelude/global_decl_with_init.carbon
@@ -11,8 +11,8 @@ var x: {.v: ()} = {.v = ()};
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.v: ()} [template]
-// CHECK:STDOUT:   %.3: () = tuple_value () [template]
-// CHECK:STDOUT:   %.4: {.v: ()} = struct_value (%.3) [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %struct: {.v: ()} = struct_value (%tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -31,10 +31,10 @@ var x: {.v: ()} = {.v = ()};
 // CHECK:STDOUT:   %.loc7_26.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_27.1: {.v: ()} = struct_literal (%.loc7_26.1)
 // CHECK:STDOUT:   %.loc7_27.2: ref () = struct_access file.%x.var, element0
-// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/global_lookup.carbon
+++ b/toolchain/check/testdata/var/no_prelude/global_lookup.carbon
@@ -12,8 +12,8 @@ var y: {.v: ()} = x;
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.v: ()} [template]
-// CHECK:STDOUT:   %.3: () = tuple_value () [template]
-// CHECK:STDOUT:   %.4: {.v: ()} = struct_value (%.3) [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %struct: {.v: ()} = struct_value (%tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -38,18 +38,18 @@ var y: {.v: ()} = x;
 // CHECK:STDOUT:   %.loc7_26.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_27.1: {.v: ()} = struct_literal (%.loc7_26.1)
 // CHECK:STDOUT:   %.loc7_27.2: ref () = struct_access file.%x.var, element0
-// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   %x.ref: ref {.v: ()} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc8_19.1: ref () = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc8_19.2: ref () = struct_access file.%y.var, element0
-// CHECK:STDOUT:   %.loc8_19.3: init () = tuple_init () to %.loc8_19.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_19.4: init () = converted %.loc8_19.1, %.loc8_19.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc8_19.5: init {.v: ()} = struct_init (%.loc8_19.4) to file.%y.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc8_20: init {.v: ()} = converted %x.ref, %.loc8_19.5 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc8_19.3: init () = tuple_init () to %.loc8_19.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_19.4: init () = converted %.loc8_19.1, %.loc8_19.3 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_19.5: init {.v: ()} = struct_init (%.loc8_19.4) to file.%y.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc8_20: init {.v: ()} = converted %x.ref, %.loc8_19.5 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%y.var, %.loc8_20
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/global_lookup_in_scope.carbon
+++ b/toolchain/check/testdata/var/no_prelude/global_lookup_in_scope.carbon
@@ -15,8 +15,8 @@ fn Main() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
 // CHECK:STDOUT:   %.2: type = struct_type {.v: ()} [template]
-// CHECK:STDOUT:   %.3: () = tuple_value () [template]
-// CHECK:STDOUT:   %.4: {.v: ()} = struct_value (%.3) [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %struct: {.v: ()} = struct_value (%tuple) [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -42,10 +42,10 @@ fn Main() {
 // CHECK:STDOUT:   %x.ref: ref {.v: ()} = name_ref x, file.%x
 // CHECK:STDOUT:   %.loc10_21.1: ref () = struct_access %x.ref, element0
 // CHECK:STDOUT:   %.loc10_21.2: ref () = struct_access %y.var, element0
-// CHECK:STDOUT:   %.loc10_21.3: init () = tuple_init () to %.loc10_21.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc10_21.4: init () = converted %.loc10_21.1, %.loc10_21.3 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc10_21.5: init {.v: ()} = struct_init (%.loc10_21.4) to %y.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc10_22: init {.v: ()} = converted %x.ref, %.loc10_21.5 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc10_21.3: init () = tuple_init () to %.loc10_21.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_21.4: init () = converted %.loc10_21.1, %.loc10_21.3 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_21.5: init {.v: ()} = struct_init (%.loc10_21.4) to %y.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc10_22: init {.v: ()} = converted %x.ref, %.loc10_21.5 [template = constants.%struct]
 // CHECK:STDOUT:   assign %y.var, %.loc10_22
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -55,10 +55,10 @@ fn Main() {
 // CHECK:STDOUT:   %.loc7_26.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc7_27.1: {.v: ()} = struct_literal (%.loc7_26.1)
 // CHECK:STDOUT:   %.loc7_27.2: ref () = struct_access file.%x.var, element0
-// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%.3]
-// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%.4]
-// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%.4]
+// CHECK:STDOUT:   %.loc7_26.2: init () = tuple_init () to %.loc7_27.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.3: init () = converted %.loc7_26.1, %.loc7_26.2 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc7_27.4: init {.v: ()} = struct_init (%.loc7_27.3) to file.%x.var [template = constants.%struct]
+// CHECK:STDOUT:   %.loc7_28: init {.v: ()} = converted %.loc7_27.1, %.loc7_27.4 [template = constants.%struct]
 // CHECK:STDOUT:   assign file.%x.var, %.loc7_28
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/import.carbon
+++ b/toolchain/check/testdata/var/no_prelude/import.carbon
@@ -20,7 +20,7 @@ var a: () = a_ref;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -36,8 +36,8 @@ var a: () = a_ref;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc4_18.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc4_18.2: init () = tuple_init () to file.%a_ref.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_19: init () = converted %.loc4_18.1, %.loc4_18.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_18.2: init () = tuple_init () to file.%a_ref.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc4_19: init () = converted %.loc4_18.1, %.loc4_18.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a_ref.var, %.loc4_19
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -46,7 +46,7 @@ var a: () = a_ref;
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -64,8 +64,8 @@ var a: () = a_ref;
 // CHECK:STDOUT: fn @__global_init() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %a_ref.ref: ref () = name_ref a_ref, file.%import_ref
-// CHECK:STDOUT:   %.loc4_13: init () = tuple_init () to file.%a.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc4_18: init () = converted %a_ref.ref, %.loc4_13 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc4_13: init () = tuple_init () to file.%a.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc4_18: init () = converted %a_ref.ref, %.loc4_13 [template = constants.%tuple]
 // CHECK:STDOUT:   assign file.%a.var, %.loc4_18
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/var/no_prelude/lookup.carbon
+++ b/toolchain/check/testdata/var/no_prelude/lookup.carbon
@@ -13,7 +13,7 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -30,8 +30,8 @@ fn Main() {
 // CHECK:STDOUT:   %x.var: ref () = var x
 // CHECK:STDOUT:   %x: ref () = bind_name x, %x.var
 // CHECK:STDOUT:   %.loc8_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %x.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc8_16.2: init () = tuple_init () to %x.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc8_17: init () = converted %.loc8_16.1, %.loc8_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var, %.loc8_17
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, %x
 // CHECK:STDOUT:   return

--- a/toolchain/check/testdata/var/no_prelude/shadowing.carbon
+++ b/toolchain/check/testdata/var/no_prelude/shadowing.carbon
@@ -23,8 +23,8 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %.1: type = tuple_type () [template]
-// CHECK:STDOUT:   %.2: () = tuple_value () [template]
-// CHECK:STDOUT:   %.3: bool = bool_literal true [template]
+// CHECK:STDOUT:   %tuple: () = tuple_value () [template]
+// CHECK:STDOUT:   %.2: bool = bool_literal true [template]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -43,23 +43,23 @@ fn Main() {
 // CHECK:STDOUT:   %NS.var: ref () = var NS
 // CHECK:STDOUT:   %NS: ref () = bind_name NS, %NS.var
 // CHECK:STDOUT:   %.loc10_17.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc10_17.2: init () = tuple_init () to %NS.var [template = constants.%.2]
-// CHECK:STDOUT:   %.loc10_18: init () = converted %.loc10_17.1, %.loc10_17.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc10_17.2: init () = tuple_init () to %NS.var [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc10_18: init () = converted %.loc10_17.1, %.loc10_17.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %NS.var, %.loc10_18
 // CHECK:STDOUT:   %NS.ref: ref () = name_ref NS, %NS
 // CHECK:STDOUT:   %.loc11_9.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc11_9.2: init () = tuple_init () to %NS.ref [template = constants.%.2]
-// CHECK:STDOUT:   %.loc11_6: init () = converted %.loc11_9.1, %.loc11_9.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc11_9.2: init () = tuple_init () to %NS.ref [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc11_6: init () = converted %.loc11_9.1, %.loc11_9.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %NS.ref, %.loc11_6
 // CHECK:STDOUT:   %.loc13_11.1: () = tuple_literal ()
 // CHECK:STDOUT:   %.loc13_11.2: type = converted %.loc13_11.1, constants.%.1 [template = constants.%.1]
 // CHECK:STDOUT:   %x.var.loc13: ref () = var x
 // CHECK:STDOUT:   %x.loc13: ref () = bind_name x, %x.var.loc13
 // CHECK:STDOUT:   %.loc13_16.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc13_16.2: init () = tuple_init () to %x.var.loc13 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc13_17: init () = converted %.loc13_16.1, %.loc13_16.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc13_16.2: init () = tuple_init () to %x.var.loc13 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc13_17: init () = converted %.loc13_16.1, %.loc13_16.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var.loc13, %.loc13_17
-// CHECK:STDOUT:   %.loc14: bool = bool_literal true [template = constants.%.3]
+// CHECK:STDOUT:   %.loc14: bool = bool_literal true [template = constants.%.2]
 // CHECK:STDOUT:   if %.loc14 br !if.then else br !if.else
 // CHECK:STDOUT:
 // CHECK:STDOUT: !if.then:
@@ -68,13 +68,13 @@ fn Main() {
 // CHECK:STDOUT:   %x.var.loc15: ref () = var x
 // CHECK:STDOUT:   %x.loc15: ref () = bind_name x, %x.var.loc15
 // CHECK:STDOUT:   %.loc15_18.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc15_18.2: init () = tuple_init () to %x.var.loc15 [template = constants.%.2]
-// CHECK:STDOUT:   %.loc15_19: init () = converted %.loc15_18.1, %.loc15_18.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc15_18.2: init () = tuple_init () to %x.var.loc15 [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc15_19: init () = converted %.loc15_18.1, %.loc15_18.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.var.loc15, %.loc15_19
 // CHECK:STDOUT:   %x.ref: ref () = name_ref x, %x.loc15
 // CHECK:STDOUT:   %.loc18_10.1: () = tuple_literal ()
-// CHECK:STDOUT:   %.loc18_10.2: init () = tuple_init () to %x.ref [template = constants.%.2]
-// CHECK:STDOUT:   %.loc18_7: init () = converted %.loc18_10.1, %.loc18_10.2 [template = constants.%.2]
+// CHECK:STDOUT:   %.loc18_10.2: init () = tuple_init () to %x.ref [template = constants.%tuple]
+// CHECK:STDOUT:   %.loc18_7: init () = converted %.loc18_10.1, %.loc18_10.2 [template = constants.%tuple]
 // CHECK:STDOUT:   assign %x.ref, %.loc18_7
 // CHECK:STDOUT:   br !if.else
 // CHECK:STDOUT:

--- a/toolchain/lower/handle_aggregates.cpp
+++ b/toolchain/lower/handle_aggregates.cpp
@@ -167,8 +167,7 @@ auto HandleStructLiteral(FunctionContext& /*context*/,
 // Emits the value representation for a struct or tuple whose elements are the
 // contents of `refs_id`.
 auto EmitAggregateValueRepr(FunctionContext& context, SemIR::TypeId type_id,
-                            SemIR::InstBlockId refs_id, llvm::Twine name)
-    -> llvm::Value* {
+                            SemIR::InstBlockId refs_id) -> llvm::Value* {
   auto value_rep = SemIR::GetValueRepr(context.sem_ir(), type_id);
   switch (value_rep.kind) {
     case SemIR::ValueRepr::Unknown:
@@ -195,9 +194,7 @@ auto EmitAggregateValueRepr(FunctionContext& context, SemIR::TypeId type_id,
 
       // Write the value representation to a local alloca so we can produce a
       // pointer to it as the value representation of the struct or tuple.
-      auto* alloca =
-          context.builder().CreateAlloca(llvm_value_rep_type,
-                                         /*ArraySize=*/nullptr, name);
+      auto* alloca = context.builder().CreateAlloca(llvm_value_rep_type);
       for (auto [i, ref] :
            llvm::enumerate(context.sem_ir().inst_blocks().Get(refs_id))) {
         context.builder().CreateStore(
@@ -222,8 +219,8 @@ auto HandleStructInit(FunctionContext& context, SemIR::InstId inst_id,
 
 auto HandleStructValue(FunctionContext& context, SemIR::InstId inst_id,
                        SemIR::StructValue inst) -> void {
-  context.SetLocal(inst_id, EmitAggregateValueRepr(context, inst.type_id,
-                                                   inst.elements_id, "struct"));
+  context.SetLocal(
+      inst_id, EmitAggregateValueRepr(context, inst.type_id, inst.elements_id));
 }
 
 auto HandleStructTypeField(FunctionContext& /*context*/,
@@ -264,8 +261,8 @@ auto HandleTupleInit(FunctionContext& context, SemIR::InstId inst_id,
 
 auto HandleTupleValue(FunctionContext& context, SemIR::InstId inst_id,
                       SemIR::TupleValue inst) -> void {
-  context.SetLocal(inst_id, EmitAggregateValueRepr(context, inst.type_id,
-                                                   inst.elements_id, "tuple"));
+  context.SetLocal(
+      inst_id, EmitAggregateValueRepr(context, inst.type_id, inst.elements_id));
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -13,13 +13,13 @@ fn Run() {
 // CHECK:STDOUT: ; ModuleID = 'assign_return_value.carbon'
 // CHECK:STDOUT: source_filename = "assign_return_value.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc7_39 = internal constant { i32, i32 } { i32 12, i32 24 }
+// CHECK:STDOUT: @tuple.loc7_39 = internal constant { i32, i32 } { i32 12, i32 24 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc7_38.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc7_38.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc7_39, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @tuple.loc7_39, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -15,32 +15,32 @@ fn Run() {
 // CHECK:STDOUT: ; ModuleID = 'base.carbon'
 // CHECK:STDOUT: source_filename = "base.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_25 = internal constant [1 x i32] [i32 1]
-// CHECK:STDOUT: @const.loc9_33 = internal constant [2 x double] [double 0x4026333333333334, double 2.200000e+00]
-// CHECK:STDOUT: @const.loc10_41 = internal constant [5 x {}] zeroinitializer
-// CHECK:STDOUT: @const.loc11_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
+// CHECK:STDOUT: @array.1.loc8_25 = internal constant [1 x i32] [i32 1]
+// CHECK:STDOUT: @array.2.loc9_33 = internal constant [2 x double] [double 0x4026333333333334, double 2.200000e+00]
+// CHECK:STDOUT: @array.3.loc10_41 = internal constant [5 x {}] zeroinitializer
+// CHECK:STDOUT: @tuple.2.loc11_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @main() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [1 x i32], align 4
 // CHECK:STDOUT:   %.loc8_24.3.array.index = getelementptr inbounds [1 x i32], ptr %a.var, i32 0, i32 0
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @const.loc8_25, i64 4, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @array.1.loc8_25, i64 4, i1 false)
 // CHECK:STDOUT:   %b.var = alloca [2 x double], align 8
 // CHECK:STDOUT:   %.loc9_32.3.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_32.6.array.index = getelementptr inbounds [2 x double], ptr %b.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @const.loc9_33, i64 16, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %b.var, ptr align 8 @array.2.loc9_33, i64 16, i1 false)
 // CHECK:STDOUT:   %c.var = alloca [5 x {}], align 8
 // CHECK:STDOUT:   %.loc10_40.3.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc10_40.6.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc10_40.9.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i32 2
 // CHECK:STDOUT:   %.loc10_40.12.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i32 3
 // CHECK:STDOUT:   %.loc10_40.15.array.index = getelementptr inbounds [5 x {}], ptr %c.var, i32 0, i32 4
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @const.loc10_41, i64 0, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @array.3.loc10_41, i64 0, i1 false)
 // CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc11_36.2.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %d.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc11_36.4.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %d.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc11_36.6.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %d.var, i32 0, i32 2
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @const.loc11_37, i64 12, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.2.loc11_37, i64 12, i1 false)
 // CHECK:STDOUT:   %e.var = alloca [3 x i32], align 4
 // CHECK:STDOUT:   %.loc12_21.1.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %d.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc12_21.2 = load i32, ptr %.loc12_21.1.tuple.elem, align 4

--- a/toolchain/lower/testdata/array/function_param.carbon
+++ b/toolchain/lower/testdata/array/function_param.carbon
@@ -15,7 +15,7 @@ fn G() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'function_param.carbon'
 // CHECK:STDOUT: source_filename = "function_param.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc12_11.1 = internal constant [3 x i32] [i32 1, i32 2, i32 3]
+// CHECK:STDOUT: @array.loc12_11.1 = internal constant [3 x i32] [i32 1, i32 2, i32 3]
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @F(ptr %arr, i32 %i) {
 // CHECK:STDOUT: entry:
@@ -30,7 +30,7 @@ fn G() -> i32 {
 // CHECK:STDOUT:   %.loc12_20.4.array.index = getelementptr inbounds [3 x i32], ptr %.loc12_20.2.temp, i32 0, i32 0
 // CHECK:STDOUT:   %.loc12_20.7.array.index = getelementptr inbounds [3 x i32], ptr %.loc12_20.2.temp, i32 0, i32 1
 // CHECK:STDOUT:   %.loc12_20.10.array.index = getelementptr inbounds [3 x i32], ptr %.loc12_20.2.temp, i32 0, i32 2
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc12_20.2.temp, ptr align 4 @const.loc12_11.1, i64 12, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc12_20.2.temp, ptr align 4 @array.loc12_11.1, i64 12, i1 false)
 // CHECK:STDOUT:   %F.call = call i32 @F(ptr %.loc12_20.2.temp, i32 1)
 // CHECK:STDOUT:   ret i32 %F.call
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/basics/numeric_literals.carbon
+++ b/toolchain/lower/testdata/basics/numeric_literals.carbon
@@ -26,8 +26,8 @@ fn F() {
 // CHECK:STDOUT: ; ModuleID = 'numeric_literals.carbon'
 // CHECK:STDOUT: source_filename = "numeric_literals.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc15_4 = internal constant [4 x i32] [i32 8, i32 9, i32 8, i32 8]
-// CHECK:STDOUT: @const.loc23_4 = internal constant [6 x double] [double 9.000000e-01, double 8.000000e+00, double 8.000000e+01, double 1.000000e+07, double 1.000000e+08, double 1.000000e-08]
+// CHECK:STDOUT: @array.1.loc15_4 = internal constant [4 x i32] [i32 8, i32 9, i32 8, i32 8]
+// CHECK:STDOUT: @array.2.loc23_4 = internal constant [6 x double] [double 9.000000e-01, double 8.000000e+00, double 8.000000e+01, double 1.000000e+07, double 1.000000e+08, double 1.000000e-08]
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F() {
 // CHECK:STDOUT: entry:
@@ -36,7 +36,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc15_3.6.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc15_3.9.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i32 2
 // CHECK:STDOUT:   %.loc15_3.12.array.index = getelementptr inbounds [4 x i32], ptr %ints.var, i32 0, i32 3
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ints.var, ptr align 4 @const.loc15_4, i64 16, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ints.var, ptr align 4 @array.1.loc15_4, i64 16, i1 false)
 // CHECK:STDOUT:   %floats.var = alloca [6 x double], align 8
 // CHECK:STDOUT:   %.loc23_3.3.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc23_3.6.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i32 1
@@ -44,7 +44,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc23_3.12.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i32 3
 // CHECK:STDOUT:   %.loc23_3.15.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i32 4
 // CHECK:STDOUT:   %.loc23_3.18.array.index = getelementptr inbounds [6 x double], ptr %floats.var, i32 0, i32 5
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @const.loc23_4, i64 48, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %floats.var, ptr align 8 @array.2.loc23_4, i64 48, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/adapt.carbon
+++ b/toolchain/lower/testdata/class/adapt.carbon
@@ -50,13 +50,13 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: ; ModuleID = 'adapt_class.carbon'
 // CHECK:STDOUT: source_filename = "adapt_class.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc9_28 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @struct.loc9_28 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @Make(ptr sret({ i32, i32 }) %return) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc9_27.2.a = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_27.4.b = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc9_28, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @struct.loc9_28, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/base.carbon
+++ b/toolchain/lower/testdata/class/base.carbon
@@ -29,14 +29,14 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT: ; ModuleID = 'base.carbon'
 // CHECK:STDOUT: source_filename = "base.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc18_36 = internal constant { { i32 }, i32 } { { i32 } { i32 4 }, i32 7 }
+// CHECK:STDOUT: @struct.2.loc18_36 = internal constant { { i32 }, i32 } { { i32 } { i32 4 }, i32 7 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @Make(ptr sret({ { i32 }, i32 }) %return) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc18_35.2.base = getelementptr inbounds { { i32 }, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc18_26.2.b = getelementptr inbounds { i32 }, ptr %.loc18_35.2.base, i32 0, i32 0
 // CHECK:STDOUT:   %.loc18_35.4.d = getelementptr inbounds { { i32 }, i32 }, ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc18_36, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @struct.2.loc18_36, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/value_access.carbon
+++ b/toolchain/lower/testdata/class/value_access.carbon
@@ -27,14 +27,14 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   %.loc15_11.5 = load i32, ptr %.loc15_11.4.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc15_11.6.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %.loc15_11.1.a, i32 0, i32 2
 // CHECK:STDOUT:   %.loc15_11.7 = load i32, ptr %.loc15_11.6.tuple.elem, align 4
-// CHECK:STDOUT:   %.loc15_11.8.tuple = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   %.loc15_11.8 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc15_11.8.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %.loc15_11.3, ptr %.loc15_11.8, align 4
-// CHECK:STDOUT:   %.loc15_11.81 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc15_11.8.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %.loc15_11.5, ptr %.loc15_11.81, align 4
-// CHECK:STDOUT:   %.loc15_11.82 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc15_11.8.tuple, i32 0, i32 2
-// CHECK:STDOUT:   store i32 %.loc15_11.7, ptr %.loc15_11.82, align 4
-// CHECK:STDOUT:   %.loc15_15.tuple.index = getelementptr inbounds { i32, i32, i32 }, ptr %.loc15_11.8.tuple, i32 0, i32 1
+// CHECK:STDOUT:   %tuple = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %tuple1 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %.loc15_11.3, ptr %tuple1, align 4
+// CHECK:STDOUT:   %tuple2 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %.loc15_11.5, ptr %tuple2, align 4
+// CHECK:STDOUT:   %tuple3 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 2
+// CHECK:STDOUT:   store i32 %.loc15_11.7, ptr %tuple3, align 4
+// CHECK:STDOUT:   %.loc15_15.tuple.index = getelementptr inbounds { i32, i32, i32 }, ptr %tuple, i32 0, i32 1
 // CHECK:STDOUT:   %.loc15_15.tuple.index.load = load i32, ptr %.loc15_15.tuple.index, align 4
 // CHECK:STDOUT:   ret i32 %.loc15_15.tuple.index.load
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/struct_param.carbon
+++ b/toolchain/lower/testdata/function/call/struct_param.carbon
@@ -13,7 +13,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'struct_param.carbon'
 // CHECK:STDOUT: source_filename = "struct_param.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc10_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
+// CHECK:STDOUT: @struct.3.loc10_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
 // CHECK:STDOUT: entry:
@@ -22,6 +22,6 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @Main() {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @const.loc10_4.3)
+// CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @struct.3.loc10_4.3)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/tuple_param.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param.carbon
@@ -13,7 +13,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'tuple_param.carbon'
 // CHECK:STDOUT: source_filename = "tuple_param.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc10_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
+// CHECK:STDOUT: @tuple.3.loc10_4.3 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F({ i32 } %b, ptr %c) {
 // CHECK:STDOUT: entry:
@@ -22,6 +22,6 @@ fn Main() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @Main() {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @const.loc10_4.3)
+// CHECK:STDOUT:   call void @F({ i32 } { i32 1 }, ptr @tuple.3.loc10_4.3)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -15,7 +15,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'tuple_param_with_return_slot.carbon'
 // CHECK:STDOUT: source_filename = "tuple_param_with_return_slot.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc12_4.4 = internal constant { i32, i32 } { i32 2, i32 3 }
+// CHECK:STDOUT: @tuple.3.loc12_4.4 = internal constant { i32, i32 } { i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F(ptr sret({ i32, i32, i32 }) %return, { i32 } %b, ptr %c) {
 // CHECK:STDOUT: entry:
@@ -36,7 +36,7 @@ fn Main() {
 // CHECK:STDOUT: define void @Main() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_4.1.temp = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   call void @F(ptr %.loc12_4.1.temp, { i32 } { i32 1 }, ptr @const.loc12_4.4)
+// CHECK:STDOUT:   call void @F(ptr %.loc12_4.1.temp, { i32 } { i32 1 }, ptr @tuple.3.loc12_4.4)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -17,14 +17,14 @@ fn Run() {
 // CHECK:STDOUT: ; ModuleID = 'array_element_access.carbon'
 // CHECK:STDOUT: source_filename = "array_element_access.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc6_37 = internal constant { i32, i32 } { i32 1, i32 2 }
-// CHECK:STDOUT: @const.loc8_35 = internal constant [2 x i32] [i32 1, i32 2]
+// CHECK:STDOUT: @tuple.loc6_37 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @array.loc8_35 = internal constant [2 x i32] [i32 1, i32 2]
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @A(ptr sret({ i32, i32 }) %return) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc6_36.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc6_36.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc6_37, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @tuple.loc6_37, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -32,7 +32,7 @@ fn Run() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc8_34.3.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_34.6.array.index = getelementptr inbounds [2 x i32], ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc8_35, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @array.loc8_35, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/index/tuple_element_access.carbon
+++ b/toolchain/lower/testdata/index/tuple_element_access.carbon
@@ -14,7 +14,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'tuple_element_access.carbon'
 // CHECK:STDOUT: source_filename = "tuple_element_access.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_37 = internal constant { i32, i32, i32 } { i32 0, i32 1, i32 2 }
+// CHECK:STDOUT: @tuple.loc8_37 = internal constant { i32, i32, i32 } { i32 0, i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @main() {
 // CHECK:STDOUT: entry:
@@ -22,7 +22,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.2.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_36.4.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc8_36.6.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 2
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @const.loc8_37, i64 12, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.loc8_37, i64 12, i1 false)
 // CHECK:STDOUT:   %b.var = alloca i32, align 4
 // CHECK:STDOUT:   %.loc9_19.1.tuple.index = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_19.2 = load i32, ptr %.loc9_19.1.tuple.index, align 4

--- a/toolchain/lower/testdata/index/tuple_return_value_access.carbon
+++ b/toolchain/lower/testdata/index/tuple_return_value_access.carbon
@@ -13,13 +13,13 @@ fn Run() {
 // CHECK:STDOUT: ; ModuleID = 'tuple_return_value_access.carbon'
 // CHECK:STDOUT: source_filename = "tuple_return_value_access.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc7_39 = internal constant { i32, i32 } { i32 12, i32 24 }
+// CHECK:STDOUT: @tuple.loc7_39 = internal constant { i32, i32 } { i32 12, i32 24 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F(ptr sret({ i32, i32 }) %return) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc7_38.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 0
 // CHECK:STDOUT:   %.loc7_38.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %return, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @const.loc7_39, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %return, ptr align 4 @tuple.loc7_39, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/let/tuple.carbon
+++ b/toolchain/lower/testdata/let/tuple.carbon
@@ -14,8 +14,8 @@ fn F() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'tuple.carbon'
 // CHECK:STDOUT: source_filename = "tuple.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
-// CHECK:STDOUT: @const.loc9_29 = internal constant { i32, i32 } { i32 4, i32 5 }
+// CHECK:STDOUT: @tuple.1.loc8_37 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
+// CHECK:STDOUT: @tuple.2.loc9_29 = internal constant { i32, i32 } { i32 4, i32 5 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @F() {
 // CHECK:STDOUT: entry:
@@ -23,39 +23,39 @@ fn F() -> i32 {
 // CHECK:STDOUT:   %.loc8_36.2.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_36.4.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc8_36.6.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 2
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @const.loc8_37, i64 12, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.1.loc8_37, i64 12, i1 false)
 // CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc9_28.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_28.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @const.loc9_29, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.2.loc9_29, i64 8, i1 false)
 // CHECK:STDOUT:   %.loc10_43.1.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc10_43.2 = load i32, ptr %.loc10_43.1.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc10_43.3.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc10_43.4 = load i32, ptr %.loc10_43.3.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc10_43.5.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 2
 // CHECK:STDOUT:   %.loc10_43.6 = load i32, ptr %.loc10_43.5.tuple.elem, align 4
-// CHECK:STDOUT:   %.loc10_43.7.tuple = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   %.loc10_43.7 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc10_43.7.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %.loc10_43.2, ptr %.loc10_43.7, align 4
-// CHECK:STDOUT:   %.loc10_43.71 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc10_43.7.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %.loc10_43.4, ptr %.loc10_43.71, align 4
-// CHECK:STDOUT:   %.loc10_43.72 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc10_43.7.tuple, i32 0, i32 2
-// CHECK:STDOUT:   store i32 %.loc10_43.6, ptr %.loc10_43.72, align 4
+// CHECK:STDOUT:   %tuple.loc10_43 = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %tuple.loc10_431 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc10_43, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %.loc10_43.2, ptr %tuple.loc10_431, align 4
+// CHECK:STDOUT:   %tuple.loc10_432 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc10_43, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %.loc10_43.4, ptr %tuple.loc10_432, align 4
+// CHECK:STDOUT:   %tuple.loc10_433 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc10_43, i32 0, i32 2
+// CHECK:STDOUT:   store i32 %.loc10_43.6, ptr %tuple.loc10_433, align 4
 // CHECK:STDOUT:   %.loc10_46.1.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc10_46.2 = load i32, ptr %.loc10_46.1.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc10_46.3.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc10_46.4 = load i32, ptr %.loc10_46.3.tuple.elem, align 4
-// CHECK:STDOUT:   %.loc10_46.5.tuple = alloca { i32, i32 }, align 8
-// CHECK:STDOUT:   %.loc10_46.5 = getelementptr inbounds { i32, i32 }, ptr %.loc10_46.5.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %.loc10_46.2, ptr %.loc10_46.5, align 4
-// CHECK:STDOUT:   %.loc10_46.53 = getelementptr inbounds { i32, i32 }, ptr %.loc10_46.5.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %.loc10_46.4, ptr %.loc10_46.53, align 4
-// CHECK:STDOUT:   %.loc10_47.4.tuple = alloca { ptr, ptr }, align 8
-// CHECK:STDOUT:   %.loc10_47.4 = getelementptr inbounds { ptr, ptr }, ptr %.loc10_47.4.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store ptr %.loc10_43.7.tuple, ptr %.loc10_47.4, align 8
-// CHECK:STDOUT:   %.loc10_47.44 = getelementptr inbounds { ptr, ptr }, ptr %.loc10_47.4.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store ptr %.loc10_46.5.tuple, ptr %.loc10_47.44, align 8
-// CHECK:STDOUT:   %.loc11_13.tuple.index = getelementptr inbounds { ptr, ptr }, ptr %.loc10_47.4.tuple, i32 0, i32 1
+// CHECK:STDOUT:   %tuple.loc10_46 = alloca { i32, i32 }, align 8
+// CHECK:STDOUT:   %tuple.loc10_464 = getelementptr inbounds { i32, i32 }, ptr %tuple.loc10_46, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %.loc10_46.2, ptr %tuple.loc10_464, align 4
+// CHECK:STDOUT:   %tuple.loc10_465 = getelementptr inbounds { i32, i32 }, ptr %tuple.loc10_46, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %.loc10_46.4, ptr %tuple.loc10_465, align 4
+// CHECK:STDOUT:   %tuple.loc10_47 = alloca { ptr, ptr }, align 8
+// CHECK:STDOUT:   %tuple.loc10_476 = getelementptr inbounds { ptr, ptr }, ptr %tuple.loc10_47, i32 0, i32 0
+// CHECK:STDOUT:   store ptr %tuple.loc10_43, ptr %tuple.loc10_476, align 8
+// CHECK:STDOUT:   %tuple.loc10_477 = getelementptr inbounds { ptr, ptr }, ptr %tuple.loc10_47, i32 0, i32 1
+// CHECK:STDOUT:   store ptr %tuple.loc10_46, ptr %tuple.loc10_477, align 8
+// CHECK:STDOUT:   %.loc11_13.tuple.index = getelementptr inbounds { ptr, ptr }, ptr %tuple.loc10_47, i32 0, i32 1
 // CHECK:STDOUT:   %.loc11_13.tuple.index.load = load ptr, ptr %.loc11_13.tuple.index, align 8
 // CHECK:STDOUT:   %.loc11_16.tuple.index = getelementptr inbounds { i32, i32 }, ptr %.loc11_13.tuple.index.load, i32 0, i32 1
 // CHECK:STDOUT:   %.loc11_16.tuple.index.load = load i32, ptr %.loc11_16.tuple.index, align 4

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -14,7 +14,7 @@ fn Main() {
 // CHECK:STDOUT: ; ModuleID = 'assignment.carbon'
 // CHECK:STDOUT: source_filename = "assignment.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc11_5 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @tuple.loc11_5 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @Main() {
 // CHECK:STDOUT: entry:
@@ -24,7 +24,7 @@ fn Main() {
 // CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc11_12.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc11_12.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %b.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @const.loc11_5, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.loc11_5, i64 8, i1 false)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/address_of_field.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_field.carbon
@@ -14,7 +14,7 @@ fn F() {
 // CHECK:STDOUT: ; ModuleID = 'address_of_field.carbon'
 // CHECK:STDOUT: source_filename = "address_of_field.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc10_47 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @struct.loc10_47 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @G(ptr)
 // CHECK:STDOUT:
@@ -23,7 +23,7 @@ fn F() {
 // CHECK:STDOUT:   %s.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc10_46.2.a = getelementptr inbounds { i32, i32 }, ptr %s.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc10_46.4.b = getelementptr inbounds { i32, i32 }, ptr %s.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %s.var, ptr align 4 @const.loc10_47, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %s.var, ptr align 4 @struct.loc10_47, i64 8, i1 false)
 // CHECK:STDOUT:   %.loc11_7.b = getelementptr inbounds { i32, i32 }, ptr %s.var, i32 0, i32 1
 // CHECK:STDOUT:   call void @G(ptr %.loc11_7.b)
 // CHECK:STDOUT:   ret void

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -14,14 +14,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'member_access.carbon'
 // CHECK:STDOUT: source_filename = "member_access.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_49 = internal constant { double, i32 } { double 0.000000e+00, i32 1 }
+// CHECK:STDOUT: @struct.loc8_49 = internal constant { double, i32 } { double 0.000000e+00, i32 1 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @main() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { double, i32 }, align 8
 // CHECK:STDOUT:   %.loc8_48.2.a = getelementptr inbounds { double, i32 }, ptr %x.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_48.4.b = getelementptr inbounds { double, i32 }, ptr %x.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %x.var, ptr align 8 @const.loc8_49, i64 16, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %x.var, ptr align 8 @struct.loc8_49, i64 16, i1 false)
 // CHECK:STDOUT:   %y.var = alloca i32, align 4
 // CHECK:STDOUT:   %.loc9_17.1.b = getelementptr inbounds { double, i32 }, ptr %x.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc9_17.2 = load i32, ptr %.loc9_17.1.b, align 4

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -13,14 +13,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
 // CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_47 = internal constant { i32, i32 } { i32 1, i32 2 }
+// CHECK:STDOUT: @struct.loc8_47 = internal constant { i32, i32 } { i32 1, i32 2 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @main() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc8_46.2.a = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_46.4.b = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @const.loc8_47, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @struct.loc8_47, i64 8, i1 false)
 // CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc9_31.1.a = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_31.2 = load i32, ptr %.loc9_31.1.a, align 4

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -13,14 +13,14 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
 // CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @const.loc8_30 = internal constant { i32, i32 } { i32 12, i32 7 }
+// CHECK:STDOUT: @tuple.loc8_30 = internal constant { i32, i32 } { i32 12, i32 7 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: define i32 @main() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc8_29.2.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc8_29.4.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 1
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @const.loc8_30, i64 8, i1 false)
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @tuple.loc8_30, i64 8, i1 false)
 // CHECK:STDOUT:   %y.var = alloca { i32, i32 }, align 8
 // CHECK:STDOUT:   %.loc9_23.1.tuple.elem = getelementptr inbounds { i32, i32 }, ptr %x.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc9_23.2 = load i32, ptr %.loc9_23.1.tuple.elem, align 4

--- a/toolchain/lower/testdata/tuple/value_formation.carbon
+++ b/toolchain/lower/testdata/tuple/value_formation.carbon
@@ -27,31 +27,31 @@ fn F() {
 // CHECK:STDOUT:   %.loc12_6.4 = load i32, ptr %.loc12_6.3.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc12_6.5.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %a.var, i32 0, i32 2
 // CHECK:STDOUT:   %.loc12_6.6 = load i32, ptr %.loc12_6.5.tuple.elem, align 4
-// CHECK:STDOUT:   %.loc12_6.7.tuple = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   %.loc12_6.7 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_6.7.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %.loc12_6.2, ptr %.loc12_6.7, align 4
-// CHECK:STDOUT:   %.loc12_6.71 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_6.7.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %.loc12_6.4, ptr %.loc12_6.71, align 4
-// CHECK:STDOUT:   %.loc12_6.72 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_6.7.tuple, i32 0, i32 2
-// CHECK:STDOUT:   store i32 %.loc12_6.6, ptr %.loc12_6.72, align 4
+// CHECK:STDOUT:   %tuple.loc12_6 = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %tuple.loc12_61 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_6, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %.loc12_6.2, ptr %tuple.loc12_61, align 4
+// CHECK:STDOUT:   %tuple.loc12_62 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_6, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %.loc12_6.4, ptr %tuple.loc12_62, align 4
+// CHECK:STDOUT:   %tuple.loc12_63 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_6, i32 0, i32 2
+// CHECK:STDOUT:   store i32 %.loc12_6.6, ptr %tuple.loc12_63, align 4
 // CHECK:STDOUT:   %.loc12_9.1.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %b.var, i32 0, i32 0
 // CHECK:STDOUT:   %.loc12_9.2 = load i32, ptr %.loc12_9.1.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc12_9.3.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %b.var, i32 0, i32 1
 // CHECK:STDOUT:   %.loc12_9.4 = load i32, ptr %.loc12_9.3.tuple.elem, align 4
 // CHECK:STDOUT:   %.loc12_9.5.tuple.elem = getelementptr inbounds { i32, i32, i32 }, ptr %b.var, i32 0, i32 2
 // CHECK:STDOUT:   %.loc12_9.6 = load i32, ptr %.loc12_9.5.tuple.elem, align 4
-// CHECK:STDOUT:   %.loc12_9.7.tuple = alloca { i32, i32, i32 }, align 8
-// CHECK:STDOUT:   %.loc12_9.7 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_9.7.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store i32 %.loc12_9.2, ptr %.loc12_9.7, align 4
-// CHECK:STDOUT:   %.loc12_9.73 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_9.7.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store i32 %.loc12_9.4, ptr %.loc12_9.73, align 4
-// CHECK:STDOUT:   %.loc12_9.74 = getelementptr inbounds { i32, i32, i32 }, ptr %.loc12_9.7.tuple, i32 0, i32 2
-// CHECK:STDOUT:   store i32 %.loc12_9.6, ptr %.loc12_9.74, align 4
-// CHECK:STDOUT:   %.loc12_10.4.tuple = alloca { ptr, ptr }, align 8
-// CHECK:STDOUT:   %.loc12_10.4 = getelementptr inbounds { ptr, ptr }, ptr %.loc12_10.4.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store ptr %.loc12_6.7.tuple, ptr %.loc12_10.4, align 8
-// CHECK:STDOUT:   %.loc12_10.45 = getelementptr inbounds { ptr, ptr }, ptr %.loc12_10.4.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store ptr %.loc12_9.7.tuple, ptr %.loc12_10.45, align 8
-// CHECK:STDOUT:   call void @G(ptr %.loc12_10.4.tuple)
+// CHECK:STDOUT:   %tuple.loc12_9 = alloca { i32, i32, i32 }, align 8
+// CHECK:STDOUT:   %tuple.loc12_94 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_9, i32 0, i32 0
+// CHECK:STDOUT:   store i32 %.loc12_9.2, ptr %tuple.loc12_94, align 4
+// CHECK:STDOUT:   %tuple.loc12_95 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_9, i32 0, i32 1
+// CHECK:STDOUT:   store i32 %.loc12_9.4, ptr %tuple.loc12_95, align 4
+// CHECK:STDOUT:   %tuple.loc12_96 = getelementptr inbounds { i32, i32, i32 }, ptr %tuple.loc12_9, i32 0, i32 2
+// CHECK:STDOUT:   store i32 %.loc12_9.6, ptr %tuple.loc12_96, align 4
+// CHECK:STDOUT:   %tuple.loc12_10 = alloca { ptr, ptr }, align 8
+// CHECK:STDOUT:   %tuple.loc12_107 = getelementptr inbounds { ptr, ptr }, ptr %tuple.loc12_10, i32 0, i32 0
+// CHECK:STDOUT:   store ptr %tuple.loc12_6, ptr %tuple.loc12_107, align 8
+// CHECK:STDOUT:   %tuple.loc12_108 = getelementptr inbounds { ptr, ptr }, ptr %tuple.loc12_10, i32 0, i32 1
+// CHECK:STDOUT:   store ptr %tuple.loc12_9, ptr %tuple.loc12_108, align 8
+// CHECK:STDOUT:   call void @G(ptr %tuple.loc12_10)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/tuple/value_forwarding.carbon
+++ b/toolchain/lower/testdata/tuple/value_forwarding.carbon
@@ -17,11 +17,11 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: define void @F(ptr %a, ptr %b) {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc10_10.2.tuple = alloca { ptr, ptr }, align 8
-// CHECK:STDOUT:   %.loc10_10.2 = getelementptr inbounds { ptr, ptr }, ptr %.loc10_10.2.tuple, i32 0, i32 0
-// CHECK:STDOUT:   store ptr %a, ptr %.loc10_10.2, align 8
-// CHECK:STDOUT:   %.loc10_10.21 = getelementptr inbounds { ptr, ptr }, ptr %.loc10_10.2.tuple, i32 0, i32 1
-// CHECK:STDOUT:   store ptr %b, ptr %.loc10_10.21, align 8
-// CHECK:STDOUT:   call void @G(ptr %.loc10_10.2.tuple)
+// CHECK:STDOUT:   %tuple = alloca { ptr, ptr }, align 8
+// CHECK:STDOUT:   %tuple1 = getelementptr inbounds { ptr, ptr }, ptr %tuple, i32 0, i32 0
+// CHECK:STDOUT:   store ptr %a, ptr %tuple1, align 8
+// CHECK:STDOUT:   %tuple2 = getelementptr inbounds { ptr, ptr }, ptr %tuple, i32 0, i32 1
+// CHECK:STDOUT:   store ptr %b, ptr %tuple2, align 8
+// CHECK:STDOUT:   call void @G(ptr %tuple)
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -12,6 +12,7 @@
 #include "toolchain/sem_ir/builtin_function_kind.h"
 #include "toolchain/sem_ir/function.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst_kind.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::SemIR {
@@ -473,6 +474,18 @@ auto InstNamer::CollectNamesInBlock(ScopeId scope_id,
       case CARBON_KIND(SpliceBlock inst): {
         CollectNamesInBlock(scope_id, inst.block_id);
         break;
+      }
+      case StructValue::Kind: {
+        add_inst_name("struct");
+        continue;
+      }
+      case CARBON_KIND(TupleValue inst): {
+        if (sem_ir_.types().Is<ArrayType>(inst.type_id)) {
+          add_inst_name("array");
+        } else {
+          add_inst_name("tuple");
+        }
+        continue;
       }
       case CARBON_KIND(VarStorage inst): {
         add_inst_name_id(inst.name_id, ".var");


### PR DESCRIPTION
Change the names for emitted globals for constants with storage to include both the name of the constant and the name of the use.

This causes the instructions to also be named in SemIR and in LLVM IR constants.