### PR TITLE
Refactor name addition, particularly for associated entities.

### DIFF
--- a/toolchain/check/handle_alias.cpp
+++ b/toolchain/check/handle_alias.cpp
@@ -69,7 +69,7 @@ auto HandleAlias(Context& context, Parse::AliasId /*node_id*/) -> bool {
 
   // Add the name of the binding to the current scope.
   context.decl_name_stack().PopScope();
-  context.decl_name_stack().AddNameToLookup(name_context, alias_id);
+  context.decl_name_stack().AddNameOrDiagnoseDuplicate(name_context, alias_id);
   return true;
 }
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -435,7 +435,7 @@ auto HandleBaseDecl(Context& context, Parse::BaseDeclId node_id) -> bool {
        SemIR::StructTypeField{SemIR::NameId::Base, base_info.type_id}}));
 
   // Bind the name `base` in the class to the base field.
-  context.decl_name_stack().AddNameToLookup(
+  context.decl_name_stack().AddNameOrDiagnoseDuplicate(
       context.decl_name_stack().MakeUnqualifiedName(node_id,
                                                     SemIR::NameId::Base),
       class_info.base_id);

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -56,7 +56,7 @@ static auto BuildAssociatedConstantDecl(
   auto assoc_id = BuildAssociatedEntity(context, interface_id, decl_id);
   auto name_context =
       context.decl_name_stack().MakeUnqualifiedName(pattern.loc_id, name_id);
-  context.decl_name_stack().AddNameToLookup(name_context, assoc_id);
+  context.decl_name_stack().AddNameOrDiagnoseDuplicate(name_context, assoc_id);
 }
 
 auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -57,14 +57,16 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
     auto name_context = context.decl_name_stack().MakeUnqualifiedName(
         context.insts().GetLocId(value_id),
         context.bind_names().Get(bind_name->bind_name_id).name_id);
-    context.decl_name_stack().AddNameToLookup(name_context, value_id);
+    context.decl_name_stack().AddNameOrDiagnoseDuplicate(name_context,
+                                                         value_id);
     value_id = bind_name->value_id;
   } else if (auto field_decl =
                  context.insts().TryGetAs<SemIR::FieldDecl>(value_id)) {
     // Introduce the field name into the class.
     auto name_context = context.decl_name_stack().MakeUnqualifiedName(
         context.insts().GetLocId(value_id), field_decl->name_id);
-    context.decl_name_stack().AddNameToLookup(name_context, value_id);
+    context.decl_name_stack().AddNameOrDiagnoseDuplicate(name_context,
+                                                         value_id);
   }
   // TODO: Handle other kinds of pattern.
 


### PR DESCRIPTION
This is so that the constant associated with a function is used after the function declaration is complete, related to changing how function constants work.