### PR TITLE
Remove unused include statement in driver.cpp

### DIFF
--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -20,7 +20,6 @@
 #include "toolchain/base/value_store.h"
 #include "toolchain/check/check.h"
 #include "toolchain/codegen/codegen.h"
-#include "toolchain/diagnostics/diagnostic_emitter.h"
 #include "toolchain/diagnostics/sorting_diagnostic_consumer.h"
 #include "toolchain/lex/lex.h"
 #include "toolchain/lower/lower.h"


### PR DESCRIPTION

This removes unused include
```
#include "toolchain/diagnostics/diagnostic_emitter.h"
```
from `./toolchain/driver/driver.cpp`