### PR TITLE
Include parse node being checked in crash backtrace.

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -716,14 +716,10 @@ static auto ProcessNodeIds(Context& context, llvm::raw_ostream* vlog_stream,
   PrettyStackTraceFunction node_dumper([&](llvm::raw_ostream& output) {
     auto loc = converter->ConvertLoc(
         node_id, [](DiagnosticLoc, const Internal::DiagnosticBase<>&) {});
-    int32_t length_this_line = std::min(
-        loc.length, static_cast<int32_t>(loc.line.size()) - loc.column_number);
-    output << loc.filename << ":" << loc.line_number << ":" << loc.column_number
-           << ": Check::Handle" << context.parse_tree().node_kind(node_id)
-           << "\n"
-           << loc.line << "\n"
-           << std::string(std::max(loc.column_number - 1, 0), ' ') << '^'
-           << std::string(std::max(length_this_line - 1, 0), '~');
+    loc.FormatLocation(output);
+    output << ": Check::Handle" << context.parse_tree().node_kind(node_id)
+           << "\n";
+    loc.FormatSnippet(output);
   });
 
   while (auto maybe_node_id = traversal.Next()) {

--- a/toolchain/diagnostics/BUILD
+++ b/toolchain/diagnostics/BUILD
@@ -13,7 +13,10 @@ filegroup(
 
 cc_library(
     name = "diagnostic_emitter",
-    srcs = ["diagnostic_consumer.cpp"],
+    srcs = [
+        "diagnostic.cpp",
+        "diagnostic_consumer.cpp",
+    ],
     hdrs = [
         "diagnostic.h",
         "diagnostic_consumer.h",

--- a/toolchain/diagnostics/diagnostic.cpp
+++ b/toolchain/diagnostics/diagnostic.cpp
@@ -1,0 +1,45 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/diagnostics/diagnostic.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace Carbon {
+
+auto DiagnosticLoc::FormatLocation(llvm::raw_ostream& out) const -> void {
+  out << filename;
+  if (line_number > 0) {
+    out << ":" << line_number;
+    if (column_number > 0) {
+      out << ":" << column_number;
+    }
+  }
+}
+
+auto DiagnosticLoc::FormatSnippet(llvm::raw_ostream& out) const -> void {
+  if (column_number <= 0) {
+    return;
+  }
+
+  // column_number is 1-based.
+  int32_t column = column_number - 1;
+
+  out << line << "\n";
+  out.indent(column);
+  out << "^";
+  // We want to ensure that we don't underline past the end of the line in
+  // case of a multiline token.
+  // TODO: revisit this once we can reference multiple ranges on multiple
+  // lines in a single diagnostic message.
+  int underline_length =
+      std::min(length, static_cast<int32_t>(line.size()) - column);
+  for (int i = 1; i < underline_length; ++i) {
+    out << '~';
+  }
+  out << '\n';
+}
+
+}  // namespace Carbon

--- a/toolchain/diagnostics/diagnostic.h
+++ b/toolchain/diagnostics/diagnostic.h
@@ -46,6 +46,14 @@ enum class DiagnosticLevel : int8_t {
 // is required to be less than SourceBuffer that it refers to due to the
 // contained filename and line references.
 struct DiagnosticLoc {
+  // Write the filename, line number, and column number corresponding to this
+  // location to the given stream.
+  auto FormatLocation(llvm::raw_ostream& out) const -> void;
+
+  // Write the source snippet corresponding to this location to the given
+  // stream.
+  auto FormatSnippet(llvm::raw_ostream& out) const -> void;
+
   // Name of the file or buffer that this diagnostic refers to.
   llvm::StringRef filename;
   // A reference to the line of the error.

--- a/toolchain/diagnostics/diagnostic_consumer.cpp
+++ b/toolchain/diagnostics/diagnostic_consumer.cpp
@@ -17,35 +17,13 @@ auto StreamDiagnosticConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
   }
 
   for (const auto& message : diagnostic.messages) {
-    *stream_ << message.loc.filename;
-    if (message.loc.line_number > 0) {
-      *stream_ << ":" << message.loc.line_number;
-      if (message.loc.column_number > 0) {
-        *stream_ << ":" << message.loc.column_number;
-      }
-    }
+    message.loc.FormatLocation(*stream_);
     *stream_ << ": ";
     if (message.level == DiagnosticLevel::Error) {
       *stream_ << "ERROR: ";
     }
     *stream_ << message.format_fn(message) << "\n";
-    if (message.loc.column_number > 0) {
-      *stream_ << message.loc.line << "\n";
-      stream_->indent(message.loc.column_number - 1);
-      *stream_ << "^";
-      int underline_length = std::max(0, message.loc.length - 1);
-      // We want to ensure that we don't underline past the end of the line in
-      // case of a multiline token.
-      // TODO: revisit this once we can reference multiple ranges on multiple
-      // lines in a single diagnostic message.
-      underline_length = std::min(
-          underline_length, static_cast<int32_t>(message.loc.line.size()) -
-                                message.loc.column_number);
-      for (int i = 0; i < underline_length; ++i) {
-        *stream_ << "~";
-      }
-      *stream_ << "\n";
-    }
+    message.loc.FormatSnippet(*stream_);
   }
 }
 


### PR DESCRIPTION
When we crash, include the source location of the parse node that we were handling, as well as the name of the check function that we were calling. Also include the source snippet, since it's easy to do so, and may avoid the need to look at the input file in some cases.