### PR TITLE
Stop skipping JSON copyright & license headers by default.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,7 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 {
   "name": "carbon-lang",
   "build": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,8 +179,12 @@ repos:
             Part of the Carbon Language project, under the Apache License v2.0 with LLVM
             Exceptions. See /LICENSE for license information.
             SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+          - --skip_pattern
+          # The default skip pattern skips JSON which we use with VSCode and
+          # it, like most file-based parsers, can support comments easily.
+          - '(^LICENSE|\.(ico))$'
           - --custom_format
-          - '\.(carbon|proto|ypp)(\.tmpl)?$'
+          - '\.(carbon|c|json|proto|ypp)(\.tmpl)?$'
           - ''
           - '// '
           - ''
@@ -209,11 +213,6 @@ repos:
           - ''
           - '-- '
           - ''
-          - --custom_format
-          - '\.c$'
-          - ''
-          - '// '
-          - ''
         exclude: |
           (?x)^(
               .bazelversion|
@@ -221,6 +220,7 @@ repos:
               compile_flags.txt|
               github_tools/requirements.txt|
               third_party/.*|
+              utils/vscode/package(-lock)?.json|
               .*\.def|
               .*\.svg|
               .*/fuzzer_corpus/.*|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -217,6 +217,7 @@ repos:
           (?x)^(
               .bazelversion|
               .github/pull_request_template.md|
+              .vscode/extensions.json|
               compile_flags.txt|
               github_tools/requirements.txt|
               third_party/.*|

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
-// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-// Exceptions. See /LICENSE for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 {
   "recommendations": [
     "bazelbuild.vscode-bazel",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 {
   "recommendations": [
     "bazelbuild.vscode-bazel",


### PR DESCRIPTION
A lot of the JSON we use is parsed by VSCode or other systems that are happy to have comments in them, and we should retain a license header there. We can exclude specific files where this is a problem. I think the `package.json` and generated lock file from it are two such cases where we can't have the license header, but we can directly exclude more as needed.

This should help make sure that when we *do* have a license header in a JSON file it stays up to date and is formatted canonically.