### PR TITLE
Move errs tie to LLVM to include test infrastructure.

### DIFF
--- a/common/init_llvm.cpp
+++ b/common/init_llvm.cpp
@@ -5,6 +5,7 @@
 #include "common/init_llvm.h"
 
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace Carbon {
 
@@ -32,6 +33,10 @@ InitLLVM::InitLLVM(int& argc, char**& argv)
   if (InitializeTargets) {
     InitializeTargets();
   }
+
+  // Printing to stderr should flush stdout. This is most noticeable when stderr
+  // is piped to stdout.
+  llvm::errs().tie(&llvm::outs());
 }
 
 InitLLVM::InitializeTargetsFn* InitLLVM::InitializeTargets = nullptr;

--- a/toolchain/driver/driver_main.cpp
+++ b/toolchain/driver/driver_main.cpp
@@ -23,10 +23,6 @@ auto main(int argc, char** argv) -> int {
 
   Carbon::SetWorkingDirForBazel();
 
-  // Printing to stderr should flush stdout. This is most noticeable when stderr
-  // is piped to stdout.
-  llvm::errs().tie(&llvm::outs());
-
   llvm::SmallVector<llvm::StringRef> args(argv + 1, argv + argc);
   auto fs = llvm::vfs::getRealFileSystem();
 


### PR DESCRIPTION
The lack of flushing can sometimes be observed when streaming test output, particularly with --dump_output. My thought is moving it into our LLVM init is probably reasonable, given the driver's already doing this for similar reasons; this means it's used in tests through our gtest_main.cpp in addition to the driver.