### PR TITLE
Start building and bundling LLD for linking.

### DIFF
--- a/bazel/check_deps/check_non_test_cc_deps.py
+++ b/bazel/check_deps/check_non_test_cc_deps.py
@@ -42,7 +42,13 @@ for dep in deps:
 
         # Other packages in the LLVM project shouldn't be accidentally used
         # in Carbon. We can expand the above list if use cases emerge.
-        if package not in ("llvm", "lld", "clang", "clang-tools-extra/clangd"):
+        if package not in (
+            "llvm",
+            "lld",
+            "clang",
+            "clang-tools-extra/clangd",
+            "libunwind",
+        ):
             sys.exit(
                 "ERROR: unexpected dependency into the LLVM project: %s" % dep
             )

--- a/toolchain/driver/BUILD
+++ b/toolchain/driver/BUILD
@@ -2,6 +2,8 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@llvm-project//llvm:binary_alias.bzl", "binary_alias")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel/cc_toolchains:defs.bzl", "cc_env")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
@@ -13,10 +15,66 @@ filegroup(
     data = glob(["testdata/**/*.carbon"]),
 )
 
+# Build rules to construct the install data tree for the Carbon toolchain.
+#
+# The directory `install` should mirror a Unix-y [FHS] style installation of
+# Carbon under some prefix (`/usr`, `/usr/local`, or possibly a home directory
+# or a custom prefix). When installed, user facing binaries, which we largely
+# expect to be solely the `carbon` driver will be at `install/bin/carbon`. We
+# collect data, private executables, and other internals used by the toolchain
+# in `install/lib/carbon`. While using a `lib` subdirectory isn't a perfect fit
+# for the FHS, having a single location where private data is collected is
+# significantly superior to spreading them across the system. This also matches
+# similar patterns used by Clang itself and several other language toolchains
+# and standard libraries.
+#
+# Code that needs data files in the toolchain should add them to paths below
+# `install/lib/carbon` here and use data dependencies on these paths so that we
+# are always testing against a realistic layout.
+
+# Copy Clang and LLVM toolchain files into a synthetic LLVM installation under
+# `install/lib/carbon/llvm` so that parts of Clang that expect to find an LLVM
+# installation at relative paths work correctly without exposing these as
+# user-facing components.
+copy_file(
+    name = "copy_lld",
+    src = "@llvm-project//lld:lld",
+    out = "install/lib/carbon/llvm/bin/lld",
+    allow_symlink = False,
+    is_executable = True,
+)
+
+[
+    binary_alias(
+        name = "install/lib/carbon/llvm/bin/" + bin_name,
+        binary = ":copy_lld",
+    )
+    for bin_name in [
+        "ld.lld",
+        "ld64.lld",
+        "lld-link",
+        "wasm-ld",
+    ]
+]
+
+filegroup(
+    name = "llvm_link_data",
+    data = ["install/lib/carbon/llvm/bin/" + bin_name for bin_name in [
+        "lld",
+        "ld.lld",
+        "ld64.lld",
+        "lld-link",
+        "wasm-ld",
+    ]],
+)
+
 cc_library(
     name = "clang_runner",
     srcs = ["clang_runner.cpp"],
     hdrs = ["clang_runner.h"],
+    data = [
+        ":llvm_link_data",
+    ],
     deps = [
         "//common:command_line",
         "//common:ostream",

--- a/toolchain/driver/clang_runner.h
+++ b/toolchain/driver/clang_runner.h
@@ -40,15 +40,16 @@ class ClangRunner {
   //
   // If `verbose` is passed as true, will enable verbose logging to the
   // `err_stream` both from the runner and Clang itself.
-  ClangRunner(llvm::StringRef exe_name, llvm::StringRef target,
+  ClangRunner(llvm::StringRef install_path, llvm::StringRef target,
               llvm::raw_ostream* vlog_stream = nullptr);
 
   // Run Clang with the provided arguments.
   auto Run(llvm::ArrayRef<llvm::StringRef> args) -> bool;
 
  private:
-  llvm::StringRef exe_name_;
-  std::string exe_path_;
+  auto GetLLVMInstallBinPath() const -> std::string;
+
+  llvm::StringRef install_path_;
   llvm::StringRef target_;
   llvm::raw_ostream* vlog_stream_;
 

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -55,7 +55,7 @@ static auto RunWithCapturedOutput(std::string& out, std::string& err,
 TEST(ClangRunnerTest, Version) {
   TestRawOstream test_os;
   std::string target = llvm::sys::getDefaultTargetTriple();
-  ClangRunner runner("./toolchain/driver/run_clang_test", target, &test_os);
+  ClangRunner runner("/test", target, &test_os);
 
   std::string out;
   std::string err;
@@ -73,7 +73,7 @@ TEST(ClangRunnerTest, Version) {
   // The target should match what we provided.
   EXPECT_THAT(out, HasSubstr((llvm::Twine("Target: ") + target).str()));
   // The installation should come from the above path of the test binary.
-  EXPECT_THAT(out, HasSubstr("InstalledDir: ./toolchain/driver"));
+  EXPECT_THAT(out, HasSubstr("InstalledDir: /test/lib/carbon/llvm/bin"));
 }
 
 // Utility to write a test file. We don't need the full power provided here yet,
@@ -123,7 +123,7 @@ TEST(ClangRunnerTest, LinkCommandEcho) {
   std::string verbose_out;
   llvm::raw_string_ostream verbose_os(verbose_out);
   std::string target = llvm::sys::getDefaultTargetTriple();
-  ClangRunner runner("./toolchain/driver/run_clang_test", target, &verbose_os);
+  ClangRunner runner("/test/install/path", target, &verbose_os);
   std::string out;
   std::string err;
   EXPECT_TRUE(RunWithCapturedOutput(out, err,


### PR DESCRIPTION
This is the first, minor steps in sketching out an installation tree for the driver, and putting LLD into it in an LLVM-compatible location. It then teaches the Clang runner to configure this private LLVM install in the driver, and the link command to use LLD. With that, we use our LLD rather than the system linker.

There are a couple of TODOs here that I plan to address in direct follow-ups. First, I want to extract all the installation tree management out from everything else and into a centralized place where we can document the structure and provide APIs for navigating it. Next I want to move the prelude over to use that infrastructure as well as LLD. I left these as TODOs as I wanted to make sure I had the core logic of finding LLD working first, and would prefer to checkpoint that rather than re-doing it locally.