### PR TITLE
Disable `google-readability-casting` as it is broken.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,10 @@ WarningsAsErrors: '*'
 #       inst_id = name_ref->value_id;
 #                 ^ unchecked access to optional value
 #     }
+# - google-readability-casting is deeply broken, and fires regularly on calls
+#   to constructors. Worse, it suggests switching to a call to a constructor
+#   which doesn't fix the warning. This has been disabled by many major users
+#   of clang-tidy (Chromium, etc).
 # - google-readability-function-size overlaps with readability-function-size.
 # - modernize-use-designated-initializers is disabled because it fires on
 #   creation of SemIR typed insts, for which we do not currently want to use
@@ -33,7 +37,7 @@ Checks:
   -*, bugprone-*, -bugprone-branch-clone, -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape, -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions, -bugprone-switch-missing-default-case,
-  -bugprone-unchecked-optional-access, google-*,
+  -bugprone-unchecked-optional-access, google-*, -google-readability-casting,
   -google-readability-function-size, -google-readability-todo,
   misc-definitions-in-headers, misc-misplaced-const, misc-redundant-expression,
   misc-static-assert, misc-unconventional-assign-operator,

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -195,7 +195,6 @@ static constexpr SIMDMaskArrayT PrefixMasks = []() constexpr {
   for (int i = 1; i < static_cast<int>(masks.size()); ++i) {
     masks[i] =
         // The SIMD types and constexpr require a C-style cast.
-        // NOLINTNEXTLINE(google-readability-casting)
         (SIMDMaskT)(std::numeric_limits<unsigned __int128>::max() >>
                     ((sizeof(SIMDMaskT) - i) * 8));
   }


### PR DESCRIPTION
I had been bothered by the confusing suggestions to replace calls to a constructor with ... calls to a constructor, claiming the original code was a C-style cast. In some code, we've worked around this by using `static_cast` but that really doesn't seem to be a readability win.

I did some research and from what I can tell this tidy check is deeply broken, with both Chromium and internal Google users disabling it due to widespread issues:
https://chromium.googlesource.com/chromium/src/+/f828a2248f0da4e7bfadfa5db324230043aaea02

We should disable it as well for now. I've removed one `NOLINT` comment for it, but not tried to remove all the `static_cast`s that are now unnecessary as that seems hard to do in any automatic way.

**Replace this paragraph with a description of what this PR is changing or
adding, and why.**

Closes #ISSUE
