### PR TITLE
Refactor modifier fetching of enclosing scopes to avoid duplicate calls.

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -183,14 +183,16 @@ static auto BuildClassDecl(Context& context, Parse::AnyClassDeclId node_id,
       .PopAndDiscardSoloNodeId<Parse::NodeKind::ClassIntroducer>();
 
   // Process modifiers.
+  auto [_, enclosing_scope_inst] =
+      context.name_scopes().GetInstIfValid(name_context.enclosing_scope_id);
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Class,
-                             name_context.enclosing_scope_id);
+                             enclosing_scope_inst);
   LimitModifiersOnDecl(context,
                        KeywordModifierSet::Class | KeywordModifierSet::Access |
                            KeywordModifierSet::Extern,
                        Lex::TokenKind::Class);
   RestrictExternModifierOnDecl(context, Lex::TokenKind::Class,
-                               name_context.enclosing_scope_id, is_definition);
+                               enclosing_scope_inst, is_definition);
 
   auto modifiers = context.decl_state_stack().innermost().modifier_set;
   if (modifiers.HasAnyOf(KeywordModifierSet::Access)) {

--- a/toolchain/check/handle_interface.cpp
+++ b/toolchain/check/handle_interface.cpp
@@ -36,8 +36,10 @@ static auto BuildInterfaceDecl(Context& context,
       .PopAndDiscardSoloNodeId<Parse::NodeKind::InterfaceIntroducer>();
 
   // Process modifiers.
+  auto [_, enclosing_scope_inst] =
+      context.name_scopes().GetInstIfValid(name_context.enclosing_scope_id);
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Interface,
-                             name_context.enclosing_scope_id);
+                             enclosing_scope_inst);
   LimitModifiersOnDecl(context, KeywordModifierSet::Access,
                        Lex::TokenKind::Interface);
 

--- a/toolchain/check/handle_let.cpp
+++ b/toolchain/check/handle_let.cpp
@@ -77,10 +77,13 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   // Process declaration modifiers.
   // TODO: For a qualified `let` declaration, this should use the target scope
   // of the name introduced in the declaration. See #2590.
+  auto [enclosing_scope_inst_id, enclosing_scope_inst] =
+      context.name_scopes().GetInstIfValid(
+          context.scope_stack().PeekNameScopeId());
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Let,
-                             context.scope_stack().PeekNameScopeId());
+                             enclosing_scope_inst);
   RequireDefaultFinalOnlyInInterfaces(context, Lex::TokenKind::Let,
-                                      context.scope_stack().PeekNameScopeId());
+                                      enclosing_scope_inst);
   LimitModifiersOnDecl(
       context, KeywordModifierSet::Access | KeywordModifierSet::Interface,
       Lex::TokenKind::Let);
