### PR TITLE
Add a marker for warnings.

### DIFF
--- a/toolchain/check/testdata/const/collapse.carbon
+++ b/toolchain/check/testdata/const/collapse.carbon
@@ -5,7 +5,7 @@
 // AUTOUPDATE
 
 // OK, `const (const i32)` is the same type as `const i32`.
-// CHECK:STDERR: collapse.carbon:[[@LINE+3]]:25: `const` applied repeatedly to the same type has no additional effect.
+// CHECK:STDERR: collapse.carbon:[[@LINE+3]]:25: WARNING: `const` applied repeatedly to the same type has no additional effect.
 // CHECK:STDERR: fn F(p: const i32**) -> const (const i32)** {
 // CHECK:STDERR:                         ^~~~~~~~~~~~~~~~~
 fn F(p: const i32**) -> const (const i32)** {

--- a/toolchain/check/testdata/const/fail_collapse.carbon
+++ b/toolchain/check/testdata/const/fail_collapse.carbon
@@ -4,7 +4,7 @@
 //
 // AUTOUPDATE
 
-// CHECK:STDERR: fail_collapse.carbon:[[@LINE+4]]:9: `const` applied repeatedly to the same type has no additional effect.
+// CHECK:STDERR: fail_collapse.carbon:[[@LINE+4]]:9: WARNING: `const` applied repeatedly to the same type has no additional effect.
 // CHECK:STDERR: fn G(p: const (const i32)**) -> i32** {
 // CHECK:STDERR:         ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/diagnostics/diagnostic_consumer.cpp
+++ b/toolchain/diagnostics/diagnostic_consumer.cpp
@@ -19,8 +19,15 @@ auto StreamDiagnosticConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
   for (const auto& message : diagnostic.messages) {
     message.loc.FormatLocation(*stream_);
     *stream_ << ": ";
-    if (message.level == DiagnosticLevel::Error) {
-      *stream_ << "ERROR: ";
+    switch (message.level) {
+      case DiagnosticLevel::Error:
+        *stream_ << "ERROR: ";
+        break;
+      case DiagnosticLevel::Warning:
+        *stream_ << "WARNING: ";
+        break;
+      case DiagnosticLevel::Note:
+        break;
     }
     *stream_ << message.format_fn(message) << "\n";
     message.loc.FormatSnippet(*stream_);


### PR DESCRIPTION
Since notes can be above, it's unclear without.