### PR TITLE
Refactor NodeCategory to provide a class API

### DIFF
--- a/common/ostream.h
+++ b/common/ostream.h
@@ -17,7 +17,7 @@
 namespace Carbon {
 
 // CRTP base class for printable types. Children (DerivedT) must implement:
-// - auto Print(llvm::raw_ostream& out) -> void
+// - auto Print(llvm::raw_ostream& out) const -> void
 template <typename DerivedT>
 class Printable {
   // Provides simple printing for debuggers.

--- a/toolchain/check/keyword_modifier_set.h
+++ b/toolchain/check/keyword_modifier_set.h
@@ -23,7 +23,7 @@ class KeywordModifierSet {
   //
   // We expect this to grow, so are using a bigger size than needed.
   // NOLINTNEXTLINE(performance-enum-size)
-  enum Enum : uint32_t {
+  enum RawEnumType : uint32_t {
     // At most one of these access modifiers allowed for a given declaration,
     // and if present it must be first:
     Private = 1 << 0,
@@ -61,7 +61,7 @@ class KeywordModifierSet {
   // Support implicit conversion so that the difference with the member enum is
   // opaque.
   // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr KeywordModifierSet(Enum set) : set_(set) {}
+  constexpr KeywordModifierSet(RawEnumType set) : set_(set) {}
 
   // Adds entries to the set.
   auto Add(KeywordModifierSet set) -> void { set_ |= set.set_; }
@@ -70,11 +70,11 @@ class KeywordModifierSet {
 
   // Returns true if there's a non-empty set intersection.
   constexpr auto HasAnyOf(KeywordModifierSet other) -> bool {
-    return !(*this & other).empty();
+    return set_ & other.set_;
   }
 
   // Returns true if empty.
-  constexpr auto empty() -> bool { return set_ == Enum::None; }
+  constexpr auto empty() -> bool { return !set_; }
 
   // Returns the set intersection.
   constexpr auto operator&(KeywordModifierSet other) -> KeywordModifierSet {
@@ -85,7 +85,7 @@ class KeywordModifierSet {
   auto operator~() -> KeywordModifierSet { return ~set_; }
 
  private:
-  Enum set_;
+  RawEnumType set_;
 };
 
 static_assert(!KeywordModifierSet(KeywordModifierSet::Access)

--- a/toolchain/parse/BUILD
+++ b/toolchain/parse/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//common:check",
         "//common:enum_base",
+        "//common:ostream",
         "//toolchain/base:index_base",
         "//toolchain/lex:token_kind",
         "@llvm-project//llvm:Support",

--- a/toolchain/parse/extract.cpp
+++ b/toolchain/parse/extract.cpp
@@ -96,7 +96,7 @@ static auto NodeIdInCategoryAccept(NodeCategory category, const Tree* tree,
                                    const Tree::SiblingIterator& it,
                                    Tree::SiblingIterator end,
                                    ErrorBuilder* trace) -> bool {
-  if (it == end || !(tree->node_kind(*it).category() & category)) {
+  if (it == end || !tree->node_kind(*it).category().HasAnyOf(category)) {
     if (trace) {
       *trace << "NodeIdInCategory " << category << " error: ";
       if (it == end) {
@@ -115,7 +115,7 @@ static auto NodeIdInCategoryAccept(NodeCategory category, const Tree* tree,
 }
 
 // Extract a `NodeIdInCategory<Category>` as a single child.
-template <NodeCategory Category>
+template <NodeCategory::RawEnumType Category>
 struct Extractable<NodeIdInCategory<Category>> {
   static auto Extract(const Tree* tree, Tree::SiblingIterator& it,
                       Tree::SiblingIterator end, ErrorBuilder* trace)

--- a/toolchain/parse/node_ids.h
+++ b/toolchain/parse/node_ids.h
@@ -50,14 +50,14 @@ const NodeKind& NodeIdForKind<K>::Kind = K;
 #include "toolchain/parse/node_kind.def"
 
 // NodeId that matches any NodeKind whose `category()` overlaps with `Category`.
-template <NodeCategory Category>
+template <NodeCategory::RawEnumType Category>
 struct NodeIdInCategory : public NodeId {
   // Support conversion from `NodeIdForKind<Kind>` if Kind's category
   // overlaps with `Category`.
   template <const NodeKind& Kind>
   // NOLINTNEXTLINE(google-explicit-constructor)
   NodeIdInCategory(NodeIdForKind<Kind> node_id) : NodeId(node_id) {
-    CARBON_CHECK(!!(Kind.category() & Category));
+    CARBON_CHECK(Kind.category().HasAnyOf(Category));
   }
 
   constexpr explicit NodeIdInCategory(NodeId node_id) : NodeId(node_id) {}

--- a/toolchain/parse/node_kind.cpp
+++ b/toolchain/parse/node_kind.cpp
@@ -10,16 +10,15 @@
 
 namespace Carbon::Parse {
 
-auto operator<<(llvm::raw_ostream& output, NodeCategory category)
-    -> llvm::raw_ostream& {
-  if (!category) {
-    output << "<none>";
+auto NodeCategory::Print(llvm::raw_ostream& out) const -> void {
+  if (!value_) {
+    out << "<none>";
   } else {
     llvm::ListSeparator sep("|");
 
-#define CARBON_NODE_CATEGORY(Name)         \
-  if (!!(category & NodeCategory::Name)) { \
-    output << sep << #Name;                \
+#define CARBON_NODE_CATEGORY(Name)   \
+  if (value_ & NodeCategory::Name) { \
+    out << sep << #Name;             \
   }
     CARBON_NODE_CATEGORY(Decl);
     CARBON_NODE_CATEGORY(Expr);
@@ -31,7 +30,6 @@ auto operator<<(llvm::raw_ostream& output, NodeCategory category)
     CARBON_NODE_CATEGORY(Statement);
 #undef CARBON_NODE_CATEGORY
   }
-  return output;
 }
 
 CARBON_DEFINE_ENUM_CLASS_NAMES(NodeKind) = {

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -525,10 +525,10 @@ struct Tree::ConvertTo<NodeIdForKind<K>> {
   static auto AllowedFor(NodeKind kind) -> bool { return kind == K; }
 };
 
-template <NodeCategory C>
+template <NodeCategory::RawEnumType C>
 struct Tree::ConvertTo<NodeIdInCategory<C>> {
   static auto AllowedFor(NodeKind kind) -> bool {
-    return !!(kind.category() & C);
+    return kind.category().HasAnyOf(C);
   }
 };
 

--- a/toolchain/parse/typed_nodes.h
+++ b/toolchain/parse/typed_nodes.h
@@ -27,7 +27,8 @@ template <typename Element, typename Comma>
 using CommaSeparatedList = llvm::SmallVector<ListItem<Element, Comma>>;
 
 // This class provides a shorthand for defining parse node kinds for leaf nodes.
-template <const NodeKind& KindT, NodeCategory Category = NodeCategory::None>
+template <const NodeKind& KindT,
+          NodeCategory::RawEnumType Category = NodeCategory::None>
 struct LeafNode {
   static constexpr auto Kind =
       KindT.Define({.category = Category, .child_count = 0});
@@ -314,7 +315,7 @@ struct ReturnType {
 };
 
 // A function signature: `fn F() -> i32`.
-template <const NodeKind& KindT, NodeCategory Category>
+template <const NodeKind& KindT, NodeCategory::RawEnumType Category>
 struct FunctionSignature {
   static constexpr auto Kind = KindT.Define(
       {.category = Category, .bracketed_by = FunctionIntroducer::Kind});
@@ -962,7 +963,7 @@ struct StructTypeLiteral {
 using ClassIntroducer = LeafNode<NodeKind::ClassIntroducer>;
 
 // A class signature `class C`
-template <const NodeKind& KindT, NodeCategory Category>
+template <const NodeKind& KindT, NodeCategory::RawEnumType Category>
 struct ClassSignature {
   static constexpr auto Kind = KindT.Define(
       {.category = Category, .bracketed_by = ClassIntroducer::Kind});
@@ -1027,7 +1028,7 @@ struct BaseDecl {
 using InterfaceIntroducer = LeafNode<NodeKind::InterfaceIntroducer>;
 
 // `interface I`
-template <const NodeKind& KindT, NodeCategory Category>
+template <const NodeKind& KindT, NodeCategory::RawEnumType Category>
 struct InterfaceSignature {
   static constexpr auto Kind = KindT.Define(
       {.category = Category, .bracketed_by = InterfaceIntroducer::Kind});
@@ -1080,7 +1081,7 @@ struct TypeImplAs {
 };
 
 // `impl T as I`
-template <const NodeKind& KindT, NodeCategory Category>
+template <const NodeKind& KindT, NodeCategory::RawEnumType Category>
 struct ImplSignature {
   static constexpr auto Kind = KindT.Define(
       {.category = Category, .bracketed_by = ImplIntroducer::Kind});
@@ -1115,7 +1116,7 @@ struct ImplDefinition {
 using NamedConstraintIntroducer = LeafNode<NodeKind::NamedConstraintIntroducer>;
 
 // `constraint NC`
-template <const NodeKind& KindT, NodeCategory Category>
+template <const NodeKind& KindT, NodeCategory::RawEnumType Category>
 struct NamedConstraintSignature {
   static constexpr auto Kind = KindT.Define(
       {.category = Category, .bracketed_by = NamedConstraintIntroducer::Kind});


### PR DESCRIPTION
Mirroring #4003 for NodeCategory.

Note we template a lot more on NodeCategory's enum, so this is a slightly more awkward delta.

Also, switch from Enum in KeywordModifierSet to RawEnumType for consistency with EnumBase. The templating on NodeCategory had me thinking about that more.