@@ -136,7 +139,7 @@ auto HandleLetDecl(Context& context, Parse::LetDeclId node_id) -> bool {
   // Add the name of the binding to the current scope.
   auto name_id = context.bind_names().Get(bind_name.bind_name_id).name_id;
   context.AddNameToLookup(name_id, pattern_id);
-  if (context.scope_stack().PeekNameScopeId() == SemIR::NameScopeId::Package) {
+  if (enclosing_scope_inst_id == SemIR::InstId::PackageNamespace) {
     context.AddExport(pattern_id);
   }
   return true;

--- a/toolchain/check/handle_variable.cpp
+++ b/toolchain/check/handle_variable.cpp
@@ -97,8 +97,10 @@ auto HandleVariableDecl(Context& context, Parse::VariableDeclId node_id)
   // Process declaration modifiers.
   // TODO: For a qualified `var` declaration, this should use the target scope
   // of the name introduced in the declaration. See #2590.
+  auto [_, enclosing_scope_inst] = context.name_scopes().GetInstIfValid(
+      context.scope_stack().PeekNameScopeId());
   CheckAccessModifiersOnDecl(context, Lex::TokenKind::Var,
-                             context.scope_stack().PeekNameScopeId());
+                             enclosing_scope_inst);
   LimitModifiersOnDecl(context, KeywordModifierSet::Access,
                        Lex::TokenKind::Var);
   auto modifiers = context.decl_state_stack().innermost().modifier_set;

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -495,14 +495,15 @@ class ImportRefResolver {
   // unresolved constants to the work stack.
   auto GetLocalNameScopeId(SemIR::NameScopeId name_scope_id)
       -> SemIR::NameScopeId {
-    auto inst_id = import_ir_.name_scopes().GetInstIdIfValid(name_scope_id);
-    if (!inst_id.is_valid()) {
+    auto [inst_id, inst] =
+        import_ir_.name_scopes().GetInstIfValid(name_scope_id);
+    if (!inst) {
       // Map scopes that aren't associated with an instruction to invalid
       // scopes. For now, such scopes aren't used, and we don't have a good way
       // to remap them.
       return SemIR::NameScopeId::Invalid;
     }
-    if (import_ir_.insts().Is<SemIR::ImplDecl>(inst_id)) {
+    if (inst->Is<SemIR::ImplDecl>()) {
       // TODO: Import the scope for an `impl` definition.
       return SemIR::NameScopeId::Invalid;
     }

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -97,18 +97,17 @@ static auto IsInstanceMethod(const SemIR::File& sem_ir,
 // performed if we find an associated entity.
 static auto ScopeNeedsImplLookup(Context& context,
                                  SemIR::NameScopeId name_scope_id) -> bool {
-  auto inst_id = context.name_scopes().GetInstIdIfValid(name_scope_id);
-  if (!inst_id.is_valid()) {
+  auto [_, inst] = context.name_scopes().GetInstIfValid(name_scope_id);
+  if (!inst) {
     return false;
   }
 
-  auto inst = context.insts().Get(inst_id);
-  if (inst.Is<SemIR::InterfaceDecl>()) {
+  if (inst->Is<SemIR::InterfaceDecl>()) {
     // Don't perform impl lookup if an associated entity is named as a member of
     // a facet type.
     return false;
   }
-  if (inst.Is<SemIR::Namespace>()) {
+  if (inst->Is<SemIR::Namespace>()) {
     // Don't perform impl lookup if an associated entity is named as a namespace
     // member.
     // TODO: This case is not yet listed in the design.

--- a/toolchain/check/modifiers.h
+++ b/toolchain/check/modifiers.h
@@ -10,21 +10,22 @@
 namespace Carbon::Check {
 
 // Reports a diagnostic if access control modifiers on this are not allowed for
-// a declaration in `enclosing_scope_id`, and updates the declaration state in
+// a declaration in `enclosing_scope_inst`, and updates the declaration state in
 // `context`.
 //
-// `enclosing_scope_id` may be Invalid for a declaration in a block scope.
+// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
 auto CheckAccessModifiersOnDecl(Context& context, Lex::TokenKind decl_kind,
-                                SemIR::NameScopeId enclosing_scope_id) -> void;
+                                std::optional<SemIR::Inst> enclosing_scope_inst)
+    -> void;
 
 // Reports a diagnostic if the method function modifiers `abstract`, `virtual`,
 // or `impl` are present but not permitted on a function declaration in
-// `enclosing_scope_id`.
+// `enclosing_scope_inst`.
 //
-// `enclosing_scope_id` may be Invalid for a declaration in a block scope.
-auto CheckMethodModifiersOnFunction(Context& context,
-                                    SemIR::NameScopeId enclosing_scope_id)
-    -> void;
+// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+auto CheckMethodModifiersOnFunction(
+    Context& context, SemIR::InstId enclosing_scope_inst_id,
+    std::optional<SemIR::Inst> enclosing_scope_inst) -> void;
 
 // Like `LimitModifiersOnDecl`, except says which modifiers are forbidden, and a
 // `context_string` (and optional `context_loc_id`) specifying the context in
@@ -48,19 +49,21 @@ inline auto LimitModifiersOnDecl(Context& context, KeywordModifierSet allowed,
 // declarations, diagnosing and removing it on:
 // - `extern` on a definition.
 // - `extern` on a scoped entity.
-auto RestrictExternModifierOnDecl(Context& context, Lex::TokenKind decl_kind,
-                                  SemIR::NameScopeId enclosing_scope_id,
-                                  bool is_definition) -> void;
+//
+// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+auto RestrictExternModifierOnDecl(
+    Context& context, Lex::TokenKind decl_kind,
+    std::optional<SemIR::Inst> enclosing_scope_inst, bool is_definition)
+    -> void;
 
 // Report a diagonostic if `default` and `final` modifiers are used on
 // declarations where they are not allowed. Right now they are only allowed
 // inside interfaces.
 //
-// `enclosing_scope_id` may be Invalid for a declaration in a block scope.
-auto RequireDefaultFinalOnlyInInterfaces(Context& context,
-                                         Lex::TokenKind decl_kind,
-                                         SemIR::NameScopeId enclosing_scope_id)
-    -> void;
+// `enclosing_scope_inst` may be nullopt for a declaration in a block scope.
+auto RequireDefaultFinalOnlyInInterfaces(
+    Context& context, Lex::TokenKind decl_kind,
+    std::optional<SemIR::Inst> enclosing_scope_inst) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -68,6 +68,7 @@ File::File(CheckIRId check_ir_id, SharedValueStores& value_stores,
       value_stores_(&value_stores),
       filename_(std::move(filename)),
       type_blocks_(allocator_),
+      name_scopes_(&insts_),
       constant_values_(ConstantId::NotConstant),
       inst_blocks_(allocator_),
       constants_(*this, allocator_) {

--- a/toolchain/sem_ir/file.h
+++ b/toolchain/sem_ir/file.h
@@ -212,9 +212,6 @@ class File : public Printable<File> {
   // that are import-related.
   ValueStore<ImportIRInstId> import_ir_insts_;
 
-  // Storage for name scopes.
-  NameScopeStore name_scopes_;
-
   // Type blocks within the IR. These reference entries in types_. Storage for
   // the data is provided by allocator_.
   BlockValueStore<TypeBlockId> type_blocks_;
@@ -222,6 +219,9 @@ class File : public Printable<File> {
   // All instructions. The first entries will always be Builtin insts, at
   // indices matching BuiltinKind ordering.
   InstStore insts_;
+
+  // Storage for name scopes.
+  NameScopeStore name_scopes_;
 
   // Constant values for instructions.
   ConstantValueStore constant_values_;


### PR DESCRIPTION
Right now, each sequential modifier verification tends to re-fetch the enclosing scope, doing equivalent verification. Change code to more explicitly do the fetch once, sharing the result, also making the enclosing scope available to the caller for other work.

Note, the type store similarly carries an inst store pointer; that's what I'm basing having the name scope store's inst store pointer on.