### PR TITLE
Add our VSCode extension as a local workspace estension.

### DIFF
--- a/.vscode/extensions/carbon-lang
+++ b/.vscode/extensions/carbon-lang
@@ -1,0 +1,1 @@
+../../utils/vscode/


### PR DESCRIPTION
This causes it to be suggested when opening the carbon-lang project with VSCode, with single-button installation.