### PR TITLE
Refactor application of name qualifiers in decl name stack.

### DIFF
--- a/toolchain/check/decl_name_stack.h
+++ b/toolchain/check/decl_name_stack.h
@@ -228,14 +228,14 @@ class DeclNameStack {
   // Returns a name context corresponding to an empty name.
   auto MakeEmptyNameContext() -> NameContext;
 
-  // Applies a Name from the name stack to given name context.
-  auto ApplyNameQualifierTo(NameContext& name_context, SemIR::LocId loc_id,
-                            SemIR::NameId name_id, bool is_unqualified) -> void;
+  // Appends a name to the given name context, and performs a lookup to find
+  // what, if anything, the name refers to.
+  auto ApplyAndLookupName(NameContext& name_context, SemIR::LocId loc_id,
+                          SemIR::NameId name_id, bool is_unqualified) -> void;
 
-  // Returns true if the context is in a state where it can resolve qualifiers.
-  // Updates name_context as needed.
-  auto TryResolveQualifier(NameContext& name_context, SemIR::LocId loc_id)
-      -> bool;
+  // Checks and returns whether the given name context can be used as a
+  // qualifier. A suitable diagnostic is issued if not.
+  auto CheckValidAsQualifier(const NameContext& name_context) -> bool;
 
   // Updates the scope on name_context as needed. This is called after
   // resolution is complete, whether for Name or expression. When updating for

--- a/toolchain/check/testdata/alias/no_prelude/fail_local_in_namespace.carbon
+++ b/toolchain/check/testdata/alias/no_prelude/fail_local_in_namespace.carbon
@@ -47,7 +47,7 @@ fn F() -> {} {
 // CHECK:STDOUT: fn @F() -> {} {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %.loc18_17: {} = struct_literal ()
-// CHECK:STDOUT:   %.loc18_9: <error> = bind_alias <invalid>, <error> [template = <error>]
+// CHECK:STDOUT:   %.loc18_12: <error> = bind_alias <invalid>, <error> [template = <error>]
 // CHECK:STDOUT:   %NS.ref: <namespace> = name_ref NS, file.%NS [template = file.%NS]
 // CHECK:STDOUT:   %a.ref: <error> = name_ref a, <error> [template = <error>]
 // CHECK:STDOUT:   return <error>

--- a/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
+++ b/toolchain/check/testdata/namespace/fail_conflict_imported_namespace_second.carbon
@@ -28,12 +28,15 @@ import library "fn";
 // CHECK:STDERR:
 namespace NS;
 
-// CHECK:STDERR: fail_conflict.carbon:[[@LINE+6]]:7: ERROR: Name qualifiers are only allowed for entities that provide a scope.
-// CHECK:STDERR: fn NS.Foo();
-// CHECK:STDERR:       ^~~
-// CHECK:STDERR: fail_conflict.carbon:[[@LINE+3]]:4: Non-scope entity referenced here.
+// CHECK:STDERR: fail_conflict.carbon:[[@LINE+9]]:4: ERROR: Name qualifiers are only allowed for entities that provide a scope.
 // CHECK:STDERR: fn NS.Foo();
 // CHECK:STDERR:    ^~
+// CHECK:STDERR: fail_conflict.carbon:[[@LINE-17]]:1: In import.
+// CHECK:STDERR: import library "fn";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: fn.carbon:4:1: Referenced non-scope entity declared here.
+// CHECK:STDERR: fn NS();
+// CHECK:STDERR: ^~~~~~~~
 fn NS.Foo();
 
 // CHECK:STDOUT: --- fn.carbon

--- a/toolchain/check/testdata/namespace/fail_decl_in_alias.carbon
+++ b/toolchain/check/testdata/namespace/fail_decl_in_alias.carbon
@@ -9,12 +9,12 @@ namespace NS;
 alias ns = NS;
 
 // Aliases can't be used when declaring names.
-// CHECK:STDERR: fail_decl_in_alias.carbon:[[@LINE+6]]:7: ERROR: Name qualifiers are only allowed for entities that provide a scope.
-// CHECK:STDERR: fn ns.A() -> i32 { return 0; }
-// CHECK:STDERR:       ^
-// CHECK:STDERR: fail_decl_in_alias.carbon:[[@LINE+3]]:4: Non-scope entity referenced here.
+// CHECK:STDERR: fail_decl_in_alias.carbon:[[@LINE+6]]:4: ERROR: Name qualifiers are only allowed for entities that provide a scope.
 // CHECK:STDERR: fn ns.A() -> i32 { return 0; }
 // CHECK:STDERR:    ^~
+// CHECK:STDERR: fail_decl_in_alias.carbon:[[@LINE-6]]:7: Referenced non-scope entity declared here.
+// CHECK:STDERR: alias ns = NS;
+// CHECK:STDERR:       ^~
 fn ns.A() -> i32 { return 0; }
 
 // CHECK:STDOUT: --- fail_decl_in_alias.carbon

--- a/toolchain/check/testdata/packages/no_prelude/export_name.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/export_name.carbon
@@ -116,12 +116,15 @@ library "fail_export_member";
 
 import library "base";
 
-// CHECK:STDERR: fail_export_member.carbon:[[@LINE+7]]:10: ERROR: Name qualifiers are only allowed for entities that provide a scope.
-// CHECK:STDERR: export C.x;
-// CHECK:STDERR:          ^
-// CHECK:STDERR: fail_export_member.carbon:[[@LINE+4]]:8: Non-scope entity referenced here.
+// CHECK:STDERR: fail_export_member.carbon:[[@LINE+10]]:8: ERROR: Name qualifiers are only allowed for entities that provide a scope.
 // CHECK:STDERR: export C.x;
 // CHECK:STDERR:        ^
+// CHECK:STDERR: fail_export_member.carbon:[[@LINE-5]]:1: In import.
+// CHECK:STDERR: import library "base";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: base.carbon:4:1: Referenced non-scope entity declared here.
+// CHECK:STDERR: class C {
+// CHECK:STDERR: ^~~~~~~~~
 // CHECK:STDERR:
 export C.x;
 

--- a/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
+++ b/toolchain/check/testdata/packages/no_prelude/fail_export_name_member.carbon
@@ -20,12 +20,15 @@ import library "a";
 
 // TODO: This diagnostic doesn't clearly explain the problem. We should instead
 // say something like: Only namespace-scope names can be exported.
-// CHECK:STDERR: fail_b.carbon:[[@LINE+6]]:10: ERROR: Name qualifiers are only allowed for entities that provide a scope.
-// CHECK:STDERR: export C.n;
-// CHECK:STDERR:          ^
-// CHECK:STDERR: fail_b.carbon:[[@LINE+3]]:8: Non-scope entity referenced here.
+// CHECK:STDERR: fail_b.carbon:[[@LINE+9]]:8: ERROR: Name qualifiers are only allowed for entities that provide a scope.
 // CHECK:STDERR: export C.n;
 // CHECK:STDERR:        ^
+// CHECK:STDERR: fail_b.carbon:[[@LINE-7]]:1: In import.
+// CHECK:STDERR: import library "a";
+// CHECK:STDERR: ^~~~~~
+// CHECK:STDERR: a.carbon:4:1: Referenced non-scope entity declared here.
+// CHECK:STDERR: class C {
+// CHECK:STDERR: ^~~~~~~~~
 export C.n;
 
 // CHECK:STDOUT: --- a.carbon


### PR DESCRIPTION
Split apart the handling of name qualifiers and the final name a little, in preparation for also handling parameters when checking name qualifiers.

Slightly improve diagnostic for non-scope qualifier.