### PR TITLE
Fix a new C-style cast `clang-tidy` error in #3963.

### DIFF
--- a/toolchain/parse/handle_decl_scope_loop.cpp
+++ b/toolchain/parse/handle_decl_scope_loop.cpp
@@ -187,7 +187,8 @@ static auto ResolveAmbiguousTokenAsDeclaration(Context& context,
         case Lex::TokenKind::Package:
           // `package.foo` is an expression; any other token after `package` is
           // a `package` introducer.
-          return context.PositionKind(Lookahead(2)) == Lex::TokenKind::Period;
+          return context.PositionKind(static_cast<Lookahead>(2)) ==
+                 Lex::TokenKind::Period;
 
         default:
           return true;


### PR DESCRIPTION
This isn't *technically* a C-style cast, but a function-style cast. And newer versions of `clang-tidy` no longer fire on this code, so it is a little sad to have to work around. But the version on our build bots seems old enough to still hit this issue (and possibly some others).

Our merge queue also doesn't seem to catch these reliably, but that's for a separate PR.